### PR TITLE
Fix annotate draw handler existence issue

### DIFF
--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
@@ -97,9 +97,15 @@ export default class AnnotateToolbarController {
 
     onCancelDrawing() {
         this.isDrawCancel = false;
-        this.drawRectangleHandler.disable();
-        this.drawPolygonHandler.disable();
-        this.drawMarkerHandler.disable();
+        if (this.drawRectangleHandle) {
+            this.drawRectangleHandler.disable();
+        }
+        if (this.drawPolygonHandler) {
+            this.drawPolygonHandler.disable();
+        }
+        if (this.drawMarkerHandler) {
+            this.drawMarkerHandler.disable();
+        }
         this.onShapeCreating({'isCreating': false});
         this.onDrawingCanceled();
     }


### PR DESCRIPTION
## Overview

This PR does the checks for the existence of draw handler before canceling them in the annotate toolbar component, which seems to be the issue on the newest develop branch.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to annotate page and open console. There should be no error messages telling you something like 'Cannot read property 'disable' of undefined'.