### PR TITLE
Handle edge cases when uploading annotations better

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
@@ -7,7 +7,7 @@
       </a>
       <h5 class="sidebar-title">Import Annotations</h5>
     </div>
-    <div class="list-group">
+    <div class="list-group" ng-show="!$ctrl.uploadData">
       <div class="list-group-item">
         <label class="btn btn-primary btn-block btn-upload-label"
                for="btn-upload"
@@ -21,89 +21,171 @@
         </label>
       </div>
     </div>
-  </div>
-    <div class="list-group" ng-if="$ctrl.dataProperties.length">
-        <div class="list-group-item">
-          <div>
-            <span title="Machine made"><strong>Machine made</strong></span>
-          </div>
-          <div class="list-group-right">
-            <rf-toggle value="$ctrl.isMachineData" on-change="$ctrl.isMachineMade()">
-            </rf-toggle>
-          </div>
-        </div>
+    <div class="list-group" ng-show="$ctrl.uploadData">
       <div class="list-group-item">
-          <span title="Label name"><strong>Label name</strong></span>
-          <div class="list-group-right">
-            <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">{{$ctrl.matchKeys.label}}</a>
-              <button type="button" class="btn btn-primary dropdown-toggle">
-                <i class="icon-caret-down"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-                <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
-                  <a ng-click="$ctrl.updateKeySelection('label', p)">{{p}}</a>
-                </li>
-              </ul>
-            </div>
-          </div>
-      </div>
-      <div class="list-group-item">
-          <span title="Description"><strong>Description</strong></span>
-          <div class="list-group-right">
-            <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">{{$ctrl.matchKeys.description}}</a>
-              <button type="button" class="btn btn-primary dropdown-toggle">
-                <i class="icon-caret-down"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-                <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
-                  <a ng-click="$ctrl.updateKeySelection('description', p)">{{p}}</a>
-                </li>
-              </ul>
-            </div>
-          </div>
-      </div>
-      <div class="list-group-item" ng-if="$ctrl.isMachineData">
-          <span title="Confidence"><strong>Confidence</strong></span>
-          <div class="list-group-right">
-            <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">{{$ctrl.matchKeys.confidence}}</a>
-              <button type="button" class="btn btn-primary dropdown-toggle">
-                <i class="icon-caret-down"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-                <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
-                  <a ng-click="$ctrl.updateKeySelection('confidence', p)">{{p}}</a>
-                </li>
-              </ul>
-            </div>
-          </div>
-      </div>
-      <div class="list-group-item"  ng-if="$ctrl.isMachineData">
-          <span title="Quality"><strong>Quality</strong></span>
-          <div class="list-group-right">
-            <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
-              <a class="btn dropdown-label">{{$ctrl.matchKeys.quality}}</a>
-              <button type="button" class="btn btn-primary dropdown-toggle">
-                <i class="icon-caret-down"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-                <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
-                  <a ng-click="$ctrl.updateKeySelection('quality', p)">{{p}}</a>
-                </li>
-              </ul>
-            </div>
-          </div>
+        <strong>
+          Select property names:
+        </strong>
       </div>
     </div>
