### PR TITLE
Clean Up API Spec/Queries/Planet Imports/Autocomplete

### DIFF
--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -2,7 +2,7 @@ package com.azavea.rf.api.utils.queryparams
 
 import java.util.UUID
 import java.sql.Timestamp
-import java.time.Instant
+import javax.xml.bind.DatatypeConverter
 
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
@@ -18,7 +18,7 @@ trait QueryParameterDeserializers {
   }
 
   implicit val deserializerTimestamp: Unmarshaller[String, Timestamp] = Unmarshaller.strict[String, Timestamp] { s =>
-    Timestamp.from(Instant.parse(s))
+    Timestamp.from(DatatypeConverter.parseDateTime(s).getTime().toInstant())
   }
 
 }

--- a/app-backend/api/src/test/scala/scene/SceneSpec.scala
+++ b/app-backend/api/src/test/scala/scene/SceneSpec.scala
@@ -189,7 +189,7 @@ class SceneSpec extends WordSpec
     }
 
     "filter by acquisition date correctly (no nulls returned)" in {
-      val url = s"$baseScene?minAcquisitionDatetime=2016-09-18T14:41:58.408544z"
+      val url = s"$baseScene?minAcquisitionDatetime=2016-09-18T14:41:58.408544Z"
       Get(url).withHeaders(List(authHeader)) ~> baseRoutes ~> check {
         responseAs[PaginatedResponse[Scene.WithRelated]].count shouldEqual 1
       }

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -15,17 +15,16 @@ export default class FilterPaneController {
         if (this.authService.isLoggedIn) {
             this.initFilters();
             this.initDatefilter();
+        } else {
+            this.$scope.$watch(() => this.authService.isLoggedIn, (isLoggedIn) => {
+                if (isLoggedIn) {
+                    this.initFilters();
+                    this.initDatefilter();
+                }
+            });
         }
 
         this.toggleDrag = {toggle: false, enabled: false};
-
-        this.$scope.$watch(() => this.authService.isLoggedIn, (isLoggedIn) => {
-            if (isLoggedIn) {
-                this.initFilters();
-                this.initDatefilter();
-            }
-        });
-
         this.$scope.$watch('$ctrl.opened', (opened) => {
             if (opened) {
                 this.$timeout(() => this.$rootScope.$broadcast('reCalcViewDimensions'), 50);

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -240,22 +240,14 @@ export default class FilterPaneController {
     initSourceFilters() {
         this.datasourceService.query().then(d => {
             this.datasources = d.results;
-            this.dynamicSourceFilters = {};
-            d.results.forEach(ds => {
-                this.dynamicSourceFilters[ds.id] = {
-                    datasource: ds,
-                    enabled: false
-                };
-            });
-            if (this.filters.datasource) {
-                if (Array.isArray(this.filters.datasource)) {
-                    this.filters.datasource.forEach(dsf => {
-                        if (this.dynamicSourceFilters[dsf]) {
-                            this.dynamicSourceFilters[dsf].enabled = true;
-                        }
-                    });
-                } else if (this.dynamicSourceFilters[this.filters.datasource]) {
-                    this.dynamicSourceFilters[this.filters.datasource].enabled = true;
+
+            let selectedId = this.filters.datasource[0];
+            if (selectedId) {
+                let matchedSource = this.datasources.find(ds => ds.id === selectedId);
+                if (matchedSource) {
+                    this.selectedDatasource = matchedSource.name;
+                } else {
+                    this.selectedDatasource = '';
                 }
             }
         });
@@ -279,10 +271,6 @@ export default class FilterPaneController {
         delete this.filters.minSunAzimuth;
         delete this.filters.maxSunAzimuth;
 
-        Object.values(this.dynamicSourceFilters)
-            .forEach((ds) => {
-                ds.enabled = false;
-            });
         this.filters.datasource = [];
 
         this.ingestFilter = 'any';
@@ -326,20 +314,14 @@ export default class FilterPaneController {
         this.cachedFilters.maxAcquisitionDatetime = this.filters.maxAcquisitionDatetime;
     }
 
-    onSourceFilterChange() {
+    clearDatasourceFilter() {
         this.filters.datasource = [];
-
-        Object.values(this.dynamicSourceFilters)
-            .filter(ds => ds.enabled)
-            .forEach(ds => this.filters.datasource.push(ds.datasource.id));
+        // Empty string preserves click to open drop-down
+        this.selectedDatasource = '';
     }
 
-    toggleSourceFilter(sourceId) {
-        if (this.dynamicSourceFilters[sourceId]) {
-            this.dynamicSourceFilters[sourceId].enabled =
-                !this.dynamicSourceFilters[sourceId].enabled;
-        }
-        this.onSourceFilterChange();
+    toggleSourceFilter(source) {
+        this.filters.datasource = [source.id];
     }
 
     openDateRangePickerModal() {

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
@@ -32,7 +32,7 @@
       <div class="filter-group-option">
         <label>Enabled</label>
         <rf-toggle-old data-model="$ctrl.dateFilterToggle.value"
-                  on-change="$ctrl.onDateFilterToggle(value)"
+                       on-change="$ctrl.onDateFilterToggle(value)"
         ></rf-toggle-old>
       </div>
     </div>
@@ -94,14 +94,17 @@
           ng-mouseleave="$ctrl.toggleDrag.toggle = false"
           ng-mouseup="$ctrl.toggleDrag.toggle = false">
         <label>Imagery sources</label>
-        <div class="filter-item tag-filter">
-          <button class="btn btn-toggle btn-small"
-                  ng-click="$ctrl.toggleSourceFilter(id)"
-                  ng-class="{'active': filter.enabled}"
-                  ng-repeat="(id, filter) in $ctrl.dynamicSourceFilters track by id">
-            {{filter.datasource.name}}
-          </button>
-        </div>
+        <input type="text"
+               placeholder="None"
+               ng-model="$ctrl.selectedDatasource"
+               uib-typeahead="ds.name for ds in $ctrl.datasources | filter:$viewValue | limitTo:8"
+               class="form-control input-dark"
+               typeahead-on-select="$ctrl.toggleSourceFilter($item)"
+               typeahead-min-length="0">
+      </div>
+      <div ng-if="$ctrl.selectedDatasource"
+           ng-click="$ctrl.clearDatasourceFilter()">
+        Clear
       </div>
     </div>
     <div class="filter-group">

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
@@ -1,10 +1,12 @@
 import angular from 'angular';
 import slider from 'angularjs-slider';
+import typeahead from 'angular-ui-bootstrap/src/typeahead';
 
 import SceneFilterPaneComponent from './sceneFilterPane.component.js';
 import SceneFilterPaneController from './sceneFilterPane.controller.js';
 
-const SceneFilterPaneModule = angular.module('components.scenes.sceneFilterPane', [slider]);
+const SceneFilterPaneModule = angular.module('components.scenes.sceneFilterPane',
+    [slider, typeahead]);
 
 SceneFilterPaneModule.component('rfSceneFilterPane', SceneFilterPaneComponent);
 SceneFilterPaneModule.controller('SceneFilterPaneController', SceneFilterPaneController);

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -354,6 +354,24 @@ paths:
       responses:
         200:
           description: SUCCESS
+          schema:
+            $ref: '#/definitions/Datasource'
+    post:
+      summary: Create a datasource
+      description: |
+        Datasources are sensors that share common metadata, like default color corrections. Scenes from
+        a given datasource can be mosaiced and color corrected together.
+      tags:
+        - Datasources
+      parameters:
+        - $ref: '#/parameters/owner'
+        - $ref: '#/parameters/name'
+      # TODO: fill in all possible responses
+      responses:
+        201:
+          description: SUCCESS
+          schema:
+            $ref: '#/definitions/Datasource'
   /uploads/:
     x-resource: Uploads
     get:
@@ -2472,15 +2490,105 @@ definitions:
       required:
         - name
         - id
+  Geometry:
+      type: object
+      description: GeoJSon geometry
+      discriminator: type
+      required:
+        - type
+      externalDocs:
+        url: http://geojson.org/geojson-spec.html#geometry-objects
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPolygon
+          description: the geometry type
+  Point2D:
+      type: array
+      maxItems: 2
+      minItems: 2
+      items:
+        type: number
+  MultiPolygon:
+      type: object
+      description: GeoJson geometry
+      externalDocs:
+        url: http://geojson.org/geojson-spec.html#id6
+      allOf:
+        - $ref: "#/definitions/Geometry"
+        - properties:
+            coordinates:
+              type: array
+              items:
+                type: array
+                items:
+                  type: array
+                  items:
+                    $ref: '#/definitions/Point2D'
+  Composite:
+    type: object
+    description: mapping of bands to RGB
+    properties:
+      label:
+        type: string
+        description: Human readable label for color composite to describe what it is useful for (e.g. natural color)
+      value:
+        type: object
+        properties:
+          redBand:
+            type: integer
+          greenBand:
+            type: integer
+          blueBand:
+            type: integer
+
+
+  DatasourceCreated:
+    type: object
+    description: Grouping of imagery by creation source
+    allOf:
+      - type: object
+        properties:
+          visibility:
+            type: string
+            description: Level of restriction on viewing
+            enum:
+              - PUBLIC
+              - ORGANIZATION
+              - PRIVATE
+          organizationId:
+            type: string
+            description: uuid for organization
+          name:
+            type: string
+            description: human label name for datasource
+          extras:
+            type: object
+            description: additional related information for a datasource
+          composites:
+            $ref: '#/definitions/Composite'
+
+  Datasource:
+    allOf:
+      - $ref: '#/definitions/BaseModel'
+      - $ref: '#/definitions/UserTrackingMixin'
+      - $ref: '#/definitions/TimeModelMixin'
+      - $ref: '#/definitions/DatasourceCreated'
+
   Scene:
     allOf:
       - $ref: '#/definitions/BaseModel'
       - $ref: '#/definitions/UserTrackingMixin'
+      - $ref: '#/definitions/TimeModelMixin'
       - type: object
         properties:
           name:
             type: string
             description: The display name of the project
+          ingestLocation:
+            type: string
+            description: Where scene is ingested (pyramided/tiled)
           ingestSizeBytes:
             type: integer
             description: Size of ingested data in bytes.
@@ -2495,7 +2603,7 @@ definitions:
             type: array
             description: Tags associated with image
             items:
-              - type: string
+              type: string
           images:
             type: array
             items:
@@ -2508,15 +2616,13 @@ definitions:
             type: string
             format: uuid
             description: Data source scene originated from
-          # TODO: make work with geometry objects
           dataFootprint:
+            $ref: '#/definitions/MultiPolygon'
             description: polygon for which this scene has data
-            type: object
             readOnly: true
-          # TODO: make work with geometry objects
           tileFootprint:
-            type: object
-            description: polygon enclosing this scene
+            $ref: '#/definitions/MultiPolygon'
+            description: polygon for tile
             readOnly: true
           sceneMetadata:
             type: object
@@ -2529,7 +2635,7 @@ definitions:
               Metadata files that should be present for processing all
               images in a scene (e.g. relevant .mtl files or .xml)
             items:
-              - type: string
+              type: string
           filterFields:
             $ref: '#/definitions/FilterFields'
           statusFields:
@@ -2589,8 +2695,8 @@ definitions:
   SceneGrid:
     type: array
     items:
-      - type: number
-        format: integer
+      type: number
+      format: integer
     readOnly: true
 
   Project:
@@ -2598,16 +2704,6 @@ definitions:
     - $ref: '#/definitions/BaseModel'
     - $ref: '#/definitions/UserTrackingMixin'
     - type: object
-      required:
-        - name
-        - description
-        - visibility
-        - tileVisibility
-        - tags
-        - extent
-        - manualOrder
-        - isAOIProject
-        - isSingleBand
       properties:
         name:
           type: string
@@ -2636,7 +2732,7 @@ definitions:
         tags:
           type: array
           items:
-            - type: string
+            type: string
         extent:
           type: object
           description: GeoJSON Geometry of project extent
@@ -2646,42 +2742,6 @@ definitions:
         isAOIProject:
           type: boolean
           description: Is true if project is an area-of-interest project
-        isSingleBand:
-          type: boolean
-          description: Is true if the project is being viewed in single band mode
-        singleBandOptions:
-          type: object
-          properties:
-            band:
-              type: number
-              format: integer
-              description: the 0-indexed band to use 
-            dataType:
-              type: string
-              description: How to display the data
-              enum:
-                - DIVERGING
-                - SEQUENTIAL
-                - CATEGORICAL
-            blendMode:
-              type: string
-              description: Blending mode
-              enum:
-                - CONTINUOUS
-                - DISCRETE
-                - NONE
-            colorScheme:
-              type: object
-              description: 'mapping of raster values to pixel colors eg: {"0" : "rgb(255,255,255)"}'
-            legendOrientation:
-              type: string
-              description: Orientation of the color legend
-              enum:
-                - LEFT
-                - RIGHT
-                - TOP
-                - BOTTOM
-                - HIDDEN
   Image:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -2760,6 +2820,9 @@ definitions:
   Band:
     type: object
     properties:
+      id:
+        type: string
+        format: UUID
       image:
         type: string
         format: UUID
@@ -2776,6 +2839,7 @@ definitions:
   Thumbnail:
     allOf:
     - $ref: '#/definitions/BaseModel'
+    - $ref: '#/definitions/TimeModelMixin'
     - type: object
       properties:
         widthPx:
@@ -3017,7 +3081,6 @@ definitions:
             - DROPBOX
             - S3
             - LOCAL
-            - PLANET
         fileType:
           type: string
           description: type of data being uploaded, limited to two options right now
@@ -3042,6 +3105,8 @@ definitions:
         source:
           type: string
           description: for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored
+        sceneMetadata:
+          $ref: '#/definitions/UploadMetadata'
   Upload:
     allOf:
     - $ref: '#/definitions/BaseModel'
@@ -3055,6 +3120,15 @@ definitions:
             type: string
         metadata:
           type: object
+  UploadMetadata:
+    type: object
+    properties:
+      sceneCloudCover:
+        type: number
+        format: float32
+      sceneAcquisitionDate:
+        type: string
+        format: datetime
   UploadPaginated:
     allOf:
     - $ref: '#/definitions/PaginatedResponse'


### PR DESCRIPTION
## Overview

Fixes a few regressions and issues that became apparent after the deploy:
 - Date parsing is now more tolerable to compliant ISO-8601 timestamps and less tolerant of improper timestamps
 - Swagger spec issues are fixed that made it difficult to query scenes
 - Fixes init for filter pane that was causing it to initialize twice
 - Fixes issue where planet data could not be imported on first try
 - Fixes bug where ingests were not being kicked off when added to a project

Adds autocomplete for drop down on datasource filter.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Going to merge this to test on staging and get it deployed. If there are comments we can add new commits.

Closes #2381 
Closes #2238  
