### PR TITLE
Replace check_database with docker-compose healthcheck

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,12 +3,6 @@
 
 Vagrant.require_version ">= 1.8"
 
-if ["up", "provision", "status"].include?(ARGV.first)
-  require_relative "deployment/vagrant/ansible_galaxy_helper"
-
-  AnsibleGalaxyHelper.install_dependent_roles("deployment/ansible")
-end
-
 ANSIBLE_VERSION = "2.3.1.0"
 
 Vagrant.configure(2) do |config|
@@ -27,7 +21,7 @@ Vagrant.configure(2) do |config|
                      "app-backend/project/.sbtboot/", "app-server/**/target/",
                      "app-backend/**/target/", "worker-tasks/**/target/",
                      ".sbt/", ".node_modules/",
-                     "deployment/ansible/roles/**/examples"],
+                     "deployment/ansible/roles/azavea*/"],
     rsync__args: ["--verbose", "--archive", "-z"],
     rsync__rsync_path: "sudo rsync"
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
@@ -77,6 +71,7 @@ Vagrant.configure(2) do |config|
       fi
 
       cd /opt/raster-foundry/deployment/ansible && \
+      ruby ../vagrant/run_ansible_galaxy.rb
       ANSIBLE_FORCE_COLOR=1 PYTHONUNBUFFERED=1 ANSIBLE_CALLBACK_WHITELIST=profile_tasks \
       ansible-playbook -u vagrant -i 'localhost,' \
           --extra-vars "host_user=#{host_user} aws_profile=#{aws_profile} \

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -2,7 +2,7 @@
 aws_cli_version: "1.10.47"
 
 docker_version: "17.*"
-docker_compose_version: "1.13.0"
+docker_compose_version: "1.16.*"
 
 shellcheck_version: "0.3.*"
 

--- a/deployment/vagrant/run_ansible_galaxy.rb
+++ b/deployment/vagrant/run_ansible_galaxy.rb
@@ -1,0 +1,2 @@
+require_relative '../vagrant/ansible_galaxy_helper'
+AnsibleGalaxyHelper.install_dependent_roles('/opt/raster-foundry/deployment/ansible')

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   graphite:
     image: sitespeedio/graphite

--- a/docker-compose.spark.yml
+++ b/docker-compose.spark.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   spark-master:
     image: raster-foundry-spark

--- a/docker-compose.swagger.yml
+++ b/docker-compose.swagger.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   swagger-editor:
     image: swaggerapi/swagger-editor:latest

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   nginx-api:
     image: raster-foundry-nginx-api:${GIT_COMMIT:-latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.3'
 services:
   postgres:
     image: quay.io/azavea/postgis:2.3-postgres9.6-slim
@@ -7,6 +7,12 @@ services:
     env_file: .env
     expose:
       - "5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
   memcached:
     image: memcached:1.4-alpine
@@ -52,6 +58,9 @@ services:
       - postgres:database.service.rasterfoundry.internal
     external_links:
       - statsd
+    depends_on:
+      postgres:
+        condition: service_healthy
     env_file: .env
     ports:
       - "9000:9000"

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -19,7 +19,6 @@ Load a database dump from S3
 }
 
 function load_database_backup() {
-    check_database
 
     pushd "${DIR}/.."
     echo "Downloading database from s3"
@@ -47,8 +46,11 @@ then
     then
         usage
     else
-        docker-compose up -d postgres
+
+        # API server won't start until Postgres is passing Health Checks
+        docker-compose up -d api-server
         load_database_backup
+        docker-compose rm -sf api-server
     fi
     exit
 fi

--- a/scripts/update
+++ b/scripts/update
@@ -16,38 +16,8 @@ Setup external project dependencies.
 "
 }
 
-
-function check_database() {
-    # Check if database is set up to continue
-
-    max=21 # 1 minute
-    counter=1
-    while true
-    do
-        echo "Checking if database is up yet (try ${counter})..."
-        set +e
-        docker-compose \
-            exec -T postgres gosu postgres psql -d rasterfoundry -c 'select 1' &>/dev/null
-        status_check=$?
-        if [ $status_check == 0 ]
-        then
-            echo "Connected to database successfully"
-            break
-        fi
-        set -e
-        if [[ ${counter} == "${max}" ]]
-        then
-            echo "Could not connect to database after some time"
-            exit 1
-        fi
-        sleep 3
-        (( counter++ ))
-    done
-}
-
 function run_database_migrations() {
     # Check if database migrations have already been initialized
-    docker-compose up -d postgres
     set +e
     docker-compose \
         exec -T postgres gosu postgres psql -d rasterfoundry -c 'select 1 from __migrations__' &>/dev/null
@@ -78,8 +48,10 @@ then
         usage
     else
         echo "Updating Scala dependencies"
-        docker-compose \
-            run --rm --no-deps api-server update
+        docker-compose up -d api-server
+
+        docker-compose exec -T api-server ./sbt update
+        docker-compose rm -sf api-server
 
         echo "Running application database migrations"
         run_database_migrations


### PR DESCRIPTION
## Overview

Using docker-compose's `healthcheck` configuration option, run `pg_isready` on the `postgres` container to determine if it is healthy before creating databases or loading data. Replaces `check_database` in `scripts/update` and `scripts/bootstrap`. 

Also, install Ansible roles inside of the VM. This gets rid of the `Duplicate Watched Directory` error from Vagrant Rsync.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

__Note: this will require you to destroy your database__

- Remove the postgres container (and associated volumes) with `docker-compose down -v`
- Delete `azavea.*` Ansible roles from outside of the VM
- Run `vagrant provision` to rebuild postgres and re-install Ansible roles
- Run `scripts/load_development_data`

Closes #1015 
