### PR TITLE
Allow map drag when drawing polygonal annotations w/o adding new nodes

### DIFF
--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
@@ -1,4 +1,4 @@
-/* globals L */
+/* globals L, _ */
 import angular from 'angular';
 import annotateToolbarTpl from './annotateToolbar.html';
 require('./annotateToolbar.scss');
@@ -16,11 +16,10 @@ const AnnotateToolbarComponent = {
 
 class AnnotateToolbarController {
     constructor(
-        $log, $scope, $ngRedux,
+        $scope, $ngRedux,
         mapService
     ) {
         'ngInject';
-        this.$log = $log;
         this.$scope = $scope;
 
         let unsubscribe = $ngRedux.connect(
@@ -47,7 +46,9 @@ class AnnotateToolbarController {
         this.getMap().then((mapWrapper) => {
             this.listeners = [
                 mapWrapper.on(L.Draw.Event.CREATED, this.createShape.bind(this)),
-                mapWrapper.on('click', this.onMapClick.bind(this))
+                mapWrapper.on('click', this.onMapClick.bind(this)),
+                mapWrapper.on('mousedown', this.onMapMousedown.bind(this)),
+                mapWrapper.on('mouseup', this.onMapMouseup.bind(this))
             ];
             this.setDrawHandlers(mapWrapper);
         });
@@ -80,6 +81,25 @@ class AnnotateToolbarController {
         }
     }
 
+    onMapMousedown() {
+        if (this.isDrawCancel && this.isDrawingPolygon) {
+            this.getMap().then((mapWrapper) => {
+                this.mapCenter = mapWrapper.map.getCenter();
+            });
+        }
+    }
+
+    onMapMouseup() {
+        if (this.isDrawCancel && this.isDrawingPolygon) {
+            this.getMap().then((mapWrapper) => {
+                let center = mapWrapper.map.getCenter();
+                if (!_.isEqual(this.mapCenter, center)) {
+                    this.drawPolygonHandler.deleteLastVertex();
+                }
+            });
+        }
+    }
+
     setDrawHandlers(mapWrapper) {
         this.drawRectangleHandler = new L.Draw.Rectangle(mapWrapper.map, {
             shapeOptions: {
@@ -108,6 +128,7 @@ class AnnotateToolbarController {
             this.drawPolygonHandler.disable();
             this.drawMarkerHandler.disable();
         } else if (shapeType === 'polygon') {
+            this.isDrawingPolygon = true;
             this.drawPolygonHandler.enable();
             this.lastHandler = this.drawPolygonHandler;
             this.drawRectangleHandler.disable();
@@ -149,6 +170,10 @@ class AnnotateToolbarController {
 
         if (this.isDrawingRectangle && e.layerType === 'rectangle') {
             this.isDrawingRectangle = false;
+        }
+
+        if (this.isDrawingPolygon && e.layerType === 'polygon') {
+            this.isDrawingPolygon = false;
         }
 
         this.onShapeCreated({

--- a/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
+++ b/app-frontend/src/app/components/map/annotateToolbar/annotateToolbar.module.js
@@ -15,9 +15,7 @@ const AnnotateToolbarComponent = {
 };
 
 class AnnotateToolbarController {
-    constructor(
-        $scope, $ngRedux,
-        mapService
+    constructor($scope, $ngRedux, mapService
     ) {
         'ngInject';
         this.$scope = $scope;


### PR DESCRIPTION
## Overview

On the annotation page, this PR allows dragging map when creating polygons without adding new nodes to the polygon.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![polygon draw and drag map](https://user-images.githubusercontent.com/16109558/34017235-da5d10e6-e0f2-11e7-9b9c-5a757e864190.gif)


## Testing Instructions

 * Go to annotation page.
 * In the middle of creating a polygon, try dragging the map - see if this adds a new node to the map or not.

Closes #2813
