### PR TITLE
Add vague name shame to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@ Brief description of what this PR does, and why it is needed.
 - [ ] Styleguide updated, if necessary
 - [ ] Swagger specification updated, if necessary
 - [ ] Symlinks from new migrations present or corrected for any new migrations
+- [ ] PR has a name that won't get you publicly shamed for vagueness
 
 ### Demo
 


### PR DESCRIPTION
## Overview

This PR adds a box to the PR checklist. The box requires the author to check that the name of their PR won't get them shamed in Slack. PR names should be descriptive enough that guessing what they do in the changelog for new releases is easy, but sometimes we're lazy.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness