### PR TITLE
styling fix for high-contrast theme datasources filter dropdown

### DIFF
--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_filter.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_filter.scss
@@ -12,4 +12,38 @@
     font-weight: 700;
     margin-bottom: 1rem;
   }
+
+  .selectize-control {
+    width: 90%;
+    margin-right: 0 !important;
+  }
+
+  .selectize-input {
+    border: 1px solid $shade-light;
+    background-color: $white;
+    color: $text-base;
+  }
+
+  .searchselect-clear {
+    background: $white;
+    border-color: $shade-light;
+    width: 3rem;
+    height: 3rem;
+    line-height: 3rem;
+    text-align: center;
+    position: absolute;
+    bottom: -8px;
+    right: 0;
+    margin: 0;
+  }
+
+  .selectize-dropdown {
+    background-color: $white;
+    color: $text-base;
+
+    .active {
+      background-color: $off-white;
+      color: $brand-primary
+    }
+  }
 }


### PR DESCRIPTION
## Overview
The layout and style of the selectize dropdown were broken in the high-contrast theme. This PR resolves those issues.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
<img width="390" alt="screen shot 2018-01-24 at 11 24 04 am" src="https://user-images.githubusercontent.com/1928955/35343974-f25002f4-00f9-11e8-8401-9913fc776b8a.png">

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Open a project
 * Browse and filter
 * Play with the datasources select

Closes #2907
