### PR TITLE
Upload split files to platform bucket rather than source bucket

### DIFF
--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -71,7 +71,8 @@ class GeoTiffS3SceneFactory(object):
                 if is_tif_too_large(local_tif.name):
                     with get_tempdir() as tempdir:
                         split_files = split_tif(local_tif.name, tempdir)
-                        keys_and_filepaths = upload_split_files(key, bucket_name, split_files)
+                        target_key = 'user-uploads/{USER}/{UPLOAD}/'.format(USER=self.owner, UPLOAD=self._upload.id)
+                        keys_and_filepaths = upload_split_files(target_key, os.getenv('DATA_BUCKET'), split_files)
 
                         images = [self.create_geotiff_image(filepath, s3_url(bucket_name, s3_key),
                                                             scene, os.path.basename(s3_key))


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Create an upload (via the API or UI) and get the ID
 * Either adjust the split threshold size in `app-tasks/rf/src/rf/uploads/geotiff/utils.py` (which will require a `vagrant rsync` and then a `docker-compose build batch`) or upload a tif larger than 1gb
 * `./scripts/console batch bash`
 *  `rf process-upload <upload-id>` and see that the split files are uploaded to an RF bucket
