### PR TITLE
Fix date selection button bug on scene filter pane.

### DIFF
--- a/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.controller.js
+++ b/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.controller.js
@@ -1,6 +1,8 @@
+/* globals _ */
 export default class DateRangePickerModalController {
-    constructor(moment, dateRangePickerConf) {
+    constructor($log, moment, dateRangePickerConf) {
         'ngInject';
+        this.$log = $log;
         this.Moment = moment;
         this.dateRangePickerConf = dateRangePickerConf;
     }
@@ -22,12 +24,22 @@ export default class DateRangePickerModalController {
     }
 
     matchesSelectedRange(range) {
-        return range.start.isSame(this._range.start) && range.end.isSame(this._range.end);
+        if (_.isEmpty(range.start) || _.isEmpty(range.end)) {
+            return true;
+        // eslint-disable-next-line no-else-return
+        } else {
+            return range.start.isSame(this._range.start) && range.end.isSame(this._range.end);
+        }
     }
 
     onPresetSelect(range, index) {
-        this._range.start = range.start;
-        this._range.end = range.end;
+        if (!_.isEmpty(range.start) && !_.isEmpty(range.end)) {
+            this._range.start = range.start;
+            this._range.end = range.end;
+            this.isRangeEmpty = false;
+        } else {
+            this.isRangeEmpty = true;
+        }
         this.selectedRangeIndex = index;
     }
 
@@ -47,8 +59,8 @@ export default class DateRangePickerModalController {
 
     apply() {
         let data = {
-            start: this._range.start,
-            end: this._range.end
+            start: this.isRangeEmpty ? {} : this._range.start,
+            end: this.isRangeEmpty ? {} : this._range.end
         };
         const selectedRange = this.getSelectedPreset();
         if (selectedRange) {

--- a/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.controller.js
+++ b/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.controller.js
@@ -1,8 +1,7 @@
 /* globals _ */
 export default class DateRangePickerModalController {
-    constructor($log, moment, dateRangePickerConf) {
+    constructor(moment, dateRangePickerConf) {
         'ngInject';
-        this.$log = $log;
         this.Moment = moment;
         this.dateRangePickerConf = dateRangePickerConf;
     }
@@ -26,10 +25,8 @@ export default class DateRangePickerModalController {
     matchesSelectedRange(range) {
         if (_.isEmpty(range.start) || _.isEmpty(range.end)) {
             return true;
-        // eslint-disable-next-line no-else-return
-        } else {
-            return range.start.isSame(this._range.start) && range.end.isSame(this._range.end);
         }
+        return range.start.isSame(this._range.start) && range.end.isSame(this._range.end);
     }
 
     onPresetSelect(range, index) {

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -1,9 +1,8 @@
 /* globals _*/
 export default class FilterPaneController {
-    constructor($log, $scope, $rootScope, $timeout, $uibModal,
+    constructor($scope, $rootScope, $timeout, $uibModal,
         datasourceService, authService, moment) {
         'ngInject';
-        this.$log = $log;
         this.$scope = $scope;
         this.$rootScope = $rootScope;
         this.$timeout = $timeout;

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -1,13 +1,15 @@
+/* globals _*/
 export default class FilterPaneController {
-    constructor(datasourceService, authService, $scope, $rootScope, $timeout,
-                $uibModal, moment) {
+    constructor($log, $scope, $rootScope, $timeout, $uibModal,
+        datasourceService, authService, moment) {
         'ngInject';
-        this.datasourceService = datasourceService;
-        this.authService = authService;
+        this.$log = $log;
         this.$scope = $scope;
         this.$rootScope = $rootScope;
         this.$timeout = $timeout;
         this.$uibModal = $uibModal;
+        this.datasourceService = datasourceService;
+        this.authService = authService;
         this.Moment = moment;
     }
 
@@ -54,48 +56,46 @@ export default class FilterPaneController {
                 end: this.Moment()
             },
             {
-                name: 'All',
-                start: this.Moment().subtract(100, 'years'),
-                end: this.Moment()
+                name: 'None',
+                start: {},
+                end: {}
             }
         ];
 
         if (this.filters.minAcquisitionDatetime && this.filters.maxAcquisitionDatetime) {
             this.datefilter.start = this.Moment(this.filters.minAcquisitionDatetime);
             this.datefilter.end = this.Moment(this.filters.maxAcquisitionDatetime);
+            this.hasDatetimeFilter = true;
         }
 
         if (!this.filters.minAcquisitionDatetime || !this.filters.maxAcquisitionDatetime) {
             this.clearDateFilter();
         } else {
-            this.dateFilterToggle = {value: true};
+            this.datefilterPreset = '';
+            this.hasDatetimeFilter = true;
         }
     }
 
     clearDateFilter() {
         delete this.filters.minAcquisitionDatetime;
         delete this.filters.maxAcquisitionDatetime;
-        this.dateFilterToggle = {value: false};
+        this.datefilterPreset = 'None';
+        this.hasDatetimeFilter = false;
     }
 
     setDateRange(start, end, preset) {
-        this.datefilter.start = start;
-        this.datefilter.end = end;
-        this.datefilterPreset = preset || false;
-        this.dateFilterToggle.value = true;
-        this.filters.minAcquisitionDatetime = start.toISOString();
-        this.filters.maxAcquisitionDatetime = end.toISOString();
-        this.cacheYearFilters();
-    }
-
-    onDateFilterToggle(value) {
-        if (value) {
-            this.filters.minAcquisitionDatetime = this.datefilter.start.toISOString();
-            this.filters.maxAcquisitionDatetime = this.datefilter.end.toISOString();
+        if (_.isEmpty({start}) || _.isEmpty(end)) {
+            this.clearDateFilter();
         } else {
-            delete this.filters.minAcquisitionDatetime;
-            delete this.filters.maxAcquisitionDatetime;
+            this.datefilter.start = start;
+            this.datefilter.end = end;
+            this.datefilterPreset = preset || false;
+            this.hasDatetimeFilter = true;
+            this.filters.minAcquisitionDatetime = start.toISOString();
+            this.filters.maxAcquisitionDatetime = end.toISOString();
         }
+
+        this.cacheYearFilters();
     }
 
     close() {

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
@@ -16,8 +16,7 @@
     <div class="filter-group">
       <div class="filter">
         <label>Date Range</label>
-        <div class="flex-fill"
-             ng-class="{'color-white': $ctrl.dateFilterToggle.value}">
+        <div class="flex-fill">
           <span ng-if="$ctrl.datefilterPreset">{{$ctrl.datefilterPreset}}</span>
           <span ng-if="!$ctrl.datefilterPreset">{{$ctrl.datefilter.start.calendar()}} to {{$ctrl.datefilter.end.calendar()}}</span>
         </div>
@@ -25,15 +24,7 @@
       <div class="filter">
         <label></label>
         <button class="btn btn-small btn-primary flex-fill"
-                ng-click="$ctrl.openDateRangePickerModal()"
-                ng-class="{'disabled': !$ctrl.dateFilterToggle.value}">Select a Date</button>
-
-      </div>
-      <div class="filter-group-option">
-        <label>Enabled</label>
-        <rf-toggle-old data-model="$ctrl.dateFilterToggle.value"
-                       on-change="$ctrl.onDateFilterToggle(value)"
-        ></rf-toggle-old>
+                ng-click="$ctrl.openDateRangePickerModal()">{{$ctrl.hasDatetimeFilter ? 'Update ' : 'Set '}}Date Filter</button>
       </div>
     </div>
     <div class="filter-group">


### PR DESCRIPTION
## Overview

This PR fixes date selection button bug on scene filter pane.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to browse scenes and turn on filter pane
 * If there is no date range filter, the button should read 'Set Date Filter'. Otherwise, it should read 'Update Date Filter'.
<img width="1920" alt="no date filter" src="https://user-images.githubusercontent.com/16109558/31287452-55d2916e-aa8f-11e7-9914-c37965e5dea9.png">

<img width="1920" alt="with date filter" src="https://user-images.githubusercontent.com/16109558/31287463-5e38af46-aa8f-11e7-965d-b3a77afb09c7.png">

 * Click on it to set date or set it to 'None' as no date filter.
<img width="1920" alt="select date range" src="https://user-images.githubusercontent.com/16109558/31287472-668cc88a-aa8f-11e7-87eb-e65f63215e4a.png">


Closes #2576 
