### PR TITLE
Update jquery

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -53,7 +53,7 @@
     "d3": "3.4.4",
     "immutable": "^3.8.2",
     "jointjs": "~1.1.0",
-    "jquery": "~2.1.4",
+    "jquery": "~3.1.1",
     "leaflet": "1.2.0",
     "leaflet-draw": "~0.4.9",
     "leaflet-draw-drag": "~0.4.4",

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -4065,13 +4065,9 @@ jointjs@~1.1.0:
     jquery "3.1.1"
     lodash "3.10.1"
 
-jquery@3.1.1:
+jquery@3.1.1, jquery@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.1.tgz#347c1c21c7e004115e0a4da32cece041fad3c8a3"
-
-jquery@~2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-2.1.4.tgz#228bde698a0c61431dc2630a6a154f15890d2317"
 
 js-base64@^2.1.9, js-base64@~2.1.8:
   version "2.1.9"


### PR DESCRIPTION
## Overview

Update jquery

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Only library that depends on it is jointjs, which uses 3.1.1 already
We don't use jquery for anything complicated, so I don't foresee any issues with it

## Testing Instructions

 * Verify that no dependencies are broken via `npm ls jquery`

Closes https://github.com/azavea/raster-foundry-platform/issues/251
