### PR TITLE
Fix password reset button; Allow Intercom APP_ID to be specified in overrides

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -19,6 +19,8 @@ const stylesLoader = 'css-loader?sourceMap!postcss-loader!sass-loader?' +
 const HERE_APP_ID = 'mXP4DZFBZGyBmuZBKNeo';
 const HERE_APP_CODE = 'kBWb6Z7ZLcuQanT_RoP60A';
 
+const INTERCOM_APP_ID = '';
+
 const basemaps = JSON.stringify({
     layers: {
         Light: {
@@ -264,7 +266,8 @@ module.exports = function (_path) {
                     BASEMAPS: basemaps,
                     API_HOST: '\'\'',
                     HERE_APP_ID: '\'' + HERE_APP_ID + '\'',
-                    HERE_APP_CODE: '\'' + HERE_APP_CODE + '\''
+                    HERE_APP_CODE: '\'' + HERE_APP_CODE + '\'',
+                    INTERCOM_APP_ID: '\'' + INTERCOM_APP_ID + '\''
                 }
             })
         ]

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -33,7 +33,10 @@ module.exports = function () {
                 'BUILDCONFIG': {
                     APP_NAME: '\'RasterFoundry?\'',
                     BASEMAPS: basemaps,
-                    API_HOST: '\'https://app.rasterfoundry.com\''
+                    API_HOST: '\'https://app.rasterfoundry.com\'',
+                    HERE_APP_ID: '\'' + HERE_APP_ID + '\'',
+                    HERE_APP_CODE: '\'' + HERE_APP_CODE + '\'',
+                    INTERCOM_APP_ID: '\'' + INTERCOM_APP_ID + '\''
                 }
             })
         ]

--- a/app-frontend/src/app/pages/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/settings/profile/profile.html
@@ -66,7 +66,8 @@
           >
           <p class="help-block">Contact support to change your username</p>
         </div>
-        <button ng-if="$ctrl.provider === 'auth0'"
+        <button type="button"
+                ng-if="$ctrl.provider === 'auth0'"
                 class="btn btn-primary btn-large"
                 ng-click="$ctrl.authService.changePassword()">
           Change Password

--- a/app-frontend/src/app/services/vendor/intercom.service.js
+++ b/app-frontend/src/app/services/vendor/intercom.service.js
@@ -1,4 +1,4 @@
-/* global Intercom */
+/* global Intercom, BUILDCONFIG */
 export default (app) => {
     class IntercomService {
         constructor($resource, $q, $http, APP_CONFIG, angularLoad) {
@@ -9,7 +9,7 @@ export default (app) => {
             this.angularLoad = angularLoad;
             this.scriptLoaded = false;
             // @TODO: load this value from the APP_CONFIG
-            this.appId = APP_CONFIG.intercomAppId;
+            this.appId = BUILDCONFIG.INTERCOM_APP_ID || APP_CONFIG.intercomAppId;
             this.srcUrl = `https://widget.intercom.io/widget/${this.appId}`;
         }
 


### PR DESCRIPTION
## Overview

This PR does two things:

- allows the Intercom `APP_ID` to be overrideable via the `overrides.js` file
- fixes the password change button so that user's logged in with email/password auth through Auth0 can request password change emails

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [:shrug:] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Try adding an INTERCOM_APP_ID to the overrides file that is senseless ('abc' is a solid choice) and then reload the webpack server
 * Ensure the Intercom widget doesn't show up
 * Try removing the INTERCOM_APP_ID from the overrides file, reload webpack, and see that the widget works.
 
 * Make sure you are logged in via email/password
 * Go to user settings and try resetting your password
 * Ensure that the Auth0 reset window thing appears

Closes #2449 
Closes #2450