### PR TITLE
Add parsing of `classify` function in mamlscript

### DIFF
--- a/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
+++ b/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
@@ -46,12 +46,13 @@ export default class ToolCreateModalController {
         let expressionTree = null;
         try {
             expressionTree = mathjs.parse(this.definitionExpression);
-            this.toolBuffer.definition = this.transformNode(expressionTree);
+            this.toolBuffer.definition = this.expressionTreeToMAML(expressionTree);
             this.toolService.createTool(this.toolBuffer).then(tool => {
                 this.dismiss();
                 this.$state.go('lab.run', { toolid: tool.id });
             });
         } catch (e) {
+            console.log(e);
             this.currentError = 'The tool definition is not valid';
             this.isProcessing = false;
         }
@@ -125,6 +126,85 @@ export default class ToolCreateModalController {
 
         return builtNode;
     }
+
+    expressionTreeToMAML(tree, value, allowCollapse = true) {
+        let mamlNode = {
+          id: this.uuid4.generate(),
+          metadata: {}
+        };
+
+        switch (tree.type) {
+          case "AssignmentNode":
+            return this.expressionTreeToMAML(tree.object, tree.value.value);
+          case "ConstantNode":
+            Object.assign(mamlNode, {
+              type: 'const',
+              constant: tree.value,
+              metadata: {
+                label: tree.value
+              }
+            });
+            break;
+          case "OperatorNode":
+            mamlNode.apply = tree.op;
+            mamlNode.metadata.label = tree.fn;
+            mamlNode.metadata.collapsable = allowCollapse;
+            break;
+          case "FunctionNode":
+            mamlNode.apply = tree.fn.name;
+            mamlNode.metadata.label = tree.fn.name;
+            if (mamlNode.apply === 'classify') {
+              const classifications = tree.args[1];
+              tree.args = [ tree.args[0] ];
+              mamlNode.classMap = {
+                classifications: this.objectNodeToClassifications(classifications)
+              };
+            }
+            break;
+          case "ParenthesisNode":
+            return this.expressionTreeToMAML(tree.content, null, false);
+          case "SymbolNode":
+            if (tree.name.startsWith('_')) {
+              mamlNode.type = 'const';
+              mamlNode.metadata.label = tree.name.substring(1);
+              if (value) {
+                mamlNode.constant = parseFloat(value);
+              }
+            } else {
+              mamlNode.type = 'src';
+              mamlNode.metadata.label = tree.name;
+            }
+            mamlNode.id = this.getSymbolId(mamlNode.metadata.label);
+            break;
+          default:
+            return false;
+        };
+
+        if (tree.args && tree.args.length) {
+          mamlNode.args = tree.args.map(a => this.expressionTreeToMAML(a));
+        }
+
+        if (tree.type === 'OperatorNode' && tree.args) {
+            mamlNode.args.forEach((c, i) => {
+                if (c.apply && c.apply === mamlNode.apply && c.metadata.collapsable) {
+                    mamlNode.args = [
+                        ...mamlNode.args.slice(0, i),
+                        ...c.args,
+                        ...mamlNode.args.slice(i + 1, mamlNode.args.length)
+                    ];
+                }
+            });
+        }
+
+        return mamlNode;
+      }
+
+      objectNodeToClassifications(node) {
+        return Object.keys(node.properties).reduce((acc, p) => {
+          acc[`${parseFloat(p)}`] = parseInt(node.properties[p].value, 10);
+          return acc;
+        }, {});
+      }
 
     isValid() {
         this.currentParsingError = '';

--- a/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
+++ b/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
@@ -207,8 +207,11 @@ export default class ToolCreateModalController {
     isValid() {
         this.currentParsingError = '';
         const parensBalanced = this.validateParenDepth();
+        const bracesBalanced = this.validateBraceDepth();
         if (!parensBalanced) {
             this.currentParsingError = 'The parentheses in this expression are not balanced';
+        } else if (!bracesBalanced) {
+            this.currentParsingError = 'The braces in this expression are not balanced';
         }
         return this.toolBuffer.title && this.definitionExpression && parensBalanced;
     }
@@ -221,6 +224,23 @@ export default class ToolCreateModalController {
                 if (c === '(') {
                     d += 1;
                 } else if (c === ')') {
+                    d -= 1;
+                }
+                return { depth: d, continue: d >= 0};
+            }
+            return acc;
+        }, { depth: 0, continue: true });
+        return result.continue && result.depth === 0;
+    }
+
+    validateBraceDepth() {
+        const expressionArray = this.definitionExpression.split('');
+        const result = expressionArray.reduce((acc, c) => {
+            if (acc.continue) {
+                let d = acc.depth;
+                if (c === '{') {
+                    d += 1;
+                } else if (c === '}') {
                     d -= 1;
                 }
                 return { depth: d, continue: d >= 0};

--- a/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
+++ b/app-frontend/src/app/components/tools/toolCreateModal/toolCreateModal.controller.js
@@ -52,7 +52,6 @@ export default class ToolCreateModalController {
                 this.$state.go('lab.run', { toolid: tool.id });
             });
         } catch (e) {
-            console.log(e);
             this.currentError = 'The tool definition is not valid';
             this.isProcessing = false;
         }
@@ -129,59 +128,59 @@ export default class ToolCreateModalController {
 
     expressionTreeToMAML(tree, value, allowCollapse = true) {
         let mamlNode = {
-          id: this.uuid4.generate(),
-          metadata: {}
+            id: this.uuid4.generate(),
+            metadata: {}
         };
 
         switch (tree.type) {
-          case "AssignmentNode":
+        case 'AssignmentNode':
             return this.expressionTreeToMAML(tree.object, tree.value.value);
-          case "ConstantNode":
+        case 'ConstantNode':
             Object.assign(mamlNode, {
-              type: 'const',
-              constant: tree.value,
-              metadata: {
-                label: tree.value
-              }
+                type: 'const',
+                constant: tree.value,
+                metadata: {
+                    label: tree.value
+                }
             });
             break;
-          case "OperatorNode":
+        case 'OperatorNode':
             mamlNode.apply = tree.op;
             mamlNode.metadata.label = tree.fn;
             mamlNode.metadata.collapsable = allowCollapse;
             break;
-          case "FunctionNode":
+        case 'FunctionNode':
             mamlNode.apply = tree.fn.name;
             mamlNode.metadata.label = tree.fn.name;
             if (mamlNode.apply === 'classify') {
-              const classifications = tree.args[1];
-              tree.args = [ tree.args[0] ];
-              mamlNode.classMap = {
-                classifications: this.objectNodeToClassifications(classifications)
-              };
+                const classifications = tree.args[1];
+                tree.args = [ tree.args[0] ];
+                mamlNode.classMap = {
+                    classifications: this.objectNodeToClassifications(classifications)
+                };
             }
             break;
-          case "ParenthesisNode":
+        case 'ParenthesisNode':
             return this.expressionTreeToMAML(tree.content, null, false);
-          case "SymbolNode":
+        case 'SymbolNode':
             if (tree.name.startsWith('_')) {
-              mamlNode.type = 'const';
-              mamlNode.metadata.label = tree.name.substring(1);
-              if (value) {
-                mamlNode.constant = parseFloat(value);
-              }
+                mamlNode.type = 'const';
+                mamlNode.metadata.label = tree.name.substring(1);
+                if (value) {
+                    mamlNode.constant = parseFloat(value);
+                }
             } else {
-              mamlNode.type = 'src';
-              mamlNode.metadata.label = tree.name;
+                mamlNode.type = 'src';
+                mamlNode.metadata.label = tree.name;
             }
             mamlNode.id = this.getSymbolId(mamlNode.metadata.label);
             break;
-          default:
+        default:
             return false;
-        };
+        }
 
         if (tree.args && tree.args.length) {
-          mamlNode.args = tree.args.map(a => this.expressionTreeToMAML(a));
+            mamlNode.args = tree.args.map(a => this.expressionTreeToMAML(a));
         }
 
         if (tree.type === 'OperatorNode' && tree.args) {
@@ -195,16 +194,15 @@ export default class ToolCreateModalController {
                 }
             });
         }
-
         return mamlNode;
-      }
+    }
 
