### PR TITLE
Read stac feature from geojson and output scene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist/
 
 # Patch files
 *.patch
+scratch/

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -1,11 +1,244 @@
 package com.azavea.rf.batch.stac
 
+import scala.util._
+import scala.io.Source
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await}
+import scala.concurrent.duration._
 import com.typesafe.scalalogging.LazyLogging
 
-object ReadStacFeature extends LazyLogging {
+import io.circe.parser._
+import io.circe._
+import io.circe.generic.JsonCodec
+import io.circe.syntax._
+
+import java.sql.Timestamp
+import java.net.URI
+import java.time.{LocalDate, ZoneOffset}
+import java.util.UUID
+import javax.imageio.ImageIO
+
+import geotrellis.vector.{Geometry, Point, Polygon, MultiPolygon}
+import geotrellis.slick.Projected
+import geotrellis.proj4.CRS
+
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.stac
+import com.azavea.rf.database.{Database => DB}
+import com.azavea.rf.database.tables._
+import com.azavea.rf.batch.util._
+import com.azavea.rf.batch.Job
+import com.azavea.rf.batch.util.conf.Config
+import com.azavea.rf.database.{Database => DB}
+
+@JsonCodec
+case class MetadataWithStartStop(start: Timestamp, end: Timestamp)
+
+object CommandLine {
+  case class Params(
+    path: String = "",
+    testRun: Boolean = false,
+    // Default will never be used because parameter is required
+    datasource: UUID = UUID.randomUUID()
+  )
+
+  val parser = new scopt.OptionParser[Params]("raster-foundry-stac-conversion") {
+    // for debugging; prevents exit from sbt console
+    override def terminate(exitState: Either[String, Unit]): Unit = ()
+
+    head("raster-foundry-stac-conversion", "0.1")
+
+    opt[Unit]('t', "test")
+      .action(
+        (_, conf) =>
+        conf.copy(testRun = true)
+      ).text("Dry run stac conversion to scene to verify output")
+
+    opt[String]('p', "path")
+      .required()
+      .action(
+        (p, conf) =>
+        conf.copy(path = p)
+      ).text("STAC geojson URI. ex: 'file:///opt/raster-foundry/app-backend/stac.geojson' 's3://{uri}' 'http://{uri}'")
+
+    opt[String]('d', "datasource")
+      .required()
+      .action(
+        (d, conf) => {
+          conf.copy(datasource = UUID.fromString(d))
+        }
+      ).text("Datasource to create scene with")
+  }
+}
+
+object ReadStacFeature extends Config with LazyLogging {
   val name = "read_stac_feature"
   def main(args: Array[String]): Unit = {
-    val allArgs = args.mkString(" ")
-    logger.info(s"Read Stac Feature operation called with args: ${allArgs}")
+    implicit val db = DB.DEFAULT
+    val params = CommandLine.parser.parse(args, CommandLine.Params()) match {
+      case Some(params) =>
+        params
+      case None =>
+        return
+    }
+    val path = params.path
+    val rootUri = new URI(path.split("/").iterator.sliding(2).map(_.headOption).flatten.mkString("/"))
+    val geojson = Source.fromInputStream(getStream(new URI(path))).getLines.mkString
+    val decoded = decode[stac.Feature](geojson)
+    decoded match {
+      case Right(stacFeature) =>
+        val scene = stacFeatureToScene(stacFeature, params.datasource, params, rootUri)
+        params.testRun match {
+          case true =>
+            logger.info(s"Test run, so scene was not actually created:\n${scene}")
+          case _ =>
+            Await.result(writeSceneToDb(scene), 5 seconds)
+        }
+      case Left(error) =>
+        logger.error(s"There was an error decoding the geojson into a stac Feature: ${error.getLocalizedMessage}")
+    }
+  }
+
+  protected def stacFeatureToScene(
+    feature: stac.Feature,
+    datasource: UUID,
+    params: CommandLine.Params,
+    rootUri: URI
+  ): Scene.Create = {
+    val thumbnailLinks = feature.links.filter(_.`type` == "thumbnail")
+
+
+    // if datasource is defined, use bands from datasource
+    val (imageAssets, metadataFiles) = feature.assets.partition(asset => asset.format.getOrElse("none") == "tif")
+
+    val sceneId = UUID.randomUUID()
+    val images = getBandedImages(imageAssets, sceneId, rootUri) // get bands from the image products
+
+    val srid = feature.geometry.srid
+
+    val geom = feature.geometry.geom.reproject(CRS.fromEpsgCode(srid), CRS.fromEpsgCode(3857))
+    val dataFootprint = geom.as[Polygon].map(g => Projected(MultiPolygon(g), 3857)).orElse(geom.as[MultiPolygon].map(g => Projected(g, 3857)))
+
+    Scene.Create(
+      id = Some(sceneId),
+      organizationId = landsat8Config.organizationUUID, // this config should be changed to a generic import config
+      ingestSizeBytes = 0,
+      visibility = Visibility.Public,
+      tags = feature.properties.provider.split(",").map(_.trim).toList,
+      datasource = datasource,
+      sceneMetadata = MetadataWithStartStop(feature.properties.start, feature.properties.end).asJson,
+      name = feature.id,
+      owner = Some(systemUser),
+      tileFootprint = Some(multipolygonFromBbox(feature.bbox)),
+      dataFootprint = dataFootprint,
+      metadataFiles = metadataFiles.map(asset => asset.href).toList, // assets that are not the primary image
+      images = images,
+      thumbnails = thumbnailLinks.map(thumbnailFromLink(_, sceneId, rootUri)).flatten.toList,
+      ingestLocation = None,
+      filterFields = SceneFilterFields(
+        cloudCover = None,
+        sunAzimuth = None,
+        sunElevation = None,
+        acquisitionDate = Some(feature.properties.start)
+      ),
+      statusFields = SceneStatusFields(
+        thumbnailStatus = thumbnailLinks.size match {
+          case 0 => JobStatus.Queued // should kick off thumbnail creation
+          case _ => JobStatus.Success
+        },
+        boundaryStatus = JobStatus.Success, // tile and data footprints are required fields
+        ingestStatus = IngestStatus.NotIngested
+      )
+    )
+  }
+
+  protected def writeSceneToDb(scene : Scene.Create)(implicit db: DB) = {
+    Users.getUserById(systemUser) flatMap { _ match {
+        case Some(user) =>
+          logger.info(s"\nuser: ${user.id}\ninserting scene: \n${scene}")
+          Scenes.insertScene(scene, user)
+        case _ =>
+          throw new RuntimeException("System user not found. Make sure migrations have been run, and that batch config is correct")
+      }
+    }
+  }
+
+  protected def getBandedImages(imageAssets: Seq[stac.Asset], sceneId: UUID, rootUri: URI): List[Image.Banded] = {
+    // get product
+    imageAssets.map(imageAsset =>
+      imageAsset.product match {
+        case Some(href) =>
+          // get product from file
+          val productJson = Source.fromInputStream(getStream(new URI(href), rootUri)).getLines.mkString
+          val decoded = decode[stac.Product](productJson)
+          decoded match {
+            case Right(stacProduct) =>
+              Some(createImage(stacProduct, imageAsset, sceneId))
+            case Left(error) =>
+              logger.error(s"There was an error decoding json into a stac Product: ${error.getLocalizedMessage}")
+              None
+          }
+        case _ => None
+      }
+    ).flatten.toList
+  }
+
+  protected def createImage(
+    product: stac.Product, imageAsset: stac.Asset, sceneId: UUID
+  ): Image.Banded = {
+    Image.Banded(
+      organizationId = landsat8Config.organizationUUID,
+      rawDataBytes = 0, // sizeFromPath(params.path),
+      visibility = Visibility.Public,
+      filename = imageAsset.href.split("/").takeRight(1)(0),
+      sourceUri = imageAsset.href,
+      owner = Some(systemUser),
+      scene = sceneId,
+      imageMetadata = product.properties,
+      resolutionMeters = product.bands.map(_.gsd).min,
+      metadataFiles = List(),
+      bands = product.bands.map(
+        band =>
+        Band.Create(
+          name = band.commonName,
+          number = band.imageBandIndex,
+          wavelength = List(band.centerWavelength.toInt)
+        )
+      )
+    )
+  }
+
+  protected def multipolygonFromBbox(bbox: Seq[Double]): Projected[MultiPolygon] = {
+    val topLeft = Point(bbox(0), bbox(1))
+    val topRight = Point(bbox(2), bbox(1))
+    val lowerRight = Point(bbox(2), bbox(3))
+    val lowerLeft = Point(bbox(0), bbox(3))
+    val poly = MultiPolygon(
+      Polygon(topLeft, topRight, lowerRight, lowerLeft, topLeft)
+    ).reproject(CRS.fromEpsgCode(4326), CRS.fromEpsgCode(3857))
+    Projected(poly, 3857)
+  }
+
+  protected def thumbnailFromLink(link: stac.Link, sceneId: UUID, rootUri: URI): Option[Thumbnail.Identified] = {
+    // fetch thumbnail, get width/height
+    try {
+      val thumb = ImageIO.read(getStream(new URI(link.href), rootUri))
+      // create thumbnail
+      val width = thumb.getWidth
+      val height = thumb.getHeight
+      Some(Thumbnail.Identified(
+        id = None,
+        organizationId = landsat8Config.organizationUUID,
+        thumbnailSize = if (width < 500) ThumbnailSize.Small else ThumbnailSize.Large,
+        widthPx = thumb.getWidth,
+        heightPx = thumb.getHeight,
+        sceneId = sceneId,
+        url = link.href
+      ))
+    } catch {
+      case e: Exception =>
+      logger.error(s"Error fetching thumbnail with URI: ${link.href}, ${rootUri}")
+      None
+    }
   }
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/SceneFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/SceneFields.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.datamodel.{JobStatus, IngestStatus}
 import geotrellis.slick.Projected
-import geotrellis.vector.Geometry
+import geotrellis.vector.MultiPolygon
 
 import io.circe.Json
 
@@ -20,8 +20,8 @@ trait SceneFields  { self: Table[_] =>
   def boundaryStatus: Rep[JobStatus]
   def sunAzimuth: Rep[Option[Float]]
   def sunElevation: Rep[Option[Float]]
-  def tileFootprint: Rep[Option[Projected[Geometry]]]
-  def dataFootprint: Rep[Option[Projected[Geometry]]]
+  def tileFootprint: Rep[Option[Projected[MultiPolygon]]]
+  def dataFootprint: Rep[Option[Projected[MultiPolygon]]]
   def ingestLocation: Rep[Option[String]]
   def ingestStatus: Rep[IngestStatus]
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Scenes.scala
@@ -8,7 +8,7 @@ import com.azavea.rf.database.{Database => DB}
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.datamodel._
 import geotrellis.slick.Projected
-import geotrellis.vector.{Extent, Geometry, Point, Polygon}
+import geotrellis.vector.{Extent, MultiPolygon, Point, Polygon}
 import com.typesafe.scalalogging.LazyLogging
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import slick.collection.heterogeneous.HNil
@@ -49,8 +49,8 @@ class Scenes(_tableTag: Tag) extends Table[Scene](_tableTag, "scenes")
   val sunAzimuth: Rep[Option[Float]] = column[Option[Float]]("sun_azimuth", O.Default(None))
   val sunElevation: Rep[Option[Float]] = column[Option[Float]]("sun_elevation", O.Default(None))
   val name: Rep[String] = column[String]("name", O.Length(255,varying=true))
-  val tileFootprint: Rep[Option[Projected[Geometry]]] = column[Option[Projected[Geometry]]]("tile_footprint", O.Length(2147483647,varying=false), O.Default(None))
-  val dataFootprint: Rep[Option[Projected[Geometry]]] = column [Option[Projected[Geometry]]]("data_footprint", O.Length(2147483647,varying=false), O.Default(None))
+  val tileFootprint: Rep[Option[Projected[MultiPolygon]]] = column[Option[Projected[MultiPolygon]]]("tile_footprint", O.Length(2147483647,varying=false), O.Default(None))
+  val dataFootprint: Rep[Option[Projected[MultiPolygon]]] = column [Option[Projected[MultiPolygon]]]("data_footprint", O.Length(2147483647,varying=false), O.Default(None))
   val metadataFiles: Rep[List[String]] = column[List[String]]("metadata_files", O.Length(2147483647,varying=false), O.Default(List.empty))
   val ingestLocation: Rep[Option[String]] = column[Option[String]]("ingest_location", O.Default(None))
   val ingestStatus: Rep[IngestStatus] = column[IngestStatus]("ingest_status")
@@ -79,8 +79,8 @@ class Scenes(_tableTag: Tag) extends Table[Scene](_tableTag, "scenes")
     UUID,
     Json,
     String,
-    Option[Projected[Geometry]],
-    Option[Projected[Geometry]],
+    Option[Projected[MultiPolygon]],
+    Option[Projected[MultiPolygon]],
     List[String],
     Option[String],
     SceneFilterFields.TupleType,
@@ -517,7 +517,7 @@ object Scenes extends TableQuery(tag => new Scenes(tag)) with LazyLogging {
     }
   }
 
-  def getScenesFootprints(sceneIds: Seq[UUID]):DBIO[Seq[Option[Projected[Geometry]]]] = {
+  def getScenesFootprints(sceneIds: Seq[UUID]):DBIO[Seq[Option[Projected[MultiPolygon]]]] = {
     Scenes
       .filter(scene => scene.id inSet sceneIds)
       .map(_.dataFootprint)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 import java.util.UUID
 
 import com.azavea.rf.bridge._
-import geotrellis.vector.Geometry
+import geotrellis.vector.MultiPolygon
 import geotrellis.slick.Projected
 
 import io.circe._
@@ -61,8 +61,8 @@ case class Scene(
   datasource: UUID,
   sceneMetadata: Json,
   name: String,
-  tileFootprint: Option[Projected[Geometry]] = None,
-  dataFootprint: Option[Projected[Geometry]] = None,
+  tileFootprint: Option[Projected[MultiPolygon]] = None,
+  dataFootprint: Option[Projected[MultiPolygon]] = None,
   metadataFiles: List[String],
   ingestLocation: Option[String] = None,
   filterFields: SceneFilterFields = new SceneFilterFields(),
@@ -112,8 +112,8 @@ object Scene {
     sceneMetadata: Json,
     name: String,
     owner: Option[String],
-    tileFootprint: Option[Projected[Geometry]],
-    dataFootprint: Option[Projected[Geometry]],
+    tileFootprint: Option[Projected[MultiPolygon]],
+    dataFootprint: Option[Projected[MultiPolygon]],
     metadataFiles: List[String],
     images: List[Image.Banded],
     thumbnails: List[Thumbnail.Identified],
@@ -165,8 +165,8 @@ object Scene {
     datasource: UUID,
     sceneMetadata: Json,
     name: String,
-    tileFootprint: Option[Projected[Geometry]],
-    dataFootprint: Option[Projected[Geometry]],
+    tileFootprint: Option[Projected[MultiPolygon]],
+    dataFootprint: Option[Projected[MultiPolygon]],
     metadataFiles: List[String],
     images: Seq[Image.WithRelated],
     thumbnails: Seq[Thumbnail],

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/stac/Asset.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/stac/Asset.scala
@@ -10,7 +10,7 @@ case class Asset (
   href: String,
   name: Option[String] ,
   product: Option[String],
-  fileFormat: Option[String]
+  format: Option[String]
 )
 
 object Asset {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,7 @@ services:
       - "9010:9010"
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
+      - ./scratch/:/opt/raster-foundry/scratch/
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro


### PR DESCRIPTION
## Overview
* Read a stac feature as geojson and create a scene from it
* Change scenes etc to use Projected[MultiPolygon] instead of Projected[Geometry]
since it's currently only enforced in the database

### Checklist
~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo / Testing instructions
product.json: https://gist.github.com/Lknechtli/a176f0658c3d8447da9e51872633cb1d
feature.json: https://gist.github.com/Lknechtli/ea3363168512538935c459834ced6af1

in the api-server container, run
`/sbt batch/assembly && java -cp batch/target/scala-2.11/rf-batch.jar com.azavea.rf.batch.Main read_stac_feature -t --path file:///opt/raster-foundry/app-backend/feature.json --datasource c14c8e97-ba85-4677-ac9c-069cfef1f0b1`
in order to see the scene created as a test run, then re run without the `-t` arg to commit it to the database and verify that everything works

Closes https://github.com/raster-foundry/raster-foundry/issues/2751