-    <div class="list-group" ng-if="$ctrl.enableImport">
+  </div>
+  <div class="list-group" ng-if="$ctrl.dataProperties.length">
+    <div class="list-group-item">
+      <div>
+        <span title="Machine made"><strong>Machine made</strong></span>
+      </div>
+      <div class="list-group-right">
+        <rf-toggle value="$ctrl.isMachineData" on-change="$ctrl.isMachineMade()">
+        </rf-toggle>
+      </div>
+    </div>
+    <div class="list-group-item">
+      <span title="Label name"><strong>Label name</strong></span>
+      <div class="list-group-right">
+        <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.label !== null">
+            {{$ctrl.matchKeys.label || 'Choose a column'}}
+          </a>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.label === null">
+            Use default val
+          </a>
+          <button type="button" class="btn btn-primary dropdown-toggle">
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('label', null)">Use default val</a>
+            </li>
+            <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('label', p)">{{p}}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="list-group-item" ng-if="$ctrl.matchKeys.label === null">
+      <span title="Default Label"><strong>Default Label</strong></span>
+      <div class="list-group-right">
+        <input type="text" class="form-control "
+               placeholder="No Default" ng-model="$ctrl.defaultKeys['label']">
+      </div>
+    </div>
+    <div class="list-group-item">
+      <span title="Description"><strong>Description</strong></span>
+      <div class="list-group-right">
+        <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description !== null">
+            {{$ctrl.matchKeys.description || 'Choose a column'}}
+          </a>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description === null">
+            Use default val
+          </a>
+          <button type="button" class="btn btn-primary dropdown-toggle">
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('description', null)">Use default val</a>
+            </li>
+            <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('description', p)">{{p}}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="list-group-item" ng-if="$ctrl.matchKeys.description === null">
+      <span title="Default Label"><strong>Default Description</strong></span>
+      <div class="list-group-right">
+        <input type="textarea" class="form-control "
+               placeholder="No Description" ng-model="$ctrl.defaultKeys['description']">
+      </div>
+    </div>
+    <div class="list-group-item" ng-if="$ctrl.isMachineData">
+      <span title="Confidence"><strong>Confidence</strong></span>
+      <div class="list-group-right">
+        <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.confidence !== null">
+            {{$ctrl.matchKeys.confidence || 'Choose a column'}}
+          </a>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.confidence === null">
+            No confidence rating
+          </a>
+          <button type="button" class="btn btn-primary dropdown-toggle">
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('confidence', null)">No confidence rating</a>
+            </li>
+            <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('confidence', p)">{{p}}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="list-group-item"  ng-if="$ctrl.isMachineData">
+      <span title="Quality"><strong>Quality</strong></span>
+      <div class="list-group-right">
+        <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.quality !== null">
+            {{$ctrl.matchKeys.quality || 'Choose a column'}}
+          </a>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.quality === null">
+            Use default val
+          </a>
+          <button type="button" class="btn btn-primary dropdown-toggle">
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('quality', null)">Use default val</a>
+            </li>
+            <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('quality', p)">{{p}}</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="list-group-item" ng-if="$ctrl.isMachineData && $ctrl.matchKeys.quality === null">
+      <span title="Default Quality"><strong>Default Quality</strong></span>
+      <div class="list-group-right">
+        <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
+          <a class="btn dropdown-label">{{$ctrl.defaultKeys['quality'] || 'None'}}</a>
+          <button type="button" class="btn btn-primary dropdown-toggle">
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a ng-click="$ctrl.defaultKeySelection('quality', 'YES')">YES</a>
+            </li>
+            <li role="menuitem">
+              <a ng-click="$ctrl.defaultKeySelection('quality', 'NO')">NO</a>
+            </li>
+            <li role="menuitem">
+              <a ng-click="$ctrl.defaultKeySelection('quality', 'MISS')">MISS</a>
+            </li>
+            <li role="menuitem">
+              <a ng-click="$ctrl.defaultKeySelection('quality', 'UNSURE')">UNSURE</a>
+            </li>
+            <li role="menuitem">
+              <a ng-click="$ctrl.defaultKeySelection('quality', null)">None</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+    <div class="list-group">
       <div class="list-group-item">
         <button class="btn btn-primary btn-block"
                 type="button"
+                ng-disabled="!$ctrl.enableImport"
+                ng-attr-title="{{$ctrl.enableImport ? 'Import' : 'Make a selection for every required column.'}}"
                 ng-click="$ctrl.onImportClick()">
           Import
         </button>
       </div>
     </div>
-</div>
+  </div>


### PR DESCRIPTION
## Overview
Allow selecting a default value when uploading annotations
Coerce description to a string to prevent api from complaining
Hide upload button once file has been selected
### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/4392704/34799387-9d51608a-f62d-11e7-8d24-b10eeb1f1150.png)

## Testing Instructions

 * Verify that you can select a default value instead of a geojson property when importing
* Verify that the upload button is hidden, and the import button is disabled instead of hidden when all required fields are not filled out

Closes https://github.com/raster-foundry/raster-foundry/issues/2870
