### PR TITLE
Use color scheme dropdown selector for single band projects

### DIFF
--- a/app-frontend/src/app/components/colorComposites/colorSchemeBuilder/colorSchemeBuilder.controller.js
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeBuilder/colorSchemeBuilder.controller.js
@@ -31,6 +31,8 @@ export default class ColorSchemeBuilderController {
             )
         ) {
             this.buffer = [ ...incomingSchemeAsArray ];
+            // coerce color scheme to map, since it's initially set as an array in the dropdown
+            this.onChange({ value: this.getBufferAsObject() });
         }
         this.isValid = true;
     }

--- a/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.html
+++ b/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.html
@@ -13,11 +13,13 @@
   <div class="modal-body" ng-if="$ctrl.currentStepIs('TYPE')">
     <div class="content">
       <h3 class="modal-content-header">Name your Project</h3>
-      <form>
+      <form ng-submit="$ctrl.handleNext()">
         <div class="form-group all-in-one">
           <label for="name"><i class="icon-project"></i></label>
           <input id="name" type="text" class="form-control"
-                placeholder="New project name" ng-model="$ctrl.projectBuffer.name">
+                 placeholder="New project name"
+                 ng-model="$ctrl.projectBuffer.name"
+          >
         </div>
         <div class="form-group color-danger"
             ng-if="$ctrl.showProjectCreateError && $ctrl.projectCreateErrorText"

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -178,53 +178,20 @@ export default class ProjectsEditColormode {
         }
     }
 
