### PR TITLE
Fix s3 exports

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -212,7 +212,7 @@ object Export extends SparkJob with Config with LazyLogging {
     conf: HadoopConfiguration
   ): Unit = {
     def path(key: SpatialKey): ExportDefinition => String = { ed =>
-      s"/${ed.output.getURLDecodedSource}/${ed.input.resolution}-${key.col}-${key.row}-${ed.id}.tiff"
+      s"${ed.output.getURLDecodedSource}/${ed.input.resolution}-${key.col}-${key.row}-${ed.id}.tiff"
     }
 
     rdd.foreachPartition({ iter =>

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
@@ -27,5 +27,5 @@ case class OutputDefinition(
   dropboxCredential: Option[String]
 ) {
   def getURLDecodedSource: String =
-    URLDecoder.decode(source.toString, "UTF-8").replace("dropbox:///", "")
+    URLDecoder.decode(source.toString, "UTF-8").replace("dropbox:///", "/")
 }

--- a/docker-compose.spark.yml
+++ b/docker-compose.spark.yml
@@ -70,7 +70,7 @@ services:
       - ./worker-tasks/:/opt/raster-foundry/worker-tasks/
       - ./.ivy2:/root/.ivy2
       - ./.sbt:/root/.sbt
-      - $HOME/.aws:/var/lib/spark/.aws:ro
+      - $HOME/.aws:/root/.aws:ro
       # Spark scratch space
       - /tmp
     working_dir: /opt/raster-foundry/worker-tasks

--- a/worker-tasks/Dockerfile
+++ b/worker-tasks/Dockerfile
@@ -5,5 +5,3 @@ USER root
 RUN \
       mkdir -p /spark-state \
       && chown spark:spark -R /spark-state
-
-USER spark


### PR DESCRIPTION
## Overview
Only prepend slash to url when it's a dropbox export
Make running spark-submit jobs easier / fix permissions error for aws config

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
```
root@39f5e6c2ecca:/var/lib/spark# spark-submit --class com.azavea.rf.batch.export.spark.Export --driver-memory 2G /opt/rf/jars/rf-batch.jar -j s3://rasterfoundry-development-data-us-east-1/export-definitions/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.json
2017-11-21 15:13:23,969 [main] WARN  org.apache.hadoop.util.NativeCodeLoader -  Unable to load native-hadoop library for your platform... using builtin-java classeswhere applicable
[Stage 0:>                                                          (0 + 2) / 2]No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-162-228-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-163-230-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
[Stage 1:>                                                          (0 + 2) / 2]No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-161-229-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-162-229-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-163-228-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-161-230-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-163-229-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-161-228-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
[Stage 1:=============================>                             (1 + 1) / 2]No codec found for s3://rasterfoundry-staging-data-us-east-1/user-exports/google-oauth2|116753943799198027869/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86/9-162-230-3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.tiff, writing without compression.
```

## Testing Instructions
* Rebuild `batch/assembly`
* Verify that exports now work and don't error out on a bad url

Example run:
``` bash
$ vagrant ssh

vagrant$ docker-compose -f docker-compose.spark.yml build
vagrant$ docker-compose -f docker-compose.sparm.yml run spark-driver --class com.azavea.rf.batch.export.spark.Export --driver-memory 2G /opt/rf/jars/rf-batch.jar -j s3://rasterfoundry-development-data-us-east-1/export-definitions/3cf7ac36-059a-4f4d-9b42-6b0ab3024b86.json
```

Closes https://github.com/azavea/raster-foundry-platform/issues/182
