### PR TITLE
Implement statistics node display in lab UI

### DIFF
--- a/app-frontend/src/app/components/tools/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/tools/diagramContainer/diagramContainer.controller.js
@@ -100,21 +100,25 @@ export default class DiagramContainerController {
                     </div>
                   </div>
                   <rf-input-node
-                    ng-if="showCellBodyType('src')"
+                    ng-if="ifCellType('src')"
+                    ng-show="showCellBody()"
                     data-model="model"
                     on-change="onChange({sourceId: sourceId, project: project, band: band})"
                   ></rf-input-node>
                   <rf-operation-node
-                    ng-if="showCellBodyType('function')"
+                    ng-if="ifCellType('function')"
+                    ng-show="showCellBody()"
                     data-model="model"
                   ></rf-operation-node>
                   <rf-constant-node
-                    ng-if="showCellBodyType('const')"
+                    ng-if="ifCellType('const')"
+                    ng-show="showCellBody()"
                     data-model="model"
                     on-change="onChange({override: override})"
                   ></rf-constant-node>
                   <rf-classify-node
-                    ng-if="showCellBodyType('classify')"
+                    ng-if="ifCellType('classify')"
+                    ng-show="showCellBody()"
                     data-model="model"
                     on-change="onChange({override: override})"
                   ></rf-classify-node>
@@ -194,9 +198,12 @@ export default class DiagramContainerController {
                     }
                 };
 
