### PR TITLE
Use redux actions for lab map and allow deletion of analyses

### DIFF
--- a/app-frontend/src/app/pages/lab/analysis/analysis.js
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.js
@@ -521,33 +521,34 @@ class LabAnalysisController {
     }
 
     onNodeClose(side) {
-        this.previewData = this.previewData[side === 'left' ? 1 : 0];
-        this.showPreview(this.previewData);
+        this.selectNode(this.previewData[side === 'left' ? 1 : 0]);
     }
 
     onLeftSelect(id) {
-        this.previewData[0] = id;
-        this.showPreview(this.previewData);
+        this.compareNodes([
+            id,
+            this.previewData[1]
+        ]);
     }
 
     onRightSelect(id) {
-        this.previewData[1] = id;
-        this.showPreview(this.previewData);
+        this.compareNodes([
+            this.previewData[0],
+            id
+        ]);
     }
 
     onSingleSelect(id) {
         this.previewData = id;
-        this.showPreview(this.previewData);
+        this.selectNode(id);
     }
 
     onLeftClose() {
-        this.previewData = this.previewData[1];
-        this.showPreview(this.previewData);
+        this.selectNode(this.previewData[1]);
     }
 
     onRightClose() {
-        this.previewData = this.previewData[0];
-        this.showPreview(this.previewData);
+        this.selectNode(this.previewData[0]);
     }
 
     onSingleClose() {
@@ -556,11 +557,9 @@ class LabAnalysisController {
 
     onCompareClick() {
         if (!Array.isArray(this.previewData)) {
-            this.previewData = [this.previewData, this.previewData];
-            this.showPreview(this.previewData);
+            this.compareNodes([this.previewData, this.previewData]);
         } else {
-            this.previewData = this.previewData[0];
-            this.showPreview(this.previewData);
+            this.selectNode(this.previewData[0]);
         }
     }
 }

--- a/app-frontend/src/app/pages/lab/browse/analyses/analyses.html
+++ b/app-frontend/src/app/pages/lab/browse/analyses/analyses.html
@@ -54,17 +54,15 @@
                                is-active="$ctrl.sortingField === 'modifiedAt'"
             >Last Modified</rf-sorting-header>
           </th>
-          <th>Privacy</th>
           <th></th>
         </tr>
-        <tr ng-repeat="analysis in $ctrl.analysesList | filter: {title: $ctrl.searchString}">
+        <tr ng-repeat="analysis in $ctrl.analysesList | filter: {title: $ctrl.searchString}" class="row-hover-controls">
           <td><a ui-sref="lab.analysis({analysisid: analysis.id, analysis: analysis})">
             {{analysis.name || 'Untitled analysis'}}
           </a></td>
           <td>{{analysis.modifiedAt | date : 'longDate'}}</td>
-          <td>{{$ctrl.formatAnalysisVisibility(analysis.visibility)}}</td>
-          <td class="text-right row-hover-controls">
-            <button><i class="icon-trash"></i></button>
+          <td class="text-right row-controls">
+            <button class="btn btn-danger" ng-click="$ctrl.onAnalysisDelete(analysis.id)"><i class="icon-trash"></i></button>
           </td>
         </tr>
       </table>

--- a/app-frontend/src/app/pages/lab/browse/analyses/analyses.html
+++ b/app-frontend/src/app/pages/lab/browse/analyses/analyses.html
@@ -55,6 +55,7 @@
             >Last Modified</rf-sorting-header>
           </th>
           <th>Privacy</th>
+          <th></th>
         </tr>
         <tr ng-repeat="analysis in $ctrl.analysesList | filter: {title: $ctrl.searchString}">
           <td><a ui-sref="lab.analysis({analysisid: analysis.id, analysis: analysis})">
@@ -62,6 +63,9 @@
           </a></td>
           <td>{{analysis.modifiedAt | date : 'longDate'}}</td>
           <td>{{$ctrl.formatAnalysisVisibility(analysis.visibility)}}</td>
+          <td class="text-right row-hover-controls">
+            <button><i class="icon-trash"></i></button>
+          </td>
         </tr>
       </table>
 

--- a/app-frontend/src/app/pages/lab/browse/analyses/analyses.js
+++ b/app-frontend/src/app/pages/lab/browse/analyses/analyses.js
@@ -108,6 +108,12 @@ class LabBrowseAnalysesController {
         this.storeSorting();
         this.fetchAnalysesList(this.currentPage);
     }
+
+    onAnalysisDelete(analysisId) {
+        this.analysisService.deleteAnalysis(analysisId).then(() => {
+            this.fetchAnalysesList(this.currentPage);
+        });
+    }
 }
 
 export default angular.module('pages.lab.browse.analyses', [])

--- a/app-frontend/src/app/redux/actions/node-actions.js
+++ b/app-frontend/src/app/redux/actions/node-actions.js
@@ -92,6 +92,6 @@ export function initNodes(payload) {
 }
 
 export default {
-    startNodePreview, startNodeCompare, selectNode, cancelNodeSelect,
+    startNodePreview, startNodeCompare, selectNode, cancelNodeSelect, compareNodes,
     setNodeError, updateNode, initNodes
 };

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -51,6 +51,9 @@ export default (app) => {
                         url: `${APP_CONFIG.tileServerLocation}/tools/:analysisId/statistics/`,
                         method: 'GET',
                         cache: false
+                    },
+                    delete: {
+                        method: 'DELETE'
                     }
                 }
             );
@@ -115,6 +118,10 @@ export default (app) => {
 
         getTemplate(id) {
             return this.Template.get({id}).$promise;
+        }
+
+        deleteAnalysis(id) {
+            return this.Analysis.delete({id}).$promise;
         }
 
         getAnalysis(id) {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2937,3 +2937,18 @@ rf-reclassify-table {
 .no-visibility {
     visibility: hidden !important;
 }
+
+.row-hover-controls {
+  .row-controls {
+    padding: 0 0.25em;
+    button {
+      opacity: 0;
+      pointer-events: none;
+      transition: all 0.125s;
+    }
+  }
+  &:hover .row-controls button {
+    opacity: 1;
+    pointer-events: all;
+  }
+}


### PR DESCRIPTION
## Overview

This PR alters the lab map controls to use redux actions so that changes made with these controls are properly persisted in the redux store.

This PR also adds in a button for each analysis on the listing page (on hover) that allows users to delete a particular analysis.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/33851219-4e37077c-de84-11e7-8ecb-9ec44d0f8cf5.png)

## Testing Instructions

For the lab map redux actions
 * Open an analysis and preview a node
 * Using the map controls, start a comparison
 * Change an analysis parameter (like band selection) and see that the comparison in maintained.
 * Do other things with the lab map controls to ensure they work as expected

For the analysis deletion:
 * Make sure you can now delete an analysis and that the deletion is persisted on reload.

Closes #2732 
Closes #2764
