### PR TITLE
Stub out batch jar cli for reading Stac asset

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -9,6 +9,7 @@ import com.azavea.rf.batch.aoi.UpdateAOIProject
 import com.azavea.rf.batch.landsat8.{ImportLandsat8, ImportLandsat8C1}
 import com.azavea.rf.batch.migration.S3ToPostgres
 import com.azavea.rf.batch.sentinel2.ImportSentinel2
+import com.azavea.rf.batch.stac.{ReadStacFeature}
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
@@ -24,7 +25,8 @@ object Main {
     ImportLandsat8C1.name  -> (ImportLandsat8C1.main(_)),
     CheckExportStatus.name -> (CheckExportStatus.main(_)),
     S3ToPostgres.name      -> (S3ToPostgres.main(_)),
-    HealthCheck.name       -> (HealthCheck.main(_))
+    HealthCheck.name       -> (HealthCheck.main(_)),
+    ReadStacFeature.name   -> (ReadStacFeature.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -1,0 +1,11 @@
+package com.azavea.rf.batch.stac
+
+import com.typesafe.scalalogging.LazyLogging
+
+object ReadStacFeature extends LazyLogging {
+  val name = "read_stac_feature"
+  def main(args: Array[String]): Unit = {
+    val allArgs = args.mkString(" ")
+    logger.info(s"Read Stac Feature operation called with args: ${allArgs}")
+  }
+}


### PR DESCRIPTION
## Overview
Stub out batch jar cli for reading Stac asset

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
![image](https://user-images.githubusercontent.com/4392704/33622353-9c6a7618-d9bb-11e7-8ef9-02646b91bf83.png)

## Testing Instructions

 *  build your batch jar `cd app-backend` `./sbt` `batch/assembly`
* run the stubbed command `java -cp batch/target/scala-2.11/rf-batch.jar com.azavea.rf.batch.Main read_stac_feature This is a list of arbitrary arguments that I expect to be returned in a console log`
* verify that the output is as expected
Closes https://github.com/raster-foundry/raster-foundry/issues/2749