### PR TITLE
Color scheme dropdown qualitative support

### DIFF
--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
@@ -1,17 +1,20 @@
 <div class="dropdown btn-group"
      uib-dropdown
-     auto-close="outsideClick">
+     auto-close="outsideClick"
+     on-toggle="$ctrl.onDropdownToggle(open)"
+>
   <button class="btn dropdown-label gradient-dropdown"
           uib-dropdown-toggle>
       <div class="gradient-bar gradient-bkg"
-          ng-style="$ctrl.colorSchemeService.colorsToBackground($ctrl.state.scheme.colors)"
+          ng-style="$ctrl.colorSchemeService.colorsToBackground(
+                      $ctrl.reflectedState.scheme.colors, 90, $ctrl.reflectedState.blending.bins)"
       ></div>
       <i class="icon-caret-down"></i>
   </button>
   <div class="dropdown-menu dropdown-menu-light colorscheme-selector" uib-dropdown-menu role="menu">
     <div ng-show="$ctrl.shouldShowView('MAIN')">
       <div class="dropdown-header">
-        <div class="dropdown-header-link-container">
+        <div class="dropdown-header-link-container" feature-flag="colorscheme-blendmodes">
           <a class="dropdown-header-link" ng-click="$ctrl.moveToView('BLENDING')">{{$ctrl.state.blending.label}}...</a>
         </div>
         <div class="dropdown-header-link-container">
@@ -19,7 +22,7 @@
         </div>
       </div>
       <ul class="dropdown-list">
-        <li ng-repeat="scheme in $ctrl.colorSchemeService.defaultColorSchemes | filter : {type: $ctrl.state.schemeType.value}"
+        <li ng-repeat="scheme in $ctrl.colorSchemeService.defaultColorSchemes | filter : $ctrl.filterToValidSchemes"
             ng-click="$ctrl.setScheme(scheme)"
             ng-class="$ctrl.getSchemeClass(scheme)"
             role="menuitem"
@@ -28,7 +31,8 @@
           <div class="selection-indicator"><i class="icon-check"></i></div>
           <div class="gradient-container" ng-class="$ctrl.getSchemeClass(scheme)">
             <div class="gradient-bar gradient-bkg"
-                 ng-style="$ctrl.colorSchemeService.colorsToBackground(scheme.colors)"
+                 ng-style="$ctrl.colorSchemeService.colorsToBackground(
+                             scheme.colors, 90, $ctrl.state.blending.bins)"
             ></div>
           </div>
         </li>
@@ -40,7 +44,7 @@
           <button class="navigation-button" ng-click="$ctrl.moveToView('MAIN')">
             <i class="icon-arrow-left"></i>
           </button>
-          <div class="dropdown-title flex-fill">
+          <div ng-click="$ctrl.moveToView('MAIN')" class="dropdown-title flex-fill">
             Color Scheme
           </div>
         </div>
@@ -64,7 +68,7 @@
           <button class="navigation-button" ng-click="$ctrl.moveToView('MAIN')">
             <i class="icon-arrow-left"></i>
           </button>
-          <div class="dropdown-title flex-fill">
+          <div ng-click="$ctrl.moveToView('MAIN')" class="dropdown-title flex-fill">
             Color Blending
           </div>
         </div>

--- a/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.controller.js
+++ b/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.controller.js
@@ -68,6 +68,11 @@ export default class NodeHistogramController {
 
                 return bp;
             });
+            this._baseScheme = {
+                colorScheme: this._breakpoints.map((bp) => bp.color),
+                bins: 0,
+                dataType: 'SEQUENTIAL'
+            };
         }
     }
 
@@ -95,16 +100,15 @@ export default class NodeHistogramController {
             return {offset: `${offset}%`, color: bp.color};
         });
 
