### PR TITLE
Workaround for map init timing

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -54,7 +54,7 @@
     "immutable": "^3.8.2",
     "jointjs": "~1.1.0",
     "jquery": "~2.1.4",
-    "leaflet": "1.0.3",
+    "leaflet": "1.2.0",
     "leaflet-draw": "~0.4.9",
     "leaflet-draw-drag": "~0.4.4",
     "leaflet-path-transform": "1.0.3",

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.controller.js
@@ -12,7 +12,7 @@ export default class MapContainerController {
         this.getMap = () => this.mapService.getMap(this.mapId);
     }
 
-    $onInit() {
+    $postLink() {
         this.initMap();
     }
 
@@ -58,7 +58,7 @@ export default class MapContainerController {
         this.$timeout(() => {
             this.map.invalidateSize();
             this.mapWrapper = this.mapService.registerMap(this.map, this.mapId, this.options);
-        }, 400);
+        }, 750);
 
         this.basemapOptions = BUILDCONFIG.BASEMAPS.layers;
         this.basemapKeys = Object.keys(this.basemapOptions);

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -75,7 +75,7 @@ class ProjectsEditController {
 
     $postLink() {
         if (this.project) {
-            this.$timeout(this.fitProjectExtent(), 100);
+            this.fitProjectExtent();
         }
     }
 

--- a/app-frontend/src/app/services/map/mapUtils.service.js
+++ b/app-frontend/src/app/services/map/mapUtils.service.js
@@ -1,6 +1,11 @@
 export default (app) => {
     class MapUtilsService {
 
+        constructor($timeout) {
+            'ngInject';
+            this.$timeout = $timeout;
+        }
+
         /** Get the extent from a project (if it exists) and fit the map to it
           * @param {MapWrapper} mapWrapper mapWrapper object of map to interact with
           * @param {Project} project to hold, e.g. specifying latlng center and zoom
@@ -9,15 +14,13 @@ export default (app) => {
           */
         fitMapToProject(mapWrapper, project, offset = 0) {
             if (project.extent) {
-                let mapBounds = mapWrapper.map.getPixelBounds();
-                if (mapBounds.min.y !== mapBounds.max.y) {
+                mapWrapper.map.invalidateSize();
+                this.$timeout(() => {
                     mapWrapper.map.fitBounds(L.geoJSON(project.extent).getBounds(), {
-                        padding: [offset, offset]
+                        padding: [offset, offset],
+                        animate: false
                     });
-                } else {
-                    // eslint-disable-next-line
-                    setTimeout(this.fitMapToProject(mapWrapper, project, offset).bind(this), 125);
-                }
+                }, 250);
             }
             return this;
         }

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -4343,7 +4343,11 @@ leaflet-path-transform@1.0.3:
   dependencies:
     leaflet-path-drag "^1.0.1"
 
-leaflet@1.0.3, leaflet@~1.0.2:
+leaflet@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.2.0.tgz#fd5d93d9cb00091f5f8a69206d0d6744c1c82697"
+
+leaflet@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.0.3.tgz#1f401b98b45c8192134c6c8d69686253805007c8"
 


### PR DESCRIPTION
## Overview

This PR adjust some of the timing logic around map intialization. It isn't perfect, but it does eliminate the map initialization errors we see (#2797).

This also upgrades our Leaflet version.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
We still need to examine this process and try remove the reliance on timeouts.


## Testing Instructions

For the fitting work-around
 * Browse to a project within the edit
 * Reload the browser and see that the map gets fit properly.

For the Leaflet upgrade
 * Use the various maps within the app and see that everything works as expected.
