### PR TITLE
Add a "raw" endpoint to render analyses as single band tifs

### DIFF
--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -50,6 +50,7 @@ class Router extends LazyLogging
             pathPrefix(JavaUUID) { (toolRunId) =>
               authenticateToolTileRoutes(toolRunId) { user =>
                 toolRoutes.tms(toolRunId, user) ~
+                  toolRoutes.raw(toolRunId, user) ~
                   toolRoutes.validate(toolRunId, user) ~
                   toolRoutes.statistics(toolRunId, user) ~
                   toolRoutes.histogram(toolRunId, user) ~

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -139,7 +139,7 @@ class ToolRoutes(implicit val database: Database) extends Authentication
   val tileResolver = new TileResolver(implicitly[Database], implicitly[ExecutionContext])
   val tmsInterpreter = BufferingInterpreter.DEFAULT
   val emptyPng = IntConstantNoDataArrayTile(Array(0), 1, 1).renderPng(RgbaPngEncoding)
-  //val emptyTiff = IntConstantNoDataArrayTile(Array(0), 1, 1).
+  val emptyTile = IntConstantNoDataArrayTile(Array(0), 1, 1)
 
   /** The central endpoint for ModelLab; serves TMS tiles given a [[ToolRun]] specification */
   def tms(
@@ -258,7 +258,9 @@ class ToolRoutes(implicit val database: Database) extends Authentication
                             NEL.fromList(exceptions) match {
                               case Some(errors) =>
                                 throw new InterpreterException(errors)
-                              case None => None
+                              case None =>
+                                val tiff = SinglebandGeoTiff(emptyTile, extent, WebMercator)
+                                Some(HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/tiff`), tiff.toByteArray)))
                             }
                         })
                     case _ => Future.successful(None)

--- a/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/ToolRoutes.scala
@@ -18,11 +18,15 @@ import com.azavea.maml.util._
 import com.azavea.maml.serve._
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.render._
 import geotrellis.raster.render.png._
+import geotrellis.raster.io.geotiff.SinglebandGeoTiff
+import geotrellis.vector.{Extent}
+import geotrellis.slick.Projected
 import akka.http.scaladsl.marshalling._
-import akka.http.scaladsl.model.{ContentType, HttpEntity, MediaTypes, StatusCodes}
+import akka.http.scaladsl.model.{ContentType, HttpEntity, MediaTypes, StatusCodes, HttpResponse}
 import akka.http.scaladsl.server._
 import cats.data.Validated._
 import cats.data.{NonEmptyList => NEL, _}
@@ -135,6 +139,7 @@ class ToolRoutes(implicit val database: Database) extends Authentication
   val tileResolver = new TileResolver(implicitly[Database], implicitly[ExecutionContext])
   val tmsInterpreter = BufferingInterpreter.DEFAULT
   val emptyPng = IntConstantNoDataArrayTile(Array(0), 1, 1).renderPng(RgbaPngEncoding)
+  //val emptyTiff = IntConstantNoDataArrayTile(Array(0), 1, 1).
 
   /** The central endpoint for ModelLab; serves TMS tiles given a [[ToolRun]] specification */
   def tms(
@@ -199,6 +204,67 @@ class ToolRoutes(implicit val database: Database) extends Authentication
                 }
                 result
               })
+            }
+          }
+        }
+      }
+    }
+
+  def raw (
+    toolRunId: UUID, user: User
+  ): Route =
+    (handleExceptions(interpreterExceptionHandler) & handleExceptions(circeDecodingError)) {
+      traceName("analysis-raw") {
+        pathPrefix("raw") {
+          parameter("bbox", "zoom".as[Int], "node".?) {
+            (bbox, zoom, node) =>
+            val nodeId = node.map(UUID.fromString(_))
+            val components = for {
+              (lastUpdateTime, ast) <- LayerCache.toolEvalRequirements(toolRunId, nodeId, user)
+              (expression, metadata) <- OptionT.pure[Future, (Expression, Option[NodeMetadata])](ast.asMaml)
+            } yield (expression, metadata, lastUpdateTime)
+            complete {
+              components.value.flatMap(
+                { data =>
+                  val result: Future[Option[HttpResponse]] = data match {
+                    case Some((expression, metadata, updateTime)) =>
+                      val extent = Projected(
+                        Extent.fromString(bbox).toPolygon, 4326
+                      ).reproject(LatLng, WebMercator)(3857).envelope
+                      val literalTree = tileResolver.resolveForExtent(expression, zoom, extent)
+                      val interpretedTile: Future[Interpreted[Tile]] =
+                        literalTree.map({ resolvedAst =>
+                                          resolvedAst
+                                            .andThen({ tmsInterpreter(_) })
+                                            .andThen({ _.as[Tile] })
+                                        })
+                      interpretedTile.map(
+                        {
+                          case Valid(tile: Tile) =>
+                            logger.debug(s"Tile successfully produced at $zoom, $extent")
+                            val tiff = SinglebandGeoTiff(tile, extent, WebMercator)
+                            Some(HttpResponse(entity = HttpEntity(ContentType(MediaTypes.`image/tiff`), tiff.toByteArray)))
+                          case Invalid(nel) =>
+                            // We'll remove tile retrieval errors and return an empty tile
+                            val exceptions = nel.filter(
+                              { e =>
+                                e match {
+                                  case S3TileResolutionError(_, _) => false
+                                  case UnknownTileResolutionError(_, _) => false
+                                  case _ => true
+                                }
+                              }
+                            )
+                            NEL.fromList(exceptions) match {
+                              case Some(errors) =>
+                                throw new InterpreterException(errors)
+                              case None => None
+                            }
+                        })
+                    case _ => Future.successful(None)
+                  }
+                  result
+                })
             }
           }
         }


### PR DESCRIPTION
## Overview

Add /tools/{uuid}/raw/?bbox={bbox}&zoom={int}&node={UUID} endpoint.
Bbox and zoom params are required, node is not

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Make a get request to 
`localhost:9101/tools/{{analysis uuid}}/raw/?bbox=-72.74242311716081,44.275545908552274,-72.73984014987947,44.27694396995378&zoom=18&token={token}`
This should return a  single band tif of the analysis with a bounding box that works for the default `Small flight import` project - try ndvi or something

Closes https://github.com/raster-foundry/raster-foundry/issues/2790
