### PR TITLE
Add method to enable displaying returned stats in tool node UI

### DIFF
--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.controller.js
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.controller.js
@@ -63,6 +63,10 @@ export default class NodeHistogramController {
         }
     }
 
+    shouldShowStats() {
+        return !this.isLoading && this.hasStats;
+    }
+
     shouldShowEmptyStats() {
         return !this.isLoading && !this.hasStats;
     }
@@ -74,5 +78,6 @@ export default class NodeHistogramController {
     shouldShowDataMessage() {
         return this.hasToolRun && !this.isLoading && !this.hasStats;
     }
+
 
 }


### PR DESCRIPTION
## Overview

Now that stats are returned, the UI was not displaying them -- this ensures that they get displayed.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![screenshot from 2017-09-22 00-53-44](https://user-images.githubusercontent.com/898060/30729860-a0b13b96-9f30-11e7-932a-58c1b82a717b.png)

## Testing Instructions

 * Load a tool in the UI and check stats