### PR TITLE
Allow annotations edit, delete, filter on sidebar

### DIFF
--- a/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.component.js
+++ b/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.component.js
@@ -1,0 +1,21 @@
+import annotateSidebarItemTpl from './annotateSidebarItem.html';
+
+const annotateSidebarItem = {
+    templateUrl: annotateSidebarItemTpl,
+    controller: 'AnnotateSidebarItemController',
+    bindings: {
+        mapId: '@',
+        data: '<',
+        annotation: '<',
+        shapeType: '<',
+        labelInputs: '<',
+        onCancelAddAnnotation: '&',
+        onAddAnnotation: '&',
+        onUpdateAnnotationStart: '&',
+        onDeleteAnnotation: '&',
+        onCancelUpdateAnnotation: '&',
+        onUpdateAnnotationFinish: '&'
+    }
+};
+
+export default annotateSidebarItem;

--- a/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.controller.js
+++ b/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.controller.js
@@ -1,0 +1,113 @@
+/* globals L, _, $*/
+
+export default class AnnotateSidebarItemController {
+    constructor(
+        $log, $scope,
+        mapService
+    ) {
+        'ngInject';
+        this.$log = $log;
+        this.$scope = $scope;
+
+        this.getMap = () => mapService.getMap(this.mapId);
+    }
+
+    $onInit() {
+        L.drawLocal.edit.handlers.edit.tooltip.subtext = '';
+    }
+
+    addAnnotation(annotation) {
+        if (this.labelObj) {
+            $('#_value').css('border-color', '#fff');
+
+            this.newLabelName = this.labelObj.originalObject.name || this.labelObj.originalObject;
+
+            this.onAddAnnotation({
+                'id': annotation.properties.id,
+                'label': this.newLabelName,
+                'description': this.newLabelDescription
+            });
+        } else {
+            $('#_value').css('border-color', '#da7976');
+        }
+    }
+
+    cancelAnnotation(annotation) {
+        if (this.isEditing) {
+            this.editHandler.disable();
+            this.isEditing = false;
+            this.onCancelUpdateAnnotation({'id': annotation.properties.id});
+        } else {
+            this.onCancelAddAnnotation({'id': annotation.properties.id});
+        }
+    }
+
+    /* eslint-disable no-underscore-dangle */
+    onAnnotationEdit(annotation) {
+        this.isEditing = true;
+
+        this.getMap().then((mapWrapper) => {
+            let annotationLayers = mapWrapper.getLayers('Annotation');
+            let annotationLayerToEdit = _.filter(annotationLayers, (l) => {
+                return _.first(_.values(l._layers))
+                    .feature.properties.id === annotation.properties.id;
+            });
+
+            let otherAnnotationLayers = _.difference(annotationLayers, annotationLayerToEdit);
+
+            mapWrapper.setLayer('Annotation', otherAnnotationLayers, true);
+            mapWrapper.setLayer('draw', annotationLayerToEdit, false);
+
+            this.setEditHandler(mapWrapper, annotationLayerToEdit[0]);
+        });
+
+        let md = _.filter(this.data.features, (f) => f.properties.id === annotation.properties.id);
+        this.newLabelName = md[0].properties.label;
+        this.newLabelDescription = md[0].properties.description;
+
+        this.initialLabelName = annotation.properties.label;
+
+        this.onUpdateAnnotationStart();
+    }
+    /* eslint-enable no-underscore-dangle */
+
+    setEditHandler(mapWrapper, editLayer) {
+        this.editHandler = new L.EditToolbar.Edit(mapWrapper.map, {
+            featureGroup: editLayer
+        });
+        this.editHandler.enable();
+    }
+
+    onAnnotationDelete(annotation) {
+        this.onDeleteAnnotation({
+            'id': annotation.properties.id,
+            'label': annotation.properties.label
+        });
+    }
+
+    updateAnnotation(annotation) {
+        this.getMap().then((mapWrapper) => {
+            if (this.labelObj) {
+                $('#_value').css('border-color', '#fff');
+
+                this.editHandler.save();
+                this.editHandler.disable();
+
+                this.newLabelName
+                    = this.labelObj.originalObject.name || this.labelObj.originalObject;
+
+                this.onUpdateAnnotationFinish({
+                    'layer': mapWrapper.getLayers('draw')[0],
+                    'id': annotation.properties.id,
+                    'label': this.newLabelName,
+                    'oldLabel': annotation.properties.label,
+                    'description': this.newLabelDescription
+                });
+
+                this.isEditing = false;
+            } else {
+                $('#_value').css('border-color', '#da7976');
+            }
+        });
+    }
+}

