### PR TITLE
Fix colormode overwriting color corrections

### DIFF
--- a/app-frontend/src/app/components/common/navBar/navBar.module.js
+++ b/app-frontend/src/app/components/common/navBar/navBar.module.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import dropdown from 'angular-ui-bootstrap/src/dropdown';
 require('../../../../assets/font/fontello/css/fontello.css');
+require('../../../../assets/font/fontello/css/animation.css');
 
 import NavBarComponent from './navBar.component.js';
 import NavBarController from './navBar.controller.js';

--- a/app-frontend/src/app/components/exports/exportDownloadModal/exportDownloadModal.html
+++ b/app-frontend/src/app/components/exports/exportDownloadModal/exportDownloadModal.html
@@ -14,7 +14,7 @@
     </ul>
     <div class="list-group" ng-show="$ctrl.isLoading">
       <span class="list-placeholder">
-        <i class="icon-load"></i>
+        <i class="icon-load animate-spin"></i>
       </span>
     </div>
   </div>

--- a/app-frontend/src/app/components/histogram/channelHistogram/channelHistogram.html
+++ b/app-frontend/src/app/components/histogram/channelHistogram/channelHistogram.html
@@ -28,7 +28,7 @@
   <nvd3 options="$ctrl.histOptions" data="$ctrl.histData" api="$ctrl.api"></nvd3>
   <div class="list-group" ng-show="!$ctrl.histData.length">
     <span class="list-placeholder">
-      <i class="icon-load"></i>
+      <i class="icon-load animate-spin"></i>
     </span>
   </div>
 </div>

--- a/app-frontend/src/app/components/projects/projectSelectModal/projectSelectModal.html
+++ b/app-frontend/src/app/components/projects/projectSelectModal/projectSelectModal.html
@@ -38,7 +38,7 @@
     </div>
     <div class="list-group" ng-show="$ctrl.loading">
       <span class="list-placeholder">
-        <i class="icon-load"></i>
+        <i class="icon-load animate-spin"></i>
       </span>
     </div>
     <div ng-if="!$ctrl.loading && $ctrl.lastProjectResult && $ctrl.lastProjectResult.count === 0"

--- a/app-frontend/src/app/components/scenes/sceneList/sceneList.html
+++ b/app-frontend/src/app/components/scenes/sceneList/sceneList.html
@@ -1,6 +1,6 @@
 <div class="list-group" ng-if="$ctrl.loading">
   <span class="list-placeholder">
-    <i class="icon-load"></i>
+    <i class="icon-load animate-spin"></i>
   </span>
 </div>
 <div class="list-group">

--- a/app-frontend/src/app/pages/error/error.html
+++ b/app-frontend/src/app/pages/error/error.html
@@ -5,7 +5,7 @@
     <h2>Oops! We seem to be having some server issues right now...</h2>
     <h4>If you keep me open, I'll load once we've got things working again</h4>
     <div class="list-placeholder">
-      <i class="icon-load"></i>
+      <i class="icon-load animate-spin"></i>
     </div>
   </div>
   <div class="column">

--- a/app-frontend/src/app/pages/imports/datasources/list/list.html
+++ b/app-frontend/src/app/pages/imports/datasources/list/list.html
@@ -9,7 +9,7 @@
       <div class="text-center" ng-show="$ctrl.isLoadingDatasources">
         <div>Loading Datasources</div>
         <span class="list-placeholder h3">
-          <i class="icon-load"></i>
+          <i class="icon-load animate-spin"></i>
         </span>
       </div>
 

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.html
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.html
@@ -21,7 +21,7 @@
         <!-- Loading indicator -->
         <div ng-show="$ctrl.loading">
           <span class="list-placeholder h3">
-            <i class="icon-load"></i>
+            <i class="icon-load animate-spin"></i>
           </span>
         </div>
         <!-- Loading indicator -->

--- a/app-frontend/src/app/pages/lab/browse/tools/tools.html
+++ b/app-frontend/src/app/pages/lab/browse/tools/tools.html
@@ -21,7 +21,7 @@
       <!-- Loading indicator -->
       <div ng-show="$ctrl.loading">
         <span class="list-placeholder h3">
-          <i class="icon-load"></i>
+          <i class="icon-load animate-spin"></i>
         </span>
       </div>
       <!-- Loading indicator -->

--- a/app-frontend/src/app/pages/projects/detail/detail.html
+++ b/app-frontend/src/app/pages/projects/detail/detail.html
@@ -17,7 +17,7 @@
             <h1 class="h3 page-title">
             <span ng-hide="$ctrl.isEditingProjectName">
               {{$ctrl.project.name}}
