### PR TITLE
Use built-in Docker subcommands for cleanup

### DIFF
--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-aws_cli_version: "1.10.47"
+aws_cli_version: "1.14.36"
 
 docker_version: "17.*"
 docker_compose_version: "1.16.*"

--- a/deployment/ansible/group_vars/jenkins
+++ b/deployment/ansible/group_vars/jenkins
@@ -1,8 +1,0 @@
----
-docker_users:
-  - "{{ ansible_user }}"
-  - "{{ jenkins_name }}"
-
-java_version: "7u121*"
-
-packer_verison: "1.0.4"

--- a/deployment/ansible/group_vars/jenkins.yml
+++ b/deployment/ansible/group_vars/jenkins.yml
@@ -1,0 +1,9 @@
+---
+docker_users:
+  - "{{ ansible_user }}"
+  - "{{ jenkins_name }}"
+
+java_version: "8u141*"
+java_major_version: "8"
+
+packer_version: "1.0.4"

--- a/deployment/ansible/inventory/bastion
+++ b/deployment/ansible/inventory/bastion
@@ -1,4 +1,2 @@
-bastion_server ansible_host=bastion.rasterfoundry.com ansible_user=ec2-user
-
 [bastion]
-bastion_server
+bastion_server ansible_host=bastion.rasterfoundry.com ansible_user=ec2-user

--- a/deployment/ansible/inventory/jenkins
+++ b/deployment/ansible/inventory/jenkins
@@ -1,4 +1,2 @@
-jenkins_master ansible_host=jenkins.staging.rasterfoundry.com ansible_user=ubuntu
-
 [jenkins]
-jenkins_master
+jenkins_master ansible_host=jenkins.staging.rasterfoundry.com ansible_user=ubuntu

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -8,7 +8,7 @@
   version: 1.0.0
 
 - src: azavea.jenkins
-  version: 1.1.1
+  version: 1.2.0
 
 - src: azavea.nginx
   version: 0.3.0

--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -14,7 +14,7 @@
         state: present,
         backrefs: yes }
     - { regexp: '(.*<numExecutors>)\d+(</numExecutors>.*)',
-        line: '\g<1>1\g<2>',
+        line: '\g<1>2\g<2>',
         state: present,
         backrefs: yes }
 
@@ -50,17 +50,11 @@
   notify:
     - Restart Jenkins
 
-- name: Setup hourly docker-gc cron task
+- name: Setup hourly Docker cleanup cron task
   cron:
-    name: "docker-gc"
+    name: "docker-prune"
     user: "{{ jenkins_name }}"
     special_time: "hourly"
-    job: >
-      /usr/bin/docker run
-      --rm
-      -e FORCE_IMAGE_REMOVAL=1
-      -v /var/run/docker.sock:/var/run/docker.sock
-      -v /etc:/etc
-      spotify/docker-gc
+    job: docker system prune -af
     state: "present"
   changed_when: False


### PR DESCRIPTION
## Overview

Instead of depending on `docker-gc`, use the built-in Docker commands for pruning stale containers and container images.

Also, update the AWS CLI, Jenkins (Ansible role), and default executor count.

Fixes https://github.com/azavea/raster-foundry-platform/issues/262

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Navigate to the Ansible project directory and execute the following command with Ansible 2.4+:

```bash
$ ansible-playbook -vv -i inventory/jenkins raster-foundry-jenkins.yml
```

It should only cite one change (the `useSecurity` subtask).