### PR TITLE
Ensure export command is visible in `rf` command line tool

### DIFF
--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -14,7 +14,7 @@ HOST = os.getenv('RF_HOST')
 API_PATH = '/api/exports/'
 
 
-@click.command()
+@click.command(name='export')
 @click.argument('export_id')
 @wrap_rollbar
 def export(export_id):


### PR DESCRIPTION
## Overview

Without the `name` attribute in the @click.command decorator the export command
is not available.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Run `docker-compose build batch`
 * Run `./scripts/console batch rf` and ensure export is listed as an option for commands