### PR TITLE
Use `ui-select` component for datasource filter on browse page

### DIFF
--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -41,7 +41,7 @@ trait DatasourceRoutes extends Authentication
     (withPagination & datasourceQueryParams) {
       (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
       complete {
-        list[Datasource](Datasources.listDatasources(page.offset, page.limit, datasourceParams, user),
+        list[Datasource](Datasources.listDatasources(page, datasourceParams, user),
                          page.offset,
                          page.limit)
       }

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -47,8 +47,8 @@
     "angular-ui-tree": "~2.22.1",
     "angular-uuid4": "^0.3.1",
     "angularjs-slider": "~6.1.1",
-    "axios": "^0.17.0",
     "auth0-lock": "~10.24.0",
+    "axios": "^0.17.0",
     "bootstrap-sass": "~3.3.6",
     "d3": "3.4.4",
     "immutable": "^3.8.2",
@@ -70,6 +70,7 @@
     "redux-promise-middleware": "^4.4.1",
     "redux-thunk": "^2.2.0",
     "type-to-reducer": "^1.0.4",
+    "ui-select": "^0.19.8",
     "webpack-fail-plugin": "^1.0.6"
   },
   "devDependencies": {

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.controller.js
@@ -115,7 +115,9 @@ export default class FilterPaneController {
 
     initDataSourceFilters() {
         if (this.selectedBrowseSource === 'Raster Foundry') {
-            this.datasourceService.query().then(d => {
+            this.datasourceService.query({
+                sort: 'name,asc'
+            }).then(d => {
                 this.datasources = d.results;
                 if (this.filters && this.filters.datasource && this.filters.datasource[0]) {
                     let matchedSource = this.datasources.find((ds) => {

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.html
@@ -45,22 +45,18 @@
           ng-mouseleave="$ctrl.toggleDrag.toggle = false"
           ng-mouseup="$ctrl.toggleDrag.toggle = false">
         <label>Imagery sources</label>
-        <div class="searchselect">
-          <input type="text"
-                 placeholder="All"
-                 ng-model="$ctrl.selectedDatasource"
-                 uib-typeahead="ds.name for ds in $ctrl.datasources | filter:$viewValue | limitTo:8"
-                 class="form-control input-dark image-source"
-                 typeahead-on-select="$ctrl.toggleSourceFilter($item)"
-                 typeahead-min-length="0"
-                 typeahead-focus-on-select="false">
-           <i class="icon-caret-down"
-              ng-if="!$ctrl.selectedDatasource"></i>
-          <div class="searchselect-clear"
-               ng-if="$ctrl.selectedDatasource"
-               ng-click="$ctrl.clearDatasourceFilter()">
-            <i class="icon-cross"></i>
-          </div>
+        <ui-select ng-model="$ctrl.selectedDatasource"
+                   theme="selectize"
+                   title="All datasources"
+                   on-select="$ctrl.toggleSourceFilter($item, $model)">
+          <ui-select-match placeholder="Search datasources" allow-clear="true">{{$select.selected.name}}</ui-select-match>
+          <ui-select-choices repeat="ds in $ctrl.datasources | filter: $select.search">
+            {{ds.name}}
+          </ui-select-choices>
+        </ui-select>
+        <div class="searchselect-clear"
+             ng-click="$ctrl.selectedDatasource && $ctrl.clearDatasourceFilter()">
+          <i class="icon-cross"></i>
         </div>
       </div>
     </div>

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -30,6 +30,8 @@ const App = angular.module(
         'angular.filter',
         '720kb.tooltips',
         'uuid4',
+        'ui.select',
+        'ngSanitize',
 
         // services
         require('./services/services.module').name,

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -35,6 +35,7 @@ import 'angular-tooltips';
 import 'mathjs';
 import 'angular-uuid4';
 import 'angular-hotkeys';
+import 'ui-select';
 
 // local scripts
 // import '../assets/js/...';

--- a/app-frontend/src/assets/styles/sass/components/_filter.scss
+++ b/app-frontend/src/assets/styles/sass/components/_filter.scss
@@ -3,6 +3,7 @@
   flex-direction: row;
   align-items: flex-start;
   font-size: 1.2rem;
+  position: relative;
   &:not(:last-child) {
     margin-bottom: 1.2rem;
   }

--- a/app-frontend/src/assets/styles/sass/components/_searchselect.scss
+++ b/app-frontend/src/assets/styles/sass/components/_searchselect.scss
@@ -29,3 +29,178 @@
   }
 
 }
+
+.searchselect-clear {
+  border-radius: 50%;
+  color: $gray;
+  border: 1px solid $gray-lighter;
+  background: $gray-lighter;
+  z-index: 1000;
+  width: 2rem;
+  height: 2rem;
+  transform: translateY(-50%);
+  align-self: center;
+  margin-top: 11px;
+  cursor: pointer;
+}
+
+.selectize-control {
+  position: relative;
+  width: 100%;
+  font-weight: 600;
+}
+.selectize-dropdown,
+.selectize-input,
+.selectize-input input {
+  color: #303030;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 18px;
+}
+.selectize-input,
+.selectize-control.single .selectize-input.input-active {
+  background: #ffffff;
+  cursor: text;
+  display: inline-block;
+}
+.selectize-input {
+  padding: 8px 8px;
+  display: inline-block;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+  box-sizing: border-box;
+  border-radius: 3px;
+  border-color: $shade-dark;
+  background-color: $shade-dark;
+  color: $gray-lightest;
+}
+.selectize-input.dropdown-active {
+  border-radius: 3px 3px 0 0;
+}
+.selectize-input > * {
+  vertical-align: baseline;
+  display: inline-block;
+}
+.selectize-input > input {
+  display: inline-block !important;
+  padding: 0 !important;
+  min-height: 0 !important;
+  max-height: none !important;
+  max-width: 100% !important;
+  margin: 0 2px 0 0 !important;
+  text-indent: 0 !important;
+  border: 0 none !important;
+  background: none !important;
+  line-height: inherit !important;
+  box-shadow: none !important;
+  color: $gray-lightest;
+}
+.selectize-input > input:focus {
+  outline: none !important;
+}
+.selectize-input::after {
+  content: ' ';
+  display: block;
+  clear: left;
+}
+.selectize-input.dropdown-active::before {
+  content: ' ';
+  display: block;
+  position: absolute;
+  background: #f0f0f0;
+  height: 1px;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+.selectize-dropdown {
+  position: absolute;
+  z-index: 10;
+  background: #ffffff;
+  margin: -6px 0 0 0;
+  border-top: 0 none;
+  box-sizing: border-box;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-radius: 0 0 $border-radius-base $border-radius-base;
+  border: 1px solid $shade-dark;
+  background-color: $shade-dark;
+  color: $gray-lightest;
+}
+.selectize-dropdown [data-selectable] {
+  cursor: pointer;
+  overflow: hidden;
+}
+.selectize-dropdown [data-selectable] .highlight {
+  background: rgba(125, 168, 208, 0.2);
+  border-radius: 1px;
+}
+.selectize-dropdown [data-selectable],
+.selectize-dropdown .optgroup-header {
+  padding: 5px 8px;
+}
+.selectize-dropdown .optgroup:first-child .optgroup-header {
+  border-top: 0 none;
+}
+.selectize-dropdown .optgroup-header {
+  color: #303030;
+  background: #ffffff;
+  cursor: default;
+}
+.selectize-dropdown .active {
+  background-color: $gray-light;
+  color: $gray-lighter;
+}
+.selectize-dropdown .active.create {
+  color: #495c68;
+}
+
+.selectize-dropdown .ui-select-choices-row:hover {
+  color: $gray-light;
+}
+.selectize-dropdown .create {
+  color: rgba(48, 48, 48, 0.5);
+}
+.selectize-dropdown-content {
+  overflow-y: auto;
+  overflow-x: hidden;
+  max-height: 200px;
+}
+.selectize-control.single .selectize-input,
+.selectize-control.single .selectize-input input {
+  cursor: pointer;
+}
+.selectize-control.single .selectize-input.input-active,
+.selectize-control.single .selectize-input.input-active input {
+  cursor: text;
+}
+.selectize-control.single .selectize-input:after {
+  content: ' ';
+  display: block;
+  position: absolute;
+  top: 50%;
+  right: 15px;
+  margin-top: -3px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 5px 5px 0 5px;
+  border-color: #808080 transparent transparent transparent;
+}
+.selectize-control.single .selectize-input.dropdown-active:after {
+  margin-top: -4px;
+  border-width: 0 5px 5px 5px;
+  border-color: transparent transparent #808080 transparent;
+}
+.selectize-control.rtl.single .selectize-input:after {
+  left: 15px;
+  right: auto;
+}
+.selectize-control.rtl .selectize-input > input {
+  margin: 0 4px 0 -2px !important;
+}
+.selectize-control .selectize-input.disabled {
+  opacity: 0.5;
+  background-color: #fafafa;
+}

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -7303,6 +7303,10 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
+ui-select@^0.19.8:
+  version "0.19.8"
+  resolved "https://registry.yarnpkg.com/ui-select/-/ui-select-0.19.8.tgz#74860848a7fd8bc494d9856d2f62776ea98637c1"
+
 uid-number@~0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"


### PR DESCRIPTION
## Overview

This PR adds the package `ui-select` and uses it to improve our datasource selection component. 

This PR also adds sorting to the datasources endpoint so that the dropdown can display datasources in abc order.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/34952522-07d82caa-f9e8-11e7-80cd-c057be5efe0f.png)

![image](https://user-images.githubusercontent.com/2442245/34954996-82b871f2-f9f0-11e7-8588-233de69b34f1.png)

## Testing Instructions

* `yarn install` (to get `ui-select`)
* with server running, try filtering by datasources when browsing


Closes #2855 
