### PR TITLE
Parse s3 prefixes more delicately

### DIFF
--- a/app-backend/api/src/main/scala/uploads/package.scala
+++ b/app-backend/api/src/main/scala/uploads/package.scala
@@ -12,7 +12,7 @@ package object uploads {
             .filter { p =>
                 val _p = p.toLowerCase
                 _p.endsWith(".tif") ||
-                _p.endsWith(".tif")
+                _p.endsWith(".tiff")
             }
     }
 }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -61,9 +61,11 @@ package object S3 {
       else get(client.listNextBatchOfObjects(listing), getObjects)
     }
 
-    val prefix = {
-      val p = source.getPath.tail
-      if(!p.endsWith("/")) s"$p/" else p
+    val prefix = source.getPath match {
+      case "" => ""
+      case "/" => ""
+      case p if !p.tail.endsWith("/") => s"${p.tail}/"
+      case p => p.tail
     }
 
     val listObjectsRequest =
@@ -90,9 +92,11 @@ package object S3 {
       else get(client.listNextBatchOfObjects(listing), getObjects)
     }
 
-    val prefix = {
-      val p = source.getPath.tail
-      if(!p.endsWith("/")) s"$p/" else p
+    val prefix = source.getPath match {
+      case "" => ""
+      case "/" => ""
+      case p if !p.tail.endsWith("/") => s"${p.tail}/"
+      case p => p.tail
     }
 
     val listObjectsRequest =
@@ -119,9 +123,11 @@ package object S3 {
       else get(client.listNextBatchOfObjects(listing), getObjects)
     }
 
-    val prefix = {
-      val p = source.getPath.tail
-      if(!p.endsWith("/")) s"$p/" else p
+    val prefix = source.getPath match {
+      case "" => ""
+      case "/" => ""
+      case p if !p.tail.endsWith("/") => s"${p.tail}/"
+      case p => p.tail
     }
 
     val listObjectsRequest =


### PR DESCRIPTION
## Overview

Assuming the prefix was going to exist caused a bug in which, when there was no
prefix specified, we sent a prefix of "/". Separately, if the s3 path was
specified as "s3://bucket" (no trailing slash), then `getPath.tail` threw an
error.

This PR more delicately handles the cases when we receive trailing slashes or no
trailing slashes and prefixes or no prefixes so that we can successfully find S3
files regardless.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Fire up your server, airflow, and frontend
 * Ask me about my public bucket
 * Try the following S3 source paths:
   * `s3://<bucket>`
   * `s3://<bucket>/`
   * `s3://<bucket>/dummy-prefix`
   * `s3://<bucket>/dummy-prefix/`
 * All of them should succeed

Closes #2423 
