### PR TITLE
Fix exports clipped using a polygon

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -112,7 +112,7 @@ object Export extends SparkJob with Config with LazyLogging {
 
       val query: ContextRDD[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]] =
         mask
-          .fold(q)(mp => q.where(Intersects(mp.reproject(LatLng, md.crs))))
+          .fold(q)(mp => q.where(Intersects(mp)))
           .result
           .withContext({ rdd => rdd.mapValues({ tile =>
             val ctile = (ld.colorCorrections |@| hist) map { _.colorCorrect(tile, _) } getOrElse tile


### PR DESCRIPTION
## Overview
Export process was re-projecting to web Mercator, and polygons were already in it.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Verify that exports clipped using a polygon no longer fail
Example run:
```
docker-compose -f docker-compose.spark.yml build spark-driver && docker-compose -f docker-compose.spark.yml run spark-driver --class com.azavea.rf.batch.export.spark.Export --driver-memory 2G /opt/rf/jars/rf-batch.jar -j s3://rasterfoundry-development-data-us-east-1/export-definitions/0c763dd9-0973-42d8-a316-d0cedf6808d6.json
```

Closes https://github.com/raster-foundry/raster-foundry/issues/2705
