### PR TITLE
Add Shapefile Upload Processing Route for Shapes API

### DIFF
--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -1,21 +1,16 @@
 package com.azavea.rf.api.shape
 
-import java.net.URL
 import java.util.UUID
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.Success
-
-import akka.http.scaladsl.server.{Route, PathMatcher}
-import akka.http.scaladsl.model.{StatusCodes, Uri}
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import io.circe._
 import io.circe.generic.JsonCodec
 import io.circe.syntax._
-
 import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 import com.azavea.rf.common._
 import com.azavea.rf.database.tables.{Shapes, Users}
@@ -23,11 +18,19 @@ import com.azavea.rf.database.query._
 import com.azavea.rf.database.{ActionRunner, Database}
 import com.azavea.rf.datamodel._
 import com.azavea.rf.datamodel.GeoJsonCodec._
+import geotrellis.shapefile.ShapeFileReader
+import better.files.{File => ScalaFile, _}
+
+import akka.http.scaladsl.server.directives.FileInfo
+import geotrellis.proj4.{CRS, LatLng, WebMercator}
+import geotrellis.slick.Projected
+import geotrellis.vector.reproject.Reproject
 
 @JsonCodec
 case class ShapeFeatureCollectionCreate (
   features: Seq[Shape.GeoJSONFeatureCreate]
 )
+
 
 trait ShapeRoutes extends Authentication
   with QueryParametersCommon
@@ -44,12 +47,63 @@ trait ShapeRoutes extends Authentication
       get { listShapes } ~
       post { createShape }
     } ~
