### PR TITLE
Color scheme dropdown

### DIFF
--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.component.js
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.component.js
@@ -1,0 +1,12 @@
+import colorSchemeDropdownTpl from './colorSchemeDropdown.html';
+const rfColorSchemeDropdown = {
+    templateUrl: colorSchemeDropdownTpl,
+    controller: 'ColorSchemeDropdownController',
+    bindings: {
+        serializedSingleBandOptions: '<',
+        onChange: '&'
+    },
+    controllerAs: '$ctrl'
+};
+
+export default rfColorSchemeDropdown;

--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.controller.js
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.controller.js
@@ -1,0 +1,207 @@
+/* global _ */
+
+const STATES = ['MAIN', 'SCHEME', 'BLENDING'];
+const MIN_BINS = 2;
+const MAX_BINS = 12;
+const ELASTIC_NAV = true;
+
+export default class ColorSchemeDropdownController {
+    constructor($scope, colorSchemeService) {
+        'ngInject';
+        this.$scope = $scope;
+        this.colorSchemeService = colorSchemeService;
+        this.bins = [0, ...[ ...Array(1 + MAX_BINS - MIN_BINS).keys()].map(b => b + MIN_BINS)];
+    }
+
+    $onChanges() {
+        this.deserializeSingleBandOptions();
+        this.mergeStates();
+    }
+
+    deserializeSingleBandOptions() {
+        this.singleBandOptions = angular.fromJson(this.serializedSingleBandOptions);
+    }
+
+    mergeStates() {
+        this.state = Object.assign(
+            {},
+            this.getInitialState(),
+            this.getStateFromSingleBandOptions()
+        );
+    }
+
+    getInitialState() {
+        return {
+            view: 'MAIN',
+            blending: {
+                label: this.getBlendingLabel(0),
+                bins: 0
+            },
+            schemeType: {
+                label: 'Sequential',
+                value: 'SEQUENTIAL'
+            },
+            scheme: this.colorSchemeService.defaultColorSchemes.find(s => s.type === 'SEQUENTIAL')
+        };
+    }
+
+    getStateFromSingleBandOptions() {
+        let stateToReturn = {};
+        if (this.singleBandOptions && this.singleBandOptions.colorScheme) {
+            const scheme = this.colorSchemeService.defaultColorSchemes.find(
+                s => _.isEqual(
+                    this.singleBandOptions.colorScheme,
+                    s.colors
+                )
+            );
+
+            if (scheme) {
+                stateToReturn.scheme = scheme;
+            }
+
+            if (this.singleBandOptions.dataType) {
+                stateToReturn.schemeType = this.colorSchemeService.defaultColorSchemeTypes.find(
+                    t => this.singleBandOptions.dataType === t.value
+                );
+            }
+
+            let blending = {
+                label: this.getBlendingLabel(0),
+                bins: 0
+            };
+
+            if (Array.isArray(this.singleBandOptions.colorScheme)) {
+                blending = {
+                    label: this.getBlendingLabel(0),
+                    bins: 0
+                };
+            } else {
+                let bins = Object.keys(this.singleBandOptions.colorScheme).length;
+                blending = {
+                    label: this.getBlendingLabel(bins),
+                    bins
+                };
+            }
+            stateToReturn[blending] = blending;
+        }
+        return stateToReturn;
+    }
+
+    getSingleBandOptionsFromState() {
+        // @TODO: need to determine way forward for setting bin values?
+        if (this.state) {
+            return {
+                colorScheme: this.state.scheme.colors,
+                dataType: this.state.schemeType.value,
+                colorBins: this.state.blending.bins
+            };
+        }
+        return {};
+    }
+
+    moveToView(view) {
+        if (STATES.includes(view)) {
+            this.state = Object.assign(
+                {},
+                this.state,
+                {
+                    view: view
+                }
+            );
+        }
+    }
+
+    setSchemeType(schemeType) {
+        this.state = Object.assign(
+            {},
+            this.state,
+            { schemeType }
+        );
+        if (ELASTIC_NAV) {
+            this.moveToView('MAIN');
+        }
+        this.reflectState();
+    }
+
+    setBlending(bins) {
+        this.state = Object.assign(
+            {},
+            this.state,
+            {
+                blending: {
+                    label: this.getBlendingLabel(bins),
+                    bins
+                }
+            }
+        );
+        if (ELASTIC_NAV) {
+            this.moveToView('MAIN');
+        }
+        this.reflectState();
+    }
+
+    setScheme(scheme) {
+        this.state = Object.assign(
+            {},
+            this.state,
+            { scheme }
+        );
+        this.reflectState();
+    }
+
+    reflectState() {
+        if (this.onChange) {
+            this.onChange({
+                value: this.getSingleBandOptionsFromState()
+            });
+        }
+    }
+
+    getSchemeClass(scheme) {
+        if (this.state) {
+            return {
+                'selected': _.isEqual(
+                                this.state.scheme.colors,
+                                scheme.colors
+                            )
+            };
+        }
+        return {};
+    }
+
+    getSchemeTypeClass(schemeType) {
+        return {
+            'selected': this.isActiveSchemeType(schemeType)
+        };
+    }
+
+    getBlendingClass(bin) {
+        if (this.state) {
+            return {
+                'selected': this.state.blending.bins === bin
+            };
+        }
+        return {};
+    }
+
+    getBlendingLabel(bin) {
+        if (bin === 0) {
+            return 'Continuous';
+        }
+        return `${bin} discrete bins`;
+    }
+
+    isActiveSchemeType(schemeType) {
+        if (this.state) {
+            return this.state.schemeType.value === schemeType.value;
+        }
+        return false;
+    }
+
+    shouldShowView(view) {
+        if (this.state) {
+            return this.state.view === view;
+        }
+        return false;
+    }
+}

