### PR TITLE
Use deployment repository master branch for production

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,8 +47,7 @@ node {
       }
 
       // Plan and apply the current state of the instracture as
-      // outlined by the `env.BRANCH_NAME` branch of the
-      // `raster-foundry-deployment` repository.
+      // outlined by the `master` branch of the deployment repository.
       //
       // Also, use the container image revision referenced above to
       // cycle in the newest version of the application into Amazon
@@ -59,7 +58,7 @@ node {
         env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
 
         checkout scm: [$class: 'GitSCM',
-                       branches: [[name: env.BRANCH_NAME]],
+                       branches: [[name: 'master']],
                        extensions: [[$class: 'RelativeTargetDirectory',
                                      relativeTargetDir: 'raster-foundry-deployment']],
                        userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',


### PR DESCRIPTION
## Overview

Ensure that the `master` branch of the deployment repository is always used for production deployments.

See deployment wiki for associated workflow changes.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

The PR build should ensure that syntax in the `Jenkinsfile` is valid. Currently, `master` of the deployment repository reflects the desired state of the infrastructure for our upcoming release.

Closes https://github.com/azavea/raster-foundry-platform/issues/145