### PR TITLE
Don't cache None tiles forever

### DIFF
--- a/app-backend/common/src/main/scala/cache/CacheClient.scala
+++ b/app-backend/common/src/main/scala/cache/CacheClient.scala
@@ -56,7 +56,13 @@ class CacheClient(client: => MemcachedClient) extends LazyLogging {
           val futureCached: Future[CachedType] = expensiveOperation
           futureCached.foreach { cachedValue =>
             try {
-              setValue(cacheKey, cachedValue)
+              // Don't cache Nones indefinitely -- we might need to tune the None
+              // ttl if it feels like it takes forever for tiles to be available
+              // after an ingest is finished
+              cachedValue match {
+                case Some(v) => setValue(cacheKey, cachedValue)
+                case None => setValue(cacheKey, cachedValue, ttlSeconds = 300)
+              }
             } catch {
               case e: Exception => logger.info(s"Cache Set Error: ${e.getMessage}")
             }

--- a/app-backend/common/src/main/scala/geotrellis/spark/io/postgres/PostgresAttributeStore.scala
+++ b/app-backend/common/src/main/scala/geotrellis/spark/io/postgres/PostgresAttributeStore.scala
@@ -114,7 +114,10 @@ class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(im
 
   def maxZoomsForLayers(layerNames: Set[String]): Future[Option[Map[String, Int]]] = {
     logger.debug(s"maxZoomsForLayers($layerNames)")
-    LayerAttributes.maxZoomsForLayers(layerNames).map(x => Option(x.toMap))
+    LayerAttributes.maxZoomsForLayers(layerNames).map {
+      case seq if seq.length > 0 => seq.toMap.some
+      case _ => None
+    }
   }
 
   def availableAttributes(id: LayerId): Seq[String] = {

--- a/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
@@ -52,7 +52,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
     }
   }
 
-  /** MultiBandMosaic tiles from TMS pyramids given that they are in the same projection.
+  /** SingleBandMosaic tiles from TMS pyramids given that they are in the same projection.
     *   If a layer does not go up to requested zoom it will be up-sampled.
     *   Layers missing color correction in the mosaic definition will be excluded.
     */


### PR DESCRIPTION
## Overview

This PR handles cases where we find a tile and don't find a tile differently for caching. Currently, when we fail to find a tile, we cache the `None` value forever. Instead, with this PR, we cache found tiles forever and `None`s for five minutes.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness~

## Testing Instructions

 * Decrease the ttl for `None` tiles from 5 minutes to a minute (or something, your choice) to save yourself some time, and throw a `println(cacheKey)` into `getOrElseUpdate` in `CacheClient.scala`
 * Bring up your server, airflow, and frontend
 * In another terminal, run `docker-compose logs -f tile-server`
 * In yet another terminal, `docker-compose exec tile-server ./sbt`, `tile/console`, and execute:

```scala
import com.azavea.rf.common.cache.kryo.KryoMemcachedClient
val client = KryoMemcachedClient.DEFAULT
```

 * From the frontend, create a project, upload a scene into it, and (once the scene is in the project but not ingested) go to the edit page
 * This will cause the tile server to try to find tiles for that scene, which it won't be able to, and the cacheKey should be printed in the `tile-server` logs
 * In your scala shell, `client.get("<that cache key>")`
 * Wait however long you set the TTL for, then `get` the cache key again
 * Result should be `null`
 * Once your scene is ingested, try refreshing the edit page
 * You should get tiles (eventually -- maybe some timeouts because the local tile server is worse, but you should at least _try_ to get tiles -- dead letters in the `tile-server` logs are a sign something is going right)

Closes #2384
