### PR TITLE
Use systems@rasterfoundry.com auth0 account instead of rf|airflow-user

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -1,8 +1,3 @@
-
-airflow {
-  user = "rf|airflow-user"
-}
-
 landsat8 {
   organization = "dfac6307-b5ef-43f7-beda-b9f208bb7726"
 
@@ -117,4 +112,8 @@ dropbox {
   appKey = ${?DROPBOX_KEY}
   appSecret = ""
   appSecret = ${?DROPBOX_SECRET}
+}
+
+auth0 {
+  systemUser = ${?AUTH0_SYSTEM_USER}
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -19,9 +19,9 @@ case class FindAOIProjects(implicit val database: DB) extends Job {
 
   def run: Unit = {
     logger.info("Finding AOI projects...")
-    Users.getUserById(airflowUser).flatMap { userOpt =>
+    Users.getUserById(systemUser).flatMap { userOpt =>
       val user = userOpt.getOrElse {
-        val e = new Exception(s"User $airflowUser doesn't exist.")
+        val e = new Exception(s"User $systemUser doesn't exist.")
         sendError(e)
         throw e
       }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -24,7 +24,7 @@ case class UpdateAOIProject(projectId: UUID)(implicit val database: DB) extends 
   def run: Unit = {
     logger.info(s"Updating Project $projectId AOI...")
     val result = for {
-      user: User                   <- OptionT(Users.getUserById(airflowUser))
+      user: User                   <- OptionT(Users.getUserById(systemUser))
       (project: Project, aoi: AOI) <- OptionT(Projects.getAOIProject(projectId, user))
       scenes: Iterable[UUID]       <- OptionT({
         val area = aoi.area

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
@@ -55,7 +55,7 @@ case class CheckExportStatus(exportId: UUID, statusBucket: String = "rasterfound
       }
 
     val result = for {
-      user <- fromOptionF[Future, String, User](Users.getUserById(airflowUser), "DB: Failed to fetch User.")
+      user <- fromOptionF[Future, String, User](Users.getUserById(systemUser), "DB: Failed to fetch User.")
       export <- fromOptionF[Future, String, Export](database.db.run(Exports.getExport(exportId, user)), "DB: Failed to fetch Export.")
       exportStatus <- EitherT.right[Future, String, Int](
         database.db.run(

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -87,7 +87,7 @@ case class CreateExportDef(exportId: UUID, region: Option[String] = None)(implic
     val startEmr = (ed: ExportDefinition, edu: String) => Future { startExportEmrJob(ed, edu) }
 
     val createExportDef = for {
-      user <- fromOptionF[Future, String, User](Users.getUserById(airflowUser), "DB: Failed to fetch User.")
+      user <- fromOptionF[Future, String, User](Users.getUserById(systemUser), "DB: Failed to fetch User.")
       export <- fromOptionF[Future, String, Export](
         database.db.run(Exports.getExport(exportId, user)), "DB: Failed to fetch Export."
       )

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
@@ -190,7 +190,7 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
                 visibility = Visibility.Public,
                 filename = tiffPath,
                 sourceUri = s"${getLandsatUrl(productId)}/${tiffPath}",
-                owner = Some(airflowUser),
+                owner = Some(systemUser),
                 scene = sceneId,
                 imageMetadata = Json.Null,
                 resolutionMeters = resolution,
@@ -208,7 +208,7 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
             datasource = landsat8Config.datasourceUUID,
             sceneMetadata = sceneMetadata.asJson,
             name = sceneName,
-            owner = Some(airflowUser),
+            owner = Some(systemUser),
             tileFootprint = targetProj.epsgCode.map(Projected(MultiPolygon(transformedExtent.toPolygon()), _)),
             dataFootprint = targetProj.epsgCode.map(Projected(MultiPolygon(transformedCoords), _)),
             metadataFiles = List(s"${landsat8Config.awsLandsatBase}${landsatPath}/${productId}_MTL.txt"),
@@ -254,10 +254,10 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
 
   def run: Unit = {
     logger.info("Importing scenes...")
-    Users.getUserById(airflowUser).flatMap { (userOpt) =>
+    Users.getUserById(systemUser).flatMap { (userOpt) =>
       scenesFromCsv(
         userOpt.getOrElse {
-          val e = new Exception(s"User $airflowUser doesn't exist.")
+          val e = new Exception(s"User $systemUser doesn't exist.")
           sendError(e)
           throw e
         })

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -190,7 +190,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
                 visibility = Visibility.Public,
                 filename = tiffPath,
                 sourceUri = s"${getLandsatUrl(productId)}/${tiffPath}",
-                owner = Some(airflowUser),
+                owner = Some(systemUser),
                 scene = sceneId,
                 imageMetadata = Json.Null,
                 resolutionMeters = resolution,
@@ -208,7 +208,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
             datasource = landsat8Config.datasourceUUID,
             sceneMetadata = sceneMetadata.asJson,
             name = landsatPath,
-            owner = Some(airflowUser),
+            owner = Some(systemUser),
             tileFootprint = targetProj.epsgCode.map(Projected(MultiPolygon(transformedExtent.toPolygon()), _)),
             dataFootprint = targetProj.epsgCode.map(Projected(MultiPolygon(transformedCoords), _)),
             metadataFiles = List(s"${landsat8Config.awsLandsatBaseC1}${landsatPath}/${productId}_MTL.txt"),
@@ -253,10 +253,10 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
 
   def run: Unit = {
     logger.info("Importing scenes...")
-    Users.getUserById(airflowUser).flatMap { userOpt =>
+    Users.getUserById(systemUser).flatMap { userOpt =>
       scenesFromCsv(
         userOpt.getOrElse {
-          val e = new Exception(s"User $airflowUser doesn't exist.")
+          val e = new Exception(s"User $systemUser doesn't exist.")
           sendError(e)
           throw e
         }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -71,7 +71,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
         visibility       = Visibility.Public,
         filename         = filename,
         sourceUri        = s"${sentinel2Config.baseHttpPath}${obj}",
-        owner            = airflowUser.some,
+        owner            = systemUser.some,
         scene            = sceneId,
         imageMetadata    = Json.Null,
         resolutionMeters = resolution,
@@ -176,7 +176,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
                         datasource = sentinel2Config.datasourceUUID,
                         sceneMetadata = sceneMetadata.asJson,
                         name = sceneName,
-                        owner = airflowUser.some,
+                        owner = systemUser.some,
                         tileFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| tileFootprint).map {
                           case (code, mp) => Projected(mp, code)
                         },
@@ -246,9 +246,9 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
 
   def run: Unit = {
     logger.info("Importing scenes...")
-    Users.getUserById(airflowUser).flatMap { userOpt =>
+    Users.getUserById(systemUser).flatMap { userOpt =>
       findScenes(startDate, userOpt.getOrElse {
-        val e = new Exception(s"User $airflowUser doesn't exist.")
+        val e = new Exception(s"User $systemUser doesn't exist.")
         sendError(e)
         throw e
       })

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -94,7 +94,7 @@ trait Config {
   private lazy val config = ConfigFactory.load()
   protected lazy val landsat8Config = config.as[Landsat8]("landsat8")
   protected lazy val sentinel2Config = config.as[Sentinel2]("sentinel2")
-  protected lazy val airflowUser = config.as[String]("airflow.user")
+  protected lazy val systemUser = config.as[String]("auth0.systemUser")
   protected lazy val exportDefConfig = config.as[ExportDef]("export-def")
   protected lazy val dropboxConfig = config.as[Dropbox]("dropbox")
   val jarPath = "s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar"

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -42,8 +42,6 @@ class ToolRoutes(implicit val database: Database) extends Authentication
   with CommonHandlers
   with KamonTraceDirectives {
 
-  val userId: String = "rf_airflow-user"
-
   lazy val memcachedClient = KryoMemcachedClient.DEFAULT
   val rfCache = new CacheClient(memcachedClient)
 

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -57,6 +57,7 @@ def download_s3_obj_by_key(bucket, key):
         outf.write(obj['Body'].read())
     return tf
 
+
 def s3_obj_exists(url):
     """Helper function to determine whether an s3 object exists
 
@@ -68,16 +69,20 @@ def s3_obj_exists(url):
 
 
 def get_jwt():
-    """Construct JSON web token for auth purposes"""
-
-    jwt_secret = os.getenv('AUTH0_CLIENT_SECRET')
-    claims = {
-        'sub': 'rf|airflow-user',
-        'iat': datetime.utcnow(),
-        'exp': datetime.utcnow() + timedelta(hours=3)
-    }
-    encoded_jwt = jwt.encode(claims, jwt_secret, algorithm='HS256')
-    return encoded_jwt
+    """Fetch an access token from the Auth0 API"""
+    r = requests.post(
+        'https://{}/oauth/token'.format(
+            os.getenv('AUTH0_DOMAIN')
+        ),
+        data={
+            'grant_type': 'refresh_token',
+            'client_id': os.getenv('AUTH0_CLIENT_ID'),
+            'refresh_token': os.getenv('AUTH0_SYSTEM_REFRESH_TOKEN')
+        }
+    )
+    r.raise_for_status()
+    json = r.json()
+    return json['id_token']
 
 
 def get_session():


### PR DESCRIPTION
## Overview
Use systems@rasterfoundry.com auth0 account instead of rf|airflow-user
Use env variables instead of hardcoded string for systems user

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

On staging and production, we will need to update the systems@rasterfoundry.com user to have root org and admin role
We also need to generate a refresh token and store it in the .env files

### Demo
```
vagrant@vagrant-ubuntu-trusty-64:/opt/raster-foundry$ docker-compose build batch && ./scripts/console batch 'rf process-upload aa1a953a-793d-4d9e-876e-9a9c6909b9f4'
Building batch
Step 1/6 : FROM openjdk:8-jre-slim
 ---> d0005849f0a6
Step 2/6 : COPY rf/requirements.txt /tmp/
 ---> Using cache
 ---> 4f6e6e8d8aa7
Step 3/6 : RUN set -ex     && gdalDeps='        gdal-bin/sid        python-gdal/sid        python-pip        python-setuptools        python-dev        build-essential        imagemagick     '     && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list     && apt-get update     && apt-get install -y --no-install-recommends ${gdalDeps}     && pip install --no-cache-dir        numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3)     && pip install --no-cache-dir -r /tmp/requirements.txt     && apt-get purge -y build-essential python-dev     && apt-get -y autoremove     && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> af47f3efcd23
Step 4/6 : COPY jars/ /opt/raster-foundry/jars/
 ---> Using cache
 ---> 7ba3ac64018f
Step 5/6 : COPY rf/ /tmp/rf
 ---> Using cache
 ---> fca8aa3c186e
Step 6/6 : RUN (cd /tmp/rf && python setup.py install)
 ---> Using cache
 ---> c79247ded39c

Successfully built c79247ded39c
Successfully tagged raster-foundry-batch:latest
Processing upload
INFO:rf.commands.process_upload:Getting upload
INFO:rf.commands.process_upload:Updating upload status
INFO:rf.commands.process_upload:Processing upload (aa1a953a-793d-4d9e-876e-9a9c6909b9f4) for user auth0|59318a9d2fbbca3e16bcfc92 with files [u's3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/aa1a953a-793d-4d9e-876e-9a9c6909b9f4/ortho_rtk_tc_22june2015_lareau.tif']
INFO:rf.commands.process_upload:Processing a geotiff upload
INFO:rf.commands.process_upload:Creating scene objects for upload aa1a953a-793d-4d9e-876e-9a9c6909b9f4, preparing to POST to API
INFO:rf.uploads.geotiff.factories:Downloading s3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/aa1a953a-793d-4d9e-876e-9a9c6909b9f4/ortho_rtk_tc_22june2015_lareau.tif => /tmp/tmp_XXVLy.tif
INFO:rf.uploads.geotiff.create_scenes:Generating Scene from /tmp/tmp_XXVLy.tif
INFO:rf.uploads.geotiff.create_footprints:Beginning process to extract footprint for image:/tmp/tmp_XXVLy.tif
INFO:rf.uploads.geotiff.create_footprints:Running GDAL command: gdal_translate /tmp/tmp_XXVLy.tif /tmp/tmpTapPyl/tmpWNzEtn.TIF -outsize 512 1955
Input file size is 11735, 44810
0...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.uploads.geotiff.create_footprints:Creating masks to extract footprints
/usr/local/lib/python2.7/dist-packages/rf-0.1.0-py2.7.egg/rf/uploads/geotiff/create_footprints.py:46: NodataShadowWarning: The dataset's nodata attribute is shadowing the alpha band. All masks will be determined by the nodata attribute
  mask = sieve(src.dataset_mask(), size=40)
/usr/local/lib/python2.7/dist-packages/rf-0.1.0-py2.7.egg/rf/uploads/geotiff/create_footprints.py:191: DeprecationWarning: 'src.affine' is deprecated.  Please switch to 'src.transform'. See https://github.com/mapbox/rasterio/issues/86 for details.
  data_footprint = extract_polygon(data_mask_tif_path)
INFO:rf.uploads.geotiff.create_footprints:Extracting shapes from footprint masks
INFO:rf.uploads.geotiff.create_footprints:Transforming footprint coordinates
/usr/local/lib/python2.7/dist-packages/rf-0.1.0-py2.7.egg/rf/uploads/geotiff/create_footprints.py:192: DeprecationWarning: 'src.affine' is deprecated.  Please switch to 'src.transform'. See https://github.com/mapbox/rasterio/issues/86 for details.
  tile_footprint = extract_polygon(tile_mask_tif_path)
INFO:rf.uploads.geotiff.create_footprints:Extracting shapes from footprint masks
INFO:rf.uploads.geotiff.create_footprints:Transforming footprint coordinates
INFO:rf.uploads.geotiff.create_thumbnails:Performing thumbnail resampling
Input file size is 11735, 44810
0...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.uploads.geotiff.create_thumbnails:Performing thumbnail warping
INFO:rf.uploads.geotiff.create_thumbnails:Creating thumbnail files
INFO:rf.uploads.geotiff.create_thumbnails:Uploading thumbnails to S3
INFO:rf.commands.process_upload:Successfully created 1 scenes ([u'31140edc-0df4-46c2-af14-0fbe496b4eec'])
INFO:rf.commands.process_upload:Finished importing scenes for upload (aa1a953a-793d-4d9e-876e-9a9c6909b9f4) for user auth0|59318a9d2fbbca3e16bcfc92 with files [u's3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/aa1a953a-793d-4d9e-876e-9a9c6909b9f4/ortho_rtk_tc_22june2015_lareau.tif']
```

## Testing Instructions

 * Log in using the systems@rasterfoundry.com user locally
* In the database, give the account root org and admin role
* Pull in the latest .env file using `./scripts/bootstrap`
* process an import using a command like `docker-compose build batch && ./scripts/console batch 'rf process-upload {{upload uuid}}'`
* Ingest a landsat scene, and verify that it uses the new systems user instead of rf|airflow-user

Closes #2707 
