### PR TITLE
Log errors when batch submitJob fails

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -423,7 +423,14 @@ trait ProjectRoutes extends Authentication
       }
       val scenesFuture = Projects.addScenesToProject(sceneIds, projectId, user)
       scenesFuture.map { scenes =>
-        val scenesToKickoff = scenes.filter(_.statusFields.ingestStatus == IngestStatus.ToBeIngested)
+        val scenesToKickoff = scenes.filter(scene =>
+          scene.statusFields.ingestStatus == IngestStatus.ToBeIngested || (
+            scene.statusFields.ingestStatus == IngestStatus.Ingesting &&
+              scene.modifiedAt.before(
+                new Timestamp((new Date(System.currentTimeMillis()-1*24*60*60*1000)).getTime)
+              )
+          )
+        )
         scenesToKickoff.map(_.id).map(kickoffSceneIngest)
       }
       complete {

--- a/app-backend/common/src/main/scala/AWSBatch.scala
+++ b/app-backend/common/src/main/scala/AWSBatch.scala
@@ -32,9 +32,18 @@ trait AWSBatch extends RollbarNotifier with LazyLogging {
     }
 
     if (runBatch) {
-      val submitJobResult = batchClient.submitJob(jobRequest)
-      logger.info(s"Submit Job Result: ${submitJobResult}")
-      submitJobResult
+      logger.info(s"Trying to submit job: ${jobName}")
+      try {
+        val submitJobResult = batchClient.submitJob(jobRequest)
+        logger.info(s"Submit Job Result: ${submitJobResult}")
+        submitJobResult
+      } catch {
+        case e: Exception =>
+          logger.error(
+            s"There was an error submitting ${jobName}; Exception: ${e.getLocalizedMessage}"
+          )
+          throw e
+      }
     } else {
       logger.warn(s"Not submitting AWS Batch -- not in production or staging, in ${awsbatchConfig.environment}")
       logger.warn(s"Job Request: ${jobName} -- ${jobDefinition} -- ${parameters}")

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -479,10 +479,12 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
                   val scenesNotIngestedQuery = for {
                     s <- Scenes if s.id.inSet(sceneIds) && s.ingestStatus.inSet(
                       Set(IngestStatus.NotIngested, IngestStatus.Failed))
-                  } yield (s.ingestStatus)
+                  } yield (s.ingestStatus, s.modifiedAt)
 
                   database.db.run {
-                    scenesNotIngestedQuery.update((IngestStatus.ToBeIngested))
+                    scenesNotIngestedQuery.update(
+                      (IngestStatus.ToBeIngested, new Timestamp((new Date).getTime))
+                    )
                   }
 
                   logger.info(s"Scene IDs right at the end: $sceneIds")


### PR DESCRIPTION
## Overview
* Update modifiedAt date when marking scenes for ingestion
* Re-ingest scenes if they are added to a project, it's been more than a day
since they were last updated, and they are not already ingested

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness


### Notes
It's not clear why some of our batch submissions are not going through, these logs will let us know if there's an exception being thrown

## Testing Instructions

 * verify the stuff compiles

Related to https://github.com/azavea/raster-foundry-platform/issues/189
Closes https://github.com/azavea/raster-foundry-platform/issues/204