### PR TITLE
Fix thumbnails on import page

### DIFF
--- a/app-frontend/src/app/services/common/thumbnail.service.js
+++ b/app-frontend/src/app/services/common/thumbnail.service.js
@@ -1,3 +1,4 @@
+/* globals BUILDCONFIG */
 export default (app) => {
     class ThumbnailService {
         constructor(authService) {
@@ -13,7 +14,7 @@ export default (app) => {
                 return thumb;
             }).url;
             if (url.startsWith('/')) {
-                return `${url}?token=${this.authService.token()}`;
+                url = `${BUILDCONFIG.API_HOST}/api${url}?token=${this.authService.token()}`;
             }
             return url;
         }


### PR DESCRIPTION
## Overview

Thumbnail route for local urls now has buildconfig api host included

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
![image](https://user-images.githubusercontent.com/4392704/29530719-234d8ed2-8673-11e7-82a7-ad3c733e4252.png)


### Notes


## Testing Instructions

 * Verify that import thumbnail urls are set properly (as a bonus, import thumbnails should work on develop now!)

Closes https://github.com/raster-foundry/raster-foundry/issues/2421
