### PR TITLE
Implement color ramps for single band projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ npm-debug.log
 \#*#
 *~
 .#*
+TAGS
 
 # Vim
 .*.swp

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -150,7 +150,7 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
           .filter(_.id === projectId)
           .map(_.manualOrder)
           .result
-      }.flatMap { p =>
+      }.flatMap { (p: Seq[Boolean]) =>
         p.headOption match {
           case Some(true) =>
             ScenesToProjects.listManualOrder(projectId, pageRequest)
@@ -215,6 +215,17 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
         .result
         .headOption
     }
+  }
+
+  /*
+   * Use to get a project if we already know the user is authorized to get it.
+   * ONLY USE ON TILE SERVER
+   * @param projectId UUID primary key of project to retrieve
+   */
+  def getProjectPreauthorized(projectId: UUID)(implicit database: DB): Future[Option[Project]] = {
+      database.db.run {
+        Projects.filter(_.id === projectId).result.headOption
+      }
   }
 
   /** Get AOI project and its AOI given a projectId and user

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/BandDataType.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/BandDataType.scala
@@ -14,7 +14,7 @@ object BandDataType {
 
   def fromString(s: String): BandDataType = s.toUpperCase match {
     case "DIVERGING" => Diverging
-    case "SEQENTIAL" => Sequential
+    case "SEQUENTIAL" => Sequential
     case "CATEGORICAL" => Categorical
   }
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorRampMosaic.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorRampMosaic.scala
@@ -1,0 +1,132 @@
+package com.azavea.rf.datamodel
+
+import com.typesafe.scalalogging.LazyLogging
+
+import geotrellis.raster._
+import geotrellis.raster.histogram._
+import geotrellis.raster.render._
+import geotrellis.raster.render.{ColorRamp, ColorMap}
+
+
+object ColorRampMosaic extends LazyLogging {
+
+  def parseColor(color: String): Int = {
+    Integer.parseUnsignedInt(
+      color.replaceFirst("#", "").replaceAll("\"", "").reverse.padTo(6, "0").reverse.padTo(8, "f").mkString,
+      16
+    )
+  }
+
+  def colorMapFromMap(
+    colorMap: Map[String, String], options: SingleBandOptions.Params, hist: Histogram[Double]
+  ) : ColorMap = {
+    val breaks = colorMap.map(
+      _ match {
+        case (colorBreak, _) =>
+          try {
+            colorBreak.toDouble
+          } catch {
+            case e : Throwable =>
+              val message = "Color Scheme keys could not be parsed to doubles"
+              logger.error(message)
+              throw new IllegalArgumentException(message).initCause(e)
+          }
+        case _ => throw new IllegalArgumentException(
+          "Color Scheme keys do not match expected structure"
+        )
+      }
+    ).toArray
+    val colors = colorMap map {
+      case (_, color: String) =>
+        try {
+          parseColor(color)
+        } catch {
+          case e : Throwable =>
+            val message = s"Color Scheme colors could not be parsed: ${color} ; ${e.getLocalizedMessage}"
+            throw new IllegalArgumentException(message)
+        }
+    }
+    val lastColor = colors.last
+    val colorRamp = ColorRamp(colors)
+    ColorMap(breaks, colorRamp)
+  }
+
+  def colorMapFromVector(
+    colors: Vector[String], options: SingleBandOptions.Params, hist: Histogram[Double]
+  ) : ColorMap = {
+    val cleanedColors = colors map { color =>
+      try {
+        parseColor(color)
+      } catch {
+        case e : Throwable =>
+          val message = s"Color in color scheme could not be parsed: $color ; ${e.getLocalizedMessage}"
+          logger.error(message)
+          throw new IllegalArgumentException(message)
+      }
+    }
+    val lastColor = cleanedColors.last
+    val colorRamp = ColorRamp(cleanedColors)
+
+    // TODO allow setting min / max through options
+    // this would also include optionally masking values outside the specified range
+    val (min, max) = hist.minMaxValues match {
+      case Some((min, max)) =>
+        (min, max)
+      case _ =>
+        val message = "Unable to get histogram min / max"
+        logger.error(message)
+        throw new IllegalArgumentException(message)
+    }
+
+    val steps = options.blendMode match {
+      case BlendMode.Continuous =>
+        255
+      case _ =>
+        if (colors.length < 255) {
+          colors.length
+        } else {
+          255
+        }
+    }
+
+    val step = (max - min) / steps
+    val breaks = for (j <- 0 until steps  ) yield (min + j * step)
+
+    // as an optimization, we could cache the color maps, but I'm not sure it's worth it
+    ColorMap(breaks.toArray, colorRamp.stops(steps)).withFallbackColor(lastColor)
+  }
+
+  def apply(tiles: List[(MultibandTile, Array[Histogram[Double]])], options: SingleBandOptions.Params)
+      : Option[MultibandTile] = {
+    val band: Int = options.band
+    val singleBandTiles = tiles map {
+      case (tile: MultibandTile, _) =>
+        tile.band(band)
+    }
+
+    if (singleBandTiles.isEmpty) {
+      None
+    } else {
+      val hist: Histogram[Double] = tiles.map{
+        case (_, histograms: Array[Histogram[Double]]) =>
+          histograms.head
+      }.reduce(_ merge _)
+      val cmap = (options.colorScheme.asArray, options.colorScheme.asObject) match {
+        case (Some(a), None) =>
+          colorMapFromVector(a.map(e => e.noSpaces), options, hist)
+        case (None, Some(o)) =>
+          colorMapFromMap(o.toMap map { case (k, v) => (k, v.noSpaces)}, options, hist)
+        case _ =>
+          val message = "Invalid color scheme format. Color schemes must be defined as an array of hex colors or a mapping of raster values to hex colors."
+          logger.error(message)
+          throw new IllegalArgumentException(message)
+      }
+      val tile = cmap.render(singleBandTiles.reduce(_ merge _))
+      val r = tile.map(_.red).interpretAs(UByteCellType)
+      val g = tile.map(_.green).interpretAs(UByteCellType)
+      val b = tile.map(_.blue).interpretAs(UByteCellType)
+      val a = tile.map(_.alpha).interpretAs(UByteCellType)
+      Some(MultibandTile(r, g, b, a))
+    }
+  }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SingleBandOptions.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SingleBandOptions.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.datamodel
 import com.azavea.rf.datamodel.color._
 
 import io.circe.generic.JsonCodec
+import io.circe.Json
 import geotrellis.raster._
 import geotrellis.raster.equalization.HistogramEqualization
 import geotrellis.raster.histogram.Histogram
@@ -16,7 +17,7 @@ object SingleBandOptions {
     band: Int,
     dataType: BandDataType,
     blendMode: BlendMode,
-    colorScheme: Map[Int, String],
+    colorScheme: Json,
     legendOrientation: String
   )
 }

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -61,7 +61,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     )
   }
 
-  def layerHistogram(layerId: UUID, zoom: Int)(implicit projectLayerIds: Set[UUID]): OptionT[Future, Array[Histogram[Double]]] = {
+  def layerHistogram(layerId: UUID, zoom: Int): OptionT[Future, Array[Histogram[Double]]] = {
     val key = s"layer-histogram-${layerId}-${zoom}"
     rfCache.cachingOptionT(key, doCache = cacheConfig.layerAttributes.enabled)(
       OptionT(

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -61,7 +61,8 @@ object GlobalSummary extends LazyLogging {
     projId: UUID,
     size: Int = 512
   )(implicit database: Database, ec: ExecutionContext, sceneIds: Set[UUID]): OptionT[Future, (Extent, Int)] =
-    Mosaic.mosaicDefinition(projId).semiflatMap({ mosaic =>
+    // TODO this should be updated to handle both multi band and single band mosaics
+    MultiBandMosaic.mosaicDefinition(projId).semiflatMap({ mosaic =>
       Future.sequence(mosaic.map { case MosaicDefinition(sceneId, _) =>
         Future {
           minAcceptableSceneZoom(sceneId, store, 256)

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -2,319 +2,76 @@ package com.azavea.rf.tile.image
 
 import com.azavea.rf.tile._
 import com.azavea.rf.database.Database
-import com.azavea.rf.database.tables.ScenesToProjects
-import com.azavea.rf.datamodel.{MosaicDefinition, WhiteBalance}
-import com.azavea.rf.common.cache.CacheClient
+import com.azavea.rf.database.tables.Projects
+import com.azavea.rf.datamodel.Project
 import geotrellis.raster._
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.raster.GridBounds
-import geotrellis.proj4._
+import geotrellis.raster.render.Png
 import geotrellis.slick.Projected
-import geotrellis.vector.{Extent, Point, Polygon}
+import geotrellis.vector.Polygon
 import cats.data._
 import cats.implicits._
 import java.util.UUID
 
-import com.azavea.rf.common.utils.TileUtils
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
 
 import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import geotrellis.spark.io.postgres.PostgresAttributeStore
-import com.azavea.rf.tile.AkkaSystem
 import com.typesafe.scalalogging.LazyLogging
 
 case class TagWithTTL(tag: String, ttl: Duration)
 
 object Mosaic extends LazyLogging with KamonTrace {
-  lazy val memcachedClient = LayerCache.memcachedClient
   implicit val database = Database.DEFAULT
-  val system = AkkaSystem.system
-  implicit val blockingDispatcher =
-    system.dispatchers.lookup("blocking-dispatcher")
 
-  val store = PostgresAttributeStore()
-  val rfCache = new CacheClient(memcachedClient)
-
-  def tileLayerMetadata(id: UUID, zoom: Int)(implicit database: Database,
-    sceneIds: Set[UUID]): OptionT[Future, (Int, TileLayerMetadata[SpatialKey])] = {
-
-    logger.debug(s"Requesting tile layer metadata (layer: $id, zoom: $zoom")
-    LayerCache.maxZoomForLayer(id).mapFilter {
-      case (pyramidMaxZoom) =>
-        val layerName = id.toString
-        for (maxZoom <- pyramidMaxZoom.get(layerName)) yield {
-          val z = if (zoom > maxZoom) maxZoom else zoom
-          blocking {
-            z -> store.readMetadata[TileLayerMetadata[SpatialKey]](LayerId(layerName, z))
-          }
-        }
-    }
-  }
-
-  def mosaicDefinition(projectId: UUID, polygonOption: Option[Projected[Polygon]])(
-    implicit database: Database): OptionT[Future, Seq[MosaicDefinition]] = {
-
-    logger.debug(s"Reading mosaic definition (project: $projectId")
-    OptionT(timedFuture("get-mosaic-definition")(ScenesToProjects.getMosaicDefinition(projectId, polygonOption)))
-  }
-
-  def mosaicDefinition(projectId: UUID)(
-    implicit database: Database): OptionT[Future, Seq[MosaicDefinition]] = {
-    mosaicDefinition(projectId, None)
-  }
-
-  /** Fetch the tile for given resolution. If it is not present, use a tile from a lower zoom level */
-  def fetch(id: UUID, zoom: Int, col: Int, row: Int)(
-      implicit database: Database,
-      sceneIds: Set[UUID]): OptionT[Future, MultibandTile] = {
-    tileLayerMetadata(id, zoom).flatMap {
-      case (sourceZoom, tlm) =>
-        val zoomDiff = zoom - sourceZoom
-        logger.debug(s"Requesting layer tile (layer: $id, zoom: $zoom, col: $col, row: $row, sourceZoom: $sourceZoom)")
-        val resolutionDiff = 1 << zoomDiff
-        val sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
-        if (tlm.bounds.includes(sourceKey)) {
-          LayerCache.layerTile(id, sourceZoom, sourceKey).map { tile =>
-            val innerCol = col % resolutionDiff
-            val innerRow = row % resolutionDiff
-            val cols = tile.cols / resolutionDiff
-            val rows = tile.rows / resolutionDiff
-            tile.crop(
-              GridBounds(
-                colMin = innerCol * cols,
-                rowMin = innerRow * rows,
-                colMax = (innerCol + 1) * cols - 1,
-                rowMax = (innerRow + 1) * rows - 1
-              )
-            ).resample(256, 256)
-          }
-        } else {
-          OptionT.none[Future, MultibandTile]
-        }
-    }
-  }
-
-  /** Fetch the tile for the given zoom level and bbox
-    * If no bbox is specified, it will use the project tileLayerMetadata layoutExtent
-    */
-  def fetchRenderedExtent(id: UUID, zoom: Int,  bbox: Option[Projected[Polygon]])(
-    implicit database: Database, sceneIds: Set[UUID]): OptionT[Future, MultibandTile] =
-    tileLayerMetadata(id, zoom).flatMap {
-      case (sourceZoom, tlm) =>
-        val extent: Extent =
-          bbox
-            .map {
-              case Projected(poly, srid) =>
-                poly.envelope.reproject(CRS.fromEpsgCode(srid), tlm.crs)
-            }
-            .getOrElse(tlm.layoutExtent)
-
-        LayerCache.layerTileForExtent(id, sourceZoom, extent)
-    }
-
-  /** Fetch all bands of a [[MultibandTile]] for the given extent and return them without assuming anything of their semantics */
-  def rawForExtent(projectId: UUID,
-                   zoom: Int,
-                   bbox: Option[Projected[Polygon]])(
-      implicit database: Database): OptionT[Future, MultibandTile] =
-    mosaicDefinition(projectId).flatMap { mosaic =>
-      implicit val sceneIds = mosaic.map {
-        case MosaicDefinition(sceneId, _) => sceneId
-      }.toSet
-
-      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
-        for (MosaicDefinition(sceneId, _) <- mosaic)
-          yield Mosaic.fetchRenderedExtent(sceneId, zoom, bbox)
-
-      val futureMergeTile: Future[Option[MultibandTile]] =
-        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
-          val tiles = maybeTiles.flatten
-          if (tiles.nonEmpty)
-            Option(tiles.reduce(_ merge _))
-          else
-            Option.empty[MultibandTile]
-        }
-
-      OptionT(futureMergeTile)
-    }
-
-  /** Fetch all bands of a [[MultibandTile]] and return them without assuming anything of their semantics */
-  def raw(projectId: UUID, zoom: Int, col: Int, row: Int)(
-    implicit database: Database): OptionT[Future, MultibandTile] =
-    mosaicDefinition(projectId).flatMap { mosaic =>
-      implicit val sceneIds = mosaic.map {
-        case MosaicDefinition(sceneId, _) => sceneId
-      }.toSet
-
-      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
-        for (MosaicDefinition(sceneId, _) <- mosaic)
-          yield Mosaic.fetch(sceneId, zoom, col, row)
-
-      val futureMergeTile: Future[Option[MultibandTile]] =
-        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
-          val tiles = maybeTiles.flatten
-          if (tiles.nonEmpty)
-            Option(tiles.reduce(_ merge _))
-          else
-            Option.empty[MultibandTile]
-        }
-
-      OptionT(futureMergeTile)
-    }
-
-  /**   Render a png from TMS pyramids given that they are in the same projection.
-    *   If a layer does not go up to requested zoom it will be up-sampled.
-    *   Layers missing color correction in the mosaic definition will be excluded.
-    *   The size of the image will depend on the selected zoom and bbox.
-    *
-    *   Note:
-    *   Currently, if the render takes too long, it will time out. Given enough requests, this
-    *   could cause us to essentially ddos ourselves, so we probably want to change
-    *   this from a simple endpoint to an airflow operation: IE the request kicks off
-    *   a render job then returns the job id
-    *
-    *   @param zoomOption  the zoom level to use
-    *   @param bboxOption the bounding box for the image
-    *   @param colorCorrect setting to determine if color correction should be applied
-    */
-  def render(projectId: UUID,
-             zoomOption: Option[Int],
-             bboxOption: Option[String],
-             colorCorrect: Boolean = true)(
-      implicit database: Database): OptionT[Future, MultibandTile] = {
-    val bboxPolygon: Option[Projected[Polygon]] =
-      try {
-        bboxOption map { bbox =>
-          Projected(Extent.fromString(bbox).toPolygon(), 4326)
-            .reproject(LatLng, WebMercator)(3857)
-        }
-      } catch {
-        case e: Exception =>
-          throw new IllegalArgumentException(
-            "Four comma separated coordinates must be given for bbox")
-            .initCause(e)
-      }
-
-    val zoom: Int = zoomOption.getOrElse(8)
-    val md = mosaicDefinition(projectId)
-    md.flatMap { mosaic =>
-      val futureTiles: Future[Seq[MultibandTile]] = {
-        implicit val sceneIds = mosaic.map {
-          case MosaicDefinition(sceneId, _) => sceneId
-        }.toSet
-
-        val tiles = mosaic.flatMap {
-          case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
-            maybeColorCorrectParams.map { colorCorrectParams =>
-              Mosaic
-                .fetchRenderedExtent(sceneId, zoom, bboxPolygon)
-                .flatMap { tile =>
-                  if (colorCorrect) {
-                    LayerCache.layerHistogram(sceneId, zoom).map { hist =>
-                      colorCorrectParams.colorCorrect(tile, hist)
-                    }
-                  } else {
-                    OptionT[Future, MultibandTile](Future(Some(tile)))
-                  }
-
-                }
-                .value
-            }.toSeq
-        }
-        Future.sequence(tiles).map(_.flatten)
-      }
-
-      val futureMergeTile =
-        for {
-          doColorCorrect <- hasColorCorrection(projectId, md)
-          tiles <- futureTiles
-        } yield colorCorrectAndMergeTiles(tiles, doColorCorrect)
-
-      OptionT(futureMergeTile)
-    }
-  }
-
-  /** Mosaic tiles from TMS pyramids given that they are in the same projection.
-    *   If a layer does not go up to requested zoom it will be up-sampled.
-    *   Layers missing color correction in the mosaic definition will be excluded.
-    */
   def apply(
       projectId: UUID,
       zoom: Int,
       col: Int,
       row: Int
-  )(
-      implicit database: Database
-  ): OptionT[Future, MultibandTile] = traceName(s"Mosaic.apply($projectId)") {
-    logger.debug(s"Creating mosaic (project: $projectId, zoom: $zoom, col: $col, row: $row)")
-    val polygonBbox = TileUtils.getTileBounds(zoom, col, row)
-    val md = mosaicDefinition(projectId, Option(polygonBbox))
-    md.flatMap { mosaic =>
-      val futureTiles: Future[Seq[MultibandTile]] = {
-        implicit val sceneIds = mosaic.map {
-          case MosaicDefinition(sceneId, _) => sceneId
-        }.toSet
-
-        val tiles = mosaic.flatMap { case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
-          maybeColorCorrectParams.map { colorCorrectParams =>
-            logger.debug(s"Getting Tile (project: $projectId, scene: $sceneId, col: $col, row: $row, zoom: $zoom)")
-            val tile = rfCache.cachingOptionT(s"tile-${sceneId}-${zoom}-${col}-${row}")(
-              Mosaic.fetch(sceneId, zoom, col, row)
-            )
-            val layerHistogram = LayerCache.layerHistogram(sceneId, zoom)
-            tile.flatMap { tile =>
-              layerHistogram.map { hist =>
-                colorCorrectParams.colorCorrect(tile, hist)
-              }
-            }.value
-          }
-        }
-        Future.sequence(tiles).map(_.flatten)
+  )(implicit database: Database)
+      : OptionT[Future, MultibandTile] = traceName(s"Mosaic.apply($projectId)") {
+    OptionT(Projects.getProjectPreauthorized(projectId)) flatMap { project =>
+      project.isSingleBand match {
+        case true =>
+          SingleBandMosaic(project, zoom, col, row)
+        case false =>
+          MultiBandMosaic(projectId, zoom, col, row)
       }
-
-      val futureMergeTile = timedFuture("color-correct-merge-tiles")(
-        for {
-          doColorCorrect <- hasColorCorrection(projectId, md)
-          tiles <- futureTiles
-        } yield colorCorrectAndMergeTiles(tiles, doColorCorrect)
-      )
-      OptionT(futureMergeTile)
     }
   }
 
-  /** Check to see if a project has color correction; if this isn't specified, default to false */
-  def hasColorCorrection(projectId: UUID,
-                         md: OptionT[Future, Seq[MosaicDefinition]])(
-      implicit database: Database) =
-    md.map { mosaic =>
-        mosaic
-          .flatMap {
-            case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
-              maybeColorCorrectParams.map(_.autoBalance.enabled)
-          }
-          .forall(identity)
+  def render(
+    projectId: UUID,
+    zoomOption: Option[Int],
+    bboxOption: Option[String],
+    colorCorrect: Boolean
+  )(implicit database: Database): OptionT[Future, MultibandTile] = {
+    OptionT(Projects.getProjectPreauthorized(projectId)) flatMap { project =>
+      project.isSingleBand match {
+        case true =>
+          /* TODO: handle single band mosaics*/
+          SingleBandMosaic.render(project, zoomOption, bboxOption, colorCorrect)
+        case false =>
+          MultiBandMosaic.render(projectId, zoomOption, bboxOption, colorCorrect)
       }
-      .value
-      .map {
-        case Some(true) => true
-        case _ => false
-      }
-
-  /** Merge tiles together, optionally color correcting */
-  def colorCorrectAndMergeTiles(
-      tiles: Seq[MultibandTile],
-      doColorCorrect: Boolean): Option[MultibandTile] =
-    traceName("Mosaic.colorCorrectAndMergeTiles") {
-      val newTiles =
-        if (doColorCorrect)
-          WhiteBalance(tiles.toList)
-        else
-          tiles
-
-      if (newTiles.isEmpty)
-        None
-      else
-        Some(newTiles.reduce(_ merge _))
     }
+  }
+
+  def raw(
+    projectId: UUID,
+    zoom: Int,
+    col: Int,
+    row: Int
+  )(implicit database: Database): OptionT[Future, MultibandTile] = {
+    MultiBandMosaic.raw(projectId, zoom, col, row)
+  }
+
+  def rawForExtent(
+    projectId: UUID,
+    zoom: Int,
+    bbox: Option[Projected[Polygon]]
+  )(implicit database: Database) : OptionT[Future, MultibandTile] = {
+    MultiBandMosaic.rawForExtent(projectId, zoom, bbox)
+  }
 }

--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -1,0 +1,319 @@
+package com.azavea.rf.tile.image
+
+import com.azavea.rf.tile._
+import com.azavea.rf.database.Database
+import com.azavea.rf.database.tables.ScenesToProjects
+import com.azavea.rf.datamodel.{MosaicDefinition, WhiteBalance}
+import com.azavea.rf.common.cache.CacheClient
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff.MultibandGeoTiff
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.raster.GridBounds
+import geotrellis.proj4._
+import geotrellis.slick.Projected
+import geotrellis.vector.{Extent, Point, Polygon}
+import cats.data._
+import cats.implicits._
+import java.util.UUID
+
+import com.azavea.rf.common.utils.TileUtils
+
+import scala.concurrent._
+import scala.concurrent.duration._
+import geotrellis.spark.io.postgres.PostgresAttributeStore
+import com.azavea.rf.tile.AkkaSystem
+import com.typesafe.scalalogging.LazyLogging
+
+object MultiBandMosaic extends LazyLogging with KamonTrace {
+  lazy val memcachedClient = LayerCache.memcachedClient
+  implicit val database = Database.DEFAULT
+  val system = AkkaSystem.system
+  implicit val blockingDispatcher =
+    system.dispatchers.lookup("blocking-dispatcher")
+
+  val store = PostgresAttributeStore()
+  val rfCache = new CacheClient(memcachedClient)
+
+  def tileLayerMetadata(id: UUID, zoom: Int)(implicit database: Database,
+    sceneIds: Set[UUID]): OptionT[Future, (Int, TileLayerMetadata[SpatialKey])] = {
+
+    logger.debug(s"Requesting tile layer metadata (layer: $id, zoom: $zoom")
+    LayerCache.maxZoomForLayer(id).mapFilter {
+      case (pyramidMaxZoom) =>
+        val layerName = id.toString
+        for (maxZoom <- pyramidMaxZoom.get(layerName)) yield {
+          val z = if (zoom > maxZoom) maxZoom else zoom
+          blocking {
+            z -> store.readMetadata[TileLayerMetadata[SpatialKey]](LayerId(layerName, z))
+          }
+        }
+    }
+  }
+
+  def mosaicDefinition(projectId: UUID, polygonOption: Option[Projected[Polygon]])(
+    implicit database: Database): OptionT[Future, Seq[MosaicDefinition]] = {
+
+    logger.debug(s"Reading mosaic definition (project: $projectId")
+    OptionT(timedFuture("get-mosaic-definition")(ScenesToProjects.getMosaicDefinition(projectId, polygonOption)))
+  }
+
+  def mosaicDefinition(projectId: UUID)(
+    implicit database: Database): OptionT[Future, Seq[MosaicDefinition]] = {
+    mosaicDefinition(projectId, None)
+  }
+
+  /** Fetch the tile for given resolution. If it is not present, use a tile from a lower zoom level */
+  def fetch(id: UUID, zoom: Int, col: Int, row: Int)(
+      implicit database: Database,
+      sceneIds: Set[UUID]): OptionT[Future, MultibandTile] = {
+    tileLayerMetadata(id, zoom).flatMap {
+      case (sourceZoom, tlm) =>
+        val zoomDiff = zoom - sourceZoom
+        logger.debug(s"Requesting layer tile (layer: $id, zoom: $zoom, col: $col, row: $row, sourceZoom: $sourceZoom)")
+        val resolutionDiff = 1 << zoomDiff
+        val sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
+        if (tlm.bounds.includes(sourceKey)) {
+          LayerCache.layerTile(id, sourceZoom, sourceKey).map { tile =>
+            val innerCol = col % resolutionDiff
+            val innerRow = row % resolutionDiff
+            val cols = tile.cols / resolutionDiff
+            val rows = tile.rows / resolutionDiff
+            tile.crop(
+              GridBounds(
+                colMin = innerCol * cols,
+                rowMin = innerRow * rows,
+                colMax = (innerCol + 1) * cols - 1,
+                rowMax = (innerRow + 1) * rows - 1
+              )
+            ).resample(256, 256)
+          }
+        } else {
+          OptionT.none[Future, MultibandTile]
+        }
+    }
+  }
+
+  /** Fetch the tile for the given zoom level and bbox
+    * If no bbox is specified, it will use the project tileLayerMetadata layoutExtent
+    */
+  def fetchRenderedExtent(id: UUID, zoom: Int,  bbox: Option[Projected[Polygon]])(
+    implicit database: Database, sceneIds: Set[UUID]): OptionT[Future, MultibandTile] =
+    tileLayerMetadata(id, zoom).flatMap {
+      case (sourceZoom, tlm) =>
+        val extent: Extent =
+          bbox
+            .map {
+              case Projected(poly, srid) =>
+                poly.envelope.reproject(CRS.fromEpsgCode(srid), tlm.crs)
+            }
+            .getOrElse(tlm.layoutExtent)
+
+        LayerCache.layerTileForExtent(id, sourceZoom, extent)
+    }
+
+  /** Fetch all bands of a [[MultibandTile]] for the given extent and return them without assuming anything of their semantics */
+  def rawForExtent(projectId: UUID,
+                   zoom: Int,
+                   bbox: Option[Projected[Polygon]])(
+    implicit database: Database): OptionT[Future, MultibandTile] =
+    mosaicDefinition(projectId).flatMap { mosaic =>
+      implicit val sceneIds = mosaic.map {
+        case MosaicDefinition(sceneId, _) => sceneId
+      }.toSet
+
+      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
+        for (MosaicDefinition(sceneId, _) <- mosaic)
+          yield MultiBandMosaic.fetchRenderedExtent(sceneId, zoom, bbox)
+
+      val futureMergeTile: Future[Option[MultibandTile]] =
+        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
+          val tiles = maybeTiles.flatten
+          if (tiles.nonEmpty)
+            Option(tiles.reduce(_ merge _))
+          else
+            Option.empty[MultibandTile]
+        }
+
+      OptionT(futureMergeTile)
+    }
+
+  /** Fetch all bands of a [[MultibandTile]] and return them without assuming anything of their semantics */
+  def raw(projectId: UUID, zoom: Int, col: Int, row: Int)(
+    implicit database: Database): OptionT[Future, MultibandTile] =
+    mosaicDefinition(projectId).flatMap { mosaic =>
+      implicit val sceneIds = mosaic.map {
+        case MosaicDefinition(sceneId, _) => sceneId
+      }.toSet
+
+      val mayhapTiles: Seq[OptionT[Future, MultibandTile]] =
+        for (MosaicDefinition(sceneId, _) <- mosaic)
+          yield MultiBandMosaic.fetch(sceneId, zoom, col, row)
+
+      val futureMergeTile: Future[Option[MultibandTile]] =
+        Future.sequence(mayhapTiles.map(_.value)).map { maybeTiles =>
+          val tiles = maybeTiles.flatten
+          if (tiles.nonEmpty)
+            Option(tiles.reduce(_ merge _))
+          else
+            Option.empty[MultibandTile]
+        }
+
+      OptionT(futureMergeTile)
+    }
+
+  /**   Render a multiband tile from TMS pyramids given that they are in the same projection.
+    *   If a layer does not go up to requested zoom it will be up-sampled.
+    *   Layers missing color correction in the mosaic definition will be excluded.
+    *   The size of the image will depend on the selected zoom and bbox.
+    *
+    *   Note:
+    *   Currently, if the render takes too long, it will time out. Given enough requests, this
+    *   could cause us to essentially ddos ourselves, so we probably want to change
+    *   this from a simple endpoint to an airflow operation: IE the request kicks off
+    *   a render job then returns the job id
+    *
+    *   @param zoomOption  the zoom level to use
+    *   @param bboxOption the bounding box for the image
+    *   @param colorCorrect setting to determine if color correction should be applied
+    */
+  def render(projectId: UUID,
+             zoomOption: Option[Int],
+             bboxOption: Option[String],
+             colorCorrect: Boolean = true)(
+      implicit database: Database): OptionT[Future, MultibandTile] = {
+    val bboxPolygon: Option[Projected[Polygon]] =
+      try {
+        bboxOption map { bbox =>
+          Projected(Extent.fromString(bbox).toPolygon(), 4326)
+            .reproject(LatLng, WebMercator)(3857)
+        }
+      } catch {
+        case e: Exception =>
+          throw new IllegalArgumentException(
+            "Four comma separated coordinates must be given for bbox")
+            .initCause(e)
+      }
+
+    val zoom: Int = zoomOption.getOrElse(8)
+    val md = mosaicDefinition(projectId)
+    md.flatMap { mosaic =>
+      val futureTiles: Future[Seq[MultibandTile]] = {
+        implicit val sceneIds = mosaic.map {
+          case MosaicDefinition(sceneId, _) => sceneId
+        }.toSet
+
+        val tiles = mosaic.flatMap {
+          case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
+            maybeColorCorrectParams.map { colorCorrectParams =>
+              MultiBandMosaic
+                .fetchRenderedExtent(sceneId, zoom, bboxPolygon)
+                .flatMap { tile =>
+                  if (colorCorrect) {
+                    LayerCache.layerHistogram(sceneId, zoom).map { hist =>
+                      colorCorrectParams.colorCorrect(tile, hist)
+                    }
+                  } else {
+                    OptionT[Future, MultibandTile](Future(Some(tile)))
+                  }
+
+                }
+                .value
+            }.toSeq
+        }
+        Future.sequence(tiles).map(_.flatten)
+      }
+
+      val futureMergeTile =
+        for {
+          doColorCorrect <- hasColorCorrection(projectId, md)
+          tiles <- futureTiles
+        } yield colorCorrectAndMergeTiles(tiles, doColorCorrect)
+
+      OptionT(futureMergeTile)
+    }
+  }
+
+  /** MultiBandMosaic tiles from TMS pyramids given that they are in the same projection.
+    *   If a layer does not go up to requested zoom it will be up-sampled.
+    *   Layers missing color correction in the mosaic definition will be excluded.
+    */
+  def apply(
+      projectId: UUID,
+      zoom: Int,
+      col: Int,
+      row: Int
+  )(
+      implicit database: Database
+  ): OptionT[Future, MultibandTile] = traceName(s"MultiBandMosaic.apply($projectId)") {
+    logger.debug(s"Creating mosaic (project: $projectId, zoom: $zoom, col: $col, row: $row)")
+    val polygonBbox: Projected[Polygon] = TileUtils.getTileBounds(zoom, col, row)
+    val md: OptionT[Future, Seq[MosaicDefinition]] = mosaicDefinition(projectId, Option(polygonBbox))
+    md.flatMap { (mosaic: Seq[MosaicDefinition]) =>
+      val futureTiles: Future[Seq[MultibandTile]] = {
+        implicit val sceneIds = mosaic.map {
+          case MosaicDefinition(sceneId, _) => sceneId
+        }.toSet
+
+        val tiles = mosaic.flatMap { case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
+          maybeColorCorrectParams.map { colorCorrectParams =>
+            logger.debug(s"Getting Tile (project: $projectId, scene: $sceneId, col: $col, row: $row, zoom: $zoom)")
+            val tile = rfCache.cachingOptionT(s"tile-${sceneId}-${zoom}-${col}-${row}")(
+              MultiBandMosaic.fetch(sceneId, zoom, col, row)
+            )
+            val layerHistogram = LayerCache.layerHistogram(sceneId, zoom)
+            tile.flatMap { tile =>
+              layerHistogram.map { hist =>
+                colorCorrectParams.colorCorrect(tile, hist)
+              }
+            }.value
+          }
+        }
+        Future.sequence(tiles).map(_.flatten)
+      }
+
+      val futureMergeTile = timedFuture("color-correct-merge-tiles")(
+        for {
+          doColorCorrect <- hasColorCorrection(projectId, md)
+          tiles <- futureTiles
+        } yield colorCorrectAndMergeTiles(tiles, doColorCorrect)
+      )
+      OptionT(futureMergeTile)
+    }
+  }
+
+  /** Check to see if a project has color correction; if this isn't specified, default to false */
+  def hasColorCorrection(projectId: UUID,
+                         md: OptionT[Future, Seq[MosaicDefinition]])(
+      implicit database: Database) =
+    md.map { mosaic =>
+        mosaic
+          .flatMap {
+            case MosaicDefinition(sceneId, maybeColorCorrectParams) =>
+              maybeColorCorrectParams.map(_.autoBalance.enabled)
+          }
+          .forall(identity)
+      }
+      .value
+      .map {
+        case Some(true) => true
+        case _ => false
+      }
+
+  /** Merge tiles together, optionally color correcting */
+  def colorCorrectAndMergeTiles(
+      tiles: Seq[MultibandTile],
+      doColorCorrect: Boolean): Option[MultibandTile] =
+    traceName("MultiBandMosaic.colorCorrectAndMergeTiles") {
+      val newTiles =
+        if (doColorCorrect)
+          WhiteBalance(tiles.toList)
+        else
+          tiles
+
+      if (newTiles.isEmpty)
+        None
+      else
+        Some(newTiles.reduce(_ merge _))
+    }
+}

--- a/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
@@ -1,0 +1,205 @@
+package com.azavea.rf.tile.image
+
+import scala.concurrent._
+import java.util.UUID
+import com.typesafe.scalalogging.LazyLogging
+import cats.data._
+import cats.implicits._
+
+import com.azavea.rf.common.utils.TileUtils
+import com.azavea.rf.common.cache.CacheClient
+import com.azavea.rf.database.Database
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
+import com.azavea.rf.database.tables.ScenesToProjects
+import com.azavea.rf.datamodel.{Project, SingleBandOptions, ColorRampMosaic}
+import com.azavea.rf.tile._
+
+import geotrellis.proj4._
+import geotrellis.raster._
+import geotrellis.raster.GridBounds
+import geotrellis.raster.histogram._
+import geotrellis.slick.Projected
+import geotrellis.spark._
+import geotrellis.spark.io._
+import geotrellis.spark.io.postgres.PostgresAttributeStore
+import geotrellis.vector.{Extent, Polygon}
+
+
+object SingleBandMosaic extends LazyLogging with KamonTrace {
+  lazy val memcachedClient = LayerCache.memcachedClient
+  implicit val database = Database.DEFAULT
+
+  val system = AkkaSystem.system
+  implicit val blockingDispatcher =
+    system.dispatchers.lookup("blocking-dispatcher")
+
+  val store = PostgresAttributeStore()
+  val rfCache = new CacheClient(memcachedClient)
+
+  def tileLayerMetadata(id: UUID, zoom: Int)(
+    implicit database: Database, sceneIds: Set[UUID]
+  ): OptionT[Future, (Int, TileLayerMetadata[SpatialKey])] = {
+    logger.debug(s"Requesting tile layer metadata (layer: $id, zoom: $zoom")
+    LayerCache.maxZoomForLayer(id).mapFilter {
+      case (pyramidMaxZoom) =>
+        val layerName = id.toString
+        for (maxZoom <- pyramidMaxZoom.get(layerName)) yield {
+          val z = if (zoom > maxZoom) maxZoom else zoom
+          blocking {
+            z -> store.readMetadata[TileLayerMetadata[SpatialKey]](LayerId(layerName, z))
+          }
+        }
+    }
+  }
+
+  /** MultiBandMosaic tiles from TMS pyramids given that they are in the same projection.
+    *   If a layer does not go up to requested zoom it will be up-sampled.
+    *   Layers missing color correction in the mosaic definition will be excluded.
+    */
+  def apply(
+    project: Project, zoom: Int, col: Int, row: Int
+  )(implicit database: Database): OptionT[Future, MultibandTile] =
+    traceName(s"SingleBandMosaic.apply(${project.id})") {
+      logger.debug(s"Creating single band mosaic (project: ${project.id}, zoom: $zoom, col: $col, row: $row)")
+
+      val polygonBbox: Projected[Polygon] = TileUtils.getTileBounds(zoom, col, row)
+      project.singleBandOptions match {
+        case Some(singleBandOptions: SingleBandOptions.Params) =>
+          val futureTiles: Future[Seq[(MultibandTile, Array[Histogram[Double]])]] = database.db.run {
+            ScenesToProjects.filter(_.projectId === project.id).map(_.sceneId).result
+          } flatMap {
+            sceneIds => {
+              Future.sequence(
+                sceneIds map { sceneId =>
+                  SingleBandMosaic
+                    .fetch(sceneId, zoom, col, row)(database, sceneIds.toSet)
+                    .value
+                    .zip(LayerCache.layerHistogram(sceneId, zoom).value)
+                    .map ({ case (tile, histogram) => for (a <- tile; b <- histogram) yield (a, b) })
+                }
+              ).map(_.flatten)
+            }
+          }
+          val futureColoredTile =
+            for {
+              tiles: Seq[(MultibandTile, Array[Histogram[Double]])] <- futureTiles
+            } yield ColorRampMosaic(tiles.toList, singleBandOptions)
+          OptionT(futureColoredTile)
+        case _ =>
+          val message = "No valid single band render options found"
+          logger.error(message)
+          throw new IllegalArgumentException(message)
+      }
+    }
+
+  def render(
+    project: Project, zoomOption: Option[Int], bboxOption: Option[String], colorCorrect: Boolean
+  )(implicit database: Database): OptionT[Future, MultibandTile] =
+    traceName(s"SingleBandMosaic.render(${project.id})") {
+    val bboxPolygon: Option[Projected[Polygon]] =
+      try {
+        bboxOption map { bbox =>
+          Projected(Extent.fromString(bbox).toPolygon(), 4326)
+            .reproject(LatLng, WebMercator)(3857)
+        }
+      } catch {
+        case e: Exception =>
+          val message = "Four comma separated coordinates must be given for bbox"
+          logger.error(message)
+          throw new IllegalArgumentException(message).initCause(e)
+      }
+    val zoom: Int = zoomOption.getOrElse(8)
+    project.singleBandOptions match {
+      case Some(singleBandOptions: SingleBandOptions.Params) =>
+        val futureTiles: Future[Seq[(MultibandTile, Array[Histogram[Double]])]] =
+          database.db.run {
+            ScenesToProjects.filter(_.projectId === project.id).map(_.sceneId).result
+          } flatMap { sceneIds: Seq[UUID] =>
+          Future.sequence(
+              sceneIds map { sceneId: UUID =>
+                SingleBandMosaic.fetchRenderedExtent(sceneId, zoom, bboxPolygon)(database, sceneIds.toSet).value
+              }
+          ).map(_.flatten)
+        }
+        colorCorrect match {
+          case true =>
+            val futureColoredRender = for {
+              tiles <- futureTiles
+            } yield ColorRampMosaic(tiles.toList, singleBandOptions)
+            OptionT(futureColoredRender)
+          case false =>
+            def processTiles(tiles: Seq[MultibandTile]): Option[MultibandTile] = {
+              val singleBandTiles = tiles.map(_.band(singleBandOptions.band))
+              singleBandTiles.isEmpty match {
+                case true =>
+                  None
+                case _ =>
+                  Some(MultibandTile(singleBandTiles.reduce(_ merge _)))
+              }
+            }
+
+            val futureColoredRender = for {
+              tiles: Seq[(MultibandTile, Array[Histogram[Double]])] <- futureTiles
+            } yield processTiles(tiles.map(_._1))
+            OptionT(futureColoredRender)
+        }
+      case None =>
+        val message = "No valid single band render options found"
+        logger.error(message)
+        throw new IllegalArgumentException(message)
+    }
+  }
+
+  /** Fetch the tile for given resolution. If it is not present, use a tile from a lower zoom level */
+  def fetch(id: UUID, zoom: Int, col: Int, row: Int)(
+      implicit database: Database,
+      sceneIds: Set[UUID]
+  ): OptionT[Future, MultibandTile] = {
+    tileLayerMetadata(id, zoom).flatMap {
+      case (sourceZoom, tlm) =>
+        val zoomDiff = zoom - sourceZoom
+        logger.debug(s"Requesting layer tile (layer: $id, zoom: $zoom, col: $col, row: $row, sourceZoom: $sourceZoom)")
+        val resolutionDiff = 1 << zoomDiff
+        val sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
+        if (tlm.bounds.includes(sourceKey)) {
+          val tile = LayerCache.layerTile(id, sourceZoom, sourceKey).map { tile =>
+            val innerCol = col % resolutionDiff
+            val innerRow = row % resolutionDiff
+            val cols = tile.cols / resolutionDiff
+            val rows = tile.rows / resolutionDiff
+            tile.crop(
+              GridBounds(
+                colMin = innerCol * cols,
+                rowMin = innerRow * rows,
+                colMax = (innerCol + 1) * cols - 1,
+                rowMax = (innerRow + 1) * rows - 1
+              )
+            ).resample(256, 256)
+          }
+          tile
+
+        } else {
+          OptionT.none[Future, MultibandTile]
+        }
+    }
+  }
+
+  def fetchRenderedExtent(id: UUID, zoom: Int,  bbox: Option[Projected[Polygon]])(
+    implicit database: Database, sceneIds: Set[UUID])
+      : OptionT[Future, (MultibandTile, Array[Histogram[Double]])] =
+    tileLayerMetadata(id, zoom).flatMap {
+      case (sourceZoom, tlm) =>
+        val extent: Extent =
+          bbox
+            .map {
+              case Projected(poly, srid) =>
+                poly.envelope.reproject(CRS.fromEpsgCode(srid), tlm.crs)
+            }.getOrElse(tlm.layoutExtent)
+        val hist = LayerCache.layerHistogram(id, sourceZoom)
+        val tile = LayerCache.layerTileForExtent(id, sourceZoom, extent)
+        for {
+          t <- tile
+          h <- hist
+        } yield (t, h)
+    }
+}

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -60,7 +60,6 @@
     "ng-rollbar": "^1.9.2",
     "nvd3": "~1.8.4",
     "ob-daterangepicker": "^0.10.3",
-    "svg-pan-zoom": "ariutta/svg-pan-zoom",
     "webpack-fail-plugin": "^1.0.6"
   },
   "devDependencies": {

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -25,7 +25,6 @@ import 'angular-messages';
 import 'angular-aria';
 import 'angular-resource';
 import 'leaflet';
-import 'svg-pan-zoom';
 import 'jointjs';
 import 'angular-load';
 import 'ng-rollbar';

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -6563,10 +6563,6 @@ supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-svg-pan-zoom@ariutta/svg-pan-zoom:
-  version "3.4.1"
-  resolved "https://codeload.github.com/ariutta/svg-pan-zoom/tar.gz/3b799ecc93ac1b3c4094b5455cafbe84ff025339"
-
 svgo@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.1.tgz#287320fed972cb097e72c2bb1685f96fe08f8034"


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Fix multi band mosaics~
- [x] Figure out why the `Small flight import` project has issues switching to single band then back to multiband, but new projects do not.

### Demo
![image](https://user-images.githubusercontent.com/4392704/29218238-2811cfbc-7e82-11e7-9ab2-c44f92f1e2e4.png)

## Testing Instructions

 * Make a single band project, or convert a multi band project to a single band project by setting the `isSingleBand` property and setting options through the api

Closes #2392 