### PR TITLE
Bug fix - can't draw rectangular annotation after single click on map

### DIFF
--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
@@ -46,7 +46,8 @@ class AnnotateToolbarController {
 
         this.getMap().then((mapWrapper) => {
             this.listeners = [
-                mapWrapper.on(L.Draw.Event.CREATED, this.createShape.bind(this))
+                mapWrapper.on(L.Draw.Event.CREATED, this.createShape.bind(this)),
+                mapWrapper.on('click', this.onMapClick.bind(this))
             ];
             this.setDrawHandlers(mapWrapper);
         });
@@ -73,6 +74,12 @@ class AnnotateToolbarController {
         this.drawMarkerHandler.disable();
     }
 
+    onMapClick() {
+        if (this.isDrawCancel && this.isDrawingRectangle) {
+            this.drawRectangleHandler.enable();
+        }
+    }
+
     setDrawHandlers(mapWrapper) {
         this.drawRectangleHandler = new L.Draw.Rectangle(mapWrapper.map, {
             shapeOptions: {
@@ -95,6 +102,7 @@ class AnnotateToolbarController {
     toggleDrawing(shapeType) {
         this.isDrawCancel = true;
         if (shapeType === 'rectangle') {
+            this.isDrawingRectangle = true;
             this.drawRectangleHandler.enable();
             this.lastHandler = this.drawRectangleHandler;
             this.drawPolygonHandler.disable();
@@ -138,6 +146,10 @@ class AnnotateToolbarController {
 
     createShape(e) {
         this.isDrawCancel = false;
+
+        if (this.isDrawingRectangle && e.layerType === 'rectangle') {
+            this.isDrawingRectangle = false;
+        }
 
         this.onShapeCreated({
             'shapeLayer': e.layer


### PR DESCRIPTION
## Overview

This PR fixes a bug when using the annotation toolbar where it does not allow to you continue drawing a rectangle after a single click on the map after the draw rectangle tool is activated.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vaguenes

## Testing Instructions

 * Go to the annotation page
 * Use the rectangle tool, single click on the map to pan or whatever to check if it still lets you create a rectangular shape.

Closes #2617
