### PR TITLE
Add `HELPCONFIG` to allow configuring help links

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -275,6 +275,12 @@ module.exports = function (_path) {
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
                     FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json')
+                },
+                'HELPCONFIG': {
+                    API_DOCS_URL: JSON.stringify('https://docs.rasterfoundry.com/'),
+                    HELP_HOME: JSON.stringify('https://help.rasterfoundry.com/'),
+                    GETTING_STARTED_WITH_PROJECTS: JSON.stringify('https://help.rasterfoundry.com/creating-projects'),
+                    DEVELOPER_RESOURCES: JSON.stringify('https://help.rasterfoundry.com/developer-resources')
                 }
             })
         ]

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -1,4 +1,4 @@
-/* global BUILDCONFIG */
+/* global BUILDCONFIG HELPCONFIG */
 
 class HomeController {
     constructor(authService, $uibModal, feedService) {
@@ -10,6 +10,7 @@ class HomeController {
 
     $onInit() {
         this.BUILDCONFIG = BUILDCONFIG;
+        this.HELPCONFIG = HELPCONFIG;
         this.feedService.getPosts().then(posts => {
             this.blogPosts = posts;
         });

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -11,7 +11,7 @@
           </p>
           <a class="btn btn-primary" ui-sref="projects.list">View Projects</a>
           <button class="btn btn-default" ng-click="$ctrl.openCreateProjectModal()">Create a new Project</button>
-          <p><a href="https://help.rasterfoundry.com/creating-projects" target="_blank">Getting started with Projects</a></p>
+          <p><a ng-href="{{$ctrl.HELPCONFIG.GETTING_STARTED_WITH_PROJECTS}}" target="_blank">Getting started with Projects</a></p>
         </rf-call-to-action-item>
         <div class="row stack-sm">
           <div class="column-6 flex-display">
@@ -25,9 +25,6 @@
                       ng-click="$ctrl.openToolCreateModal()">
                 Create a new Tool
               </button>
-              <!-- <p> -->
-              <!-- <a href="https://help.rasterfoundry.com/working-with-tools" target="_blank">Getting started with Tools</a> -->
-              <!-- </p> -->
             </rf-call-to-action-item>
           </div>
           <div class="column-6 flex-display">
@@ -38,9 +35,9 @@
               <a class="btn btn-tertiary" ui-sref="settings.tokens.api">Manage API Tokens</a>
               <div class="hide-sm"></div>
               <p>
-                <a href="https://help.rasterfoundry.com/developer-resources" target="_blank">Developer Resources</a>
+                <a ng-href="{{$ctrl.HELPCONFIG.DEVELOPER_RESOURCES}}" target="_blank">Developer Resources</a>
                 <br>
-                <a href="https://docs.rasterfoundry.com/" target="_blank">API Documentation</a>
+                <a ng-href="{{$ctrl.HELPCONFIG.API_DOCS_URL}}" target="_blank">API Documentation</a>
               </p>
             </rf-call-to-action-item>
           </div>
@@ -68,7 +65,7 @@
           <section class="aside-footer">
             <h5>Help</h5>
             <ul class="list-unstyled">
-              <li><a href="https://help.rasterfoundry.com/" target="_blank">Help Center</a></li>
+              <li><a ng-href="{{$ctrl.HELPCONFIG.HELP_HOME}}" target="_blank">Help Center</a></li>
             </ul>
           </section>
         </div>


### PR DESCRIPTION
## Overview

This PR adds a configuration object to `app-frontend/config/webpack/global.js` to allow customization of help links.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Try the help links on the home page and make sure they work as intended
 * Try overriding these settings or changing them in the global file, restart webpack, and see that the changes are reflected in the UI

Closes #2720
