### PR TITLE
Standardize on AmazonS3ClientBuilder usage

### DIFF
--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -3,11 +3,7 @@ package com.rasterfoundry.api.uploads
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
-import com.amazonaws.auth.{
-  AWSCredentials,
-  AWSSessionCredentials,
-  AWSStaticCredentialsProvider
-}
+import com.amazonaws.auth.{AWSCredentials, AWSSessionCredentials}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.amazonaws.services.securitytoken.model.AssumeRoleWithWebIdentityRequest
@@ -15,24 +11,24 @@ import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.datamodel.User
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
+
 @JsonCodec
-final case class Credentials(
-    AccessKeyId: String,
-    Expiration: String,
-    SecretAccessKey: String,
-    SessionToken: String
-) extends AWSCredentials
+final case class Credentials(AccessKeyId: String,
+                             Expiration: String,
+                             SecretAccessKey: String,
+                             SessionToken: String)
+    extends AWSCredentials
     with AWSSessionCredentials {
-  override def getAWSAccessKeyId = this.AccessKeyId
-  override def getAWSSecretKey = this.SecretAccessKey
-  override def getSessionToken = this.SessionToken
+  override def getAWSAccessKeyId: String = this.AccessKeyId
+
+  override def getAWSSecretKey: String = this.SecretAccessKey
+
+  override def getSessionToken: String = this.SessionToken
 }
 
 @JsonCodec
