### PR TITLE
Jitter ingest status sleep time and kickoff ingests exactly once for uploads

### DIFF
--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import random
 import time
 
 from airflow.operators.python_operator import PythonOperator
@@ -136,7 +137,7 @@ def wait_for_success(response, cluster_id):
             logger.info('Updating status of %s. Old Status: %s New Status: %s',
                         step_id, current_status, status)
             current_status = status
-        time.sleep(5)
+        time.sleep(45 + random.randint(0, 30))
     is_success = (current_status == 'COMPLETED')
     if is_success:
         logger.info('Successfully completed ingest for %s', step_id)

--- a/app-tasks/dags/process_upload.py
+++ b/app-tasks/dags/process_upload.py
@@ -69,6 +69,7 @@ def process_upload(*args, **kwargs):
                 upload.datasource,
                 upload.organizationId,
                 upload.id,
+                upload.projectId,
                 upload.visibility,
                 [],
                 upload.owner,

--- a/app-tasks/requirements.txt
+++ b/app-tasks/requirements.txt
@@ -11,4 +11,5 @@ ipython==5.1.0
 pyjwt==1.4.2
 rollbar==0.13.11
 dnspython==1.15.0
-planet==1.0.0
+planet==1.0
+retrying==1.3.3

--- a/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
@@ -38,7 +38,8 @@ def get_planet_thumbnail(organization_id, thumbnail_uri, planet_key, scene_id):
         for chunk in response.iter_content(1024):
             filehandle.write(chunk)
 
-    thumbnail_key = '/thumbnails/{}.png'.format(scene_id)
+    thumbnail_key = '{}.png'.format(scene_id)
+    thumbnail_uri = '/thumbnails/{}.png'.format(scene_id)
     logger.info('Uploading thumbnails to S3: %s', thumbnail_key)
     s3_bucket_name = os.getenv('THUMBNAIL_BUCKET')
     s3_bucket = boto3.resource('s3').Bucket(s3_bucket_name)
@@ -50,7 +51,7 @@ def get_planet_thumbnail(organization_id, thumbnail_uri, planet_key, scene_id):
         256,
         256,
         'SMALL',
-        thumbnail_key,
+        thumbnail_uri,
         sceneId=scene_id
     )
 

--- a/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
@@ -56,6 +56,7 @@ def get_planet_thumbnail(organization_id, thumbnail_uri, planet_key, scene_id):
 
 
 def create_planet_scene(planet_feature, datasource, organization_id, planet_key,
+                        ingest_status=IngestStatus.TOBEINGESTED,
                         visibility=Visibility.PRIVATE, tags=[], owner=None):
     """Create a Raster Foundry scene from Planet scenes
 
@@ -117,7 +118,7 @@ def create_planet_scene(planet_feature, datasource, organization_id, planet_key,
         name,
         JobStatus.QUEUED,
         JobStatus.QUEUED,
-        IngestStatus.TOBEINGESTED,
+        ingest_status,
         [],
         owner=owner,
         images=images,


### PR DESCRIPTION
## Overview

This PR fixes two bugs:

1. Increase and jitter the sleep delay in the `wait_for_status` step of ingests. We set this to exactly 5 seconds previously, so if several `launch_spark_ingest` tasks started at the same time, they'd all query their step statuses at the same time as well, and often. This PR increases the time to 45 seconds as a base and adds between 0 and 30 seconds of jitter.
2. Check for projectId in the `GeoTiffS3SceneFactory`. This PR sets the created scene's ingest status based on whether the upload has a project. If the upload has a project, it sets the status to `NOTINGESTED`, since adding the scene to a project will set its status to `TOBEINGESTED` and kick off an ingest. If the upload doesn't have a project, it sets the scene's status to `TOBEINGESTED`, since uploading imagery is an adequate signal of intent for us to ingest the scene.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

This may not actually fix #2404, but I think it will. Exponential backoff is overkill for things that we expect to complete within a minute after they start, so increasing the time and adding the jitter should be sufficient.

## Testing Instructions

 * bring up your server, airflow, and frontend
 * Add a Landsat 8 scene to a project -- one ingest should be kicked off
 * Upload an image _without_ an associated project -- one ingest should be kicked off
 * Upload an image _with_ an associated project -- one ingest should be kicked off
 * Upload a planet image _without_ an associated project -- one ingest should be kicked off
 * Upload a planet image _with_ an associated project -- one ingest should be kicked off
 * None of the `launch_spark_ingest` tasks should fail because of rate limiting

Closes #2391 
Closes #2404 
