### PR TITLE
Store analysis sort order in local storage

### DIFF
--- a/app-frontend/src/app/pages/lab/browse/tools/tools.html
+++ b/app-frontend/src/app/pages/lab/browse/tools/tools.html
@@ -39,7 +39,7 @@
       </div>
 
       <!-- Temporarily removed ng-click until after demo done and detail page designed. -->
-      <table class="paginated-results-table">
+      <table class="paginated-results-table" ng-show="!$ctrl.loading">
         <tr class="header">
           <th>
             <rf-sorting-header direction="$ctrl.sortingDirection"


### PR DESCRIPTION
## Overview

This PR uses local storage to persist the sort order of analyses so that user's can have their preferences maintained. The username is included in the key so that the setting won't cross over user accounts if they are using the same browser.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Change the sorting of the analyses
 * Navigate away and then come back to the analysis listing
 * Check that the analyses are still sorted in the same way