-final case class CredentialsWithBucketPath(
-    credentials: Credentials,
-    bucketPath: String
-)
+final case class CredentialsWithBucketPath(credentials: Credentials,
+                                           bucketPath: String)
 
 object CredentialsService extends Config with LazyLogging {
 
@@ -60,10 +56,7 @@ object CredentialsService extends Config with LazyLogging {
       stsCredentials.getSessionToken
     )
 
-    val s3 = AmazonS3ClientBuilder.standard
-      .withCredentials(new AWSStaticCredentialsProvider(credentials))
-      .withRegion(region)
-      .build()
+    val s3 = AmazonS3ClientBuilder.defaultClient()
 
     // Add timestamp object to test credentials
     val now = new Timestamp(new Date().getTime)

--- a/app-backend/batch/src/main/scala/util/package.scala
+++ b/app-backend/batch/src/main/scala/util/package.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.batch
 
 import java.io._
 import java.net._
-import java.util.Scanner
+import java.nio.charset.Charset
 
 import cats.implicits._
 import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
@@ -104,10 +104,7 @@ package object util extends LazyLogging {
   def readString(fileUri: URI): String = {
     val is = getStream(fileUri)
     try {
-      // A jdk [input stream -> string] method which avoids the IOUtils' 'toString' deprecation:
-      // https://community.oracle.com/blogs/pat/2004/10/23/stupid-scanner-tricks
-      val scan: Scanner = new Scanner(is).useDelimiter("\\A")
-      if (scan.hasNext()) scan.next() else ""
+      IOUtils.toString(is, Charset.defaultCharset())
     } finally {
       is.close()
     }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -1,34 +1,23 @@
 package com.rasterfoundry.common
 
-import jp.ne.opt.chronoscala.Imports._
-import org.apache.commons.io.IOUtils
-import com.amazonaws.auth._
-import com.amazonaws.regions._
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
-import com.amazonaws.services.s3.model.{
-  ListObjectsRequest,
-  ObjectListing,
-  ObjectMetadata,
-  S3Object
-}
-import com.amazonaws.HttpMethod
-import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
-import java.io._
+import java.io.File
 import java.net._
 import java.time.{Duration, ZoneOffset}
 import java.util.Date
+
+import com.amazonaws.HttpMethod
+import com.amazonaws.regions._
+import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
+import jp.ne.opt.chronoscala.Imports._
+import org.apache.commons.io.IOUtils
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.util.Properties
 
 package object S3 {
-
-  lazy val client = AmazonS3ClientBuilder
-    .standard()
-    .withCredentials(new DefaultAWSCredentialsProviderChain())
-    .withForceGlobalBucketAccessEnabled(true)
-    .build()
+  lazy val client: AmazonS3 = AmazonS3ClientBuilder.defaultClient()
 
   def clientWithRegion(region: Regions): AmazonS3 =
     AmazonS3ClientBuilder
@@ -81,7 +70,8 @@ package object S3 {
       new GeneratePresignedUrlRequest(bucket, key)
     generatePresignedUrlRequest.setMethod(HttpMethod.GET)
     generatePresignedUrlRequest.setExpiration(
-      Date.from(expiration.toInstant(ZoneOffset.UTC)))
+      Date.from(expiration.toInstant(ZoneOffset.UTC))
+    )
     client.generatePresignedUrl(generatePresignedUrlRequest)
   }
 

--- a/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
+++ b/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
@@ -1,19 +1,16 @@
 package com.rasterfoundry.common.utils
 
-import com.rasterfoundry.common.S3
-import com.typesafe.scalalogging.LazyLogging
-import geotrellis.util.{FileRangeReader, RangeReader}
-import geotrellis.spark.io.s3.util.S3RangeReader
-import geotrellis.spark.io.s3.AmazonS3Client
-import geotrellis.spark.io.http.util.HttpRangeReader
-
-import com.amazonaws.services.s3.AmazonS3URI
-import org.apache.http.client.utils.URLEncodedUtils
-
-import java.nio.file.Paths
+import java.net.{URI, URL}
 import java.nio.charset.Charset
-import java.net.URI
-import java.net.URL
+import java.nio.file.Paths
+
+import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
+import com.typesafe.scalalogging.LazyLogging
+import geotrellis.spark.io.http.util.HttpRangeReader
+import geotrellis.spark.io.s3.AmazonS3Client
+import geotrellis.spark.io.s3.util.S3RangeReader
+import geotrellis.util.{FileRangeReader, RangeReader}
+import org.apache.http.client.utils.URLEncodedUtils
 
 object RangeReaderUtils extends LazyLogging {
   def fromUri(uri: String): Option[RangeReader] = {
@@ -44,7 +41,7 @@ object RangeReaderUtils extends LazyLogging {
 
       case "s3" =>
         val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))
-        val s3Client = AmazonS3Client(S3.client)
+        val s3Client = new AmazonS3Client(AmazonS3ClientBuilder.defaultClient())
         Some(S3RangeReader(s3Uri.getBucket, s3Uri.getKey, s3Client))
 
       case scheme =>

--- a/app-backend/db/src/main/scala/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/OrganizationDao.scala
@@ -5,9 +5,8 @@ import java.sql.Timestamp
 import java.util.UUID
 
 import cats.implicits._
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.model.{CannedAccessControlList, ObjectMetadata}
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
@@ -68,7 +67,8 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
     query.filter(id).select
 
   def createOrganization(
-      newOrg: Organization.Create): ConnectionIO[Organization] =
+      newOrg: Organization.Create
+  ): ConnectionIO[Organization] =
     create(newOrg.toOrganization(true))
 
   def update(org: Organization, id: UUID): ConnectionIO[Int] = {
@@ -87,7 +87,8 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       organizationId: UUID,
       page: PageRequest,
       searchParams: SearchQueryParameters,
-      actingUser: User): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
+      actingUser: User
+  ): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
     for {
       organizationO <- OrganizationDao.getOrganizationById(organizationId)
       isDefaultOrg <- organizationO match {
@@ -212,23 +213,23 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       groupRole
     )
 
-    createUserGroupRole(organizationId,
-                        actingUser,
-                        subjectId,
-                        userGroupRoleCreate,
-                        platformId,
-                        false.pure[ConnectionIO])
+    createUserGroupRole(
+      organizationId,
+      actingUser,
+      subjectId,
+      userGroupRoleCreate,
+      platformId,
+      false.pure[ConnectionIO]
+    )
   }
 
   def deactivateUserRoles(
       actingUser: User,
       subjectId: String,
-      organizationId: UUID): ConnectionIO[List[UserGroupRole]] = {
-    val userGroup = UserGroupRole.UserGroup(
-      subjectId,
-      GroupType.Organization,
-      organizationId
-    )
+      organizationId: UUID
+  ): ConnectionIO[List[UserGroupRole]] = {
+    val userGroup =
+      UserGroupRole.UserGroup(subjectId, GroupType.Organization, organizationId)
     UserGroupRoleDao.deactivateUserGroupRoles(userGroup, actingUser)
   }
 
@@ -247,9 +248,11 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
     md.setContentLength(logoByte.length)
 
     s3Client.putObject(dataBucket, s"${prefix}/${key}", logoStream, md)
-    s3.setObjectAcl(dataBucket,
-                    s"${prefix}/${key}",
-                    CannedAccessControlList.PublicRead)
+    s3.setObjectAcl(
+      dataBucket,
+      s"${prefix}/${key}",
+      CannedAccessControlList.PublicRead
+    )
 
     val uri = s"https://s3.amazonaws.com/${dataBucket}/${prefix}/${key}"
     val updateTime = new Timestamp(new java.util.Date().getTime)
@@ -334,7 +337,8 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       pageRequest: PageRequest,
       searchParams: SearchQueryParameters,
       platformId: UUID,
-      user: User): ConnectionIO[PaginatedResponse[Organization]] = {
+      user: User
+  ): ConnectionIO[PaginatedResponse[Organization]] = {
     val organizationSearchBuilder = {
       OrganizationDao
         .viewFilter(user)
@@ -353,7 +357,8 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
 
   def searchOrganizations(
       user: User,
-      searchParams: SearchQueryParameters): ConnectionIO[List[Organization]] = {
+      searchParams: SearchQueryParameters
+  ): ConnectionIO[List[Organization]] = {
     OrganizationDao
       .viewFilter(user)
       .filter(searchParams)


### PR DESCRIPTION
## Overview

Use `AmazonS3ClientBuilder.defaultClient()`, which builds a client using the `S3CredentialsProviderChain` and `DefaultAwsRegionProviderChain` vs. the constructor with default credential provider and region. Also, fix deprecation warnings with `IOUtils` and Kryo `toBytesWithClass()`.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

- Go through the process of uploading a GeoTIFF
- Go through the process of supplying a GeoTIFF via S3 URI
- Ensure that both processes complete successfully

Closes #1822
