### PR TITLE
Fixed a layout bug in high-contract theme introduced with #2852

### DIFF
--- a/app-frontend/src/assets/styles/sass/base/_grid.scss
+++ b/app-frontend/src/assets/styles/sass/base/_grid.scss
@@ -3,7 +3,6 @@
   display: flex;
   flex-wrap: wrap;
   margin-bottom: 1rem;
-  max-width: 100%;
 
   &.nowrap {
     flex-wrap: nowrap;
@@ -17,10 +16,6 @@
   .row {
     margin-left: -1rem;
     margin-right: -1rem;
-  }
-
-  @include respond-to(md-down) {
-    max-width: 100%;
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/components/_content.scss
+++ b/app-frontend/src/assets/styles/sass/components/_content.scss
@@ -1,6 +1,7 @@
 .content {
   padding: 2rem;
   word-wrap: break-word;
+  max-width: 100%;
 
   .content {
     padding: 0;


### PR DESCRIPTION
## Overview

We had implemented a `max-width` on the `.row` to fix https://github.com/raster-foundry/raster-foundry/issues/2812

While this fixed our layout issue, it introduced an unexpected bug for our **high-contrast theme** referenced here: https://github.com/azavea/raster-foundry-platform/issues/238

This PR removes the `max-width` from `.row` and puts it on our `.content` class. This is a much safer fix due to our limited use of `.content` throughout the app, whereas, `.row` is used in nearly every view of the application. 

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] PR has a name that won't get you publicly shamed for vagueness~

### Demo

**Before:**
<img width="1432" alt="screen shot 2018-01-08 at 4 38 52 pm" src="https://user-images.githubusercontent.com/1928955/34693637-764dd8ca-f492-11e7-9e8b-cc3efbf51db0.png">

**After:**
<img width="1432" alt="screen shot 2018-01-08 at 4 38 41 pm" src="https://user-images.githubusercontent.com/1928955/34693645-7c29f198-f492-11e7-91a4-33716530034d.png">

## Testing Instructions

 * Go to projects list page
 * Are the buttons messed up?

Closes https://github.com/azavea/raster-foundry-platform/issues/238
