### PR TITLE
Remove 'trash' buttons from Scenes list

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -51,8 +51,8 @@
         ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
         ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
         ng-repeat="scene in $ctrl.$parent.sceneList track by scene.id">
-      <button class="btn btn-square btn-danger" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
-        <i class="icon-trash"></i>
+      <button class="btn btn-square btn-ghost" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
+        Remove
       </button>
     </rf-scene-item>
   </div>


### PR DESCRIPTION
## Overview

The trash icon was confusing to users. It suggested that the scene could be permanently deleted from Raster Foundry. We want to be clear that the user will remove the scene from their project.

### Demo

![image](https://user-images.githubusercontent.com/1809908/34273499-95a3899c-e662-11e7-8c76-452bdf3e564f.png)

## Testing Instructions

 * Open a project
 * Look at the scenes
 * Does it look appropriate? "Remove" a good label?

Closes #2827 