### PR TITLE
Fix project list when project name is long

### DIFF
--- a/app-frontend/src/assets/styles/sass/base/_grid.scss
+++ b/app-frontend/src/assets/styles/sass/base/_grid.scss
@@ -3,6 +3,7 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 1rem;
+  max-width: 100%;
 
   &.nowrap {
     flex-wrap: nowrap;
@@ -12,7 +13,7 @@
   &.no-margin {
     margin-bottom: 0;
   }
-  
+
   .row {
     margin-left: -1rem;
     margin-right: -1rem;


### PR DESCRIPTION
## Overview

Long project names were breaking the layout on wide screens. This sets a maximum width to ensure the project list items do not extend beyond the page.

### Demo

#### Before
![image](https://user-images.githubusercontent.com/1809908/34272582-cafb649c-e65e-11e7-8595-2e68f196e7bb.png)

#### After
![image](https://user-images.githubusercontent.com/1809908/34272594-d680c564-e65e-11e7-9967-d5eea55504b4.png)

## Testing Instructions

 * Create a project with a very long name (try 200 characters minimum)
 * Set browser width to 1201px or wider
 * Check to see if the layout breaks (see screenshot above)

Closes #2812
