### PR TITLE
Remove installation of third-party vagrant-rsync plugin

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -22,12 +22,6 @@ then
         # Ensure that a directory exists to house AWS profiles.
         mkdir -p "${HOME}/.aws"
 
-        # Install vagrant-rsync plugin for speedy file watching
-        echo "Checking for vagrant-rsync plugin..."
-        if ! vagrant plugin list | grep -qE "^vagrant-rsync \(.*\)$"; then
-            echo "Installing vagrant-rsync..."
-            vagrant plugin install vagrant-rsync
-        fi
         vagrant up --provision
     fi
 fi


### PR DESCRIPTION
## Overview

This plugin is not needed as the functionality for rsync exists in Vagrant itself.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

Execute the following sequence of commands:

```bash
$ vagrant plugin uninstall
$ vagrant plugin list
vagrant-hostmanager (1.8.7)                 
vagrant-share (1.1.9, system)               
$ vagrant rsync-auto
```

If the virtual machine is up, `rsync` based synchronization should continue to work without `vagrant-rsync` installed.