### PR TITLE
Update Airflow configuration file after 1.8.x upgrade

### DIFF
--- a/app-tasks/usr/local/airflow/airflow.cfg
+++ b/app-tasks/usr/local/airflow/airflow.cfg
@@ -4,9 +4,11 @@ airflow_home = /usr/local/airflow
 
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository
+# This path must be absolute
 dags_folder = /opt/raster-foundry/app-tasks/dags
 
-# The folder where airflow should store its log files. This location
+# The folder where airflow should store its log files
+# This path must be absolute
 base_log_folder = /usr/local/airflow/logs
 
 # Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
@@ -18,8 +20,8 @@ remote_log_conn_id = ${AIRFLOW_REMOTE_LOG_CONN_ID}
 
 # Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
-# deprecated option for remote log storage, use remote_base_log_folder instead!
-# s3_log_folder =
+# DEPRECATED option for remote log storage, use remote_base_log_folder instead!
+s3_log_folder =
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor
@@ -50,6 +52,10 @@ dag_concurrency = 16
 # Are DAGs paused by default at creation
 dags_are_paused_at_creation = False
 
+# When not using pools, tasks are run in the "default pool",
+# whose size is guided by this config element
+non_pooled_task_slot_count = 128
+
 # The maximum number of active DAG runs per DAG
 max_active_runs_per_dag = 16
 
@@ -70,9 +76,44 @@ donot_pickle = False
 # How long before timing out a python file import while filling the DagBag
 dagbag_import_timeout = 30
 
+# The class to use for running task instances in a subprocess
+task_runner = BashTaskRunner
+
+# If set, tasks without a `run_as_user` argument will be run with this user
+# Can be used to de-elevate a sudo user running Airflow when executing tasks
+default_impersonation =
+
+# What security module to use (for example kerberos):
+security =
+
+# Turn unit test mode on (overwrites many configuration options with test
+# values at runtime)
+unit_test_mode = False
+
+[cli]
+# In what way should the cli access the API. The LocalClient will use the
+# database directly, while the json_client will use the api running on the
+# webserver
+api_client = airflow.api.client.local_client
+endpoint_url = ${AIRFLOW_BASE_URL}
+
+[api]
+# How to authenticate users of the API
+auth_backend = airflow.api.auth.backend.default
+
+[operators]
+# The default owner assigned to each new operator, unless
+# provided explicitly or passed via `default_args`
+default_owner = Airflow
+default_cpus = 1
+default_ram = 512
+default_disk = 512
+default_gpus = 0
+
+
 [webserver]
 # The base url of your website as airflow cannot guess what domain or
-# cname you are using. This is use in automated emails that
+# cname you are using. This is used in automated emails that
 # airflow sends to point links to the right web server
 base_url = ${AIRFLOW_BASE_URL}
 
@@ -82,8 +123,21 @@ web_server_host = 0.0.0.0
 # The port on which to run the web server
 web_server_port = 8080
 
-# The time the gunicorn webserver waits before timing out on a worker
+# Paths to the SSL certificate and key for the web server. When both are
+# provided SSL will be enabled. This does not change the web server port.
+web_server_ssl_cert =
+web_server_ssl_key =
+
+# Number of seconds the gunicorn webserver waits before timing out on a worker
 web_server_worker_timeout = 120
+
+# Number of workers to refresh at a time. When set to 0, worker refresh is
+# disabled. When nonzero, airflow periodically refreshes webserver workers by
+# bringing up new ones and killing old ones.
+worker_refresh_batch_size = 1
+
+# Number of seconds to wait before refreshing a batch of workers.
+worker_refresh_interval = 60
 
 # Secret key used to run your flask app
 secret_key = ${AIRFLOW_SECRET_KEY}
@@ -95,29 +149,60 @@ workers = ${AIRFLOW_WEBSERVER_WORKERS}
 # sync (default), eventlet, gevent
 worker_class = gevent
 
-# Expose the configuration file in the web server
-expose_config = true
+# Log files for the gunicorn webserver. '-' means log to stderr.
+access_logfile = -
+error_logfile = -
 
-# Set to true to turn on authentication : http://pythonhosted.org/airflow/installation.html#web-authentication
+# Expose the configuration file in the web server
+expose_config = True
+
+# Set to true to turn on authentication:
+# http://pythonhosted.org/airflow/security.html#web-authentication
 authenticate = False
 
 # Filter the list of dags by owner name (requires authentication to be enabled)
 filter_by_owner = False
 