--- a/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.html
+++ b/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.html
@@ -1,0 +1,49 @@
+<div class="list-group-item list-sidebar-drawn-annotations" ng-if="$ctrl.annotation.geometry && !$ctrl.isEditing">
+  <div>
+      <i class="icon-cloud"
+         ng-if="$ctrl.annotation.geometry.coordinates.length === 1"></i>
+      <i class="icon-sun"
+         ng-if="$ctrl.annotation.geometry.coordinates.length === 2"></i>
+  </div>
+  <div>
+    <h5>{{$ctrl.annotation.properties.label}}</h5>
+  </div>
+  <div class="list-group-right actions-annotations">
+    <a title="Clone" ng-click="$ctrl.onAnnotationClone($ctrl.annotation)"><i class="icon-arrows-cw"></i></a>
+    <a title="Edit" ng-click="$ctrl.onAnnotationEdit($ctrl.annotation)"><i class="icon-pencil"></i></a>
+    <a title="Delete" ng-click="$ctrl.onAnnotationDelete($ctrl.annotation)"><i class="icon-trash"></i></a>
+  </div>
+</div>
+<div class="list-group-item" ng-if="!$ctrl.annotation.geometry || $ctrl.isEditing">
+  <div class='annotation-new'>
+    <div angucomplete-alt
+         pause="100"
+         initial-value='$ctrl.initialLabelName'
+         selected-object="$ctrl.labelObj"
+         local-data="$ctrl.labelInputs"
+         search-fields="name"
+         title-field="name"
+         minlength="1"
+         input-class="form-control annotation-label"
+         match-class="annotation-highlight"
+         override-suggestions="true">
+    </div>
+    <textarea class="form-control"
+              ng-model="$ctrl.newLabelDescription"
+              ng-if="!$ctrl.annotation.geometry || $ctrl.isEditing"></textarea>
+    <input type="button"
+           class="btn btn-light annotation-cancel"
+           value="Cancel"
+           ng-click="$ctrl.cancelAnnotation($ctrl.annotation)"/>
+    <input type="button"
+           class="btn btn-tertiary annotation-confirm"
+           value="Add"
+           ng-click="$ctrl.addAnnotation($ctrl.annotation)"
+           ng-if="!$ctrl.isEditing"/>
+    <input type="button"
+           class="btn btn-tertiary annotation-confirm"
+           value="Update"
+           ng-click="$ctrl.updateAnnotation($ctrl.annotation)"
+           ng-if="$ctrl.isEditing"/>
+  </div>
+</div>

--- a/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.module.js
+++ b/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.module.js
@@ -1,0 +1,14 @@
+import angular from 'angular';
+import AnnotateSidebarItemComponent from './annotateSidebarItem.component.js';
+import AnnotateSidebarItemController from './annotateSidebarItem.controller.js';
+require('./annotateSidebarItem.scss');
+
+const AnnotateSidebarItemModule = angular.module('components.map.annotateSidebarItem', []);
+
+AnnotateSidebarItemModule.component('rfAnnotateSidebarItem', AnnotateSidebarItemComponent);
+AnnotateSidebarItemModule.controller(
+    'AnnotateSidebarItemController',
+    AnnotateSidebarItemController
+);
+
+export default AnnotateSidebarItemModule;

--- a/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.scss
+++ b/app-frontend/src/app/components/map/annotateSidebarItem/annotateSidebarItem.scss
@@ -1,0 +1,75 @@
+.list-group-item.list-sidebar-drawn-annotations div {
+    display: inline-block;
+}
+
+.list-group-item.list-sidebar-drawn-annotations div:nth-child(1) {
+    border: 1px solid #969cac;
+    width: 35px;
+    height: 35px;
+}
+
+.list-group-item.list-sidebar-drawn-annotations div:nth-child(1) i {
+    text-align: center;
+    vertical-align: middle;
+    line-height: 35px;
+    font-size: 24px;
+}
+
+.list-group-item.list-sidebar-drawn-annotations div:nth-child(2) h5 {
+    font-weight: normal;
+}
+
+.list-group-right.actions-annotations {
+    width: 100%;
+}
+
+.list-group-right.actions-annotations a {
+    text-decoration: none;
+    margin: 2px;
+}
+
+.list-group-right.actions-annotations a:nth-child(1) i,
+.list-group-right.actions-annotations a:nth-child(2) i {
+    border: 1px solid #969cac;
+    border-radius: 2px;
+    color: #969cac;
+
+}
+
+.list-group-right.actions-annotations a:nth-child(3) i {
+    border: 1px solid #da7976;
+    border-radius: 2px;
+    color: #da7976;
+}
+
+.annotation-new {
+    width: 100%;
+    margin: 0px;
+}
+
+.angucomplete-holder {
+    margin-bottom: 10px;
+}
+
+.annotation-new.form-control.annotation-label {
+    height:  35px;
+}
+
+.annotation-new textarea.form-control {
+    height: 150px;
+    margin-bottom: 10px;
+    resize: none;
+}
+
+.annotation-new input.btn.btn-tertiary.annotation-confirm,
+.annotation-new input.btn.btn-tertiary.annotation-cancel {
+    width: 76px;
+}
+
+.annotation-new input.btn.btn-tertiary.annotation-confirm{
+    float: right;
+}
+
+.annotation-highlight {
+    color: #da7976;
+}

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
@@ -1,17 +1,13 @@
 import annotateToolbarTpl from './annotateToolbar.html';
 
