### PR TITLE
Explicitly Order resolvers for Dependencies in `build.sbt`

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -24,14 +24,21 @@ lazy val commonSettings = Seq(
     "-Ypartial-unification",
     "-Ypatmat-exhaust-depth", "100"
   ),
-  resolvers ++= Seq(
+  externalResolvers := Seq(
+    "Geotoolkit Repo" at "http://maven.geotoolkit.org",
+    "Open Source Geospatial Foundation Repo" at "http://download.osgeo.org/webdav/geotools/",
+    DefaultMavenRepository,
     Resolver.sonatypeRepo("snapshots"),
+    Resolver.bintrayRepo("azavea", "maven"),
     Resolver.bintrayRepo("lonelyplanet", "maven"),
     Resolver.bintrayRepo("guizmaii", "maven"),
     Resolver.bintrayRepo("kwark", "maven"), // Required for Slick 3.1.1.2, see https://github.com/azavea/raster-foundry/pull/1576
     "locationtech-releases" at "https://repo.locationtech.org/content/groups/releases",
     "locationtech-snapshots" at "https://repo.locationtech.org/content/groups/snapshots",
-    Resolver.bintrayRepo("naftoligug", "maven")
+    Resolver.bintrayRepo("naftoligug", "maven"),
+    Classpaths.sbtPluginReleases,
+    Opts.resolver.sonatypeReleases,
+    Resolver.bintrayIvyRepo("kamon-io", "sbt-plugins")
   ),
   shellPrompt := { s => Project.extract(s).currentProject.id + " > " },
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -1,10 +1,3 @@
-resolvers ++= Seq(
-  Classpaths.sbtPluginReleases,
-  Opts.resolver.sonatypeReleases
-)
-
-resolvers += Resolver.bintrayIvyRepo("kamon-io", "sbt-plugins")
-
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")


### PR DESCRIPTION
## Overview

This follows a fix from other projects that have run into this issue where maven
central says it has the dependency (in this case JAI); however, all the links to
the actual files are incorrect. This fixes the problem by explicitly setting the
resolver order to one where the dependency is known to exist.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

Testing this is kind of a pain because downloading dependencies from scratch on a local machine takes a while. The best test might be if the build for this PR succeeds - thus reviewing this PR might be limited to reviewing the code rather than functionality.

_If_ you desire to test this more fully, the best way to verify this fixes the problem would be to do the following:
 * Delete the ivy cache in `app-backend/project/.ivy`
 * While on develop, download dependencies
```
./scripts/console api-server ./sbt
project api
update
```
 * This should error out by failing to find a dependency (re-running it will solve the problem)
 * Delete the ivy cache, switch to this branch, and attempt to run update (no errors should occur)

Closes #2938 
