### PR TITLE
Update geotiff tile-footprint generation to handle multiple NODATA areas

### DIFF
--- a/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_footprints.py
@@ -49,7 +49,13 @@ def extract_footprints(organization_id, tif_path):
 
         data_footprint = [feature['geometry']['coordinates'] for feature in geojson['features'] if feature['properties']['DN'] == 255]
 
-        xs, ys = zip(*data_footprint[0][0])
+        xs = []
+        ys = []
+
+        for area in data_footprint:
+          xst, yst = zip(*area[0])
+          xs += xst
+          ys += yst
 
         xmin = min(xs)
         xmax = max(xs)


### PR DESCRIPTION
## Overview

This PR makes a small change to the processing of the `gdal_polygonize.py` output to handle scenarios where there are multiple NODATA areas.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 I tested the new method in a REPL with the output from the `gdal_polygonize` output manually. Not sure if there is a better approach here.

Closes #2975
