### PR TITLE
Sort scenes by acquisition date if available

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/SceneFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/SceneFields.scala
@@ -11,6 +11,7 @@ import io.circe.Json
 
 trait SceneFields  { self: Table[_] =>
   def name: Rep[String]
+  def createdAt: Rep[java.sql.Timestamp]
   def datasource: Rep[UUID]
   def sceneMetadata: Rep[Json]
   def cloudCover: Rep[Option[Float]]

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/SceneFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/SceneFieldsSort.scala
@@ -19,7 +19,9 @@ class SceneFieldsSort[E, D <: SceneFields](f: E => D) extends QuerySort[E] {
       case "month" =>
         query.sortBy(q => datePart("month", f(q).acquisitionDate).byOrder(ord))
       case "acquisitionDatetime" =>
-        query.sortBy(f(_).acquisitionDate.byOrder(ord))
+        query.sortBy(q =>
+          f(q).acquisitionDate.getOrElse(f(q).createdAt).byOrder(ord)
+        )
       case "sunAzimuth" =>
         query.sortBy(f(_).sunAzimuth.byOrder(ord))
       case "sunElevation" =>

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
@@ -187,7 +187,7 @@ export default class ProjectAddScenesBrowseController {
         delete params.sceneid;
         this.sceneService.query(
             Object.assign({
-                sort: 'createdAt,desc',
+                sort: 'acquisitionDatetime,desc',
                 pageSize: '20',
                 maxCreateDatetime: this.sceneLoadingTime
             }, params)
@@ -225,7 +225,7 @@ export default class ProjectAddScenesBrowseController {
         delete params.sceneid;
         this.sceneService.query(
             Object.assign({
-                sort: 'createdAt,desc',
+                sort: 'acquisitionDatetime,desc',
                 pageSize: '20',
                 page: this.infScrollPage,
                 maxCreateDatetime: this.sceneLoadingTime


### PR DESCRIPTION
## Overview
Fall back to createdAt if acquisitionDate is null

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
Previewed scene is the bottom one labelled `August 23, 2017`
the two green scenes don't have an acquisition date, and are inserted into the order according to their created time.
![image](https://user-images.githubusercontent.com/4392704/31449993-49705bd2-ae76-11e7-8d75-009294767306.png)

## Testing Instructions

 * View a list of scenes in the project scene browser
* In psql, change the createdAt time for one of the scenes with an acquisition date in the middle to a very early date. EG: `update scenes set created_at = date '2001-09-28' where id = 'df7d4882-2e47-4559-ada3-c74303ef237e';`
* reload the list and verify that the scene order has not changed
* Verify that scenes with no acquisition date are ordered correctly, using the created time instead of the missing acquisition date

Closes #2577
