### PR TITLE
Bulk annotation mode and interrupt fix

### DIFF
--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.component.js
@@ -6,6 +6,8 @@ const annotateToolbar = {
     bindings: {
         mapId: '@',
         disableToolbarAction: '<',
+        bulkMode: '<',
+        onDrawingCanceled: '&',
         onShapeCreating: '&',
         onShapeCreated: '&'
     }

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
@@ -14,6 +14,8 @@ export default class AnnotateToolbarController {
 
     $onInit() {
         this.isDrawCancel = false;
+        this.inBulkMode = false;
+        this.lastHandler = null;
 
         this.getMap().then((mapWrapper) => {
             this.listeners = [
@@ -23,6 +25,14 @@ export default class AnnotateToolbarController {
         });
 
         this.$scope.$on('$destroy', this.$onDestroy.bind(this));
+    }
+
+    $onChanges(changes) {
+        if (changes.bulkMode && changes.bulkMode.currentValue) {
+            this.enableBulkCreate();
+        } else if (changes.bulkMode) {
+            this.disableBulkCreate();
+        }
     }
 
     $onDestroy() {
@@ -59,18 +69,30 @@ export default class AnnotateToolbarController {
         this.isDrawCancel = true;
         if (shapeType === 'rectangle') {
             this.drawRectangleHandler.enable();
+            this.lastHandler = this.drawRectangleHandler;
             this.drawPolygonHandler.disable();
             this.drawMarkerHandler.disable();
         } else if (shapeType === 'polygon') {
             this.drawPolygonHandler.enable();
+            this.lastHandler = this.drawPolygonHandler;
             this.drawRectangleHandler.disable();
             this.drawMarkerHandler.disable();
         } else {
             this.drawMarkerHandler.enable();
+            this.lastHandler = this.drawMarkerHandler;
             this.drawPolygonHandler.disable();
             this.drawRectangleHandler.disable();
         }
         this.onShapeCreating({'isCreating': true});
+    }
+
+    enableBulkCreate() {
+        this.inBulkMode = true;
+    }
+
+    disableBulkCreate() {
+        this.inBulkMode = false;
+        this.onCancelDrawing();
     }
 
     onCancelDrawing() {
@@ -79,6 +101,7 @@ export default class AnnotateToolbarController {
         this.drawPolygonHandler.disable();
         this.drawMarkerHandler.disable();
         this.onShapeCreating({'isCreating': false});
+        this.onDrawingCanceled();
     }
 
     createShape(e) {
@@ -87,5 +110,13 @@ export default class AnnotateToolbarController {
         this.onShapeCreated({
             'shapeLayer': e.layer
         });
+
+        if (this.inBulkMode && this.lastHandler) {
+            this.$scope.$evalAsync(() => {
+                this.isDrawCancel = true;
+                this.lastHandler.enable();
+                this.onShapeCreating({isCreating: true});
+            });
+        }
     }
 }

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.html
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.html
@@ -2,7 +2,8 @@
   <div class="annotate-toolbar">
     <div class="column" ng-if="!$ctrl.isDrawCancel">
       <div class="annotate-toolbar-header row align-center">
-        <span>New annotation</span>
+        <span ng-if="!$ctrl.inBulkMode">New annotation</span>
+        <span ng-if="$ctrl.inBulkMode">New bulk annotation</span>
       </div>
       <div class="annotate-toolbar-actions row align-center">
         <button class="btn btn-primary btn-anno-rectangle"
@@ -24,12 +25,14 @@
     </div>
     <div class="column" ng-if="$ctrl.isDrawCancel">
       <div class="annotate-toolbar-header row align-center">
-        <span>Draw annotation</span>
+          <span ng-if="!$ctrl.inBulkMode">Draw annotation</span>
+          <span ng-if="$ctrl.inBulkMode">Draw bulk annotation</span>
       </div>
       <div class="annotate-toolbar-actions row align-center">
         <button class="btn btn-primary btn-anno-cancel"
                 ng-click="$ctrl.onCancelDrawing()">
-          Cancel
+                <span ng-if="!$ctrl.inBulkMode">Cancel</span>
+                <span ng-if="$ctrl.inBulkMode">Finish</span>
         </button>
       </div>
     </div>

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.component.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.component.js
@@ -13,6 +13,7 @@ const annotateSidebarItem = {
         onDeleteAnnotation: '&',
         onUpdateAnnotationFinish: '&',
         onCancelUpdateAnnotation: '&',
+        onBulkCreate: '&',
         onQaChecked: '&'
     }
 };

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
@@ -34,6 +34,11 @@ export default class AnnotateSidebarItemController {
         });
     }
 
+    onAnnotationBulkCreate($event, annotation) {
+        $event.stopPropagation();
+        this.onBulkCreate({'annotation': annotation});
+    }
+
     cancelAnnotation(annotation) {
         this.onCancelUpdateAnnotation({
             'annotation': annotation,

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
@@ -29,6 +29,10 @@
     </div>
   </div>
   <div class="list-group-right actions-annotations">
+      <a title="Bulk Create"
+      ng-click="$ctrl.disableSidebarAction || $ctrl.onAnnotationBulkCreate($event, $ctrl.annotation)"
+      ng-disabled="$ctrl.disableSidebarAction">
+     Bulk Create</a>
     <a title="Clone"
        ng-click="$ctrl.disableSidebarAction || $ctrl.onAnnotationClone($event, $ctrl.annotation)"
        ng-disabled="$ctrl.disableSidebarAction">

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -807,6 +807,8 @@ export default class AnnotateController {
                 if (!answer) {
                     event.preventDefault();
                     this.$state.go(fromState, fromParams);
+                } else {
+                    this.allowInterruptions();
                 }
             }
         );

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -444,6 +444,14 @@ export default class AnnotateController {
             let geojsonData = shapeLayer.toGeoJSON();
             this.createEditableDrawLayer(mapWrapper, geojsonData.geometry);
             this.addNewAnnotationIdToData();
+            if (this.bulkTemplate) {
+                this.onUpdateAnnotationFinish(
+                    this.annoToExport.features.slice(-1)[0].properties.id,
+                    this.bulkTemplate.properties.label,
+                    this.bulkTemplate.properties.description,
+                    false
+                );
+            }
         });
     }
 
@@ -639,6 +647,14 @@ export default class AnnotateController {
             );
         });
         this.$timeout(() => angular.element('#_values').focus());
+    }
+
+    onBulkCreate(annotation) {
+        this.bulkTemplate = annotation;
+    }
+
+    onBulkCreateFinish() {
+        this.bulkTemplate = false;
     }
 
     updateFilterAndMapRender(label) {

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.controller.js
@@ -47,7 +47,6 @@ export default class AnnotateController {
             this.disableTransformHandler(mapWrapper);
         });
         this.disableEditHandler();
