### PR TITLE
Clean up gradient dropdown style

### DIFF
--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
@@ -1,9 +1,9 @@
-<div class="dropdown btn-group"
+<div class="dropdown gradient-dropdown"
      uib-dropdown
      auto-close="outsideClick"
      on-toggle="$ctrl.onDropdownToggle(open)"
 >
-  <button class="btn dropdown-label gradient-dropdown"
+  <button class="btn"
           uib-dropdown-toggle
           ng-disabled="$ctrl.disabled"
   >
@@ -35,7 +35,6 @@
             class="dropdown-list-item"
             title="{{scheme.label}}"
         >
-          <div class="selection-indicator"><i class="icon-check"></i></div>
           <div class="gradient-container" ng-class="$ctrl.getSchemeClass(scheme)">
             <div class="gradient-bar gradient-bkg"
                  ng-style="$ctrl.colorSchemeService.colorsToBackground(
@@ -70,9 +69,6 @@
             ng-class="$ctrl.getSchemeTypeClass(schemeType)"
             ng-click="$ctrl.setSchemeType(schemeType)"
         >
-          <div class="selection-indicator">
-            <i class="icon-check"></i>
-          </div>
           {{schemeType.label}} <span ng-if="$ctrl.isActiveSchemeType('CATEGORICAL')">(needs discrete bins)</span>
         </li>
       </ul>
@@ -94,7 +90,6 @@
             ng-class="$ctrl.getBlendingClass(bin)"
             ng-click="$ctrl.setBlending(bin)"
         >
-          <div class="selection-indicator"><i class="icon-check"></i></div>
           <div class="label">
             <ng-pluralize count="bin"
                           when="{

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -32,11 +32,9 @@
         <ul class="sidebar-list">
           <li>
             <span class="label">Band</span>
-            <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">
+            <div class="dropdown fixedwidth" uib-dropdown uib-dropdown-toggle>
+              <button class="btn btn-dropdown-transitional dropdown-label">
                 Band {{$ctrl.getActiveSingleBand()}}
-              </a>
-              <button type="button" class="btn btn-light dropdown-toggle">
                 <i class="icon-caret-down"></i>
               </button>
               <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
@@ -77,10 +75,8 @@
              <li>
               <span class="label">Blue</span>
               <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-                <a class="btn dropdown-label">
+                <button class="btn btn-dropdown-transitional dropdown-label">
                   Band {{$ctrl.getActiveBand('blueBand')}}
-                </a>
-                <button type="button" class="btn btn-light dropdown-toggle">
                   <i class="icon-caret-down"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
@@ -94,10 +90,8 @@
             <li>
               <span class="label">Green</span>
               <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-                <a class="btn dropdown-label">
+                <button class="btn btn-dropdown-transitional dropdown-label">
                   Band {{$ctrl.getActiveBand('greenBand')}}
-                </a>
-                <button type="button" class="btn btn-light dropdown-toggle">
                   <i class="icon-caret-down"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
@@ -111,10 +105,8 @@
             <li>
               <span class="label">Red</span>
               <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-                <a class="btn dropdown-label">
+                <button class="btn btn-dropdown-transitional dropdown-label">
                   Band {{$ctrl.getActiveBand('redBand')}}
-                </a>
-                <button type="button" class="btn btn-light dropdown-toggle">
                   <i class="icon-caret-down"></i>
                 </button>
                 <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">

--- a/app-frontend/src/assets/styles/sass/_imports.scss
+++ b/app-frontend/src/assets/styles/sass/_imports.scss
@@ -72,7 +72,8 @@
   "components/tags",
   "components/slider",
   "components/gradient-bar",
-  "components/searchselect";
+  "components/searchselect",
+  "components/gradient-dropdown";
 
 /* * * *
  * Pages

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -398,39 +398,6 @@ rf-project-editor .leaflet-tile {
   }
 }
 
-.sidebar {
-    rf-color-scheme-dropdown {
-        //height: 2.4em;
-        .dropdown {
-            padding: 0;
-        }
-        .dropdown-label {
-            border-radius: 2px;
-        }
-        .gradient-dropdown {
-            padding: 0;
-            display: flex;
-            flex-direction: row;
-            align-items: stretch;
-
-            > .gradient-bar {
-                align-self: center;
-                flex: 1;
-                margin: 0 0.5rem 0 0.5rem;
-            }
-            .icon-caret-down {
-                display: block;
-                height: 100%;
-                flex: 0;
-                align-self: stretch;
-                padding: 0.9rem 1rem 0.9rem 1rem;
-                background: $shade-light;
-                color: white;
-            }
-        }
-    }
-}
-
 .list-group-item .sidebar-list {
   width: 100%;
   li {
@@ -2361,20 +2328,6 @@ rf-color-scheme-builder {
     }
   }
 }
-.gradient-bar {
-  flex: 1;
-  border-radius: 12px;
-  border: 1px solid #999;
-}
-.gradient-container {
-  border: 2px solid rgba(0,0,0,0);
-  border-radius: 15px;
-  padding: 2px;
-  flex: 1;
-  &.selected {
-    border: 2px solid $brand-primary;
-  }
-}
 
 ul.gradient-dropdown {
   padding: 0;
@@ -2575,14 +2528,6 @@ rf-histogram-breakpoint {
   }
 }
 
-.gradient-dropdown {
-  height: 100%;
-  width: 100%;
-  padding: 0 1em;
-  display: flex;
-  align-items: center;
-}
-
 .dropdown-titlebar {
   display: flex;
   align-items: center;
@@ -2661,7 +2606,7 @@ ul.dropdown-list {
     &:last-child {
       border-bottom: none;
     }
-    &:focus, &:active {
+    &:active {
       outline: none;
     }
   }
@@ -2741,11 +2686,14 @@ rf-node-histogram {
       height: 100%;
     }
     .dropdown-toggle {
-        background: $shade-dark;
-        font-weight: 700;
-        color: white;
-        border: 1px solid $shade-dark;
-        border-radius: 3px;
+      background: $shade-dark;
+      font-weight: 700;
+      color: white;
+      border: 1px solid $shade-dark;
+      border-radius: 3px;
+      &.dropdown:hover {
+        background-color: inherit;
+      }
     }
   }
 }
@@ -2976,16 +2924,6 @@ rf-reclassify-table {
         /* outline: 2px solid $brand-secondary; */
         /* outline-radius: 5px; */
         box-shadow: 0 0 3pt 2pt $brand-secondary;
