### PR TITLE
Correctly implement histogram equalization in color-correction

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -170,15 +170,19 @@ object ColorCorrect {
 
   def apply(rgbTile: MultibandTile, rgbHist: Array[Histogram[Double]], params: Params): MultibandTile = {
     var _rgbTile = rgbTile
+    var _rgbHist = rgbHist
     val gammas = params.getGamma
-    if (params.equalize.enabled) _rgbTile = HistogramEqualization(rgbTile, rgbHist)
+    if (params.equalize.enabled) {
+      _rgbTile = HistogramEqualization(rgbTile, rgbHist)
+      _rgbHist = _rgbTile.histogramDouble()
+    }
 
     val layerRgbClipping = {
       val range = 1 until 255
       var isCorrected = true
       val iMaxMin: Array[(Int, Int)] = Array.ofDim(3)
-      cfor(0)(_ < rgbHist.length, _ + 1) { index =>
-        val hst = rgbHist(index)
+      cfor(0)(_ < _rgbHist.length, _ + 1) { index =>
+        val hst = _rgbHist(index)
         val imin = hst.minValue().map(_.toInt).getOrElse(0)
         val imax = hst.maxValue().map(_.toInt).getOrElse(255)
         iMaxMin(index) = (imin, imax)


### PR DESCRIPTION
## Overview

Fixes a bug that was causing histogram equalization to return bizarre-looking results. I've verified that the output is now correct by comparing to GraphicsMagick's histogram equalization. However, the results are still...not all that great, although I think they now qualify as somewhat useful rather than completely useless. See notes for further discussion.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Demo

![histogramequalization](https://user-images.githubusercontent.com/447977/28844856-0d012e4e-76d4-11e7-94b0-8c4be814b6d3.png)
The left window is a screenshotted and then GraphicsMagicked version of the scene, while the right window is the output from Raster Foundry's histogram equalization.

### Notes

- The reason for the bug was that histogram equalization would stretch the image's histogram, but the subsequent normalization and clipping steps were performed using the _original_ image's histogram, which usually had a much smaller range of values than the equalized histogram. This caused most values to fall outside the 0-255 range even after "normalization", and so they were being clipped to white, while the remainder ended up transformed into completely different colors.
- The corrected auto-contrast still doesn't (in my opinion) provide decent results across a range of different scenes. I played around with some different techniques using screenshots and image-editing software, and it seems like there is still some work to do to get there. Here are the outstanding problems / issues I've noticed, in increasing order of difficulty:
  - I think we're supposed to be normalizing each scene that we display before displaying it, but this doesn't seem to be working as effectively as it could be. One problem may be if we're not excluding no-data values (which tend to be zero) from the normalization, it could block the rest of the histogram from spreading out to take advantage of the lower values. This seems to explain why the following histogram has a gap at the bottom, but it doesn't explain why there is a gap at the top: ![histogram1](https://user-images.githubusercontent.com/447977/28846667-40e7401c-76da-11e7-84e9-f447a96356f2.png)
  - We have continuing problems with the tiler which prevent manually correcting issues with the auto-correct. For example, if I try to manually clip a scene to the edges of its histogram, on my local machine nothing happens, and on staging I get this: ![histogram2](https://user-images.githubusercontent.com/447977/28846938-56bfa1a8-76db-11e7-9557-133c68ecde93.png)
  - Even if both of the above problems are fixed, things like clouds may be a confounding factor. For example, if I use GIMP to perform manual color correction on two of the "Color Correct Me" scenes, one of them comes out really nicely and the other one doesn't improve very much. I'm guessing that the denser clouds in the top image block the histogram from expanding upward in the same way that no-data values may be blocking downward expansion. ![normalizeexamples](https://user-images.githubusercontent.com/447977/28847265-9840ebd6-76dc-11e7-9023-6d02b92122c8.png) . One way we might be able to address this would be to take a best guess at histogram clipping points based on the cloud cover of a scene. If a scene is 12% clouds, we could assume that the brightest 12% of pixels are clouds and just clip to there. That's definitely a non-standard technique so we'd want to do more research to see if it actually provides good results.


## Testing Instructions

 * Go to color-correction for an ingested scene.
 * Click auto-contrast
 * Confirm that the results, while not exactly _natural looking_, are also not completely insane. It should look like someone got a little too excited about the saturation slider.

Closes #2210 
(Including @notthatbreezy as a reviewer to get a sense of what the remaining issues are)