-    setActiveColorSchemeType(type) {
-        if (this.activeColorSchemeType.value !== type.value) {
-            this.activeColorSchemeType = type;
-            const firstSchemeOfType = this.colorSchemeService.defaultColorSchemes.find(
-                s => s.type === type.value
-            );
-            this.setActiveColorScheme(firstSchemeOfType, true);
-        }
-    }
-
-    getActiveColorSchemeType() {
-        if (!this.isLoading) {
-            return this.activeColorSchemeType;
-        }
-        return null;
-    }
-
-    setActiveColorBlendMode(blendMode) {
-        if (this.activeColorBlendMode.value !== blendMode.value) {
-            this.activeColorBlendMode = blendMode;
-            this.projectBuffer.singleBandOptions.blendMode = this.activeColorBlendMode.value;
-            this.updateProjectFromBuffer();
-        }
-    }
-
-    getActiveColorBlendMode() {
-        if (!this.isLoading) {
-            return this.activeColorBlendMode;
-        }
-        return null;
-    }
-
     shouldShowColorScheme() {
         return (
-            this.activeColorSchemeType && (
-                this.activeColorSchemeType.value === 'SEQUENTIAL' ||
-                this.activeColorSchemeType.value === 'DIVERGING'
-            )
+            this.projectBuffer.singleBandOptions &&
+                this.projectBuffer.singleBandOptions.dataType === 'SEQUENTIAL' ||
+                this.projectBuffer.singleBandOptions.dataType === 'DIVERGING'
         );
     }
 
     shouldShowColorSchemeBuilder() {
-        return this.activeColorSchemeType.value === 'CATEGORICAL';
+        return this.projectBuffer.singleBandOptions.dataType === 'CATEGORICAL';
     }
 
     shouldShowBlendMode() {
-        return this.activeColorSchemeType.value !== 'CATEGORICAL';
+        return this.projectBuffer.singleBandOptions.dataType !== 'CATEGORICAL';
     }
 
     updateProjectFromBuffer() {
@@ -336,6 +303,21 @@ export default class ProjectsEditColormode {
     redrawMosaic() {
         this.$parent.layerFromProject();
     }
+
+    onColorSchemeChange(colorSchemeOptions) {
+        let oldOptions = this.projectBuffer.singleBandOptions;
+        this.activeColorSchemeType = oldOptions.dataType;
+        if (
+            JSON.stringify(colorSchemeOptions.colorScheme) !==
+                JSON.stringify(oldOptions.colorScheme)
+        ) {
+            this.activeColorSchemeType = colorSchemeOptions.dataType;
+            this.projectBuffer.singleBandOptions = Object.assign(
+                {},
+                this.projectBuffer.singleBandOptions,
+                colorSchemeOptions
+            );
+            this.updateProjectFromBuffer();
+        }
+    }
 }
-
-

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -103,7 +103,7 @@ export default class ProjectsEditColormode {
         this.defaultSingleBandOptions = {
             band: 0,
             dataType: scheme.type,
-            colorScheme: this.colorSchemeService.colorsToDiscreteScheme(scheme.colors),
+            colorScheme: scheme.colors,
             colorBins: 0,
             legendOrientation: 'left'
         };

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -47,13 +47,15 @@
           <li>
             <span class="label">Color scheme</span>
             <rf-color-scheme-dropdown
-                color-scheme-options="$ctrl.getSerializedSingleBandOptions()"
-                on-change="$ctrl.onColorSchemeChange(value)"
+              color-scheme-options="$ctrl.getSerializedSingleBandOptions()"
+              on-change="$ctrl.onColorSchemeChange(value)"
             ></rf-color-scheme-dropdown>
             <i class="icon-info"></i>
           </li>
           <li ng-if="$ctrl.shouldShowColorSchemeBuilder()">
-            <rf-color-scheme-builder color-scheme="$ctrl.projectBuffer.singleBandOptions.colorScheme" on-change="$ctrl.onSchemeColorsChange(value)"/>
+            <rf-color-scheme-builder
+                color-scheme="$ctrl.projectBuffer.singleBandOptions.colorScheme"
+                on-change="$ctrl.onSchemeColorsChange(value)"/>
           </li>
         </ul>
       </div>

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -45,42 +45,11 @@
             <i class="icon-info"></i>
           </li>
           <li>
-            <span class="label">Nature of Data</span>
-            <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">
-                {{$ctrl.getActiveColorSchemeType().label}}
-              </a>
-              <button type="button" class="btn btn-light dropdown-toggle">
-                <i class="icon-caret-down"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-                <li  ng-repeat="type in $ctrl.colorSchemeService.defaultColorSchemeTypes" role="menuitem">
-                  <a ng-click="$ctrl.setActiveColorSchemeType(type)">{{type.label}}</a>
-                </li>
-              </ul>
-            </div>
-            <i class="icon-info"></i>
-          </li>
-          <li ng-if="$ctrl.showShowBlendMode()">
-            <span class="label">Blend Mode</span>
-            <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">
-                {{$ctrl.getActiveColorBlendMode().label}}
-              </a>
-              <button type="button" class="btn btn-light dropdown-toggle">
-                <i class="icon-caret-down"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-                <li  ng-repeat="mode in $ctrl.colorSchemeService.defaultColorBlendModes" role="menuitem">
-                  <a ng-click="$ctrl.setActiveColorBlendMode(mode)">{{mode.label}}</a>
-                </li>
-              </ul>
-            </div>
-            <i class="icon-info"></i>
-          </li>
-          <li>
             <span class="label">Color scheme</span>
-            <rf-color-scheme-dropdown serialized-single-band-options="$ctrl.getSerializedSingleBandOptions()"></rf-color-scheme-dropdown>
+            <rf-color-scheme-dropdown
+                color-scheme-options="$ctrl.getSerializedSingleBandOptions()"
+                on-change="$ctrl.onColorSchemeChange(value)"
+            ></rf-color-scheme-dropdown>
             <i class="icon-info"></i>
           </li>
           <li ng-if="$ctrl.shouldShowColorSchemeBuilder()">

--- a/app-frontend/src/app/services/projects/colorScheme.defaults.json
+++ b/app-frontend/src/app/services/projects/colorScheme.defaults.json
@@ -1,21 +1,5 @@
 {
     "colorSchemes": [{
-        "label": "Blue to orange",
-        "colors": ["#2586AB", "#4EA3C8", "#7FB8D4", "#ADD8EA", "#C8E1E7", "#EDECEA", "#F0E7BB", "#F5CF7D", "#F9B737", "#E68F2D", "#D76B27"],
-        "type": "DIVERGING"
-    }, {
-        "label": "Light yellow to orange",
-        "colors": ["#118C8C", "#429D91", "#61AF96", "#75C59B", "#A2CF9F", "#C5DAA3", "#E6E5A7", "#E3D28F", "#E0C078", "#DDAD62", "#D29953", "#CA8746", "#C2773B"],
-        "type": "DIVERGING"
-    }, {
-        "label": "Blue to red",
-        "colors": ["#2791C3", "#5DA1CA", "#83B2D1", "#A8C5D8", "#CCDBE0", "#E9D3C1", "#DCAD92", "#D08B6C", "#C66E4B", "#BD4E2E"],
-        "type": "DIVERGING"
-    }, {
-        "label": "Green to red-orange",
-        "colors": ["#569543", "#9EBD4D", "#BBCA7A", "#D9E2B2", "#E4E7C4", "#E6D6BE", "#E3C193", "#DFAC6C", "#DB9842", "#B96230"],
-        "type": "DIVERGING"
-    }, {
         "label": "Viridis",
         "colors": ["#440154", "#482878", "#3e4989", "#31688e", "#26868e", "#1f9e89", "#35b779", "#6ece58", "#b5de2b", "#F0F921"],
         "type": "SEQUENTIAL"
@@ -51,6 +35,22 @@
         "label": "Classification: Muted terrain",
         "colors": ["#CEE1E8", "#7CBCB5", "#82B36D", "#94C279", "#D1DE8D", "#EDECC3", "#CCAFB4", "#C99884"],
         "type": "SEQUENTIAL"
+    }, {
+        "label": "Blue to orange",
+        "colors": ["#2586AB", "#4EA3C8", "#7FB8D4", "#ADD8EA", "#C8E1E7", "#EDECEA", "#F0E7BB", "#F5CF7D", "#F9B737", "#E68F2D", "#D76B27"],
+        "type": "DIVERGING"
+    }, {
+        "label": "Light yellow to orange",
+        "colors": ["#118C8C", "#429D91", "#61AF96", "#75C59B", "#A2CF9F", "#C5DAA3", "#E6E5A7", "#E3D28F", "#E0C078", "#DDAD62", "#D29953", "#CA8746", "#C2773B"],
+        "type": "DIVERGING"
+    }, {
+        "label": "Blue to red",
+        "colors": ["#2791C3", "#5DA1CA", "#83B2D1", "#A8C5D8", "#CCDBE0", "#E9D3C1", "#DCAD92", "#D08B6C", "#C66E4B", "#BD4E2E"],
+        "type": "DIVERGING"
+    }, {
+        "label": "Green to red-orange",
+        "colors": ["#569543", "#9EBD4D", "#BBCA7A", "#D9E2B2", "#E4E7C4", "#E6D6BE", "#E3C193", "#DFAC6C", "#DB9842", "#B96230"],
+        "type": "DIVERGING"
     }, {
         "label": "Raster Foundry Categorical",
         "colors": ["#FFFFFF", "#959CAC", "#465076"],

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -400,7 +400,6 @@ rf-project-editor .leaflet-tile {
     }
     .fixedwidth,
     rf-color-scheme-dropdown {
-
       width: 20rem;
     }
     .label {
@@ -435,6 +434,39 @@ rf-project-editor .leaflet-tile {
       }
     }
   }
+}
+
+.sidebar {
+    rf-color-scheme-dropdown {
+        //height: 2.4em;
+        .dropdown {
+            padding: 0;
+        }
+        .dropdown-label {
+            border-radius: 2px;
+        }
+        .gradient-dropdown {
+            padding: 0;
+            display: flex;
+            flex-direction: row;
+            align-items: stretch;
+
+            > .gradient-bar {
+                align-self: center;
+                flex: 1;
+                margin: 0 0.5rem 0 0.5rem;
+            }
+            .icon-caret-down {
+                display: block;
+                height: 100%;
+                flex: 0;
+                align-self: stretch;
+                padding: 0.9rem 1rem 0.9rem 1rem;
+                background: $shade-light;
+                color: white;
+            }
+        }
+    }
 }
 
 .list-group-item .sidebar-list {


### PR DESCRIPTION
## Overview

Use color scheme dropdown selector for single band projects

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/4392704/30456500-e125b810-9971-11e7-8af2-ef0e0337a7a2.png)


### Notes

Bins are not implemented, for the same reason that they are not implemented in the node histograms
Categorical color schemes when selected do not show the correct color scheme selected - Not sure it's worth fixing this until we decide how we actually want this part of the app to work.

## Testing Instructions

 * Verify that you can now set color schemes for single band projects again.

Closes #2508
