### PR TITLE
Filter scene grid endpoint on user visibility

### DIFF
--- a/app-backend/api/src/main/scala/grid/Routes.scala
+++ b/app-backend/api/src/main/scala/grid/Routes.scala
@@ -34,11 +34,11 @@ trait GridRoutes extends Authentication
     }
   }
 
-  def getGrid(z: Int, x: Int, y: Int): Route = authenticate { _ =>
+  def getGrid(z: Int, x: Int, y: Int): Route = authenticate { user =>
     gridQueryParameters { gridParams =>
       complete {
         val tileBounds = TileUtils.TileCoordinates(z, x, y).childrenTileBounds
-        Future.sequence(Scenes.sceneGrid(gridParams, tileBounds))
+        Future.sequence(Scenes.sceneGrid(gridParams, user, tileBounds))
       }
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -338,8 +338,9 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     }
   }
 
-  def sceneGrid(params: CombinedGridQueryParams, bboxes: Seq[Projected[Polygon]])(implicit database: DB) = {
+  def sceneGrid(params: CombinedGridQueryParams, user: User, bboxes: Seq[Projected[Polygon]])(implicit database: DB) = {
     val filteredScenes = Scenes
+      .filterUserVisibility(user)
       .filterByOrganization(params.orgParams)
       .filterByUser(params.userParams)
       .filterByTimestamp(params.timestampParams)


### PR DESCRIPTION
## Overview

Fix grid endpoint returning counts that include ALL scenes, rather than just scenes the user has permission to view

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Create a filter that returns a couple of scenes that are public and uploaded by another user, then change their visibility to PRIVATE. The same filter should no longer show any scenes in the panel or the grid.
