### PR TITLE
Add ingest handling for Sentinel-2 Jpeg2000 images

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -80,7 +80,7 @@ sentinel2 {
 
   bandLookup = {
     # 10m
-    B02: { "name": "blue - 2", "number": 0, "wavelength": [457, 539]},
+    B02: { "name": "blue - 2", "number": 0, "wavelength": [457, 523]},
     B03: {"name": "green - 3", "number": 0, "wavelength": [542, 578]},
     B04: {"name": "red - 4", "number": 0, "wavelength": [650, 680]},
     B08: {"name": "near infrared - 8", "number": 0, "wavelength": [784, 900]},
@@ -94,7 +94,7 @@ sentinel2 {
     # 60m
     B01: {"name": "coastal aerosol - 1", "number": 0, "wavelength": [433, 453]},
     B09: {"name": "water vapor - 9", "number": 0, "wavelength": [935, 955]},
-    B10: {"name": "cirrus - 10", "number": 0, "wavelength": [1365, 1395]}
+    B10: {"name": "cirrus - 10", "number": 0, "wavelength": [1365, 1385]}
   }
 
   datasourceId = "4a50cb75-815d-4fe5-8bc1-144729ce5b42"

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/BandMapping.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/BandMapping.scala
@@ -8,4 +8,4 @@ import io.circe.generic.JsonCodec
   * @param target The band number in the multibandtile on write
   */
 @JsonCodec
-case class BandMapping(source: Int, target: Int)
+case class BandMapping(source: Int, target: TargetBand)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/TargetBand.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/model/TargetBand.scala
@@ -1,0 +1,12 @@
+package com.azavea.rf.batch.ingest.model
+
+import io.circe.generic.JsonCodec
+
+/** An object defining the name and number of target bands in band mappings
+  *
+  * @param name: the name of the target band
+  * @param index: The band number in the multibandtile on write. Starts at 1
+  *               to line up with source data like Landsat and Sentinel
+  */
+@JsonCodec
+case class TargetBand(name: String, index: Int)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
@@ -212,7 +212,7 @@ object Ingest extends SparkJob with LazyLogging with Config {
     val tileSize = layer.output.tileSize
     val destCRS = layer.output.crs
     val ndPattern = layer.output.ndPattern
-    val bandCount: Int = layer.sources.map(_.bandMaps.map(_.target).max).max
+    val bandCount: Int = layer.sources.map(_.bandMaps.map(_.target.index).max).max
     val layoutScheme = ZoomedLayoutScheme(destCRS, tileSize)
     val s3Client = S3Client.DEFAULT
     val repartitionSize =
@@ -249,7 +249,7 @@ object Ingest extends SparkJob with LazyLogging with Config {
           source.bandMaps.map { bm: BandMapping =>
             // GeoTrellis multi-band tiles are 0 indexed
             val band = maskedChip.band(bm.source - 1).reproject(chipExtent, geotiff.crs, destCRS)
-            (ProjectedExtent(band.extent, destCRS), bm.target - 1) -> band.tile
+            (ProjectedExtent(band.extent, destCRS), bm.target.index - 1) -> band.tile
           }
         }
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala
@@ -47,7 +47,9 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
           s"${tileInfoPath}/B05.jp2",
           s"${tileInfoPath}/B06.jp2",
           s"${tileInfoPath}/B07.jp2",
-          s"${tileInfoPath}/B8A.jp2"
+          s"${tileInfoPath}/B8A.jp2",
+          s"${tileInfoPath}/B11.jp2",
+          s"${tileInfoPath}/B12.jp2"
         )
       case 60f =>
         List(

--- a/app-backend/batch/src/test/resources/ingest/awsJob.json
+++ b/app-backend/batch/src/test/resources/ingest/awsJob.json
@@ -19,28 +19,28 @@
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 1}]
+            "bandMaps": [{"source": 1, "target": {"name": "1", "index": 1}}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B3.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 2}]
+            "bandMaps": [{"source": 1, "target": {"name": "2", "index": 2}}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B2.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 3}]
+            "bandMaps": [{"source": 1, "target": {"name": "3", "index": 3}}]
         }, {
             "uri": "http://landsat-pds.s3.amazonaws.com/L8/107/035/LC81070352015218LGN00/LC81070352015218LGN00_B5.TIF",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 4}]
+            "bandMaps": [{"source": 1, "target": {"name": "4", "index": 4}}]
         }]
     }]
 }

