### PR TITLE
Enable pagination and searching for Tools

### DIFF
--- a/app-frontend/src/app/components/tools/toolSearch/toolSearch.controller.js
+++ b/app-frontend/src/app/components/tools/toolSearch/toolSearch.controller.js
@@ -10,7 +10,7 @@ export default class ToolSearchController {
     }
 
     onSearchAction() {
-        this.onSearch({text: this.searchText});
+        this.onSearch({value: this.searchText});
     }
 
     clearSearch() {

--- a/app-frontend/src/app/components/tools/toolSearch/toolSearch.html
+++ b/app-frontend/src/app/components/tools/toolSearch/toolSearch.html
@@ -1,12 +1,14 @@
 <nav ng-show="$ctrl.$state.$current.name === 'market.search'">
   <ng-submit ng-submit="$ctrl.onSearchAction()">
     <div class="form-group search-form">
-      <input type="text"
-             id="search-input"
+      <input id="search-input"
              class="form-control"
              placeholder="Search for tools"
              ng-model="$ctrl.searchText"
-             ng-keyup="$event.keyCode == 13 && $ctrl.onSearchAction()"/>
+             ng-model-options="{
+               debounce: 500
+             }"
+             ng-change="$ctrl.onSearchAction()"/>
       <button ng-click="$ctrl.onSearchAction()" type="button" class="btn btn-link">
         <i class="icon-search"></i>
       </button>

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -288,7 +288,7 @@ function marketStates($stateProvider) {
         })
         .state('market.search', {
             title: 'Tool Search',
-            url: '/search?:query?toolcategory&tooltag',
+            url: '/search?:page?:query?toolcategory&tooltag',
             templateUrl: marketSearchTpl,
             controller: 'MarketSearchController',
             controllerAs: '$ctrl'

--- a/app-frontend/src/app/pages/market/search/search.controller.js
+++ b/app-frontend/src/app/pages/market/search/search.controller.js
@@ -17,9 +17,10 @@ export default class MarketSearchController {
     $onInit() {
         this.initFilters();
         this.initSearchTerms();
-        this.fetchToolList(this.$state.params.page || 1);
+        this.fetchToolList(this.$state.params.page);
         this.fetchToolTags();
         this.fetchToolCategories();
+        this.searchString = '';
 
         this.$scope.$on('$destroy', () => {
             if (this.activeModal) {
@@ -57,7 +58,7 @@ export default class MarketSearchController {
         }
     }
 
-    fetchToolList(page) {
+    fetchToolList(page = 1) {
         this.loadingTools = true;
         this.toolService.query(
             {
@@ -164,12 +165,15 @@ export default class MarketSearchController {
         this.search();
     }
 
-    search() {
-        this.$state.go('market.search', {
-            query: this.searchTerms.join(' '),
-            toolcategory: this.selectedToolCategories.join(' '),
-            tooltag: this.selectedToolTags.join(' ')
-        });
+    search(value) {
+        this.searchString = value;
+        if (this.searchString) {
+            this.toolService.searchQuery().then(tools => {
+                this.toolList = tools;
+            });
+        } else {
+            this.fetchToolList();
+        }
     }
 
     toggleTag(index) {

--- a/app-frontend/src/app/pages/market/search/search.controller.js
+++ b/app-frontend/src/app/pages/market/search/search.controller.js
@@ -17,7 +17,7 @@ export default class MarketSearchController {
     $onInit() {
         this.initFilters();
         this.initSearchTerms();
-        this.fetchToolList();
+        this.fetchToolList(this.$state.params.page || 1);
         this.fetchToolTags();
         this.fetchToolCategories();
 
@@ -57,12 +57,25 @@ export default class MarketSearchController {
         }
     }
 
-    fetchToolList() {
+    fetchToolList(page) {
         this.loadingTools = true;
         this.toolService.query(
-            this.queryParams
+            {
+                pageSize: 10,
+                page: page - 1
+            }
         ).then(d => {
+            this.currentPage = page;
             this.updatePagination(d);
+            let replace = !this.$state.params.page;
+            this.$state.transitionTo(
+                this.$state.$current.name,
+                {page: this.currentPage},
+                {
+                    location: replace ? 'replace' : true,
+                    notify: false
+                }
+            );
             this.lastToolResponse = d;
             this.toolList = d.results;
             this.loadingTools = false;
@@ -175,7 +188,6 @@ export default class MarketSearchController {
         if (this.activeModal) {
             this.activeModal.dismiss();
         }
-
         this.activeModal = this.$uibModal.open({
             component: 'rfToolCreateModal'
         });

--- a/app-frontend/src/app/pages/market/search/search.html
+++ b/app-frontend/src/app/pages/market/search/search.html
@@ -32,16 +32,16 @@
 
       <!-- Pagination -->
       <div class="list-group text-center"
-           ng-show="!$ctrl.loading && $ctrl.queryResult && $ctrl.pagination.show && !$ctrl.errorMsg">
+           ng-show="!$ctrl.loading && $ctrl.lastToolResponse && $ctrl.pagination.show && !$ctrl.errorMsg">
         <ul uib-pagination
-            items-per-page="$ctrl.queryResult.pageSize"
-            total-items="$ctrl.queryResult.count"
+            items-per-page="$ctrl.lastToolResponse.pageSize"
+            total-items="$ctrl.lastToolResponse.count"
             ng-model="$ctrl.currentPage"
             max-size="4"
             rotate="true"
             boundary-link-numbers="true"
             force-ellipses="true"
-            ng-change="$ctrl.populateToolList($ctrl.currentPage)">
+            ng-change="$ctrl.fetchToolList($ctrl.currentPage)">
         </ul>
       </div>
       <!-- Pagination -->

--- a/app-frontend/src/app/pages/market/search/search.html
+++ b/app-frontend/src/app/pages/market/search/search.html
@@ -7,7 +7,7 @@
       <div class="dashboard-header">
         <h1 class="h3">Tools</h1>
         <div class="flex-fill"></div>
-        <rf-tool-search on-search="$ctrl.search(text)"></rf-tool-search>
+        <rf-tool-search on-search="$ctrl.search(value)"></rf-tool-search>
         <a class="btn btn-primary" ng-click="$ctrl.openToolCreateModal()">New tool</a>
       </div>
       <!-- Dashboard Header -->
@@ -20,19 +20,29 @@
       </div>
       <!-- Loading indicator -->
 
-      <p class="font-size-small">Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} tools</p>
+      <p class="font-size-small"
+         ng-if="!$ctrl.searchString"
+      >
+        Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} tools
+      </p>
+
+      <p class="font-size-small"
+         ng-if="$ctrl.searchString"
+      >
+         Showing results for "{{$ctrl.searchString}}"
+      </p>
 
       <!-- Temporarily removed ng-click until after demo done and detail page designed. -->
       <rf-tool-item
           class="panel panel-off-white"
-          ng-repeat="toolData in $ctrl.toolList"
+          ng-repeat="toolData in $ctrl.toolList | filter: {title: $ctrl.searchString}"
           tool-data="toolData"
           ng-click=""
       ></rf-tool-item>
 
       <!-- Pagination -->
       <div class="list-group text-center"
-           ng-show="!$ctrl.loading && $ctrl.lastToolResponse && $ctrl.pagination.show && !$ctrl.errorMsg">
+           ng-show="!$ctrl.loading && $ctrl.lastToolResponse && $ctrl.pagination.show && !$ctrl.errorMsg &&!$ctrl.searchString">
         <ul uib-pagination
             items-per-page="$ctrl.lastToolResponse.pageSize"
             total-items="$ctrl.lastToolResponse.count"


### PR DESCRIPTION
## Overview

This PR does two things:

- fixes pagination on the tool list
- enables searching on the tool list

The search bypasses pagination as a way to work around the lack of search support in the API. When a search is being done, all tools are requested and then filtered on the front-end.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/30299341-4215a0d8-971d-11e7-945f-e35557596f58.png)

### Notes

Eventually, this will not scale.

## Testing Instructions

 * Bring up the tool list page, and see that it is paginated as one would expect
 * Try searching for some tools that appear on pages other than the first page, and see that they appear

Closes #2486
