### PR TITLE
Set catchup to false for scheduled DAGs

### DIFF
--- a/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
+++ b/app-tasks/dags/aoi-monitoring/find_aoi_projects_to_update.py
@@ -36,7 +36,8 @@ dag = DAG(
     dag_id='find_aoi_projects_to_update',
     default_args=default_args,
     schedule_interval=datetime.timedelta(hours=6),
-    concurrency=1
+    concurrency=1,
+    catchup=False
 )
 
 #############

--- a/app-tasks/dags/import_landsat8_scenes.py
+++ b/app-tasks/dags/import_landsat8_scenes.py
@@ -20,7 +20,8 @@ dag = DAG(
     dag_id='find_landsat8_scenes',
     default_args=args,
     schedule_interval=schedule,
-    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24)),
+    catchup=False
 )
 
 bash_cmd = "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_landsat8 {{ yesterday_ds }}"

--- a/app-tasks/dags/import_sentinel2_scenes.py
+++ b/app-tasks/dags/import_sentinel2_scenes.py
@@ -19,7 +19,8 @@ dag = DAG(
     dag_id='import_sentinel2_scenes',
     default_args=args,
     schedule_interval=None,
-    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24))
+    concurrency=int(os.getenv('AIRFLOW_DAG_CONCURRENCY', 24)),
+    catchup=False
 )
 
 bash_cmd = "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_sentinel2 {{ yesterday_ds }}"


### PR DESCRIPTION
## Overview

This PR sets catchup to `False` for scheduled DAGs so we don't have to care about excessive backfills any time the database gets lit on :fire: for mysterious reasons.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * `./scripts/server --with-airflow`
 * Go to the webserver and turn `find_aoi_projects_to_update` on
 * Go to DAG runs -- you shouldn't have thousands of them, just the ones for today

Closes #2417 