-    pathPrefix(JavaUUID) { shapeId =>
-      pathEndOrSingleSlash {
-        get { getShape(shapeId) } ~
-        put { updateShape(shapeId) } ~
-        delete { deleteShape(shapeId) }
+      post {
+        pathPrefix("upload") {
+          pathEndOrSingleSlash {
+            authenticate { user =>
+              val tempFile = ScalaFile.newTemporaryFile()
+              val response = storeUploadedFile("name", (_) => tempFile.toJava) { (m, _) =>
+                processShapefile(user, tempFile, m)
+              }
+              tempFile.delete()
+              response
+            }
+          }
+        } ~
+          pathPrefix(JavaUUID) { shapeId =>
+            pathEndOrSingleSlash {
+              get { getShape(shapeId) } ~
+                put { updateShape(shapeId) } ~
+                delete { deleteShape(shapeId) }
+            }
+          }
       }
+  }
+
+  def processShapefile(user: User, tempFile: ScalaFile, fileMetadata: FileInfo) = {
+    val unzipped = tempFile.unzip()
+    val matches = unzipped.glob("*.shp")
+    matches.hasNext match {
+      case true => {
+        val shapeFile = matches.next()
+        val features = ShapeFileReader.readMultiPolygonFeatures(shapeFile.toString)
+
+        // Only reads first feature
+        features match {
+          case Nil => complete(StatusCodes.ClientError(400)("Bad Request", "No MultiPolygons detected in Shapefile"))
+          case feature +: _ => {
+            val geometry = feature.geom
+            val reprojectedGeometry = Projected(Reproject(geometry, LatLng, WebMercator), 3857)
+            reprojectedGeometry.isValid match {
+              case true => {
+                val shape = Shape.create(
+                  Some(user.id),
+                  user.organizationId,
+                  fileMetadata.fileName,
+                  None,
+                  Some(reprojectedGeometry)
+                )
+                complete(Shapes.insertShapes(Seq(shape), user))
+              }
+              case _ => {
+                val reason = "No valid MultiPolygons found, please ensure coordinates are in EPSG:4326 before uploading"
+                complete(StatusCodes.ClientError(400)("Bad Request", reason))
+              }
+            }
+          }
+        }
+      }
+      case _ => complete(StatusCodes.ClientError(400)("Bad Request", "No Shapefile Found in Archive"))
     }
   }
 

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -52,6 +52,7 @@ trait ShapeRoutes extends Authentication
           pathEndOrSingleSlash {
             authenticate { user =>
               val tempFile = ScalaFile.newTemporaryFile()
+              tempFile.deleteOnExit()
               val response = storeUploadedFile("name", (_) => tempFile.toJava) { (m, _) =>
                 processShapefile(user, tempFile, m)
               }
@@ -93,7 +94,7 @@ trait ShapeRoutes extends Authentication
                   None,
                   Some(reprojectedGeometry)
                 )
-                complete(Shapes.insertShapes(Seq(shape), user))
+                complete(StatusCodes.Created, Shapes.insertShapes(Seq(shape), user))
               }
               case _ => {
                 val reason = "No valid MultiPolygons found, please ensure coordinates are in EPSG:4326 before uploading"

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -129,6 +129,8 @@ lazy val apiDependencies = dbDependencies ++ migrationsDependencies ++
   Dependencies.ammoniteOps,
   Dependencies.geotrellisSlick,
   Dependencies.geotrellisS3,
+  Dependencies.geotrellisShapefile,
+  Dependencies.betterFiles,
   Dependencies.caffeine,
   Dependencies.scaffeine,
   Dependencies.findbugAnnotations,

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   val geotrellisSlick         = "org.locationtech.geotrellis" %% "geotrellis-slick"                  % Version.geotrellis
   val geotrellisVector        = "org.locationtech.geotrellis" %% "geotrellis-vector"                 % Version.geotrellis
   val geotrellisUtil          = "org.locationtech.geotrellis" %% "geotrellis-util"                   % Version.geotrellis
+  val geotrellisShapefile     = "org.locationtech.geotrellis" %% "geotrellis-shapefile"              % Version.geotrellis
   val spark                   = "org.apache.spark"            %% "spark-core"                        % Version.spark % "provided"
   val sparkCore               = "org.apache.spark"            %% "spark-core"                        % Version.spark
   val hadoopAws               = "org.apache.hadoop"            % "hadoop-aws"                        % Version.hadoop
@@ -68,4 +69,5 @@ object Dependencies {
   val nimbusJose              = "com.guizmaii"                %% "scala-nimbus-jose-jwt"             % Version.nimbusJose
   val auth0                   = "com.auth0"                    % "auth0"                             % Version.auth0
   val slickMigrationAPI       = "io.github.nafg"              %% "slick-migration-api"               % Version.slickMigrationAPI
+  val betterFiles             = "com.github.pathikrit"        %% "better-files"                      % Version.betterFiles
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -1,7 +1,7 @@
 object Version {
   val rasterFoundry      = "0.1"
   val akka               = "2.5.6"
-  val akkaHttp           = "10.0.10"
+  val akkaHttp           = "10.1.0-RC1"
   val geotrellis         = "1.2.1-SNAPSHOT"
   val hikariCP           = "3.2.0"
   val postgres           = "42.1.1"
@@ -46,4 +46,5 @@ object Version {
   val nimbusJose         = "0.6.0"
   val auth0              = "1.5.0"
   val slickMigrationAPI  = "0.4.0"
+  val betterFiles        = "3.4.0"
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1932,6 +1932,29 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /shapes/upload:
+    x-resource: Projects
+    post:
+      summary: Create shapes belonging to the current user using POSTed data
+      tags:
+        - Imagery
+      consumes:
+        - multipart/form-data
+      parameters:
+        - name: name
+          in: formData
+          type: file
+          required: true
+      responses:
+        201:
+          description: GeoJSON shapes successfully created
+          schema:
+            $ref: '#/definitions/ShapeFeatureCollection'
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
   /shapes/{uuid}:
     x-resouce: Projects
     get:

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -25,6 +25,17 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
+    location /api/shapes/upload {
+        client_max_body_size 20m;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_read_timeout 20s;
+        proxy_redirect off;
+
+        proxy_pass http://api-server-upstream;
+    }
+
     location ~* ^\/api\/exports\/.*\/files\/.* {
         limit_req zone=download burst=5 nodelay;
 


### PR DESCRIPTION
## Overview

This commit adds a new route (/api/shapes/upload/) that accepts a multipart form
upload with a zipfile in the "name" field for processing. This zipfile is
expected to contain a shapefile with at least one geometry. A shape will created
using the filename for the file uploaded. Users will have the opportunity to
adjust the name of the shape after upload if they desire to do so in the UI.

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] Swagger specification updated, if necessary
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![shapefileupload](https://user-images.githubusercontent.com/898060/35234052-e0a31344-ff6d-11e7-917a-cab77e2c6ea7.png)

### Notes

Support in GeoTrellis for parsing OGC WKT projections is not very complete -- currently GeoTrellis attempts to match the WKT string which can be kind of brittle. As a result, the endpoint added here makes the assumption that all uploads are in lat/lng. As GeoTrellis supports WKT parsing more directly or we add that ability in RF we can relax this assumption. Errors caused by not being in lat/lng are caught by first checking the validity of the geometry prior to parsing.

Additionally, it was unclear how we should handle a shapefile with multiple polygons and naming them. We could create shapes for each one and use a field to name them instead of relying on the filename for naming a polygon -- @jmorrison1847 and @designmatty suggested only parsing a single shape to start. It doesn't make much difference on the backend if we decide to go the other route, but could complicate the UI a little.

## Testing Instructions

 * Start the API server and frontend
 * Log in and obtain a token
 * Make a `POST` request with `multipart/form-data` with a single field ("name") with a zip file containing a shapefile and all sidecar files
 * Check that the response is a new created shape

Closes https://github.com/azavea/raster-foundry-platform/issues/246
