### PR TITLE
Add band editing to datasource detail UI

### DIFF
--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.html
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.html
@@ -12,6 +12,70 @@
       </div>
       <!-- Dashboard Header -->
       <div class="cta-row">
+        <rf-call-to-action-item title="Bands" class="panel panel-off-white">
+          <div class="cta-flex-text">
+            Add or change the names and numbers of bands for the <strong>{{$ctrl.datasource.name}}</strong> datasource.
+          </div>
+          <table class="table">
+            <thead>
+              <tr>
+                <th>Index</th>
+                <th>Number</th>
+                <th>Name</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr ng-repeat="band in $ctrl.bandsBuffer"
+                  ng-class="{'table-row-changed': val.changed}"
+              >
+                <td>
+                  {{$index}}
+                </td>
+                <td>
+                  <input type="text" class="form-control" placeholder="Band Number"
+                         ng-model="band.number"
+                         ng-model-options="{ debounce: 500 }"
+                         ng-change="$ctrl.updateBandBuffer($index, band)"
+                         ng-disabled="!$ctrl.isOwner">
+                </td>
+                <td>
+                  <input type="text" class="form-control" placeholder="Band name"
+                         ng-model="band.name"
+                         ng-model-options="{ debounce: 500 }"
+                         ng-change="$ctrl.updateBandBuffer($index, band)"
+                         ng-disabled="!$ctrl.isOwner">
+                </td>
+                <td class="text-right">
+                  <div ng-show="$ctrl.isOwner">
+                    <button class="btn btn-small" ng-click="$ctrl.removeBand($index)">
+                      <span class="sr-only">Delete</span>
+                      <i class="icon-trash"></i>
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="colormode-actions" ng-show="$ctrl.isOwner">
+            <div>
+              <button type="button" class="btn btn-outline"
+                      ng-click="$ctrl.addBand()">
+                + Add an additional band
+              </button>
+            </div>
+            <div ng-show="$ctrl.changedBandsBuffer">
+              <button class="btn" ng-click="$ctrl.resetBandsBuffer()">
+                Cancel
+              </button>
+              <button class="btn btn-default" ng-click="$ctrl.saveBufferedBands()">
+                Save Changes
+              </button>
+            </div>
+          </div>
+        </rf-call-to-action-item>
+      </div>
+      <div class="cta-row">
         <rf-call-to-action-item title="Color modes" class="panel panel-off-white">
           <div class="cta-flex-text">
             Create preset false color composites that will be available for all imagery from the <strong>{{$ctrl.datasource.name}}</strong> datasource.
@@ -20,9 +84,9 @@
             <thead>
               <tr>
                 <th>Name</th>
-                <th>Red band</th>
-                <th>Green band</th>
-                <th>Blue band</th>
+                <th>Red band index</th>
+                <th>Green band index</th>
+                <th>Blue band index</th>
               </tr>
             </thead>
             <tbody>
@@ -32,23 +96,27 @@
                 <td>
                   <input type="text" class="form-control" placeholder="Color mode name"
                          ng-model="val.label"
+                         ng-model-options="{ debounce: 500 }"
                          ng-change="$ctrl.onBufferChange(preset)" ng-disabled="!$ctrl.isOwner">
                 </td>
                 <td>
                   <input type="text" class="form-control" placeholder="Red Band"
                          ng-model="val.value.redBand"
+                         ng-model-options="{ debounce: 500 }"
                          ng-change="$ctrl.updateBuffer(preset, 'redBand', val.value.redBand)"
                          ng-disabled="!$ctrl.isOwner">
                 </td>
                 <td>
                   <input type="text" class="form-control" placeholder="Green Band"
                          ng-model="val.value.greenBand"
+                         ng-model-options="{ debounce: 500 }"
                          ng-change="$ctrl.updateBuffer(preset, 'greenBand', val.value.greenBand)"
                          ng-disabled="!$ctrl.isOwner">
                 </td>
                 <td>
                   <input type="text" class="form-control" placeholder="Blue Band"
                          ng-model="val.value.blueBand"
+                         ng-model-options="{ debounce: 500 }"
                          ng-change="$ctrl.updateBuffer(preset, 'blueBand', val.value.blueBand)"
                          ng-disabled="!$ctrl.isOwner">
                 </td>

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
@@ -41,6 +41,7 @@ class DatasourceDetailController {
 
     initBuffers() {
         this.colorCompositesBuffer = _.cloneDeep(this.datasource.composites);
+        this.bandsBuffer = _.cloneDeep(this.datasource.bands);
     }
 
     openImportModal() {
@@ -60,7 +61,8 @@ class DatasourceDetailController {
         });
         this.datasourceService.updateDatasource(Object.assign(this.datasource, {
             composites: newBuffer
-        })).then(() => {
+        })).then((ds) => {
+            this.datasource = ds;
             this.changedBuffer = false;
             this.colorCompositesBuffer = newBuffer;
         }, (err) => {
@@ -97,6 +99,46 @@ class DatasourceDetailController {
                 this.isDatasourceVisibilityUpdated = false;
             }
         );
+    }
+
+    addBand() {
+        this.bandsBuffer = [
+            ...this.bandsBuffer,
+            {
+                name: '',
+                number: ''
+            }
+        ];
+        this.changedBandsBuffer = true;
+    }
+
+    removeBand(index) {
+        this.bandsBuffer = [
+            ...this.bandsBuffer.slice(0, index),
+            ...this.bandsBuffer.slice(index + 1, this.bandsBuffer.length)
+        ];
+        this.changedBandsBuffer = true;
+    }
+
+    updateBandBuffer(index, band) {
+        this.bandsBuffer[index] = band;
+        this.changedBandsBuffer = true;
+    }
+
+    saveBufferedBands() {
+        this.datasourceService.updateDatasource(Object.assign(this.datasource, {
+            bands: this.bandsBuffer
+        })).then((ds) => {
+            this.datasource = ds;
+            this.resetBandsBuffer();
+        }, (err) => {
+            this.$log.log('Error saving datasource', err);
+        });
+    }
+
+    resetBandsBuffer() {
+        this.bandsBuffer = _.cloneDeep(this.datasource.bands);
+        this.changedBandsBuffer = false;
     }
 
     addCompositeRow() {

--- a/app-frontend/src/app/pages/imports/imports.html
+++ b/app-frontend/src/app/pages/imports/imports.html
@@ -11,7 +11,10 @@
           Vector
         </a>
         <a ui-sref="imports.datasources.list"
-           ui-sref-active="active">
+           ng-class="{
+             active: ('imports.datasources.list' | includedByState) ||
+                    ('imports.datasources.detail' | includedByState)
+             }">
           Datasources
         </a>
       </nav>


### PR DESCRIPTION
## Overview

This PR adds band editing to the datasource details UI.

There is also a fix for the datasources link in the secondary nav-bar not being highlighted when you go to a datasource's detail view.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![localhost_9091_imports_datasources_detail_697a0b91-b7a8-446e-842c-97cda155554d 2](https://user-images.githubusercontent.com/2442245/34849741-7be2d7ac-f6f1-11e7-8f8f-f1f1487137fe.png)

![localhost_9091_imports_datasources_detail_697a0b91-b7a8-446e-842c-97cda155554d 1](https://user-images.githubusercontent.com/2442245/34849742-7bec0cb4-f6f1-11e7-9795-3089270f25ef.png)


## Testing Instructions

 * Create a new datasource
 * Add, remove, edit bands (saving them along the way) and make sure things persist
 * Make sure cancelling edits works as expected
 * Go to a datasource not owned by your user and make sure you can't edit the bands

Closes #2894
