### PR TITLE
Determine annotation organization from user

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -69,7 +69,6 @@ case class AnnotationProperties(
 @JsonCodec
 case class AnnotationPropertiesCreate(
     owner: Option[String],
-    organizationId: UUID,
     label: String,
     description: Option[String],
     machineGenerated: Option[Boolean],
@@ -102,7 +101,6 @@ object Annotation {
     @JsonCodec
     case class Create(
         owner: Option[String],
-        organizationId: UUID,
         label: String,
         description: Option[String],
         machineGenerated: Option[Boolean],
@@ -122,7 +120,7 @@ object Annotation {
                 now, // modifiedAt
                 user.id, // modifiedBy
                 ownerId, // owner
-                organizationId,
+                user.organizationId,
                 label,
                 description,
                 machineGenerated,
@@ -141,7 +139,6 @@ object Annotation {
         def toAnnotationCreate(): Annotation.Create = {
             Annotation.Create(
                 properties.owner,
-                properties.organizationId,
                 properties.label,
                 properties.description,
                 properties.machineGenerated,

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -228,21 +228,6 @@ class AnnotateController {
         );
     }
 
-    importLocalAnnotations(annotationGeojson) {
-        let newAnnotations = {
-            type: 'FeatureCollection',
-            features: annotationGeojson.features.map(annotation => {
-                return Object.assign({}, annotation, {
-                    properties: Object.assign({}, annotation.properties, {
-                        organizationId: this.user.organizationId
-                    })
-                });
-            })
-        };
-
-        this.createAnnotations(newAnnotations);
-    }
-
     onClearAnnotation() {
         let answer = this.$window.confirm('Delete ALL annotations from this project?');
         if (answer) {
@@ -282,7 +267,6 @@ class AnnotateController {
         let annotationCollection = wrapFeatureCollection(
             propertiesToAnnotationFeature({
                 geometry: shape.geometry,
-                organizationId: this.user.organizationId,
                 label,
                 description
             })

--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.module.js
@@ -88,7 +88,7 @@ class AnnotateImportController {
     }
 
     onImportClick() {
-        this.$parent.importLocalAnnotations({
+        this.$parent.createAnnotations({
             'type': 'FeatureCollection',
             'features': this.uploadData.features.map((feature) => {
                 let confidence = null;


### PR DESCRIPTION
## Overview

This PR removes the need for providing an `organizationId` when creating annotations. Instead, the owning organization is always assumed to be the same organization as the user.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * With the network tools open create some annotations and notice that they do not have `organizationId` as a property and that the server doesn't complain

Closes #2904
