### PR TITLE
Fixes style issues with imagery sources dropdown

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
@@ -51,7 +51,8 @@
                  uib-typeahead="ds.name for ds in $ctrl.datasources | filter:$viewValue | limitTo:8"
                  class="form-control input-dark image-source"
                  typeahead-on-select="$ctrl.toggleSourceFilter($item)"
-                 typeahead-min-length="0">
+                 typeahead-min-length="0"
+                 typeahead-focus-on-select="false">
            <i class="icon-caret-down"
               ng-if="!$ctrl.selectedDatasource"></i>
           <div class="searchselect-clear"

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
@@ -44,17 +44,21 @@
           ng-mouseleave="$ctrl.toggleDrag.toggle = false"
           ng-mouseup="$ctrl.toggleDrag.toggle = false">
         <label>Imagery sources</label>
-        <input type="text"
-               placeholder="All"
-               ng-model="$ctrl.selectedDatasource"
-               uib-typeahead="ds.name for ds in $ctrl.datasources | filter:$viewValue | limitTo:8"
-               class="form-control input-dark image-source"
-               typeahead-on-select="$ctrl.toggleSourceFilter($item)"
-               typeahead-min-length="0">
-        <div class="clear-image-source-filter"
-             ng-if="$ctrl.selectedDatasource"
-             ng-click="$ctrl.clearDatasourceFilter()">
-          <i class="icon-cross"></i>
+        <div class="searchselect">
+          <input type="text"
+                 placeholder="All"
+                 ng-model="$ctrl.selectedDatasource"
+                 uib-typeahead="ds.name for ds in $ctrl.datasources | filter:$viewValue | limitTo:8"
+                 class="form-control input-dark image-source"
+                 typeahead-on-select="$ctrl.toggleSourceFilter($item)"
+                 typeahead-min-length="0">
+           <i class="icon-caret-down"
+              ng-if="!$ctrl.selectedDatasource"></i>
+          <div class="searchselect-clear"
+               ng-if="$ctrl.selectedDatasource"
+               ng-click="$ctrl.clearDatasourceFilter()">
+            <i class="icon-cross"></i>
+          </div>
         </div>
       </div>
     </div>

--- a/app-frontend/src/assets/styles/sass/_imports.scss
+++ b/app-frontend/src/assets/styles/sass/_imports.scss
@@ -71,7 +71,8 @@
   "components/instructions",
   "components/tags",
   "components/slider",
-  "components/gradient-bar";
+  "components/gradient-bar",
+  "components/searchselect";
 
 /* * * *
  * Pages

--- a/app-frontend/src/assets/styles/sass/components/_searchselect.scss
+++ b/app-frontend/src/assets/styles/sass/components/_searchselect.scss
@@ -1,0 +1,28 @@
+.searchselect {
+  width: 100%;
+  position: relative;
+  cursor: pointer;
+
+  & > .icon-caret-down {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+  }
+
+  & > .searchselect-clear {
+    border-radius: 50%;
+    color: $gray;
+    border: 1px solid $gray-lighter;
+    background: $gray-lighter;
+    position: absolute;
+    z-index: 1000;
+    right: 1rem;
+    top: 50%;
+    width: 2rem;
+    height: 2rem;
+    transform: translateY(-50%);
+  }
+
+}

--- a/app-frontend/src/assets/styles/sass/components/_searchselect.scss
+++ b/app-frontend/src/assets/styles/sass/components/_searchselect.scss
@@ -1,7 +1,10 @@
 .searchselect {
   width: 100%;
   position: relative;
-  cursor: pointer;
+
+  & > input {
+    cursor: pointer;
+  }
 
   & > .icon-caret-down {
     position: absolute;


### PR DESCRIPTION
## Overview

The custom imagery sources dropdown had a few style issues. There was not a caret to incidate a dropdown. The clear button was not a proper circle.

### Demo

![fm0iitosbp](https://user-images.githubusercontent.com/1809908/34275162-06a3734e-e66a-11e7-99aa-ac91d75b67ae.gif)

### Notes

I created a new SCSS component "search-select". It seems like we should move in the different of treating this like a reusable component.

I think there are some other enhancements that are needed. For example, I think it would be more clear if we showed a pointer instead of text cursor on hover. But those changes will require a larger collaboration with a developer. This fixes the immediate issues.

## Testing Instructions

 * Go to Browse Scenes view
 * Open filter panel
 * Take a look at the Imagery sources element

Closes #2650