### PR TITLE
Add spark local ingest option to `rf`

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,5 +1,9 @@
 FROM openjdk:8-jre-slim
 
+ENV SPARK_VERSION 2.1.0
+ENV HADOOP_VERSION 2.7
+ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
+
 COPY rf/requirements.txt /tmp/
 RUN set -ex \
     && gdalDeps=' \
@@ -13,13 +17,16 @@ RUN set -ex \
     ' \
     && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends ${gdalDeps} \
+    && apt-get install -y --no-install-recommends ${gdalDeps} wget \
     && pip install --no-cache-dir \
            numpy==$(grep "numpy" /tmp/requirements.txt | cut -d= -f3) \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && apt-get purge -y build-essential python-dev \
     && apt-get -y autoremove \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /usr/lib/spark \
+    && wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
+      | tar -xzC /usr/lib/spark --strip-components=1
 
 COPY jars/ /opt/raster-foundry/jars/
 

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -105,10 +105,18 @@ def launch_spark_ingest_job(ingest_def_uri, ingest_def_id, scene_id, local=False
 
 
 def execute_local_ingest_job(scene_id, ingest_s3_uri):
-    """Execute ingest job locally with a spark local cluster"""
+    """Execute ingest job locally with a spark local cluster
 
+    Args:
+        scene_id (str): ID of scene to ingest
+        ingest_s3_uri (str): S3 location for ingest definition
+    """
+
+    ingest_cores = os.getenv('LOCAL_INGEST_CORES', 32)
+    ingest_memory = os.getenv('LOCAL_INGEST_MEM_GB', 48)
     command = ['spark-submit',
-               '--master', 'local[32]', '--driver-memory', '48g',
+               '--master', 'local[{}]'.format(ingest_cores),
+               '--driver-memory', '{}g'.format(ingest_memory),
                '--class', 'com.azavea.rf.batch.ingest.spark.Ingest',
                '/opt/raster-foundry/jars/rf-batch.jar',
                '-t', '--overwrite', '-s', scene_id, '-j', ingest_s3_uri

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
     env_file: .env
     environment:
       - RF_HOST=http://rasterfoundry.com:9000
+      - LOCAL_INGEST_CORES=2
+      - LOCAL_INGEST_MEM_GB=4
     command: rf
 
   tile-server:


### PR DESCRIPTION
## Overview

Adds the ability to ingest scenes with a spark local cluster in development by adding a new option an including spark in the batch docker container.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Find a scene ID for a local scene in development
 * Rebuild the batch container
`docker-compose build batch`
 * Ensure that batch assembly jar has been built
```
./scripts/console api-server ./sbt
project batch
assembly
```
 * Run local ingest `rf ingest-scene --ignore-previous --local <scene-id>` (don't need to wait for it to finish, but should at least start)