### PR TITLE
Do not show uningested scene thumbnails in project edit by default

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -141,7 +141,9 @@ export default class ProjectsEditController {
                     mapWrapper.addLayer(
                         'Uningested Scenes',
                         overlay,
-                        true
+                        {
+                            showLayer: false
+                        }
                     );
                 });
             });

--- a/app-frontend/src/app/services/map/map.service.js
+++ b/app-frontend/src/app/services/map/map.service.js
@@ -271,23 +271,32 @@ class MapWrapper {
     /** Add a layer to the set of layers identified by an id
      * @param {string} id layer id
      * @param {L.Layer} layer layer to add
-     * @param {Boolean?} showToggle show a toggle in the layer picker
+     * @param {Object} opts various options to configure the layer
      * @returns {this} this
      */
-    addLayer(id, layer, showToggle) {
-        if (showToggle) {
+    addLayer(id, layer, opts) {
+        const options = Object.assign(
+            {
+                showToggle: true,
+                showLayer: true
+            },
+            opts
+        );
+        if (options.showToggle) {
             this._toggleableLayers.add(id);
-        } else if (showToggle === false) {
+        } else {
             this._toggleableLayers.delete(id);
         }
 
-        this._layerGroup.addLayer(layer);
-        let layerList = this.getLayers(id);
-        if (layerList && layerList.length) {
-            layerList.push(layer);
+        let layerList = [
+            ...this.getLayers(id),
+            ...[layer]
+        ];
+        if (options.showLayer) {
+            this._layerGroup.addLayer(layer);
             this._layerMap.set(id, layerList);
         } else {
-            this._layerMap.set(id, [layer]);
+            this._hiddenLayerMap.set(id, layerList);
         }
         return this;
     }


### PR DESCRIPTION
## Overview

This makes a change to the `addLayer` method of the map service. It now takes an object of options that can override certain default settings (such as initial layer visibility).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Open a project with some un-ingested scenes in the editor. See that the thumbnails aren't visible by default.
* Using the layer-picker, enable the thumbnails of un-ingested scenes. See that they show up.

Closes #2473
