### PR TITLE
Indicate Scene Permissions on Results in Browser

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -27,10 +27,19 @@
   </div>
   <div class="list-group-right">
     <rf-toggle-old
-      ng-if="$ctrl.onSelect && !$ctrl.isDisabled"
+      ng-if="$ctrl.onSelect && !$ctrl.isDisabled && $ctrl.hasDownloadPermission()"
       model="$ctrl.selectedStatus"
       on-change="$ctrl.toggleSelected($event)">
     </rf-toggle-old>
+    <div class="scene-item-lock"
+      tooltips
+      tooltip-template="This imagery requires additional access{{$ctrl.repository.service.permissionSource}}."
+      tooltip-size="small"
+      tooltip-class="rf-tooltip"
+      tooltip-side="left"
+      ng-if="!$ctrl.hasDownloadPermission()">
+      <span class="icon-locked"></span>
+    </div>
     <ng-transclude>
     </ng-transclude>
   </div>

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -72,6 +72,13 @@ class SceneItemController {
         let acqDate = this.scene.filterFields.acquisitionDate;
         return acqDate ? acqDate : this.scene.createdAt;
     }
+
+    hasDownloadPermission() {
+        if (this.repository.service.getScenePermissions(this.scene).includes('download')) {
+            return true;
+        }
+        return false;
+    }
 }
 
 const SceneItemModule = angular.module('components.scenes.sceneItem', []);

--- a/app-frontend/src/app/services/scenes/planetRepository.service.js
+++ b/app-frontend/src/app/services/scenes/planetRepository.service.js
@@ -10,6 +10,8 @@ export default (app) => {
             this.uploadService = uploadService;
             this.modalService = modalService;
             this.$state = $state;
+
+            this.permissionSource = ' from planet.com';
             this.skipThumbnailClipping = true;
         }
 
@@ -376,6 +378,15 @@ export default (app) => {
                     });
                 });
             });
+        }
+
+        getScenePermissions(scene) {
+            let result = [];
+            if (scene && scene.permissions
+                && scene.permissions.includes('assets.analytic:download')) {
+                result.push('download');
+            }
+            return result;
         }
     }
 

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -214,6 +214,14 @@ export default (app) => {
         addToProject(projectId, scenes) {
             return this.projectService.addScenes(projectId, scenes.map(scene => scene.id));
         }
+
+        getScenePermissions(scene) {
+            let result = [];
+            if (scene) {
+                result.push('download');
+            }
+            return result;
+        }
     }
 
     app.service('RasterFoundryRepository', RasterFoundryRepository);

--- a/app-frontend/src/app/services/vendor/planetLabs.service.js
+++ b/app-frontend/src/app/services/vendor/planetLabs.service.js
@@ -107,7 +107,9 @@ export default (app) => {
                         sunAzimuth: feature.properties.sun_azimuth,
                         sunElevation: feature.properties.sun_elevation
                     },
-                    statusFields: {}
+                    statusFields: {},
+                    // eslint-disable-next-line no-underscore-dangle
+                    permissions: feature._permissions
                 };
             });
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -105,6 +105,13 @@ dl.meta-list > dd {
   margin-right: 0rem
 }
 
+.scene-item-lock {
+  color: $shade-normal;
+  background-color: $off-white;
+  border-radius: 2px;
+  padding: 5px;
+}
+
 //
 
 


### PR DESCRIPTION
## Overview

This PR allows indicating scene permissions on filtered scenes in the browser.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

For Planet scenes - if they do not have download permissions, locked:

<img width="1920" alt="pl-not-dl" src="https://user-images.githubusercontent.com/16109558/35826136-d89722a8-0a85-11e8-90f1-8c8daffa7f35.png">

For Planet scenes - if they have download permissions, not locked:

<img width="1920" alt="pl-dl" src="https://user-images.githubusercontent.com/16109558/35826121-ccf22d76-0a85-11e8-96f0-b1ee1bb1f5f8.png">

For RF scenes - not locked:

<img width="1920" alt="rf" src="https://user-images.githubusercontent.com/16109558/35825878-268f894c-0a85-11e8-8db6-74aa1af69fb1.png">





## Testing Instructions

 * Deactivate the feature flags
 * Go to scene browser
 * Select RF data repo and browse scenes - they should not be locked
 * Switch to Planet Labs repo and browse scenes - scenes within California may not be locked as users should have download permissions (per planet terms); scenes in other places may be locked.

Closes #2927 
