### PR TITLE
Consistently use upload completion method

### DIFF
--- a/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
@@ -103,6 +103,8 @@ export default class ProjectCreateModalController {
 
         this.modalService.open({
             component: 'rfSceneImportModal',
+            backdrop: 'static',
+            keyboard: false,
             resolve: {
                 project: () => this.project
             }

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -133,12 +133,13 @@ export default class SceneImportModalController {
                 return this.fileUploads &&
                     this.uploadedFileCount + this.abortedUploadCount === this.fileUploads.length;
             },
-            onExit: () => this.finishS3Upload()
+            onExit: () => this.finishUpload()
         }, {
             name: 'S3_UPLOAD',
             previous: () => 'IMPORT',
             next: () => 'IMPORT_SUCCESS',
-            onEnter: () => this.startS3Upload()
+            onEnter: () => this.startS3Upload(),
+            onExit: () => this.finishUpload()
         }, {
             name: 'IMPORT_SUCCESS',
             allowDone: () => true
@@ -146,6 +147,7 @@ export default class SceneImportModalController {
             name: 'IMPORT_PLANET',
             previous: () => 'IMPORT',
             onEnter: () => this.startPlanetUpload(),
+            onExit: () => this.finishUpload(),
             next: () => 'IMPORT_SUCCESS'
         }, {
             name: 'IMPORT_ERROR',
@@ -297,7 +299,7 @@ export default class SceneImportModalController {
             });
     }
 
-    finishS3Upload() {
+    finishUpload() {
         this.upload.uploadStatus = 'UPLOADED';
         this.uploadService.update(this.upload).then(() => {
             this.allowInterruptions();
@@ -316,8 +318,6 @@ export default class SceneImportModalController {
             }, err => {
                 this.uploadError(err);
                 this.handlePrevious();
-            }).finally(() => {
-                this.allowInterruptions();
             });
     }
 


### PR DESCRIPTION
## Overview

This PR ensures that the `finishUpload` method, which sets the proper upload status and allows interruptions, is called after all types of uploads complete.

This also adjusts the modal parameters to disable the clicking outside of the modal to exit during the import process since I was able to accidentally do this multiple times  (the cancel button still works).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Make sure dev tools are open to capture requests
 * Try each sort of import (local, s3, and planet) and ensure that a PUT request that sets the status to `UPLOADED` is made after the upload/import is completed. Also make sure that you can exit the modal

Closes #2847 
