### PR TITLE
Set maxZoom at map level

### DIFF
--- a/app-frontend/src/app/components/map/labMap/labMap.controller.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.controller.js
@@ -48,7 +48,8 @@ export default class LabMapController {
             touchZoom: !this.options.static,
             boxZoom: !this.options.static,
             keyboard: !this.options.static,
-            tap: !this.options.static
+            tap: !this.options.static,
+            maxZoom: 30
         }).setView(
             this.initialCenter ? this.initialCenter : [0, 0],
             this.initialZoom ? this.initialZoom : 2

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
@@ -49,7 +49,8 @@ export default class MapContainerController {
             touchZoom: !this.options.static,
             boxZoom: !this.options.static,
             keyboard: !this.options.static,
-            tap: !this.options.static
+            tap: !this.options.static,
+            maxZoom: 30
         }).setView(
             this.initialCenter ? this.initialCenter : [0, 0],
             this.initialZoom ? this.initialZoom : 2

--- a/app-frontend/src/app/components/map/staticMap/staticMap.controller.js
+++ b/app-frontend/src/app/components/map/staticMap/staticMap.controller.js
@@ -41,7 +41,8 @@ export default class StaticMapController {
             touchZoom: false,
             boxZoom: false,
             keyboard: false,
-            tap: false
+            tap: false,
+            maxZoom: 30
         }).setView(
             this.initialCenter ? this.initialCenter : [0, 0],
             this.initialZoom ? this.initialZoom : 2

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
@@ -45,8 +45,7 @@ export default class ProjectItemController {
             this.authService.token()
         );
 
-        const tileLayerOptions = {maxZoom: 30};
-        let layer = L.tileLayer(url, tileLayerOptions);
+        let layer = L.tileLayer(url);
 
         this.getMap().then(m => {
             m.addLayer('share-layer', layer);

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -120,7 +120,7 @@ export default class LabRunController {
             if (url0 && url1) {
                 this.previewLayers = [
                     L.tileLayer(url0),
-                    L.tileLayer(url1),
+                    L.tileLayer(url1)
                 ];
             }
         } else {

--- a/app-frontend/src/app/pages/lab/run/run.controller.js
+++ b/app-frontend/src/app/pages/lab/run/run.controller.js
@@ -1,8 +1,6 @@
 /* global L */
 import { FrameView } from '../../../components/map/labMap/frame.module.js';
 
-const tileLayerOptions = {maxZoom: 30};
-
 export default class LabRunController {
     constructor( // eslint-disable-line max-params
         $log, $scope, $timeout, $element, $window, $document, $uibModal, $rootScope,
@@ -121,14 +119,14 @@ export default class LabRunController {
             let url1 = this.getNodeUrl(this.previewData[1]);
             if (url0 && url1) {
                 this.previewLayers = [
-                    L.tileLayer(url0, tileLayerOptions),
-                    L.tileLayer(url1, tileLayerOptions)
+                    L.tileLayer(url0),
+                    L.tileLayer(url1),
                 ];
             }
         } else {
             let url0 = this.getNodeUrl(this.previewData);
             if (url0) {
-                this.previewLayers = [L.tileLayer(url0, tileLayerOptions)];
+                this.previewLayers = [L.tileLayer(url0)];
             }
         }
     }

--- a/app-frontend/src/app/pages/projects/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/projects/detail/detail.controller.js
@@ -74,8 +74,7 @@ export default class ProjectsDetailController {
             this.authService.token()
         );
 
-        let options = {maxZoom: 30};
-        let layer = L.tileLayer(url, options);
+        let layer = L.tileLayer(url);
 
         this.getMap().then(m => {
             m.addLayer('share-layer', layer);

--- a/app-frontend/src/app/services/map/layer.service.js
+++ b/app-frontend/src/app/services/map/layer.service.js
@@ -87,7 +87,7 @@ export default (app) => {
                 });
             }
             return this.getMosaicLayerURL().then((url) => {
-                let options = {maxZoom: 30, bounds: this.bounds};
+                let options = {bounds: this.bounds};
                 this._mosaicTiles = L.tileLayer(url, options);
                 return this._mosaicTiles;
             });
@@ -99,18 +99,6 @@ export default (app) => {
             return this.$q((resolve) => {
                 resolve(`${this.tileServer}/${this.projectId}/{z}/{x}/{y}/${formattedParams}`);
             });
-        }
-
-        /**
-         * Helper function to inject required tile layer query params into an object
-         *
-         * @param {object} object containing tile query params
-         * @returns {object} initial object with necessary params injected
-         */
-        tileLayerParams() {
-            return {
-                tag: (new Date()).getTime()
-            };
         }
 
         /**


### PR DESCRIPTION
## Overview

This PR moves setting `maxZoom` from the individual tile layers to the maps. #1940 popped up because each call to `L.tileLayer` needed to set `maxZoom` individually, and we missed one. That's an annoying thing to have to keep doing when they're all going on just a few maps and we always picked 30. Also there was a function that wasn't called anywhere that I deleted.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to each of the map views (tools, share, and project edit)
 * On each, verify that you continue to request tiles when you zoom in up to level 30

Closes #1940