-                this.scope.showCellBodyType = (type) => {
+                this.scope.ifCellType = (type) => {
+                    return this.scope.model.get('cellType') === type;
+                };
+
+                this.scope.showCellBody = () => {
                     return (
-                        this.scope.model.get('cellType') === type &&
                         this.scope.currentView === 'BODY' &&
                         !this.scope.isCollapsed
                     );

--- a/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.html
+++ b/app-frontend/src/app/components/tools/diagramNodeHeader/diagramNodeHeader.html
@@ -11,11 +11,11 @@
     <div class="node-dropdown-menu" ng-show="$ctrl.showMenu">
       <ul>
         <span ng-repeat="menuItem in $ctrl.menuItems">
-        <li ng-if="menuItem.type !== 'divider'"
-            ng-click="menuItem.callback($event, $ctrl.model)">
-            {{menuItem.label}}
-        </li>
-        <li ng-if="menuItem.type === 'divider'" class="divider"></li>
+          <li ng-if="menuItem.type !== 'divider'"
+              ng-click="menuItem.callback($event, $ctrl.model)">
+              {{menuItem.label}}
+          </li>
+          <li ng-if="menuItem.type === 'divider'" class="divider"></li>
         </span>
       </ul>
     </div>

--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.component.js
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.component.js
@@ -1,0 +1,13 @@
+import nodeStatisticsTpl from './nodeStatistics.html';
+
+const nodeStatistics = {
+    templateUrl: nodeStatisticsTpl,
+    controller: 'NodeStatisticsController',
+    bindings: {
+        model: '<',
+        toolrun: '<',
+        size: '<'
+    }
+};
+
+export default nodeStatistics;

--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.controller.js
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.controller.js
@@ -1,0 +1,78 @@
+/* global _ */
+
+export default class NodeHistogramController {
+    constructor($scope, toolService) {
+        'ngInject';
+        this.$scope = $scope;
+        this.toolService = toolService;
+    }
+
+    $onInit() {
+        this.initSize();
+        this.isLoading = false;
+        this.hasStats = false;
+        this.digitCount = 5;
+        this.emptyStats = {
+            dataCells: '',
+            mean: '',
+            median: '',
+            mode: '',
+            stddev: '',
+            zmin: '',
+            zmax: ''
+        };
+    }
+
+    initSize() {
+        let size = this.size;
+        this.model.set('size', {width: size.width, height: 290});
+    }
+
+    $onChanges() {
+        this.fetchStats();
+    }
+
+    fetchStats() {
+        if (
+            this.model &&
+            this.toolrun &&
+            this.toolrun.id
+        ) {
+            const nodeId = this.model.get('id');
+            const runId = this.toolrun.id;
+
+            this.hasToolRun = true;
+            this.isLoading = true;
+
+            this.toolService.getNodeStatistics(runId, nodeId).then(stats => {
+                // Scrub the response of angular remnants to tell if it's actually empty
+                this.stats = Object.keys(stats).reduce((acc, s) => {
+                    if (!s.startsWith('$')) {
+                        acc[s] = stats[s];
+                    }
+                    return acc;
+                }, {});
+
+                this.hasStats = !_.isEmpty(this.stats);
+                this.isLoading = false;
+            });
+        } else {
+            this.hasToolRun = false;
+            this.isLoading = false;
+            this.hasStats = false;
+        }
+    }
+
+    shouldShowEmptyStats() {
+        return !this.isLoading && !this.hasStats;
+    }
+
+    shouldShowApplyMessage() {
+        return !this.hasToolRun && !this.isLoading && !this.hasStats;
+    }
+
+    shouldShowDataMessage() {
+        return this.hasToolRun && !this.isLoading && !this.hasStats;
+    }
+
+}

--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.html
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.html
@@ -1,0 +1,28 @@
+<div class="node-statistics">
+    <div class="classify-node-preview-row with-border"
+         ng-repeat="(label, value) in $ctrl.stats"
+         ng-if="$ctrl.shouldShowStats()"
+    >
+        <div class="classify-node-class header">{{label}}</div>
+        <div class="classify-node-class">{{value}}</div>
+    </div>
+
+    <div class="classify-node-preview-row with-border"
+        ng-repeat="(label, value) in $ctrl.emptyStats"
+        ng-if="$ctrl.shouldShowEmptyStats()"
+    >
+       <div class="classify-node-class header">{{label}}</div>
+       <div class="classify-node-class">{{value}}</div>
+    </div>
+
+</div>
+<div class="node-controls overlayed" ng-if="$ctrl.shouldShowEmptyStats()">
+    <div class="node-data-placeholder" ng-if="$ctrl.shouldShowApplyMessage()">
+        <span class="icon icon-warning color-warning"></span>
+        <div class="message">Fill out all input fields and apply changes to view statistics</div>
+    </div>
+    <div class="node-data-placeholder" ng-if="$ctrl.shouldShowDataMessage()">
+        <span class="icon icon-warning color-warning"></span>
+        <div class="message">No statistics are available for this node</div>
+    </div>
+</div>

--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.module.js
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.module.js
@@ -1,0 +1,11 @@
+import angular from 'angular';
+
+import NodeStatistics from './nodeStatistics.component.js';
+import NodeStatisticsController from './nodeStatistics.controller.js';
+
+const NodeStatisticsModule = angular.module('components.statistics.nodeStatistics', []);
+
+NodeStatisticsModule.component('rfNodeStatistics', NodeStatistics);
+NodeStatisticsModule.controller('NodeStatisticsController', NodeStatisticsController);
+
+export default NodeStatisticsModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -35,6 +35,7 @@ export default angular.module('index.components', [
     require('./components/tools/operationNode/operationNode.module.js').name,
     require('./components/tools/constantNode/constantNode.module.js').name,
     require('./components/tools/classifyNode/classifyNode.module.js').name,
+    require('./components/tools/nodeStatistics/nodeStatistics.module.js').name,
     require('./components/map/nodeSelector/nodeSelector.module.js').name,
 
     // map components

--- a/app-frontend/src/app/services/tools/tool.service.js
+++ b/app-frontend/src/app/services/tools/tool.service.js
@@ -39,6 +39,11 @@ export default (app) => {
                         url: `${APP_CONFIG.tileServerLocation}/tools/:toolId/histogram/`,
                         method: 'GET',
                         cache: false
+                    },
+                    statistics: {
+                        url: `${APP_CONFIG.tileServerLocation}/tools/:toolId/statistics/`,
+                        method: 'GET',
+                        cache: false
                     }
                 }
             );
@@ -135,6 +140,15 @@ export default (app) => {
         getNodeHistogram(toolRun, nodeId) {
             return this.ToolRun.histogram({
                 toolId: toolRun, node: nodeId, voidCache: true,
+                token: this.authService.token()
+            }).$promise;
+        }
+
+        getNodeStatistics(toolRun, nodeId) {
+            return this.ToolRun.statistics({
+                toolId: toolRun,
+                node: nodeId,
+                voidCache: true,
                 token: this.authService.token()
             }).$promise;
         }

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2670,8 +2670,8 @@ nvd3 {
   .message {
     flex: 1;
   }
-  .icon {
-    margin: 0 1em;
+  > *:not(:last-child) {
+    margin-right: 1em;
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1644,7 +1644,8 @@ rf-node-statistics {
   align-items: stretch;
   position: relative;
   max-height: 240px;
-  overflow: visible;
+  overflow: hidden;
+  border-radius: 0 0 5px 5px;
 }
 
 .operation-node-body {
@@ -2659,7 +2660,7 @@ nvd3 {
 
 .node-data-placeholder {
   font-weight: 700;
-  text-align: left;
+  text-align: center;
   padding: 1em;
   width: 90%;
   background: #fafafa;

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1636,6 +1636,17 @@ rf-classify-node {
   overflow: hidden;
 }
 
+rf-node-statistics {
+  flex: 1;
+  cursor: auto;
+  pointer-events: auto;
+  flex-direction: column;
+  align-items: stretch;
+  position: relative;
+  max-height: 240px;
+  overflow: visible;
+}
+
 .operation-node-body {
   display: flex;
   flex: 1;
@@ -1649,6 +1660,13 @@ rf-classify-node {
 
 
 .classify-node-preview {
+  display: flex;
+  display: flex;
+  flex-direction: column;
+  padding: 1em;
+}
+
+.node-statistics {
   display: flex;
   display: flex;
   flex-direction: column;
@@ -2544,6 +2562,7 @@ ul.dropdown-list {
   right: 0;
   transform: translateY(-50%);
   margin-right: 1em;
+  z-index: 1;
 }
 .node-button {
   padding: 0.2em;
@@ -2633,6 +2652,27 @@ nvd3 {
     background: rgba(0, 0, 0, 0.3);
     border: 1px solid rgba(0, 0, 0, 0.5);
     border-radius: 3px;
+    &.light {
+      background: none;
+    }
+}
+
+.node-data-placeholder {
+  font-weight: 700;
+  text-align: left;
+  padding: 1em;
+  width: 90%;
+  background: #fafafa;
+  border: 1px solid $gray-lightest;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  .message {
+    flex: 1;
+  }
+  .icon {
+    margin: 0 1em;
+  }
 }
 
 /* Component: Reclassify Modal */


### PR DESCRIPTION
## Overview

This PR adds a control to nodes to display stats about that node.

### Checklist

- [ ] Styleguide updated, if necessary
- [ ] Swagger specification updated, if necessary
- [ ] Symlinks from new migrations present or corrected for any new migrations
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Demo


![image](https://user-images.githubusercontent.com/2442245/30442764-70435de4-994b-11e7-93ef-8fe65e08ae34.png)

![image](https://user-images.githubusercontent.com/2442245/30443404-58378318-994d-11e7-8a98-67d5818368d4.png)


### Notes

There is currently a problem with the statistics endpoint in that it is returning a 204 when we expect to get data back. This PR build on the expected behavior and so should 'just work' when the bug is fixed.

We are lacking an icon for stats (could be something like a capital sigma), so I opted to write-out 'stats' for clarity.


## Testing Instructions

 * Check that the proper message is displayed when you view stats without having applied changes
 
* Check that after applying inputs, a different message is displayed (saying that stats aren't available)

* If desired, you can use the `emptyStats` object and set `this.stats` to a stubbed object in the response handling of the `fetchStats` method in the `node-statitistics.controller` (after the reduce) to see how they are displayed. 

Closes #2521 
