### PR TITLE
Explicitly use options in cache client

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/MapTokens.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/MapTokens.scala
@@ -67,12 +67,12 @@ object MapTokens extends TableQuery(tag => new MapTokens(tag)) with LazyLogging 
       .headOption
   }
 
-  def validateMapToken(projectId: UUID, mapTokenId: UUID): DBIO[Int] = {
+  def validateMapToken(projectId: UUID, mapTokenId: UUID): DBIO[Option[MapToken]] = {
     MapTokens
       .filter(_.id === mapTokenId)
       .filter(_.projectId === projectId)
-      .length
       .result
+      .headOption
   }
 
   def listMapTokens(offset: Int, limit: Int, user: User, queryParameters: CombinedMapTokenQueryParameters):ListQueryResult[MapToken] = {

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -52,9 +52,7 @@ trait TileAuthentication extends Authentication
     parameter('mapToken).flatMap { mapToken =>
       val mapTokenId = UUID.fromString(mapToken)
 
-      val doesTokenExist = rfCache.caching(s"project-$projectId-token-$mapToken", 300) {
-        readOneDirect(MapTokens.validateMapToken(projectId, mapTokenId))
-      }
+      val doesTokenExist = readOneDirect(MapTokens.validateMapToken(projectId, mapTokenId))
 
       onSuccess(doesTokenExist).flatMap {
         case 1 => provide(true)

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -52,10 +52,12 @@ trait TileAuthentication extends Authentication
     parameter('mapToken).flatMap { mapToken =>
       val mapTokenId = UUID.fromString(mapToken)
 
-      val doesTokenExist = readOneDirect(MapTokens.validateMapToken(projectId, mapTokenId))
+      val doesTokenExist = rfCache.caching(s"project-$projectId-token-$mapToken", 300) {
+        readOneDirect(MapTokens.validateMapToken(projectId, mapTokenId))
+      }
 
       onSuccess(doesTokenExist).flatMap {
-        case 1 => provide(true)
+        case Some(_) => provide(true)
         case _ => provide(false)
       }
     }


### PR DESCRIPTION
## Overview

From the issue:

There is a regularly encountered issue in the cache client where we do not capture all cases in a [match](https://github.com/raster-foundry/raster-foundry/blob/develop/app-backend/common/src/main/scala/cache/CacheClient.scala#L66) statement. Part of this stems from being flippant about when options can be encountered and not. This task is to change the signature and use `Option` everywhere to help ensure every case is accounted for.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

It will be hard to verify that this actually resolves the problem since it was not consistent across all environments.

## Testing Instructions

 * Get tiles for a project at a bunch of zoom levels are make sure there are no runtime cache errors

Closes #2678