+# Filtering mode. Choices include user (default) and ldapgroup.
+# Ldap group filtering requires using the ldap backend
+#
+# Note that the ldap server needs the "memberOf" overlay to be set up
+# in order to user the ldapgroup mode.
+owner_mode = user
+
+# Default DAG orientation. Valid values are:
+# LR (Left->Right), TB (Top->Bottom), RL (Right->Left), BT (Bottom->Top)
+dag_orientation = LR
+
+# Puts the webserver in demonstration mode; blurs the names of Operators for
+# privacy.
+demo_mode = False
+
+# The amount of time (in secs) webserver will wait for initial handshake
+# while fetching logs from other worker machine
+log_fetch_timeout_sec = 5
+
+# By default, the webserver shows paused DAGs. Flip this to hide paused
+# DAGs by default
+hide_paused_dags_by_default = False
+
 [email]
-email_backend = airflow.utils.send_email_smtp
+email_backend = airflow.utils.email.send_email_smtp
+
 
 [smtp]
-# If you want airflow to send emails on retries, failure, and you want to
-# the airflow.utils.send_email function, you have to configure an smtp
-# server here
+# If you want airflow to send emails on retries, failure, and you want to use
+# the airflow.utils.email.send_email_smtp function, you have to configure an
+# smtp server here
 smtp_host = localhost
 smtp_starttls = True
 smtp_ssl = False
-smtp_user = airflow
+# Uncomment and set the user/pass settings if you want to use SMTP AUTH
+# smtp_user = airflow
+# smtp_password = airflow
 smtp_port = 25
-smtp_password = airflow
-smtp_mail_from = airflow@airflow.local
+smtp_mail_from = airflow@airflow.com
+
 
 [celery]
 # This section only applies if you are using the CeleryExecutor in
@@ -148,11 +233,15 @@ broker_url = redis://cache.service.rasterfoundry.internal:6379/0
 celery_result_backend = redis://cache.service.rasterfoundry.internal:6379/0
 
 # Celery Flower is a sweet UI for Celery. Airflow has a shortcut to start
-# it `airflow flower`. This defines the port that Celery Flower runs on
+# it `airflow flower`. This defines the IP that Celery Flower runs on
+flower_host = 0.0.0.0
+
+# This defines the port that Celery Flower runs on
 flower_port = 5555
 
 # Default queue that tasks get assigned to and that worker listen on.
 default_queue = default
+
 
 [scheduler]
 # Task instances listen for external kill signal (when you clear tasks
@@ -165,13 +254,46 @@ job_heartbeat_sec = 5
 # how often the scheduler should run (in seconds).
 scheduler_heartbeat_sec = 5
 
+# after how much time should the scheduler terminate in seconds
+# -1 indicates to run continuously (see also num_runs)
+run_duration = -1
+
+# after how much time a new DAGs should be picked up from the filesystem
+min_file_process_interval = 0
+
+dag_dir_list_interval = 300
+
+# How often should stats be printed to the logs
+print_stats_interval = 180
+
+child_process_log_directory = /usr/local/airflow/logs/scheduler
+
+# Local task jobs periodically heartbeat to the DB. If the job has
+# not heartbeat in this many seconds, the scheduler will mark the
+# associated task instance as failed and will re-schedule the task.
+scheduler_zombie_task_threshold = 300
+
+# Turn off scheduler catchup by setting this to False.
+# Default behavior is unchanged and
+# Command Line Backfills still work, but the scheduler
+# will not do scheduler catchup if this is False,
+# however it can be set on a per DAG basis in the
+# DAG definition (catchup)
+catchup_by_default = True
+
 # Statsd (https://github.com/etsy/statsd) integration settings
-# statsd_on =  False
-# statsd_host =  localhost
-# statsd_port =  8125
-# statsd_prefix = airflow
+statsd_on = False
+statsd_host = localhost
+statsd_port = 8125
+statsd_prefix = airflow
 
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run. However airflow will never
 # use more threads than the amount of cpu cores available.
 max_threads = 2
+
+authenticate = False
+
+[admin]
+# UI to hide sensitive variable fields when set to True
+hide_sensitive_variable_fields = True


### PR DESCRIPTION
## Overview

This is mostly to keep explicit configuration settings up-to-date. I only made changes to the following settings:

- `endpoint_url` (new; made it align with `base_url`)
- `worker_refresh_internal` (new; 30s to 60s)
- `print_stats_interval` (new; 30s to 180s)

### Notes

A diff of the configuration file changes since the last version of Airflow we ran: https://github.com/apache/incubator-airflow/compare/1.7.1.3...1.8.1

## Testing Instructions

May be best to follow James' PR instructions [here](https://github.com/raster-foundry/raster-foundry/pull/2413). But, as long as the services start up (and stay up), I think things will be fine.