### PR TITLE
Use correct branch for CI deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,6 @@ node {
 
     env.AWS_DEFAULT_REGION = 'us-east-1'
     env.RF_ARTIFACTS_BUCKET = 'rasterfoundry-global-artifacts-us-east-1'
-    env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
 
     // Execute `cibuild` wrapped within a plugin that translates
     // ANSI color codes to something that renders inside the Jenkins
@@ -26,9 +25,13 @@ node {
 
     if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
       // When a release branch is used, override `env.RF_DOCS_BUCKET`
-      // so that the production documentation site is published by `cipublish`.
+      // and `env.RF_DEPLOYMENT_BRANCH`.
       if (env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
         env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
+        env.RF_DEPLOYMENT_BRANCH = 'master'
+      } else {
+        env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
+        env.RF_DEPLOYMENT_BRANCH = 'develop'
       }
 
       // Publish container images built and tested during `cibuild`
@@ -58,7 +61,7 @@ node {
         env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
 
         checkout scm: [$class: 'GitSCM',
-                       branches: [[name: 'master']],
+                       branches: [[name: env.RF_DEPLOYMENT_BRANCH]],
                        extensions: [[$class: 'RelativeTargetDirectory',
                                      relativeTargetDir: 'raster-foundry-deployment']],
                        userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',


### PR DESCRIPTION
## Overview

Ensure that the `master` branch of the deployment repository is always used for production deployments. Also, ensure the `develop` branch is used otherwise.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

The [following](http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/develop/156/) Jenkins build was executed with the contents of the `Jenkinsfile` in this branch.