### PR TITLE
Fix sort order being indeterminate when objects have the same value

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ImageFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ImageFields.scala
@@ -1,8 +1,11 @@
 package com.azavea.rf.database.fields
 
+import java.util.UUID
+
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 
 trait ImageFields  { self: Table[_] =>
+  def id: Rep[UUID]
   def rawDataBytes: Rep[Long]
   def filename: Rep[String]
   def sourceuri: Rep[String]

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/NameField.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/NameField.scala
@@ -1,8 +1,11 @@
 package com.azavea.rf.database.fields
 
+import java.util.UUID
+
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 
 trait NameField  { self: Table[_] =>
+  def id: Rep[UUID]
   def name: Rep[String]
 }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/OrganizationFkFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/OrganizationFkFields.scala
@@ -1,5 +1,7 @@
 package com.azavea.rf.database.fields
 
+import java.util.UUID
+
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.database.query.OrgQueryParameters
 import com.azavea.rf.database.tables.Organizations
@@ -7,7 +9,8 @@ import com.azavea.rf.datamodel.{Organization, User}
 import slick.lifted.ForeignKeyQuery
 
 trait OrganizationFkFields  { self: Table[_] =>
-  def organizationId: Rep[java.util.UUID]
+  def id: Rep[UUID]
+  def organizationId: Rep[UUID]
   def organizationsFk: ForeignKeyQuery[Organizations, Organization]
 }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ProjectFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ProjectFields.scala
@@ -1,8 +1,11 @@
 package com.azavea.rf.database.fields
 
+import java.util.UUID
+
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 
 trait ProjectFields  { self: Table[_] =>
+  def id: Rep[UUID]
   def name: Rep[String]
   def slugLabel: Rep[String]
   def description: Rep[String]

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/SceneFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/SceneFields.scala
@@ -10,6 +10,7 @@ import geotrellis.vector.Geometry
 import io.circe.Json
 
 trait SceneFields  { self: Table[_] =>
+  def id: Rep[UUID]
   def name: Rep[String]
   def createdAt: Rep[java.sql.Timestamp]
   def datasource: Rep[UUID]

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ToolRunFields.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/ToolRunFields.scala
@@ -1,7 +1,10 @@
 package com.azavea.rf.database.fields
 
+import java.util.UUID
+
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 
 trait ToolRunFields { self: Table[_] =>
+  def id: Rep[UUID]
   def name: Rep[Option[String]]
 }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/fields/VisibilityField.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/fields/VisibilityField.scala
@@ -1,9 +1,12 @@
 package com.azavea.rf.database.fields
 
+import java.util.UUID
+
 import com.azavea.rf.database.ExtendedPostgresDriver.api._
 import com.azavea.rf.datamodel.Visibility
 
 trait VisibilityField  { self: Table[_] =>
+  val id: Rep[UUID]
   val visibility: Rep[Visibility]
 }
 

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ImageFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ImageFieldsSort.scala
@@ -12,11 +12,11 @@ class ImageFieldsSort[E, D <: ImageFields](f: E => D) extends QuerySort[E] {
   ): Query[E, U, C] = {
     field match {
       case "name" =>
-        query.sortBy(f(_).rawDataBytes.byOrder(ord))
+        query.sortBy(q => (f(q).rawDataBytes.byOrder(ord), f(q).id))
       case "filename" =>
-        query.sortBy(f(_).filename.byOrder(ord))
+        query.sortBy(q => (f(q).filename.byOrder(ord), f(q).id))
       case "sourceuri" =>
-        query.sortBy(f(_).filename.byOrder(ord))
+        query.sortBy(q => (f(q).filename.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/NameFieldSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/NameFieldSort.scala
@@ -12,7 +12,7 @@ class NameFieldSort[E, D <: NameField](f: E => D) extends QuerySort[E] {
   ): Query[E, U, C] = {
     field match {
       case "name" =>
-        query.sortBy(f(_).name.byOrder(ord))
+        query.sortBy(q => (f(q).name.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/OrganizationFkSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/OrganizationFkSort.scala
@@ -11,7 +11,7 @@ class OrganizationFkSort[E, D <: OrganizationFkFields](f: E => D) extends QueryS
     ord: Order
   ): Query[E, U, C] = {
     field match {
-      case "organization" => query.sortBy(f(_).organizationId.byOrder(ord))
+      case "organization" => query.sortBy(q => (f(q).organizationId.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ProjectFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ProjectFieldsSort.scala
@@ -12,9 +12,9 @@ class ProjectFieldsSort[E, D <: ProjectFields](f: E => D) extends QuerySort[E] {
   ): Query[E, U, C] = {
     field match {
       case "name" =>
-        query.sortBy(f(_).name.byOrder(ord))
+        query.sortBy(q => (f(q).name.byOrder(ord), f(q).id))
       case "slugLabel" =>
-        query.sortBy(f(_).slugLabel.byOrder(ord))
+        query.sortBy(q => (f(q).slugLabel.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/SceneFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/SceneFieldsSort.scala
@@ -15,19 +15,19 @@ class SceneFieldsSort[E, D <: SceneFields](f: E => D) extends QuerySort[E] {
   ): Query[E, U, C] = {
     field match {
       case "datasource" =>
-        query.sortBy(f(_).datasource.byOrder(ord))
+        query.sortBy(q => (f(q).datasource.byOrder(ord), f(q).id))
       case "month" =>
-        query.sortBy(q => datePart("month", f(q).acquisitionDate).byOrder(ord))
+        query.sortBy(q => (datePart("month", f(q).acquisitionDate).byOrder(ord), f(q).id))
       case "acquisitionDatetime" =>
         query.sortBy(q =>
-          f(q).acquisitionDate.getOrElse(f(q).createdAt).byOrder(ord)
+          (f(q).acquisitionDate.getOrElse(f(q).createdAt).byOrder(ord), f(q).createdAt.byOrder(ord), f(q).id)
         )
       case "sunAzimuth" =>
-        query.sortBy(f(_).sunAzimuth.byOrder(ord))
+        query.sortBy(q => (f(q).sunAzimuth.byOrder(ord), f(q).id))
       case "sunElevation" =>
-        query.sortBy(f(_).sunElevation.byOrder(ord))
+        query.sortBy(q => (f(q).sunElevation.byOrder(ord), f(q).id))
       case "cloudCover" =>
-        query.sortBy(f(_).cloudCover.byOrder(ord))
+        query.sortBy(q => (f(q).cloudCover.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ToolCategoryFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ToolCategoryFieldsSort.scala
@@ -12,7 +12,7 @@ class ToolCategoryFieldsSort[E, D <: ToolCategoryFields](f: E => D) extends Quer
   ): Query[E, U, C] = {
     field match {
       case "category" =>
-        query.sortBy(f(_).category.byOrder(ord))
+        query.sortBy(q => (f(q).category.byOrder(ord), f(q).slugLabel))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ToolRunFieldsSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/ToolRunFieldsSort.scala
@@ -12,7 +12,7 @@ class ToolRunFieldsSort[E, D <: ToolRunFields](f: E => D) extends QuerySort[E] {
   ): Query[E, U, C] = {
     field match {
       case "name" =>
-        query.sortBy(f(_).name.byOrder(ord))
+        query.sortBy(q => (f(q).name.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/UserFieldSort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/UserFieldSort.scala
@@ -14,7 +14,7 @@ class UserFieldSort[E, D <: UserFields](f: E => D) extends QuerySort[E] {
       case "id" =>
         query.sortBy(f(_).id.byOrder(ord))
       case "role" =>
-        query.sortBy(f(_).role.byOrder(ord))
+        query.sortBy(q => (f(q).role.byOrder(ord), f(q).id))
       case _ => query
     }
   }

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/sort/VisibilitySort.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/sort/VisibilitySort.scala
@@ -11,7 +11,7 @@ class VisibilitySort[E, D <: VisibilityField](f: E => D) extends QuerySort[E] {
     ord: Order
   ): Query[E, U, C] = {
     field match {
-      case "visibility" => query.sortBy(f(_).visibility.byOrder(ord))
+      case "visibility" => query.sortBy(q => (f(q).visibility.byOrder(ord), f(q).id))
       case _ => query
     }
   }


### PR DESCRIPTION
## Overview
Fix sort order for scenes not being consistent between page requests if a block of scenes have the same acquisition date / created date by falling back to id

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions
* Make a request to the scenes endpoint which results in a decent number of scenes
I used: `http://localhost:9091/api/scenes?bbox=-202.85156250000003,-28.76765910569124,18.808593750000004,67.87554134672945&dataRepo=Raster+Foundry&forProjectId=5801c9b1-1867-457a-a4e1-fd84cbbad289&maxCreateDatetime=2017-12-27T15:49:33.621Z&minCloudCover=0&pageSize=20&projectid=5801c9b1-1867-457a-a4e1-fd84cbbad289&sort=acquisitionDatetime,desc&page=0`
* Make another request for the second page, and one with a page size that covers both pages
* Verify that the result of pages 0 and 1 of the first page size match page 0 of the doubled page size. 
I used jq to make it easier to read then did a diff (https://stedolan.github.io/jq/)
```
cat 10-0.json | jq '.results | .[] | {id: .id, acquired: .filterFields.acquisitionDate, createdAt: .createdAt, name: .name}' > 10.txt
```
```
cat 10-1.json | jq '.results | .[] | {id: .id, acquired: .filterFields.acquisitionDate, createdAt: .createdAt, name: .name}' >> 10.txt
```
```
cat 20-0.json | jq '.results | .[] | {id: .id, acquired: .filterFields.acquisitionDate, createdAt: .createdAt, name: .name}' > 20.txt
```
```
diff 10.txt 20.txt
```
where 10-0.json, 10-1.json contain the results for the request with a page size of 10, pages 0 and 1
and 20-0.json contains page 0 with a page size of 20
* Verify that each of the filters that were modified do not throw errors when run

Closes #2766 
