### PR TITLE
Add Annotation Toolbar Component

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -23,6 +23,7 @@
     "test-watch": "karma start karma.conf.js --auto-watch --no-single-run"
   },
   "dependencies": {
+    "angucomplete-alt": "^3.0.0",
     "angular": "~1.5.8",
     "angular-animate": "~1.5.8",
     "angular-aria": "~1.5.8",

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
@@ -1,0 +1,18 @@
+import annotateToolbarTpl from './annotateToolbar.html';
+
+/*
+  @param {string} mapId id of map to use
+  @param {object?} geom geometry containing FeatureCollection
+  @param {function(geometry: Object)} onSave function to call when the save button is clicked.\
+ */
+const annotateToolbar = {
+    templateUrl: annotateToolbarTpl,
+    controller: 'AnnotateToolbarController',
+    bindings: {
+        mapId: '@',
+        geom: '<?',
+        onSave: '&'
+    }
+};
+
+export default annotateToolbar;

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
@@ -1,0 +1,172 @@
+/* globals L */
+const _ = require('lodash');
+
+export default class AnnotateToolbarController {
+    constructor(
+        $log, $scope, $compile,
+        mapService
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.$scope = $scope;
+        this.$compile = $compile;
+        this.getMap = () => mapService.getMap(this.mapId);
+    }
+
+    $onInit() {
+        this.getMap().then((mapWrapper) => {
+            this.listeners = [
+                mapWrapper.on(L.Draw.Event.CREATED, this.addShape.bind(this))
+            ];
+            this.setDrawHandlers(mapWrapper);
+        });
+        this.labelInputs = [];
+        this.labelOriginalObject = {};
+    }
+
+    $onDestroy() {
+        this.getMap().then((mapWrapper) => {
+            this.listeners.forEach((listener) => {
+                mapWrapper.off(listener);
+            });
+            mapWrapper.deleteLayers('Annotation');
+        });
+    }
+
+    setDrawHandlers(mapWrapper) {
+        this.drawRectangleHandler = new L.Draw.Rectangle(mapWrapper.map, {
+            shapeOptions: {
+                weight: 2,
+                fillOpacity: 0.2
+            }
+        });
+        this.drawPolygonHandler = new L.Draw.Polygon(mapWrapper.map, {
+            allowIntersection: false,
+            shapeOptions: {
+                weight: 2,
+                fillOpacity: 0.2
+            }
+        });
+        this.drawMarkerHandler = new L.Draw.Marker(mapWrapper.map, {
+            icon: L.divIcon({'className': 'annotate-marker'})
+        });
+    }
+
+    toggleDrawing(shapeType) {
+        if (shapeType === 'rectangle') {
+            this.drawRectangleHandler.enable();
+            this.drawPolygonHandler.disable();
+            this.drawMarkerHandler.disable();
+        } else if (shapeType === 'polygon') {
+            this.drawPolygonHandler.enable();
+            this.drawRectangleHandler.disable();
+            this.drawMarkerHandler.disable();
+        } else {
+            this.drawMarkerHandler.enable();
+            this.drawRectangleHandler.disable();
+            this.drawPolygonHandler.disable();
+        }
+    }
+
+    addShape(e) {
+        let layer = e.layer;
+        let compiled = this.makePopup(layer);
+        layer.bindPopup(compiled[0], {
+            'closeButton': false,
+            'pane': 'annotationPopups'
+        });
+        this.getMap().then((mapWrapper) => {
+            mapWrapper.addLayer('Annotation', e.layer, true);
+            layer.openPopup();
+        });
+    }
+
+    makePopup(layer) {
+        let popupScope = this.$scope.$new();
+        popupScope.allLabels = this.labelInputs;
+        let popupContent = angular.element(
+            `
+            <form novalidate class="simple-form">
+                <label class="leaflet-popup-label">Label: <br/>
+                <div angucomplete-alt
+                    pause="100"
+                    selected-object="labelObj"
+                    local-data="allLabels"
+                    search-fields="name"
+                    title-field="name"
+                    minlength="1"
+                    input-class="form-control ng-pristine ng-untouched ng-valid ng-empt"
+                    match-class="highlight"
+                    override-suggestions="true"/>
+                </div></label><br/>
+                <label class="leaflet-popup-label">Description: <br/>
+                <textarea class="form-control ng-pristine ng-untouched ng-valid ng-empty"
+                    ng-model="description"></textarea></label><br/>
+                <input type="button" class="btn btn-light"
+                    ng-click="cancelAnnotation()" value="Cancel" />
+                <input type="submit" class="btn btn-tertiary" style="float: right;"
+                    ng-click="addAnnotation(labelObj, description)" value="Add" />
+            </form>
+            `
+        );
+        popupScope.cancelAnnotation = () => {
+            this.deleteLabelAndLayer(layer);
+        };
+        popupScope.addAnnotation = (labelObj, description) => {
+            let label = this.getLabelFromAutocomplete(labelObj);
+            this.addLabelToLayer(label, description, layer);
+            this.addLayerToGeoms(layer, label, description);
+            this.onSave({
+                geoJsonAnnotation: () => {
+                    this.geom.features = _.uniq(this.geom.features);
+                    return this.geom;
+                }});
+        };
+        return this.$compile(popupContent)(popupScope);
+    }
+
+    getLabelFromAutocomplete(label) {
+        this.labelOriginalObject = label.originalObject;
+        let theLabel = '';
+        if (_.has(this.labelOriginalObject, 'name')) {
+            theLabel = this.labelOriginalObject.name;
+        } else {
+            theLabel = this.labelOriginalObject;
+        }
+        if (!_.find(this.labelInputs, (eachInput) => eachInput.name === theLabel)) {
+            this.labelInputs.push({'name': theLabel});
+        }
+        return theLabel;
+    }
+
+    addLabelToLayer(label, description, newLayer) {
+        newLayer.bindPopup(
+            `
+            <label class="leaflet-popup-label">Label:<br/>
+                <p>${label}</p></label><br/>
+            <label class="leaflet-popup-label">Description:<br/>
+                <p>${description}</p></label>
+            `
+        );
+    }
+
+    addLayerToGeoms(layer, label, description) {
+        let newShape = layer.toGeoJSON();
+        newShape.properties = {
+            'label': label,
+            'description': description,
+            'id': new Date().getTime()
+        };
+        this.geom.features.push(newShape);
+    }
+
+    deleteLabelAndLayer(newLayer) {
+        this.getMap().then((mapWrapper) => {
+            let layers = mapWrapper.getLayers('Annotation');
+            _.remove(layers, (lyr) => {
+                return lyr === newLayer;
+            });
+            mapWrapper.setLayer('Annotation', layers, true);
+        });
+    }
+}

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.html
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.html
@@ -1,0 +1,21 @@
+<div class="annotate-toolbar">
+  <div class="column">
+    <div class="annotate-toolbar-header row align-center">
+      <span>New annotation</span>
+    </div>
+    <div class="annotate-toolbar-actions row align-center">
+      <button class="btn btn-primary"
+              ng-click="$ctrl.toggleDrawing('rectangle')">
+        Rectangle
+      </button>
+      <button class="btn btn-primary"
+              ng-click="$ctrl.toggleDrawing('polygon')">
+        Polygon
+      </button>
+      <button class="btn btn-primary"
+              ng-click="$ctrl.toggleDrawing('marker')">
+        Point
+      </button>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+import AnnotateToolbarComponent from './annotateToolbar.component.js';
+import AnnotateToolbarController from './annotateToolbar.controller.js';
+require('./annotateToolbar.scss');
+
+const AnnotateToolbarModule = angular.module('components.map.annotateToolbar', []);
+
+AnnotateToolbarModule.component('rfAnnotateToolbar', AnnotateToolbarComponent);
+AnnotateToolbarModule.controller('AnnotateToolbarController', AnnotateToolbarController);
+
+export default AnnotateToolbarModule;

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.scss
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.scss
@@ -1,0 +1,76 @@
+@import "../../../../assets/styles/sass/settings/_colors.scss";
+.annotate-toolbar {
+  background: $shade-dark;
+  position: absolute;
+  top: 2em;
+  left: 50%;
+  z-index: 950;
+  box-shadow: 1px 3px 5px $shade-dark;
+  border-radius: 5px;
+  display: flex;
+  justify-content: center;
+}
+.annotate-toolbar-header {
+  flex: 1;
+  color: #fff;
+  font-weight: bold;
+  padding: .3em 5em .3em 5em;
+}
+
+.annotate-toolbar-actions {
+  padding: 1em 1em 0 1em;
+  button {
+    margin: 0 0.5rem 0 0.5rem;
+  }
+  .btn-group {
+    margin: 0 0.5rem 0 0.5rem;
+  }
+}
+
+.annotate-marker{
+  background: $brand-primary;
+  border-radius: 50%;
+  border: 2px solid $shade-dark;
+}
+
+.leaflet-popup-tip{
+  background-color: $shade-dark;
+}
+
+.leaflet-popup-content-wrapper,
+.leaflet-popup-content,
+ {
+  background-color: $shade-dark;
+  -webkit-border-radius: 5px !important;
+  -moz-border-radius: 5px !important;
+  border-radius: 5px !important;
+ }
+
+.leaflet-popup-content-wrapper{
+  width: 250px;
+}
+
+.leaflet-popup-label {
+    color: white;
+    margin-right: 0px;
+    width: 211px;
+}
+
+.leaflet-popup-content-wrapper label:nth-child(1) input,
+.leaflet-popup-content-wrapper label:nth-child(3) textarea{
+    height: 21px;
+    width: 100%;
+}
+.leaflet-popup-content-wrapper label:nth-child(3) textarea{
+    height: 75px;
+}
+// .sidebar-overlay {
+//   background: white;
+//   opacity: 0.5;
+//   width: 40rem;
+//   position: absolute;
+//   top: 0;
+//   left: 0;
+//   bottom: 0;
+//   z-index: 950;
+// }

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -36,8 +36,12 @@ export default angular.module('index.components', [
     require('./components/map/mapContainer/mapContainer.module.js').name,
     require('./components/map/staticMap/staticMap.module.js').name,
     require('./components/map/drawToolbar/drawToolbar.module.js').name,
+
     require('./components/map/labMap/labMap.module.js').name,
     require('./components/map/mapSearchModal/mapSearchModal.module.js').name,
+
+    require('./components/map/annotateToolbar/annotateToolbar.module.js').name,
+
 
     // settings components
     require('./components/settings/refreshTokenModal/refreshTokenModal.module.js').name,

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -29,6 +29,7 @@ const App = angular.module(
         'angular.filter',
         '720kb.tooltips',
         'uuid4',
+        'angucomplete-alt',
 
         // services
         require('./services/services.module').name,

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -34,6 +34,7 @@ import 'angular-filter';
 import 'angular-tooltips';
 import 'mathjs';
 import 'angular-uuid4';
+import 'angucomplete-alt';
 
 // local scripts
 // import '../assets/js/...';

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -1,10 +1,129 @@
 export default class AnnotateController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $scope
+        $log, $state, $scope,
+        mapService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
         this.$scope = $scope;
+        this.getMap = () => mapService.getMap('edit');
+    }
+
+    $onInit() {
+        this.importedAnno = {};
+        this.annoToPass = {
+            'type': 'FeatureCollection',
+            features: []
+        };
+        this.annoToExport = {};
+        this.getMap().then((mapWrapper) => {
+            // TODO figure out why creating and using a new map pane with higher z-index for popups
+            // still can't bring the popups up from the annotate toolbar
+            mapWrapper.map.createPane('annotationPopups');
+            mapWrapper.map.getPane('annotationPopups').style.zIndex = 1050;
+        });
+    }
+
+    importLocalAnnotations() {
+        this.importedAnno = {
+            'type': 'FeatureCollection',
+            'features': [
+                {
+                    'type': 'Feature',
+                    'properties': {
+                        'label': 'Philadelphia',
+                        'description': 'This is Philly.',
+                        'id': new Date().getTime()
+                    },
+                    'geometry': {
+                        'type': 'Polygon',
+                        'coordinates': [
+                            [
+                                [
+                                    -76.97021484375,
+                                    39.62261494094297
+                                ],
+                                [
+                                    -74.718017578125,
+                                    39.62261494094297
+                                ],
+                                [
+                                    -74.718017578125,
+                                    40.78885994449482
+                                ],
+                                [
+                                    -76.97021484375,
+                                    40.78885994449482
+                                ],
+                                [
+                                    -76.97021484375,
+                                    39.62261494094297
+                                ]
+                            ]
+                        ]
+                    }
+                }
+            ]
+        };
+        this.drawImportedAnnotations(this.importedAnno);
+        this.annoToPass.features = this.importedAnno.features.concat(
+            this.annoToExport.features ? this.annoToExport.features : []
+        );
+    }
+
+    drawImportedAnnotations(geoJsonData) {
+        this.getMap().then((mapWrapper)=>{
+            let geoJsonLayer = L.geoJSON(geoJsonData, {
+                style: () => {
+                    return {
+                        weight: 2,
+                        fillOpacity: 0.2,
+                        opacity: 0.5
+                    };
+                },
+                onEachFeature: (feature, layer) => {
+                    layer.bindPopup(
+                        `
+                        <label class="leaflet-popup-label">Label:<br/>
+                        <p>${feature.properties.label}</p></label><br/>
+                        <label class="leaflet-popup-label">Description:<br/>
+                        <p>${feature.properties.description}</p></label>
+                        `,
+                        {
+                            'closeButton': false,
+                            'pane': 'annotationPopups'
+                        }
+                    );
+                }
+            });
+            mapWrapper.addLayer(
+                'Annotation',
+                geoJsonLayer,
+                true
+            );
+        });
+    }
+
+    exportAnnotations() {
+        if (this.annoToExport.features && this.annoToExport.features.length) {
+            this.$log.log(this.annoToExport);
+        } else if (this.annoToPass.features && this.annoToPass.features.length) {
+            this.$log.log(this.annoToPass);
+        } else {
+            this.$log.log('Nothing to export.');
+        }
+        this.getMap().then((mapWrapper) => {
+            mapWrapper.deleteLayers('Annotation');
+        });
+        this.annoToExport = {};
+        this.annoToPass = {
+            'type': 'FeatureCollection',
+            features: []
+        };
+    }
+
+    onAnnotationSave(data) {
+        this.annoToExport = data();
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
@@ -1,3 +1,8 @@
+<rf-annotate-toolbar
+  map-id="edit"
+  geom="$ctrl.annoToPass",
+  on-save="$ctrl.onAnnotationSave(geoJsonAnnotation)">
+</rf-annotate-toolbar>
 <div class="sidebar-header">
 <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
   <i class="icon-arrow-left"></i>
@@ -11,10 +16,16 @@
         <span class="text">This is some text about annotating.</span>
       </div>
       <div class="list-group-right column-6 nogutter btn-group">
-        <button class="btn btn-primary btn-block" type="button">
+        <button
+          class="btn btn-primary btn-block"
+          type="button"
+          ng-click="$ctrl.importLocalAnnotations()">
           Import
         </button>
-        <button class="btn btn-primary btn-block" type="button">
+        <button
+          class="btn btn-primary btn-block"
+          type="button"
+          ng-click="$ctrl.exportAnnotations(geoJsonAnnotation)">
           Export
         </button>
       </div>

--- a/app-frontend/src/app/services/map/map.service.js
+++ b/app-frontend/src/app/services/map/map.service.js
@@ -285,6 +285,7 @@ class MapWrapper {
         let layerList = this.getLayers(id);
         if (layerList && layerList.length) {
             layerList.push(layer);
+            this._layerMap.set(id, layerList);
         } else {
             this._layerMap.set(id, [layer]);
         }

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -83,6 +83,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+angucomplete-alt@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/angucomplete-alt/-/angucomplete-alt-3.0.0.tgz#7c59bec4e9b7f9563a0dc6153c83386e4ac251df"
+
 angular-animate@~1.5.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-animate/-/angular-animate-1.5.11.tgz#1baa43c303d1b93c4e6aa89453b39114b7a1c669"


### PR DESCRIPTION
## Overview

This PR adds an annotation toolbar component for drawing points, rectangles, and polygons, and for adding their labels through popups.  The label name field in the popup has autocomplete feature based on labels already created.  

Editing and/or deleting labels, shapes, and geometries will be implemented in a future PR - which probably not in this component but on the sidebar

The import button now renders a hard-coded feature collection, which is passed to the component to be combined with other drawn shapes.  Hope this could result in a quicker process when adding the real import feature.

The export button now logs all annotations to the console in geojson format, which is for future developments.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

Add a new shape and label (with autocomplete).
<img width="1680" alt="06" src="https://user-images.githubusercontent.com/16109558/28547077-31e9dc04-709b-11e7-80d2-67db03099849.png">


### Notes

* The stylesheet is located at `app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.scss`. @designmatty edit, move, remove them as you see fit.
* This PR has two commits. The first has its own PR in [here](https://github.com/azavea/raster-foundry/pull/2285).  The second contains the updates for this PR.
* Validations on label fields will be a task for the next round.

## Testing Instructions

 * Go to `/projects/edit/:project_id/annotate`
 * Click on import to load the hard-coded feature collection and see if it renders.  OR don't import it and go to the next step.
 * Click on any shape type button on the annotation tool to draw shapes and add labels.
<img width="1680" alt="04" src="https://user-images.githubusercontent.com/16109558/28547496-1cca51c6-709d-11e7-829d-eb317d5b4f80.png">

 * Create multiple labels with same names to test if the autocomplete works as intended.
 * Click on 'Cancel' on the popup to see if it will delete the shape from the map. 
 * Click on "Import" button in the middle of drawing polygons, if you have not done so before to see if it adds the hard-coded shape in and does not interfere any drawn annotations.
 * Click on "Export" and check if all drawn annotations are logged there in geojson with correct labels.
<img width="1680" alt="07" src="https://user-images.githubusercontent.com/16109558/28547482-0b051d86-709d-11e7-8e95-9cd929a1fdb7.png">


Closes #2277 