-        // Example code used for displaying discrete colors instead of a gradient
-        // if (this._options.discrete) {
-        //     let offsetData = data.map((currentValue, index, array) => {
-        //         if (index !== array.length - 1) {
-        //             return {offset: array[index + 1].offset, color: currentValue.color};
-        //         }
-        //         return currentValue;
-        //     });
-        //     data = _.flatten(_.zip(data, offsetData));
-        // }
+        if (this._options.baseScheme && this._options.baseScheme.colorBins > 0) {
+            let offsetData = data.map((currentValue, index, array) => {
+                if (index !== array.length - 1) {
+                    return {offset: array[index + 1].offset, color: currentValue.color};
+                }
+                return currentValue;
+            });
+            data = _.flatten(_.zip(data, offsetData));
+        }
 
         if (this._options.masks.min || this._options.discrete) {
             let last = _.last(data);
@@ -271,7 +275,7 @@ export default class NodeHistogramController {
 
         let index = this._breakpoints.findIndex((b) => b === bp);
 
-        if (!this._options.baseScheme || this._options.baseScheme.dataType !== 'CATEGORICAL') {
+        if (!this._options.baseScheme || this._options.baseScheme.colorBins === 0) {
             if (index === 0) {
                 this.recalculateBreakpointsFromRange(breakpoint, max);
             } else if (index === this._breakpoints.length - 1) {
@@ -318,21 +322,40 @@ export default class NodeHistogramController {
     }
 
     shouldShowBreakpoint(index) {
-        if (!this._options.baseScheme || this._options.baseScheme.dataType !== 'CATEGORICAL') {
+        if (!this._options.baseScheme ||
+            this._options.baseScheme.colorBins === 0
+           ) {
             return index === 0 || index === this._breakpoints.length - 1;
         }
         return true;
     }
 
+    getColorBins(colors, bins) {
+        const step = (colors.length - 1) / (bins - 1);
+        return _.range(0, bins).map((i) => colors[Math.round(step * i)]);
+    }
+
     onColorSchemeChange(colorSchemeOptions) {
         if (this._options.baseScheme &&
+            colorSchemeOptions.colorBins === this._options.baseScheme.colorBins &&
             JSON.stringify(colorSchemeOptions.colorScheme) ===
             JSON.stringify(this._options.baseScheme.colorScheme)
            ) {
             return;
         }
-        this.rescaleBreakpoints(0, colorSchemeOptions.colorScheme.length - 1);
-        this._breakpoints = colorSchemeOptions.colorScheme.map((color, index, arr) => {
+        let min = this._options.range.min;
+        let max = this._options.range.max;
+
+        const binned = colorSchemeOptions.colorBins > 0;
+
+        let numColors = binned ?
+            colorSchemeOptions.colorBins : colorSchemeOptions.colorScheme.length;
+
+        this.rescaleBreakpoints(0, numColors - 1);
+        let colors = binned ?
+            this.getColorBins(colorSchemeOptions.colorScheme, colorSchemeOptions.colorBins) :
+            colorSchemeOptions.colorScheme;
+        this._breakpoints = colors.map((color, index, arr) => {
             let isEndpoint = index === 0 || index === arr.length - 1;
             return {
                 id: uuid(),
@@ -346,6 +369,6 @@ export default class NodeHistogramController {
         });
         this._options.scale = colorSchemeOptions.dataType;
         this._options.baseScheme = colorSchemeOptions;
-        this.rescaleBreakpoints(this._options.range.min, this._options.range.max);
+        this.rescaleBreakpoints(min, max);
     }
 }

--- a/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
+++ b/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
@@ -25,7 +25,10 @@
 </div>
 
 <div class="graph-container">
-  <nvd3 ng-attr-id="chart-{{$ctrl.id}}" options="$ctrl.histOptions" data="$ctrl.plot" api="$ctrl.api"></nvd3>
+  <nvd3 ng-attr-id="chart-{{$ctrl.id}}"
+        options="$ctrl.histOptions"
+        data="$ctrl.plot"
+        api="$ctrl.api"></nvd3>
   <rf-histogram-breakpoint
     ng-repeat="bp in $ctrl._breakpoints track by bp.id"
     ng-if="$ctrl.shouldShowBreakpoint($index)"

--- a/app-frontend/src/app/components/settings/featureFlagOverrides/featureFlagOverrides.html
+++ b/app-frontend/src/app/components/settings/featureFlagOverrides/featureFlagOverrides.html
@@ -8,18 +8,21 @@
     <div class="feature-flags-actions">
       Flag:
       <button id="feature-flag--{{flag.key}}--enable"
+              type="button"
               class="btn"
               ng-click="$ctrl.featureFlags.enable(flag)"
               ng-class="{'btn-primary': $ctrl.featureFlags.isOverridden(flag.key) && $ctrl.featureFlags.isOn(flag.key)}">
         On
       </button>
       <button id="feature-flag--{{flag.key}}--disable"
+              type="button"
               class="btn"
               ng-click="$ctrl.featureFlags.disable(flag)"
               ng-class="{'btn-primary': $ctrl.featureFlags.isOverridden(flag.key) && !$ctrl.featureFlags.isOn(flag.key)}">
         Off
       </button>
       <button id="feature-flag--{{flag.key}}--reset"
+              type="button"
               class="btn"
               ng-click="$ctrl.featureFlags.reset(flag)"
               ng-class="{'btn-primary': !$ctrl.featureFlags.isOverridden(flag.key)}">

--- a/app-frontend/src/app/components/tools/diagramContainer/diagramContainer.controller.js
+++ b/app-frontend/src/app/components/tools/diagramContainer/diagramContainer.controller.js
@@ -84,10 +84,24 @@ export default class DiagramContainerController {
         }
 
         if (!this.paper) {
+            let el = $(this.$element);
+            let height = el.height();
+            if (height === 0) {
+                let resetDimensions = () => {
+                    let elHeight = el.height();
+                    if (elHeight !== 0) {
+                        this.paper.setDimensions(el.width(), elHeight);
+                        this.scaleToContent();
+                    } else {
+                        this.$timeout(resetDimensions, 500);
+                    }
+                };
+                this.$scope.$evalAsync(resetDimensions);
+            }
             this.paper = new joint.dia.Paper({
                 el: this.workspaceElement,
-                height: $(this.workspaceElement).height(),
-                width: $(this.workspaceElement).width(),
+                height: height,
+                width: el.width(),
                 gridSize: 25,
                 drawGrid: {
                     name: 'doubleMesh',
@@ -122,10 +136,10 @@ export default class DiagramContainerController {
             this.paper.$el.on('wheel', this.onMouseWheel.bind(this));
 
             this.onWindowResize = () => {
-                let width = this.$element[0].offsetWidth;
-                let height = this.$element[0].offsetHeight;
+                let owidth = this.$element[0].offsetWidth;
+                let oheight = this.$element[0].offsetHeight;
                 this.paper.setDimensions(
-                    width, height
+                    owidth, oheight
                 );
             };
             this.$window.addEventListener('resize', this.onWindowResize);

--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -189,7 +189,7 @@ export default (app) => {
                     });
                 }
 
-                this.featureFlagOverrides.setUser(profile.user_id);
+                this.featureFlagOverrides.setUser(profile);
                 // Flags set in the `/config` endpoint; default.
                 let configFlags = this.featureFlags.get().map((flag) => flag.key);
                 // Now that we've authenticated, trigger an override of the default
@@ -279,6 +279,7 @@ export default (app) => {
                 );
                 if (this.isLoggedIn) {
                     this.setReauthentication(token);
+                    this.featureFlagOverrides.setUser(this.profile());
                 }
                 return this.isLoggedIn;
             } catch (e) {

--- a/app-frontend/src/app/services/projects/colorScheme.defaults.json
+++ b/app-frontend/src/app/services/projects/colorScheme.defaults.json
@@ -52,6 +52,10 @@
         "colors": ["#569543", "#9EBD4D", "#BBCA7A", "#D9E2B2", "#E4E7C4", "#E6D6BE", "#E3C193", "#DFAC6C", "#DB9842", "#B96230"],
         "type": "DIVERGING"
     }, {
+        "label": "Pastel1",
+        "colors": ["#fbb4ae", "#b3cde3", "#ccebc5", "#decbe4", "#fed9a6", "#ffffcc", "#e5d8bd", "#fddaec", "#f2f2f2"],
+        "type": "CATEGORICAL"
+    }, {
         "label": "Raster Foundry Categorical",
         "colors": ["#FFFFFF", "#959CAC", "#465076"],
         "type": "CATEGORICAL"

--- a/app-frontend/src/app/services/projects/colorScheme.service.js
+++ b/app-frontend/src/app/services/projects/colorScheme.service.js
@@ -1,3 +1,5 @@
+/* globals _ */
+
 const {
     colorSchemes: defaultColorSchemes,
     colorSchemeTypes: defaultColorSchemeTypes,
@@ -42,11 +44,20 @@ export default (app) => {
             }, {});
         }
 
+        toBinnedColors(colors) {
+            let numColors = colors.length;
+            return _.zip(
+                colors.map((color, index) => `${color} ${index / numColors * 100}%`),
+                colors.map((color, index) => `${color} ${(index + 1) / numColors * 100}%`)
+            ).join(', ');
+        }
+
         // colors:string[] => { string: string }
         // colors are expected in css hex style (#FFFFFF)
-        colorsToBackground(colors, direction = 90) {
+        colorsToBackground(colors, direction = 90, bins = 0) {
+            let colorString = bins > 0 ? this.toBinnedColors(colors) : colors.join(', ');
             const style = {
-                background: `linear-gradient(${direction}deg, ${colors.join(', ')})`
+                background: `linear-gradient(${direction}deg, ${colorString})`
             };
             return style;
         }

--- a/app-frontend/src/app/services/tools/labUtils.service.js
+++ b/app-frontend/src/app/services/tools/labUtils.service.js
@@ -175,19 +175,29 @@ export default (app) => {
                             return map;
                         }, {});
                         let clip = 'none';
-                        if (this.scope.histogramOptions.masks) {
-                            if (this.scope.histogramOptions.masks.min &&
-                                this.scope.histogramOptions.masks.max) {
+                        let options = this.scope.histogramOptions;
+                        if (options.masks) {
+                            if (options.masks.min &&
+                                options.masks.max) {
                                 clip = 'both';
-                            } else if (this.scope.histogramOptions.masks.min) {
+                            } else if (options.masks.min) {
                                 clip = 'left';
-                            } else if (this.scope.histogramOptions.masks.max) {
+                            } else if (options.masks.max) {
                                 clip = 'right';
                             }
                         }
+                        let scale = options.scale ?
+                            options.scale : 'SEQUENTIAL';
+
+                        if (scale === 'CATEGORICAL') {
+                            scale = 'QUALITATIVE[#000000]';
+                            scale = 'SEQUENTIAL';
+                        } else if (options.baseScheme && options.baseScheme.colorBins > 0) {
+                            scale = `QUALITATIVE[${_.last(this.scope.breakpoints).color}]`;
+                        }
+
                         let renderDef = {
-                            scale: this.scope.histogramOptions.scale ?
-                                this.scope.histogramOptions.scale : 'SEQUENTIAL',
+                            scale: scale,
                             breakpoints: newBreakpoints,
                             clip: clip
                         };

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2411,6 +2411,7 @@ rf-histogram-breakpoint {
 
 .colorscheme-selector {
   padding: 0;
+  min-width: 24rem;
 }
 .dropdown-header {
   display: flex;
@@ -2454,6 +2455,7 @@ rf-histogram-breakpoint {
     text-align: left;
     font-weight: bold;
     color: $brand-primary;
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
## Overview
Fix categorical breakpoints appearing before selecting categorical color scheme
Save blending mode
Fix random lab initialization errors when reloading page
Adjust logic calling onChange function from dropdown: Only call when the number
of bins is changed on the current scheme, or when the scheme is changed.
Fix webpack lint error
Add Pastel color scheme

Use QUALITATIVE[#xxxxx] instead of CATEGORICAL for renderDef

 * There is a bug on the backend with displaying qualitative color schemes - see
   #2571 for details


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/4392704/30887341-fe02b5e8-a2e8-11e7-9e45-d7014a8e3e81.png)
![image](https://user-images.githubusercontent.com/4392704/30887349-048b58f2-a2e9-11e7-9202-8df8348881e4.png)
![image](https://user-images.githubusercontent.com/4392704/30887352-0a72b260-a2e9-11e7-905a-1eb7de97555a.png)
![image](https://user-images.githubusercontent.com/4392704/30887355-160a1c80-a2e9-11e7-99a3-3858dc84da7a.png)

## Notes
The backend currently doesn't support categorical color schemes per #2571

## Testing Instructions

In the node histogram:
* Verify that you can select a number of discrete bins. The color schemes should now show the colors without any blending
* Verify that selecting a categorical color scheme automatically selects a 2 discrete bins
* Verify that the color schemes are not updated until you actually select a color scheme if you switch scheme types (the top right selector)
* Verify that the single band options in the project edit view still works
* Verify that that the blend mode selector is feature flagged by logging into a non `dev@rasterfoundry.com` user. To enable it on any user, add this to their user_metadata on auth0: 
```
{
  "featureFlags": [
    {
      "key": "tools-ui",
      "active": true
    },
    {
      "key": "colorscheme-blendmodes",
      "active": true
    }
  ]
}
```

Closes #2537 
