### PR TITLE
Use project tiles to preview node if node is a source

### DIFF
--- a/app-frontend/src/app/pages/lab/run/navbar/navbar.html
+++ b/app-frontend/src/app/pages/lab/run/navbar/navbar.html
@@ -3,35 +3,35 @@
   <span class="navbar-detail-title" ng-attr-title="{{$ctrl.toolService.currentTool.title}}">
     {{$ctrl.toolService.currentTool.title}}
   </span>
-  <div class="dropdown-navbardetail"
-       uib-dropdown
-       on-toggle="toggled($ctrl.optionsOpen)">
-    <a uib-dropdown-toggle>
-      <span class="sr-only">Tool options dropdown</span>
-      <i class="icon-caret-down"></i>
-    </a>
-    <ul class="dropdown-menu" aria-labelledby="dLabel">
-      <li>
-        <a ui-sref=".">
-          Tool details
-        </a>
-      </li>
-      <li>
-        <a ui-sref=".">
-          Run
-        </a>
-      </li>
-      <li>
-        <a ui-sref=".">
-          Build
-        </a>
-      </li>
-      <li role="separator" class="divider"></li>
-      <li><a>Save</a></li>
-      <li><a>Save as...</a></li>
-      <li><a>Export</a></li>
-      <li><a class="color-danger">Delete</a>
-      </li>
-    </ul>
-  </div>
+  <!--<div class="dropdown-navbardetail"-->
+       <!--uib-dropdown-->
+       <!--on-toggle="toggled($ctrl.optionsOpen)">-->
+    <!--<a uib-dropdown-toggle>-->
+      <!--<span class="sr-only">Tool options dropdown</span>-->
+      <!--<i class="icon-caret-down"></i>-->
+    <!--</a>-->
+    <!--<ul class="dropdown-menu" aria-labelledby="dLabel">-->
+      <!--<li>-->
+        <!--<a ui-sref=".">-->
+          <!--Tool details-->
+        <!--</a>-->
+      <!--</li>-->
+      <!--<li>-->
+        <!--<a ui-sref=".">-->
+          <!--Run-->
+        <!--</a>-->
+      <!--</li>-->
+      <!--<li>-->
+        <!--<a ui-sref=".">-->
+          <!--Build-->
+        <!--</a>-->
+      <!--</li>-->
+      <!--<li role="separator" class="divider"></li>-->
+      <!--<li><a>Save</a></li>-->
+      <!--<li><a>Save as...</a></li>-->
+      <!--<li><a>Export</a></li>-->
+      <!--<li><a class="color-danger">Delete</a>-->
+      <!--</li>-->
+    <!--</ul>-->
+  <!--</div>-->
 </span>

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -376,6 +376,8 @@ export default (app) => {
         }
 
         getProjectLayerURL(project, token) {
+            let projectId = typeof project === 'object' ? project.id : project;
+
             let params = {
                 tag: new Date().getTime()
             };
@@ -386,7 +388,7 @@ export default (app) => {
 
             let formattedParams = L.Util.getParamString(params);
 
-            return `${this.tileServer}/${project.id}/{z}/{x}/{y}/${formattedParams}`;
+            return `${this.tileServer}/${projectId}/{z}/{x}/{y}/${formattedParams}`;
         }
 
         getZoomLevel(bbox) {

--- a/app-frontend/src/app/services/tools/labUtils.service.js
+++ b/app-frontend/src/app/services/tools/labUtils.service.js
@@ -38,13 +38,15 @@ export default (app) => {
                       <span class="icon-map"></span>
                       </button>
                       <button class="btn node-button" type="button"
-                              ng-if="model.get('cellType') !== 'const'"
+                              ng-if="model.get('cellType') !== 'const' && 
+                               model.get('cellType') !== 'src'"
                               ng-class="{'active': currentView === 'HISTOGRAM'}"
                               ng-click="toggleHistogram()">
                       <span class="icon-histogram"></span>
                       </button>
                       <button class="btn node-button" type="button"
-                              ng-if="model.get('cellType') !== 'const'"
+                              ng-if="model.get('cellType') !== 'const' && 
+                               model.get('cellType') !== 'src'"
                               ng-class="{'active': currentView === 'STATISTICS'}"
                               ng-click="toggleStatistics()">
                           Stats


### PR DESCRIPTION
## Overview

Makes it so that source nodes use project tiles for comparison purposes.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![project-compare](https://user-images.githubusercontent.com/898060/30876481-c91b398c-a2c4-11e7-80a4-c21fad7100de.png)


### Notes

This means that we no longer are comparing the "band" that is the source, but the project. I'm not sure that was a desired feature, to be honest so I don't think it's a loss.

Also, you will have to choose to compare on the preview map rather than selecting nodes because that is broken (see https://github.com/raster-foundry/raster-foundry/issues/2564)

## Testing Instructions

 * Start frontend and either point it at staging or a local development environment
 * Use a simple tool to load a project

Closes #1949
