### PR TITLE
Planet import fix, checkbox update for icomoon

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -316,6 +316,8 @@ export default class SceneImportModalController {
             }, err => {
                 this.uploadError(err);
                 this.handlePrevious();
+            }).finally(() => {
+                this.allowInterruptions();
             });
     }
 

--- a/app-frontend/src/assets/styles/sass/components/_form.scss
+++ b/app-frontend/src/assets/styles/sass/components/_form.scss
@@ -229,9 +229,9 @@ div.checkbox {
   }
 
   &:before {
-    content: '\e803'; // see fontello.css .icon-check:before
+    content: "\e911"; // see fontello.css .icon-check:before
     order: 0;
-    font-family: "fontello";
+    font-family: "icomoon";
     font-style: normal;
     font-weight: normal;
     -webkit-font-smoothing: antialiased;
@@ -286,7 +286,7 @@ div.checkbox {
 
     &:not(.active):before {
       visibility: visible;
-      opacity: .6;
+      opacity: 0;
       transform: scale(1);
     }
   }


### PR DESCRIPTION
## Overview

This PR fixes the import modal to allow exiting the modal after a Planet import.

This also fixes the styles for checkboxes to use the new iconfont.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/33998650-2dc9539e-e0b6-11e7-8e71-5e9bf80ba931.png)

### Notes
We need to adjust the `toggle` component to handle the new iconfont and styling. The checkmarks are appearing next to the boxes. The `toggle-old` component which we are using in some places now works as before.

## Testing Instructions

 * Do a planet import and see that you can exit the modal after
 * Try out some checkboxes on the scene browser

Closes #2824 
Closes #2801
