### PR TITLE
Use batch jar path environment variable for export jobs

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -46,7 +46,7 @@ export-def {
   bucketName  = "export-definitions"
   awsDataproc = "dataproc.rasterfoundry.com."
   sparkJarS3  = "s3://rasterfoundry-global-artifacts-us-east-1/batch"
-  sparkJar    = "rf-batch-761c316.jar"
+  sparkJar    = ${?BATCH_JAR_PATH}
   sparkClass  = "com.azavea.rf.batch.export.spark.Export"
   sparkMemory = "2G"
 }


### PR DESCRIPTION
## Overview

Fixes issue where edits to the batch jar were not being picked up because the
jar used in spark was hardcoded for export jobs.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

Closes #2741
