### PR TITLE
Restrict tool run query to owners

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
@@ -51,7 +51,7 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
 
   def getToolRun(id: UUID, user: User): DBIO[Option[ToolRun]] =
     ToolRuns
-      .filterToSharedOrganizationIfNotInRoot(user)
+      .filterToOwner(user)
       .filter(_.id === id)
       .result
       .headOption
@@ -59,7 +59,7 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
   def listToolRuns(offset: Int, limit: Int,
                    toolRunParams: CombinedToolRunQueryParameters, user: User): ListQueryResult[ToolRun] = {
     val dropRecords = limit * offset
-    val accessibleToolRuns = ToolRuns.filterToSharedOrganizationIfNotInRoot(user)
+    val accessibleToolRuns = ToolRuns.filterToOwner(user)
     val toolRunFilterQuery = accessibleToolRuns
       .filterByTimestamp(toolRunParams.timestampParams)
       .filterByToolRunParams(toolRunParams.toolRunParams)


### PR DESCRIPTION
## Overview

Right now we do not have a concept of organizations in Raster Foundry so filtering to organizations means that users can see everyone else's analyses. This PR switches the restriction to "owner" so that only owner tool runs show up.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [ ] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to the "Tools" section of the UI and you should only see tool runs created by your user
