### PR TITLE
Staging Bug Fix - Annotation page refresh upon new shape creation in a new project

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -504,7 +504,7 @@ export default class AnnotateController {
             });
         }
         this.disableToolbarAction = true;
-        this.scrollToItem(id);
+        this.$anchorScroll('anchor' + id.toString());
         this.$timeout(() => angular.element('#_value').focus());
     }
 
@@ -554,7 +554,7 @@ export default class AnnotateController {
                     if (!this.disableSidebarAction && !this.clickedId) {
                         this.hoveredId = feature.properties.id;
                         this.setLayerStyle(e.target, RED, 'annotate-hover-marker');
-                        this.scrollToItem(this.hoveredId);
+                        this.$anchorScroll('anchor' + this.hoveredId.toString());
                         this.$scope.$evalAsync();
                     }
                 }).on('mouseout', (e) => {
@@ -577,7 +577,7 @@ export default class AnnotateController {
                                 }
                                 this.clickedId = feature.properties.id;
                                 this.setLayerStyle(e.target, RED, 'annotate-hover-marker');
-                                this.scrollToItem(this.clickedId);
+                                this.$anchorScroll('anchor' + this.clickedId.toString());
                                 this.$scope.$evalAsync();
                             } else {
                                 delete this.clickedId;
@@ -597,15 +597,6 @@ export default class AnnotateController {
             target.setStyle({'color': color});
         } else if (target.feature.geometry.type === 'Point') {
             target.setIcon(L.divIcon({'className': iconClass}));
-        }
-    }
-
-    scrollToItem(id) {
-        let newHash = 'anchor' + id;
-        if (this.$location.hash() !== newHash) {
-            this.$location.hash(newHash);
-        } else {
-            this.$anchorScroll();
         }
     }
 
@@ -668,8 +659,10 @@ export default class AnnotateController {
                 'description': description
             }
         });
-        this.scrollToItem(id);
-        this.$timeout(() => angular.element('#_values').focus());
+        this.$timeout(() => {
+            this.$anchorScroll('anchor' + id.toString());
+            angular.element('#_values').focus();
+        });
     }
 
     onUpdateAnnotationStart(annotation) {
@@ -681,7 +674,7 @@ export default class AnnotateController {
         this.disableSidebarAction = true;
         this.editId = annotation.properties.id;
 
-        this.scrollToItem(this.editId);
+        this.$anchorScroll('anchor' + this.editId.toString());
 
         this.getMap().then((mapWrapper) => {
             this.createEditableDrawLayer(mapWrapper, annotation.geometry);


### PR DESCRIPTION
## Overview

So it turned out that appending hashes (for the autoscroll to happen) to the url caused the bug. Somehow, right after creating a new project, if you go to the annotation page and you do anything that triggers appending hashes to URL (like creating new shapes, hover or click on shape/sidebar item - all for autoscrolling purpose), the page wants to refresh. It does not happen in an existing project though.

This PR fixes such issue by simply avoiding appending hashes to the URL, and just use `$anchorScroll` alone...

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Create a new project and go to annotation page within this new project
 * Create/edit/clone/click/hover annotations. Check if page refresh happens when you don't intend it to. Check if the autoscroll still happens as you expected.

Closes #2432 
