### PR TITLE
Create new label name autocomplete for annotations

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@turf/area": "^4.7.3",
     "@turf/distance": "^4.7.3",
-    "angucomplete-alt": "^3.0.0",
     "angular": "~1.5.8",
     "angular-animate": "~1.5.8",
     "angular-aria": "~1.5.8",

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
@@ -73,19 +73,22 @@ export default class AnnotateSidebarItemController {
     onLabelNameChange() {
         if (this.labelNameInput.length >= 3) {
             this.matchLabelName(this.labelNameInput);
+        } else {
+            this.showMatchedLabels = false;
         }
         this.isInvalid = false;
     }
 
     matchLabelName(labelName) {
-        this.labelInputsMatch = this.labelInputs.reduce((accu, label) => {
-            if (label.name.includes(labelName)) {
-                accu.push(label);
-            }
-            return accu;
-        }, []);
+        this.labelInputsMatch = this.labelInputs.filter((label) => {
+            return label.name.toString().toUpperCase().includes(labelName.toString().toUpperCase());
+        });
         if (this.labelInputsMatch.length) {
             this.showMatchedLabels = true;
+            this.labelInputsMatch.sort((a, b) => a.name.length - b.name.length);
+            if (this.labelInputsMatch.length >= 4) {
+                this.labelInputsMatch = this.labelInputsMatch.slice(0, 4);
+            }
         }
     }
 

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
@@ -47,16 +47,14 @@ export default class AnnotateSidebarItemController {
     }
 
     updateAnnotation(annotation) {
-        if (this.labelObj) {
+        if (this.labelNameInput) {
             this.isInvalid = false;
-            this.newLabelName
-                = this.labelObj.originalObject.name || this.labelObj.originalObject;
-        } else if (annotation.properties.label) {
-            this.isInvalid = false;
-            this.newLabelName = annotation.properties.label;
+            this.newLabelName = this.labelNameInput;
         } else {
             this.isInvalid = true;
         }
+
+        this.showMatchedLabels = false;
 
         if (this.newLabelName) {
             this.onUpdateAnnotationFinish({
@@ -70,5 +68,33 @@ export default class AnnotateSidebarItemController {
 
     onQaCheck(annotation, qa) {
         this.onQaChecked({annotation, qa});
+    }
+
+    onLabelNameChange() {
+        if (this.labelNameInput.length >= 3) {
+            this.matchLabelName(this.labelNameInput);
+        }
+        this.isInvalid = false;
+    }
+
+    matchLabelName(labelName) {
+        this.labelInputsMatch = this.labelInputs.reduce((accu, label) => {
+            if (label.name.includes(labelName)) {
+                accu.push(label);
+            }
+            return accu;
+        }, []);
+        if (this.labelInputsMatch.length) {
+            this.showMatchedLabels = true;
+        }
+    }
+
+    onSelectLabelName(labelName) {
+        this.labelNameInput = labelName.name;
+        this.showMatchedLabels = false;
+    }
+
+    onTextFieldClick() {
+        this.showMatchedLabels = false;
     }
 }

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.controller.js
@@ -1,15 +1,16 @@
-/* globals L, $*/
-
 export default class AnnotateSidebarItemController {
     constructor(
-        $log, $scope
+        $log, $scope, $timeout
     ) {
         'ngInject';
         this.$log = $log;
         this.$scope = $scope;
+        this.$timeout = $timeout;
     }
 
     $onInit() {
+        this.minMatchedLabelLength = 3;
+        this.maxMatchedLabels = 4;
     }
 
     onAnnotationClone($event, annotation) {
@@ -71,23 +72,23 @@ export default class AnnotateSidebarItemController {
     }
 
     onLabelNameChange() {
-        if (this.labelNameInput.length >= 3) {
-            this.matchLabelName(this.labelNameInput);
-        } else {
-            this.showMatchedLabels = false;
-        }
+        this.showMatchedLabels = false;
         this.isInvalid = false;
+        if (this.labelNameInput.length >= this.minMatchedLabelLength) {
+            this.matchLabelName(this.labelNameInput);
+        }
     }
 
     matchLabelName(labelName) {
+        let normalizedLabel = labelName.toString().toUpperCase();
         this.labelInputsMatch = this.labelInputs.filter((label) => {
-            return label.name.toString().toUpperCase().includes(labelName.toString().toUpperCase());
+            return label.name.toString().toUpperCase().includes(normalizedLabel);
         });
         if (this.labelInputsMatch.length) {
             this.showMatchedLabels = true;
             this.labelInputsMatch.sort((a, b) => a.name.length - b.name.length);
-            if (this.labelInputsMatch.length >= 4) {
-                this.labelInputsMatch = this.labelInputsMatch.slice(0, 4);
+            if (this.labelInputsMatch.length >= this.maxMatchedLabels) {
+                this.labelInputsMatch = this.labelInputsMatch.slice(0, this.maxMatchedLabels);
             }
         }
     }
@@ -95,9 +96,22 @@ export default class AnnotateSidebarItemController {
     onSelectLabelName(labelName) {
         this.labelNameInput = labelName.name;
         this.showMatchedLabels = false;
+        this.isMouseOnLabelOption = false;
     }
 
-    onTextFieldClick() {
-        this.showMatchedLabels = false;
+    onLabelFieldBlur() {
+        if (!this.isMouseOnLabelOption) {
+            this.showMatchedLabels = false;
+        }
+    }
+
+    onLabelFieldFocus() {
+        if (this.labelNameInput.length >= this.minMatchedLabelLength) {
+            this.matchLabelName(this.labelNameInput);
+        }
+    }
+
+    onHoverOption(isMouseHovered) {
+        this.isMouseOnLabelOption = isMouseHovered;
     }
 }

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
@@ -56,20 +56,22 @@
              ng-model="$ctrl.labelNameInput"
              ng-change="$ctrl.onLabelNameChange()"
              ng-class="{'is-invalid': $ctrl.isInvalid }"
-             ng-blur="$ctrl.showMatchedLabels = false"
-             ng-focus="$ctrl.showMatchedLabels = true"
+             ng-blur="$ctrl.onLabelFieldBlur()"
+             ng-focus="$ctrl.onLabelFieldFocus()"
              placeholder="{{$ctrl.annotation.properties.label || 'Label name...'}}">
       <div class="label-name-selections"
            ng-if="$ctrl.showMatchedLabels">
         <div class="label-name-option"
              ng-repeat="label in $ctrl.labelInputsMatch"
-             ng-click="$ctrl.onSelectLabelName(label)">
+             ng-click="$ctrl.onSelectLabelName(label)"
+             ng-mouseover="$ctrl.onHoverOption(true)"
+             ng-mouseleave="$ctrl.onHoverOption(false)">
              {{label.name}}
         </div>
       </div>
     <textarea class="form-control label-text"
               ng-init="$ctrl.newLabelDescription = $ctrl.annotation.properties.description"
-              ng-click="$ctrl.onTextFieldClick()"
+
               ng-model="$ctrl.newLabelDescription"
               ng-if="!$ctrl.annotation.geometry || ($ctrl.editId === $ctrl.annotation.properties.id)"
               placeholder="Description..."></textarea>

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
@@ -56,6 +56,8 @@
              ng-model="$ctrl.labelNameInput"
              ng-change="$ctrl.onLabelNameChange()"
              ng-class="{'is-invalid': $ctrl.isInvalid }"
+             ng-blur="$ctrl.showMatchedLabels = false"
+             ng-focus="$ctrl.showMatchedLabels = true"
              placeholder="{{$ctrl.annotation.properties.label || 'Label name...'}}">
       <div class="label-name-selections"
            ng-if="$ctrl.showMatchedLabels">

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
@@ -50,21 +50,24 @@
 <div class="list-group-item" ng-if="!$ctrl.annotation.geometry || ($ctrl.editId === $ctrl.annotation.properties.id)">
   <div class='annotation-new'>
     <form>
-    <angucomplete-alt pause="100"
-                      initial-value="$ctrl.annotation.properties.label"
-                      selected-object="$ctrl.labelObj"
-                      placeholder="{{$ctrl.annotation.properties.label || 'Label name...'}}"
-                      local-data="$ctrl.labelInputs"
-                      search-fields="name"
-                      title-field="name"
-                      minlength="1"
-                      input-class="form-control annotation-label"
-                      match-class="annotation-highlight"
-                      override-suggestions="true"
-                      ng-class="{'is-invalid': $ctrl.isInvalid }">
-    </angucomplete-alt>
-    <textarea class="form-control"
+      <input type="text"
+             class="form-control label-name-input"
+             ng-init="$ctrl.labelNameInput = $ctrl.annotation.properties.label"
+             ng-model="$ctrl.labelNameInput"
+             ng-change="$ctrl.onLabelNameChange()"
+             ng-class="{'is-invalid': $ctrl.isInvalid }"
+             placeholder="{{$ctrl.annotation.properties.label || 'Label name...'}}">
+      <div class="label-name-selections"
+           ng-if="$ctrl.showMatchedLabels">
+        <div class="label-name-option"
+             ng-repeat="label in $ctrl.labelInputsMatch"
+             ng-click="$ctrl.onSelectLabelName(label)">
+             {{label.name}}
+        </div>
+      </div>
+    <textarea class="form-control label-text"
               ng-init="$ctrl.newLabelDescription = $ctrl.annotation.properties.description"
+              ng-click="$ctrl.onTextFieldClick()"
               ng-model="$ctrl.newLabelDescription"
               ng-if="!$ctrl.annotation.geometry || ($ctrl.editId === $ctrl.annotation.properties.id)"
               placeholder="Description..."></textarea>

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.scss
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.scss
@@ -95,23 +95,6 @@ i.icon-check.qa-check {
   margin: 0px;
 }
 
-.angucomplete-holder {
-  margin-bottom: 10px;
-}
-
-angucomplete-alt {
-  &.is-invalid {
-    .angucomplete-holder {
-      border: 1px solid $red;
-      border-radius: 2px;
-    }
-  }
-}
-
-.annotation-new.form-control.annotation-label {
-  height:  35px;
-}
-
 .annotation-new textarea.form-control {
   height: 150px;
   margin-bottom: 10px;
@@ -127,6 +110,32 @@ angucomplete-alt {
   float: right;
 }
 
-.annotation-highlight {
-  color: $red;
+.label-name-input {
+  &.is-invalid {
+    border: 1px solid $red;
+    border-radius: 2px;
+  }
+}
+
+.label-name-selections {
+  border: 1px solid $gray-lighter;
+  display: block;
+  z-index: 1000;
+  position: absolute;
+  background-color: $white;
+  width: 100%;
+}
+
+.label-name-option {
+  padding: 6px 12px;
+}
+
+.label-name-option:hover{
+  color: $white;
+  background-color: $shade-normal;
+  cursor: pointer;
+}
+
+.label-text{
+  margin-top: 10px;
 }

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -29,7 +29,6 @@ const App = angular.module(
         'angular.filter',
         '720kb.tooltips',
         'uuid4',
-        'angucomplete-alt',
 
         // services
         require('./services/services.module').name,

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -33,7 +33,6 @@ import 'angular-filter';
 import 'angular-tooltips';
 import 'mathjs';
 import 'angular-uuid4';
-import 'angucomplete-alt';
 import 'angular-hotkeys';
 
 // local scripts

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -124,10 +124,6 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-angucomplete-alt@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/angucomplete-alt/-/angucomplete-alt-3.0.0.tgz#7c59bec4e9b7f9563a0dc6153c83386e4ac251df"
-
 angular-animate@~1.5.8:
   version "1.5.11"
   resolved "https://registry.yarnpkg.com/angular-animate/-/angular-animate-1.5.11.tgz#1baa43c303d1b93c4e6aa89453b39114b7a1c669"


### PR DESCRIPTION
## Overview

This PR fixes the annotation name's selection issue during autocomplete, since angucomplete-alt is being a brat when you don't want to select any autocomplete options but it still selects one for you if you hover and click elsewhere.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to annotation page.
 * Create annotations, check if it gives autocomplete options correctly and lets you select the options you want.

Closes #2611 
