### PR TITLE
Add sorting to tool-runs

### DIFF
--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -46,7 +46,7 @@ trait ToolRunRoutes extends Authentication
   def listToolRuns: Route = authenticate { user =>
     (withPagination & toolRunQueryParameters) { (page, runParams) =>
       complete {
-        list(ToolRuns.listToolRuns(page.offset, page.limit, runParams, user), page.offset, page.limit)
+        list(ToolRuns.listToolRuns(page.offset, page.limit, page.sort, runParams, user), page.offset, page.limit)
       }
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ToolRunFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ToolRunFields.scala
@@ -1,0 +1,7 @@
+package com.azavea.rf.database.fields
+
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
+
+trait ToolRunFields { self: Table[_] =>
+  def name: Rep[Option[String]]
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ToolRunFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ToolRunFieldsSort.scala
@@ -1,0 +1,19 @@
+package com.azavea.rf.database.sort
+
+import com.azavea.rf.database.fields.ToolRunFields
+import com.lonelyplanet.akka.http.extensions.Order
+import com.azavea.rf.database.ExtendedPostgresDriver.api._
+
+class ToolRunFieldsSort[E, D <: ToolRunFields](f: E => D) extends QuerySort[E] {
+  def apply[U, C[_]](
+    query: Query[E, U, C],
+    field: String,
+    ord: Order
+  ): Query[E, U, C] = {
+    field match {
+      case "name" =>
+        query.sortBy(f(_).name.byOrder(ord))
+      case _ => query
+    }
+  }
+}

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ToolRuns.scala
@@ -1,21 +1,25 @@
 package com.azavea.rf.database.tables
 
 import java.util.UUID
+import java.util.Date
 import java.sql.Timestamp
 
 import com.typesafe.scalalogging.LazyLogging
 
 import slick.model.ForeignKeyAction
 import slick.dbio.DBIO
+import com.lonelyplanet.akka.http.extensions.Order
 
 import com.azavea.rf.datamodel._
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
+import com.azavea.rf.database.sort._
 import com.azavea.rf.database.fields._
 import com.azavea.rf.database.query._
 
 import io.circe.Json
 
 class ToolRuns(_TableTag: Tag) extends Table[ToolRun](_TableTag, "tool_runs")
+    with ToolRunFields
     with UserFkVisibleFields
     with OrganizationFkFields
     with TimestampFields {
@@ -43,8 +47,46 @@ class ToolRuns(_TableTag: Tag) extends Table[ToolRun](_TableTag, "tool_runs")
 object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
   type TableQuery = Query[ToolRuns, ToolRun, Seq]
 
+  implicit val toolRunsSorter: QuerySorter[ToolRuns] =
+    new QuerySorter(
+      new ToolRunFieldsSort(identity[ToolRuns]),
+      new OrganizationFkSort(identity[ToolRuns]),
+      new VisibilitySort(identity[ToolRuns]),
+      new TimestampSort(identity[ToolRuns])
+    )
+
   implicit class withToolRunsTableQuery[M, U, C[_]](toolruns: ToolRuns.TableQuery) extends
       ToolRunDefaultQuery[M, U, C](toolruns)
+
+  def sortToolRuns(toolRuns: Seq[ToolRun], sort: Map[String, Order])= {
+    sort.keys.headOption match {
+      case Some("name") => {
+        sort.get("name") match {
+          case Some(Order.Asc) =>
+            toolRuns.sortWith((toolRun1, toolRun2) => toolRun1.name.getOrElse("").toLowerCase < toolRun2.name.getOrElse("").toLowerCase)
+          case _ =>
+            toolRuns.sortWith((toolRun1, toolRun2) => toolRun1.name.getOrElse("").toLowerCase > toolRun2.name.getOrElse("").toLowerCase)
+        }
+      }
+      case Some("createdAt") => {
+        sort.get("createdAt") match {
+          case Some(Order.Asc) =>
+            toolRuns.sortWith((toolRun1, toolRun2) => toolRun1.createdAt.before(toolRun2.createdAt))
+          case _ =>
+            toolRuns.sortWith((toolRun1, toolRun2) => toolRun1.createdAt.after(toolRun2.createdAt))
+        }
+      }
+      case Some("modifiedAt") => {
+        sort.get("modifiedAt") match {
+          case Some(Order.Asc) =>
+            toolRuns.sortWith((toolRun1, toolRun2) => toolRun1.modifiedAt.before(toolRun2.modifiedAt))
+          case _ =>
+            toolRuns.sortWith((toolRun1, toolRun2) => toolRun1.modifiedAt.after(toolRun2.modifiedAt))
+        }
+      }
+      case _ => toolRuns
+    }
+  }
 
   def insertToolRun(tr: ToolRun.Create, user: User): DBIO[ToolRun] =
     (ToolRuns returning ToolRuns).forceInsert(tr.toToolRun(user))
@@ -56,13 +98,14 @@ object ToolRuns extends TableQuery(tag => new ToolRuns(tag)) with LazyLogging {
       .result
       .headOption
 
-  def listToolRuns(offset: Int, limit: Int,
-                   toolRunParams: CombinedToolRunQueryParameters, user: User): ListQueryResult[ToolRun] = {
+  def listToolRuns(offset: Int, limit: Int, sort: Map[String, Order], toolRunParams: CombinedToolRunQueryParameters,
+                   user: User): ListQueryResult[ToolRun] = {
     val dropRecords = limit * offset
     val accessibleToolRuns = ToolRuns.filterToOwner(user)
     val toolRunFilterQuery = accessibleToolRuns
       .filterByTimestamp(toolRunParams.timestampParams)
       .filterByToolRunParams(toolRunParams.toolRunParams)
+      .sort(sort)
 
     ListQueryResult[ToolRun](
       (toolRunFilterQuery

--- a/app-frontend/src/app/components/common/sortingHeader/sortingHeader.html
+++ b/app-frontend/src/app/components/common/sortingHeader/sortingHeader.html
@@ -1,0 +1,6 @@
+<a ng-click="$ctrl.onSortChange()">
+  <span ng-transclude></span>
+  <i ng-if="$ctrl.isActive"
+     ng-class="$ctrl.getIconClass()"
+  ></i>
+</a>

--- a/app-frontend/src/app/components/common/sortingHeader/sortingHeader.js
+++ b/app-frontend/src/app/components/common/sortingHeader/sortingHeader.js
@@ -1,0 +1,26 @@
+import sortingHeaderTemplate from './sortingHeader.html';
+
+const sortingHeaderComponent = {
+    templateUrl: sortingHeaderTemplate,
+    controller: 'SortingHeaderController',
+    bindings: {
+        direction: '<',
+        isActive: '<',
+        onSortChange: '&'
+    },
+    transclude: true
+};
+
+class SortingHeaderController {
+    constructor() {
+        'ngInject';
+    }
+
+    getIconClass() {
+        return this.direction === 'asc' ? 'icon-caret-up' : 'icon-caret-down';
+    }
+}
+
+export default angular.module('components.common.sortingHeader', [])
+    .component('rfSortingHeader', sortingHeaderComponent)
+    .controller('SortingHeaderController', SortingHeaderController);

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -68,6 +68,7 @@ export default angular.module('index.components', [
     require('./components/common/datePickerModal/datePickerModal.module.js').name,
     require('./components/common/statusTag/statusTag.module.js').name,
     require('./components/common/search/search.js').name,
+    require('./components/common/sortingHeader/sortingHeader.js').name,
 
 
     // Single components for new domains

--- a/app-frontend/src/app/pages/lab/browse/tools/tools.html
+++ b/app-frontend/src/app/pages/lab/browse/tools/tools.html
@@ -41,8 +41,18 @@
       <!-- Temporarily removed ng-click until after demo done and detail page designed. -->
       <table class="paginated-results-table">
         <tr class="header">
-          <th>Name</th>
-          <th>Last Modified</th>
+          <th>
+            <rf-sorting-header direction="$ctrl.sortingDirection"
+                               on-sort-change="$ctrl.onSortChange('name')"
+                               is-active="$ctrl.sortingField === 'name'"
+            >Name</rf-sorting-header>
+          </th>
+          <th>
+            <rf-sorting-header direction="$ctrl.sortingDirection"
+                               on-sort-change="$ctrl.onSortChange('modifiedAt')"
+                               is-active="$ctrl.sortingField === 'modifiedAt'"
+            >Last Modified</rf-sorting-header>
+          </th>
           <th>Privacy</th>
         </tr>
         <tr ng-repeat="tool in $ctrl.toolList | filter: {title: $ctrl.searchString}">

--- a/app-frontend/src/app/pages/lab/browse/tools/tools.js
+++ b/app-frontend/src/app/pages/lab/browse/tools/tools.js
@@ -8,6 +8,10 @@ class LabBrowseToolsController {
 
     $onInit() {
         this.BUILDCONFIG = BUILDCONFIG;
+        this.sortingField = 'modifiedAt';
+        this.defaultSortingDirection = 'desc';
+        this.sortingDirection = this.defaultSortingDirection;
+
         this.fetchToolList(this.$state.params.page);
     }
 
@@ -16,7 +20,8 @@ class LabBrowseToolsController {
         this.toolService.toolRunQuery(
             {
                 pageSize: 10,
-                page: page - 1
+                page: page - 1,
+                sort: this.serializedSort()
             }
         ).then(d => {
             this.currentPage = page;
@@ -54,6 +59,22 @@ class LabBrowseToolsController {
             return 'Public';
         }
         return 'Private';
+    }
+
+    serializedSort() {
+        return `${this.sortingField},${this.sortingDirection}`;
+    }
+
+    onSortChange(field) {
+        if (field === this.sortingField) {
+            // Toggle sorting direction if the same field is being used
+            this.sortingDirection =
+                this.sortingDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            this.sortingField = field;
+            this.sortingDirection = this.defaultSortingDirection;
+        }
+        this.fetchToolList(this.currentPage);
     }
 }
 

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -12,7 +12,10 @@
     <a href
        class=""
        ui-sref="projects.edit.colormode"
-       ui-sref-active="active"
+       ng-class="{
+         active: ('projects.edit.colormode' | includedByState) ||
+                 ('projects.edit.advancedcolor' | includedByState)
+       }"
        data-title="Color mode">
       <i class="icon-color-correct"></i>
       <span>Color mode</span>

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2868,6 +2868,10 @@ rf-reclassify-table {
   th {
     text-align: left;
     padding: $cell-padding;
+    font-weight: bold;
+    a {
+      font-weight: bold;
+    }
   }
   td {
     padding: $cell-padding;


### PR DESCRIPTION
## Overview

Adds sorting by `name`, `createdAt`, and `modifiedAt` fields to the tool-run list endpoint (`GET /api/tool-runs`).

This is done via the `sort` query parameter. Ex: `sort=createdAt,asc`

This also adds sorting to the front-end tool-run listing UI.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Demo

![image](https://user-images.githubusercontent.com/2442245/33447489-78aa7b9e-d5d1-11e7-9e6e-4020fbddfdea.png)

## Testing Instructions

 * Start up the server
 * Send an header-authorized request to `http://localhost:9091/api/tool-runs?page=0&pageSize=10&sort=modifiedAt,asc`
 * See that the sorting makes sense
 * Try some other sorting
 * Use the front-end to sort

Closes #2754 
Closes #2637
