### PR TITLE
Display 'Untitled tool' on tool page instead of blank

### DIFF
--- a/app-frontend/src/app/pages/lab/browse/tools/tools.html
+++ b/app-frontend/src/app/pages/lab/browse/tools/tools.html
@@ -46,7 +46,7 @@
           <th>Privacy</th>
         </tr>
         <tr ng-repeat="tool in $ctrl.toolList | filter: {title: $ctrl.searchString}">
-          <td><a ui-sref="lab.tool({toolid: tool.id, tool: tool})">{{tool.name}}</a></td>
+          <td><a ui-sref="lab.tool({toolid: tool.id, tool: tool})">{{tool.name || 'Untitled tool'}}</a></td>
           <td>{{tool.modifiedAt | date : 'longDate'}}</td>
           <td>{{$ctrl.formatToolVisibility(tool.visibility)}}</td>
         </tr>


### PR DESCRIPTION
## Overview

Because we use a tool's title to display a link to a tool, if a tool had no title, there was no link to click. This PR displays 'Untitled tool' instead of nothing in this case.

Trivial. Merging.

Closes #2658 