--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
@@ -1,0 +1,90 @@
+<div class="dropdown btn-group" uib-dropdown auto-close="outsideClick">
+  <a class="btn dropdown-label gradient-dropdown-label">
+      <div class="gradient-bar gradient-bkg"
+          ng-style="$ctrl.colorSchemeService.colorsToBackground($ctrl.state.scheme.colors)"
+      ></div>
+  </a>
+  <button type="button" class="btn btn-light dropdown-toggle" uib-dropdown-toggle >
+    <i class="icon-caret-down"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-light colorscheme-selector" uib-dropdown-menu role="menu">
+    <div ng-show="$ctrl.shouldShowView('MAIN')">
+      <div class="dropdown-header">
+        <div class="dropdown-header-link-container">
+          <a class="dropdown-header-link" ng-click="$ctrl.moveToView('BLENDING')">{{$ctrl.state.blending.label}}...</a>
+        </div>
+        <div class="dropdown-header-link-container">
+          <a class="dropdown-header-link" ng-click="$ctrl.moveToView('SCHEME')">{{$ctrl.state.schemeType.label}}...</a>
+        </div>
+      </div>
+      <ul class="dropdown-list">
+        <li ng-repeat="scheme in $ctrl.colorSchemeService.defaultColorSchemes | filter : {type: $ctrl.state.schemeType.value}"
+            ng-click="$ctrl.setScheme(scheme)"
+            ng-class="$ctrl.getSchemeClass(scheme)"
+            role="menuitem"
+            class="dropdown-list-item"
+        >
+          <div class="selection-indicator"><i class="icon-check"></i></div>
+          <div class="gradient-container" ng-class="$ctrl.getSchemeClass(scheme)">
+            <div class="gradient-bar gradient-bkg"
+                 ng-style="$ctrl.colorSchemeService.colorsToBackground(scheme.colors)"
+            ></div>
+          </div>
+        </li>
+      </ul>
+    </div>
+    <div ng-show="$ctrl.shouldShowView('SCHEME')">
+      <div class="dropdown-header">
+        <div class="dropdown-titlebar">
+          <button class="navigation-button" ng-click="$ctrl.moveToView('MAIN')">
+            <i class="icon-arrow-left"></i>
+          </button>
+          <div class="dropdown-title flex-fill">
+            Color Scheme
+          </div>
+        </div>
+      </div>
+      <ul class="dropdown-list">
+        <li class="dropdown-list-item"
+            ng-repeat="schemeType in $ctrl.colorSchemeService.defaultColorSchemeTypes"
+            ng-class="$ctrl.getSchemeTypeClass(schemeType)"
+            ng-click="$ctrl.setSchemeType(schemeType)"
+        >
+          <div class="selection-indicator">
+            <i class="icon-check"></i>
+          </div>
+          {{schemeType.label}} <span ng-if="$ctrl.isActiveSchemeType('CATEGORICAL')">(needs discrete bins)</span>
+        </li>
+      </ul>
+    </div>
+    <div ng-show="$ctrl.shouldShowView('BLENDING')">
+      <div class="dropdown-header">
+        <div class="dropdown-titlebar">
+          <button class="navigation-button" ng-click="$ctrl.moveToView('MAIN')">
+            <i class="icon-arrow-left"></i>
+          </button>
+          <div class="dropdown-title flex-fill">
+            Color Blending
+          </div>
+        </div>
+      </div>
+      <ul class="dropdown-list">
+        <li class="dropdown-list-item"
+            ng-repeat="bin in $ctrl.bins"
+            ng-class="$ctrl.getBlendingClass(bin)"
+            ng-click="$ctrl.setBlending(bin)"
+        >
+          <div class="selection-indicator"><i class="icon-check"></i></div>
+          <div class="label">
+            <ng-pluralize count="bin"
+                          when="{
+                            '0': 'Continuous',
+                            'other': '{} discrete bins'
+                          }">
+            </ng-pluralize>
+          </div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.module.js
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.module.js
@@ -1,0 +1,17 @@
+import angular from 'angular';
+import ColorSchemeDropdownComponent from './colorSchemeDropdown.component.js';
+import ColorSchemeDropdownController from './colorSchemeDropdown.controller.js';
+
+const ColorSchemeDropdownModule = angular.module('components.colorSchemeDropdown', []);
+
+ColorSchemeDropdownModule.component(
+    'rfColorSchemeDropdown',
+    ColorSchemeDropdownComponent
+);
+
+ColorSchemeDropdownModule.controller(
+    'ColorSchemeDropdownController',
+    ColorSchemeDropdownController
+);
+
+export default ColorSchemeDropdownModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -69,4 +69,5 @@ export default angular.module('index.components', [
     require('./components/colorComposites/colorSchemeBuilder/colorSchemeBuilder.module.js').name,
     require('./components/histogram/channelHistogram/channelHistogram.module.js').name,
     require('./components/histogram/histogramBreakpoint/histogramBreakpoint.module.js').name,
+    require('./components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.module.js').name
 ]);

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -88,7 +88,7 @@ export default class ProjectsEditColormode {
             this.colorSchemeService.defaultColorSchemes.find(
                 s => _.isEqual(
                     this.projectBuffer.singleBandOptions.colorScheme,
-                    this.colorSchemeService.colorsToDiscreteScheme(s.colors)
+                    s.colors
                 )
             );
 
@@ -107,6 +107,10 @@ export default class ProjectsEditColormode {
             blendMode: 'CONTINUOUS',
             legendOrientation: 'left'
         };
+    }
+
+    getSerializedSingleBandOptions() {
+        return angular.toJson(this.projectBuffer.singleBandOptions);
     }
 
     toggleProjectSingleBandMode(state) {
@@ -156,7 +160,7 @@ export default class ProjectsEditColormode {
             this.projectBuffer.singleBandOptions.dataType = scheme.type;
             if (scheme.type !== 'CATEGORICAL') {
                 this.projectBuffer.singleBandOptions.colorScheme =
-                    this.colorSchemeService.colorsToDiscreteScheme(this.activeColorScheme.colors);
+                    this.activeColorScheme.colors;
             } else if (scheme.breaks) {
                 this.projectBuffer.singleBandOptions.colorScheme =
                     this.colorSchemeService

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -103,6 +103,11 @@
             </div>
             <i class="icon-info"></i>
           </li>
+          <li>
+            <span class="label">Color scheme</span>
+            <rf-color-scheme-dropdown serialized-single-band-options="$ctrl.getSerializedSingleBandOptions()"></rf-color-scheme-dropdown>
+            <i class="icon-info"></i>
+          </li>
           <li ng-if="$ctrl.shouldShowColorSchemeBuilder()">
             <rf-color-scheme-builder color-scheme="$ctrl.projectBuffer.singleBandOptions.colorScheme" on-change="$ctrl.onSchemeColorsChange(value)"/>
           </li>

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -398,7 +398,9 @@ rf-project-editor .leaflet-tile {
       margin-left: 0;
       padding: 1rem 0 1rem 0;
     }
-    .fixedwidth {
+    .fixedwidth,
+    rf-color-scheme-dropdown {
+
       width: 20rem;
     }
     .label {
@@ -2182,7 +2184,7 @@ rf-color-scheme-builder {
 }
 
 .color-scheme-break {
-  width: 60px;
+  width: 85px;
 }
 
 .dropdown-menu .gradient-dropdown-item {
@@ -2200,14 +2202,26 @@ rf-color-scheme-builder {
       color: $brand-primary;
     }
   }
-  .gradient-bar {
-    flex: 1;
+}
+.gradient-bar {
+  flex: 1;
+  border-radius: 12px;
+  border: 1px solid #999;
+}
+.gradient-container {
+  border: 2px solid rgba(0,0,0,0);
+  border-radius: 15px;
+  padding: 2px;
+  flex: 1;
+  &.selected {
+    border: 2px solid $brand-primary;
   }
 }
 
 ul.gradient-dropdown {
   padding: 0;
 }
+
 
 .graph-container {
   user-select: none;
@@ -2287,4 +2301,98 @@ rf-histogram-breakpoint {
 
 .histogram-spacer {
   height: 3em;
+}
+
+.colorscheme-selector {
+  min-width: 230px;
+  max-height: 233px;
+  overflow-y: auto;
+  padding: 0;
+}
+.dropdown-header {
+  display: flex;
+  align-items: stretch;
+  height: 38px;
+  background: $off-white;
+  border-bottom: 1px solid $gray-lightest;
+  .dropdown-header-link-container {
+    align-self: center;
+    padding: 0rem 0rem 0rem 1rem;
+    :last-child {
+      padding: 0rem 1rem 0rem 0rem;
+    }
+  }
+  :last-child {
+    flex: 1;
+    text-align: right;
+  }
+}
+
+.gradient-dropdown-label {
+  padding: 0 1rem;
+  height: 35px;
+  display: flex;
+  align-items: center;
+}
+
+.dropdown-titlebar {
+  display: flex;
+  align-items: center;
+  .navigation-button {
+    font-size: 22px;
+    width: 3.5rem;
+    align-self: stretch;
+    background: none;
+    border: none;
+    color: $brand-primary;
+  }
+  .dropdown-title {
+    text-align: left;
+    font-weight: bold;
+    align-self: center;
+  }
+}
+
+ul.dropdown-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  li.dropdown-list-item {
+    margin: 0;
+    padding: 1rem 1rem 1rem 0rem;
+    border-bottom: 1px solid $gray-lightest;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    .label {
+      font-weight: normal;
+    }
+    .selection-indicator {
+      width: 3.5rem;
+      text-align: center;
+      i {
+        color: $brand-primary;
+        display: none;
+      }
+    }
+    span {
+      font-style: italic;
+      margin-left: 1rem;
+    }
+    &:hover {
+      background: $gray-lightest;
+    }
+    &.selected {
+      color: $brand-primary;
+      .selection-indicator i {
+        display: inline;
+      }
+    }
+    &:last-child {
+      border-bottom: none;
+    }
+    &:focus, &:active {
+      outline: none;
+    }
+  }
 }

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -96,7 +96,7 @@
   }
 }
 
-/* 
+/*
  * Solid bg-color buttons
  */
 .btn-default {
@@ -160,7 +160,7 @@
   border-color: transparent;
 }
 
-/* 
+/*
  * Ghost buttons, borders only
  */
 .btn-ghost {
@@ -183,7 +183,7 @@
   @include ghost-button-states($shade-normal, #fff);
 }
 
-/* 
+/*
  * Button styled link a link
  */
 .btn-link {
@@ -333,5 +333,7 @@
     padding-right: 1rem;
     flex-grow: 0;
     flex-shrink: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 }


### PR DESCRIPTION
## Overview

This adds a dropdown component that contains various color-scheme configuration options.

There are some rough edges that we probably won't get ironed out until the backend and some other parts are solidified.

### Checklist

- [ ] Styleguide updated, if necessary
- [ ] Swagger specification updated, if necessary
- [ ] Symlinks from new migrations present or corrected for any new migrations
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/29788648-61cfd834-8c01-11e7-932c-e5f0b5c4109c.png)


### Notes

I believe we still need some clarity around how we're handling discrete color-schemes in this context. As a result, there is a bit of hand-waving since the test environment doesn't match the context in which we'll be using the dropdown.

Since angular doesn't play nice with propagating changes to component with an object that is one-way bound, the input to the dropdown is serialized (`angular.toJson` works well for this). 

## Testing Instructions

You'll want to put the dropdown somewhere. Passing it single-band-options isn't necessary to test the base functionality.

```
<li>
    <span class="label">Color scheme</span>
    <rf-color-scheme-dropdown serialized-single-band-options="$ctrl.getSerializedSingleBandOptions()"></rf-color-scheme-dropdown>
    <i class="icon-info"></i>
</li>
```

 * Click around in the dropdown and see that it works as expected.

Closes #2386 
