### PR TITLE
Add measurement tool to lab map

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -23,6 +23,8 @@
     "test-watch": "karma start karma.conf.js --auto-watch --no-single-run"
   },
   "dependencies": {
+    "@turf/area": "^4.7.3",
+    "@turf/distance": "^4.7.3",
     "angucomplete-alt": "^3.0.0",
     "angular": "~1.5.8",
     "angular-animate": "~1.5.8",

--- a/app-frontend/src/app/components/map/labMap/labMap.controller.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.controller.js
@@ -211,7 +211,7 @@ export default class LabMapController {
 
     setPopupContent(shapeType, measurement, layer) {
         let popupScope = this.$scope.$new();
-        let type = shapeType === 'polyline' ? 'Length ' : 'Area ';
+        let type = shapeType === 'polyline' ? 'Distance ' : 'Area ';
         let unit = shapeType === 'polyline' ? ' Meters ' : ' Sq. Meters ';
         let popupContent = angular.element(
             `

--- a/app-frontend/src/app/components/map/labMap/labMap.controller.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.controller.js
@@ -1,9 +1,12 @@
 // import Map from 'es6-map';
-/* globals BUILDCONFIG */
+/* globals BUILDCONFIG, mathjs*/
+
+import turfArea from '@turf/area';
+import turfDistance from '@turf/distance';
 
 export default class LabMapController {
     constructor(
-        $log, $document, $element, $scope, $timeout,
+        $log, $document, $element, $scope, $timeout, $compile,
         mapService
     ) {
         'ngInject';
@@ -12,6 +15,7 @@ export default class LabMapController {
         this.$element = $element;
         this.$scope = $scope;
         this.$timeout = $timeout;
+        this.$compile = $compile;
         this.mapService = mapService;
         this.getMap = () => this.mapService.getMap(this.mapId);
     }
@@ -29,6 +33,10 @@ export default class LabMapController {
     }
 
     $onDestroy() {
+        this.mapWrapper.deleteLayers('Measurement');
+        this.drawListener.forEach((listener) => this.map.off(listener));
+        this.disableDrawHandlers();
+
         this.mapService.deregisterMap(this.mapId);
         delete this.mapWrapper;
         if (this.clickListener) {
@@ -59,10 +67,33 @@ export default class LabMapController {
         this.$timeout(() => {
             this.map.invalidateSize();
             this.mapWrapper = this.mapService.registerMap(this.map, this.mapId, this.options);
+            this.setDrawListeners();
+            this.setDrawHandlers();
         }, 400);
 
         this.basemapOptions = BUILDCONFIG.BASEMAPS.layers;
         this.basemapKeys = Object.keys(this.basemapOptions);
+    }
+
+    setDrawListeners() {
+        this.drawListener = [
+            this.mapWrapper.on(L.Draw.Event.CREATED, this.createMeasureShape.bind(this))
+        ];
+    }
+
+    setDrawHandlers() {
+        this.drawPolygonHandler = new L.Draw.Polygon(this.mapWrapper.map, {
+            allowIntersection: false,
+            shapeOptions: {
+                weight: 2,
+                fillOpacity: 0.2
+            }
+        });
+        this.drawPolylineHandler = new L.Draw.Polyline(this.mapWrapper.map, {
+            shapeOptions: {
+                weight: 2
+            }
+        });
     }
 
     zoomIn() {
@@ -141,5 +172,105 @@ export default class LabMapController {
             return {'background': `url(${url}) no-repeat center`};
         }
         return {};
+    }
+
+    createMeasureShape(e) {
+        this.disableDrawHandlers();
+        this.addMeasureShapeToMap(e.layer, e.layerType);
+    }
+
+    disableDrawHandlers() {
+        this.drawPolygonHandler.disable();
+        this.drawPolylineHandler.disable();
+    }
+
+    addMeasureShapeToMap(layer, type) {
+        let measurement = this.measureCal(type, layer);
+        let compiledPopup = this.setPopupContent(type, measurement, layer);
+        let measureLayers = this.mapWrapper.getLayers('Measurement');
+        measureLayers.push(layer.bindPopup(compiledPopup[0]));
+        this.mapWrapper.setLayer('Measurement', measureLayers, false);
+        layer.openPopup();
+    }
+
+    measureCal(shapeType, layer) {
+        let dataGeojson = layer.toGeoJSON();
+        if (shapeType === 'polygon') {
+            return mathjs.round(turfArea(dataGeojson), 2).toString();
+        } else if (shapeType === 'polyline') {
+            let length = 0;
+            dataGeojson.geometry.coordinates.forEach((v, i, a) => {
+                if (i !== a.length - 1) {
+                    length += turfDistance(v, a[i + 1], 'kilometers');
+                }
+            });
+            return mathjs.round(length * 1000, 2).toString();
+        }
+        return '';
+    }
+
+    setPopupContent(shapeType, measurement, layer) {
+        let popupScope = this.$scope.$new();
+        let type = shapeType === 'polyline' ? 'Length ' : 'Area ';
+        let unit = shapeType === 'polyline' ? ' Meters ' : ' Sq. Meters ';
+        let popupContent = angular.element(
+            `
+                <div>
+                    <label class="leaflet-popup-label m-popup-title">${type} Measurement</label><hr>
+                    <label class="leaflet-popup-label m-popup-result">
+                        <span class="m-popup-number">${measurement}</span>&nbsp;&nbsp;${unit}
+                    </label>
+                    <input type="button" class="btn btn-secondary measure-delete-btn"
+                           ng-click="deleteMeasureShape()" value="Delete" />
+                </div>
+            `
+        );
+        popupScope.deleteMeasureShape = () => {
+            this.removeMeasureLayer(layer);
+        };
+        return this.$compile(popupContent)(popupScope);
+    }
+
+    removeMeasureLayer(layer) {
+        let measureLayers = this.mapWrapper.getLayers('Measurement');
+        let indexOfLayer = measureLayers.indexOf(layer);
+        if (indexOfLayer !== -1) {
+            measureLayers.splice(indexOfLayer, 1);
+        }
+        this.mapWrapper.setLayer('Measurement', measureLayers, false);
+    }
+
+    toggleMeasurePicker(event) {
+        event.stopPropagation();
+        const onClick = () => {
+            this.measurePickerOpen = false;
+            this.$document.off('click', this.clickListener);
+            this.$scope.$evalAsync();
+        };
+        if (!this.measurePickerOpen) {
+            this.measurePickerOpen = true;
+            this.clickListener = onClick;
+            this.$document.on('click', onClick);
+        } else {
+            this.measurePickerOpen = false;
+            this.$document.off('click', this.clickListener);
+            delete this.clickListener;
+        }
+    }
+
+    toggleMeasure(shapeType) {
+        if (shapeType === 'Polygon') {
+            this.drawPolygonHandler.enable();
+            this.drawPolylineHandler.disable();
+        } else if (shapeType === 'Polyline') {
+            this.drawPolylineHandler.enable();
+            this.drawPolygonHandler.disable();
+        }
+    }
+
+    onLabMapClose() {
+        this.mapWrapper.deleteLayers('Measurement');
+        this.disableDrawHandlers();
+        this.onClose();
     }
 }

--- a/app-frontend/src/app/components/map/labMap/labMap.html
+++ b/app-frontend/src/app/components/map/labMap/labMap.html
@@ -49,8 +49,32 @@
         </div>
       </div>
     </div>
+    <div class="filler"></div>
+    <button class="btn btn-default btn-square btn-small"
+            title="Measure"
+            ng-click="$ctrl.toggleMeasurePicker($event)">
+      <span class="icon-check"></span>
+    </button>
+    <div class="measure-dropdown-control layer-picker"
+         ng-show="$ctrl.measurePickerOpen">
+      <div class="layer-picker-title">Pick Measurement</div>
+      <div class="dropdown-arrow"></div>
+      <div class="layer-picker-body">
+        <div class="layer-picker-option"
+             ng-click="$ctrl.toggleMeasure('Polygon')">
+          <div class="layer-picker-label">
+            Polygon
+          </div>
+        </div>
+        <div class="layer-picker-option"
+             ng-click="$ctrl.toggleMeasure('Polyline')">
+          <div class="layer-picker-label">
+            Polyline
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
-
   <div class="filler"></div>
   <button class="btn btn-square btn-small"
           title="Compare"
@@ -62,7 +86,7 @@
   <div class="filler"></div>
   <button class="btn btn-default btn-square btn-small"
           title="Close"
-          ng-click="$ctrl.onClose()">
+          ng-click="$ctrl.onLabMapClose()">
     <span class="icon-close"></span>
   </button>
 </div>

--- a/app-frontend/src/app/components/map/labMap/labMap.html
+++ b/app-frontend/src/app/components/map/labMap/labMap.html
@@ -63,13 +63,13 @@
         <div class="layer-picker-option"
              ng-click="$ctrl.toggleMeasure('Polygon')">
           <div class="layer-picker-label">
-            Polygon
+            Area
           </div>
         </div>
         <div class="layer-picker-option"
              ng-click="$ctrl.toggleMeasure('Polyline')">
           <div class="layer-picker-label">
-            Polyline
+            Distance
           </div>
         </div>
       </div>

--- a/app-frontend/src/app/components/map/labMap/labMap.module.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.module.js
@@ -3,6 +3,11 @@ import LabMapComponent from './labMap.component.js';
 import LabMapController from './labMap.controller.js';
 require('./frame.module.js');
 
+require('./labMap.scss');
+
+require('leaflet-draw/dist/leaflet.draw.css');
+require('leaflet-draw/dist/leaflet.draw.js');
+
 const LabMapModule = angular.module('components.map.labMap', []);
 
 LabMapModule.component('rfLabMap', LabMapComponent);

--- a/app-frontend/src/app/components/map/labMap/labMap.scss
+++ b/app-frontend/src/app/components/map/labMap/labMap.scss
@@ -1,0 +1,27 @@
+@import "../../../../assets/styles/sass/settings/_colors.scss";
+
+.measure-dropdown-control {
+  position: absolute;
+  transform: translateX(-100%);
+  left: -1em;
+  top: 1em;
+}
+
+.m-popup-title{
+    font-size: 18px;
+}
+
+.m-popup-result {
+    margin-bottom: 20px;
+    margin-top: 10px;
+    font-weight: normal;
+}
+
+.m-popup-number{
+    font-size: 18px;
+    font-style: italic;
+}
+
+.measure-delete-btn{
+    width: 100%;
+}

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -2,6 +2,38 @@
 # yarn lockfile v1
 
 
+"@mapbox/geojson-area@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"
+  dependencies:
+    wgs84 "0.0.0"
+
+"@turf/area@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/area/-/area-4.7.3.tgz#5cc45b5a524e98e1c171e7190709c669ca699305"
+  dependencies:
+    "@mapbox/geojson-area" "^0.2.2"
+    "@turf/meta" "^4.7.3"
+
+"@turf/distance@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-4.7.3.tgz#b5ab48a09a642706d65c39b919433d5d2cc571b1"
+  dependencies:
+    "@turf/helpers" "^4.7.3"
+    "@turf/invariant" "^4.7.3"
+
+"@turf/helpers@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-4.7.3.tgz#bc312ac43cab3c532a483151c4c382c5649429e9"
+
+"@turf/invariant@^4.7.3":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-4.7.3.tgz#538f367d23c113fc849d70c9a524b8563874601d"
+
+"@turf/meta@^4.7.3":
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-4.7.4.tgz#6de2f1e9890b8f64b669e4b47c09b20893063977"
+
 Base64@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.2.1.tgz#ba3a4230708e186705065e66babdd4c35cf60028"
@@ -7267,6 +7299,10 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+
+wgs84@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
 
 whatwg-fetch@>=0.10.0:
   version "2.0.1"


### PR DESCRIPTION
## Overview

This PR adds a feature to allow measuring length and area in lab map. It uses leaflet draw and brings in two additional methods in turf.js to calculate areas and distances. Results are displayed in metric units via popups. Measurements can be deleted along with their shapes. They will also be deleted after closing the lab map.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

![measurement in lab map](https://raw.githubusercontent.com/aaronxsu/MyData/master/gifs/rf-pr-gifs/measurement-in-lab-map.gif)

### Notes

The icon of the measurement control is now a placeholder since its icon is pending (issue number: 2548)


## Testing Instructions

 * Go to lab map
 * Use measurement control to measure area and length
 * Check if it behaves as you expected.

Closes #2410
