### PR TITLE
Staging Bug Fix - the persistence of annotation rotate handles

### DIFF
--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
@@ -2,13 +2,11 @@
 
 export default class AnnotateSidebarItemController {
     constructor(
-        $log, $scope, $location, $anchorScroll
+        $log, $scope
     ) {
         'ngInject';
         this.$log = $log;
         this.$scope = $scope;
-        this.$location = $location;
-        this.$anchorScroll = $anchorScroll;
     }
 
     $onInit() {

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.scss
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.scss
@@ -120,7 +120,7 @@ angucomplete-alt {
 
 .annotation-new input.btn.btn-tertiary.annotation-confirm,
 .annotation-new input.btn.btn-tertiary.annotation-cancel {
-  width: 76px;
+  width: 90px;
 }
 
 .annotation-new input.btn.btn-tertiary.annotation-confirm{


### PR DESCRIPTION
## Overview

This PR fixes bugs on staging concerning annotation edit/rotate/resize so that:
* The old annotation rotate handles won't show if pressing "r" key (to rotate) again under the rotate mode. New rotate handles will show for controlling the most current shape.
* The old annotation rotate handles won't show if pressing any arrows keys to move shape around. It will automatically switch to shape edit mode.
* It allows you to switch between rotate and edit modes by pressing "r" and "e" keys respectively whenever there is a red shape (indicating an editable/rotatable shape) on the map.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

![new edit and rotate](https://raw.githubusercontent.com/aaronxsu/MyData/master/gifs/rf-annotations/new-rotate-edit.gif)


### Notes

Rotating/Rescaling is only allowed when you see a red shape on the map, i.e., the shape is editable.


## Testing Instructions

 * Go to `projects/edit/:projectId/annotate`
 * Create a new annotation
 * Click on a shape or a sidebar item, hit "e" key from the keyboard or click on edit button to enter edit mode. (Can also test under clone mode.)
 * Click on the red shape and hit "r" key to enter rotate/rescale mode. Hit "r" key again to check if the rotate handles are updated. Hit "e" key to check if it goes into shape edit mode and if there is any rotate handle left.
 * Under rotate mode, hit any arrow key to move shape around and check if old rotate handles are gone and replaced by shape edit handles.
* Do whatever makes sense to you to see if it does weird stuff again...


Closes #2451 
