### PR TITLE
Styles project export's output sidebar for high-contrast theme

### DIFF
--- a/app-frontend/src/app/components/common/navBar/navBar.html
+++ b/app-frontend/src/app/components/common/navBar/navBar.html
@@ -4,7 +4,7 @@
     <a href
        ui-sref="home"
        class="brand">
-      <img ng-attr-src="{{$ctrl.assetLogo}}">
+      <img ng-attr-src="{{$ctrl.assetLogo}}" style="max-width: 50px;">
     </a>
     <span class="navbar-vertical-divider"></span>
     <nav>

--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/layout/_sidebar.scss
@@ -26,4 +26,16 @@
   .header-controls .btn-default {
     @extend .btn-light;
   }
+
+  .sidebar-list-item {
+    border-bottom-color: $border-color-default;
+
+    &.selected {
+      background-color: $off-white;
+    }
+
+    p.color-light {
+      color: $text-base !important;
+    }
+  }
 }


### PR DESCRIPTION
## Overview
Fixes a styling issue in the high-contrast theme. On Project > Export > Output processing there was dark styling left over from the default theme.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [ ] PR has a name that won't get you publicly shamed for vagueness

### Demo
<img width="402" alt="screen shot 2018-01-16 at 10 58 34 am" src="https://user-images.githubusercontent.com/1928955/34998822-1fb8b86e-faae-11e7-9b77-340e6f602623.png">

## Testing Instructions

 * Open a project
 * Go to exports
 * Click on output processing

Closes #2857
