### PR TITLE
Trigger deployment stages of build for branches prefixed with /test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,10 +23,10 @@ node {
 
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /(release|hotfix|test)\//) {
       // When a release branch is used, override `env.RF_DOCS_BUCKET`
       // and `env.RF_DEPLOYMENT_BRANCH`.
-      if (env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+      if (env.BRANCH_NAME =~ /(release|hotfix)\//) {
         env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
         env.RF_DEPLOYMENT_BRANCH = 'master'
       } else {
@@ -70,7 +70,7 @@ node {
         // When a release branch is used, override `env.RF_SETTINGS_BUCKET`
         // so that it uses the production infrastructure configuration
         // settings.
-        if (env.BRANCH_NAME.startsWith('release/') || env.BRANCH_NAME.startsWith('hotfix/')) {
+        if (env.BRANCH_NAME =~ /(release|hotfix)\//) {
           env.RF_SETTINGS_BUCKET = 'rasterfoundry-production-config-us-east-1'
 
           def slackMessage = ":rasterfoundry: production deployment in-progress... <${env.BUILD_URL}|View Build>"


### PR DESCRIPTION
## Overview

When a branch is prefixed with `/test`, treat it similarly to how we treat `develop` now.

In addition, simplify the expressions used to match `release/` and `hotfix/` branches.

Resolves https://github.com/azavea/raster-foundry-platform/issues/250

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

See: http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/test%252Fhmc%252Fdeploy-on-test-prefix/2/

## Testing Instructions

Review Jenkins build output and ensure that none of the conditions were altered in the process of condensing multiple conditions into one regular expression.