### PR TITLE
Add Packer to Jenkins deployment configuration

### DIFF
--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -4,3 +4,5 @@ docker_users:
   - "{{ jenkins_name }}"
 
 java_version: "7u121*"
+
+packer_verison: "1.0.4"

--- a/deployment/ansible/raster-foundry-jenkins.yml
+++ b/deployment/ansible/raster-foundry-jenkins.yml
@@ -9,6 +9,7 @@
 
   roles:
     - { role: azavea.ntp }
+    - { role: azavea.packer }
     - { role: raster-foundry.aws-cli }
     - { role: raster-foundry.docker }
     - { role: raster-foundry.shellcheck }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -15,3 +15,6 @@
 
 - src: azavea.ntp
   version: 0.1.1
+
+- src: azavea.packer
+  version: 0.2.0


### PR DESCRIPTION
## Overview

Ensure that Packer is installed on Jenkins in order to support building custom AWS Batch AMIs.

Addresses part of https://github.com/azavea/raster-foundry-platform/issues/123

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

SSH into the Jenkins CI server and ensure that you get the same output as below:

```bash
ubuntu@ip-172-31-52-80:~$ packer -v
1.0.4
```