-/*
-  @param {string} mapId id of map to use
-  @param {object?} geom geometry containing FeatureCollection
-  @param {function(geometry: Object)} onSave function to call when the save button is clicked.
- */
 const annotateToolbar = {
     templateUrl: annotateToolbarTpl,
     controller: 'AnnotateToolbarController',
     bindings: {
         mapId: '@',
-        geom: '<?',
-        onSave: '&'
+        isLabeling: '<',
+        onShapeCreating: '&',
+        onShapeCreated: '&'
     }
 };
 

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
@@ -1,27 +1,28 @@
 /* globals L */
-const _ = require('lodash');
 
 export default class AnnotateToolbarController {
     constructor(
-        $log, $scope, $compile,
+        $log, $scope,
         mapService
     ) {
         'ngInject';
         this.$log = $log;
         this.$scope = $scope;
-        this.$compile = $compile;
+
         this.getMap = () => mapService.getMap(this.mapId);
     }
 
     $onInit() {
+        this.isDrawCancel = false;
+
         this.getMap().then((mapWrapper) => {
             this.listeners = [
-                mapWrapper.on(L.Draw.Event.CREATED, this.addShape.bind(this))
+                mapWrapper.on(L.Draw.Event.CREATED, this.createShape.bind(this))
             ];
             this.setDrawHandlers(mapWrapper);
         });
-        this.labelInputs = [];
-        this.labelOriginalObject = {};
+
+        this.$scope.$on('$destroy', this.$onDestroy.bind(this));
     }
 
     $onDestroy() {
@@ -29,7 +30,7 @@ export default class AnnotateToolbarController {
             this.listeners.forEach((listener) => {
                 mapWrapper.off(listener);
             });
-            mapWrapper.deleteLayers('Annotation');
+            mapWrapper.deleteLayers('draw');
         });
     }
 
