### PR TITLE
Annotation API Spec

### DIFF
--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3592,9 +3592,10 @@ definitions:
           qualityCheck:
             type: string
             enum:
-              - PASS
-              - FAIL
-              - NEUTRAL
+              - YES
+              - NO
+              - MISS
+              - MATCH
           projectId:
             type: string
             format: uuid
@@ -3621,9 +3622,10 @@ definitions:
           qualityCheck:
             type: string
             enum:
-              - PASS
-              - FAIL
-              - NEUTRAL
+              - YES
+              - NO
+              - MISS
+              - MATCH
       geometry:
         $ref: "#/definitions/Geometry"
 
@@ -3649,9 +3651,10 @@ definitions:
           qualityCheck:
             type: string
             enum:
-              - PASS
-              - FAIL
-              - NEUTRAL
+              - YES
+              - NO
+              - MISS
+              - MATCH
       geometry:
         $ref: "#/definitions/Geometry"
 

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -750,9 +750,9 @@ paths:
         - $ref: '#/parameters/AnnotationQualityCheck'
       responses:
         200:
-          description: Geojson feature collection containing paginated annotations of this project
+          description: GeoJSON feature collection containing paginated annotations of this project
           schema:
-            $ref: '#/definitions/AnnotationFeatureCollection'
+            $ref: '#/definitions/AnnotationFeatureCollectionPaginated'
 
     post:
       summary: Create annotations of this project
@@ -767,7 +767,7 @@ paths:
             $ref: '#/definitions/AnnotationFeatureCollectionCreate'
       responses:
         201:
-          description: Geojson annotations successfully created
+          description: GeoJSON annotations successfully created
           schema:
             $ref: '#/definitions/AnnotationFeatureCollection'
         default:
@@ -786,7 +786,7 @@ paths:
         - $ref: '#/parameters/uuid2'
       responses:
         200:
-          description: Geojson feature containing one annotation from this project
+          description: GeoJSON feature containing one annotation from this project
           schema:
             $ref: '#/definitions/AnnotationFeature'
 
@@ -2601,7 +2601,7 @@ definitions:
         - id
   Geometry:
       type: object
-      description: GeoJSon geometry
+      description: GeoJSON geometry
       discriminator: type
       required:
         - type
@@ -2626,7 +2626,7 @@ definitions:
         type: number
   MultiPolygon:
       type: object
-      description: GeoJson geometry
+      description: GeoJSON geometry
       externalDocs:
         url: https://tools.ietf.org/html/rfc7946#section-3.1
       allOf:
@@ -3473,7 +3473,7 @@ definitions:
         description: epsg projection code
       mask:
         type: object
-        description: geojson multipolygon
+        description: GeoJSON multipolygon
       stitch:
         type: boolean
         description: stitch tiles into a single geotiff if possible
@@ -3510,7 +3510,7 @@ definitions:
         description: "required resolution (currently it's zoom level)"
       mask:
         type: object
-        description: geojson multipolygon
+        description: GeoJSON multipolygon
       layers:
         type: object
         properties:
@@ -3663,7 +3663,20 @@ definitions:
       features:
         type: array
         items:
-          $ref: "#/definitions/AnnotationFeature"
+          $ref: '#/definitions/AnnotationFeature'
+
+  AnnotationFeatureCollectionPaginated:
+    type: object
+    allOf:
+      - $ref: '#/definitions/PaginatedResponse'
+      - type: object
+        properties:
+          type:
+            type: string
+          features:
+            type: array
+            items:
+              $ref: '#/definitions/AnnotationFeature'
 
   AnnotationFeatureCollectionCreate:
     type: object
@@ -3673,4 +3686,4 @@ definitions:
       features:
         type: array
         items:
-          $ref: "#/definitions/AnnotationFeatureCreate"
+          $ref: '#/definitions/AnnotationFeatureCreate'

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -738,6 +738,90 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /projects/{uuid}/annotations/:
+    x-resource: Projects
+    get:
+      summary: Get all annotations belonging to a project
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - $ref: '#/parameters/AnnotationLabel'
+        - $ref: '#/parameters/AnnotationQualityCheck'
+      responses:
+        200:
+          description: Geojson feature collection containing paginated annotations of this project
+          schema:
+            $ref: '#/definitions/AnnotationFeatureCollection'
+
+    post:
+      summary: Create annotations of this project
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - name: annotations
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AnnotationFeatureCollectionCreate'
+      responses:
+        201:
+          description: Geojson annotations successfully created
+          schema:
+            $ref: '#/definitions/AnnotationFeatureCollection'
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
+  /projects/{uuid}/annotations/{uuid2}:
+    x-resouce: Projects
+    get:
+      summary: Get an annotation belonging to a project
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - $ref: '#/parameters/uuid2'
+      responses:
+        200:
+          description: Geojson feature containing one annotation from this project
+          schema:
+            $ref: '#/definitions/AnnotationFeature'
+
+    put:
+      summary: Update an annotation of this project
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - $ref: '#/parameters/uuid2'
+        - name: annotation
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/AnnotationFeatureUpdate'
+      responses:
+        204:
+          description: No content, update successful
+
+    delete:
+      summary: Delete an annotation
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uuid'
+        - $ref: '#/parameters/uuid2'
+      responses:
+        204:
+          description: Deletion successful.
+        404:
+          description: The UUID parameter does not refer to an annotation or the user does not have access to the project it refers to.
+          schema:
+            $ref: '#/definitions/Error'
+
+
   /projects/{uuid}/areas-of-interest/:
     x-resource: Projects
     get:
