### PR TITLE
Modify importer to separate Sentinel-2A and 2B scenes

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -92,7 +92,10 @@ sentinel2 {
     B10: {"name": "cirrus - 10", "number": 0, "wavelength": [1365, 1385]}
   }
 
-  datasourceId = "4a50cb75-815d-4fe5-8bc1-144729ce5b42"
+  datasourceIds = {
+    "S2A": "4a50cb75-815d-4fe5-8bc1-144729ce5b42",
+    "S2B": "c33db82d-afdb-43cb-a6ac-ba899e48638d"
+  }
 
   # Base http path for constructing resource URLs for Sentinel 2 assets
   baseHttpPath = "https://sentinel-s2-l1c.s3.amazonaws.com/"

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -68,14 +68,14 @@ trait Config {
   protected case class Sentinel2(
     organization: String,
     bandLookup: Sentinel2Bands,
-    datasourceId: String,
+    datasourceIds: Map[String, String],
     baseHttpPath: String,
     awsRegion: Option[String],
     bucketName: String,
     targetProj: String
   ) {
     def organizationUUID = UUID.fromString(organization)
-    def datasourceUUID = UUID.fromString(datasourceId)
+    def datasourceUUIDs = datasourceIds
     def targetProjCRS = CRS.fromName(targetProj)
     def bandByName(key: String): Option[Band.Create] =
       bandLookup.getClass.getDeclaredFields.toList.filter(_.getName == key).map { field =>

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -347,6 +347,18 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     }
   }
 
+  def getDatasourcesScenesForDay(date: LocalDate, datasourceIds: Seq[UUID])(implicit database: DB): Future[Seq[String]] = {
+    database.db.run {
+      Scenes
+        .filterByDate(date)
+        .filter{scene =>
+          scene.datasource inSetBind datasourceIds
+        }
+        .map(_.name)
+        .result
+    }
+  }
+
 
   def sceneGrid(params: CombinedGridQueryParams, user: User, bboxes: Seq[Projected[Polygon]])(implicit database: DB) = {
     val filteredScenes = Scenes


### PR DESCRIPTION
## Overview

Modifies the batch import to handle separating the Sentinel 2A and 2B datasources.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/33740955-93906474-db70-11e7-8e0b-df5cd392f73a.png)

## Testing Instructions

 * `batch/assembly` in sbt
 * `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_sentinel2 <YYYY-MM-DD>`

Closes #2786 
