### PR TITLE
Fix project export - don't assume a tool is being used

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -193,14 +193,16 @@ export default class NewExportController {
     }
 
     finalizeExportOptions() {
-        Object.values(this.currentToolSources).forEach(src => {
-            this.toolService.updateToolRunSource(
-                this.currentToolRun,
-                src.id,
-                this.project.id,
-                src.band
-            );
-        });
+        if (this.currentToolSources) {
+            Object.values(this.currentToolSources).forEach(src => {
+                this.toolService.updateToolRunSource(
+                    this.currentToolRun,
+                    src.id,
+                    this.project.id,
+                    src.band
+                );
+            });
+        }
         if (this.getCurrentTarget().value === 'externalS3') {
             this.exportOptions.source = this.exportTargetURI;
         } else if (this.getCurrentTarget().value === 'dropbox') {


### PR DESCRIPTION
## Overview

On starting an export, we were assuming that a tool was being used. When an export was started while using non-tool processing options (natural-color, raw, and color-corrected) these assumptions caused us to attempt a `null` -> `Object` cast, which results in an error.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Notes

Exports for tool-based processing options will not work until #2666 is merged.

## Testing Instructions

 * Try to export using a non-tool processing option. It should work.
