### PR TITLE
Use STS to retrieve S3 credentials

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -64,6 +64,7 @@ s3 {
   region = ${?AWS_REGION}
   dataBucket = ${?DATA_BUCKET}
   thumbnailBucket = ${?THUMBNAIL_BUCKET}
+  scopedUploadRoleArn = ${?SCOPED_UPLOAD_ROLE_ARN}
 }
 
 intercom {

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -3,13 +3,15 @@ package com.azavea.rf.api.uploads
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
-import com.azavea.rf.api.utils.{Auth0Exception, Config}
+import com.azavea.rf.api.utils.Config
 import com.azavea.rf.datamodel.User
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.amazonaws.auth.{AWSCredentials, AWSSessionCredentials, AWSStaticCredentialsProvider}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import com.amazonaws.services.securitytoken.model.AssumeRoleWithWebIdentityRequest
 import com.typesafe.scalalogging.LazyLogging
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -38,60 +40,43 @@ case class CredentialsWithBucketPath (
   bucketPath: String
 )
 
-object Auth0DelegationService extends Config with LazyLogging {
+object CredentialsService extends Config with LazyLogging {
   import com.azavea.rf.api.AkkaSystem._
 
-  val uri = Uri(s"https://$auth0Domain/delegation")
-
-  // The AWS Delegation response has many things, most of which we don't care
-  // about. We only want the "Credentials" key, so we setup this path to
-  // optionally retrieve it from Json response.
-  private val credentialsPath = root.Credentials.as[Credentials]
-
-  def getCredentials(user: User, uploadId: UUID, jwt: String): Future[CredentialsWithBucketPath] = {
-    val params = FormData(
-      "api-type" -> "aws",
-      "client_id" -> auth0ClientId,
-      "grant_type" -> "urn:ietf:params:oauth:grant-type:jwt-bearer",
-      "id_token" -> jwt,
-      "target" -> auth0ClientId
-    ).toEntity
+  def getCredentials(user: User, uploadId: UUID, jwt: String): CredentialsWithBucketPath = {
     val path = s"user-uploads/${user.id}/${uploadId.toString}"
+    val stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient;
+    val stsRequest = new AssumeRoleWithWebIdentityRequest
 
-    Http()
-      .singleRequest(HttpRequest(
-        method = HttpMethods.POST,
-        uri = uri,
-        entity = params
-      ))
-      .flatMap {
-        case HttpResponse(StatusCodes.OK, _, entity, _) =>
-          Unmarshal(entity).to[Json].map(credentialsPath.getOption).map {
-            case Some(credentials) => {
-              val s3 = AmazonS3ClientBuilder.standard
-                         .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                         .withRegion(region)
-                         .build()
+    stsRequest.setRoleArn(scopedUploadRoleArn)
+    stsRequest.setRoleSessionName(s"upload${uploadId}")
+    stsRequest.setWebIdentityToken(jwt)
+    stsRequest.setDurationSeconds(900)
 
-              // Add timestamp object to test credentials
-              val now = new Timestamp(new Date().getTime)
-              s3.putObject(
-                dataBucket,
-                s"${path}/RFUploadAccessTestFile",
-                s"Allow Upload Access for RF: ${path} at ${now.toString}"
-              )
+    val stsCredentials = stsClient.assumeRoleWithWebIdentity(stsRequest).getCredentials
 
-              val bucketUrl = s3.getUrl(dataBucket, path)
+    val credentials = Credentials(
+      stsCredentials.getAccessKeyId,
+      stsCredentials.getExpiration.toString,
+      stsCredentials.getSecretAccessKey,
+      stsCredentials.getSessionToken
+    )
 
-              CredentialsWithBucketPath(credentials, bucketUrl.toString)
-            }
-            case None => throw new Auth0Exception(
-              StatusCodes.InternalServerError,
-              "Missing credentials in AWS STS delegation response"
-            )
-          }
-        case HttpResponse(errCode, _, err, _) =>
-          throw new Auth0Exception(errCode, err.toString)
-      }
+    val s3 = AmazonS3ClientBuilder.standard
+               .withCredentials(new AWSStaticCredentialsProvider(credentials))
+               .withRegion(region)
+               .build()
+
+    // Add timestamp object to test credentials
+    val now = new Timestamp(new Date().getTime)
+    s3.putObject(
+      dataBucket,
+      s"${path}/RFUploadAccessTestFile",
+      s"Allow Upload Access for RF: ${path} at ${now.toString}"
+    )
+
+    val bucketUrl = s3.getUrl(dataBucket, path)
+
+    CredentialsWithBucketPath(credentials, bucketUrl.toString)
   }
 }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -126,10 +126,12 @@ trait UploadRoutes extends Authentication
   }
 
   def getUploadCredentials(uploadId: UUID): Route = authenticate { user =>
-    validateTokenHeader { jwt =>
-      onSuccess(readOne[Upload](Uploads.getUpload(uploadId, user))) {
-        case Some(_) => complete(Auth0DelegationService.getCredentials(user, uploadId, jwt))
-        case None => complete(StatusCodes.NotFound)
+    authenticateWithParameter { _ =>
+      parameter('token) { jwt =>
+        onSuccess(readOne[Upload](Uploads.getUpload(uploadId, user))) {
+          case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
+          case None => complete(StatusCodes.NotFound)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -36,4 +36,6 @@ trait Config {
   val tileServerLocation = tileServerConfig.getString("location")
 
   val dropboxClientId = dropboxConfig.getString("appKey")
+
+  val scopedUploadRoleArn = s3Config.getString("scopedUploadRoleArn")
 }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -163,7 +163,8 @@ lazy val common = Project("common", file("common"))
     Dependencies.ammoniteOps,
     Dependencies.chill,
     Dependencies.cats,
-    Dependencies.awsBatchSdk
+    Dependencies.awsBatchSdk,
+    Dependencies.awsStsSdk
   )})
 
 lazy val migrations = Project("migrations", file("migrations"))

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -65,6 +65,7 @@ object Dependencies {
   val kamonStatsd             = "io.kamon"                    %% "kamon-statsd"                      % Version.kamon
   val kamonAkkaHttp           = "io.kamon"                    %% "kamon-akka-http"                   % Version.kamonAkkaHttp
   val awsBatchSdk             = "com.amazonaws"                % "aws-java-sdk-batch"                % Version.awsBatchSdk
+  val awsStsSdk               = "com.amazonaws"                % "aws-java-sdk-sts"                  % Version.awsStsSdk
   val mamlJvm                 = "com.azavea"                  %% "maml-jvm"                          % Version.maml
   val mamlSpark               = "com.azavea"                  %% "maml-spark"                        % Version.maml
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -38,6 +38,7 @@ object Version {
   val ficus              = "1.4.0"
   val awsSdk             = "1.11.92"
   val awsBatchSdk        = "1.11.196"
+  val awsStsSdk          = "1.11.232"
   val dnsJava            = "2.1.8"
   val dropbox            = "2.1.1"
   val scalaCheck         = "1.13.4"


### PR DESCRIPTION
## Overview

This PR removes use of the Auth0 delegation endpoint and uses the STS API to retrieve limited scope credentials for interaction with S3.

### Checklist

~- [x] Styleguide updated, if necessary~
~- [x] Swagger specification updated, if necessary~
~- [x] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Hit the `/uploads/<uploadid>/credentials` endpoint with a GET and see that credentials are returned as before.
