### PR TITLE
Add override support for `APP_NAME` in frontend

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -258,11 +258,12 @@ module.exports = function (_path) {
                 filename: 'index.html',
                 template: path.join(_path, 'src', 'tpl-index.html'),
                 heapLoad: DEVELOPMENT ? '2743344218' : '3505855839',
-                development: DEVELOPMENT
+                development: DEVELOPMENT,
+                APP_NAME: 'Raster Foundry'
             }),
             new webpack.DefinePlugin({
                 'BUILDCONFIG': {
-                    APP_NAME: '\'RasterFoundry\'',
+                    APP_NAME: '\'Raster Foundry\'',
                     BASEMAPS: basemaps,
                     API_HOST: '\'\'',
                     HERE_APP_ID: '\'' + HERE_APP_ID + '\'',

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -3,6 +3,10 @@
 /* no-console: 0 */
 
 const webpack = require('webpack');
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const NODE_ENV = process.env.NODE_ENV || 'production';
+const DEVELOPMENT = NODE_ENV === 'production' ? false : true;
 
 const basemaps = JSON.stringify({
     layers: {
@@ -26,12 +30,20 @@ const basemaps = JSON.stringify({
     default: 'Light'
 });
 
-module.exports = function () {
+module.exports = function (_path) {
     return {
         plugins: [
+            new HtmlWebpackPlugin({
+                filename: 'index.html',
+                template: path.join(_path, 'src', 'tpl-index.html'),
+                heapLoad: DEVELOPMENT ? '2743344218' : '3505855839',
+                development: DEVELOPMENT,
+                APP_NAME: 'Raster Foundry'
+            }),
+
             new webpack.DefinePlugin({
                 'BUILDCONFIG': {
-                    APP_NAME: '\'RasterFoundry?\'',
+                    APP_NAME: '\'Raster Foundry\'',
                     BASEMAPS: basemaps,
                     API_HOST: '\'https://app.rasterfoundry.com\'',
                     HERE_APP_ID: '\'' + HERE_APP_ID + '\'',

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 function runBlock(
     $rootScope, jwtHelper, $state, $location, $window, APP_CONFIG,
     authService, localStorage, rollbarWrapperService, intercomService,
@@ -13,8 +14,9 @@ function runBlock(
 
     $rootScope.$on('$stateChangeStart', function (e, toState, params) {
         function setupState() {
+            let appName = BUILDCONFIG.APP_NAME;
             $window.document.title = toState.title ?
-                `Raster Foundry - ${toState.title}` : 'Raster Foundry';
+                `${appName} - ${toState.title}` : appName;
             if (APP_CONFIG.error && toState.name !== 'error') {
                 e.preventDefault();
                 $state.go('error');

--- a/app-frontend/src/tpl-index.html
+++ b/app-frontend/src/tpl-index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Raster Foundry</title>
+    <title>{%= o.htmlWebpackPlugin.options.APP_NAME %}</title>
     <base href="/">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">


### PR DESCRIPTION
## Overview

Before this commit, APP_NAME was not being used to replace the title
in the templated javascript or in the titles for views.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Copy `overrides.template.js`
 * Replace `APP_NAME` with something that is obvious
 * Observe that the application name in a chrome tab is replaced with what you used in the previous step
