### PR TITLE
UI fixes for project list view, bulk annotations, and lab panning

### DIFF
--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.controller.js
@@ -97,7 +97,7 @@ export default class AnnotateToolbarController {
 
     onCancelDrawing() {
         this.isDrawCancel = false;
-        if (this.drawRectangleHandle) {
+        if (this.drawRectangleHandler) {
             this.drawRectangleHandler.disable();
         }
         if (this.drawPolygonHandler) {

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -233,21 +233,45 @@
     <div class="content">
       <h3 class="no-margin">Upload in progress...</h3>
       <div class="list-group">
-          <div class="list-group-item no-flex" ng-repeat="file in $ctrl.selectedFiles">
+          <div class="list-group-item no-flex" ng-repeat="upload in $ctrl.fileUploads track by upload.file.name">
             <div class="list-group-item-contents">
               <div class="list-group-overflow">
                 <span title="{{$ctrl.scene.name}}">
-                  <strong class="color-dark">{{file.name}}</strong>
+                  <strong class="color-dark">{{upload.file.name}}</strong>
                 </span>
                 <br>
-                <span>{{file.size | byteFmt: 2}}</span>
+                <span ng-if="upload.progress">
+                  {{upload.file.size * (upload.progress.loaded / upload.progress.total) | byteFmt: 2}} /
+                </span>
+                <span>{{upload.file.size | byteFmt: 2}}</span>
               </div>
               <div class="list-group-right">
-                {{$ctrl.uploadProgressPct[file.name] || '0%'}}
+                {{$ctrl.uploadProgressPct[upload.file.name] || '0%'}}
+                <button title="Retry Upload"
+                        class="btn btn-square"
+                        ng-if="upload.api.failed"
+                        ng-click="$ctrl.retryUpload(upload)">
+                  <i class="icon-arrows-cw"></i>
+                </button>
+                <button title="Cancel Upload"
+                        class="btn btn-square btn-danger"
+                        ng-if="!upload.aborted && !upload.finished"
+                        ng-click="$ctrl.abortUpload(upload)">
+                  <i class="icon-cross"></i>
+                </button>
+                <button disabled="true"
+                        ng-if="upload.finished"
+                        class="btn btn-square btn-secondary">
+                  <i class="icon-check"></i>
+                </button>
               </div>
             </div>
             <div class="list-group-item-contents">
-              <div class="upload-progress-bar" ng-style="{ 'flex': $ctrl.uploadProgressFlexString[file.name] || '0 0' }"></div>
+              <div class="upload-progress-bar"
+                   ng-style="{ 'flex': $ctrl.uploadProgressFlexString[upload.file.name] || '0 0' }"
+                   ng-class="{ 'cancelled': upload.aborted, 'failed': upload.error }"
+              >
+              </div>
             </div>
           </div>
         </div>

--- a/app-frontend/src/app/components/tools/diagramContainer/diagramContainer.html
+++ b/app-frontend/src/app/components/tools/diagramContainer/diagramContainer.html
@@ -3,7 +3,8 @@
      ng-style="$ctrl.workspaceStyle"
 >
 </div>
-<div class="map-container-controls">
+<div class="map-container-controls"
+     ng-class="{ 'is-dragging': $ctrl.panActive }">
   <button class="btn btn-default btn-square btn-small"
           title="Zoom In"
           ng-click="$ctrl.zoomIn()">

--- a/app-frontend/src/app/pages/projects/list/list.html
+++ b/app-frontend/src/app/pages/projects/list/list.html
@@ -46,7 +46,7 @@
       <p class="font-size-small"
          ng-if="!$ctrl.searchString"
       >
-       Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} tools
+       Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} projects
       </p>
 
       <p class="font-size-small"

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -819,7 +819,6 @@ div.lab-workspace.is-dragging {
   }
 }
 
-
 .lab-control-panel {
   position: absolute;
   z-index: 500;
@@ -920,7 +919,12 @@ div.lab-workspace.is-dragging {
   background: $shade-dark;
   padding: .5em;
   border-radius: 3px;
-  pointer-event: none;
+  &.is-dragging {
+      pointer-events: none;
+      * {
+          pointer-events: none;
+      }
+  }
 }
 
 .map-zoom {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -692,6 +692,12 @@ rf-box-select-item{
   transition: flex-grow .5s;
   flex: 0 0;
   margin-top: 10px !important;
+  &.cancelled {
+      background: $shade-light;
+  }
+  &.failed {
+      background: $danger;
+  }
 }
 
 


### PR DESCRIPTION
## Overview

Changes 'x of y tools' to 'x of y project' on project list view
Stop creating shapes when user finishes bulk annotation creation
Fix diagram jumping when dragging over lab controls

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Verify that the project list view now says "x of y projects" instead of tools
* Verify that when finishing bulk annotation, it cancels draw mode
* Verify that when panning the lab diagram and your mouse goes over the zoom controls, it no longer causes the view to jump
* Verify aborting / retrying in scene upload modal
  - If all uploads complete, move to next modal view. Otherwise, require manual intervention
  - Aborting removes a file from the upload object and allows you to continue manually
  - Retrying adds the file back to the Upload object file list
  - errored requests (unplug your ethernet?) must be restarted or aborted
  - buttons make sense

Closes #2642 
Closes #2644 
Closes #2540
Closes #2316