@@ -53,6 +54,7 @@ export default class AnnotateToolbarController {
     }
 
     toggleDrawing(shapeType) {
+        this.isDrawCancel = true;
         if (shapeType === 'rectangle') {
             this.drawRectangleHandler.enable();
             this.drawPolygonHandler.disable();
@@ -63,109 +65,26 @@ export default class AnnotateToolbarController {
             this.drawMarkerHandler.disable();
         } else {
             this.drawMarkerHandler.enable();
-            this.drawRectangleHandler.disable();
             this.drawPolygonHandler.disable();
+            this.drawRectangleHandler.disable();
         }
+        this.onShapeCreating({'isCreating': true});
     }
 
-    addShape(e) {
-        let layer = e.layer;
-        let compiled = this.makePopup(layer);
-        layer.bindPopup(compiled[0], {
-            'closeButton': false
-        });
-        this.getMap().then((mapWrapper) => {
-            mapWrapper.addLayer('Annotation', layer, true);
-            layer.openPopup();
-        });
+    onCancelDrawing() {
+        this.isDrawCancel = false;
+        this.drawRectangleHandler.disable();
+        this.drawPolygonHandler.disable();
+        this.drawMarkerHandler.disable();
+        this.onShapeCreating({'isCreating': false});
     }
 
-    makePopup(layer) {
-        let popupScope = this.$scope.$new();
-        popupScope.allLabels = this.labelInputs;
-        let popupContent = angular.element(
-            `
-            <form novalidate class="simple-form">
-                <label class="leaflet-popup-label">Label: <br/>
-                <div angucomplete-alt
-                    pause="100"
-                    selected-object="labelObj"
-                    local-data="allLabels"
-                    search-fields="name"
-                    title-field="name"
-                    minlength="1"
-                    input-class="form-control ng-pristine ng-untouched ng-valid ng-empt"
-                    match-class="highlight"
-                    override-suggestions="true"/>
-                </div></label><br/>
-                <label class="leaflet-popup-label">Description: <br/>
-                <textarea class="form-control ng-pristine ng-untouched ng-valid ng-empty"
-                    ng-model="description"></textarea></label><br/>
-                <input type="button" class="btn btn-light"
-                    ng-click="cancelAnnotation()" value="Cancel" />
-                <input type="submit" class="btn btn-tertiary" style="float: right;"
-                    ng-click="addAnnotation(labelObj, description)" value="Add" />
-            </form>
-            `
-        );
-        popupScope.cancelAnnotation = () => {
-            this.deleteLabelAndLayer(layer);
-        };
-        popupScope.addAnnotation = (labelObj, description) => {
-            let label = this.getLabelFromAutocomplete(labelObj);
-            this.addLabelToLayer(label, description, layer);
-            this.addLayerToGeoms(layer, label, description);
-            this.onSave({
-                geoJsonAnnotation: () => {
-                    this.geom.features = _.uniq(this.geom.features);
-                    return this.geom;
-                }});
-        };
-        return this.$compile(popupContent)(popupScope);
-    }
+    createShape(e) {
+        this.isDrawCancel = false;
 
-    getLabelFromAutocomplete(label) {
-        this.labelOriginalObject = label.originalObject;
-        let theLabel = '';
-        if (_.has(this.labelOriginalObject, 'name')) {
-            theLabel = this.labelOriginalObject.name;
-        } else {
-            theLabel = this.labelOriginalObject;
-        }
-        if (!_.find(this.labelInputs, (eachInput) => eachInput.name === theLabel)) {
-            this.labelInputs.push({'name': theLabel});
-        }
-        return theLabel;
-    }
-
-    addLabelToLayer(label, description, newLayer) {
-        newLayer.bindPopup(
-            `
-            <label class="leaflet-popup-label">Label:<br/>
-                <p>${label}</p></label><br/>
-            <label class="leaflet-popup-label">Description:<br/>
-                <p>${description}</p></label>
-            `
-        );
-    }
-
-    addLayerToGeoms(layer, label, description) {
-        let newShape = layer.toGeoJSON();
-        newShape.properties = {
-            'label': label,
-            'description': description,
-            'id': new Date().getTime()
-        };
-        this.geom.features.push(newShape);
-    }
-
-    deleteLabelAndLayer(newLayer) {
-        this.getMap().then((mapWrapper) => {
-            let layers = mapWrapper.getLayers('Annotation');
-            _.remove(layers, (lyr) => {
-                return lyr === newLayer;
-            });
-            mapWrapper.setLayer('Annotation', layers, true);
+        this.onShapeCreated({
+            'shapeLayer': e.layer,
+            'shapeType': e.layerType
         });
     }
 }

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.html
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.html
@@ -1,20 +1,34 @@
 <div class="annotate-toolbar">
-  <div class="column">
+  <div class="column" ng-if="!$ctrl.isDrawCancel">
     <div class="annotate-toolbar-header row align-center">
       <span>New annotation</span>
     </div>
     <div class="annotate-toolbar-actions row align-center">
       <button class="btn btn-primary"
-              ng-click="$ctrl.toggleDrawing('rectangle')">
+              ng-click="$ctrl.toggleDrawing('rectangle')"
+              ng-disabled="$ctrl.isLabeling">
         Rectangle
       </button>
       <button class="btn btn-primary"
-              ng-click="$ctrl.toggleDrawing('polygon')">
+              ng-click="$ctrl.toggleDrawing('polygon')"
+              ng-disabled="$ctrl.isLabeling">
         Polygon
       </button>
       <button class="btn btn-primary"
-              ng-click="$ctrl.toggleDrawing('marker')">
+              ng-click="$ctrl.toggleDrawing('marker')"
+              ng-disabled="$ctrl.isLabeling">
         Point
+      </button>
+    </div>
+  </div>
+  <div class="column" ng-if="$ctrl.isDrawCancel">
+    <div class="annotate-toolbar-header row align-center">
+      <span>Draw annotation</span>
+    </div>
+    <div class="annotate-toolbar-actions row align-center">
+      <button class="btn btn-primary"
+              ng-click="$ctrl.onCancelDrawing()">
+        Cancel
       </button>
     </div>
   </div>

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.scss
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.scss
@@ -33,44 +33,13 @@
   border: 2px solid $shade-dark;
 }
 
-.leaflet-popup-tip{
-  background-color: $shade-dark;
+.annotate-sidebar-overlay{
+  background: white;
+  opacity: 0.5;
+  width: 40rem;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 950;
 }
-
-.leaflet-popup-content-wrapper,
-.leaflet-popup-content,
- {
-  background-color: $shade-dark;
-  -webkit-border-radius: 5px !important;
-  -moz-border-radius: 5px !important;
-  border-radius: 5px !important;
- }
-
-.leaflet-popup-content-wrapper{
-  width: 250px;
-}
-
-.leaflet-popup-label {
-    color: white;
-    margin-right: 0px;
-    width: 211px;
-}
-
-.leaflet-popup-content-wrapper label:nth-child(1) input,
-.leaflet-popup-content-wrapper label:nth-child(3) textarea{
-    height: 21px;
-    width: 100%;
-}
-.leaflet-popup-content-wrapper label:nth-child(3) textarea{
-    height: 75px;
-}
-// .sidebar-overlay {
-//   background: white;
-//   opacity: 0.5;
-//   width: 40rem;
-//   position: absolute;
-//   top: 0;
-//   left: 0;
-//   bottom: 0;
-//   z-index: 950;
-// }

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -41,6 +41,7 @@ export default angular.module('index.components', [
     require('./components/map/mapSearchModal/mapSearchModal.module.js').name,
 
     require('./components/map/annotateToolbar/annotateToolbar.module.js').name,
+    require('./components/map/annotateSidebarItem/annotateSidebarItem.module.js').name,
 
 
     // settings components

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -1,3 +1,5 @@
+/* globals L, _ */
+
 export default class AnnotateController {
     constructor( // eslint-disable-line max-params
         $log, $state, $scope,
@@ -16,9 +18,72 @@ export default class AnnotateController {
             'type': 'FeatureCollection',
             features: []
         };
+        this.labelInputs = [{'name': 'All', 'id': 0}];
+        this.filterLabel = {'name': 'All'};
+
+        this.labelFilter = (annotation) => {
+            if (annotation.properties.label === this.filterLabel.name) {
+                return true;
+            } else if (this.filterLabel.name === 'All') {
+                return true;
+            }
+            return false;
+        };
+
+        this.filteredAnnotations = {
+            'type': 'FeatureCollection',
+            'features': []
+        };
+
+        this.$scope.$on('$destroy', this.$onDestroy.bind(this));
+    }
+
+    $onDestroy() {
+        this.getMap().then((mapWrapper) => {
+            mapWrapper.deleteLayers('Annotation');
+            mapWrapper.deleteLayers('draw');
+        });
+    }
+
+    onFilterChange(filterLabel) {
+        this.getMap().then((mapWrapper) => {
+            mapWrapper.deleteLayers('Annotation');
+            if (filterLabel.name !== 'All') {
+                this.filteredAnnotations = {
+                    'type': 'FeatureCollection',
+                    'features': _.filter(this.annoToExport.features, (f) => {
+                        return f.properties.label === filterLabel.name;
+                    })
+                };
+                mapWrapper.setLayer(
+                    'Annotation',
+                    this.createLayersOneByOne(this.filteredAnnotations.features),
+                    true
+                );
+            } else {
+                this.filteredAnnotations = {
+                    'type': 'FeatureCollection',
+                    'features': []
+                };
+                mapWrapper.setLayer(
+                    'Annotation',
+                    this.createLayersOneByOne(this.annoToExport.features),
+                    true
+                );
+            }
+        });
+    }
+
+    createLayersOneByOne(features) {
+        return _.map(features, (f) => {
+            return this.createLayerWithPopupFromGeojson(
+                {'type': 'FeatureCollection', 'features': [f]}
+            );
+        });
     }
 
     importLocalAnnotations() {
+        // TODO import should change filter to its corresponding label when the filter mode is on
         this.importedAnno = {
             'type': 'FeatureCollection',
             'features': [
@@ -33,74 +98,38 @@ export default class AnnotateController {
                         'type': 'Polygon',
                         'coordinates': [
                             [
-                                [
-                                    -76.97021484375,
-                                    39.62261494094297
-                                ],
-                                [
-                                    -74.718017578125,
-                                    39.62261494094297
-                                ],
-                                [
-                                    -74.718017578125,
-                                    40.78885994449482
-                                ],
-                                [
-                                    -76.97021484375,
-                                    40.78885994449482
-                                ],
-                                [
-                                    -76.97021484375,
-                                    39.62261494094297
-                                ]
+                                [-76.97021484375, 39.62261494094297],
+                                [-74.718017578125, 39.62261494094297],
+                                [-74.718017578125, 40.78885994449482],
+                                [-76.97021484375, 40.78885994449482],
+                                [-76.97021484375, 39.62261494094297]
                             ]
                         ]
                     }
                 }
             ]
         };
-        this.drawImportedAnnotations(this.importedAnno);
-        this.annoToExport.features = this.annoToExport.features.concat(this.importedAnno.features);
-    }
 
-    drawImportedAnnotations(geoJsonData) {
-        this.getMap().then((mapWrapper)=>{
-            let geoJsonLayer = L.geoJSON(geoJsonData, {
-                style: () => {
-                    return {
-                        weight: 2,
-                        fillOpacity: 0.2,
-                        opacity: 0.5
-                    };
-                },
-                onEachFeature: (feature, layer) => {
-                    layer.bindPopup(
-                        `
-                        <label class="leaflet-popup-label">Label:<br/>
-                        <p>${feature.properties.label}</p></label><br/>
-                        <label class="leaflet-popup-label">Description:<br/>
-                        <p>${feature.properties.description}</p></label>
-                        `,
-                        {
-                            closeButton: false
-                        }
-                    );
-                }
-            });
-            mapWrapper.addLayer(
+        let importedLayer = this.createLayersOneByOne(this.importedAnno.features);
+        this.getMap().then((mapWrapper) => {
+            mapWrapper.setLayer(
                 'Annotation',
-                geoJsonLayer,
+                _.union(mapWrapper.getLayers('Annotation'), importedLayer),
                 true
             );
         });
+        this.annoToExport.features = this.annoToExport.features.concat(this.importedAnno.features);
+
+        this.labelInputs = _.chain(this.annoToExport.features)
+                            .map((f) => {
+                                return {'name': f.properties.label, 'id': new Date().getTime()};
+                            })
+                            .uniqBy('name')
+                            .value();
+        this.labelInputs.push({'name': 'All', 'id': 0});
     }
 
-    exportAnnotations() {
-        if (this.annoToExport.features && this.annoToExport.features.length) {
-            this.$log.log(this.annoToExport);
-        } else {
-            this.$log.log('Nothing to export.');
-        }
+    onClearAnnotation() {
         this.getMap().then((mapWrapper) => {
             mapWrapper.deleteLayers('Annotation');
         });
@@ -108,9 +137,202 @@ export default class AnnotateController {
             'type': 'FeatureCollection',
             features: []
         };
+        this.labelInputs = [{'name': 'All', 'id': 0}];
     }
 
-    onAnnotationSave(data) {
-        this.annoToExport = data();
+    onAnnotationsExport() {
+        if (this.filteredAnnotations.features && this.filteredAnnotations.features.length) {
+            this.$log.log(this.filteredAnnotations);
+            if (this.filterLabel.name === 'All') {
+                this.onClearAnnotation();
+            }
+        } else if (this.annoToExport.features && this.annoToExport.features.length) {
+            this.$log.log(this.annoToExport);
+            this.onClearAnnotation();
+        } else {
+            this.$log.log('Nothing to export.');
+        }
     }
+
+    onShapeCreating(isCreating) {
+        this.isCreating = isCreating;
+    }
+
+    onAddShapeToDrawLayer(shapeLayer, shapeType) {
+        this.getMap().then((mapWrapper) => mapWrapper.setLayer('draw', shapeLayer, false));
+        this.addNewAnnotationIdToData(shapeType);
+    }
+
+    addNewAnnotationIdToData(shapeType) {
+        if (this.filterLabel.name === 'All') {
+            this.annoToExport.features.push({
+                'properties': {
+                    'id': new Date().getTime(),
+                    'type': shapeType
+                }
+            });
+        } else {
+            this.annoToExport.features.push({
+                'properties': {
+                    'id': new Date().getTime(),
+                    'type': shapeType,
+                    'label': this.filterLabel.name
+                }
+            });
+        }
+
+        this.isLabeling = true;
+    }
+
+    onCancelAddAnnotation(id) {
+        _.remove(this.annoToExport.features, (f) => f.properties.id === id);
+        this.getMap().then((mapWrapper) => mapWrapper.deleteLayers('draw'));
+        this.isLabeling = false;
+        this.isCreating = false;
+    }
+
+    onAddAnnotation(id, label, description) {
+        this.getMap().then((mapWrapper) => {
+            let newGeojson = this.createGeojsonWithMetadata(mapWrapper, id, label, description);
+            let newLayer = this.createLayerWithPopupFromGeojson(newGeojson);
+            let layers = (mapWrapper.getLayers('Annotation') || []).concat(newLayer);
+
+            _.remove(this.annoToExport.features, (f) => {
+                return f.properties.id === id;
+            });
+            this.annoToExport.features.push(newGeojson);
+
+            mapWrapper.setLayer('Annotation', layers, true);
+            mapWrapper.deleteLayers('draw');
+        });
+
+        this.labelInputs.push({'name': label, 'id': new Date().getTime()});
+        this.labelInputs = _.chain(this.labelInputs).uniqBy('name').sortBy('id').value();
+
+        this.isLabeling = false;
+        this.isCreating = false;
+
+        if (this.filterLabel.name !== 'All' && this.filterLabel.name !== label) {
+            this.filterLabel.name = label;
+            this.onFilterChange(this.filterLabel);
+        }
+    }
+
+    createGeojsonWithMetadata(mapWrapper, id, label, description) {
+        let geojson = _.first(mapWrapper.getLayers('draw')).toGeoJSON();
+        geojson.properties = {
+            'id': id,
+            'label': label,
+            'description': description
+        };
+        return geojson;
+    }
+
+    createLayerWithPopupFromGeojson(geojsonData) {
+        return L.geoJSON(geojsonData, {
+            style: () => {
+                return {
+                    weight: 2,
+                    fillOpacity: 0.2,
+                    opacity: 0.5
+                };
+            },
+            pointToLayer: (geoJsonPoint, latlng) => {
+                return L.marker(latlng, {'icon': L.divIcon({'className': 'annotate-marker'})});
+            },
+            onEachFeature: (feature, layer) => {
+                layer.bindPopup(
+                    `
+                    <label class="leaflet-popup-label">Label:<br/>
+                    <p>${feature.properties.label}</p></label><br/>
+                    <label class="leaflet-popup-label">Description:<br/>
+                    <p>${feature.properties.description}</p></label>
+                    `,
+                    {closeButton: false}
+                );
+            }
+        });
+    }
+
+
+    onUpdateAnnotationStart() {
+        this.isLabeling = true;
+        this.isCreating = true;
+    }
+
+
+    onCancelUpdateAnnotation(id) {
+        this.getMap().then((mapWrapper) => {
+            let originalData = _.filter(this.annoToExport.features, f => f.properties.id === id);
+            let originalDataLayer = this.createLayerWithPopupFromGeojson(originalData[0]);
+            let layers = _.union(
+                mapWrapper.getLayers('Annotation'),
+                [originalDataLayer]
+            );
+            mapWrapper.setLayer('Annotation', layers, true);
+            mapWrapper.deleteLayers('draw');
+        });
+        this.isLabeling = false;
+        this.isCreating = false;
+    }
+
+    /* eslint-disable no-underscore-dangle */
+    onDeleteAnnotation(id, label) {
+        _.remove(this.annoToExport.features, f => f.properties.id === id);
+
+        if (!_.find(this.annoToExport.features, f => f.properties.label === label)) {
+            _.remove(this.labelInputs, (i) => i.name === label);
+            this.filterLabel = {'name': 'All'};
+            this.onFilterChange(this.filterLabel);
+        }
+
+        this.getMap().then((mapWrapper) => {
+            let annotationLayers = mapWrapper.getLayers('Annotation');
+
+            _.remove(annotationLayers, (l) => {
+                return _.first(_.values(l._layers))
+                    .feature.properties.id === id;
+            });
+
+            mapWrapper.setLayer('Annotation', annotationLayers, true);
+        });
+    }
+    /* eslint-enable no-underscore-dangle */
+
+    /* eslint-disable no-underscore-dangle */
+    onUpdateAnnotationFinish(layer, id, label, oldLabel, description) {
+        let geojsonData = layer.toGeoJSON();
+        geojsonData.features[0].properties = {
+            'id': id,
+            'label': label,
+            'description': description
+        };
+        let updatedLayer = this.createLayerWithPopupFromGeojson(geojsonData);
+
+        this.getMap().then((mapWrapper) => {
+            let layers = _.union(mapWrapper.getLayers('Annotation'), [updatedLayer]);
+            mapWrapper.deleteLayers('draw');
+            mapWrapper.setLayer('Annotation', layers, true);
+        });
+
+        _.remove(this.annoToExport.features, (f) => f.properties.id === id);
+        this.annoToExport.features.push(geojsonData.features[0]);
+
+        this.isLabeling = false;
+        this.isCreating = false;
+
+        if (label !== oldLabel) {
+            if (!_.find(this.annoToExport.features, f => f.properties.label === oldLabel)) {
+                _.remove(this.labelInputs, (i) => i.name === oldLabel);
+            }
+            this.labelInputs.push({'name': label, 'id': new Date().getTime()});
+            this.labelInputs = _.chain(this.labelInputs).uniqBy('name').sortBy('id').value();
+        }
+
+        if (this.filterLabel.name !== 'All') {
+            this.filterLabel = {'name': label};
+        }
+        this.onFilterChange(this.filterLabel);
+    }
+    /* eslint-enable no-underscore-dangle */
 }

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
@@ -1,8 +1,9 @@
 <!-- Annotate Toolbar Component -->
 <rf-annotate-toolbar
   map-id="edit"
-  geom="$ctrl.annoToExport",
-  on-save="$ctrl.onAnnotationSave(geoJsonAnnotation)">
+  is-labeling="$ctrl.isLabeling"
+  on-shape-creating="$ctrl.onShapeCreating(isCreating)"
+  on-shape-created="$ctrl.onAddShapeToDrawLayer(shapeLayer, shapeType)">
 </rf-annotate-toolbar>
 <!-- Annotate Toolbar Component -->
 
@@ -23,13 +24,15 @@
         <button
           class="btn btn-primary btn-block"
           type="button"
-          ng-click="$ctrl.importLocalAnnotations()">
+          ng-click="$ctrl.importLocalAnnotations()"
+          ng-disabled="$ctrl.isCreating">
           Import
         </button>
         <button
           class="btn btn-primary btn-block"
           type="button"
-          ng-click="$ctrl.exportAnnotations(geoJsonAnnotation)">
+          ng-click="$ctrl.onAnnotationsExport(geoJsonAnnotation)"
+          ng-disabled="$ctrl.isCreating">
           Export
         </button>
       </div>
@@ -54,28 +57,36 @@
       <div class="list-group">
         <div class="list-group-item filter-annotations">
           <div>
-            <span><strong>Filter Placeholder</span></strong>
+            <span><strong>Filter by label</span></strong>
+          </div>
+          <div class="list-group-right column-6 nogutter filter-annotations-select">
+            <select
+              ng-init="$ctrl.filterLabel = {'name': 'All'}"
+              ng-model="$ctrl.filterLabel"
+              ng-change="$ctrl.onFilterChange($ctrl.filterLabel)"
+              ng-options="label.name for label in $ctrl.labelInputs track by label.name"
+              ng-disabled="$ctrl.isCreating">
+            </select>
           </div>
         </div>
       </div>
       <div class="list-group"
-           ng-repeat="annotation in $ctrl.annoToExport.features">
-        <div class="list-group-item list-sidebar-annotations">
-          <div>
-              <i class="icon-cloud"
-                 ng-if="annotation.geometry.coordinates.length === 1"></i>
-              <i class="icon-sun"
-                 ng-if="annotation.geometry.coordinates.length === 2"></i>
-          </div>
-          <div>
-            <h5>{{annotation.properties.label}}</h5>
-          </div>
-          <div class="list-group-right actions-annotations">
-            <a title="Clone"><i class="icon-arrows-cw"></i></a>
-            <a title="Edit"><i class="icon-pencil"></i></a>
-            <a title="Delete"><i class="icon-trash"></i></a>
-          </div>
-        </div>
+           ng-repeat="annotation in $ctrl.annoToExport.features | filter: $ctrl.labelFilter"
+           ng-mouseenter="$ctrl.annotationSidebarMouseHover($event, annotation, true)"
+           ng-mouseleave="$ctrl.annotationSidebarMouseHover($event, annotation, false)">
+        <rf-annotate-sidebar-item
+          map-id="edit"
+          data="$ctrl.annoToExport"
+          annotation="annotation"
+          shape-type="$ctrl.drawnShapeType"
+          label-inputs="$ctrl.labelInputs"
+          on-cancel-add-annotation="$ctrl.onCancelAddAnnotation(id)"
+          on-add-annotation="$ctrl.onAddAnnotation(id, label, description)"
+          on-update-annotation-start="$ctrl.onUpdateAnnotationStart()"
+          on-delete-annotation="$ctrl.onDeleteAnnotation(id, label)"
+          on-cancel-update-annotation="$ctrl.onCancelUpdateAnnotation(id)"
+          on-update-annotation-finish="$ctrl.onUpdateAnnotationFinish(layer, id, label, oldLabel, description)">
+        </rf-annotate-sidebar-item>
       </div>
   </div>
 </div>

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -1,5 +1,6 @@
 import angular from 'angular';
 import AnnotateController from './annotate.controller.js';
+require('./annotate.scss');
 
 const AnnotateModule = angular.module('pages.projects.edit.annotate', []);
 

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.scss
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.scss
@@ -1,0 +1,55 @@
+@import "../../../../../assets/styles/sass/settings/_colors.scss";
+.sidebar-project.no-annotation,
+.list-group-item.no-annotation{
+    border-style: none;
+}
+
+.panel.panel-off-white.no-annotation {
+    height: 75px;
+    border: 1px solid #e9e9ea;
+    background-color:#f5f7f7;
+}
+.panel.panel-off-white.no-annotation p {
+    text-align: center;
+    vertical-align: middle;
+    line-height: 75px;
+}
+
+.list-group-item.filter-annotations {
+    border-style: none;
+}
+
+.list-group-item.filter-annotations p {
+    flex-direction: row;
+}
+
+.list-group-right.column-6.nogutter.filter-annotations-select select{
+    width: 190px;
+    height: 32px;
+}
+
+.list-group-right.column-6.nogutter.filter-annotations-select select:disabled{
+    cursor: not-allowed;
+}
+
+.leaflet-popup-tip {
+   background-color: $shade-dark;
+}
+
+.leaflet-popup-content-wrapper,
+.leaflet-popup-content {
+    background-color: $shade-dark;
+    -webkit-border-radius: 5px !important;
+    -moz-border-radius: 5px !important;
+    border-radius: 5px !important;
+}
+
+.leaflet-popup-content-wrapper{
+    width: 250px;
+}
+
+.leaflet-popup-label {
+    color: white;
+    margin-right: 0px;
+    width: 211px;
+}


### PR DESCRIPTION
## Overview

This PR contains changes reflecting the updated UI design (-mainly moved the add/edit UI from map popups to sidebar items).

This PR allows annotations' edit, delete, and filter on sidebar.

Editing an annotation will allow you to edit its shape and label name/description (validation on label name is set so that it can't be blank - similar to the validation when creating a new annotation). Label name change/update after editing will affect candidate label names for autocomplete.

Deleting an annotation will both delete it from the sidebar and from the map.  If there's no annotation of such label name left, such label name is deleted from the autocomplete candidates as well.

Filtering on label names will reflect both on sidebar and on map. Editing label name under the filter mode will switch the filter to the newly updated label name. Deleting annotations under the filter mode will switch to "all" filter if there is no annotation left under such pre-selected label name.

Export (currently, in the form of console logs) will respect the filter - export under the filter mode will only export the filtered annotations, but all annotations are kept on the map.  But exporting all annotations with no filter will clear them from the map.



### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

### Demo

*ADD/UPDATE ANNOTATION:*
<img width="1680" alt="screen shot 2017-08-04 at 10 05 41 am" src="https://user-images.githubusercontent.com/16109558/28982978-9a1dc960-7925-11e7-9953-1fe27aafbf08.png">

<img width="1680" alt="screen shot 2017-08-04 at 10 06 35 am" src="https://user-images.githubusercontent.com/16109558/28983055-f6c54f94-7925-11e7-9fe1-f87007b29fd1.png">

* Label name can't be blank. 
* Adding new annotations will disable some buttons.


*EDIT:*
<img width="1680" alt="screen shot 2017-08-04 at 10 06 42 am" src="https://user-images.githubusercontent.com/16109558/28983075-0a3f962e-7926-11e7-8ac9-0f3b89ccbd2c.png">

* Label name has autocomplete.
* "Update" button will update annotation shape and metadata.
* "Cancel" button will make no change to map and to data.
* Some buttons are disabled in edit mode as well.

*FILTER:*
<img width="1680" alt="screen shot 2017-08-04 at 10 07 27 am" src="https://user-images.githubusercontent.com/16109558/28983180-852a3e0c-7926-11e7-8894-37e41dd864c9.png">

* Try editing and deleting annotation under the filter mode to see if they behave as intended/as mentioned in the overview.


### Notes

* Page/component specific css are located in their corresponding directory
* Label names in the filter dropdown/selection are in the order of their creation time - except "All" is always on top.
* Clone icon and icons for polygons and points - all in the sidebar - are currently placeholders. Formal icons are pending.

## Testing Instructions

 * Go to `/projects/edit/:project_id/annotate`
 * Try import, draw, edit, delete, filter, export annotations to make sure they function as you expected. Note that the "clone" function (first icon of the three icons of an annotation on the sidebar) should not do anything, yet.

Closes #2279, #2280
