### PR TITLE
Hide non-endpoint breakpoints for continuous node color schemes

### DIFF
--- a/app-frontend/src/app/components/histogram/histogramBreakpoint/histogramBreakpoint.component.js
+++ b/app-frontend/src/app/components/histogram/histogramBreakpoint/histogramBreakpoint.component.js
@@ -9,7 +9,6 @@ const histogramBreakpoint = {
         range: '<',
         precision: '<',
         options: '<',
-        onColorChange: '&',
         onBreakpointChange: '&'
     }
 };

--- a/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
+++ b/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
@@ -28,6 +28,7 @@
   <nvd3 ng-attr-id="chart-{{$ctrl.id}}" options="$ctrl.histOptions" data="$ctrl.plot" api="$ctrl.api"></nvd3>
   <rf-histogram-breakpoint
     ng-repeat="bp in $ctrl._breakpoints track by bp.id"
+    ng-if="$ctrl.shouldShowBreakpoint($index)"
     ng-mouseover="$ctrl.lastMouseOver = bp.id"
     ng-class="{'active': $ctrl.lastMouseOver === bp.id}"
     data-color="bp.color"
@@ -35,7 +36,6 @@
     data-range="$ctrl.histogramRange"
     data-precision="$ctrl.precision"
     data-options="bp.options"
-    on-color-change="$ctrl.onColorChange(bp, color)"
     on-breakpoint-change="$ctrl.onChange(bp, breakpoint)"
   ></rf-histogram-breakpoint>
   <div class="histogram-placeholder" ng-if="$ctrl.usingDefaultData">Fill out all input fields and apply changes to view histogram</div>


### PR DESCRIPTION
## Overview

Hide non-endpoint breakpoints for continuous node color schemes

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
![image](https://user-images.githubusercontent.com/4392704/30496048-3a858cd2-9a1c-11e7-823a-e48ce49b815a.png)

### Notes

Categorical color schemes appear to be broken on the backend, I tried `QUALITATIVE[#000000]` as the dataType but it defaults to viridis as when there's an error parsing the color scheme


## Testing Instructions

 * Verify that continuous color schemes no longer have intermediary breakpoints
* Verify that categorical color schemes show the intermediary breakpoints

Closes #2527