-        this.allowInterruptions();
         this.$window.removeEventListener('beforeunload', this.onWindowUnload);
     }
 
@@ -368,7 +367,6 @@ export default class AnnotateController {
     /* eslint-enable no-underscore-dangle */
 
     onShapeCreating(isCreating) {
-        this.preventInterruptions();
         this.isCreating = isCreating;
         this.disableSidebarAction = isCreating;
     }
@@ -579,7 +577,6 @@ export default class AnnotateController {
                 this.onFilterChange(this.filterLabel);
             }
         });
-        this.allowInterruptions();
     }
 
     disableTransformHandler(mapWrapper) {
@@ -590,7 +587,6 @@ export default class AnnotateController {
     }
 
     onCloneAnnotation(geometry, label, description) {
-        this.preventInterruptions();
         this.deleteClickedHighlight();
 
         this.disableSidebarAction = true;
@@ -618,7 +614,6 @@ export default class AnnotateController {
 
     onUpdateAnnotationStart(annotation) {
         this.getMap().then((mapWrapper) => {
-            this.preventInterruptions();
             this.deleteClickedHighlight();
             this.disableTransformHandler(mapWrapper);
 
@@ -707,7 +702,6 @@ export default class AnnotateController {
                 this.getMap().then((mapWrapper) => mapWrapper.deleteLayers('draw'));
             }
         }
-        this.allowInterruptions();
     }
 
 
@@ -813,27 +807,6 @@ export default class AnnotateController {
                 polygonLayer.transform.enable({rotation: true, scaling: true});
                 mapWrapper.map.panTo(polygonLayer.getCenter());
             }
-        }
-    }
-
-    preventInterruptions() {
-        this.stateChangeCanceller = this.$rootScope.$on('$stateChangeStart',
-            (event, toState, toParams, fromState, fromParams) => {
-                let answer = this.$window.confirm('Leave this page?');
-                if (!answer) {
-                    event.preventDefault();
-                    this.$state.go(fromState, fromParams);
-                } else {
-                    this.allowInterruptions();
-                }
-            }
-        );
-    }
-
-    allowInterruptions() {
-        if (this.stateChangeCanceller) {
-            this.stateChangeCanceller();
-            delete this.stateChangeCanceller();
         }
     }
 

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
@@ -1,6 +1,8 @@
 <div class="flex-column" ui-view>
   <rf-annotate-toolbar map-id="edit"
                        disable-toolbar-action="$ctrl.disableToolbarAction"
+                       bulk-mode="$ctrl.bulkTemplate"
+                       on-drawing-canceled="$ctrl.onBulkCreateFinish()"
                        on-shape-creating="$ctrl.onShapeCreating(isCreating)"
                        on-shape-created="$ctrl.onShapeCreated(shapeLayer)">
   </rf-annotate-toolbar>
@@ -33,7 +35,17 @@
       </div>
     </div>
   </div>
+
   <div class="sidebar-scrollable no-annotation">
+      <div class="content"
+          ng-if="$ctrl.bulkTemplate">
+       <div class="alert alert-default">
+         <p class="">You're currently in bulk create mode</p>
+         <div class="text-center">
+           <button class="btn btn-primary" ng-click="$ctrl.onBulkCreateFinish()">Finish</button>
+         </div>
+       </div>
+     </div>
     <div class="content"
          ng-if="!$ctrl.annoToExport.features.length">
       <div class="alert alert-default">
@@ -79,6 +91,7 @@
                                   label-inputs="$ctrl.labelInputs"
                                   edit-id="$ctrl.editId"
                                   disable-sidebar-action="$ctrl.disableSidebarAction"
+                                  on-bulk-create="$ctrl.onBulkCreate(annotation)"
                                   on-clone-annotation="$ctrl.onCloneAnnotation(geometry, label, description)"
                                   on-update-annotation-start="$ctrl.onUpdateAnnotationStart(annotation)"
                                   on-delete-annotation="$ctrl.onDeleteAnnotation(id, label)"


### PR DESCRIPTION
## Overview

This PR does two things:

- fixes the navigation interrupt logic to ensure the interrupt is deactivated
- adds a bulk annotation mode that speeds up the annotation process for like objects

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/31288864-abcd307e-aa94-11e7-8884-4e49e06854a1.png)

![image](https://user-images.githubusercontent.com/2442245/31288871-b4cfa9d6-aa94-11e7-93c2-359bab1c5e26.png)

### Notes

We don't have an icon and thus this the 'Bulk Create' link is pretty ugly.

## Testing Instructions

 * Create an annotation
 * Click 'Bulk Create' on that annotation
 * Select the type of shapes you want to create
 * Create many annotations
 * Make sure hitting the 'Finish' button works as you'd expect

Closes #2608 
