### PR TITLE
Use combination of 2 Docker Compose configurations for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,8 +79,8 @@ node {
 
         dir('raster-foundry-deployment') {
           wrap([$class: 'AnsiColorBuildWrapper']) {
-            sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
-            sh 'docker-compose -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+            sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+            sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
           }
         }
       }


### PR DESCRIPTION
## Overview

Use:

```
-f docker-compose.yml -f docker.compose.ci.yml
```

Both need to be specified, but override file is skipped.

See: https://docs.docker.com/compose/extends/

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This is an attempt to consolidate some of the directives specified in multiple Docker Compose configuration files.

## Testing Instructions

TBD

Depends on https://github.com/azavea/raster-foundry-deployment/pull/111