### PR TITLE
Add custom color-composite UI

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -1,3 +1,43 @@
+const availableBands = [
+    {
+        label: 'Band 0',
+        value: 0
+    }, {
+        label: 'Band 1',
+        value: 1
+    }, {
+        label: 'Band 2',
+        value: 2
+    }, {
+        label: 'Band 3',
+        value: 3
+    }, {
+        label: 'Band 4',
+        value: 4
+    }, {
+        label: 'Band 5',
+        value: 5
+    }, {
+        label: 'Band 6',
+        value: 6
+    }, {
+        label: 'Band 7',
+        value: 7
+    }, {
+        label: 'Band 8',
+        value: 8
+    }, {
+        label: 'Band 9',
+        value: 9
+    }, {
+        label: 'Band 10',
+        value: 10
+    }, {
+        label: 'Band 11',
+        value: 11
+    }
+];
+
 export default class ProjectsEditColormode {
     constructor($scope, colorCorrectService, projectService) {
         'ngInject';
@@ -8,9 +48,34 @@ export default class ProjectsEditColormode {
     }
 
     $onInit() {
+        this.isLoading = true;
+        this.availableBands = availableBands;
         this.currentBands = null;
         this.correction = null;
-        this.$parent.sceneListQuery.then(() => {
+        this.defaultColorModes = {
+            custom: {
+                label: 'Custom',
+                value: {
+                    mode: 'custom-rgb',
+                    blueBand: 1,
+                    redBand: 3,
+                    greenBand: 2
+                }
+            },
+            singleband: {
+                label: 'Single Band',
+                value: {
+                    mode: 'single',
+                    band: 0
+                }
+            }
+        };
+        this.initSceneLayers();
+    }
+
+    initSceneLayers() {
+        const sceneListQuery = this.$parent.sceneListQuery || this.$parent.getSceneList();
+        return sceneListQuery.then(() => {
             let layer = this.$parent.sceneLayers.values().next();
             if (layer && layer.value) {
                 layer.value.getColorCorrection().then((correction) => {
@@ -20,38 +85,91 @@ export default class ProjectsEditColormode {
                         blueBand: correction.blueBand
                     };
                     this.correction = correction;
+                    if (!this.correction.mode) {
+                        this.correction.mode = 'multi';
+                    }
+                    this.$parent.fetchUnifiedComposites().then(() => {
+                        this.unifiedComposites =
+                            Object.assign(
+                                {},
+                                this.$parent.unifiedComposites,
+                                this.defaultColorModes
+                            );
+                        this.activeColorModeKey = this.initActiveColorMode();
+                        this.isLoading = false;
+                    });
                 });
             }
         });
     }
 
-    isActiveColorMode(key) {
-        const unifiedComposites = this.$parent.unifiedComposites;
-        if (unifiedComposites) {
-            let keyBands = unifiedComposites[key].value;
+    initActiveColorMode() {
+        const key = Object.keys(this.unifiedComposites).find(k => {
+            const c = this.unifiedComposites[k].value;
 
-            let isActive = this.currentBands &&
-                keyBands.redBand === this.currentBands.redBand &&
-                keyBands.greenBand === this.currentBands.greenBand &&
-                keyBands.blueBand === this.currentBands.blueBand;
+            if (!c.mode) {
+                return this.correction.redBand === c.redBand &&
+                    this.correction.greenBand === c.greenBand &&
+                    this.correction.blueBand === c.blueBand;
+            }
 
-            return isActive;
+            return this.correction.mode === c.mode &&
+                this.correction.redBand === c.redBand &&
+                this.correction.greenBand === c.greenBand &&
+                this.correction.blueband === c.blueBand;
+        });
+
+        if (!key) {
+            this.initCustomCorrection();
+            return 'custom';
         }
-        return false;
+
+        return key;
     }
 
-    setBands(bandName) {
-        const unifiedComposites = this.$parent.unifiedComposites;
-        if (unifiedComposites) {
-            this.currentBands = unifiedComposites[bandName].value;
-            this.correction = Object.assign(this.correction, this.currentBands);
-            const promise = this.colorCorrectService.bulkUpdate(
-                this.projectService.currentProject.id,
-                Array.from(this.$parent.sceneLayers.keys()),
-                this.correction
-            );
-            this.redrawMosaic(promise);
+    initCustomCorrection() {
+        this.unifiedComposites.custom.value.redBand = this.correction.redBand;
+        this.unifiedComposites.custom.value.greenBand = this.correction.greenBand;
+        this.unifiedComposites.custom.value.blueBand = this.correction.blueBand;
+        this.correction.mode = 'custom-rgb';
+    }
+
+    getActiveColorMode() {
+        return this.unifiedComposites[this.activeColorModeKey];
+    }
+
+
+    setActiveColorMode(key, save = true) {
+        this.activeColorModeKey = key;
+        this.correction = Object.assign({}, this.correction, this.getActiveColorMode().value);
+        if (save) {
+            this.saveCorrection();
         }
+    }
+
+    isActiveColorMode(key) {
+        return key === this.activeColorModeKey;
+    }
+
+    getActiveBand(bandName) {
+        return this.getActiveColorMode().value[bandName];
+    }
+
+    setActiveBand(bandName, bandValue, save = true) {
+        this.correction[bandName] = bandValue;
+        this.unifiedComposites.custom.value[bandName] = bandValue;
+        if (save) {
+            this.saveCorrection();
+        }
+    }
+
+    saveCorrection() {
+        const promise = this.colorCorrectService.bulkUpdate(
+            this.projectService.currentProject.id,
+            Array.from(this.$parent.sceneLayers.keys()),
+            this.correction
+        );
+        this.redrawMosaic(promise);
     }
 
     /**

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -15,14 +15,95 @@
   </ul>
 </div>
 <div class="sidebar-scrollable">
-  <div class="list-group">
+  <div class="list-group" ng-if="!$ctrl.isLoading">
+    <div class="list-group-item with-rows">
+      <div class="list-group-item-content">
+        <div>
+          <span title="custom"><strong>Custom</strong></span>
+        </div>
+        <div class="list-group-right">
+          <rf-toggle value="$ctrl.isActiveColorMode('custom')" on-change="$ctrl.setActiveColorMode('custom')">
+            <i class="icon-check"></i>
+          </rf-toggle>
+        </div>
+      </div>
+      <div class="list-group-item-content" ng-if="$ctrl.isActiveColorMode('custom')">
+          <ul class="sidebar-list">
+             <li>
+              <span class="label">Blue</span>
+              <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
+                <a class="btn dropdown-label">
+                  Band {{$ctrl.getActiveBand('blueBand')}}
+                </a>
+                <button type="button" class="btn btn-light dropdown-toggle">
+                  <i class="icon-caret-down"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+                  <li ng-repeat="band in $ctrl.availableBands" role="menuitem">
+                    <a ng-click="$ctrl.setActiveBand('blueBand', band.value)">{{band.label}}</a>
+                  </li>
+                </ul>
+              </div>
+              <i class="icon-info"></i>
+            </li>
+            <li>
+              <span class="label">Green</span>
+              <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
+                <a class="btn dropdown-label">
+                  Band {{$ctrl.getActiveBand('greenBand')}}
+                </a>
+                <button type="button" class="btn btn-light dropdown-toggle">
+                  <i class="icon-caret-down"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+                  <li ng-repeat="band in $ctrl.availableBands" role="menuitem">
+                    <a ng-click="$ctrl.setActiveBand('greenBand', band.value)">{{band.label}}</a>
+                  </li>
+                </ul>
+              </div>
+              <i class="icon-info"></i>
+            </li>
+            <li>
+              <span class="label">Red</span>
+              <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
+                <a class="btn dropdown-label">
+                  Band {{$ctrl.getActiveBand('redBand')}}
+                </a>
+                <button type="button" class="btn btn-light dropdown-toggle">
+                  <i class="icon-caret-down"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+                  <li ng-repeat="band in $ctrl.availableBands" role="menuitem">
+                    <a ng-click="$ctrl.setActiveBand('redBand', band.value)">{{band.label}}</a>
+                  </li>
+                </ul>
+              </div>
+              <i class="icon-info"></i>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="list-group-item with-rows">
+      <div class="list-group-item-content">
+        <span title="Single Band"><strong>Single Band</strong></span>
+        <div class="list-group-right">
+          <rf-toggle value="$ctrl.isActiveColorMode('single')" on-change="$ctrl.setActiveColorMode('single')">
+            <i class="icon-check"></i>
+          </rf-toggle>
+        </div>
+      </div>
+      <div class="list-group-item-content" ng-if="$ctrl.isActiveColorMode('single')">
+        <button class="btn btn-block btn-secondary">Single band parameters</button>
+      </div>
+    </div>
     <div class="list-group-item"
          ng-repeat="(key, composite) in $ctrl.$parent.unifiedComposites track by $index">
       <div style="flex-direction: row;">
         <span title="{{composite.label}}"><strong>{{composite.label}}</strong></span>
       </div>
       <div class="list-group-right">
-        <rf-toggle value="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setBands(key)">
+        <rf-toggle value="$ctrl.isActiveColorMode(key)" on-change="$ctrl.setActiveColorMode(key)">
           <i class="icon-check"></i>
         </rf-toggle>
       </div>

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -85,13 +85,15 @@ export default class ProjectsEditController {
 
     getSceneList() {
         this.sceneRequestState = {loading: true};
-        this.sceneListQuery = this.projectService.getAllProjectScenes(
+
+        const sceneListQuery = this.projectService.getAllProjectScenes(
             {
                 projectId: this.projectId,
                 pending: false
             }
         );
-        this.sceneListQuery.then(
+
+        sceneListQuery.then(
             (allScenes) => {
                 this.addUningestedScenesToMap(allScenes.filter(
                     (scene) => scene.statusFields.ingestStatus !== 'INGESTED'
@@ -111,6 +113,8 @@ export default class ProjectsEditController {
         ).finally(() => {
             this.sceneRequestState.loading = false;
         });
+
+        return sceneListQuery;
     }
 
     addUningestedScenesToMap(scenes) {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -293,6 +293,9 @@ rf-project-editor .leaflet-tile {
   flex-direction: row;
   align-items: start;
   flex: 1;
+  & + .list-group-item-content {
+    margin-top: 1rem;
+  }
   .list-group-overflow {
     flex: 1;
     align-self: stretch;
@@ -398,7 +401,6 @@ rf-project-editor .leaflet-tile {
     .fixedwidth {
       width: 20rem;
     }
-
     .label {
       flex: 1;
       font-weight: 700;
@@ -431,9 +433,12 @@ rf-project-editor .leaflet-tile {
       }
     }
   }
-
-
 }
+
+.list-group-item .sidebar-list {
+  width: 100%;
+}
+
 .sidebar-content {
   padding: 1rem;
 }
@@ -1593,7 +1598,7 @@ table.upload-info {
     }
   }
 }
-.list-group-item {
+.list-group-item.no-border {
   border-bottom: none;
 }
 .list-group-item:last-of-type {


### PR DESCRIPTION
## Overview

Primarily, this PR adds the UI components for custom color-composite definition. The user can choose how the bands within the project are mapped to RGB space.

Once a user leaves the color-mode section, if they have defined a custom composite that matches an existing composite, the UI will show the existing composite as being in-use. This isn't the best, but with our current correction structures, I think it's a reasonable middle-ground.

If a user sets up a color-composite, but then uses a different composite, the custom composite is not persisted in any way.

This PR also adds a non-functioning 'Single Band' composite option. In a later PR, this will be made to function.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

![image](https://user-images.githubusercontent.com/2442245/28790059-ab9ba82a-75f5-11e7-862d-d245069887bd.png)


![image](https://user-images.githubusercontent.com/2442245/28790055-a7859fa2-75f5-11e7-97b9-1e6d9762af9e.png)


### Notes

The format of custom, rgb, and single-band corrections may change and thus some code here may also have to change.


## Testing Instructions

 * Try creating a custom color-composite and switch between that and the existing composites to make sure everything functions as expected.

Closes #2325
