### PR TITLE
Use provided color ramp in tool endpoint

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -221,27 +221,29 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     toolRunId: UUID,
     subNode: Option[UUID],
     user: User,
-    voidCache: Boolean = false
+    colorRamp: ColorRamp
   ): OptionT[Future, ColorMap] = traceName("LayerCache.toolRunColorMap") {
-    val cacheKey = s"colormap-$toolRunId-${subNode}-${user.id}"
-    if (voidCache) rfCache.delete(cacheKey)
+    val cacheKey = s"colormap-$toolRunId-${subNode}-${user.id}-${colorRamp.getClass.getName}"
     rfCache.cachingOptionT(cacheKey, doCache = cacheConfig.tool.enabled) {
       traceName("LayerCache.toolRunColorMap (no cache)") {
         for {
-          (tool, toolRun) <- LayerCache.toolAndToolRun(toolRunId, user, voidCache)
-          (ast, params) <- LayerCache.toolEvalRequirements(toolRunId, subNode, user, voidCache)
+          (tool, toolRun) <- LayerCache.toolAndToolRun(toolRunId, user)
+          (ast, params) <- LayerCache.toolEvalRequirements(toolRunId, subNode, user)
           nodeId <- OptionT.pure[Future, UUID](subNode.getOrElse(ast.id))
           metadata <- OptionT.fromOption[Future](params.metadata.get(nodeId))
-          cRamp <- OptionT.fromOption[Future](metadata.colorRamp).orElse(OptionT.pure[Future, ColorRamp](geotrellis.raster.render.ColorRamps.Viridis))
-          cmap <- OptionT.fromOption[Future](metadata.classMap.map(_.toColorMap)).orElse({
-            for {
-              breaks <- OptionT.fromOption[Future](metadata.breaks)
-            } yield cRamp.toColorMap(breaks)
-          }).orElse({
-            for {
-              hist <- OptionT.fromOption[Future](metadata.histogram).orElse(LayerCache.modelLayerGlobalHistogram(toolRunId, subNode, user, voidCache))
-            } yield cRamp.toColorMap(hist)
-          })
+          cRamp <- OptionT.fromOption[Future](metadata.colorRamp)
+                     .orElse(OptionT.pure[Future, ColorRamp](geotrellis.raster.render.ColorRamps.Viridis))
+          cmap <- OptionT.fromOption[Future](metadata.classMap.map(_.toColorMap))
+                    .orElse({
+                      for {
+                        breaks <- OptionT.fromOption[Future](metadata.breaks)
+                      } yield cRamp.toColorMap(breaks)
+                    }).orElse({
+                      for {
+                        hist <- OptionT.fromOption[Future](metadata.histogram)
+                                  .orElse(LayerCache.modelLayerGlobalHistogram(toolRunId, subNode, user))
+                      } yield cRamp.toColorMap(hist)
+                    })
         } yield cmap
       }
     }

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -122,10 +122,10 @@ class ToolRoutes(implicit val database: Database) extends Authentication
               parameter(
                 'node.?,
                 'cramp.?("viridis")
-              ) { (node, colorRamp) =>
+              ) { (node, colorRampName) =>
                 complete {
                   val nodeId = node.map(UUID.fromString(_))
-                  val cRamp = providedRamps.get(colorRamp).getOrElse(providedRamps("viridis"))
+                  val colorRamp = providedRamps.get(colorRampName).getOrElse(providedRamps("viridis"))
                   val responsePng = for {
                     (toolRun, tool) <- LayerCache.toolAndToolRun(toolRunId, user)
                     (ast, params)   <- LayerCache.toolEvalRequirements(toolRunId, nodeId, user)
@@ -137,7 +137,7 @@ class ToolRoutes(implicit val database: Database) extends Authentication
                         case Invalid(errors) => throw InterpreterException(errors)
                       }
                     })
-                    cMap            <- LayerCache.toolRunColorMap(toolRunId, nodeId, user, cRamp)
+                    cMap            <- LayerCache.toolRunColorMap(toolRunId, nodeId, user, colorRamp, colorRampName)
                   } yield {
                     logger.debug(s"Tile successfully produced at $z/$x/$y")
                     tile.renderPng(cMap)

--- a/app-backend/tool/src/main/scala/ast/ClassMap.scala
+++ b/app-backend/tool/src/main/scala/ast/ClassMap.scala
@@ -5,7 +5,6 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import spire.std.any._
 
-@JsonCodec
 case class ClassMap(
   classifications: Map[Double, Int]
 ) {
@@ -30,7 +29,6 @@ case class ClassMap(
 }
 
 object ClassMap {
-  @JsonCodec
   case class Options(
     boundaryType: ClassBoundaryType = LessThanOrEqualTo,
     ndValue: Int = NODATA,

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -6,9 +6,11 @@ import geotrellis.raster.io._
 import geotrellis.raster.histogram._
 import geotrellis.raster.render._
 import geotrellis.raster.mapalgebra.focal._
+import cats.syntax.either._
 import spray.json._
 import DefaultJsonProtocol._
 import io.circe._
+import io.circe.generic.semiauto._
 import io.circe.syntax._
 import io.circe.parser._
 
@@ -127,5 +129,18 @@ trait MapAlgebraUtilityCodecs {
       case Left(fail) => throw fail
     }
   }
+
+  val defaultClassMapDecoder: Decoder[ClassMap] = deriveDecoder[ClassMap]
+  val hexClassMapDecoder: Decoder[ClassMap] = new Decoder[ClassMap] {
+    final def apply(c: HCursor): Decoder.Result[ClassMap] = {
+      for {
+        hexes <- c.downField("classifications").as[Map[Double, String]]
+      } yield {
+        new ClassMap(hexes.mapValues(new java.math.BigInteger(_, 16).intValue()))
+      }
+    }
+  }
+  implicit val classMapDecoder: Decoder[ClassMap] = defaultClassMapDecoder or hexClassMapDecoder
+  implicit val classMapEncoder: Encoder[ClassMap] = deriveEncoder[ClassMap]
 }
 


### PR DESCRIPTION
## Overview

Color ramps were no longer being passed through to the cached function which produces color maps. This PR ensures that color ramps are used when provided. Currently supported color ramps: "viridis", "inferno", "magma", "lightYellowToOrange", "classificationBoldLandUse".

Specifying color and associated breaks can still be done, though this is accomplished via the `ToolRun` metadata field. Consider this `Tool` definition:
```json
{
        "id": "0cc2aef3-ba7d-4b7a-bccf-ca993ad7d6df",
        "args": [
            {
                "id": "7d9f3b46-12ce-49f2-9912-36badb352b9b",
                "type": "src",
                "metadata": null
            }
        ],
        "apply": "focalMean",
        "metadata": null,
        "neighborhood": {
            "type": "square",
            "extent": 1
        }
    }
```

If we want to specify an alternative color ramp to be used, we can do so in a one-off fashion by providing one of the above mentioned color ramps in the query parameter 'cramp' of our request. If, instead, we need to specify the breaks as well as their corresponding colors, metadata overrides on the `ToolRun` definition are used. For example:
```json
{
	"sources": {
		"7d9f3b46-12ce-49f2-9912-36badb352b9b": {
			"id": "eb5adbb3-113e-42ad-be2b-aa2410b4e54b",
			"band": 3,
			"type": "project",
			"celltype": "uint16ud0"
		}
	},
	"metadata": {
		"0cc2aef3-ba7d-4b7a-bccf-ca993ad7d6df": {
			"label": "test",
			"description": null,
			"histogram": null,
			"colorRamp": null,
			"classMap": {
				"classifications": {
					"5000": 0,
					"2000": 12,
					"9000": 123
				}
			},
			"breaks": null
		}
	}
}
```
Note: I've specified the node which I want to be colored according to the provided mapping.

Note also: colors are provided as integers. 0 is transparent (all its bits are 0, thus its alpha bits must be 0 too). If there's a specific color you'd like to use, it is necessary to convert from RGBA to integer (facilities which might make this conversion easier exist in `geotrellis.raster.render`: https://github.com/locationtech/geotrellis/blob/master/raster/src/main/scala/geotrellis/raster/render/package.scala).