@@ -1770,6 +1854,21 @@ parameters:
         - createdAt,asc
         - modifiedAt,desc
         - modifiedAt,asc
+  AnnotationQualityCheck:
+    name: AnnotationQualityCheck
+    description: Quality check on annotations
+    in: query
+    type: string
+    required: true
+    enum:
+      - PASS
+      - FAIL
+      - NEUTRAL
+  AnnotationLabel:
+    name: AnnotationLabel
+    in: query
+    description: name of a label
+    type: string
   name:
     name: name
     in: query
@@ -2507,12 +2606,17 @@ definitions:
       required:
         - type
       externalDocs:
-        url: http://geojson.org/geojson-spec.html#geometry-objects
+        url: https://tools.ietf.org/html/rfc7946#section-3.1
       properties:
         type:
           type: string
           enum:
             - MultiPolygon
+            - Polygon
+            - MultiLineString
+            - LineString
+            - MuliPoint
+            - Point
           description: the geometry type
   Point2D:
       type: array
@@ -2524,7 +2628,7 @@ definitions:
       type: object
       description: GeoJson geometry
       externalDocs:
-        url: http://geojson.org/geojson-spec.html#id6
+        url: https://tools.ietf.org/html/rfc7946#section-3.1
       allOf:
         - $ref: "#/definitions/Geometry"
         - properties:
@@ -3463,3 +3567,110 @@ definitions:
         items:
           type: string
           format: uuid
+
+  AnnotationFeature:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        allOf:
+        - $ref: '#/definitions/BaseModel'
+        - $ref: '#/definitions/TimeModelMixin'
+        - $ref: '#/definitions/UserTrackingMixin'
+        - type: object
+        properties:
+          label:
+            type: string
+          description:
+            type: string
+          machineGenerated:
+            type: boolean
+          confidence:
+            type: number
+            format: float
+          qualityCheck:
+            type: string
+            enum:
+              - PASS
+              - FAIL
+              - NEUTRAL
+          projectId:
+            type: string
+            format: uuid
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  AnnotationFeatureUpdate:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        type: object
+        properties:
+          label:
+            type: string
+          description:
+            type: string
+          machineGenerated:
+            type: boolean
+          confidence:
+            type: number
+            format: float
+          qualityCheck:
+            type: string
+            enum:
+              - PASS
+              - FAIL
+              - NEUTRAL
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  AnnotationFeatureCreate:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        allOf:
+        - $ref: '#/definitions/BaseCreate'
+        - type: object
+        properties:
+          label:
+            type: string
+          description:
+            type: string
+          machineGenerated:
+            type: boolean
+          confidence:
+            type: number
+            format: float
+          qualityCheck:
+            type: string
+            enum:
+              - PASS
+              - FAIL
+              - NEUTRAL
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  AnnotationFeatureCollection:
+    type: object
+    properties:
+      type:
+        type: string
+      features:
+        type: array
+        items:
+          $ref: "#/definitions/AnnotationFeature"
+
+  AnnotationFeatureCollectionCreate:
+    type: object
+    properties:
+      type:
+        type: string
+      features:
+        type: array
+        items:
+          $ref: "#/definitions/AnnotationFeatureCreate"


### PR DESCRIPTION
## Overview

@aaronxsu and I paired on this one.

### The annotations API spec

All endpoints return GeoJSON. 

#### New Endpoints

All annotation endpoints are nested under the projects endpoint, as we don't foresee annotations existing outside of the project context.

##### `/projects/{uuid}/annotations`
  - `GET` all of the annotations belonging to a project
  - `POST` a new annotation

We think this should be paginated (at least by default) as the number of annotations for a single project could be _very_ large. This will require clients to intelligently navigate the paging mechanism to display all annotations, but we think this is preferable to returning an unknown number of annotations.

##### `projects/{uuid}/annotations/{uuid2}`
  - `GET` a single annotation
  - `PUT` an update of a single annotation
  - `DELETE` an annotation

#### Structure

An annotation has the following fields:

  - `label`: string
  - `description`: string
  - `machineGenerated`: boolean
  - `confidence`: number between 0 and 1
  - `qualityCheck`: enum of `PASS`, `FAIL`, `NEUTRAL` (could use feedback on the naming here for both the field name and the enums...could it just be `quality`?)
  - `projectId`: UUID

Closes #2338
