### PR TITLE
Add button to reverse lab node color schemes

### DIFF
--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.controller.js
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.controller.js
@@ -57,7 +57,8 @@ export default class ColorSchemeDropdownController {
                 label: 'Sequential',
                 value: 'SEQUENTIAL'
             },
-            scheme: this.colorSchemeService.defaultColorSchemes.find(s => s.type === 'SEQUENTIAL')
+            scheme: this.colorSchemeService.defaultColorSchemes.find(s => s.type === 'SEQUENTIAL'),
+            reversed: false
         };
     }
 
@@ -102,6 +103,7 @@ export default class ColorSchemeDropdownController {
                 };
             }
             stateToReturn.blending = blending;
+            stateToReturn.reversed = this._colorSchemeOptions.reversed;
         }
         return stateToReturn;
     }
@@ -112,7 +114,8 @@ export default class ColorSchemeDropdownController {
             return {
                 colorScheme: this.state.scheme.colors,
                 dataType: this.state.schemeType.value,
-                colorBins: this.state.blending.bins
+                colorBins: this.state.blending.bins,
+                reversed: this.state.reversed
             };
         }
         return {};
@@ -256,5 +259,9 @@ export default class ColorSchemeDropdownController {
         if (!open) {
             this.mergeStates();
         }
+    }
+
+    reverseColors() {
+        this.state.reversed = !this.state.reversed;
     }
 }

--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
@@ -7,7 +7,10 @@
           uib-dropdown-toggle>
       <div class="gradient-bar gradient-bkg"
           ng-style="$ctrl.colorSchemeService.colorsToBackground(
-                      $ctrl.reflectedState.scheme.colors, 90, $ctrl.reflectedState.blending.bins)"
+                      $ctrl.reflectedState.scheme.colors,
+                      90,
+                      $ctrl.reflectedState.blending.bins,
+                      $ctrl.state.reversed)"
       ></div>
       <i class="icon-caret-down"></i>
   </button>
@@ -32,8 +35,16 @@
           <div class="gradient-container" ng-class="$ctrl.getSchemeClass(scheme)">
             <div class="gradient-bar gradient-bkg"
                  ng-style="$ctrl.colorSchemeService.colorsToBackground(
-                             scheme.colors, 90, $ctrl.state.blending.bins)"
+                             scheme.colors,
+                             90,
+                             $ctrl.state.blending.bins,
+                             $ctrl.state.reversed)"
             ></div>
+          </div>
+          <div class="reverse-indicator"
+               ng-class="{'active': $ctrl.state.reversed}"
+               ng-click="$ctrl.reverseColors()">
+            <i class="icon-exchange"></i>
           </div>
         </li>
       </ul>

--- a/app-frontend/src/app/services/projects/colorScheme.service.js
+++ b/app-frontend/src/app/services/projects/colorScheme.service.js
@@ -54,8 +54,11 @@ export default (app) => {
 
         // colors:string[] => { string: string }
         // colors are expected in css hex style (#FFFFFF)
-        colorsToBackground(colors, direction = 90, bins = 0) {
-            let colorString = bins > 0 ? this.toBinnedColors(colors) : colors.join(', ');
+        colorsToBackground(colors, direction = 90, bins = 0, reversed) {
+            let orderedColors = reversed ? colors.slice().reverse() : colors;
+            let colorString = bins > 0 ?
+                this.toBinnedColors(orderedColors) :
+                orderedColors.join(', ');
             const style = {
                 background: `linear-gradient(${direction}deg, ${colorString})`
             };

--- a/app-frontend/src/app/services/settings/featureFlagOverrides.service.js
+++ b/app-frontend/src/app/services/settings/featureFlagOverrides.service.js
@@ -68,7 +68,7 @@ export default app => {
                 let profileFlags = this.userProfile &&
                     this.userProfile.user_metadata &&
                     this.userProfile.user_metadata.featureFlags;
-                let f = profileFlags.find((flag) => flag.key === flagName);
+                let f = profileFlags && profileFlags.find((flag) => flag.key === flagName);
                 cached = f ? f.active : false;
             }
             return cached;

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2486,6 +2486,18 @@ ul.dropdown-list {
         display: none;
       }
     }
+    .reverse-indicator {
+      padding: .25em;
+      margin: .25em 0 .25em .25em;
+      text-align: center;
+      border-radius: 3px;
+      color: $brand-primary;
+      visibility: hidden;
+      &.active {
+          background: $brand-primary;
+          color: $white;
+      }
+    }
     span {
       font-style: italic;
       margin-left: 1rem;
@@ -2497,6 +2509,9 @@ ul.dropdown-list {
       color: $brand-primary;
       .selection-indicator i {
         display: inline;
+      }
+      .reverse-indicator {
+        visibility: initial;
       }
     }
     &:last-child {


### PR DESCRIPTION
## Overview
Add button to reverse lab node color schemes

Preserve min/max bounds on breakpoints when switching color schemes

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
![colorscheme_dropdown](https://user-images.githubusercontent.com/4392704/30933423-8565ef50-a398-11e7-9889-b0c6e356ea86.gif)

### Notes

Doesn't do anything for single band options - we'll catch it up later along with the rest of the color scheme dropdown stuff

## Testing Instructions

 * Verify that you can reverse color schemes in node histograms
* Verify that breakpoint min/max positions are preserved when switching between color schemes

Depends on #2573
Closes #2581 
Closes #2567
