### PR TITLE
Enable ToolRun Statistics

### DIFF
--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -50,9 +50,9 @@ class Router extends LazyLogging
                 authenticateToolTileRoutes(toolRunId) { user =>
                   toolRoutes.tms(toolRunId, user, TileSources.cachedTmsSource) ~
                     toolRoutes.validate(toolRunId, user) ~
+                    toolRoutes.statistics(toolRunId, user) ~
                     toolRoutes.histogram(toolRunId, user) ~
-                    toolRoutes.preflight(toolRunId, user) ~
-                    toolRoutes.statistics(toolRunId, user)
+                    toolRoutes.preflight(toolRunId, user)
                 }
               }
             }


### PR DESCRIPTION
## Overview

The stats endpoint was being ignored due to short circuiting of akka-http's URI matching logic. Rearranging the endpoints fixed this.


## Testing Instructions

 * Ask for stats on a `ToolRun`

Closes #2543
