### PR TITLE
Upgrade airflow to 1.8.1 and decrease boto logging verbosity

### DIFF
--- a/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
+++ b/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
@@ -20,7 +20,6 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 
 logging.getLogger('rf').addHandler(ch)
-logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
 

--- a/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
+++ b/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
@@ -30,7 +30,7 @@ default_args = {
     'start_date': datetime.datetime(2017, 4, 7)
 }
 
-DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
+DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id, exec_date')
 
 # TODO: update this schedule to something more reasonable/carefully chosen
 dag = DAG(
@@ -73,9 +73,10 @@ def kickoff_aoi_project_update_checks(**context):
     project_ids = xcom['project_ids']
     logger.info('Found projects to check for updates: %s', project_ids)
     for project_id in project_ids:
-        run_id = 'update_aoi_{}_{}'.format(project_id, datetime.datetime.now().isoformat())
+        exec_date = datetime.datetime.now()
+        run_id = 'update_aoi_{}_{}'.format(project_id, exec_date.isoformat())
         conf = json.dumps({'project_id': project_id})
-        dag_args = DagArgs(dag_id=UPDATE_DAG_ID, conf=conf, run_id=run_id)
+        dag_args = DagArgs(dag_id=UPDATE_DAG_ID, conf=conf, run_id=run_id, exec_date=exec_date)
         trigger_dag(dag_args)
 
 find_operator = PythonOperator(

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -19,7 +19,6 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 
 logging.getLogger('rf').addHandler(ch)
-logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
 

--- a/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
+++ b/app-tasks/dags/aoi-monitoring/update_aoi_projects.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 from airflow.models import DAG
-from airflow.operators import PythonOperator
+from airflow.operators.python_operator import PythonOperator
 from airflow.exceptions import AirflowException
 
 from rf.utils.exception_reporting import wrap_rollbar

--- a/app-tasks/dags/export_project.py
+++ b/app-tasks/dags/export_project.py
@@ -23,7 +23,6 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 
 logging.getLogger('rf').addHandler(ch)
-logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
 

--- a/app-tasks/dags/export_project.py
+++ b/app-tasks/dags/export_project.py
@@ -9,7 +9,7 @@ import dns.resolver
 import boto3
 
 from airflow.models import DAG
-from airflow.operators import PythonOperator
+from airflow.operators.python_operator import PythonOperator
 from airflow.exceptions import AirflowException
 from rf.utils.exception_reporting import wrap_rollbar
 

--- a/app-tasks/dags/import_landsat8_scenes.py
+++ b/app-tasks/dags/import_landsat8_scenes.py
@@ -27,7 +27,6 @@ bash_cmd = "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.M
 
 landsat8_finder = BashOperator(
     task_id='import_new_landsat8_scenes',
-    provide_context=True,
     bash_command=bash_cmd,
     on_failure_callback=failure_callback,
     dag=dag

--- a/app-tasks/dags/import_sentinel2_scenes.py
+++ b/app-tasks/dags/import_sentinel2_scenes.py
@@ -26,7 +26,6 @@ bash_cmd = "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.M
 
 sentinel2_importer = BashOperator(
     task_id='import_sentinel2',
-    provide_context=True,
     bash_command=bash_cmd,
     on_failure_callback=failure_callback,
     dag=dag

--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -28,7 +28,6 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 
 logging.getLogger('rf').addHandler(ch)
-logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
 

--- a/app-tasks/dags/process_upload.py
+++ b/app-tasks/dags/process_upload.py
@@ -24,7 +24,6 @@ ch.setLevel(logging.INFO)
 ch.setFormatter(formatter)
 
 logging.getLogger('rf').addHandler(ch)
-logging.getLogger().addHandler(ch)
 
 logger = logging.getLogger(__name__)
 

--- a/app-tasks/requirements.txt
+++ b/app-tasks/requirements.txt
@@ -1,7 +1,7 @@
 numpy==1.11.1
 boto3==1.4.4
 celery>=3.1.17,<3.1.99
-airflow[async,celery,crypto,hive,password,postgres,s3,slack]==1.7.1.3
+apache-airflow[async,celery,crypto,hive,password,postgres,s3,slack]==1.8.1
 redis==2.10.5
 pytest==2.9.2
 pytest-runner==2.9

--- a/app-tasks/rf/src/rf/__init__.py
+++ b/app-tasks/rf/src/rf/__init__.py
@@ -4,3 +4,6 @@ import logging
 from logging import NullHandler
 
 logging.getLogger(__name__).addHandler(NullHandler())
+logging.getLogger('boto3').setLevel(logging.WARNING)
+logging.getLogger('botocore').setLevel(logging.WARNING)
+logging.getLogger('nose').setLevel(logging.WARNING)

--- a/app-tasks/usr/local/airflow/plugins/rest_api.py
+++ b/app-tasks/usr/local/airflow/plugins/rest_api.py
@@ -15,7 +15,7 @@ from airflow.bin.cli import trigger_dag
 # Flask Blueprint for Triggering a Dag
 APIBlueprint = Blueprint('api', __name__, url_prefix='/api')
 
-DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id')
+DagArgs = namedtuple('DagArgs', 'dag_id, conf, run_id, exec_date')
 
 DAG = namedtuple('DAG', 'dag_id, id_field')
 DAGs = {
@@ -49,7 +49,7 @@ def trigger_dag_api(dag_id):
     run_id = 'api_trigger_{}_{}'.format(obj_id, execution_date.isoformat())
 
     conf = json.dumps(json_params)
-    dag_args = DagArgs(dag_id=dag_id, conf=conf, run_id=run_id)
+    dag_args = DagArgs(dag_id=dag_id, conf=conf, run_id=run_id, exec_date=execution_date)
     trigger_dag(dag_args)
     return jsonify(dag_id=dag_id, run_id=run_id)
 


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/5702984/29276280-12d71ef2-80dc-11e7-9e80-d0b6bb14b10f.png)

## Notes

- one big upgrade is the navigability of the UI -- in the screenshot, you can see that the UI home now shows both DAG runs _and_ task instances, which will help us diagnose faster when a DAG run gets created but tasks never get scheduled
- there's a pending deprecation warning about `provide_context=True`, but removing it breaks things :rage:

## Testing Instructions

 * rebuild your airflow containers -- `docker-compose -f docker-compose.airflow.yml build`
 * bring up your server, frontend, and airflow
 * get visibility on the airflow webserver logs -- `docker-compose -f docker-compose.airflow.yml logs -f airflow-webserver`
 * do an upload -- the airflow task should get kicked off
 * export a project -- the airflow task should get kicked off
 * check out logs
    * you shouldn't see super verbose boto logs about resetting dropped connections, etc.
    * you shouldn't see duplicate messages from the rf and root loggers
 * this whole time, the airflow webserver logs shouldn't be repeatedly warning you about pending deprecation for:
   * direct operator import
   * `provide_context` in `BashOperator`s

Closes #2374
