### PR TITLE
Explicitly set tile-server log level to `INFO`

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 akka {
-  loglevel = DEBUG
+  loglevel = INFO
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }

--- a/app-backend/tile/src/main/resources/application.conf
+++ b/app-backend/tile/src/main/resources/application.conf
@@ -1,5 +1,10 @@
-akka.http {
+akka {
+  loglevel = INFO
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}
 
+akka.http {
   server {
     pipelining-limit = 16
     pipelining-limit = ${?TILE_AKKA_HTTP_PIPELINE_LIMIT}


### PR DESCRIPTION
## Overview

This PR explicitly sets the log-level for the tile-server to `INFO`

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Spin up the server and make some tile requests: there shouldn't be any `DEBUG` level log output

Closes #2794 
