### PR TITLE
Remove race condition for ingest queuing

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Projects.scala
@@ -485,10 +485,12 @@ object Projects extends TableQuery(tag => new Projects(tag)) with LazyLogging {
                     scenesNotIngestedQuery.update(
                       (IngestStatus.ToBeIngested, new Timestamp((new Date).getTime))
                     )
+                  }.flatMap {
+                    _ => {
+                      logger.info(s"Scene IDs right at the end: $sceneIds")
+                      listSelectProjectScenes(projectId, sceneIds)
+                    }
                   }
-
-                  logger.info(s"Scene IDs right at the end: $sceneIds")
-                  listSelectProjectScenes(projectId, sceneIds)
                 }
               }
             }


### PR DESCRIPTION
## Overview

Prior to this commit sometimes scenes would not be returned for scenes to insert
because the query would happen before scenes were updated in the database.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

I'm not sure this is really testable -- I tried to introduce the race condition using `Thread.sleep` at various spots on develop + this branch and was unable to reproduce the problem. The best example I have is a set of logs from staging that show the problem manifesting itself on develop and not when this branch was deployed to test it out.

![not-kicking-off](https://user-images.githubusercontent.com/898060/34016762-17b64cfc-e0f1-11e7-849a-a3f78f46f3a6.png)

This first screenshot shows the number of scenes added vs number of scenes being kicked off for ingest processing to not be equal.

![is-kicking-off](https://user-images.githubusercontent.com/898060/34016777-294e92a8-e0f1-11e7-8633-1d526d05a89f.png)

The second set are logs showing the number added and number being queued to be equal when this branch is deployed.