### PR TITLE
Don't kickoff ingests twice

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -330,14 +330,7 @@ trait ProjectRoutes extends Authentication
       if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
         complete(StatusCodes.RequestEntityTooLarge)
       }
-      val scenesFuture = Projects.addScenesToProject(sceneIds, projectId, user)
-      scenesFuture.map { scenes =>
-        val scenesToKickoff = scenes.filter(_.statusFields.ingestStatus == IngestStatus.ToBeIngested)
-        scenesToKickoff.map(_.id).map(kickoffSceneIngest)
-      }
-      complete {
-        scenesFuture
-      }
+      complete { Projects.addScenesToProject(sceneIds, projectId, user) }
     }
   }
 


### PR DESCRIPTION
## Overview

This PR takes out kicking off ingests a second time from adding scenes to projects. `addScenesToProject` calls `Scenes.update` to set ingest statuses to `TOBEINGESTED`. After that, we were finding all the scenes with statuses equal to `TOBEINGESTED` and kicking off ingest a second time.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~

## Testing Instructions

 * Bring up your server, frontend, airflow
 * Upload a scene into a project
 * Verify that only one ingest DAG is kicked off

Closes #2343 
