### PR TITLE
Add '_dn' analytic types for Planet import

### DIFF
--- a/app-tasks/rf/src/rf/uploads/planet/factories.py
+++ b/app-tasks/rf/src/rf/uploads/planet/factories.py
@@ -198,7 +198,7 @@ class PlanetSceneFactory(object):
         Returns:
             str
         """
-        acceptable_types = ['analytic', 'basic_analytic']
+        acceptable_types = ['analytic', 'basic_analytic', 'analytic_dn', 'basic_analytic_dn']
         logger.info('Determining Analytics Asset Type')
         for acceptable_type in acceptable_types:
             if acceptable_type in asset_dict:


### PR DESCRIPTION
## Overview

Updates the whitelist of acceptable types for Planet imports.

### Checklist

~- [x] Styleguide updated, if necessary~
~- [x] Swagger specification updated, if necessary~
~- [x] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
