### PR TITLE
Run airflow container as root instead of airflow

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -4,11 +4,6 @@ ENV AIRFLOW_HOME /usr/local/airflow
 
 COPY requirements.txt /tmp/
 RUN set -ex \
-    addgroup --system airflow \
-    && adduser --disabled-password --system --group \
-               --uid 1000 --home /var/lib/airflow \
-               --shell /usr/sbin/nologin \
-               airflow \
     && mkdir -p ${AIRFLOW_HOME} \
     && gdalDeps=' \
        gdal-bin/sid \

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -10,7 +10,6 @@ RUN set -ex \
                --shell /usr/sbin/nologin \
                airflow \
     && mkdir -p ${AIRFLOW_HOME} \
-    && chown airflow:airflow -R ${AIRFLOW_HOME} \
     && gdalDeps=' \
        gdal-bin/sid \
        python-gdal/sid \
@@ -32,7 +31,6 @@ RUN set -ex \
 COPY rf/ /tmp/rf
 RUN (cd /tmp/rf && python setup.py install)
 
-USER airflow
 WORKDIR ${AIRFLOW_HOME}
 
 COPY usr/local/airflow/airflow.cfg ${AIRFLOW_HOME}/airflow.cfg


### PR DESCRIPTION
## Overview

To pull down images and write them to /tmp, the user in the container
needs to be able to write to the location where /tmp is mounted outside the
container. The airflow user can't do that, but root can. Celery will get mad,
but that's fine.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Look on my [logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logEventViewer:group=/aws/batch/job;stream=jobStagingIngestScene/default/c06be807-e4b7-4fc4-998c-583f3e44befc) ye mighty and despair