### PR TITLE
Add shared/consistent sorting for scene ordering in projects

### DIFF
--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/ScenesToProjects.scala
@@ -246,7 +246,6 @@ class ScenesToProjectesTableQuery[M, U, C[_]](scenesToProjects: ScenesToProjects
 
   def sortDefault: ScenesToProjects.TableQuery = {
     scenesToProjects
-      .sortBy(_.sceneOrder.asc.nullsLast)
-      .sortBy(_.sceneId.asc)
+      .sortBy(s2p => (s2p.sceneOrder.asc.nullsLast, s2p.sceneId.asc))
   }
 }


### PR DESCRIPTION
## Overview

This commit adds more explicit scene ordering for projects. In cases where
`scene_order` was undefined the sort ordering was non-deterministic. This commit
adds an abstract sort method for `ScenesToProjects` queries that sorts by
`sceneOrder` and then the ID of the scene. In cases where `sceneOrder` is
defined then that will be used for sorting still.
### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Make a `GET` request to: `http://localhost:9091/api/projects/3bc4ca13-d63e-4d62-ba22-363f28144ed2/order` and note the scene order is sorted alphabetically
 * Make a `PUT` request to `http://localhost:9091/api/projects/3bc4ca13-d63e-4d62-ba22-363f28144ed2/order` with the body of:
 ```json
[
        "a9453bed-67ae-47c3-8320-25b6112c95df",
        "2fdc678b-80a9-4dfe-99dc-981f501a3e88",
        "89588702-aa3d-4b3f-b564-d46b199dc2ce"
]
```
 * Make another `GET` request to `http://localhost:9091/api/projects/3bc4ca13-d63e-4d62-ba22-363f28144ed2/order` and verify the order is the same as the `PUT` request in the response

Closes https://github.com/raster-foundry/raster-foundry/issues/2917
