### PR TITLE
Redirect requests for /tiles to tile service root

### DIFF
--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -14,8 +14,10 @@ server {
 
 	include /etc/nginx/includes/tiler-security-headers.conf;
 
+	# This route is deprecated; requests are rewritten for 
+	# backwards-compatibility.
 	location ~ /tiles/(.*) {
-		return 301 $scheme://$http_host/$1$is_args$args;
+		rewrite /tiles/(.*) /$1 last;
 	}
 
 	location / {


### PR DESCRIPTION
## Overview

Currently, nginx redirects requests to `/tiles` to `$scheme://$http_host/$request_uri`. This _should_ let tile requests over HTTP and HTTPS be routed using the desired protocol, but on Staging all requests seem to be redirected to use http. To fix, this PR explicitly sets the protocol for the redirect based on `HTTP-X-FORWARDED-PROTO`.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * In development, set the `.env` file's `TILE_SERVER_LOCATION` to `http://localhost:9101/tiles` and run `scripts/server`. Ensure that requests to the tile server are redirected to `http://localhost:9101/<route>`

 * This change was deployed to Staging and tagged with commit # f561e29. If this deployment is still live, Try to visit the `Projects` page on https://app.staging.rasterfoundry.com, and make sure tiles are delivered correctly.

* It may also be good to verify redirects with `cURL`. 
```bash
$ curl -i "https://tiles.staging.rasterfoundry.com/tiles/<project_id>/2/1/1/\?token\=<RF API token>" 
HTTP/1.1 301 Moved Permanently
Date: Wed, 25 Oct 2017 20:08:42 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Server: nginx
Location: https://tiles.staging.rasterfoundry.com/<project_id>/2/1/1/\?token\=<RF API token>
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff
```

Closes #XXX
