### PR TITLE
Handle missing images when scenes' images don't exist in s3

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/airflow/ImportLandsat8C1.scala
@@ -19,7 +19,7 @@ import java.util.UUID
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
-import scala.util.{Failure, Success}
+import scala.util.{Try, Failure, Success}
 import scala.util.control.Breaks._
 
 case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), threshold: Int = 10)(implicit val database: DB) extends Job {
@@ -74,10 +74,18 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
     rootUrl
   }
 
+  // Getting the image size is the only place where the s3 object
+  // is required to exist -- so handle the missing object by returning
+  // a -1 for the image's size
   protected def sizeFromPath(tifPath: String, productId: String): Int = {
     val path = s"c1/${getLandsatPath(productId)}/$tifPath"
     logger.info(s"Getting object size for path: $path")
-    s3Client.getObject(landsat8Config.bucketName, path).getObjectMetadata.getContentLength.toInt
+    Try(
+      s3Client.getObject(landsat8Config.bucketName, path).getObjectMetadata.getContentLength.toInt
+    ) match {
+      case Success(size) => size
+      case Failure(_) => -1
+    }
   }
 
   protected def createThumbnails(sceneId: UUID, productId: String): List[Thumbnail.Identified] = {


### PR DESCRIPTION
## Overview

The Landsat 8 importers should understand that not every image file for every
scene is always going to be available (human error might happen, or some images
just might not exist). Instead of failing when that occurs, it should return
some signal value that the image wasn't available and get on with the rest of
what it wants to do. This commit sets that signal value to -1 and lets importer
carry on its merry way.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

### Notes

It's unclear how frequently this occurs -- for June 7, 2016, there were three scenes that had missing imagery, and for the date I picked at random in the new period, there were none. Possibly we care about doing some manual correction after the fact, in which case logging scene IDs with missing imagery might be useful, but it's extremely easy information to recover anyway, especially given that we expose `minRawDataBytes` and `maxRawDataBytes` as filters on images, and therefore also on scenes.

If you want to pick a different date with known bad imagery, check out the most recent `landsat-import` job [logs in cloudwatch](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/aws/batch/job;streamFilter=typeLogStreamPrefix); there are plenty to choose from. You'll know you're in the right place if you see `com.azavea.shaded.amazonaws.services.s3.model.AmazonS3Exception: The specified key does not exist.`

## Testing Instructions

 * assemble your batch jar -- `./sbt batch/assembly` from the app-backend directory
 * Open a bash console in an airflow worker: `./scripts/console airflow-worker bash`
 * Run the Landsat 8 import for a date known to include some missing images, e.g., June 7, 2016: `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_landsat8 2016-06-07`
 * Run the Landsat 8 import for a date in the new metadata era to make sure that still works (it's unclear if any of those dates have missing imagery yet, but at a minimum there shouldn't be runtime errors): `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_landsat8 <date>` where `date` is some date after May 1, 2017
 * Both runs should succeed 

Closes #2352 
