### PR TITLE
Allow for AST validation w/o toolrun

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
@@ -170,7 +170,7 @@ package object ast {
   )(implicit sc: SparkContext): Interpreted[TileLayerRDD[SpatialKey]] = {
 
     /* Guarantee correctness before performing Map Algebra */
-    val pure = Interpreter.interpretPure[Unit](ast, sourceMapping)
+    val pure = Interpreter.interpretPure[Unit](ast, sourceMapping, false)
     val over = Interpreter.overrideParams(ast, overrides)
     val rdds = sourceMapping.mapValues(r => fetch(r, zoom, sceneLocs, projLocs)).sequence
 

--- a/app-backend/tool/src/main/scala/eval/InterpreterError.scala
+++ b/app-backend/tool/src/main/scala/eval/InterpreterError.scala
@@ -11,53 +11,64 @@ import io.circe.syntax._
   *  instances of InterpreterError.
   */
 sealed trait InterpreterError {
-  val id: UUID
+  val scope: String
   def repr: String
 }
 
 /** An unbound parameter encountered during evaluation  */
 case class MissingParameter(id: UUID) extends InterpreterError {
-  def repr = s"Unbound parameter at $id encountered, unable to evaluate"
+  val scope = id.toString
+  def repr = s"Unbound parameter at $scope encountered, unable to evaluate"
 }
 
 case class IncorrectArgCount(id: UUID, expected: Int, actual: Int) extends InterpreterError {
-  def repr = s"Operation ${id} was given ${actual} args, but expected ${expected}"
+  val scope = id.toString
+  def repr = s"Operation ${scope} was given ${actual} args, but expected ${expected}"
 }
 
 case class UnhandledCase(id: UUID) extends InterpreterError {
+  val scope = id.toString
   def repr = s"Some branch of Interpreter logic has yet to be implemented: ${id}"
 }
 
 case class UnsubstitutedRef(id: UUID) extends InterpreterError {
+  val scope = id.toString
   def repr = s"Unsubstituted Tool reference found: ${id}"
 }
 
 case class NoSourceLeaves(id: UUID) extends InterpreterError {
+  val scope = id.toString
   def repr = s"The Operation ${id} has only Constant leaves"
 }
 
 case class NoBandGiven(id: UUID) extends InterpreterError {
+  val scope = "i/o"
   def repr = s"No band value given for Scene ${id}"
 }
 
 case class AttributeStoreFetchError(id: UUID) extends InterpreterError {
+  val scope = "i/o"
   def repr = s"Unable to fetch an S3AttributeStore for Scene ${id}"
 }
 
 /** An error encountered when a bound parameter's source can't be resolved */
 case class RasterRetrievalError(id: UUID, refId: UUID) extends InterpreterError {
+  val scope = "i/o"
   def repr = s"Unable to retrieve raster for ${refId} on AST node ${id}"
 }
 
 case class DatabaseError(id: UUID) extends InterpreterError {
+  val scope = "i/o"
   def repr = s"Unable to retrieve ToolRun $id or its associated Tool from the database"
 }
 
-case class ASTDecodeError(id: UUID, msg: DecodingFailure) extends InterpreterError {
-  def repr = s"Unable to decode the AST associated with ToolRun ${id}: ${msg}"
+case class ASTDecodeError(msg: DecodingFailure) extends InterpreterError {
+  val scope = "global"
+  def repr = s"Unable to decode AST: ${msg}"
 }
 
 case class InvalidOverride(id: UUID) extends InterpreterError {
+  val scope = id.toString
   def repr = s"Node ${id} was given an incompatible override value"
 }
 
@@ -65,7 +76,7 @@ object InterpreterError {
   implicit val encodeInterpreterErrors: Encoder[InterpreterError] =
     new Encoder[InterpreterError] {
       final def apply(err: InterpreterError): Json = JsonObject.fromMap {
-        Map("node" -> err.id.asJson, "reason" -> err.repr.asJson)
+        Map("scope" -> err.scope.asJson, "reason" -> err.repr.asJson)
       }.asJson
     }
 }

--- a/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
+++ b/app-backend/tool/src/test/scala/eval/InterpreterSpec.scala
@@ -102,17 +102,17 @@ class InterpreterSpec
 
     val tms = Interpreter.interpretPure[Unit](
       ast = src1 - src2,
-      sourceMapping = Map(src1.id -> tileRef(4), src2.id -> tileRef(5))
+      sourceMapping = Map(src1.id -> tileRef(4), src2.id -> tileRef(5)),
+      false
     )
 
     tms shouldBe Valid(())
-
   }
 
   it("interpretPure - multiple errors") {
     val ast: MapAlgebraAST = Addition(List(randomSourceAST), UUID.randomUUID, None)
 
-    Interpreter.interpretPure[Unit](ast, Map.empty) match {
+    Interpreter.interpretPure[Unit](ast, Map.empty, false) match {
       case Invalid(nel) => nel.size shouldBe 2
       case Valid(_) => fail
     }


### PR DESCRIPTION
## Overview

This PR provides an endpoint at `/api/tools/validate` to which json can be posted. That JSON will be returned if it is valid. If not, the errors on the tree that are encountered will be sent back in its place.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~


## Testing Instruction

Tests have been added to the `api` project. Manual testing requires only that you post putative AST json to `/api/tools/validate`

Closes #2226