--- a/app-backend/batch/src/test/resources/ingest/localJob.json
+++ b/app-backend/batch/src/test/resources/ingest/localJob.json
@@ -19,28 +19,28 @@
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 1}]
+            "bandMaps": [{"source": 1, "target": {"name": "1", "index": 1}}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B3.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 2}]
+            "bandMaps": [{"source": 1, "target": {"name": "2", "index": 2}}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B2.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 3}]
+            "bandMaps": [{"source": 1, "target": {"name": "3", "index": 3}}]
         }, {
             "uri": "file:///opt/rf/test-resources/imagery/landsat-clipped-B5.tif",
             "extent": [138.8339238,  34.9569460, 141.4502449,  37.1094577],
             "extentCrs": "epsg:32654",
             "cellSize": {"width": 37.151447651062888, "height": -37.151447651062888},
             "crs": "epsg:32654",
-            "bandMaps": [{"source": 1, "target": 4}]
+            "bandMaps": [{"source": 1, "target": {"name": "4", "index": 4}}]
         }]
     }]
 }

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/ingest/model/IngestDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/ingest/model/IngestDefinitionSpec.scala
@@ -42,7 +42,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 1
+      |              "target": {"name": "1", "index": 1}
       |            }
       |          ]
       |        },
@@ -63,7 +63,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 2
+      |              "target": {"name": "2", "index": 2}
       |            }
       |          ]
       |        },
@@ -84,7 +84,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 3
+      |              "target": {"name": "3", "index": 3}
       |            }
       |          ]
       |        },
@@ -105,7 +105,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 4
+      |              "target": {"name": 4, "index": 4}
       |            }
       |          ]
       |        }
@@ -151,7 +151,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 1
+      |              "target": {"name": "1", "index": 1}
       |            }
       |          ]
       |        },
@@ -172,7 +172,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 2
+      |              "target": {"name": "2", "index": 2}
       |            }
       |          ]
       |        },
@@ -193,7 +193,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 3
+      |              "target": {"name": "3", "index": 3}
       |            }
       |          ]
       |        },
@@ -214,7 +214,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 4
+      |              "target": {"name": "4", "index": 4}
       |            }
       |          ]
       |        }
@@ -249,7 +249,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 1
+      |              "target": {"name": "1", "index": 1}
       |            }
       |          ]
       |        },
@@ -258,7 +258,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 2
+      |              "target": {"name": "2", "index": 2}
       |            }
       |          ]
       |        },
@@ -267,7 +267,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 3
+      |              "target": {"name": "3", "index": 3}
       |            }
       |          ]
       |        },
@@ -276,7 +276,7 @@ class IngestDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       |          "bandMaps": [
       |            {
       |              "source": 1,
-      |              "target": 4
+      |              "target": {"name": "4", "index": 4}
       |            }
       |          ]
       |        }

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -8,8 +8,13 @@ import click
 from ..utils.io import IngestStatus
 from ..models import Scene
 from ..ingest.models import Ingest
-from ..ingest import create_landsat8_ingest, create_ingest_definition
+from ..ingest import (
+    create_landsat8_ingest,
+    create_sentinel2_ingest,
+    create_ingest_definition
+)
 from ..uploads.landsat8.settings import datasource_id as landsat_id
+from ..uploads.sentinel2.settings import datasource_id as sentinel2_id
 from ..utils.emr import get_cluster_id, wait_for_emr_success
 
 logger = logging.getLogger(__name__)
@@ -54,10 +59,12 @@ def save_ingest_def_to_s3(scene_id, ignore_previous=False):
     logger.info('Successfully updated scene (%s) status', scene_id)
 
     logger.info('Creating ingest definition')
-    if scene.datasource != landsat_id:
-        ingest_definition = create_ingest_definition(scene)
-    else:
+    if scene.datasource == landsat_id:
         ingest_definition = create_landsat8_ingest(scene)
+    elif scene.datasource == sentinel2_id:
+        ingest_definition = create_sentinel2_ingest(scene)
+    else:
+        ingest_definition = create_ingest_definition(scene)
     ingest_definition.put_in_s3()
     logger.info('Successfully created and pushed ingest definition for scene %s', scene)
 

--- a/app-tasks/rf/src/rf/ingest/__init__.py
+++ b/app-tasks/rf/src/rf/ingest/__init__.py
@@ -1,2 +1,3 @@
 from .landsat8_ingest import create_landsat8_ingest
+from .sentinel2_ingest import create_sentinel2_ingest
 from .geotiff_ingest import create_ingest_definition

--- a/app-tasks/rf/src/rf/ingest/geotiff_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/geotiff_ingest.py
@@ -44,7 +44,8 @@ def get_source_definition(image):
 
     uri = get_safe_uri(image.sourceUri)
 