-              <i class="icon-load" ng-show="$ctrl.isSavingProjectNameEdit"></i>
+              <i class="icon-load animate-spin" ng-show="$ctrl.isSavingProjectNameEdit"></i>
               </span>
             </h1>
             <div class="color-danger" ng-if="$ctrl.showError">

--- a/app-frontend/src/app/pages/projects/detail/exports/exports.html
+++ b/app-frontend/src/app/pages/projects/detail/exports/exports.html
@@ -43,7 +43,7 @@
 <div class="column-8" ng-if="$ctrl.isLoadingExports">
   <div class="list-group">
     <div class="list-placeholder">
-      <i class="icon-load"></i>
+      <i class="icon-load animate-spin"></i>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/pages/projects/detail/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/detail/scenes/scenes.html
@@ -45,7 +45,7 @@
 <div class="column-8" ng-if="$ctrl.isLoadingScenes">
   <div class="list-group">
     <div class="list-placeholder">
-      <i class="icon-load"></i>
+      <i class="icon-load animate-spin"></i>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -12,6 +12,11 @@
     </div>
   </div>
 </div>
+<div class="sidebar-overlay" ng-show="!$ctrl.corrections || $ctrl.isLoading">
+  <div class="sidebar-loading">
+    <span class="icon-load animate-spin"></span>
+  </div>
+</div>
 <div class="sidebar-scrollable">
   <div class="list-group" ng-if="!$ctrl.isLoading">
     <div class="list-group-item list-group-item-stacked"

--- a/app-frontend/src/app/pages/projects/list/list.html
+++ b/app-frontend/src/app/pages/projects/list/list.html
@@ -19,7 +19,7 @@
       <!-- Loading indicator -->
       <div ng-show="$ctrl.loading">
         <span class="list-placeholder h3">
-          <i class="icon-load"></i>
+          <i class="icon-load animate-spin"></i>
         </span>
       </div>
       <!-- Loading indicator -->

--- a/app-frontend/src/app/pages/settings/tokens/api/api.html
+++ b/app-frontend/src/app/pages/settings/tokens/api/api.html
@@ -29,6 +29,6 @@
 </div>
 <div class="list-group" ng-show="$ctrl.loading">
   <span class="list-placeholder">
-    <i class="icon-load"></i>
+    <i class="icon-load animate-spin"></i>
   </span>
 </div>

--- a/app-frontend/src/app/pages/settings/tokens/map/map.html
+++ b/app-frontend/src/app/pages/settings/tokens/map/map.html
@@ -16,6 +16,6 @@
 </div>
 <div class="list-group" ng-show="$ctrl.loading">
   <span class="list-placeholder">
-    <i class="icon-load"></i>
+    <i class="icon-load animate-spin"></i>
   </span>
 </div>

--- a/app-frontend/src/app/services/projects/colorCorrect.service.js
+++ b/app-frontend/src/app/services/projects/colorCorrect.service.js
@@ -150,6 +150,22 @@ export default (app) => {
             ).$promise;
         }
 
+        bulkUpdateColorMode(projectId, corrections, bands) {
+            const resolvedBands = bands ||
+                  (({redBand, greenBand, blueBand, mode}) =>
+                   ({redBand, greenBand, blueBand, mode}))(this.getDefaultColorCorrection());
+            const bulkData = corrections.map(({id, correction}) => {
+                return {
+                    sceneId: id,
+                    params: Object.assign({}, correction, resolvedBands)
+                };
+            });
+            return this.bulkColorCorrect.create(
+                { projectId },
+                { items: bulkData }
+            ).$promise;
+        }
+
     }
 
     app.service('colorCorrectService', ColorCorrectService);

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2863,3 +2863,14 @@ rf-reclassify-table {
     box-shadow: 2px 2px 4px rgba(0,0,0,0.25);
     border-radius: 3px;
 }
+
+.sidebar-loading {
+    font-size: 3rem;
+    width: 100%;
+    height: 100%;
+    text-align: center;
+    vertical-align: center;
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+}


### PR DESCRIPTION
## Overview

Fetch all color corrections for project when loading colormode view, then selectively overwrite just the required properties for each
Disable sidebar while everything is loading
Add animations to all loading icons


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Verify that if you set separate color corrections for each scene in a project, changing the color mode will preserve the separate settings.
* Verify that the sidebar is disabled while loading all color mode info
* Verify that loading icons are now animated

Closes #2653
