### PR TITLE
Add retry and backoff to ingest statuses

### DIFF
--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -4,6 +4,7 @@ import subprocess
 
 import boto3
 import click
+from retrying import retry
 
 from ..utils.io import IngestStatus
 from ..models import Scene
@@ -96,7 +97,7 @@ def launch_spark_ingest_job(ingest_def_uri, ingest_def_id, scene_id):
     is_success = wait_for_emr_success(step_id, cluster_id)
     return is_success
 
-
+@retry(wait_exponential_multiplier=2000, wait_exponential_max=30000, stop_max_attempt_number=5)
 def execute_ingest_emr_job(scene_id, ingest_s3_uri, ingest_def_id, cluster_id):
     """Kick off ingest in AWS EMR
 
@@ -143,6 +144,8 @@ def execute_ingest_emr_job(scene_id, ingest_s3_uri, ingest_def_id, cluster_id):
     logger.info('Received response from EMR API: %s', response)
     return response
 
+
+@retry(wait_exponential_multiplier=2000, wait_exponential_max=30000, stop_max_attempt_number=2)
 def wait_for_status(ingest_def_id):
     """Wait for a result from the Spark job
 

--- a/app-tasks/rf/src/rf/ingest/models/ingest.py
+++ b/app-tasks/rf/src/rf/ingest/models/ingest.py
@@ -81,11 +81,15 @@ class Ingest(object):
             cls.INGEST_STATUS_BUCKET, ingest_id
         )
 
-        total_time = 0
+        start_time = time.time()
         while True:
+            run_time = time.time() - start_time
+            if run_time > 60 * 60:
+                raise Exception('Waiting for over an hour for ingest to complete, assuming failed')
             try:
                 s3resp = client.get_object(Bucket=cls.INGEST_STATUS_BUCKET, Key=ingest_id)
                 result = json.loads(s3resp['Body'].read())
+                logger.info('Took %s seconds to get ingest status', run_time)
                 break
             except ClientError:
                 logger.info('Ingest %s has not yet completed', ingest_id)

--- a/app-tasks/rf/src/rf/utils/emr.py
+++ b/app-tasks/rf/src/rf/utils/emr.py
@@ -3,6 +3,7 @@ import time
 
 import boto3
 import dns.resolver
+from retrying import retry
 
 logger = logging.getLogger(__name__)
 
@@ -14,6 +15,7 @@ def get_cluster_id():
     return cluster_id.to_text().strip('"')
 
 
+@retry(wait_exponential_multiplier=2000, wait_exponential_max=30000, stop_max_attempt_number=5)
 def wait_for_emr_success(step_id, cluster_id):
     """Wait for batch success/failure given an initial EMR response
 


### PR DESCRIPTION
## Overview

Fixes issues when too many jobs were kicked off at once and EMR would return throttling errors that we did not catch.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #2641 
