### PR TITLE
Check for all sentinel datasource ids in ingest process

### DIFF
--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -15,7 +15,7 @@ from ..ingest import (
     create_ingest_definition
 )
 from ..uploads.landsat8.settings import datasource_id as landsat_id
-from ..uploads.sentinel2.settings import datasource_id as sentinel2_id
+from ..uploads.sentinel2.settings import datasource_ids as sentinel2_ids
 from ..utils.exception_reporting import wrap_rollbar
 from ..utils.emr import get_cluster_id, wait_for_emr_success
 
@@ -66,7 +66,7 @@ def save_ingest_def_to_s3(scene_id, ignore_previous=False):
     logger.info('Creating ingest definition')
     if scene.datasource == landsat_id:
         ingest_definition = create_landsat8_ingest(scene)
-    elif scene.datasource == sentinel2_id:
+    elif scene.datasource in sentinel2_ids:
         ingest_definition = create_sentinel2_ingest(scene)
     else:
         ingest_definition = create_ingest_definition(scene)

--- a/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
+++ b/app-tasks/rf/src/rf/uploads/sentinel2/settings.py
@@ -44,7 +44,7 @@ band_lookup = {
     'B10': {'name': 'cirrus - 10', 'number': 0, 'wavelength': [1365, 1395]}
 }
 
-datasource_id = '4a50cb75-815d-4fe5-8bc1-144729ce5b42'
+datasource_ids = ['4a50cb75-815d-4fe5-8bc1-144729ce5b42', 'c33db82d-afdb-43cb-a6ac-ba899e48638d']
 
 # Base http path for constructing resource URLs for Sentinel 2 assets
 base_http_path = 'https://sentinel-s2-l1c.s3.amazonaws.com/{key_path}'


### PR DESCRIPTION
## Overview

Adds Sentinel-2B id to ingest settings and checks against all sentinel ids in ingest processing.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness