### PR TITLE
Initialize Color Correction Values to Sane Defaults

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.controller.js
@@ -155,8 +155,11 @@ export default class ProjectsColorAdjustController {
         this.onFilterChange();
     }
 
-    storeToggle(value, correctionName) {
+    storeToggle(value, correctionName, paramsArray) {
         this.correction[correctionName].enabled = value;
+        if (value) {
+            this.setCorrectionDefault(correctionName, paramsArray);
+        }
         this.onFilterChange();
     }
 
@@ -182,5 +185,11 @@ export default class ProjectsColorAdjustController {
             typeof clipping.blue.min !== 'undefined' ||
             typeof clipping.blue.max !== 'undefined';
         this.onFilterChange();
+    }
+
+    setCorrectionDefault(correctionName, paramsArray) {
+        paramsArray.forEach((param) => {
+            this.correction[correctionName][param] = 1;
+        });
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
@@ -39,7 +39,7 @@
         <div class="filter-group">
           <div class="filter-group-header">
             <rf-toggle-old data-model="$ctrl.correction.sigmoidalContrast.enabled"
-                       on-change="$ctrl.storeToggle(value, 'sigmoidalContrast')">
+                       on-change="$ctrl.storeToggle(value, 'sigmoidalContrast', ['alpha', 'beta'])">
             </rf-toggle-old>
             <h5>Sigmoidal Contrast</h5>
             <i class="icon-info"
@@ -90,7 +90,7 @@
         <div class="filter-group">
           <div class="filter-group-header">
             <rf-toggle-old data-model="$ctrl.correction.gamma.enabled"
-                       on-change="$ctrl.storeToggle(value, 'gamma')">
+                       on-change="$ctrl.storeToggle(value, 'gamma', ['redGamma', 'greenGamma', 'blueGamma'])">
             </rf-toggle-old>
             <h5>Color Balance</h5>
             <i class="icon-info"
@@ -169,7 +169,7 @@
         <div class="filter-group">
           <div class="filter-group-header">
             <rf-toggle-old data-model="$ctrl.correction.saturation.enabled"
-                       on-change="$ctrl.storeToggle(value, 'saturation')">
+                       on-change="$ctrl.storeToggle(value, 'saturation', ['saturation'])">
             </rf-toggle-old>
             <h5 class="h5">Saturation</h5>
           </div>


### PR DESCRIPTION
## Overview

This PR initializes color correction values to sane defaults.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to `projects/edit/projectID/advancedcolor/adjust`
 * Turn on "Sigmoidal Contrast", "Color Balance", "Saturation"
 * See if the defaults are set as 1 for sliders and input boxes

Closes #2654
