### PR TITLE
Cache datasource get requests

### DIFF
--- a/app-frontend/src/app/services/scenes/datasource.service.js
+++ b/app-frontend/src/app/services/scenes/datasource.service.js
@@ -17,7 +17,7 @@ export default (app) => {
                     },
                     get: {
                         method: 'GET',
-                        cache: false
+                        cache: true
                     },
                     create: {
                         method: 'POST'


### PR DESCRIPTION
## Overview

Caches `get` requests for specific datasources on the frontend to prevent a ton of duplicate requests.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Fire up server environment + frontend
 * Go to browse and verify duplicate requests for the same datasource ID are cached

Closes #2863 
