### PR TITLE
Fix caching to avoid cached NODATA tile errors

### DIFF
--- a/app-backend/common/src/main/scala/cache/CacheClient.scala
+++ b/app-backend/common/src/main/scala/cache/CacheClient.scala
@@ -54,14 +54,14 @@ class CacheClient(client: => MemcachedClient) extends LazyLogging {
       futureCached.flatMap({ value =>
         if (value != null) {
           // cache hit
-          Future.successful(Some(value.asInstanceOf[CachedType]))
+          Future.successful(value.asInstanceOf[Option[CachedType]])
         } else {
           // cache miss
           val futureCached: Future[Option[CachedType]] = expensiveOperation
           futureCached.onComplete {
             case Success(cachedValue) => {
               cachedValue match {
-                case Some(v) => setValue(cacheKey, v)
+                case Some(v) => setValue(cacheKey, cachedValue)
                 case None => setValue(cacheKey, cachedValue, ttlSeconds = 300)
               }
             }


### PR DESCRIPTION
## Overview

This PR fixes an error that occurred when reading NODATA tiles from the cache (stored in the cache as `None`s).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This will change the format of cached objects will create errors

## Testing Instructions

 * Request a tile that should be NODATA within the bounds of the project
