### PR TITLE
Add source parameter to feed endpoint

### DIFF
--- a/app-backend/api/src/main/scala/feed/Routes.scala
+++ b/app-backend/api/src/main/scala/feed/Routes.scala
@@ -6,8 +6,14 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling._
+import kamon.akka.http.KamonTraceDirectives
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
 import com.azavea.rf.common.UserErrorHandler
+import com.azavea.rf.database.query._
+import com.azavea.rf.api.utils.queryparams._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
 
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -17,53 +23,87 @@ import scala.concurrent.duration._
 import com.typesafe.scalalogging.LazyLogging
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 
-trait FeedRoutes extends UserErrorHandler {
+trait FeedRoutes extends UserErrorHandler
+    with FeedQueryParametersDirective
+    with KamonTraceDirectives {
   val feedRoutes: Route = handleExceptions(userExceptionHandler) {
     pathEndOrSingleSlash {
-      get { complete { FeedService.getFeed() }}
+      get {
+        (feedQueryParameters) { (feedParams) =>
+          traceName("feed-proxy")
+          complete { FeedService.getFeed(feedParams) }
+        }
+      }
     }
   }
+}
+
+trait FeedQueryParametersDirective extends QueryParametersCommon {
+  val feedQueryParameters = parameters(
+    (
+      'source.as[String].?
+    )
+  ).as(FeedQueryParameters.apply _)
 }
 
 object FeedService extends LazyLogging {
   import com.azavea.rf.api.AkkaSystem._
 
-  val feedCache: AsyncLoadingCache[Int, String] =
+  val feedCache: AsyncLoadingCache[String, String] =
     Scaffeine()
       .expireAfterWrite(1.hours)
-      .maximumSize(1)
-      .buildAsyncFuture((i: Int) => fetchFeed())
+      .maximumSize(100) // adjust as needed
+      .buildAsyncFuture((source: String) => fetchFeed(source))
 
-  val gidUri = Uri("https://medium.com/m/global-identity?redirectUrl=https://blog.rasterfoundry.com/latest?format=json")
-  def fetchFeed(): Future[String] = {
-    Http()
-      .singleRequest(HttpRequest(method = GET, uri = gidUri))
-      .flatMap {
-        case HttpResponse(StatusCodes.Found, headers, _, _) =>
-          val location: Option[HttpHeader] = headers.find((header) => header.is("location"))
-          location match {
-            case Some(loc: HttpHeader) =>
-              Http()
-                .singleRequest(
-                  HttpRequest(
-                    method = GET,
-                    uri = loc.value,
-                    entity = HttpEntity(ContentTypes.`application/json`, "")
-                  )
-                )
-                .flatMap {
-                  case HttpResponse(StatusCodes.OK, _, entity, _) =>
-                    Unmarshal(entity).to[String]
-                  case HttpResponse(errCode, _, error, _) =>
-                    throw new Exception(s"Error fetching feed: $errCode, $error")
-                }
-            case _ =>
-              throw new Exception("Error fetching feed: Unable to obtain global id for request")
+  val defaultRedirectUri = "https://blog.rasterfoundry.com/latest?format=json"
+  val gidUri = "https://medium.com/m/global-identity"
+  def fetchFeed(source: String): Future[String] = {
+    source contains "medium.com" match {
+      case true =>
+        val uri = source
+        Http()
+          .singleRequest(HttpRequest(
+                           method = GET,
+                           uri = uri,
+                           entity = HttpEntity(ContentTypes.`application/json`, "")
+                         ))
+          .flatMap {
+            case HttpResponse(StatusCodes.OK, _, entity, _) =>
+              Unmarshal(entity).to[String]
+            case HttpResponse(errCode, _, error, _) =>
+              throw new Exception(s"Error fetching feed: $errCode, $error")
           }
-      }
+      case false =>
+        val uri = Uri(gidUri).withRawQueryString("redirectUrl="+source)
+        Http()
+          .singleRequest(HttpRequest(method = GET, uri = uri))
+          .flatMap {
+            case HttpResponse(StatusCodes.Found, headers, _, _) =>
+              val location: Option[HttpHeader] = headers.find((header) => header.is("location"))
+              location match {
+                case Some(loc: HttpHeader) =>
+                  Http()
+                    .singleRequest(
+                      HttpRequest(
+                        method = GET,
+                        uri = loc.value,
+                        entity = HttpEntity(ContentTypes.`application/json`, "")
+                      )
+                    )
+                    .flatMap {
+                      case HttpResponse(StatusCodes.OK, _, entity, _) =>
+                        Unmarshal(entity).to[String]
+                      case HttpResponse(errCode, _, error, _) =>
+                        throw new Exception(s"Error fetching feed: $errCode, $error")
+                    }
+                case _ =>
+                  throw new Exception("Error fetching feed: Unable to obtain global id for request")
+              }
+          }
+    }
   }
 
-  def getFeed(): Future[String] = {
-    feedCache.get(1)
+  def getFeed(feedParams: FeedQueryParameters): Future[String] = {
+    feedCache.get(feedParams.source.getOrElse(defaultRedirectUri))
   }
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/QueryParameters.scala
@@ -267,3 +267,8 @@ case class AnnotationQueryParameters(
   maxConfidence: Option[Double] = None,
   quality: Option[String] = None
 )
+
+@JsonCodec
+case class FeedQueryParameters(
+  source: Option[String] = None
+)

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -273,7 +273,8 @@ module.exports = function (_path) {
                     AUTH0_PRIMARY_COLOR: JSON.stringify('#465076'),
                     LOGOFILE: JSON.stringify('raster-foundry-logo.svg'),
                     LOGOURL: JSON.stringify(false),
-                    FAVICON_DIR: JSON.stringify('/favicon')
+                    FAVICON_DIR: JSON.stringify('/favicon'),
+                    FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json')
                 }
             })
         ]

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -1,12 +1,18 @@
 'use strict';
-/* globals module */
+/* globals process module */
 /* no-console: 0 */
 
-const webpack = require('webpack');
 const path = require('path');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+
 const NODE_ENV = process.env.NODE_ENV || 'production';
 const DEVELOPMENT = NODE_ENV === 'production' ? false : true;
+
+const HERE_APP_ID = 'v88MqS5fQgxuHyIWJYX7';
+const HERE_APP_CODE = '5pn07ENomTHOap0u7nQSFA';
+
+const INTERCOM_APP_ID = '';
 
 const basemaps = JSON.stringify({
     layers: {

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -56,7 +56,7 @@
             </p>
             <a class="btn btn-light" ui-sref="settings.profile">Manage account</a>
           </section>
-          <section>
+          <section ng-if="$ctrl.blogPosts && $ctrl.blogPosts.length">
             <h5>From our blog</h5>
             <ul class="list-unstyled">
               <li ng-repeat="post in $ctrl.blogPosts">

--- a/app-frontend/src/app/services/common/feed.service.js
+++ b/app-frontend/src/app/services/common/feed.service.js
@@ -13,7 +13,8 @@ export default (app) => {
             return this.$q((resolve, reject) => {
                 this.$http({
                     method: 'GET',
-                    url: `${BUILDCONFIG.API_HOST}/api/feed`
+                    url: `${BUILDCONFIG.API_HOST}/api/feed/` +
+                        `?source=${BUILDCONFIG.FEED_SOURCE}`
                 }).then(response => {
                     let raw = response.data;
                     try {

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1671,6 +1671,8 @@ paths:
   /feed/:
     get:
       summary: Get the cached RSS feed
+      parameters:
+        - $ref: '#/parameters/source'
       tags:
         - Users
       responses:
@@ -2210,6 +2212,12 @@ parameters:
       - COMPLETE
       - FAILED
       - ABORTED
+  source:
+    name: source
+    description: Feed source URI
+    in: query
+    type: string
+    required: false
 
 definitions:
   RenderDefinition:


### PR DESCRIPTION
## Overview

Feed endpoint now takes a source parameter, defaulting to blog.rasterfoundry.com

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] Swagger specification updated, if necessary
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Feeds must be links to publications - not users.

## Testing Instructions

 * Verify that the normal feed works
* Verify that changing the feed in the overrides file to something like `https://brightthemag.com/latest?format=json` works

Closes #2684