-      objectNodeToClassifications(node) {
+    objectNodeToClassifications(node) {
         return Object.keys(node.properties).reduce((acc, p) => {
-          acc[`${parseFloat(p)}`] = parseInt(node.properties[p].value, 10);
-          return acc;
+            acc[`${parseFloat(p)}`] = parseInt(node.properties[p].value, 10);
+            return acc;
         }, {});
-      }
+    }
 
     isValid() {
         this.currentParsingError = '';


### PR DESCRIPTION
## Overview

This PR adds support for a `classify` function in *mamlscript*.

Syntactically, this is really a first pass but it is pretty straightforward:

`classify(input_expression, classifications)`

- `input_expression` is any valid *mamlscript* expression. Ex: `A + B + C`
- `classifications` is an object mapping the maximum value of a class (double as string) to an output value (integer). Ex: `{ "0.0": 0, "1.0" : 1}`

Additionally, this PR also adds like-operation merging. Previously, an expression like `A + B + C` would have been parsed into a tree more like `A + (B + C)`. This would stack, so expressions could end up unnecessarily deep (`A + (B + (C + (D + E)))`). This is accomplished in a way that respects parenthetical groupings.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

`classify((NIR - R)/(NIR + R), {"0.0": 0, "1.0": 1})`

![image](https://user-images.githubusercontent.com/2442245/29927023-1ad49fee-8e33-11e7-8b97-0ce4d4e0cc75.png)


`A + B + C + (D + E)`

![image](https://user-images.githubusercontent.com/2442245/29926971-eb5d09b8-8e32-11e7-9dcb-58cf64597ac1.png)

### Notes

We'll soon be moving this work to a separate library so that it can be made more robust and tested. (https://github.com/raster-foundry/maml.js)

## Testing Instructions

* Make an expression with the classify function and see that it works
* Make an expression with repeated operations (A + B + C) and see that they are combined

Closes #2448 
Closes #2367
