### PR TITLE
Create modal service to centralize modal state

### DIFF
--- a/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.controller.js
+++ b/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.controller.js
@@ -4,14 +4,14 @@ const sunAzimuthRange = {min: 0, max: 360};
 
 export default class AOIFilterPaneController {
     constructor(
-        $scope, $rootScope, $timeout, $uibModal,
+        $scope, $rootScope, $timeout, modalService,
         datasourceService, authService, moment
     ) {
         'ngInject';
         this.$scope = $scope;
         this.$rootScope = $rootScope;
         this.$timeout = $timeout;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.datasourceService = datasourceService;
         this.authService = authService;
         this.Moment = moment;

--- a/app-frontend/src/app/components/exports/exportItem/exportItem.controller.js
+++ b/app-frontend/src/app/components/exports/exportItem/exportItem.controller.js
@@ -1,8 +1,8 @@
 export default class ExportItemController {
-    constructor($scope, $uibModal, exportService) {
+    constructor($scope, modalService, exportService) {
         'ngInject';
         this.$scope = $scope;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.exportService = exportService;
     }
 
@@ -15,11 +15,7 @@ export default class ExportItemController {
     }
 
     openDownloadModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfExportDownloadModal',
             resolve: {
                 export: () => this.export

--- a/app-frontend/src/app/components/exports/exportItem/exportItem.controller.js
+++ b/app-frontend/src/app/components/exports/exportItem/exportItem.controller.js
@@ -15,7 +15,7 @@ export default class ExportItemController {
     }
 
     openDownloadModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfExportDownloadModal',
             resolve: {
                 export: () => this.export

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
@@ -1,13 +1,13 @@
 /* globals BUILDCONFIG */
 
 export default class MapContainerController {
-    constructor($document, $element, $scope, $timeout, $uibModal, mapService) {
+    constructor($document, $element, $scope, $timeout, modalService, mapService) {
         'ngInject';
         this.$document = $document;
         this.$element = $element;
         this.$scope = $scope;
         this.$timeout = $timeout;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.mapService = mapService;
         this.getMap = () => this.mapService.getMap(this.mapId);
     }
@@ -203,17 +203,11 @@ export default class MapContainerController {
     }
 
     openMapSearchModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
-            component: 'rfMapSearchModal',
-            resolve: { }
-        });
-
-        this.activeModal.result.then(
-            location => {
+        this.modalService
+            .open({
+                component: 'rfMapSearchModal',
+                resolve: { }
+            }).result.then(location => {
                 const mapView = location.mapView;
                 this.map.fitBounds([
                     [mapView.bottomRight.latitude, mapView.bottomRight.longitude],

--- a/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
@@ -1,11 +1,11 @@
 /* global BUILDCONFIG */
 
 export default class ProjectCreateModalController {
-    constructor($state, projectService, $uibModal) {
+    constructor($state, projectService, modalService) {
         'ngInject';
         this.$state = $state;
         this.projectService = projectService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
     }
 
     $onInit() {
@@ -99,20 +99,14 @@ export default class ProjectCreateModalController {
     }
 
     startImport() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
+        this.closeWithData();
 
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 project: () => this.project
             }
         });
-
-        this.closeWithData();
-
-        return this.activeModal;
     }
 
     createProject() {

--- a/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
@@ -101,7 +101,7 @@ export default class ProjectCreateModalController {
     startImport() {
         this.closeWithData();
 
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 project: () => this.project

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
@@ -2,7 +2,7 @@ import projectPlaceholder from '../../../../assets/images/transparent.svg';
 
 export default class ProjectItemController {
     constructor($scope, $state, $attrs, $log, projectService, mapService, mapUtilsService,
-                authService, $uibModal) {
+                authService, modalService) {
         'ngInject';
         this.$scope = $scope;
         this.$state = $state;
@@ -11,7 +11,7 @@ export default class ProjectItemController {
         this.mapService = mapService;
         this.mapUtilsService = mapUtilsService;
         this.authService = authService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$log = $log;
 
         this.projectPlaceholder = projectPlaceholder;
@@ -74,11 +74,7 @@ export default class ProjectItemController {
     }
 
     publishModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfProjectPublishModal',
             resolve: {
                 project: () => this.project,
@@ -86,14 +82,9 @@ export default class ProjectItemController {
                 shareUrl: () => this.projectService.getProjectShareURL(this.project)
             }
         });
-
-        return this.activeModal;
     }
     deleteModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-        this.activeModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
                 title: () => 'Delete Project?',
@@ -109,16 +100,18 @@ export default class ProjectItemController {
                 cancelText: () => 'Cancel'
             }
         });
-        this.activeModal.result.then(
-            () => {
-                this.projectService.deleteProject(this.project.id).then(
-                    () => {
-                        this.$state.reload();
-                    },
-                    (err) => {
-                        this.$log.debug('error deleting project', err);
-                    }
-                );
-            });
+
+        modal.result.then(() => {
+            this.projectService.deleteProject(this.project.id).then(
+                () => {
+                    this.$state.reload();
+                },
+                (err) => {
+                    this.$log.debug('error deleting project', err);
+                }
+            );
+        });
+
+        return modal;
     }
 }

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
@@ -74,7 +74,7 @@ export default class ProjectItemController {
     }
 
     publishModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfProjectPublishModal',
             resolve: {
                 project: () => this.project,
@@ -111,7 +111,5 @@ export default class ProjectItemController {
                 }
             );
         });
-
-        return modal;
     }
 }

--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.controller.js
@@ -1,12 +1,13 @@
 export default class ProjectPublishModalController {
-    constructor($q, projectService, $log, tokenService, authService, $uibModal, $window, $state) {
+    constructor($q, projectService, $log, tokenService, authService,
+                modalService, $window, $state) {
         'ngInject';
 
         this.authService = authService;
         this.projectService = projectService;
         this.$log = $log;
         this.tokenService = tokenService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$q = $q;
         this.$window = $window;
         this.$state = $state;

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -16,14 +16,14 @@ const SceneDetailModalComponent = {
 
 class SceneDetailModalController {
     constructor(
-        $log, $state, $uibModal, $scope,
+        $log, $state, modalService, $scope,
         moment, sceneService, datasourceService, mapService,
         authService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$scope = $scope;
         this.Moment = moment;
         this.sceneService = sceneService;
@@ -63,16 +63,12 @@ class SceneDetailModalController {
             images: images
         }];
 
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneDownloadModal',
             resolve: {
                 downloads: () => downloadSets
             }
         });
-
-        this.dismiss();
-
-        return this.activeModal;
     }
 
     getSceneBounds() {
@@ -124,22 +120,16 @@ class SceneDetailModalController {
     }
 
     openDatePickerModal(date) {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
-            component: 'rfDatePickerModal',
-            windowClass: 'auto-width-modal',
-            resolve: {
-                config: () => Object({
-                    selectedDay: this.Moment(date)
-                })
-            }
-        });
-
-        this.activeModal.result.then(
-            selectedDay => {
+        this.modalService
+            .open({
+                component: 'rfDatePickerModal',
+                windowClass: 'auto-width-modal',
+                resolve: {
+                    config: () => Object({
+                        selectedDay: this.Moment(date)
+                    })
+                }
+            }).result.then(selectedDay => {
                 this.updateAcquisitionDate(selectedDay);
             });
     }

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -63,7 +63,7 @@ class SceneDetailModalController {
             images: images
         }];
 
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneDownloadModal',
             resolve: {
                 downloads: () => downloadSets

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -1,12 +1,12 @@
 /* globals _*/
 export default class FilterPaneController {
-    constructor($scope, $rootScope, $timeout, $uibModal,
+    constructor($scope, $rootScope, $timeout, modalService,
         datasourceService, authService, moment) {
         'ngInject';
         this.$scope = $scope;
         this.$rootScope = $rootScope;
         this.$timeout = $timeout;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.datasourceService = datasourceService;
         this.authService = authService;
         this.Moment = moment;
@@ -324,11 +324,7 @@ export default class FilterPaneController {
     }
 
     openDateRangePickerModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfDateRangePickerModal',
             resolve: {
                 config: () => Object({
@@ -338,11 +334,12 @@ export default class FilterPaneController {
             }
         });
 
-        this.activeModal.result.then(
-            range => {
-                if (range) {
-                    this.setDateRange(range.start, range.end, range.preset);
-                }
-            });
+        modal.result.then(range => {
+            if (range) {
+                this.setDateRange(range.start, range.end, range.preset);
+            }
+        });
+
+        return modal;
     }
 }

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -339,7 +339,5 @@ export default class FilterPaneController {
                 this.setDateRange(range.start, range.end, range.preset);
             }
         });
-
-        return modal;
     }
 }

--- a/app-frontend/src/app/components/scenes/sceneList/sceneList.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneList/sceneList.controller.js
@@ -1,13 +1,13 @@
 export default class SceneListController {
     constructor( // eslint-disable-line max-params
-        $log, sceneService, $state, authService, $uibModal
+        $log, sceneService, $state, authService, modalService
     ) {
         'ngInject';
         this.$log = $log;
         this.sceneService = sceneService;
         this.$state = $state;
         this.authService = authService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
     }
 
     $onInit() {
@@ -67,11 +67,7 @@ export default class SceneListController {
     }
 
     viewSceneDetail(scene) {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {
                 scene: () => scene
@@ -80,21 +76,13 @@ export default class SceneListController {
     }
 
     importModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {}
         });
     }
 
     downloadModal(scene) {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
         let images = scene.images.map((image) => {
             return {
                 filename: image.filename,
@@ -109,7 +97,7 @@ export default class SceneListController {
             images: images
         }];
 
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneDownloadModal',
             resolve: {
                 downloads: () => downloadSets
@@ -118,11 +106,7 @@ export default class SceneListController {
     }
 
     deleteModal(scene) {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
                 title: () => 'Delete Imported Scene?',
@@ -139,17 +123,18 @@ export default class SceneListController {
             }
         });
 
-        this.activeModal.result.then(
-            () => {
-                this.sceneService.deleteScene(scene).then(
-                    () => {
-                        this.$state.reload();
-                    },
-                    (err) => {
-                        this.$log.debug('error deleting scene', err);
-                    }
-                );
-            });
+        modal.result.then(() => {
+            this.sceneService.deleteScene(scene).then(
+                () => {
+                    this.$state.reload();
+                },
+                (err) => {
+                    this.$log.debug('error deleting scene', err);
+                }
+            );
+        });
+
+        return modal;
     }
 
     shouldShowSceneList() {

--- a/app-frontend/src/app/components/scenes/sceneList/sceneList.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneList/sceneList.controller.js
@@ -67,7 +67,7 @@ export default class SceneListController {
     }
 
     viewSceneDetail(scene) {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {
                 scene: () => scene
@@ -76,7 +76,7 @@ export default class SceneListController {
     }
 
     importModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {}
         });
@@ -97,7 +97,7 @@ export default class SceneListController {
             images: images
         }];
 
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneDownloadModal',
             resolve: {
                 downloads: () => downloadSets
@@ -133,8 +133,6 @@ export default class SceneListController {
                 }
             );
         });
-
-        return modal;
     }
 
     shouldShowSceneList() {

--- a/app-frontend/src/app/components/settings/tokenItem/tokenItem.controller.js
+++ b/app-frontend/src/app/components/settings/tokenItem/tokenItem.controller.js
@@ -34,7 +34,7 @@ export default class TokenItem {
     }
 
     publishModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfProjectPublishModal',
             resolve: {
                 project: () => this.project,

--- a/app-frontend/src/app/components/settings/tokenItem/tokenItem.controller.js
+++ b/app-frontend/src/app/components/settings/tokenItem/tokenItem.controller.js
@@ -1,8 +1,8 @@
 export default class TokenItem {
-    constructor(projectService, $uibModal) {
+    constructor(projectService, modalService) {
         'ngInject';
         this.projectService = projectService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
     }
 
     $onInit() {
@@ -34,11 +34,7 @@ export default class TokenItem {
     }
 
     publishModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfProjectPublishModal',
             resolve: {
                 project: () => this.project,
@@ -46,7 +42,5 @@ export default class TokenItem {
                 shareUrl: () => this.projectService.getProjectShareURL(this.project)
             }
         });
-
-        return this.activeModal;
     }
 }

--- a/app-frontend/src/app/components/tools/classifyNode/classifyNode.module.js
+++ b/app-frontend/src/app/components/tools/classifyNode/classifyNode.module.js
@@ -105,8 +105,6 @@ class ClassifyNodeController {
                 hard: true
             });
         });
-
-        return modal;
     }
 }
 

--- a/app-frontend/src/app/components/tools/classifyNode/classifyNode.module.js
+++ b/app-frontend/src/app/components/tools/classifyNode/classifyNode.module.js
@@ -14,12 +14,12 @@ const ClassifyNodeComponent = {
 
 class ClassifyNodeController {
     constructor(
-        $log, $scope, $ngRedux, $uibModal,
+        $log, $scope, $ngRedux, modalService,
         reclassifyService, toolService
     ) {
         'ngInject';
         this.$log = $log;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.reclassifyService = reclassifyService;
         this.toolService = toolService;
 
@@ -86,7 +86,7 @@ class ClassifyNodeController {
     }
 
     showReclassifyModal() {
-        this.activeModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfReclassifyModal',
             resolve: {
                 breaks: () => this.breaks.map(b => Object.assign({}, b)),
@@ -94,7 +94,7 @@ class ClassifyNodeController {
             }
         });
 
-        this.activeModal.result.then(breaks => {
+        modal.result.then(breaks => {
             const classmap = this.breaksToClassmap(breaks);
             this.updateNode({
                 payload: Object.assign({}, this.node, {
@@ -105,6 +105,8 @@ class ClassifyNodeController {
                 hard: true
             });
         });
+
+        return modal;
     }
 }
 

--- a/app-frontend/src/app/components/tools/inputNode/inputNode.module.js
+++ b/app-frontend/src/app/components/tools/inputNode/inputNode.module.js
@@ -15,11 +15,11 @@ const InputNodeComponent = {
 
 class InputNodeController {
     constructor(
-        $uibModal, $scope, $ngRedux, $log,
+        modalService, $scope, $ngRedux, $log,
         projectService, toolService
     ) {
         'ngInject';
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$scope = $scope;
         this.$log = $log;
         this.projectService = projectService;
@@ -84,28 +84,23 @@ class InputNodeController {
     }
 
     selectProjectModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
-            component: 'rfProjectSelectModal',
-            resolve: {
-                project: () => this.selectedProject && this.selectedProject.id || false,
-                content: () => ({title: 'Select a project'})
-            }
-        });
-
-        this.activeModal.result.then(project => {
-            this.selectedProject = project;
-            this.checkValidity();
-            this.updateNode({
-                payload: Object.assign({}, this.node, {
-                    projId: project.id
-                }),
-                hard: !this.toolErrors.size
+        this.modalService
+            .open({
+                component: 'rfProjectSelectModal',
+                resolve: {
+                    project: () => this.selectedProject && this.selectedProject.id || false,
+                    content: () => ({title: 'Select a project'})
+                }
+            }).result.then(project => {
+                this.selectedProject = project;
+                this.checkValidity();
+                this.updateNode({
+                    payload: Object.assign({}, this.node, {
+                        projId: project.id
+                    }),
+                    hard: !this.toolErrors.size
+                });
             });
-        });
     }
 
     onBandChange() {

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -3,7 +3,7 @@ function runBlock(
     $rootScope, jwtHelper, $state, $location, $window, APP_CONFIG,
     $ngRedux, $timeout,
     authService, localStorage, rollbarWrapperService, intercomService,
-    featureFlags, perUserFeatureFlags
+    featureFlags, perUserFeatureFlags, modalService
 ) {
     'ngInject';
     let flagsPromise;
@@ -56,6 +56,9 @@ function runBlock(
         function setupState() {
             let idToken = localStorage.get('idToken');
             let accessToken = localStorage.get('accessToken');
+
+            modalService.closeActiveModal();
+
             if (idToken && accessToken) {
                 if (!authService.verifyAuthCache()) {
                     rollbarWrapperService.init();

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -1,10 +1,10 @@
 /* global BUILDCONFIG HELPCONFIG */
 
 class HomeController {
-    constructor(authService, $uibModal, feedService) {
+    constructor(authService, modalService, feedService) {
         'ngInject';
         this.authService = authService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.feedService = feedService;
     }
 
@@ -16,32 +16,14 @@ class HomeController {
         });
     }
 
-    $onDestroy() {
-
-    }
-
     openCreateProjectModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfProjectCreateModal'
         });
-
-        this.activeModal.result.then(() => {
-
-        });
-
-        return this.activeModal;
     }
 
     openToolCreateModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfToolCreateModal'
         });
     }

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -17,13 +17,13 @@ class HomeController {
     }
 
     openCreateProjectModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfProjectCreateModal'
         });
     }
 
     openToolCreateModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfToolCreateModal'
         });
     }

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.controller.js
@@ -38,7 +38,7 @@ class DatasourceDetailController {
     }
 
     openImportModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 datasource: () => this.datasource

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.controller.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.controller.js
@@ -2,10 +2,10 @@
 
 class DatasourceDetailController {
     constructor(
-        $stateParams, $uibModal, datasourceService
+        $stateParams, modalService, datasourceService
     ) {
         'ngInject';
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.datasourceId = $stateParams.datasourceid;
         this.datasourceService = datasourceService;
     }
@@ -38,22 +38,12 @@ class DatasourceDetailController {
     }
 
     openImportModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 datasource: () => this.datasource
             }
         });
-
-        this.activeModal.result.then(() => {
-
-        });
-
-        return this.activeModal;
     }
 
     saveColorCorrection() {

--- a/app-frontend/src/app/pages/imports/imports.controller.js
+++ b/app-frontend/src/app/pages/imports/imports.controller.js
@@ -1,34 +1,20 @@
 /* global BUILDCONFIG */
 
 class ImportsController {
-    constructor(authService, $uibModal) {
+    constructor(authService, modalService) {
         'ngInject';
         this.authService = authService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
     }
 
     $onInit() {
         this.BUILDCONFIG = BUILDCONFIG;
     }
 
-    $onDestroy() {
-
-    }
-
     openCreateDatasourceModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfDatasourceCreateModal'
         });
-
-        this.activeModal.result.then(() => {
-
-        });
-
-        return this.activeModal;
     }
 
 }

--- a/app-frontend/src/app/pages/imports/imports.controller.js
+++ b/app-frontend/src/app/pages/imports/imports.controller.js
@@ -12,7 +12,7 @@ class ImportsController {
     }
 
     openCreateDatasourceModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfDatasourceCreateModal'
         });
     }

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.js
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.js
@@ -180,7 +180,7 @@ class LabBrowseTemplatesController {
     }
 
     openToolCreateModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfToolCreateModal'
         });
     }

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.js
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.js
@@ -2,7 +2,7 @@
 
 class LabBrowseTemplatesController {
     constructor( // eslint-disable-line max-params
-        $log, $scope, $state, toolService, toolTagService, toolCategoryService, $uibModal
+        $log, $scope, $state, toolService, toolTagService, toolCategoryService, modalService
     ) {
         'ngInject';
         this.toolService = toolService;
@@ -11,7 +11,7 @@ class LabBrowseTemplatesController {
         this.$scope = $scope;
         this.$state = $state;
         this.$log = $log;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
     }
 
     $onInit() {
@@ -21,12 +21,6 @@ class LabBrowseTemplatesController {
         this.fetchToolTags();
         this.fetchToolCategories();
         this.searchString = '';
-
-        this.$scope.$on('$destroy', () => {
-            if (this.activeModal) {
-                this.activeModal.dismiss();
-            }
-        });
     }
 
     initFilters() {
@@ -186,10 +180,7 @@ class LabBrowseTemplatesController {
     }
 
     openToolCreateModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfToolCreateModal'
         });
     }

--- a/app-frontend/src/app/pages/lab/navbar/navbar.controller.js
+++ b/app-frontend/src/app/pages/lab/navbar/navbar.controller.js
@@ -1,12 +1,12 @@
 import * as LabActions from '../../../redux/actions/lab-actions';
 
 export default class LabNavbarController {
-    constructor(toolService, $state, $uibModal, $ngRedux, $scope) {
+    constructor(toolService, $state, modalService, $ngRedux, $scope) {
         'ngInject';
 
         this.toolService = toolService;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$ngRedux = $ngRedux;
 
         let unsubscribe = $ngRedux.connect(this.mapStateToThis, LabActions)(this);

--- a/app-frontend/src/app/pages/lab/tool/tool.js
+++ b/app-frontend/src/app/pages/lab/tool/tool.js
@@ -5,7 +5,7 @@ import NodeActions from '../../../redux/actions/node-actions';
 
 class LabToolController {
     constructor(
-        $ngRedux, $scope, $rootScope, $state, $timeout, $element, $window, $document, $uibModal,
+        $ngRedux, $scope, $rootScope, $state, $timeout, $element, $window, $document, modalService,
         mapService, projectService, authService, mapUtilsService, toolService, tokenService,
         APP_CONFIG
     ) {
@@ -17,7 +17,7 @@ class LabToolController {
         this.$element = $element;
         this.$window = $window;
         this.$document = $document;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
 
         let unsubscribe = $ngRedux.connect(
             this.mapStateToThis,
@@ -165,12 +165,8 @@ class LabToolController {
     }
 
     publishModal(tileUrl) {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
         if (tileUrl) {
-            this.activeModal = this.$uibModal.open({
+            return this.modalService.open({
                 component: 'rfProjectPublishModal',
                 resolve: {
                     tileUrl: () => tileUrl,
@@ -179,7 +175,7 @@ class LabToolController {
                 }
             });
         }
-        return this.activeModal;
+        return false;
     }
 
     fitProjectExtent(project) {

--- a/app-frontend/src/app/pages/lab/tool/tool.js
+++ b/app-frontend/src/app/pages/lab/tool/tool.js
@@ -166,7 +166,7 @@ class LabToolController {
 
     publishModal(tileUrl) {
         if (tileUrl) {
-            return this.modalService.open({
+            this.modalService.open({
                 component: 'rfProjectPublishModal',
                 resolve: {
                     tileUrl: () => tileUrl,

--- a/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.controller.js
@@ -42,7 +42,7 @@ const addMethods = [
 
 export default class AOIParametersController {
     constructor(
-        $log, $q, $scope, $state, $uibModal, $timeout,
+        $log, $q, $scope, $state, modalService, $timeout,
         moment, projectService, aoiService, authService, mapService,
         projectEditService
     ) {
@@ -53,7 +53,7 @@ export default class AOIParametersController {
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.Moment = moment;
         this.updateFrequencies = updateFrequencies;
         this.projectService = projectService;
@@ -216,22 +216,16 @@ export default class AOIParametersController {
     }
 
     openDatePickerModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
-            component: 'rfDatePickerModal',
-            windowClass: 'auto-width-modal',
-            resolve: {
-                config: () => Object({
-                    selectedDay: this.aoiProjectParameters.aoisLastChecked
-                })
-            }
-        });
-
-        this.activeModal.result.then(
-            selectedDay => {
+        this.modalService
+            .open({
+                component: 'rfDatePickerModal',
+                windowClass: 'auto-width-modal',
+                resolve: {
+                    config: () => Object({
+                        selectedDay: this.aoiProjectParameters.aoisLastChecked
+                    })
+                }
+            }).result.then(selectedDay => {
                 this.updateStartDate(selectedDay);
             });
     }

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 export default class ProjectAddScenesBrowseController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $uibModal, $scope, $timeout, mapService, sceneService,
+        $log, $state, modalService, $scope, $timeout, mapService, sceneService,
         projectService, gridLayerService, sessionStorage
     ) {
         'ngInject';
@@ -12,7 +12,7 @@ export default class ProjectAddScenesBrowseController {
         this.$parent = $scope.$parent.$ctrl;
         this.$log = $log;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$scope = $scope;
         this.$timeout = $timeout;
         this.sceneService = sceneService;
@@ -428,27 +428,21 @@ export default class ProjectAddScenesBrowseController {
             return;
         }
 
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
-            component: 'rfProjectAddScenesModal',
-            resolve: {
-                scenes: () => this.selectedScenes,
-                selectScene: () => this.setSelected.bind(this),
-                selectNoScenes: () => this.selectNoScenes.bind(this),
-                project: () => this.project
-            }
-        });
-
-        this.activeModal.result.then(sceneIds => {
-            this.projectSceneIds = this.projectSceneIds.concat(sceneIds);
-            this.selectNoScenes();
-        }).finally(() => {
-            delete this.activeModal;
-            this.$parent.getSceneList();
-        });
+        this.modalService
+            .open({
+                component: 'rfProjectAddScenesModal',
+                resolve: {
+                    scenes: () => this.selectedScenes,
+                    selectScene: () => this.setSelected.bind(this),
+                    selectNoScenes: () => this.selectNoScenes.bind(this),
+                    project: () => this.project
+                }
+            }).result.then(sceneIds => {
+                this.projectSceneIds = this.projectSceneIds.concat(sceneIds);
+                this.selectNoScenes();
+            }).finally(() => {
+                this.$parent.getSceneList();
+            });
     }
 
     openDetailPane(scene) {
@@ -502,11 +496,7 @@ export default class ProjectAddScenesBrowseController {
     }
 
     openSceneDetailModal(scene) {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {
                 scene: () => scene

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
@@ -496,7 +496,7 @@ export default class ProjectAddScenesBrowseController {
     }
 
     openSceneDetailModal(scene) {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {
                 scene: () => scene

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -2,7 +2,7 @@ import {Map} from 'immutable';
 
 export default class ProjectsEditController {
     constructor( // eslint-disable-line max-params
-        $log, $q, $state, $scope, $uibModal, $timeout,
+        $log, $q, $state, $scope, modalService, $timeout,
         authService, projectService, projectEditService,
         mapService, mapUtilsService, layerService,
         datasourceService, imageOverlayService, thumbnailService
@@ -12,7 +12,7 @@ export default class ProjectsEditController {
         this.$q = $q;
         this.$state = $state;
         this.$scope = $scope;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.authService = authService;
         this.projectService = projectService;
         this.projectEditService = projectEditService;
@@ -25,12 +25,6 @@ export default class ProjectsEditController {
     }
 
     $onInit() {
-        this.$scope.$on('$destroy', () => {
-            if (this.activeModal) {
-                this.activeModal.dismiss();
-            }
-        });
-
         this.mosaicLayer = new Map();
         this.sceneLayers = new Map();
         this.projectId = this.$state.params.projectid;
@@ -242,11 +236,7 @@ export default class ProjectsEditController {
     }
 
     publishModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfProjectPublishModal',
             resolve: {
                 project: () => this.project,
@@ -257,14 +247,10 @@ export default class ProjectsEditController {
     }
 
     openExportModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.getMap().then(m => {
+        return this.getMap().then(m => {
             return m.map.getZoom();
         }).then(zoom => {
-            this.activeModal = this.$uibModal.open({
+            return this.modalService.open({
                 component: 'rfProjectExportModal',
                 resolve: {
                     project: () => this.project,

--- a/app-frontend/src/app/pages/projects/edit/edit.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.controller.js
@@ -236,7 +236,7 @@ export default class ProjectsEditController {
     }
 
     publishModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfProjectPublishModal',
             resolve: {
                 project: () => this.project,
@@ -250,7 +250,7 @@ export default class ProjectsEditController {
         return this.getMap().then(m => {
             return m.map.getZoom();
         }).then(zoom => {
-            return this.modalService.open({
+            this.modalService.open({
                 component: 'rfProjectExportModal',
                 resolve: {
                     project: () => this.project,

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.controller.js
@@ -1,11 +1,11 @@
 export default class ProjectsScenesController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $scope, $uibModal, projectService
+        $log, $state, $scope, modalService, projectService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.projectId = $state.params.projectid;
         this.$parent = $scope.$parent.$ctrl;
         this.projectService = projectService;
@@ -28,11 +28,7 @@ export default class ProjectsScenesController {
     openSceneDetailModal(scene) {
         this.$parent.removeHoveredScene();
 
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {
                 scene: () => scene
@@ -42,21 +38,11 @@ export default class ProjectsScenesController {
 
 
     openImportModal() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-
-        this.activeModal = this.$uibModal.open({
+        return this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 project: () => this.project
             }
         });
-
-        this.activeModal.result.then(() => {
-
-        });
-
-        return this.activeModal;
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.controller.js
@@ -28,7 +28,7 @@ export default class ProjectsScenesController {
     openSceneDetailModal(scene) {
         this.$parent.removeHoveredScene();
 
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {
                 scene: () => scene
@@ -38,7 +38,7 @@ export default class ProjectsScenesController {
 
 
     openImportModal() {
-        return this.modalService.open({
+        this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 project: () => this.project

--- a/app-frontend/src/app/pages/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/projects/list/list.controller.js
@@ -104,8 +104,6 @@ class ProjectsListController {
                 this.populateProjectList(1);
             }
         });
-
-        return modal;
     }
 }
 

--- a/app-frontend/src/app/pages/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/projects/list/list.controller.js
@@ -2,12 +2,12 @@
 
 class ProjectsListController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $uibModal, $scope, projectService, userService
+        $log, $state, modalService, $scope, projectService, userService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.projectService = projectService;
         this.userService = userService;
         this.$scope = $scope;
@@ -95,21 +95,17 @@ class ProjectsListController {
     }
 
     createNewProject() {
-        if (this.newProjectModal) {
-            this.newProjectModal.dismiss();
-        }
-
-        this.newProjectModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfProjectCreateModal'
         });
 
-        this.newProjectModal.result.then((data) => {
+        modal.result.then((data) => {
             if (data && data.reloadProjectList) {
                 this.populateProjectList(1);
             }
         });
 
-        return this.newProjectModal;
+        return modal;
     }
 }
 

--- a/app-frontend/src/app/pages/projects/navbar/navbar.controller.js
+++ b/app-frontend/src/app/pages/projects/navbar/navbar.controller.js
@@ -1,11 +1,11 @@
 export default class ProjectsNavbarController {
-    constructor(projectService, projectEditService, $state, $uibModal, $scope) {
+    constructor(projectService, projectEditService, $state, modalService, $scope) {
         'ngInject';
 
         this.projectService = projectService;
         this.projectEditService = projectEditService;
         this.$state = $state;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$scope = $scope;
     }
 

--- a/app-frontend/src/app/pages/settings/connections/connections.controller.js
+++ b/app-frontend/src/app/pages/settings/connections/connections.controller.js
@@ -111,8 +111,6 @@ class ConnectionsController {
         modal.result.then(() => {
             this.connectToDropbox();
         });
-
-        return modal;
     }
 
     onDropboxError(uri) {

--- a/app-frontend/src/app/pages/settings/connections/connections.controller.js
+++ b/app-frontend/src/app/pages/settings/connections/connections.controller.js
@@ -5,7 +5,7 @@ import planetLogo from '../../../../assets/images/planet-logo-light.png';
 
 class ConnectionsController {
     constructor(
-        $log, $state, $interval, $uibModal, $location,
+        $log, $state, $interval, modalService, $location,
         dropboxService, authService, userService, APP_CONFIG
     ) {
         'ngInject';
@@ -13,7 +13,7 @@ class ConnectionsController {
         this.$log = $log;
         this.$state = $state;
         this.$interval = $interval;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$location = $location;
         this.config = APP_CONFIG;
 
@@ -93,10 +93,7 @@ class ConnectionsController {
     }
 
     reconnectToDropbox() {
-        if (this.activeModal) {
-            this.activeModal.dismiss();
-        }
-        this.activeModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
                 title: () => 'Reconnect to Dropbox?',
@@ -110,15 +107,18 @@ class ConnectionsController {
                 cancelText: () => 'Cancel'
             }
         });
-        this.activeModal.result.then(
-            () => {
-                this.connectToDropbox();
-            });
+
+        modal.result.then(() => {
+            this.connectToDropbox();
+        });
+
+        return modal;
     }
 
     onDropboxError(uri) {
-        this.$log.log(uri);
-        this.activeModal = this.$uibModal.open({
+        this.$log.error('Dropbox setup failed.', uri);
+
+        const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
                 title: () => 'Dropbox Error',
@@ -131,7 +131,8 @@ class ConnectionsController {
                 cancelText: () => 'Cancel'
             }
         });
-        this.activeModal.result.then(() => {
+
+        modal.result.then(() => {
             this.connectToDropbox();
         });
     }
@@ -139,35 +140,18 @@ class ConnectionsController {
     onDropboxCallback(uri) {
         this.dropboxService.confirmCode(uri).then(() => {
             this.dropboxConnected = true;
-        }, () => {
-            this.$log.error('Dropbox setup failed.', uri);
-            this.activeModal = this.$uibModal.open({
-                component: 'rfConfirmationModal',
-                resolve: {
-                    title: () => 'API Error',
-                    subtitle: () => '',
-                    content: () =>
-                        '<div class="text-center color-danger">' +
-                        'There was an error while connecting your account to dropbox' +
-                        '</div>',
-                    confirmText: () => 'Try Again',
-                    cancelText: () => 'Cancel'
-                }
-            });
-            this.activeModal.result.then(() => {
-                this.connectToDropbox();
-            });
-        });
+        }, () => this.onDropboxError(uri));
     }
 
     connectToPlanet() {
-        this.activeModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfEnterTokenModal',
             resolve: {
                 title: () => 'Enter your Planet API Token'
             }
         });
-        this.activeModal.result.then((token) => {
+
+        modal.result.then((token) => {
             this.userService.updatePlanetToken(token).then(() => {
                 this.user.planetCredential = true;
             }, (err) => {

--- a/app-frontend/src/app/pages/settings/tokens/api/api.controller.js
+++ b/app-frontend/src/app/pages/settings/tokens/api/api.controller.js
@@ -1,11 +1,11 @@
 class ApiTokensController {
-    constructor($log, $uibModal, $stateParams, $state, tokenService, authService, APP_CONFIG) {
+    constructor($log, modalService, $stateParams, $state, tokenService, authService, APP_CONFIG) {
         'ngInject';
         this.$log = $log;
 
         this.tokenService = tokenService;
         this.authService = authService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.$stateParams = $stateParams;
         this.APP_CONFIG = APP_CONFIG;
         this.$state = $state;
@@ -19,7 +19,7 @@ class ApiTokensController {
             this.tokenService
                 .createApiToken(this.$stateParams.code)
                 .then((authResult) => {
-                    this.$uibModal.open({
+                    this.modalService.open({
                         component: 'rfRefreshTokenModal',
                         resolve: {
                             refreshToken: () => authResult.refresh_token,
@@ -47,7 +47,7 @@ class ApiTokensController {
 
     createToken(name) {
         this.authService.createRefreshToken(name).then((authResult) => {
-            this.$uibModal.open({
+            this.modalService.open({
                 component: 'rfRefreshTokenModal',
                 resolve: {
                     refreshToken: () => authResult.refreshToken,
@@ -64,7 +64,8 @@ class ApiTokensController {
 
     deleteToken(token) {
         let id = token.id;
-        let deleteModal = this.$uibModal.open({
+
+        const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
                 title: () => 'Delete refresh token?',
@@ -74,18 +75,18 @@ class ApiTokensController {
                 cancelText: () => 'Cancel'
             }
         });
-        deleteModal.result.then(
-            () => {
-                this.tokenService.deleteApiToken({id: id}).then(
-                    () => {
-                        this.fetchTokens();
-                    },
-                    (err) => {
-                        this.$log.debug('error deleting refresh token', err);
-                        this.fetchTokens();
-                    }
-                );
-            });
+
+        modal.result.then(() => {
+            this.tokenService.deleteApiToken({id: id}).then(
+                () => {
+                    this.fetchTokens();
+                },
+                (err) => {
+                    this.$log.debug('error deleting refresh token', err);
+                    this.fetchTokens();
+                }
+            );
+        });
     }
 }
 

--- a/app-frontend/src/app/pages/settings/tokens/map/map.controller.js
+++ b/app-frontend/src/app/pages/settings/tokens/map/map.controller.js
@@ -1,12 +1,12 @@
 class MapTokensController {
-    constructor($log, $q, $uibModal, tokenService, authService) {
+    constructor($log, $q, modalService, tokenService, authService) {
         'ngInject';
         this.$log = $log;
         this.$q = $q;
 
         this.tokenService = tokenService;
         this.authService = authService;
-        this.$uibModal = $uibModal;
+        this.modalService = modalService;
         this.loading = true;
 
         this.fetchTokens();
@@ -33,7 +33,7 @@ class MapTokensController {
     }
 
     deleteToken(token) {
-        let deleteModal = this.$uibModal.open({
+        const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
                 title: () => 'Delete map token?',
@@ -43,18 +43,18 @@ class MapTokensController {
                 cancelText: () => 'Cancel'
             }
         });
-        deleteModal.result.then(
-            () => {
-                this.tokenService.deleteMapToken({id: token.id}).then(
-                    () => {
-                        this.fetchTokens();
-                    },
-                    (err) => {
-                        this.$log.debug('error deleting map token', err);
-                        this.fetchTokens();
-                    }
-                );
-            });
+
+        modal.result.then(() => {
+            this.tokenService.deleteMapToken({id: token.id}).then(
+                () => {
+                    this.fetchTokens();
+                },
+                (err) => {
+                    this.$log.debug('error deleting map token', err);
+                    this.fetchTokens();
+                }
+            );
+        });
     }
 
     updateToken(token, name) {

--- a/app-frontend/src/app/services/common/modal.service.js
+++ b/app-frontend/src/app/services/common/modal.service.js
@@ -1,0 +1,26 @@
+export default (app) => {
+    class ModalService {
+        constructor($uibModal) {
+            this.$uibModal = $uibModal;
+            this.activeModal = false;
+        }
+
+        open(modalConfig, closeActive = true) {
+            if (closeActive) {
+                this.closeActiveModal();
+            }
+
+            const modal = this.$uibModal.open(modalConfig);
+            this.activeModal = modal;
+            return modal;
+        }
+
+        closeActiveModal() {
+            if (this.activeModal) {
+                this.activeModal.dismiss();
+            }
+        }
+    }
+
+    app.service('modalService', ModalService);
+};

--- a/app-frontend/src/app/services/services.module.js
+++ b/app-frontend/src/app/services/services.module.js
@@ -58,6 +58,7 @@ require('./common/mousetip.service')(shared);
 require('./common/feed.service')(shared);
 require('./common/thumbnail.service')(shared);
 require('./common/decimal.filter')(shared);
+require('./common/modal.service')(shared);
 
 
 export default shared;


### PR DESCRIPTION
## Overview

This PR adds a modal service that manages the state of modals across the application. This allows for some simpler flows when it comes to using modals.

The service has two main methods: `open` and `closeActiveModal`.

**`open(modalConfig, closeActive = true)`**
This is used exactly like the original call to `$uibModal.open`. Calling the method through the service allows the service to keep track of the modal. By default this closes any other active modal. Passing `false` to `closeActive` keeps any currently open modal open.

**`closeActiveModal()`**
This dismisses the active modal.

We can now leverage this service to globally close any modal on location change, which eliminates the remnant modal problems when the user hits back with a modal open, or is forced to logout when a modal is open. In addition, this eliminates a bit of duplicated code as each controller no longer needs to manually close or keep track of active modals.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

If a call to `open` passes `false` to `closeActive` and the previously active modal is not properly managed, you could end up with an orphaned modal. This could be dealt with by keeping track of previously active modals at the service level but for now seems like a premature optimization as all of our calls to `open` do not override this default param.

## Testing Instructions

 * Spot test a few of the modals within the app -> make sure they open as expected and that when you hit the back or forward buttons that the modal is dismissed
 * Make sure to test a few of the multi-stage modals (project creation is one)

Closes #2597
