### PR TITLE
Mark Scene as failed if ingest definition fails

### DIFF
--- a/app-tasks/dags/ingest_project_scenes.py
+++ b/app-tasks/dags/ingest_project_scenes.py
@@ -173,10 +173,14 @@ def create_ingest_definition_op(*args, **kwargs):
     logger.info('Successfully updated scene (%s) status', scene_id)
 
     logger.info('Creating ingest definition')
-    if scene.datasource != landsat_id:
-        ingest_definition = create_ingest_definition(scene)
-    else:
-        ingest_definition = create_landsat8_ingest(scene)
+    try:
+        if scene.datasource != landsat_id:
+            ingest_definition = create_ingest_definition(scene)
+        else:
+            ingest_definition = create_landsat8_ingest(scene)
+    except:
+        scene.ingestStatus = IngestStatus.FAILED
+        scene.update()
     ingest_definition.put_in_s3()
     logger.info('Successfully created and pushed ingest definition for scene %s', scene_id)
 


### PR DESCRIPTION
## Overview

Ensure that Scenes are marked "FAILED" if generating an ingest definition fails.

### Checklist

- [ ] ~Styleguide updated, if necessary~
- [ ] ~Swagger specification updated, if necessary~
- [ ] ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * `./scripts/server --with-airflow`
 * Use the UI to upload a tiff that isn't from Landsat, but lie to RF and tell it that it _is_ Landsat.
 * Use either the UI or DB to confirm that the scene ingest_status gets set to FAILED, either in the UI or DB.

Closes #2469
