### PR TITLE
Shorten RfmlTileResolver

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -122,7 +122,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
   }
 
 
-  val tileResolver = new RfmlTileResolver(implicitly[Database], implicitly[ExecutionContext])
+  val tileResolver = new TileResolver(implicitly[Database], implicitly[ExecutionContext])
 
   /** Calculate the histogram for the least resolute zoom level to automatically render tiles */
   def modelLayerGlobalHistogram(

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -134,7 +134,7 @@ class ToolRoutes(implicit val database: Database) extends Authentication
     }
   }
 
-  val tileResolver = new RfmlTileResolver(implicitly[Database], implicitly[ExecutionContext])
+  val tileResolver = new TileResolver(implicitly[Database], implicitly[ExecutionContext])
   val tmsInterpreter = BufferingInterpreter.DEFAULT
   val emptyPng = IntConstantNoDataArrayTile(Array(0), 1, 1).renderPng(RgbaPngEncoding)
 

--- a/app-backend/tile/src/main/scala/tool/TileResolver.scala
+++ b/app-backend/tile/src/main/scala/tool/TileResolver.scala
@@ -31,7 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 /** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */
-class RfmlTileResolver(db: Database, ec: ExecutionContext) extends LazyLogging {
+class TileResolver(db: Database, ec: ExecutionContext) extends LazyLogging {
 
   implicit val database: Database = db
   implicit val execution: ExecutionContext = ec


### PR DESCRIPTION
## Overview

The build is failing due to a filename being too long. I've been unable to reproduce this locally but have shortened the filename that (we think) is responsible. Hopefully this change will be sufficient, though I don't see how we can test it other than merging to see what happens.