### PR TITLE
Use ingest status filter when constructing mosaics

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -504,8 +504,14 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
   import Scenes.datePart
 
 
-  def filterByTileFootprint(polygonOption: Option[Projected[Polygon]]): Scenes.TableQuery = {
-    polygonOption match {
+  /** Filters scenes by ingest status and intersection to guarantee that we are not
+    * returning non-ingested scenes
+    *
+    * @param polygonOption
+    * @return
+    */
+  def getMosaicScenes(polygonOption: Option[Projected[Polygon]]): Scenes.TableQuery = {
+    val polygonFilteredScenes = polygonOption match {
       case Some(polygon) => {
         scenes.filter{ scene =>
           scene.tileFootprint.intersects(polygon)
@@ -513,6 +519,7 @@ class ScenesTableQuery[M, U, C[_]](scenes: Scenes.TableQuery) extends LazyLoggin
       }
       case _ => scenes
     }
+    polygonFilteredScenes.filter(scene => scene.ingestStatus === IngestStatus.fromString("INGESTED"))
   }
 
   /** TODO: it isn't currently clear how to implement enum type ordering.

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
@@ -153,7 +153,7 @@ object ScenesToProjects extends TableQuery(tag => new ScenesToProjects(tag)) wit
 
   def getMosaicDefinition(projectId: UUID, polygonOption: Option[Projected[Polygon]])(implicit database: DB): Future[Option[Seq[MosaicDefinition]]] = {
     val query = for {
-      (s2p, s) <- ScenesToProjects join Scenes.filterByTileFootprint(polygonOption) on (_.sceneId === _.id)
+      (s2p, s) <- ScenesToProjects join Scenes.getMosaicScenes(polygonOption) on (_.sceneId === _.id)
     } yield {
       s2p
     }


### PR DESCRIPTION
## Overview

Prior to this commit uningested scenes would be added to the mosaic definition
and the tile server would throw an error in response, failing to render tiles
that _were_ ingested but intersected with an uningested scene.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![tiles-on-pr](https://user-images.githubusercontent.com/898060/33835206-b215b288-de53-11e7-8fab-a94307b6d05a.png)

Tiles loaded in PR, no errors in tile server

## Testing Instructions

 * Open a project with an uningested scene on develop
 * Add an uningested scene in the same project
 * Browse over it, observe errors
 * Switch to this branch, see that there are no errors, reload page -- observe no errors

Closes #2473 
