### PR TITLE
Add global statistics endpoint for tool-runs

### DIFF
--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -47,6 +47,7 @@ class Router extends LazyLogging
               toolRoutes.tms(TileSources.cachedTmsSource) ~
               toolRoutes.validate ~
               toolRoutes.histogram ~
+              toolRoutes.statistics ~
               toolRoutes.preflight
             }
           }

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -4,12 +4,14 @@ import com.azavea.rf.tool.ast._
 
 import geotrellis.raster.io._
 import geotrellis.raster.histogram._
+import geotrellis.raster.summary.Statistics
 import geotrellis.raster.render._
 import geotrellis.raster.mapalgebra.focal._
 import spray.json._
 import DefaultJsonProtocol._
 import io.circe._
 import io.circe.syntax._
+import io.circe.generic.semiauto._
 import io.circe.parser._
 
 import java.security.InvalidParameterException
@@ -108,7 +110,6 @@ trait MapAlgebraUtilityCodecs {
 
   implicit val colorRampDecoder: Decoder[ColorRamp] =
     Decoder[Vector[Int]].map({ ColorRamp(_) })
-
   implicit val colorRampEncoder: Encoder[ColorRamp] = new Encoder[ColorRamp] {
     final def apply(cRamp: ColorRamp): Json = cRamp.colors.toArray.asJson
   }
@@ -116,10 +117,12 @@ trait MapAlgebraUtilityCodecs {
   implicit val histogramDecoder: Decoder[Histogram[Double]] = Decoder[Json].map { js =>
     js.noSpaces.parseJson.convertTo[Histogram[Double]]
   }
-
   implicit val histogramEncoder: Encoder[Histogram[Double]] = new Encoder[Histogram[Double]] {
     final def apply(hist: Histogram[Double]): Json = hist.toJson.asJson
   }
+
+  implicit val statsDecoder: Decoder[Statistics[Double]] = deriveDecoder
+  implicit val statsEncoder: Encoder[Statistics[Double]] = deriveEncoder
 
   implicit val sprayJsonEncoder: Encoder[JsValue] = new Encoder[JsValue] {
     final def apply(jsvalue: JsValue): Json = parse(jsvalue.compactPrint) match {


### PR DESCRIPTION
## Overview

Global stats (min, max, central tendency) on tool runs are desirable. It is not sensible to calculate these results exactly, but we can give a reasonable estimate using the histograms we generate for automatic coloring. This PR piggybacks on histogram functionality to return a `Statistics` object which serializes like this:

```json
{
    "dataCells": 65536,
    "mean": 43290.12355041505,
    "median": 56568.93128076629,
    "mode": 0,
    "stddev": 29786.034076076023,
    "zmin": 0,
    "zmax": 132628
}
```
It would be great to include this on the AST (and that's something we're pursuing) but this should provide the functionality we want in the meantime

## Testing Instructions

 * Find a working `tool-run`
 * Navigate to `/tiles/tools/<TOOLRUN-ID>/statistics`
 * There are your statistics

Closes #2314
