### PR TITLE
Hide node histogram breakpoints until they are hovered

### DIFF
--- a/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
+++ b/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
@@ -43,7 +43,7 @@
   <rf-histogram-breakpoint
       ng-if="$ctrl.plot && bp.options.style !== 'hidden' && !$ctrl.isSource"
       ng-repeat="bp in $ctrl.breakpoints track by bp.id"
-      ng-mouseover="!$ctrl.isSource && $ctrl.lastMouseOver = bp.id"
+      ng-mouseover="$ctrl.onBpMouseover(bp)"
       ng-class="{'active': $ctrl.lastMouseOver === bp.id}"
       data-color="bp.color"
       data-breakpoint="bp.value"

--- a/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.module.js
+++ b/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.module.js
@@ -448,6 +448,12 @@ class NodeHistogramController {
             })
         });
     }
+
+    onBpMouseover({id}) {
+        if (!this.isSource) {
+            this.lastMouseOver = id;
+        }
+    }
 }
 
 const NodeHistogramModule = angular.module('components.histogram.nodeHistogram', []);

--- a/app-frontend/src/app/redux/histogram-utils.js
+++ b/app-frontend/src/app/redux/histogram-utils.js
@@ -16,11 +16,11 @@ export function breakpointsFromRenderDefinition(renderDefinition, idGenerator) {
             }).sort((a, b) => a.value - b.value);
         _.first(breakpoints).options = {
             style: 'bar',
-            alwaysShowNumbers: true
+            alwaysShowNumbers: false
         };
         _.last(breakpoints).options = {
             style: 'bar',
-            alwaysShowNumbers: true
+            alwaysShowNumbers: false
         };
         return breakpoints;
     }


### PR DESCRIPTION
## Overview
Hide node histogram breakpoints until they are hovered

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Open the lab and view a non-input histogram
* Verify that the number inputs are hidden until you mouse over the breakpoint bar

Closes #2807 