### PR TITLE
Add result stats component, fix glitch

### DIFF
--- a/app-frontend/src/app/pages/projects/list/list.html
+++ b/app-frontend/src/app/pages/projects/list/list.html
@@ -42,17 +42,17 @@
       </div>
       <!-- No project placeholder -->
 
-      <p class="font-size-small"
+      <div class="result-stats"
          ng-if="(!$ctrl.searchString && $ctrl.pagination.count > 0)"
       >
        Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} projects
-      </p>
+      </div>
 
-      <p class="font-size-small"
+      <div class="result-stats"
          ng-if="($ctrl.searchString && $ctrl.pagination.count > 0)"
       >
         Showing results for "{{$ctrl.searchString}}"
-      </p>
+      </div>
 
       <!-- Project List -->
       <div ng-if="!$ctrl.loading && $ctrl.projectList.length > 0" class="row stack-xs">

--- a/app-frontend/src/app/pages/projects/list/list.html
+++ b/app-frontend/src/app/pages/projects/list/list.html
@@ -42,15 +42,14 @@
       </div>
       <!-- No project placeholder -->
 
-
       <p class="font-size-small"
-         ng-if="!$ctrl.searchString"
+         ng-if="(!$ctrl.searchString && $ctrl.pagination.count > 0)"
       >
        Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} projects
       </p>
 
       <p class="font-size-small"
-         ng-if="$ctrl.searchString"
+         ng-if="($ctrl.searchString && $ctrl.pagination.count > 0)"
       >
         Showing results for "{{$ctrl.searchString}}"
       </p>

--- a/app-frontend/src/assets/styles/sass/app.scss
+++ b/app-frontend/src/assets/styles/sass/app.scss
@@ -73,7 +73,8 @@
   "components/instructions",
   "components/tags",
   "components/slider",
-  "components/gradient-bar";
+  "components/gradient-bar",
+  "components/result-stats";
 
 /* * * *
  * Pages

--- a/app-frontend/src/assets/styles/sass/components/_result-stats.scss
+++ b/app-frontend/src/assets/styles/sass/components/_result-stats.scss
@@ -1,0 +1,9 @@
+//
+// Search results
+// --------------------------------------------------
+.result-stats {
+  font-size: 1.3rem;
+  line-height: 1.8;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Overview

Adds a dedicated SCSS component for Result Stats ('Showing 1-2 of 2 projects'). This improves the semantics of the markup, which previously treated these as paragraphs. 

Also cleans up an issue where these stats were displayed even when a user had zero projects.

### Demo

![image](https://user-images.githubusercontent.com/1809908/32295728-84d402ae-bf20-11e7-95d7-b184a7ca51d1.png)

![image](https://user-images.githubusercontent.com/1809908/32295749-967dfa78-bf20-11e7-8d5d-efb027eea663.png)

## Testing Instructions

* Navigate to the Projects view
* Remove all of your projects or somehow get an instance with no projects to verify that the `result-stats` don't appear
* Examine markup and SCSS for new result-stats component