### PR TITLE
Reduce Database Load during Sentinel 2 Import

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -1,5 +1,7 @@
 package com.azavea.rf.batch.sentinel2
 
+import java.net.URI
+
 import com.azavea.rf.batch.Job
 import com.azavea.rf.database.{Database => DB}
 import com.azavea.rf.database.tables.{Scenes, Users}
@@ -96,21 +98,25 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       ) :: Nil
   }
 
+  def getSentinel2Products(date: LocalDate): List[URI] = {
+    s3Client
+      .listKeys(
+        s3bucket  = sentinel2Config.bucketName,
+        s3prefix  = s"products/${date.getYear}/${date.getMonthValue}/${date.getDayOfMonth}/",
+        ext       = "productInfo.json",
+        recursive = true
+      ).toList
+  }
+
   def findScenes(date: LocalDate, user: User): Future[List[Option[Scene]]] = {
     logger.info(s"Searching for new scenes on $date")
-    Future.sequence(
-      s3Client
-        .listKeys(
-          s3bucket  = sentinel2Config.bucketName,
-          s3prefix  = s"products/${date.getYear}/${date.getMonthValue}/${date.getDayOfMonth}/",
-          ext       = "productInfo.json",
-          recursive = true
-        )
-        .toList
-        .map { uri =>
+    Scenes.getDatasourceScenesForDay(date, sentinel2Config.datasourceUUID).map { existingScenes =>
+      Future.sequence {
+        val keys = getSentinel2Products(date)
+        keys.map { uri =>
           Future {
             val optList = for {
-              json      <- s3Client.getObject(uri.getHost, uri.getPath.tail).getObjectContent.toJson
+              json <- s3Client.getObject(uri.getHost, uri.getPath.tail).getObjectContent.toJson
               tilesJson <- json.hcursor.downField("tiles").as[List[Json]].toOption
             } yield {
               tilesJson.flatMap { tileJson =>
@@ -119,100 +125,111 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
                     val sceneId = UUID.randomUUID()
                     val sceneName = s"S2 $tilePath"
 
-                    Scenes.sceneNameExistsForUser(sceneName, user).flatMap { exists =>
-                      if (exists) {
-                        logger.warn(s"Skipping tile $tilePath - already exists")
-                        Future(None)
+                    if (existingScenes.contains(sceneName)) {
+                      logger.info(s"Skipping scene creation for ${tilePath} - ${sceneName}")
+                      Future(None)
+                    } else {
+                      logger.info(s"Starting scene creation for sentinel 2 scene: ${tilePath}")
+                      val tileinfo =
+                        s3Client
+                          .getObject(sentinel2Config.bucketName, s"${tilePath}/tileInfo.json")
+                          .getObjectContent
+                          .toJson
+                          .getOrElse(Json.Null)
+
+                      logger.info(s"Creating images for sentinel 2 scene: ${tilePath}")
+                      val images = List(10f, 20f, 60f).map(createImages(sceneId, tileinfo, _)).reduce(_ ++ _)
+
+
+                      logger.info(s"Extracting polygons for ${tilePath}")
+                      val tileFootprint = multiPolygonFromJson(tileinfo, "tileGeometry", sentinel2Config.targetProjCRS)
+                      val dataFootprint = multiPolygonFromJson(tileinfo, "tileDataGeometry", sentinel2Config.targetProjCRS)
+
+                      logger.info(s"Getting scene metadata for ${tilePath}")
+                      val sceneMetadata: Map[String, String] = getSceneMetadata(tileinfo)
+
+                      val awsBase = s"https://${sentinel2Config.bucketName}.s3.amazonaws.com"
+
+                      val metadataFiles = List(
+                        s"$awsBase/$tilePath/tileInfo.json",
+                        s"$awsBase/$tilePath/metadata.xml",
+                        s"$awsBase/$tilePath/productInfo.json"
+                      )
+
+                      val cloudCover = sceneMetadata.get("dataCoveragePercentage").map(_.toFloat)
+                      val acquisitionDate = sceneMetadata.get("timeStamp").map { dt =>
+                        new java.sql.Timestamp(
+                          ZonedDateTime
+                            .parse(dt)
+                            .toInstant
+                            .getEpochSecond * 1000l
+                        )
                       }
-                      else {
-                        logger.info(s"Starting scene creation for sentinel 2 scene: ${tilePath}")
-                        val tileinfo =
-                          s3Client
-                            .getObject(sentinel2Config.bucketName, s"${tilePath}/tileInfo.json")
-                            .getObjectContent
-                            .toJson
-                            .getOrElse(Json.Null)
 
-                        val images = List(10f, 20f, 60f).map(createImages(sceneId, tileinfo, _)).reduce(_ ++ _)
-
-                        val (tileFootprint, dataFootprint) =
-                          multiPolygonFromJson(tileinfo, "tileGeometry", sentinel2Config.targetProjCRS) ->
-                            multiPolygonFromJson(tileinfo, "tileDataGeometry", sentinel2Config.targetProjCRS)
-
-                        val sceneMetadata: Map[String, String] = getSceneMetadata(tileinfo)
-
-                        val awsBase = s"https://${sentinel2Config.bucketName}.s3.amazonaws.com"
-
-                        val metadataFiles = List(
-                          s"$awsBase/$tilePath/tileInfo.json",
-                          s"$awsBase/$tilePath/metadata.xml",
-                          s"$awsBase/$tilePath/productInfo.json"
+                      logger.info(s"Creating scene case class ${tilePath}")
+                      val scene = Scene.Create(
+                        id = sceneId.some,
+                        organizationId = sentinel2Config.organizationUUID,
+                        ingestSizeBytes = 0,
+                        visibility = Visibility.Public,
+                        tags = List("Sentinel-2", "JPEG2000"),
+                        datasource = sentinel2Config.datasourceUUID,
+                        sceneMetadata = sceneMetadata.asJson,
+                        name = sceneName,
+                        owner = airflowUser.some,
+                        tileFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| tileFootprint).map {
+                          case (code, mp) => Projected(mp, code)
+                        },
+                        dataFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| dataFootprint).map {
+                          case (code, mp) => Projected(mp, code)
+                        },
+                        metadataFiles = metadataFiles,
+                        images = images,
+                        thumbnails = createThumbnails(sceneId, tilePath),
+                        ingestLocation = None,
+                        filterFields = SceneFilterFields(
+                          cloudCover = cloudCover,
+                          acquisitionDate = acquisitionDate
+                        ),
+                        statusFields = SceneStatusFields(
+                          thumbnailStatus = JobStatus.Success,
+                          boundaryStatus = JobStatus.Success,
+                          ingestStatus = IngestStatus.NotIngested
                         )
+                      )
 
-                        val cloudCover = sceneMetadata.get("dataCoveragePercentage").map(_.toFloat)
-                        val acquisitionDate = sceneMetadata.get("timeStamp").map { dt =>
-                          new java.sql.Timestamp(
-                            ZonedDateTime
-                              .parse(dt)
-                              .toInstant
-                              .getEpochSecond * 1000l
-                          )
-                        }
-
-                        val scene = Scene.Create(
-                          id = sceneId.some,
-                          organizationId = sentinel2Config.organizationUUID,
-                          ingestSizeBytes = 0,
-                          visibility = Visibility.Public,
-                          tags = List("Sentinel-2", "JPEG2000"),
-                          datasource = sentinel2Config.datasourceUUID,
-                          sceneMetadata = sceneMetadata.asJson,
-                          name = sceneName,
-                          owner = airflowUser.some,
-                          tileFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| tileFootprint).map { case (code, mp) => Projected(mp, code) },
-                          dataFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| dataFootprint).map { case (code, mp) => Projected(mp, code) },
-                          metadataFiles = metadataFiles,
-                          images = images,
-                          thumbnails = createThumbnails(sceneId, tilePath),
-                          ingestLocation = None,
-                          filterFields = SceneFilterFields(
-                            cloudCover = cloudCover,
-                            acquisitionDate = acquisitionDate
-                          ),
-                          statusFields = SceneStatusFields(
-                            thumbnailStatus = JobStatus.Success,
-                            boundaryStatus = JobStatus.Success,
-                            ingestStatus = IngestStatus.NotIngested
-                          )
-                        )
-
-                        logger.info(s"Importing scene $sceneId...")
-                        val future =
-                          Scenes.insertScene(scene, user).map(_.toScene).recover {
-                            case e: PSQLException => {
-                              logger.error(s"An error occurred during scene $sceneId import. Skipping...")
-                              logger.error(e.stackTraceString)
-                              sendError(e)
-                              scene.toScene(user)
-                            }
-                          }
-
-                        future onComplete {
-                          case Success(s) => logger.info(s"Finished importing scene ${s.id}.")
-                          case Failure(e) => {
-                            logger.error(s"An error occurred during scene $sceneId import.")
+                      logger.info(s"Importing scene $sceneId...")
+                      val future =
+                        Scenes.insertScene(scene, user).map(_.toScene).recover {
+                          case e: PSQLException => {
+                            logger.error(s"An error occurred during scene $sceneId import. Skipping...")
                             logger.error(e.stackTraceString)
                             sendError(e)
+                            scene.toScene(user)
+                          }
+                          case e => {
+                            logger.error("An unknown error occurred during scene import")
+                            logger.error(e.stackTraceString)
+                            sendError(e)
+                            scene.toScene(user)
                           }
                         }
-                        future.map(Some(_))
+
+                      future onComplete {
+                        case Success(s) => logger.info("Finished importing scene.")
+                        case Failure(e) => {
+                          logger.error(s"An error occurred during scene $sceneId import.")
+                          logger.error(e.stackTraceString)
+                          sendError(e)
+                        }
                       }
+                      future.map(Some(_))
                     }
                   }
                 }
-                sceneResult.recoverWith{
+                sceneResult.recoverWith {
                   case e => {
-                    logger.error("An error occurred during scene import.")
+                    logger.error(s"An error occurred during scene import: ${uri.getPath.tail}")
                     logger.error(e.stackTraceString)
                     sendError(e)
                     Failure(e)
@@ -223,8 +240,9 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
             Future.sequence(optList.getOrElse(Nil))
           }.flatMap(identity)
         }
-    ).map(_.flatten)
-  }
+      }.map(_.flatten)
+    }
+  }.flatten
 
   def run: Unit = {
     logger.info("Importing scenes...")


### PR DESCRIPTION
## Overview

When importing Sentinel 2 scenes the importer checks that a scene has not
already been added before adding the scene. Before this commit a database call
would be made for each scene and would produce a heavy load on the database. To
get around this problem, this commit instead retrieves a list of scenes first
and uses that for comparisons when doing the import.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This makes an assumption that there will not be duplicate imports within a single job.

## Testing Instructions

 * Run assembly for the batch container:
```
./scripts/console api-server bash
./sbt
project batch
assembly
```
 * In the container, kick off an import -- kill it after a few scenes get imported
```
java -cp /opt/raster-foundry/app-backend/batch/target/scala-2.11/rf-batch.jar com.azavea.rf.batch.Main import_sentinel2 2017-03-20
```
 * Restart the same job and ensure that some log messages about skipping scenes are printed
