### PR TITLE
Add param to generate empty grid layer

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.controller.js
@@ -144,7 +144,7 @@ export default class ProjectAddScenesBrowseController {
             });
 
             this.gridLayer = this.gridLayerService.createNewGridLayer(
-                Object.assign({}, this.queryParams)
+                Object.assign({}, this.queryParams), true
             );
             // 100 is just a placeholder "big" number to leave plenty of space for basemaps
             this.gridLayer.setZIndex(100);


### PR DESCRIPTION
## Overview

This PR adds a param to grid layer creation that will disable the requests to the scene grid endpoints.

This enables us to keep the grid visible for filtering but disable the scene count portion of the functionality.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/33771848-937e46c8-dc00-11e7-9b1c-e406a5a4cc30.png)

## Testing Instructions

 * Browse for imagery and notice that the grid is present but that no scene totals are requested or displayed.