### PR TITLE
Add notification stub to project AOI updates

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -1,5 +1,10 @@
 package com.azavea.rf.batch.aoi
 
+import com.auth0.client.mgmt._
+import com.auth0.client.mgmt.filter.UserFilter
+import com.auth0.client.auth._
+import com.auth0.json.auth.TokenHolder
+
 import com.azavea.rf.batch.Job
 import com.azavea.rf.database.tables._
 import com.azavea.rf.database.{Database => DB}
@@ -22,40 +27,65 @@ case class UpdateAOIProject(projectId: UUID)(implicit val database: DB) extends 
   import database.driver.api._
 
   def run: Unit = {
+    val authApi = new AuthAPI(auth0Config.domain, auth0Config.clientId, auth0Config.clientSecret)
+    val mgmtTokenRequest = authApi.requestToken(s"https://${auth0Config.domain}/api/v2/")
+    val mgmtToken = mgmtTokenRequest.execute
+    val mgmtApi = new ManagementAPI(auth0Config.domain, mgmtToken.getAccessToken)
+
     logger.info(s"Updating Project $projectId AOI...")
     val result = for {
       user: User                   <- OptionT(Users.getUserById(systemUser))
       (project: Project, aoi: AOI) <- OptionT(Projects.getAOIProject(projectId, user))
-      scenes: Iterable[UUID]       <- OptionT({
-        val area = aoi.area
-        val queryParams =
-          aoi
-            .filters.as[CombinedSceneQueryParams]
-            .getOrElse(throw new Exception(s"No valid queryParams passed: ${aoi.filters}"))
+      scenes: Iterable[UUID]       <- OptionT(
+        {
+          val area = aoi.area
+          val queryParams =
+            aoi
+              .filters.as[CombinedSceneQueryParams]
+              .getOrElse(throw new Exception(s"No valid queryParams passed: ${aoi.filters}"))
 
-        val scenes: Future[Iterable[UUID]] = (for {
-          sceneIds <- OptionT.liftF(
-            database.db.run {
-              Scenes
-                .filterScenes(queryParams)
-                .filterUserVisibility(user)
-                .filter { s => s.dataFootprint.intersects(area) && s.createdAt > project.aoisLastChecked }
-                .map { _.id }
-                .result
+          val scenes: Future[Iterable[UUID]] = (
+            for {
+              sceneIds <- OptionT.liftF(
+                database.db.run {
+                  Scenes
+                    .filterScenes(queryParams)
+                    .filterUserVisibility(user)
+                    .filter { s => s.dataFootprint.intersects(area) && s.createdAt > project.aoisLastChecked }
+                    .map { _.id }
+                    .result
+                }
+              )
+              projects <- OptionT.liftF(Projects.addScenesToProject(sceneIds, projectId, user))
+            } yield projects.map(_.id)).value.map(_.getOrElse(Seq()))
+
+
+          scenes.map {
+            scenesSeq => {
+              logger.info(s"Project $projectId is updated.")
+              Projects.updateProject(
+                project.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)),
+                projectId,
+                user
+              )
+              scenesSeq.some
             }
-          )
-          projects <- OptionT.liftF(Projects.addScenesToProject(sceneIds, projectId, user))
-        } yield projects.map(_.id)).value.map(_.getOrElse(Seq()))
+          }
+        }
+      )
+    } yield (scenes, project)
 
-        scenes.map { scenesSeq => {
-          logger.info(s"Project $projectId is updated.")
-          Projects.updateProject(project.copy(aoisLastChecked = Timestamp.from(ZonedDateTime.now.toInstant)), projectId, user)
-          scenesSeq.some
-        } }
-      })
-    } yield scenes
-
-    val future: Future[Iterable[UUID]] = result.value.map { _.getOrElse(Seq()) }
+    val future: Future[Iterable[UUID]] = result.value.map {
+      (option: Option[(Iterable[UUID], Project)]) =>
+      option match {
+        case Some((scenes: Iterable[UUID], project: Project)) =>
+          val user = mgmtApi.users().get(project.owner, new UserFilter()).execute()
+          logger.info(s"Notifications stub - ${project.owner} -> ${user.getEmail}")
+          scenes
+        case _ =>
+          Seq()
+      }
+    }
 
     future onComplete {
       case Success(seq) => {


### PR DESCRIPTION
## Overview
Add stub for notifications to project AOI updates

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
```
root@a4c19aa20b71:/# rf update-aoi-project e3c1ec07-26d8-44f1-b6aa-b1ea8ba2ed99
17:44:02.755 [INFO ] c.z.h.HikariDataSource - HikariPool-1 - Started.
17:44:02.937 [INFO ] c.z.h.p.PoolBase - HikariPool-1 - Driver does not support get/set network timeout for connections. (Method org.postgresql.jdbc.PgConnection.getNetworkTimeout() is not yet implemented.)
17:44:03.191 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding uuid -> java.util.UUID
17:44:03.192 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding text -> java.lang.String
17:44:03.192 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding bool -> Boolean
17:44:03.222 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _uuid -> scala.collection.Seq
17:44:03.227 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _text -> scala.collection.Seq
17:44:03.227 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _int8 -> scala.collection.Seq
17:44:03.227 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _int4 -> scala.collection.Seq
17:44:03.227 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _int2 -> scala.collection.Seq
17:44:03.228 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _float4 -> scala.collection.Seq
17:44:03.228 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _float8 -> scala.collection.Seq
17:44:03.228 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _bool -> scala.collection.Seq
17:44:03.228 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _date -> scala.collection.Seq
17:44:03.229 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _time -> scala.collection.Seq
17:44:03.229 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding _timestamp -> scala.collection.Seq
17:44:03.254 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding int4range -> com.github.tminglei.slickpg.Range
17:44:03.254 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding int8range -> com.github.tminglei.slickpg.Range
17:44:03.255 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding numrange -> com.github.tminglei.slickpg.Range
17:44:03.255 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding tsrange -> com.github.tminglei.slickpg.Range
17:44:03.255 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding daterange -> com.github.tminglei.slickpg.Range
17:44:03.280 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding json -> io.circe.Json
17:44:03.281 [INFO ] c.a.r.d.ExtendedPostgresDriver -  >>> binding jsonb -> io.circe.Json
17:44:04.980 [INFO ] c.a.r.b.a.UpdateAOIProject - Updating Project e3c1ec07-26d8-44f1-b6aa-b1ea8ba2ed99 AOI...
[DEBUG] [01/23/2018 17:44:06.196] [main] [EventStream(akka://find_aoi_projects-system)] logger log1-Logging$DefaultLogger started
[DEBUG] [01/23/2018 17:44:06.197] [main] [EventStream(akka://find_aoi_projects-system)] Default Loggers started
17:44:07.337 [INFO ] c.a.r.d.t.Projects$ - Number of sceneToProject inserts: 2
17:44:07.484 [INFO ] c.a.r.d.t.Projects$ - Scene IDs right at the end: Vector(94645b74-abb7-44c3-a6cf-0cebf7d9ff4b, c4bf4867-5964-4c19-a18d-8c83dc906544)
17:44:07.917 [INFO ] c.a.r.b.a.UpdateAOIProject - Project e3c1ec07-26d8-44f1-b6aa-b1ea8ba2ed99 is updated.
17:44:08.576 [INFO ] c.a.r.b.a.UpdateAOIProject - Notifications stub - auth0|59318a9d2fbbca3e16bcfc92 -> dev@rasterfoundry.com
17:44:08.578 [INFO ] c.a.r.b.a.UpdateAOIProject - Updated Project e3c1ec07-26d8-44f1-b6aa-b1ea8ba2ed99 with scenes: 94645b74-abb7-44c3-a6cf-0cebf7d9ff4b,c4bf4867-5964-4c19-a18d-8c83dc906544
[DEBUG] [01/23/2018 17:44:08.637] [find_aoi_projects-system-akka.actor.default-dispatcher-2] [EventStream] shutting down: StandardOutLogger started
INFO:rf.commands.update_aoi_project:Checking whether e3c1ec07-26d8-44f1-b6aa-b1ea8ba2ed99 has updated scenes available
INFO:rf.commands.update_aoi_project:Successfully completed project e3c1ec07-26d8-44f1-b6aa-b1ea8ba2ed99 update
```
### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Rebuild batch/assembly
* run `rf update-aoi-project` on a project which should detect and add new scenes
* Verify that it logs the notifications stub

Closes #2922