-    band_maps = [{'source': band.number, 'target': band.number} for band in image.bands]
+    band_maps = [{'source': band.number,
+                  'target': {'name': band.name, 'index': band.number}} for band in image.bands]
     if image.resolutionMeters < MIN_RESOLUTION_METERS:
         width = MIN_RESOLUTION_METERS
         height = MIN_RESOLUTION_METERS

--- a/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
@@ -1,0 +1,188 @@
+import os
+import subprocess
+
+import boto3
+from botocore.exceptions import ClientError
+
+import rf.uploads.geotiff.io as geotiff_io
+from rf.utils.io import s3_obj_exists
+from rf.ingest import geotiff_ingest
+from rf.models import Image, Scene
+
+from .models import Ingest, Layer, Source
+
+layer_s3_bucket = os.getenv('TILE_SERVER_BUCKET')
+
+
+def process_jp2000(scene_id, jp2_source):
+    """Converts a Jpeg 2000 file to a tif
+
+    Args:
+        scene_id (str): scene the image is associated with
+        jp2_source (str): url to a jpeg 2000 file
+
+    Return:
+        str: s3 url to the converted tif
+    """
+
+    s3client = boto3.client('s3')
+    in_bucket, in_key = geotiff_io.s3_bucket_and_key_from_url(jp2_source)
+    in_bucket = in_bucket.replace(r'.s3.amazonaws.com', '')
+    fname_part = os.path.split(in_key)[-1]
+    out_bucket = os.getenv('DATA_BUCKET')
+    out_key = os.path.join('sentinel-2-tifs',
+                           scene_id,
+                           fname_part.replace('.jp2', '.tif'))
+    jp2_fname = os.path.join('/tmp', fname_part)
+    tif_fname = jp2_fname.replace('.jp2', '.tif')
+    # Explicitly setting nbits is necessary because geotrellis only likes
+    # powers of 2, and for some reason the value on the jpeg 2000 files
+    # after translation is 15
+    cmd = ['gdal_translate',
+           '-a_nodata', '0', # set 0 to nodata value
+           '-co', 'NBITS=16', # explicitly set nbits = 16
+           jp2_fname,
+           tif_fname]
+
+    dst_url = geotiff_io.s3_url(out_bucket, out_key)
+
+    # check if the object is already there
+    try:
+        s3client.head_object(Bucket=out_bucket, Key=out_key)
+        processed = True
+    except ClientError:
+        processed = False
+
+    # If the object is already there, we've converted this scene
+    # before
+    if not processed:
+        # Download the original jp2000 file
+        with open(jp2_fname, 'wb') as src:
+            body = s3client.get_object(
+                Bucket=in_bucket,
+                Key=in_key
+            )['Body']
+            src.write(body.read())
+
+        # Translate the original file and add 0 as a nodata value
+        subprocess.check_call(cmd)
+
+        # Upload the converted tif
+        with open(tif_fname, 'r') as dst:
+            s3client.put_object(
+                Bucket=out_bucket,
+                Key=out_key,
+                Body=dst
+            )
+
+    # Return the s3 url to the converted image
+    return dst_url
+
+
+def make_tif_image_copy(image):
+    """Translate an images jp2 file to tif and return a copy
+
+    Args:
+        image (Image): image to copy data from
+
+    Return:
+        Image: the image copy
+    """
+
+    copied = Image.from_dict(image.to_dict())
+    copied.sourceUri = process_jp2000(image.scene, image.sourceUri)
+    return copied
+
+
+def copy_scene(scene):
+    """Create a copy of this scene with images converted to tifs in s3
+
+    Args:
+        scene (Scene): scene to copy images from
+
+    Return:
+        Scene: the copied scene with substitute images
+    """
+
+    copied = Scene.from_dict(scene.to_dict())
+    copied.images = [make_tif_image_copy(image) for image in scene.images]
+    return copied
+
+
+def get_source(image, extent):
+    """Construct source for a Sentinel-2 image
+    Args:
+        image (Image): the image to construct a source for
+        extent (list[int]): scene extent of the scene this image belongs to
+
+    Return:
+        Source
+    """
+    uri = image.sourceUri
+    # Sentinel-2 is split into one tif per band
+    band = image.bands[0]
+    # Band names are in the template "red - 4"
+    band_maps = [
+        {'source': 1,
+         'target': {'name': band.name,
+                    'index': get_band_index(band.name)}}
+    ]
+    cell_size = {'width': image.resolutionMeters,
+                 'height': image.resolutionMeters}
+    return Source(uri, band_maps, cell_size)
+
+
+def get_band_index(band_name):
+    """Get the write-index value for a Sentinel-2 image band
+
+    For bands 1 through 8, we return the band number. For 8A,
+    we return 9. For bands above 8A, we add one to the band
+    number.
+
+    Args:
+        band_name (str): the name of the band, e.g. "nir - 8A"
+
+    Return:
+        int
+    """
+
+    name, num = band_name.split(' - ')
+    if num.lower() == '8a':
+        return 9
+    elif num.lower() > '8a':
+        return int(num) + 1
+    else:
+        return int(num)
+
+
+def get_sentinel2_layer(scene):
+    """Construct layer for Sentinel-2 scene
+
+    Args:
+        scene (Scene): Sentinel-2 scene to construct layer 4
+
+    Returns:
+        Layer
+    """
+
+    extent = scene.get_extent()
+    output_uri = 's3://{}/layers'.format(layer_s3_bucket)
+    sources = [get_source(image, extent) for image in scene.images]
+    cell_size = {'width': 30, 'height': 30}
+    return Layer(scene.id, output_uri, sources, cell_size)
+
+
+def create_sentinel2_ingest(scene):
+    """Translate the Sentinel 2 imagery to geotiff and create ingest definition
+
+    Args:
+        scene (Scene): scene to create an ingest definition for
+
+    Return:
+        Ingest
+    """
+
+    copied = copy_scene(scene)
+    layer = get_sentinel2_layer(copied)
+    id = copied.id
+    return Ingest(id, [layer])

