### PR TITLE
Adjust logout timer

### DIFF
--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -384,9 +384,11 @@ export default (app) => {
                 try {
                     const expDate = this.jwtHelper.getTokenExpirationDate(accessToken);
                     const nowDate = new Date();
-                    const timeoutMillis = expDate.getTime() - nowDate.getTime() - 5 * 60 * 1000;
+                    const timeoutMillis = expDate.getTime() - nowDate.getTime();
                     // Store in case we need to cancel for some reason
-                    this.pendingReauth = this.$timeout(() => this.login(null), timeoutMillis);
+                    this.pendingReauth = this.$timeout(() => {
+                        this.logout();
+                    }, timeoutMillis);
                 } catch (e) {
                     this.$state.go('login');
                 }


### PR DESCRIPTION
## Overview

This should fix the issue where your jwt expires, then the login fails afterward.


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes
In the future, we should redirect back to the page they were on
Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * Wait until your token expires and see if logging in again without reloading fails.
   * not actually. Just merge this if it looks good, it shouldn't make the problem worse 

Closes #2815
