### PR TITLE
Remove unnecessary python-dev build dependency

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -11,9 +11,6 @@ RUN set -ex \
                airflow \
     && mkdir -p ${AIRFLOW_HOME} \
     && chown airflow:airflow -R ${AIRFLOW_HOME} \
-    && buildDeps=' \
-       python-dev/sid \
-    ' \
     && gdalDeps=' \
        gdal-bin/sid \
        python-gdal/sid \
@@ -25,13 +22,11 @@ RUN set -ex \
     && echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list \
     && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ${buildDeps} \
     && apt-get install -y --no-install-recommends ${gdalDeps} \
     && apt-get install -y --no-install-recommends ${javaDeps} \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
-    && apt-get purge -y --auto-remove ${buildDeps} \
     && rm -rf /var/lib/apt/lists/*
 
 COPY rf/ /tmp/rf


### PR DESCRIPTION
## Overview

After some experimentation, it does not appear that the Airflow container image needs the `python-dev` package as a build dependency (or at all). Previous failures with the `python-numpy` package go away once this dependency is removed.

## Testing Instructions

From inside of the Vagrant virtual machine, execute the following command and ensure that it builds the `airflow-webserver` container image properly:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker-compose -f docker-compose.airflow.yml build airflow-webserver
```

For laughs, use the following commands to ensure that important tools are still at the desired versions:

```bash
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker-compose -f docker-compose.airflow.yml run --rm --entrypoint bash airflow-webserver 
airflow@f4f9e0201402:/usr/local/airflow$ gdalinfo --version
GDAL 2.2.1, released 2017/06/23
airflow@f4f9e0201402:/usr/local/airflow$ java -version
openjdk version "1.8.0_144"
OpenJDK Runtime Environment (build 1.8.0_144-8u144-b01-1-b01)
OpenJDK 64-Bit Server VM (build 25.144-b01, mixed mode)
```