-    }
-}
-
-.selected {
-    pointer-events: auto;
-    cursor: not-allowed;
-    box-shadow: 0 0 3pt 2pt $brand-secondary;
-
-    * {
-        pointer-events: none;
     }
 }
 

--- a/app-frontend/src/assets/styles/sass/base/_base.scss
+++ b/app-frontend/src/assets/styles/sass/base/_base.scss
@@ -2,14 +2,14 @@
 	box-sizing: border-box;
 }
 
-html { 
-	font-size: 62.5%; 
+html {
+	font-size: 62.5%;
 	font-family: $font-base;
   height: 100%;
 }
 
 body {
-	font-size: 14px; 
+	font-size: 14px;
 	font-size: 1.4rem;
 	color: $text-base;
   height: 100%;

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -360,7 +360,7 @@
 .btn-dropdown-transitional {
   text-align: left;
   position: relative;
-  padding-left: 9px;
+  padding-left: 8px;
   width: 100%;
 
   .icon-caret-down {

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -356,3 +356,17 @@
     border-bottom-left-radius: 0;
   }
 }
+
+.btn-dropdown-transitional {
+  text-align: left;
+  position: relative;
+  padding-left: 9px;
+  width: 100%;
+
+  .icon-caret-down {
+    position: absolute;
+    right: 3px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+}

--- a/app-frontend/src/assets/styles/sass/components/_gradient-bar.scss
+++ b/app-frontend/src/assets/styles/sass/components/_gradient-bar.scss
@@ -11,7 +11,7 @@
   border: 2px solid rgba(0,0,0,0);
   border-radius: 2px;
   flex: 1;
-  padding: 2px;
+  padding: 1px;
   &.selected {
     border: 2px solid $brand-primary;
   }

--- a/app-frontend/src/assets/styles/sass/components/_gradient-bar.scss
+++ b/app-frontend/src/assets/styles/sass/components/_gradient-bar.scss
@@ -1,4 +1,18 @@
 .gradient-bar {
-    height: 2rem;
-    display: block;
+  height: 2rem;
+  display: block;
+  align-self: center;
+  flex: 1;
+  border: 1px solid #434958;
+  border-radius: 2px;
+}
+
+.gradient-container {
+  border: 2px solid rgba(0,0,0,0);
+  border-radius: 2px;
+  flex: 1;
+  padding: 2px;
+  &.selected {
+    border: 2px solid $brand-primary;
+  }
 }

--- a/app-frontend/src/assets/styles/sass/components/_gradient-dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_gradient-dropdown.scss
@@ -1,0 +1,44 @@
+.gradient-dropdown {
+
+  & > button {
+    background-color: #fff;
+    padding: 5px 3px 5px 9px;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    line-height: 2;
+
+    .gradient-bar {
+      margin-right: 3px;
+    }
+
+    &:hover {
+      color: #fff;
+    }
+  }
+
+  .icon-caret-down {
+    display: block;
+    height: 100%;
+    flex: 0;
+    align-self: stretch;
+    position: relative;
+    top: 4px;
+  }
+
+  .dropdown {
+      padding: 0;
+  }
+
+  .dropdown-label {
+      border-radius: 2px;
+  }
+
+  .dropdown-list-item {
+    padding-left: 5px !important;
+  }
+
+}
+
+

--- a/app-frontend/src/assets/styles/sass/components/_gradient-dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_gradient-dropdown.scss
@@ -36,7 +36,8 @@
   }
 
   .dropdown-list-item {
-    padding-left: 5px !important;
+    padding: 0.2rem 1rem 0.2rem 0.6rem !important;
+    height: 34px;
   }
 
 }


### PR DESCRIPTION
## Overview

Some style and frontend cleanup for the gradient dropdown.

### Demo

![ncff3uszp2](https://user-images.githubusercontent.com/1809908/34311718-30b1322a-e72d-11e7-8860-071b69744c9e.gif)

### Notes

I needed to restyle the other dropdowns in the Color Mode view to match to appropriate style for the gradient dropdown. All of the dropdowns were set up as button groups, but they were not using the button group functionality. I simplified these into single buttons.

## Testing Instructions

 * Make sure to look at the gradient dropdown on both the Color Mode view and in the lab

Closes #2842
