### PR TITLE
Rename Batch environment variables for AoI commands

### DIFF
--- a/app-tasks/rf/src/rf/commands/find_aoi_projects.py
+++ b/app-tasks/rf/src/rf/commands/find_aoi_projects.py
@@ -8,8 +8,8 @@ import boto3
 logger = logging.getLogger(__name__)
 
 ENVIRONMENT = os.getenv('ENVIRONMENT').title()
-AWS_BATCH_JOB_NAME_AOI_UPDATE = os.getenv('AWS_BATCH_JOB_NAME_AOI_UPDATE')
-AWS_BATCH_QUEUE_AOI_UPDATE = os.getenv('AWS_BATCH_QUEUE_AOI_UPDATE', 'queue{}Default'.format(ENVIRONMENT))
+BATCH_JOB_NAME_AOI_UPDATE = os.getenv('BATCH_JOB_NAME_AOI_UPDATE')
+BATCH_QUEUE_AOI_UPDATE = os.getenv('BATCH_QUEUE_AOI_UPDATE', 'queue{}Default'.format(ENVIRONMENT))
 
 
 @click.command(name='find-aoi-projects')
@@ -50,7 +50,7 @@ def kickoff_aoi_project_update_checks(project_ids):
 
     for project_id in project_ids:
         parameters = {'projectId': project_id}
-        client.submit_job(jobName=AWS_BATCH_JOB_NAME_AOI_UPDATE,
-                          jobQueue=AWS_BATCH_QUEUE_AOI_UPDATE,
-                          jobDefinition=AWS_BATCH_JOB_NAME_AOI_UPDATE,
+        client.submit_job(jobName=BATCH_JOB_NAME_AOI_UPDATE,
+                          jobQueue=BATCH_QUEUE_AOI_UPDATE,
+                          jobDefinition=BATCH_JOB_NAME_AOI_UPDATE,
                           parameters=parameters)


### PR DESCRIPTION
## Overview

Previous environment variables prefixed with `AWS_BATCH_` were getting wiped by AWS Batch at job scheduling time. This led to variable values always set to `None`.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

[This](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=jobStagingFindAoiProjects/default/52529b32-1289-4153-a200-97dd87a5c61f) job should have `AWS_BATCH_JOB_NAME_AOI_UPDATE` set, but it does not. Adding a prefix to the environment variable in [this](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=jobStagingFindAoiProjects/default/b39d711b-46df-4dfe-a017-d45b89dfb208) job allowed `T_AWS_BATCH_JOB_NAME_AOI_UPDATE ` to come through.