### PR TITLE
Add Annotations to Sidebar

### DIFF
--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
@@ -3,7 +3,7 @@ import annotateToolbarTpl from './annotateToolbar.html';
 /*
   @param {string} mapId id of map to use
   @param {object?} geom geometry containing FeatureCollection
-  @param {function(geometry: Object)} onSave function to call when the save button is clicked.\
+  @param {function(geometry: Object)} onSave function to call when the save button is clicked.
  */
 const annotateToolbar = {
     templateUrl: annotateToolbarTpl,

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
@@ -72,11 +72,10 @@ export default class AnnotateToolbarController {
         let layer = e.layer;
         let compiled = this.makePopup(layer);
         layer.bindPopup(compiled[0], {
-            'closeButton': false,
-            'pane': 'annotationPopups'
+            'closeButton': false
         });
         this.getMap().then((mapWrapper) => {
-            mapWrapper.addLayer('Annotation', e.layer, true);
+            mapWrapper.addLayer('Annotation', layer, true);
             layer.openPopup();
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -12,17 +12,10 @@ export default class AnnotateController {
 
     $onInit() {
         this.importedAnno = {};
-        this.annoToPass = {
+        this.annoToExport = {
             'type': 'FeatureCollection',
             features: []
         };
-        this.annoToExport = {};
-        this.getMap().then((mapWrapper) => {
-            // TODO figure out why creating and using a new map pane with higher z-index for popups
-            // still can't bring the popups up from the annotate toolbar
-            mapWrapper.map.createPane('annotationPopups');
-            mapWrapper.map.getPane('annotationPopups').style.zIndex = 1050;
-        });
     }
 
     importLocalAnnotations() {
@@ -67,9 +60,7 @@ export default class AnnotateController {
             ]
         };
         this.drawImportedAnnotations(this.importedAnno);
-        this.annoToPass.features = this.importedAnno.features.concat(
-            this.annoToExport.features ? this.annoToExport.features : []
-        );
+        this.annoToExport.features = this.annoToExport.features.concat(this.importedAnno.features);
     }
 
     drawImportedAnnotations(geoJsonData) {
@@ -91,8 +82,7 @@ export default class AnnotateController {
                         <p>${feature.properties.description}</p></label>
                         `,
                         {
-                            'closeButton': false,
-                            'pane': 'annotationPopups'
+                            closeButton: false
                         }
                     );
                 }
@@ -108,16 +98,13 @@ export default class AnnotateController {
     exportAnnotations() {
         if (this.annoToExport.features && this.annoToExport.features.length) {
             this.$log.log(this.annoToExport);
-        } else if (this.annoToPass.features && this.annoToPass.features.length) {
-            this.$log.log(this.annoToPass);
         } else {
             this.$log.log('Nothing to export.');
         }
         this.getMap().then((mapWrapper) => {
             mapWrapper.deleteLayers('Annotation');
         });
-        this.annoToExport = {};
-        this.annoToPass = {
+        this.annoToExport = {
             'type': 'FeatureCollection',
             features: []
         };

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
@@ -1,15 +1,19 @@
+<!-- Annotate Toolbar Component -->
 <rf-annotate-toolbar
   map-id="edit"
-  geom="$ctrl.annoToPass",
+  geom="$ctrl.annoToExport",
   on-save="$ctrl.onAnnotationSave(geoJsonAnnotation)">
 </rf-annotate-toolbar>
-<div class="sidebar-header">
-<a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
-  <i class="icon-arrow-left"></i>
-</a>
-<h5 class="sidebar-title">Annotations</h5>
-</div>
+<!-- Annotate Toolbar Component -->
+
+<!-- Static Sidebar -->
 <div class="sidebar-project">
+  <div class="sidebar-header">
+    <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit">
+    <i class="icon-arrow-left"></i>
+    </a>
+    <h5 class="sidebar-title">Annotations</h5>
+  </div>
   <ul class="sidebar-list">
     <li>
       <div class="label">
@@ -32,3 +36,47 @@
     </li>
   </ul>
 </div>
+<div class="sidebar-project no-annotation">
+<div class="list-group"
+     ng-if="!$ctrl.annoToExport.features.length">
+  <div class="list-group-item no-annotation">
+    <div class="panel panel-off-white no-annotation">
+      <p>No annotations have been made</p>
+    </div>
+  </div>
+</div>
+</div>
+<!-- Static Sidebar -->
+
+<!-- Scrollable Sidebar -->
+<div class="sidebar-scrollable">
+  <div ng-if="$ctrl.annoToExport.features.length">
+      <div class="list-group">
+        <div class="list-group-item filter-annotations">
+          <div>
+            <span><strong>Filter Placeholder</span></strong>
+          </div>
+        </div>
+      </div>
+      <div class="list-group"
+           ng-repeat="annotation in $ctrl.annoToExport.features">
+        <div class="list-group-item list-sidebar-annotations">
+          <div>
+              <i class="icon-cloud"
+                 ng-if="annotation.geometry.coordinates.length === 1"></i>
+              <i class="icon-sun"
+                 ng-if="annotation.geometry.coordinates.length === 2"></i>
+          </div>
+          <div>
+            <h5>{{annotation.properties.label}}</h5>
+          </div>
+          <div class="list-group-right actions-annotations">
+            <a title="Clone"><i class="icon-arrows-cw"></i></a>
+            <a title="Edit"><i class="icon-pencil"></i></a>
+            <a title="Delete"><i class="icon-trash"></i></a>
+          </div>
+        </div>
+      </div>
+  </div>
+</div>
+<!-- Scrollable Sidebar -->

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1947,7 +1947,6 @@ rf-node-selector {
     }
   }
 }
-
 .leaflet-frame {
   position: absolute;
   /* border: 1px solid red; */
@@ -1985,4 +1984,73 @@ rf-node-selector {
   height: 40px;
 
   pointer-events: auto;
+}
+
+// page: projects/edit/:project_id/annoate
+.sidebar-project.no-annotation,
+.list-group-item.no-annotation{
+    border-style: none;
+}
+
+.panel.panel-off-white.no-annotation {
+    height: 75px;
+    border: 1px solid #e9e9ea;
+    background-color:#f5f7f7;
+}
+.panel.panel-off-white.no-annotation p {
+    text-align: center;
+    vertical-align: middle;
+    line-height: 75px;
+}
+
+.list-group-item.filter-annotations {
+    border-style: none;
+}
+
+.list-group-item.filter-annotations p {
+    flex-direction: row;
+}
+
+.list-group-item.list-sidebar-annotations div {
+    flex-direction: row;
+}
+
+.list-group-item.list-sidebar-annotations div:nth-child(1) {
+    border: 1px solid #969cac;
+    width: 35px;
+    height: 35px;
+}
+
+.list-group-item.list-sidebar-annotations div:nth-child(1) i {
+    text-align: center;
+    vertical-align: middle;
+    line-height: 35px;
+    font-size: 24px;
+}
+
+.list-group-item.list-sidebar-annotations div:nth-child(2) h5 {
+    font-weight: normal;
+}
+
+.list-group-right.actions-annotations{
+    width: 100%;
+}
+
+.list-group-right.actions-annotations a {
+    text-decoration: none;
+    margin: 2px;
+}
+
+.list-group-right.actions-annotations a:nth-child(1) i,
+.list-group-right.actions-annotations a:nth-child(2) i {
+    border: 1px solid #969cac;
+    border-radius:2px;
+    color: #969cac;
+
+}
+
+.list-group-right.actions-annotations a:nth-child(3) i {
+    border: 1px solid #da7976;
+    border-radius:2px;
+    color: #da7976;
 }


### PR DESCRIPTION
## Overview

This PR adds annotations created by the annotation tool/imported by the user to the sidebar.  If no annotations created/imported, a notice will display.  The icons representing polygons and points before each label, and the "clone" icon/button are placeholders, which will be replaced once we have them added in the assets.  The clone/edit/delete icon/button functionalities will be implemented in the next PR. The label filter will be added in the PR after the next.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

<img width="1680" alt="02" src="https://user-images.githubusercontent.com/16109558/28595997-7a747fe6-7164-11e7-95de-e49f9da4f557.png">
Sun and cloud icons are placeholders for points and polygons respectively.

### Notes

* The styles are in _shame.scss
* The first commit (annotation toolbar component) is for [this open PR](https://github.com/azavea/raster-foundry/pull/2313). The second commit is actually listing annotations on the sidebar.


## Testing Instructions

 * Go to `/projects/edit/:project_id/annotate`
 * See if the page looks like this:
<img width="1680" alt="01" src="https://user-images.githubusercontent.com/16109558/28596096-faf8429c-7164-11e7-9194-ada81f7be945.png">

 * Import annotations, create new annotations with the toolbar and see if they are listed correctly on the sidebar.
<img width="1680" alt="02" src="https://user-images.githubusercontent.com/16109558/28596281-cab213f0-7165-11e7-8773-7b302be63a09.png">

 * Export the annotations.  Check if annotations disappear from the map and the sidebar. Check if they are correctly logged in the console.

Closes #2278
