### PR TITLE
Extract token from header instead of parameter

### DIFF
--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -45,7 +45,7 @@ object CredentialsService extends Config with LazyLogging {
 
   def getCredentials(user: User, uploadId: UUID, jwt: String): CredentialsWithBucketPath = {
     val path = s"user-uploads/${user.id}/${uploadId.toString}"
-    val stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient;
+    val stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient
     val stsRequest = new AssumeRoleWithWebIdentityRequest
 
     stsRequest.setRoleArn(scopedUploadRoleArn)

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -126,12 +126,10 @@ trait UploadRoutes extends Authentication
   }
 
   def getUploadCredentials(uploadId: UUID): Route = authenticate { user =>
-    authenticateWithParameter { _ =>
-      parameter('token) { jwt =>
-        onSuccess(readOne[Upload](Uploads.getUpload(uploadId, user))) {
-          case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
-          case None => complete(StatusCodes.NotFound)
-        }
+    extractTokenHeader { jwt =>
+      onSuccess(readOne[Upload](Uploads.getUpload(uploadId, user))) {
+        case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
+        case None => complete(StatusCodes.NotFound)
       }
     }
   }


### PR DESCRIPTION
## Overview

This bug was introduced when switching over to OIDC for uploads; the auth
parameters should have been extracted from the header and not a query parameter
which is how it was before.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![screenshot from 2017-11-27 11-24-16](https://user-images.githubusercontent.com/898060/33277124-95b6526c-d365-11e7-8986-d2abad09e329.png)

## Testing Instructions

 * Spin up development environment and upload a local file through the project creation workflow
