### PR TITLE
Parse bucket more delicately from upload s3 source

### DIFF
--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -23,6 +23,23 @@ package object S3 {
     .withRegion(Regions.US_EAST_1)
     .build()
 
+  def bucketAndPrefixFromURI(uri: URI): (String, String) = {
+    val prefix = uri.getPath match {
+      case "" => ""
+      case "/" => ""
+      case p if !p.tail.endsWith("/") => s"${p.tail}/"
+      case p => p.tail
+    }
+
+    val bucket = (uri.getHost, uri.getAuthority) match {
+      case (null, authority) => authority
+      case (host, null) => host
+      case _ => throw new IllegalStateException(s"Ambiguous bucket parse: $uri")
+    }
+
+    (bucket, prefix)
+  }
+
   def getObject(uri: URI): S3Object = {
     val s3uri = new AmazonS3URI(uri)
     client.getObject(s3uri.getBucket, s3uri.getKey)
@@ -61,16 +78,11 @@ package object S3 {
       else get(client.listNextBatchOfObjects(listing), getObjects)
     }
 
-    val prefix = source.getPath match {
-      case "" => ""
-      case "/" => ""
-      case p if !p.tail.endsWith("/") => s"${p.tail}/"
-      case p => p.tail
-    }
+    val (bucket, prefix) = bucketAndPrefixFromURI(source)
 
     val listObjectsRequest =
       new ListObjectsRequest()
-        .withBucketName(source.getHost)
+        .withBucketName(bucket)
         .withPrefix(prefix)
         .withDelimiter("/")
 
@@ -92,16 +104,11 @@ package object S3 {
       else get(client.listNextBatchOfObjects(listing), getObjects)
     }
 
-    val prefix = source.getPath match {
-      case "" => ""
-      case "/" => ""
-      case p if !p.tail.endsWith("/") => s"${p.tail}/"
-      case p => p.tail
-    }
+    val (bucket, prefix) = bucketAndPrefixFromURI(source)
 
     val listObjectsRequest =
       new ListObjectsRequest()
-        .withBucketName(source.getHost)
+        .withBucketName(bucket)
         .withPrefix(prefix)
         .withDelimiter("/")
 
@@ -123,16 +130,11 @@ package object S3 {
       else get(client.listNextBatchOfObjects(listing), getObjects)
     }
 
-    val prefix = source.getPath match {
-      case "" => ""
-      case "/" => ""
-      case p if !p.tail.endsWith("/") => s"${p.tail}/"
-      case p => p.tail
-    }
+    val (bucket, prefix) = bucketAndPrefixFromURI(source)
 
     val listObjectsRequest =
       new ListObjectsRequest()
-        .withBucketName(source.getHost)
+        .withBucketName(bucket)
         .withPrefix(prefix)
         .withDelimiter("/")
 

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -33,7 +33,7 @@ package object S3 {
 
     val bucket = (uri.getHost, uri.getAuthority) match {
       case (null, authority) => authority
-      case (host, null) => host
+      case (host, _) => host
       case _ => throw new IllegalStateException(s"Ambiguous bucket parse: $uri")
     }
 


### PR DESCRIPTION
## Overview

Similar to the problem with prefixes, we were making too strong an assumption
about what we'd be able to parse from the user-input bucket. When a bucket
name contains all underscores rather than dashes, the bucket name is available
under uri.getAuthority rather than uri.getHost. Using getHost caused us to make
a request to s3 without telling it which bucket to look in.
Brief description of what this PR does, and why it is needed.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Bring up all ur stuff
 * Do an s3 upload from that one bucket that we know breaks (ask me about this if you don't know which one it is)
 * watch as it magically succeeds
 * anyway the good news is, the bucket policy is definitely fine

Closes #2423 again