### PR TITLE
Add notification step to ingest process with stubbed notifications

### DIFF
--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -86,7 +86,7 @@ trait UserRoutes extends Authentication
 
   def getAuth0User: Route = authenticate { user =>
     complete {
-      Auth0UserService.getAuth0User(user)
+      Auth0UserService.getAuth0User(user.id)
     }
   }
 
@@ -94,7 +94,7 @@ trait UserRoutes extends Authentication
     user =>
     entity(as[Auth0UserUpdate]) { userUpdate =>
       complete {
-        Auth0UserService.updateAuth0User(user, userUpdate)
+        Auth0UserService.updateAuth0User(user.id, userUpdate)
       }
     }
   }

--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -119,4 +119,7 @@ dropbox {
 
 auth0 {
   systemUser = ${?AUTH0_SYSTEM_USER}
+  clientId = ${?AUTH0_MANAGEMENT_CLIENT_ID}
+  clientSecret = ${?AUTH0_MANAGEMENT_SECRET}
+  domain = ${?AUTH0_DOMAIN}
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -10,23 +10,25 @@ import com.azavea.rf.batch.landsat8.{ImportLandsat8, ImportLandsat8C1}
 import com.azavea.rf.batch.migration.S3ToPostgres
 import com.azavea.rf.batch.sentinel2.ImportSentinel2
 import com.azavea.rf.batch.stac.{ReadStacFeature}
+import com.azavea.rf.batch.notification.NotifyIngestStatus
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
-    Export.name            -> (Export.main(_)),
-    Ingest.name            -> (Ingest.main(_)),
-    ImportLandsat8.name    -> (ImportLandsat8.main(_)),
-    ImportSentinel2.name   -> (ImportSentinel2.main(_)),
-    CreateExportDef.name   -> (CreateExportDef.main(_)),
-    FindAOIProjects.name   -> (FindAOIProjects.main(_)),
-    UpdateAOIProject.name  -> (UpdateAOIProject.main(_)),
-    S3Copy.name            -> (S3Copy.main(_)),
-    DropboxCopy.name       -> (DropboxCopy.main(_)),
-    ImportLandsat8C1.name  -> (ImportLandsat8C1.main(_)),
-    CheckExportStatus.name -> (CheckExportStatus.main(_)),
-    S3ToPostgres.name      -> (S3ToPostgres.main(_)),
-    HealthCheck.name       -> (HealthCheck.main(_)),
-    ReadStacFeature.name   -> (ReadStacFeature.main(_))
+    Export.name             -> (Export.main(_)),
+    Ingest.name             -> (Ingest.main(_)),
+    ImportLandsat8.name     -> (ImportLandsat8.main(_)),
+    ImportSentinel2.name    -> (ImportSentinel2.main(_)),
+    CreateExportDef.name    -> (CreateExportDef.main(_)),
+    FindAOIProjects.name    -> (FindAOIProjects.main(_)),
+    UpdateAOIProject.name   -> (UpdateAOIProject.main(_)),
+    S3Copy.name             -> (S3Copy.main(_)),
+    DropboxCopy.name        -> (DropboxCopy.main(_)),
+    ImportLandsat8C1.name   -> (ImportLandsat8C1.main(_)),
+    CheckExportStatus.name  -> (CheckExportStatus.main(_)),
+    S3ToPostgres.name       -> (S3ToPostgres.main(_)),
+    HealthCheck.name        -> (HealthCheck.main(_)),
+    ReadStacFeature.name    -> (ReadStacFeature.main(_)),
+    NotifyIngestStatus.name -> (NotifyIngestStatus.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/Notification.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/Notification.scala
@@ -1,0 +1,83 @@
+package com.azavea.rf.batch.notification
+
+import com.auth0.client.mgmt._
+import com.auth0.client.mgmt.filter.UserFilter
+import com.auth0.client.auth._
+import com.auth0.json.auth.TokenHolder
+import com.typesafe.scalalogging.LazyLogging
+import java.util.UUID
+import scala.concurrent.Future
+
+import com.azavea.rf.batch.Job
+import com.azavea.rf.database.{Database => DB}
+import com.azavea.rf.database.tables.{ScenesToProjects, Projects, Scenes}
+import com.azavea.rf.datamodel._
+import com.azavea.rf.common.S3
+
+
+case class NotifyIngestStatus(sceneId: UUID)(implicit val database: DB) extends Job {
+  val name = NotifyIngestStatus.name
+
+  def getSceneConsumers(sceneId: UUID): Future[Seq[String]] = {
+    ScenesToProjects.allProjects(sceneId) flatMap { pids: Seq[UUID] =>
+      Future.sequence {
+        pids.map { pid: UUID =>
+          Projects.getProjectPreauthorized(pid) map {
+            _.getOrElse {
+              throw new Exception(s"Project $pid (consuming $sceneId) has no owner to notify")
+            }.owner
+          }
+        }
+      }
+    }
+  }
+
+  def getSceneOwner(sceneId: UUID): Future[String] = {
+    Scenes.getScenePreauthorized(sceneId) flatMap { scene: Option[Scene.WithRelated] =>
+      Future {
+        scene.getOrElse {
+          throw new Exception(s"Scene $sceneId has no owner to notify")
+        }.owner
+      }
+    }
+  }
+
+  def run: Unit = {
+    val authApi = new AuthAPI(auth0Config.domain, auth0Config.clientId, auth0Config.clientSecret)
+    val mgmtTokenRequest = authApi.requestToken(s"https://${auth0Config.domain}/api/v2/")
+    val mgmtToken = mgmtTokenRequest.execute
+    val mgmtApi = new ManagementAPI(auth0Config.domain, mgmtToken.getAccessToken)
+
+    for {
+      consumers <- getSceneConsumers(sceneId)
+      owner <- getSceneOwner(sceneId)
+    } yield {
+      (owner +: consumers)
+        .distinct
+        .filter(_ != auth0Config.systemUser)
+        .map { uid: String =>
+          try {
+            val user = mgmtApi.users().get(uid, new UserFilter()).execute()
+            logger.info(s"Notification stub - ${uid} -> ${user.getEmail}")
+          } catch {
+            case e: Throwable => logger.info(s"No user found for this id: ${uid}")
+          }
+        }
+      stop
+    }
+  }
+}
+
+object NotifyIngestStatus extends LazyLogging {
+  val name = "notify_ingest_status"
+
+  def main(args: Array[String]): Unit = {
+    implicit val db = DB.DEFAULT
+
+    val job = args.toList match {
+      case List(id:String) => NotifyIngestStatus(UUID.fromString(id))
+    }
+
+    job.run
+  }
+}

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -91,10 +91,19 @@ trait Config {
     def client(accessToken: String) = new DbxClientV2(config, accessToken)
   }
 
+  case class Auth0(
+    clientId: String,
+    clientSecret: String,
+    systemUser: String,
+    domain: String
+  )
+
+
   private lazy val config = ConfigFactory.load()
   protected lazy val landsat8Config = config.as[Landsat8]("landsat8")
   protected lazy val sentinel2Config = config.as[Sentinel2]("sentinel2")
   protected lazy val systemUser = config.as[String]("auth0.systemUser")
+  protected lazy val auth0Config = config.as[Auth0]("auth0")
   protected lazy val exportDefConfig = config.as[ExportDef]("export-def")
   protected lazy val dropboxConfig = config.as[Dropbox]("dropbox")
   val jarPath = "s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar"

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -228,7 +228,8 @@ lazy val batch = Project("batch", file("batch"))
       Dependencies.caffeine,
       Dependencies.scaffeine,
       Dependencies.mamlJvm,
-      Dependencies.mamlSpark
+      Dependencies.mamlSpark,
+      Dependencies.auth0
     )
   })
   .settings(assemblyShadeRules in assembly := Seq(

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -260,6 +260,21 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     }
   }
 
