### PR TITLE
Allow editing uploaded scene's properties and metadata.

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.controller.js
@@ -26,7 +26,7 @@ export default class SceneDetailModalController {
             this.datasourceLoaded = true;
             this.datasource = d;
         });
-        this.acqDateDisplay = this.setAqcDateDisplay();
+        this.accDateDisplay = this.setAccDateDisplay();
         this.isUploadDone = true;
     }
 
@@ -71,7 +71,7 @@ export default class SceneDetailModalController {
         }
     }
 
-    setAqcDateDisplay() {
+    setAccDateDisplay() {
         return this.scene.filterFields && this.scene.filterFields.acquisitionDate ?
             this.formatAcqDate(this.scene.filterFields.acquisitionDate) :
             'MM/DD/YYYY';
@@ -79,7 +79,6 @@ export default class SceneDetailModalController {
 
     updateMetadata() {
         // TODO: visibility and data source should be editable eventually
-        // TODO: sunAzimuth and sunElevation can't be changed, might be backend issue?
         this.isUploadDone = false;
         if (!this.newFilterFields.acquisitionDate) {
             this.newFilterFields.acquisitionDate = this.scene.filterFields.acquisitionDate;
@@ -126,8 +125,10 @@ export default class SceneDetailModalController {
     }
 
     updateAcquisitionDate(selectedDay) {
-        this.newFilterFields.acquisitionDate = selectedDay.toISOString();
-        this.acqDateDisplay = selectedDay.format('MM/DD/YYYY');
+        if (selectedDay) {
+            this.newFilterFields.acquisitionDate = selectedDay.toISOString();
+            this.accDateDisplay = selectedDay.format('MM/DD/YYYY');
+        }
     }
 
     /* eslint-disable consistent-return */

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.controller.js
@@ -2,13 +2,16 @@
 
 export default class SceneDetailModalController {
     constructor(
-        $state, sceneService, datasourceService, mapService, $uibModal
+        $log, $state, $uibModal,
+        moment, sceneService, datasourceService, mapService
     ) {
         'ngInject';
+        this.$log = $log;
         this.$state = $state;
+        this.$uibModal = $uibModal;
+        this.Moment = moment;
         this.sceneService = sceneService;
         this.datasourceService = datasourceService;
-        this.$uibModal = $uibModal;
         this.scene = this.resolve.scene;
         this.getMap = () => mapService.getMap('scene-preview-map');
     }
@@ -19,10 +22,12 @@ export default class SceneDetailModalController {
             mapWrapper.setThumbnail(this.scene, false, true);
             mapWrapper.map.fitBounds(this.getSceneBounds());
         });
-        this.datasourceService.get(this.scene.datasource).then(d => {
+        this.datasourceService.get(this.scene.dataSource).then(d => {
             this.datasourceLoaded = true;
             this.datasource = d;
         });
+        this.acqDateDisplay = this.setAqcDateDisplay();
+        this.isUploadDone = true;
     }
 
     openDownloadModal() {
@@ -57,5 +62,91 @@ export default class SceneDetailModalController {
 
     closeWithData(data) {
         this.close({$value: data});
+    }
+
+    toggleMetadataEdit() {
+        this.isEditMetadata = !this.isEditMetadata;
+        if (!this.isEditMetadata) {
+            this.updateMetadata();
+        }
+    }
+
+    setAqcDateDisplay() {
+        return this.scene.filterFields && this.scene.filterFields.acquisitionDate ?
+            this.formatAcqDate(this.scene.filterFields.acquisitionDate) :
+            'MM/DD/YYYY';
+    }
+
+    updateMetadata() {
+        // TODO: visibility and data source should be editable eventually
+        // TODO: sunAzimuth and sunElevation can't be changed, might be backend issue?
+        this.isUploadDone = false;
+        if (!this.newFilterFields.acquisitionDate) {
+            this.newFilterFields.acquisitionDate = this.scene.filterFields.acquisitionDate;
+        }
+        this.scene = Object.assign(this.scene, {
+            'modifiedAt': this.Moment().toISOString(),
+            'modifiedBy': this.scene.owner,
+            'sceneMetadata': this.newSceneMetadata,
+            'filterFields': this.newFilterFields
+        });
+        this.sceneService.update(this.scene).then(
+            () => {
+                this.isUploadDone = true;
+            },
+            () => {
+                this.isUploadDone = false;
+            }
+        );
+    }
+
+    formatAcqDate(date) {
+        return date.length ? this.Moment(date).format('MM/DD/YYYY') : 'MM/DD/YYYY';
+    }
+
+    openDatePickerModal(date) {
+        if (this.activeModal) {
+            this.activeModal.dismiss();
+        }
+
+        this.activeModal = this.$uibModal.open({
+            component: 'rfDatePickerModal',
+            windowClass: 'auto-width-modal',
+            resolve: {
+                config: () => Object({
+                    selectedDay: this.Moment(date)
+                })
+            }
+        });
+
+        this.activeModal.result.then(
+            selectedDay => {
+                this.updateAcquisitionDate(selectedDay);
+            });
+    }
+
+    updateAcquisitionDate(selectedDay) {
+        this.newFilterFields.acquisitionDate = selectedDay.toISOString();
+        this.acqDateDisplay = selectedDay.format('MM/DD/YYYY');
+    }
+
+    /* eslint-disable consistent-return */
+    getMaxBound(field) {
+        if (field === 'cloudCover') {
+            return 100;
+        } else if (field === 'sunAzimuth') {
+            return 360;
+        } else if (field === 'sunElevation') {
+            return 180;
+        }
+    }
+    /* eslint-enable consistent-return */
+
+    onFilterValChange(field) {
+        if (this.newFilterFields[field] < 0) {
+            this.newFilterFields[field] = 0;
+        } else if (this.newFilterFields[field] > this.getMaxBound(field)) {
+            this.newFilterFields[field] = this.getMaxBound(field);
+        }
     }
 }

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
@@ -21,7 +21,7 @@
           <dt ng-repeat-start="(field, value) in $ctrl.scene.filterFields">
             {{field}}
           </dt>
-          <dd ng-repeat-end>{{field !== 'acquisitionDate' ? value : $ctrl.acqDateDisplay}}</dd>
+          <dd ng-repeat-end>{{field !== 'acquisitionDate' ? value : $ctrl.accDateDisplay}}</dd>
           <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>
           <dd ng-if-end>{{$ctrl.scene.createdAt | date}}</dd>
           <dt ng-if-start="$ctrl.scene.modifiedAt">Modified Date</dt>
@@ -47,13 +47,13 @@
                    placeholder="{{field}}"
                    ng-if="field !== 'acquisitionDate'"
                    ng-change="$ctrl.onFilterValChange(field)">
-            <div class="dropdown btn-group fixedwidth acq-date"
+            <div class="dropdown btn-group fixedwidth acc-date-field"
                  ng-click="$ctrl.openDatePickerModal(value)"
                  ng-if="field === 'acquisitionDate'">
-              <a class="btn dropdown-label acq-date">
-                {{$ctrl.acqDateDisplay}}
+              <a class="btn dropdown-label acc-date-label">
+                {{$ctrl.accDateDisplay}}
               </a>
-              <button type="button" class="btn btn-light dropdown-toggle acq-date">
+              <button type="button" class="btn btn-light dropdown-toggle acc-date-toggle">
                 <i class="icon-calendar"></i>
               </button>
             </div>

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
@@ -9,33 +9,74 @@
         <strong class="color-dark">{{$ctrl.scene.name}}</strong><br>
           {{$ctrl.datasourceLoaded ? $ctrl.datasource.name : 'Loading datasource'}}
         </p>
+        <button class="btn btn-default"
+                ng-click="$ctrl.toggleMetadataEdit()"
+                ng-if="$ctrl.scene.owner !== 'rf|airflow-user'">
+                {{$ctrl.isEditMetadata ? 'Save ' : 'Edit '}}metadata
+        </button>
       </div>
       <div class="scene-metadata-scrollable">
         <h5 class="color-dark">Scene properties</h5>
-        <dl class="meta-list">
+        <dl class="meta-list" ng-if="!$ctrl.isEditMetadata && $ctrl.isUploadDone">
           <dt ng-repeat-start="(field, value) in $ctrl.scene.filterFields">
             {{field}}
           </dt>
-          <dd ng-repeat-end>{{value}}</dd>
+          <dd ng-repeat-end>{{field !== 'acquisitionDate' ? value : $ctrl.acqDateDisplay}}</dd>
           <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>
           <dd ng-if-end>{{$ctrl.scene.createdAt | date}}</dd>
           <dt ng-if-start="$ctrl.scene.modifiedAt">Modified Date</dt>
           <dd ng-if-end>{{$ctrl.scene.modifiedAt | date}}</dd>
           <dt ng-if-start="$ctrl.scene.datasource">Datasource</dt>
           <dd ng-if-end>{{$ctrl.scene.datasource}}</dd>
-          <dt>Visiblity</dt>
+          <dt>Visibility</dt>
           <dd>{{$ctrl.scene.visibility}}</dd>
           <dt ng-repeat-start="(field, value) in $ctrl.scene.statusFields">
             {{field}}
           </dt>
           <dd ng-repeat-end>{{value}}</dd>
         </dl>
+        <dl class="meta-list" ng-if="$ctrl.isEditMetadata">
+          <dt ng-repeat-start="(field, value) in $ctrl.scene.filterFields">
+            {{field}}
+          </dt>
+          <dd ng-repeat-end>
+            <input type="number"
+                   ng-model="$ctrl.newFilterFields[field]"
+                   ng-init="$ctrl.newFilterFields[field] = value"
+                   class="form-control scene-detail-field"
+                   placeholder="{{field}}"
+                   ng-if="field !== 'acquisitionDate'"
+                   ng-change="$ctrl.onFilterValChange(field)">
+            <div class="dropdown btn-group fixedwidth acq-date"
+                 ng-click="$ctrl.openDatePickerModal(value)"
+                 ng-if="field === 'acquisitionDate'">
+              <a class="btn dropdown-label acq-date">
+                {{$ctrl.acqDateDisplay}}
+              </a>
+              <button type="button" class="btn btn-light dropdown-toggle acq-date">
+                <i class="icon-calendar"></i>
+              </button>
+            </div>
+          </dd>
+        </dl>
         <h5 class="color-dark">Scene metadata</h5>
-        <dl class="meta-list">
+        <dl class="meta-list"  ng-if="!$ctrl.isEditMetadata && $ctrl.isUploadDone">
           <dt ng-repeat-start="(metaKey, metaVal) in $ctrl.scene.sceneMetadata">
             {{metaKey}}
           </dt>
           <dd ng-repeat-end>{{metaVal}}</dd>
+        </dl>
+        <dl class="meta-list"  ng-if="$ctrl.isEditMetadata">
+          <dt ng-repeat-start="(metaKey, metaVal) in $ctrl.scene.sceneMetadata">
+            {{metaKey}}
+          </dt>
+          <dd ng-repeat-end>
+            <input type="text"
+                   ng-model="$ctrl.newSceneMetadata[metaKey]"
+                   ng-init="$ctrl.newSceneMetadata[metaKey] = metaVal"
+                   class="form-control scene-detail-field"
+                   placeholder="{{field}}">
+          </dd>
         </dl>
       </div>
     </div>
@@ -48,7 +89,7 @@
   <div class="modal-footer">
     <button type="button" class="btn pull-left"
             ng-click="$ctrl.closeWithData(1)">
-      Done
+      Close
     </button>
     <button type="button" class="btn btn-default pull-right"
             ng-click="$ctrl.openDownloadModal()">

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import SceneDetailModalComponent from './sceneDetailModal.component.js';
 import SceneDetailModalController from './sceneDetailModal.controller.js';
+require('./sceneDetailModal.scss');
 
 const SceneDetailModalModule = angular.module('components.scenes.sceneDetailModal', []);
 

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.scss
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.scss
@@ -1,0 +1,32 @@
+@import "../../../../assets/styles/sass/settings/_colors.scss";
+
+input.form-control.scene-detail-field {
+    height: 32px;
+    border: none;
+    border-bottom: 3px dotted $gray-lightest;
+    color: $brand-tertiary;
+    font-style: italic;
+}
+
+a.btn.dropdown-label.acq-date {
+    color: $brand-tertiary;
+    font-style: italic;
+    border: none;
+    border-bottom: 3px dotted $gray-lightest;
+}
+
+a.btn.dropdown-label.acq-date:hover {
+    background-color: $gray-lightest;
+}
+
+button.btn.btn-light.dropdown-toggle.acq-date {
+    border: none;
+    border-bottom: 3px dotted $gray-lightest;
+    background-color: white;
+    color: $gray-lightest;
+}
+
+button.btn.btn-light.dropdown-toggle.acq-date:hover{
+    background-color: $gray-lightest;
+    color: white;
+}

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.scss
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.scss
@@ -1,6 +1,6 @@
 @import "../../../../assets/styles/sass/settings/_colors.scss";
 
-input.form-control.scene-detail-field {
+.form-control.scene-detail-field {
     height: 32px;
     border: none;
     border-bottom: 3px dotted $gray-lightest;
@@ -8,25 +8,27 @@ input.form-control.scene-detail-field {
     font-style: italic;
 }
 
-a.btn.dropdown-label.acq-date {
+.acc-date-field{
+    border-bottom: 3px dotted $gray-lightest;
+}
+
+.dropdown-label.acc-date-label {
     color: $brand-tertiary;
     font-style: italic;
     border: none;
-    border-bottom: 3px dotted $gray-lightest;
 }
 
-a.btn.dropdown-label.acq-date:hover {
+.dropdown-label.acc-date-label:hover {
     background-color: $gray-lightest;
 }
 
-button.btn.btn-light.dropdown-toggle.acq-date {
+.dropdown-toggle.acc-date-toggle {
     border: none;
-    border-bottom: 3px dotted $gray-lightest;
     background-color: white;
     color: $gray-lightest;
 }
 
-button.btn.btn-light.dropdown-toggle.acq-date:hover{
+.dropdown-toggle.acc-date-toggle:hover{
     background-color: $gray-lightest;
     color: white;
 }

--- a/app-frontend/src/app/components/scenes/sceneList/sceneList.html
+++ b/app-frontend/src/app/components/scenes/sceneList/sceneList.html
@@ -8,7 +8,7 @@
       scene="scene"
       ng-repeat="scene in $ctrl.sceneList track by scene.id">
     <div class="dropdown btn-group" uib-dropdown ng-if="$ctrl.sceneActions && $ctrl.sceneActions.length">
-      <button class="btn" ng-click="$ctrl.onActionClick($ctrl.sceneActions[0])">
+      <button class="btn" ng-click="$ctrl.onActionClick($ctrl.sceneActions[0], scene)">
         {{$ctrl.sceneActions[0].label}}
       </button>
       <button type="button" class="btn" uib-dropdown-toggle ng-if="$ctrl.sceneActions.length > 1">
@@ -62,4 +62,3 @@
     <a href ng-click="$ctrl.populateSceneList(1)">Try again</a>
   </span>
 </div>
-

--- a/app-frontend/src/app/services/scenes/scene.service.js
+++ b/app-frontend/src/app/services/scenes/scene.service.js
@@ -7,7 +7,7 @@ export default (app) => {
 
             this.Scene = $resource(
                 `${BUILDCONFIG.API_HOST}/api/scenes/:id/`, {
-                    id: '@properties.id'
+                    id: '@id'
                 }, {
                     query: {
                         method: 'GET',
@@ -15,6 +15,10 @@ export default (app) => {
                     },
                     get: {
                         method: 'GET',
+                        cache: false
+                    },
+                    update: {
+                        method: 'PUT',
                         cache: false
                     }
                 }
@@ -57,6 +61,9 @@ export default (app) => {
             return styledGeojson;
         }
 
+        update(sceneParams = {}) {
+            return this.Scene.update(sceneParams).$promise;
+        }
     }
 
     app.service('sceneService', SceneService);


### PR DESCRIPTION
## Overview

This PR allows you to edit an uploaded scene's properties and metadata within the scene detail modal.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo
Edit mode:
<img width="1920" alt="screen shot 2017-09-21 at 2 10 42 pm" src="https://user-images.githubusercontent.com/16109558/30711811-f018de90-9ed7-11e7-86de-49399d8009fc.png">
 Date picker:
<img width="1920" alt="screen shot 2017-09-21 at 2 10 53 pm" src="https://user-images.githubusercontent.com/16109558/30711827-ffa2a738-9ed7-11e7-9325-89c4fd8e46e5.png">


### Notes

* `visibility` and `dataSource` are set as not editable at this point. `sunAzimuth` and `sunElevation` can be edited on the frontend but cannot actually be changed through bulk update.
* Some css changes per the design is in the sceneDetailModal directory. @designmatty 


## Testing Instructions

 * Go to `/imports`
 * Click on "View" of a scene item. If this is your upload, you should see an "Edit Metadata" button.
 * Make changes to these fields. After you click "Save Metadata", new changes should be reflected.
 * Refresh the page just to make sure if this scene item's metadata are actually updated.

Closes #2235
