### PR TITLE
Clean up planet filters and browsing

### DIFF
--- a/app-frontend/src/app/components/scenes/planetSceneDetailModal/planetSceneDetailModal.controller.js
+++ b/app-frontend/src/app/components/scenes/planetSceneDetailModal/planetSceneDetailModal.controller.js
@@ -13,7 +13,7 @@ export default class PlanetSceneDetailModalController {
         });
     }
 
-    $onInit() {
+    $postLink() {
         this.getMap().then(mapWrapper => {
             // the order of the below two function calls is important
             mapWrapper.map.fitBounds(this.getSceneBounds());
@@ -26,6 +26,6 @@ export default class PlanetSceneDetailModalController {
     }
 
     getSceneBounds() {
-        return L.geoJSON(this.scene.dataFootprint).getBounds();
+        return L.geoJSON(this.scene.tileFootprint).getBounds();
     }
 }

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -51,15 +51,17 @@ export default class FilterPaneController {
     }
 
     onSelectBrowseSource(browseSource) {
-        let isBrowseSourceChanged = browseSource !== this.selectedBrowseSource;
-        if (isBrowseSourceChanged && browseSource === 'Planet Labs') {
+        if (browseSource === this.selectedBrowseSource) {
+            return;
+        }
+        if (browseSource === 'Planet Labs') {
             if (!this.userPlanetCredential) {
                 this.connectToPlanet();
             } else {
                 this.onPassPlanetToken({planetToken: this.userPlanetCredential});
                 this.onBrowseSourceChanged(browseSource);
             }
-        } else if (isBrowseSourceChanged && browseSource === 'Raster Foundry') {
+        } else if (browseSource === 'Raster Foundry') {
             this.onBrowseSourceChanged(browseSource);
         }
     }

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -51,21 +51,20 @@ export default class FilterPaneController {
     }
 
     onSelectBrowseSource(browseSource) {
-        if (browseSource !== this.selectedBrowseSource) {
-            if (browseSource === 'Planet Labs') {
-                if (!this.userPlanetCredential) {
-                    this.connectToPlanet();
-                } else {
-                    this.onPassPlanetToken({planetToken: this.userPlanetCredential});
-                    this.onBrowseSourceChange(browseSource);
-                }
+        let isBrowseSourceChanged = browseSource !== this.selectedBrowseSource;
+        if (isBrowseSourceChanged && browseSource === 'Planet Labs') {
+            if (!this.userPlanetCredential) {
+                this.connectToPlanet();
             } else {
-                this.onBrowseSourceChange(browseSource);
+                this.onPassPlanetToken({planetToken: this.userPlanetCredential});
+                this.onBrowseSourceChanged(browseSource);
             }
+        } else if (isBrowseSourceChanged && browseSource === 'Raster Foundry') {
+            this.onBrowseSourceChanged(browseSource);
         }
     }
 
-    onBrowseSourceChange(browseSource) {
+    onBrowseSourceChanged(browseSource) {
         this.selectedBrowseSource = browseSource;
         this.selectedDatasource = '';
         this.initDataSourceFilters();
@@ -99,7 +98,7 @@ export default class FilterPaneController {
                 this.userPlanetCredential = token;
                 if (this.userPlanetCredential) {
                     this.onPassPlanetToken({planetToken: this.userPlanetCredential});
-                    this.onBrowseSourceChange('Planet Labs');
+                    this.onBrowseSourceChanged('Planet Labs');
                 }
             }, (err) => {
                 this.$log.log('There was an error updating the user with a planet api token', err);

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -55,30 +55,37 @@ export default class FilterPaneController {
             if (browseSource === 'Planet Labs') {
                 if (!this.userPlanetCredential) {
                     this.connectToPlanet();
+                } else {
+                    this.onPassPlanetToken({planetToken: this.userPlanetCredential});
+                    this.onBrowseSourceChange(browseSource);
                 }
-                this.onPassPlanetToken({planetToken: this.userPlanetCredential});
+            } else {
+                this.onBrowseSourceChange(browseSource);
             }
-            this.selectedBrowseSource = browseSource;
-            this.selectedDatasource = '';
-            this.initDataSourceFilters();
-            this.datefilter = {
-                start: this.Moment().subtract(1, 'months'),
-                end: this.Moment()
-            };
-            this.hasDatetimeFilter = true;
-            this.datefilterPreset = 'The last month';
-
-            this.newParams = Object.assign({}, {
-                datasource: [],
-                minAcquisitionDatetime: this.datefilter.start.toISOString(),
-                maxAcquisitionDatetime: this.datefilter.end.toISOString()
-            });
-
-            this.onFilterChange({
-                newFilters: this.newParams,
-                sourceRepo: this.selectedBrowseSource
-            });
         }
+    }
+
+    onBrowseSourceChange(browseSource) {
+        this.selectedBrowseSource = browseSource;
+        this.selectedDatasource = '';
+        this.initDataSourceFilters();
+        this.datefilter = {
+            start: this.Moment().subtract(1, 'months'),
+            end: this.Moment()
+        };
+        this.hasDatetimeFilter = true;
+        this.datefilterPreset = 'The last month';
+
+        this.newParams = Object.assign({}, {
+            datasource: [],
+            minAcquisitionDatetime: this.datefilter.start.toISOString(),
+            maxAcquisitionDatetime: this.datefilter.end.toISOString()
+        });
+
+        this.onFilterChange({
+            newFilters: this.newParams,
+            sourceRepo: this.selectedBrowseSource
+        });
     }
 
     connectToPlanet() {
@@ -91,7 +98,8 @@ export default class FilterPaneController {
             this.userService.updatePlanetToken(token).then(() => {
                 this.userPlanetCredential = token;
                 if (this.userPlanetCredential) {
-                    this.selectedBrowseSource = 'Planet Labs';
+                    this.onPassPlanetToken({planetToken: this.userPlanetCredential});
+                    this.onBrowseSourceChange('Planet Labs');
                 }
             }, (err) => {
                 this.$log.log('There was an error updating the user with a planet api token', err);

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.controller.js
@@ -14,11 +14,13 @@ export default class SceneItemController {
     $onInit() {
         this.datasourceLoaded = false;
 
-        if (this.apiSource === 'Raster Foundry') {
+        if (!this.apiSource || this.apiSource === 'Raster Foundry') {
             this.datasourceService.get(this.scene.datasource).then(d => {
                 this.datasourceLoaded = true;
                 this.datasource = d;
             });
+        } else if (this.apiSource === 'Planet Labs') {
+            this.getPlanetThumbnail();
         }
 
         if (this.isDraggable) {
@@ -30,10 +32,6 @@ export default class SceneItemController {
                     this.mapService.disableFootprints = false;
                 }
             });
-        }
-
-        if (this.apiSource === 'Planet Labs') {
-            this.getPlanetThumbnail();
         }
     }
 

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -2,7 +2,7 @@
   <div ng-if="$ctrl.isDraggable" ui-tree-handle>
     <i class="icon-gripper"></i>
   </div>
-  <div ng-if="$ctrl.apiSource === 'Raster Foundry'">
+  <div ng-if="!$ctrl.apiSource || $ctrl.apiSource === 'Raster Foundry'">
     <rf-status-tag entity-type="scene"
                    status="$ctrl.scene.statusFields.ingestStatus"></rf-status-tag>
     <img ng-if="$ctrl.scene.thumbnails[0]"

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
@@ -402,6 +402,7 @@ export default class ProjectAddScenesBrowseController {
         this.queryParams = Object.assign({
             bbox: this.queryParams.bbox
         }, newParams);
+        this.filters = Object.assign({}, this.queryParams);
         this.onQueryParamsChange();
         this.updateSceneGrid();
     }


### PR DESCRIPTION
## Overview

This PR fixes issues in [a previous planet related PR](https://github.com/raster-foundry/raster-foundry/pull/2675) in terms of:
- Session storage for planet filters
- Planet scene display in the planet scene detail modal
- Debounce planet API calls

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

### Notes

- Known issue 1: The image overlay does not seem to know how to plot a scene with multiple stripes, which corresponds to multipolygon tile footprint
<img width="1920" alt="screen shot 2017-12-06 at 7 38 56 pm" src="https://user-images.githubusercontent.com/16109558/33692821-57be3c18-dabd-11e7-87b8-eb5548dd4460.png">

- Known issue 2: planet API will respond 400 if the geometry filter crosses the prime meridian.
- Will rebase the commits in this PR once  [this previous planet related PR](https://github.com/raster-foundry/raster-foundry/pull/2675) is merged.
- Adding planet scene to project or downloading will be another card.

## Testing Instructions

 * Go to scene browse page
 * Filter/zoom/pan to browse planet scenes

Closes https://github.com/azavea/raster-foundry-platform/issues/184
