### PR TITLE
Fix `getBaseUrl` in authService to use current location

### DIFF
--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -171,7 +171,7 @@ export default (app) => {
         }
 
         getBaseURL() {
-            let host = BUILDCONFIG.API_HOST || this.$location.host();
+            let host = this.$location.host();
             let protocol = this.$location.protocol();
             let port = this.$location.port();
             let formattedPort = port !== 80 && port !== 443 ? ':' + port : '';


### PR DESCRIPTION
## Overview

Uses window location instead of the API url within the auth service.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

* build (`yarn run build`)
* start dev server (`yarn run start`)
* serve from a different URL (you can use https://github.com/indexzero/http-server for this: `http-server dist -P http://localhost:9091 -p 8082`)
* try logging in
