### PR TITLE
Rename jobUpdateAoiProject parameter to projectId

### DIFF
--- a/app-tasks/rf/src/rf/commands/find_aoi_projects.py
+++ b/app-tasks/rf/src/rf/commands/find_aoi_projects.py
@@ -49,7 +49,7 @@ def kickoff_aoi_project_update_checks(project_ids):
     logger.info('Found projects to check for updates: %s', project_ids)
 
     for project_id in project_ids:
-        parameters = {'project': project_id}
+        parameters = {'projectId': project_id}
         client.submit_job(jobName=AWS_BATCH_JOB_NAME_AOI_UPDATE,
                           jobQueue=AWS_BATCH_QUEUE_AOI_UPDATE,
                           jobDefinition=AWS_BATCH_JOB_NAME_AOI_UPDATE,


### PR DESCRIPTION
## Overview

Rename the parameter for `jobUpdateAoiProject` from `project` to `projectId`.

### Checklist

- [x ] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

Ensure that `projectId` is the parameter name for `jobUpdateAoiProject`.
