### PR TITLE
Serve tiles from service root instead of /tiles

### DIFF
--- a/app-backend/tile/src/it/resources/application.conf
+++ b/app-backend/tile/src/it/resources/application.conf
@@ -18,7 +18,7 @@ gatling {
   }
 
   tms {
-    template = "/tiles/${projectId}/${z}/${x}/${y}/?token=${authToken}"
+    template = "/${projectId}/${z}/${x}/${y}/?token=${authToken}"
     minZoom = 1
     maxZoom = 20
     randomSeed = 42

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -31,31 +31,29 @@ class Router extends LazyLogging
 
   def root = cors() {
     handleExceptions(tileExceptionHandler) {
-      pathPrefix("tiles") {
-        pathPrefix(JavaUUID) { projectId =>
-          projectTileAccessAuthorized(projectId) {
-            case true => MosaicRoutes.mosaicProject(projectId)(database)
-            case _ => reject(AuthorizationFailedRejection)
-          }
-        } ~
-        pathPrefix("healthcheck") {
-          pathEndOrSingleSlash {
-            get {
-              HealthCheckRoute.root
-            }
-          }
-        } ~
-        pathPrefix("tools") {
+      pathPrefix(JavaUUID) { projectId =>
+        projectTileAccessAuthorized(projectId) {
+          case true => MosaicRoutes.mosaicProject(projectId)(database)
+          case _ => reject(AuthorizationFailedRejection)
+        }
+      } ~
+      pathPrefix("healthcheck") {
+        pathEndOrSingleSlash {
           get {
-            (handleExceptions(interpreterExceptionHandler) & handleExceptions(circeDecodingError)) {
-              pathPrefix(JavaUUID) { (toolRunId) =>
-                authenticateToolTileRoutes(toolRunId) { user =>
-                  toolRoutes.tms(toolRunId, user) ~
-                    toolRoutes.validate(toolRunId, user) ~
-                    toolRoutes.statistics(toolRunId, user) ~
-                    toolRoutes.histogram(toolRunId, user) ~
-                    toolRoutes.preflight(toolRunId, user)
-                }
+            HealthCheckRoute.root
+          }
+        }
+      } ~
+      pathPrefix("tools") {
+        get {
+          (handleExceptions(interpreterExceptionHandler) & handleExceptions(circeDecodingError)) {
+            pathPrefix(JavaUUID) { (toolRunId) =>
+              authenticateToolTileRoutes(toolRunId) { user =>
+                toolRoutes.tms(toolRunId, user) ~
+                  toolRoutes.validate(toolRunId, user) ~
+                  toolRoutes.statistics(toolRunId, user) ~
+                  toolRoutes.histogram(toolRunId, user) ~
+                  toolRoutes.preflight(toolRunId, user)
               }
             }
           }

--- a/app-backend/tile/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/tile/src/test/scala/auth/AuthSpec.scala
@@ -11,7 +11,7 @@ class AuthSpec extends WordSpec
 
   "tile authentication" should {
     "reject anonymous users" in {
-      Get("/tiles/tools/a89ae9bb-47e5-469c-8329-9c491a1011ae") ~> router.root ~> check {
+      Get("/tools/a89ae9bb-47e5-469c-8329-9c491a1011ae") ~> router.root ~> check {
         rejection
       }
     }
@@ -19,7 +19,7 @@ class AuthSpec extends WordSpec
 
   "tile authentication" should {
     "reject invalid tokens" in {
-      Get("/tiles/tools/a89ae9bb-47e5-469c-8329-9c491a1011ae/?token=not-valid") ~> router.root ~> check {
+      Get("/tools/a89ae9bb-47e5-469c-8329-9c491a1011ae/?token=not-valid") ~> router.root ~> check {
         rejection
       }
     }

--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -1,25 +1,29 @@
 server {
-    listen 80 default_server;
-    server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com;
-    return 301 https://$host$request_uri;
+	listen 80 default_server;
+	server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com;
+	return 301 https://$host$request_uri;
 }
 
 upstream tile-server-upstream {
-    server tile-server:9900;
+	server tile-server:9900;
 }
 
 server {
-    listen 443 default_server;
-    server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com localhost;
+	listen 443 default_server;
+	server_name tiles.staging.rasterfoundry.com tiles.rasterfoundry.com localhost;
 
-    include /etc/nginx/includes/tiler-security-headers.conf;
+	include /etc/nginx/includes/tiler-security-headers.conf;
 
-    location / {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+	location ~ /tiles/(.*) {
+		return 301 $scheme://$http_host/$1$is_args$args;
+	}
 
-        proxy_pass http://tile-server-upstream;
-    }
+	location / {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 20s;
+		proxy_redirect off;
+
+		proxy_pass http://tile-server-upstream;
+	}
 }


### PR DESCRIPTION
## Overview

Remove the `/tiles` prefix from tile server routes. Now Tiles are served from the `https://${TILE_SERVER_LOCATION}` as opposed to `https://${TILE_SERVER_LOCATION}/tiles`

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

N/A


## Testing Instructions
 * Run `scripts/update`.
 * Start the app and attempt to display a project. Tile requests should fail.
 * Change `TILE_SERVER_LOCATION` to `http://localhost:9101` (no trailing `/`)
 * Restart the app, load a project, and ensure tiles are being served correctly. 


Closes #1471 
Needs azavea/raster-foundry-deployment# (TBD)