+  def getScenePreauthorized(sceneId: UUID)
+              (implicit database: DB): Future[Option[Scene.WithRelated]] = {
+
+    database.db.run {
+      val action = Scenes
+        .filter(_.id === sceneId)
+        .joinWithRelated
+        .result
+      logger.debug(s"Total Query for scenes -- SQL: ${action.statements.headOption}")
+      action
+    } map { result =>
+      Scene.WithRelated.fromRecords(result).headOption
+    }
+  }
+
   /** Retrieve single scene from database for caching purposes
     * This does not filter by user and should not be used by standard routes.
     *

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
@@ -229,4 +229,12 @@ object ScenesToProjects extends TableQuery(tag => new ScenesToProjects(tag)) wit
       .map(_.sceneId)
       .result
   }
+
+  def allProjects(sceneId: UUID)(implicit database: DB): Future[Seq[UUID]] = database.db.run {
+    ScenesToProjects
+      .filter(_.sceneId === sceneId)
+      .sortBy(_.sceneOrder.asc.nullsLast)
+      .map(_.projectId)
+      .result
+  }
 }

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -66,4 +66,5 @@ object Dependencies {
   val mamlJvm                 = "com.azavea"                  %% "maml-jvm"                          % Version.maml
   val mamlSpark               = "com.azavea"                  %% "maml-spark"                        % Version.maml
   val nimbusJose              = "com.guizmaii"                %% "scala-nimbus-jose-jwt"             % Version.nimbusJose
+  val auth0                   = "com.auth0"                    % "auth0"                             % Version.auth0
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -44,4 +44,5 @@ object Version {
   val kamonAkkaHttp      = "0.6.8"
   val maml               = "0.0.2-fba7908"
   val nimbusJose         = "0.6.0"
+  val auth0              = "1.5.0"
 }

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -174,6 +174,8 @@ def wait_for_status(ingest_def_id):
     scene.update()
     logger.info('Successfully updated scene %s\'s ingest status', scene.id)
 
+    notify_for_scene_ingest_status(scene.id)
+
     if scene.ingestStatus == IngestStatus.FAILED:
         raise Exception('Failed to ingest {} for user {}'.format(scene_id, scene.owner))
 
@@ -197,4 +199,22 @@ def metadata_to_postgres(uri, scene_id):
     logger.debug('Bash command to store metadata: %s', ' '.join(bash_cmd))
     subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
     logger.info('Successfully completed metadata postgres write for scene %s', scene_id)
+    return True
+
+def notify_for_scene_ingest_status(scene_id):
+    """Notify users that are using this scene as well as the scene owner that
+    the ingest status of this scene has changed
+
+    Args:
+        scene_id (Scene): the scene which has an updated status
+    """
+
+    bash_cmd = [
+        'java', '-cp',
+        '/opt/raster-foundry/jars/rf-batch.jar',
+        'com.azavea.rf.batch.Main',
+        'notify_ingest_status',
+        scene_id
+    ]
+    subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
     return True


### PR DESCRIPTION
## Overview

This PR adds a step to the ingest process that gathers the consumers and owner of the ingested scene to send notifications to them.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * in the sbt console `batch/assembly`
 * find a scene id that is in multiple projects (or just one if you want)
 * in the batch container run `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main notify_ingest_status <scene id>`

Closes #2659
