### PR TITLE
Use `API_HOST` for project export url

### DIFF
--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -113,7 +113,7 @@ export default (app) => {
                     },
                     export: {
                         method: 'POST',
-                        url: '/api/exports/'
+                        url: `${BUILDCONFIG.API_HOST}/api/exports/`
                     },
                     listExports: {
                         method: 'GET',


### PR DESCRIPTION
## Overview

This PR uses `API_HOST` from the build config to create the project export url.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Make sure that a project export still works
 * Override the API_HOST to use staging and see that the export request is POSTed there