--- a/app-tasks/rf/src/rf/models/band.py
+++ b/app-tasks/rf/src/rf/models/band.py
@@ -20,7 +20,7 @@ class Band(BaseModel):
         self.wavelength = wavelength
 
     def __repr__(self):
-        return '<Band: {name}-{number}'.format(name=self.name, number=self.number)
+        return '<Band: {name}-{number}>'.format(name=self.name, number=self.number)
 
     @classmethod
     def from_dict(cls, d):

--- a/app-tasks/rf/src/rf/models/image.py
+++ b/app-tasks/rf/src/rf/models/image.py
@@ -44,7 +44,7 @@ class Image(BaseModel):
         return cls(
             d.get('organizationId'), d.get('rawDataBytes'), d.get('visibility'), d.get('filename'),
             d.get('sourceUri'), bands, d.get('imageMetadata'), d.get('resolutionMeters'),
-            d.get('scene'), d.get('owner')
+            d.get('metadataFiles'), d.get('scene'), d.get('owner')
         )
 
     def to_dict(self):

--- a/app-tasks/rf/src/rf/uploads/geotiff/io.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/io.py
@@ -59,7 +59,7 @@ def s3_url(bucket, key):
 
 
 def s3_bucket_and_key_from_url(s3_url):
-    parts = urlparse.urlparse(s3_url) 
+    parts = urlparse.urlparse(s3_url)
     # parts.path[1:] drops the leading slash that urlparse includes
     return (parts.netloc, parts.path[1:])
 


### PR DESCRIPTION
## Overview

Sentinel-2 images couldn't be ingested for at least two reasons. The files were
in jpeg 2000, rather than geotiff, file format, and the bands didn't have
strictly numeric labels. This commit adds processing to convert jpeg 2000s to
tifs for ingest and expands the BandMaps representation to include a label and
an index-on-write, so we can deal with inconvenient labels for bands like "8A".

It also includes some minor fixups like a typo in `rf/models/band.py`s' `__repr__`
function.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

~I'm waiting to remove `WIP` until #2505 is merged, since this will become a part of it~ It's merged

~I think we might also have some of the wavelength ranges recorded incorrectly. I'm checking those before removing `WIP` as well.~ We did -- included fixup in a separate commit

A few issues were discovered in the process:

- with the bands issue, we'll need some sort of front-end handling and probably a migration
  to deal with labels and indices-on-write as first class citizens of `Band`s (#2512)
- ~something is wrong with how we're deserializing scenes from the API in the `rf` library. I'll fix that before removing `[WIP]`, since it makes the testing instructions insane.~ fixed, we just dropped a field
- we weren't importing all of the Sentinel 2 bands. I included [a fix for that in this PR](https://github.com/raster-foundry/raster-foundry/blob/e463a14fe5b4a9e26944a9cef9b1a6528d4a48f8/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/airflow/ImportSentinel2.scala#L51-L52),
  but my best guess is that 0% of our currently imported Sentinel 2 imagery includes bands 11 and 12.


## Testing Instructions

 * Assemble your batch jar
 * Get a sentinel 2 scene ID from your database
 * Open up an `airflow-worker` console
 * `rf ingest-scene <scene id>` -- it should create the ingest definition and then kick off an ingest
 * this will never finish though because the cluster has opinions about which batch jar to use, so kill it once the ingest is kicked off
 * now: `spark-submit` using the same parameters as the step that got kicked off in EMR and your local batch jar
 * it should succeed

Closes #2150