### PR TITLE
Add new fix for kicking off ingests when new scenes added to project

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -450,8 +450,7 @@ trait ProjectRoutes extends Authentication
       if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
         complete(StatusCodes.RequestEntityTooLarge)
       }
-      val scenesFuture = Projects.addScenesToProject(sceneIds, projectId, user)
-      scenesFuture.map { scenes =>
+      val scenesFuture = Projects.addScenesToProject(sceneIds, projectId, user).map { scenes =>
         val scenesToKickoff = scenes.filter(scene =>
           scene.statusFields.ingestStatus == IngestStatus.ToBeIngested || (
             scene.statusFields.ingestStatus == IngestStatus.Ingesting &&
@@ -462,6 +461,7 @@ trait ProjectRoutes extends Authentication
         )
         logger.info(s"Kicking off ${scenesToKickoff.size} scene ingests")
         scenesToKickoff.map(_.id).map(kickoffSceneIngest)
+        scenes
       }
       complete {
         scenesFuture


### PR DESCRIPTION
## Overview

Fixes an issue where scenes were only being kicked off sometimes for users when
adding scenes to a project

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Start Server, ensure no errors are thrown when adding scene to a project

Closes #2817 

This is pretty trivial, going to merge once tests pass