### PR TITLE
Fix node stats number alignment, decimal places, and commas

### DIFF
--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.controller.js
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.controller.js
@@ -3,9 +3,10 @@
 const visibleStats = ['mean', 'median', 'mode', 'stddev', 'zmin', 'zmax'];
 
 export default class NodeHistogramController {
-    constructor($scope, toolService) {
+    constructor($scope, $filter, toolService) {
         'ngInject';
         this.$scope = $scope;
+        this.$filter = $filter;
         this.toolService = toolService;
     }
 
@@ -78,5 +79,11 @@ export default class NodeHistogramController {
         return this.hasToolRun && !this.isLoading && !this.hasStats;
     }
 
-
+    parseStatValDisplay(val) {
+        let result = this.$filter('number')(val, 5);
+        if (result && result.length && result !== '-∞' && result !== '∞') {
+            result = result.split(',').join('');
+        }
+        return result;
+    }
 }

--- a/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.html
+++ b/app-frontend/src/app/components/tools/nodeStatistics/nodeStatistics.html
@@ -4,7 +4,7 @@
          ng-if="$ctrl.shouldShowStats()"
     >
         <div class="classify-node-class header">{{label}}</div>
-        <div class="classify-node-class">{{value | setDecimal : 5}}</div>
+        <div class="classify-node-class">{{$ctrl.parseStatValDisplay(value)}}</div>
     </div>
 
     <div class="classify-node-preview-row with-border"
@@ -12,7 +12,7 @@
         ng-if="$ctrl.shouldShowEmptyStats()"
     >
        <div class="classify-node-class header">{{label}}</div>
-       <div class="classify-node-class">{{value | setDecimal : 5}}</div>
+       <div class="classify-node-class">{{$ctrl.parseStatValDisplay(value)}}</div>
     </div>
 </div>
 <div class="node-controls overlayed" ng-if="$ctrl.shouldShowEmptyStats()">

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1692,6 +1692,7 @@ rf-node-statistics {
     border-left: 1px solid $gray-lightest;
     margin-right: 0.5rem;
   }
+  text-align:right;
 }
 
 .node-controls {


### PR DESCRIPTION
## Overview

This PR:
- makes numbers in node statistics right-aligned
- forces these numbers to have same number of decimal places with no commas

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Go to the lab and configure tool inputs.
 * Open the statistics of the function node and check if they are right-aligned and all have 5 decimal places with no commas, no matter integers or decimals

Closes #2651 