### PR TITLE
Remove ability to apply auto color corrections

### DIFF
--- a/app-frontend/src/app/components/histogram/channelHistogram/channelHistogram.html
+++ b/app-frontend/src/app/components/histogram/channelHistogram/channelHistogram.html
@@ -31,28 +31,6 @@
       <i class="icon-load"></i>
     </span>
   </div>
-  <rf-histogram-breakpoint
-    ng-mouseover="$ctrl.lastMouseOver = 'min'"
-    ng-class="{'active': $ctrl.lastMouseOver === 'min'}"
-    data-color="black"
-    data-breakpoint="$ctrl.lowerClip"
-    data-range="{min: $ctrl.minClip, max: $ctrl.maxClip}"
-    data-precision="0"
-    data-options="{style: 'bar', alwaysShowNumbers: true}"
-    on-color-change="$ctrl.changeMinColor(color)"
-    on-breakpoint-change="$ctrl.onMinBreakpointChange(breakpoint)"
-  ></rf-histogram-breakpoint>
-  <rf-histogram-breakpoint
-    ng-mouseover="$ctrl.lastMouseOver = 'max'"
-    ng-class="{'active': $ctrl.lastMouseOver === 'max'}"
-    data-color="white"
-    data-breakpoint="$ctrl.upperClip"
-    data-range="{min: $ctrl.minClip, max: $ctrl.maxClip}"
-    data-precision="0"
-    data-options="{style: 'bar', alwaysShowNumbers: true}"
-    on-color-change="$ctrl.changeMaxColor(color)"
-    on-breakpoint-change="$ctrl.onMaxBreakpointChange(breakpoint)"
-  ></rf-histogram-breakpoint>
 </div>
 <div class="histogram-spacer"></div>
 <div class="color-filters-container">

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
@@ -27,6 +27,7 @@ export default class ProjectsColorAdjustController {
         };
 
         let alphaOptions = {
+            value: 1,
             floor: 0,
             ceil: 1,
             step: 0.01,
@@ -35,7 +36,7 @@ export default class ProjectsColorAdjustController {
         };
 
         let betaOptions = {
-            value: 0.6,
+            value: 1,
             floor: 0,
             ceil: 10,
             step: 0.1,

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.html
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.html
@@ -1,7 +1,7 @@
 <div ui-view class="flex-column">
   <div class="sidebar-static">
     <div class="sidebar-header">
-      <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit.color">
+      <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit.colormode">
         <i class="icon-arrow-left"></i>
       </a>
       <h5 class="sidebar-title">Advanced Color Correction</h5>

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -2,7 +2,7 @@
   <div class="sidebar-header">
     <h5 class="sidebar-title">Color Mode</h5>
     <div class="header-controls">
-      <a ng-hide="$ctrl.projectBuffer.isSingleBand" ui-sref="projects.edit.color"
+      <a ng-hide="$ctrl.projectBuffer.isSingleBand" ui-sref="projects.edit.advancedcolor"
         class="btn btn-primary">Corrections</a>
     </div>
   </div>


### PR DESCRIPTION
## Overview
Remove ability to apply auto color corrections (keeping component for later)
Remove breakpoints from color correction histogram

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
![image](https://user-images.githubusercontent.com/4392704/31282432-8b5461e6-aa80-11e7-9a4e-feeb0644fe3a.png)

## Testing Instructions

 * Verify that clicking the corrections button under color mode goes directly to the advanced color mode
* Verify that there are no breakpoints on the color correction histogram
Closes https://github.com/azavea/raster-foundry-platform/issues/151
Closes #2578 
