### PR TITLE
Create admin routes, with user management and team tabs roughed out

### DIFF
--- a/app-frontend/src/app/components/common/dropdown/dropdown.html
+++ b/app-frontend/src/app/components/common/dropdown/dropdown.html
@@ -1,0 +1,17 @@
+<div class="rf-dropdown-container" >
+  <button type="button"
+          class="btn"
+          ng-class="$ctrl.options.buttonClasses || ['btn-small', 'btn-transparent']"
+          ng-class="{active: $ctrl.open}"
+          ng-click="$ctrl.toggleDropdown($event)"
+          ng-transclude>
+  </button>
+  <div class="rf-dropdown" ng-show="$ctrl.open">
+    <div class="rf-dropdown-item"
+         ng-click="item.callback()"
+         ng-class="item.classes || []"
+         ng-repeat="item in $ctrl.options.items track by $index">
+      {{item.label}}
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/common/dropdown/dropdown.module.js
+++ b/app-frontend/src/app/components/common/dropdown/dropdown.module.js
@@ -1,0 +1,53 @@
+import angular from 'angular';
+import template from './dropdown.html';
+
+const TableDropdownComponent = {
+    templateUrl: template,
+    controller: 'DropdownController',
+    bindings: {
+        options: '<'
+    },
+    transclude: true
+};
+
+// handle case where user click is intercepted by opening another dropdown
+let openDropdownListener = null;
+
+class DropdownController {
+    constructor($document, $scope) {
+        this.$document = $document;
+        this.$scope = $scope;
+    }
+
+    toggleDropdown(event) {
+        event.stopPropagation();
+        this.open = !this.open;
+
+        if (this.open && !this.clickListener) {
+            if (openDropdownListener) {
+                openDropdownListener();
+            }
+            const onClick = () => {
+                this.open = false;
+                this.$document.off('click', this.clickListener);
+                this.$scope.$evalAsync();
+                delete this.clickListener;
+                openDropdownListener = null;
+            };
+            this.clickListener = onClick;
+            openDropdownListener = onClick;
+            this.$document.on('click', onClick);
+        } else if (!this.open && this.clickListener) {
+            this.$document.off('click', this.clickListener);
+            openDropdownListener = null;
+            delete this.clickListener;
+        }
+    }
+}
+
+const DropdownModule = angular.module('components.dropdown', []);
+
+DropdownModule.component('rfDropdown', TableDropdownComponent);
+DropdownModule.controller('DropdownController', DropdownController);
+
+export default DropdownModule;

--- a/app-frontend/src/app/components/common/navBar/navBar.html
+++ b/app-frontend/src/app/components/common/navBar/navBar.html
@@ -43,6 +43,7 @@
   <!-- Nav Right -->
   <div class="navbar-section secondary">
     <nav>
+      <div class="admin-logo" ui-sref="organization.metrics" feature-flag="profile-org-edit"></div>
       <div ng-if="$ctrl.authService.isLoggedIn" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
         <a href uib-dropdown-toggle>
           <img ng-if="$ctrl.authService.getProfile().picture" class="avatar" ng-src="{{$ctrl.authService.getProfile().picture}}">

--- a/app-frontend/src/app/components/settings/userModal/userModal.html
+++ b/app-frontend/src/app/components/settings/userModal/userModal.html
@@ -22,7 +22,7 @@
       <label>
         Email
         <input
-            type="text"
+            type="email"
             class="form-control"
             name="email"
             ng-model="email">

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -84,6 +84,7 @@ export default angular.module('index.components', [
     require('./components/common/statusTag/statusTag.module.js').name,
     require('./components/common/search/search.js').name,
     require('./components/common/sortingHeader/sortingHeader.js').name,
+    require('./components/common/dropdown/dropdown.module.js').name,
 
 
     // Single components for new domains

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -92,7 +92,13 @@ const App = angular.module(
         require('./pages/settings/tokens/api/api.module.js').name,
         require('./pages/settings/tokens/map/map.module.js').name,
         require('./pages/settings/connections/connections.module.js').name,
-        require('./pages/settings/organizations/organizations.module.js').name
+        require('./pages/settings/organizations/organizations.module.js').name,
+
+        require('./pages/organization/organization.module.js').name,
+        require('./pages/organization/metrics/metrics.module.js').name,
+        require('./pages/organization/teams/teams.module.js').name,
+        require('./pages/organization/users/users.module.js').name,
+        require('./pages/organization/settings/settings.module.js').name
     ]
 );
 

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -50,6 +50,13 @@ import importsDatasourcesTpl from './pages/imports/datasources/datasources.html'
 import importsDatasourcesListTpl from './pages/imports/datasources/list/list.html';
 import importsDatasourcesDetailTpl from './pages/imports/datasources/detail/detail.html';
 
+import organizationTpl from './pages/organization/organization.html';
+import organizationMetricsTpl from './pages/organization/metrics/metrics.html';
+import organizationUsersTpl from './pages/organization/users/users.html';
+import organizationTeamsTpl from './pages/organization/teams/teams.html';
+import organizationSettingsTpl from './pages/organization/settings/settings.html';
+
+
 function projectEditStates($stateProvider) {
     let addScenesQueryParams = [
         'maxCloudCover',
@@ -430,6 +437,47 @@ function importStates($stateProvider) {
         });
 }
 
+function adminStates($stateProvider) {
+    $stateProvider
+        .state('organization', {
+            parent: 'root',
+            title: 'Organization',
+            url: '/organization/:id',
+            templateUrl: organizationTpl,
+            controller: 'OrganizationController',
+            controllerAs: '$ctrl',
+            abstract: true
+        })
+        .state('organization.metrics', {
+            title: 'Organization Metrics',
+            url: '/metrics',
+            templateUrl: organizationMetricsTpl,
+            controller: 'OrganizationMetricsController',
+            controllerAs: '$ctrl'
+        })
+        .state('organization.users', {
+            title: 'Organization Users',
+            url: '/users',
+            templateUrl: organizationUsersTpl,
+            controller: 'OrganizationUsersController',
+            controllerAs: '$ctrl'
+        })
+        .state('organization.teams', {
+            title: 'Organization Teams',
+            url: '/teams',
+            templateUrl: organizationTeamsTpl,
+            controller: 'OrganizationTeamsController',
+            controllerAs: '$ctrl'
+        })
+        .state('organization.settings', {
+            title: 'Organization Settings',
+            url: '/settings',
+            templateUrl: organizationSettingsTpl,
+            controller: 'OrganizationSettingsController',
+            controllerAs: '$ctrl'
+        });
+}
+
 function routeConfig($urlRouterProvider, $stateProvider, $urlMatcherFactoryProvider, $locationProvider) {
     'ngInject';
 
@@ -450,6 +498,7 @@ function routeConfig($urlRouterProvider, $stateProvider, $urlMatcherFactoryProvi
     shareStates($stateProvider);
     homeStates($stateProvider);
     importStates($stateProvider);
+    adminStates($stateProvider);
 
     $stateProvider
         .state('error', {

--- a/app-frontend/src/app/pages/organization/metrics/metrics.html
+++ b/app-frontend/src/app/pages/organization/metrics/metrics.html
@@ -1,0 +1,9 @@
+<pre>
+metrics.html
+
+Tiles served
+Projects created
+Images uploaded
+Toolsr created
+Top referers
+</pre>

--- a/app-frontend/src/app/pages/organization/metrics/metrics.module.js
+++ b/app-frontend/src/app/pages/organization/metrics/metrics.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+
+class OrganizationMetricsController {
+    constructor() {
+        //eslint-disable-next-line
+        console.log('Organization Metrics Controller');
+    }
+}
+
+const OrganizationMetricsModule = angular.module('pages.organization.metrics', []);
+OrganizationMetricsModule.controller(
+    'OrganizationMetricsController', OrganizationMetricsController
+);
+
+export default OrganizationMetricsModule;

--- a/app-frontend/src/app/pages/organization/organization.html
+++ b/app-frontend/src/app/pages/organization/organization.html
@@ -1,0 +1,35 @@
+<div class="admin-header">
+  <div class="admin-logo">
+  </div>
+  <div class="admin-logo-name">
+    Administration
+  </div>
+</div>
+
+<div class="admin-tabs">
+  <div class="admin-tab"
+       ui-sref="organization.metrics"
+       ui-sref-active="active"
+  >
+    Metrics
+  </div>
+  <div class="admin-tab"
+       ui-sref="organization.users"
+       ui-sref-active="active"
+  >
+    User Management
+  </div>
+  <div class="admin-tab"
+       ui-sref="organization.teams"
+       ui-sref-active="active"
+  >
+    Teams
+  </div>
+  <div class="admin-tab"
+       ui-sref="organization.settings"
+       ui-sref-active="active"
+  >
+    Organization Settings
+  </div>
+</div>
+<ui-view></ui-view>

--- a/app-frontend/src/app/pages/organization/organization.module.js
+++ b/app-frontend/src/app/pages/organization/organization.module.js
@@ -1,0 +1,13 @@
+import angular from 'angular';
+
+class OrganizationController {
+    constructor() {
+        //eslint-disable-next-line
+        console.log('Organization Controller');
+    }
+}
+
+const OrganizationModule = angular.module('pages.organization', []);
+OrganizationModule.controller('OrganizationController', OrganizationController);
+
+export default OrganizationModule;

--- a/app-frontend/src/app/pages/organization/settings/settings.html
+++ b/app-frontend/src/app/pages/organization/settings/settings.html
@@ -1,0 +1,10 @@
+settings.html
+
+<pre>
+* Set pinned project
+* Default sharing settings?
+* Uploading logo, org name
+* Third party integrations?
+* Default notification settings
+* Default limits for users: number of projects a user can create, amount of data uploaded
+</pre>

--- a/app-frontend/src/app/pages/organization/settings/settings.module.js
+++ b/app-frontend/src/app/pages/organization/settings/settings.module.js
@@ -1,0 +1,15 @@
+import angular from 'angular';
+
+class OrganizationSettingsController {
+    constructor() {
+        //eslint-disable-next-line
+        console.log('Organization Settings Controller');
+    }
+}
+
+const OrganizationSettingsModule = angular.module('pages.organization.settings', []);
+OrganizationSettingsModule.controller(
+    'OrganizationSettingsController', OrganizationSettingsController
+);
+
+export default OrganizationSettingsModule;

--- a/app-frontend/src/app/pages/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/organization/teams/teams.html
@@ -1,0 +1,35 @@
+<div class="admin-users-content container column-stretch dashboard">
+  <div class="admin-users-actions">
+    <input type="text" class="form-control user-search" placeholder="Search for teams">
+    <button type="button" class="btn btn-primary"
+            ng-click="$ctrl.newTeamModal()">
+      New Team
+    </button>
+  </div>
+  <table class="admin-table admin-team-table">
+    <tbody>
+      <tr ng-repeat="team in $ctrl.teams track by team.id">
+        <td class="name">
+          Team Name
+        </td>
+        <td class="users">
+          <a class="users-more" title="See all users">...</a>
+          <div class="user-avatar"
+               ng-repeat="user in team.users track by user"
+               ng-attr-title="{{user}}"
+          ></div>
+        </td>
+        <td class="teams">
+          20 Members
+        </td>
+        <td class="actions">
+          <rf-dropdown
+              data-options="team.options"
+          >
+            <span class="icon-caret-down"></span>
+          </rf-dropdown>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app-frontend/src/app/pages/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/organization/teams/teams.module.js
@@ -1,0 +1,79 @@
+import angular from 'angular';
+
+class OrganizationTeamsController {
+    constructor(modalService) {
+        this.modalService = modalService;
+
+        this.teams = [
+            {
+                id: '1',
+                name: 'Team one',
+                users: [1, 2, 3, 4, 5]
+            },
+            {
+                id: '2',
+                name: 'Team two',
+                users: [1, 2, 3, 4, 5]
+            },
+            {
+                id: '3',
+                name: 'Team three',
+                users: [1, 2, 3, 4, 5]
+            },
+            {
+                id: '4',
+                name: 'Team four',
+                users: [1, 2, 3, 4, 5]
+            }
+        ];
+        this.teams.forEach((team) => Object.assign(team, {
+            options: {
+                items: this.itemsForTeam(team)
+            }
+        }));
+    }
+
+    itemsForTeam(team) {
+        /* eslint-disable */
+        return [
+            {
+                label: 'Edit',
+                callback: () => {
+                    console.log('edit callback for team:', team);
+                },
+                classes: []
+            },
+            {
+                label: 'Add to team...',
+                callback: () => {
+                    console.log('Add to team... callback for team:', team);
+                },
+                classes: []
+            },
+            {
+                label: 'Delete',
+                callback: () => {
+                    console.log('delete callback for team:', team);
+                },
+                classes: ['color-danger']
+            }
+        ];
+        /* eslint-enable */
+    }
+
+    newTeamModal() {
+        this.modalService.open({
+            component: 'rfTeamModal',
+            resolve: { },
+            size: 'sm'
+        }).result.then((result) => {
+            // eslint-disable-next-line
+            console.log('team modal closed with value:', result);
+        });
+    }
+}
+
+const OrganizationTeamsModule = angular.module('pages.organization.teams', []);
+OrganizationTeamsModule.controller('OrganizationTeamsController', OrganizationTeamsController);
+
+export default OrganizationTeamsModule;

--- a/app-frontend/src/app/pages/organization/users/users.html
+++ b/app-frontend/src/app/pages/organization/users/users.html
@@ -1,0 +1,35 @@
+<div class="admin-users-content container column-stretch dashboard">
+  <div class="admin-users-actions">
+    <input type="text" class="form-control user-search" placeholder="Search for users">
+    <button type="button" class="btn btn-primary"
+            ng-click="$ctrl.newUserModal()">
+      New User
+    </button>
+  </div>
+  <table class="admin-table admin-user-table">
+    <tbody>
+      <tr ng-repeat="user in $ctrl.users track by $index">
+        <td class="username">
+          <div class="user-avatar"></div>
+          <div>
+            {{user.name}}
+          </div>
+        </td>
+        <td class="emails">
+          {{user.email}}
+        </td>
+        <td class="roles">
+          {{user.role}}
+        </td>
+        <td class="teams">
+          {{user.teams.length}} Teams
+        </td>
+        <td class="actions">
+          <rf-dropdown data-options="user.options">
+            <span class="icon-caret-down"></span>
+          </rf-dropdown>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app-frontend/src/app/pages/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/organization/users/users.module.js
@@ -1,0 +1,86 @@
+import angular from 'angular';
+
+class OrganizationUsersController {
+    constructor(modalService) {
+        this.modalService = modalService;
+        this.fetchUsers();
+    }
+
+    fetchUsers() {
+        this.users = [
+            {
+                id: '1',
+                name: 'user one',
+                email: 'user@example.com',
+                role: 'Manager',
+                teams: [1]
+            },
+            {
+                id: '2',
+                name: 'user two',
+                email: 'user@example.com',
+                role: 'Viewer',
+                teams: []
+            },
+            {
+                id: '3',
+                name: 'user three',
+                email: 'user@example.com',
+                role: 'Uploader',
+                teams: [1, 2, 3]
+            },
+            {
+                id: '4',
+                name: 'user four',
+                email: 'user@example.com',
+                role: 'Uploader',
+                teams: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+            }
+        ];
+
+        this.users.forEach(
+            (user) => Object.assign(
+                user, {
+                    options: {
+                        items: this.itemsForUser(user)
+                    }
+                }
+            ));
+    }
+
+    itemsForUser(user) {
+        /* eslint-disable */
+        return [
+            {
+                label: 'Edit',
+                callback: () => {
+                    console.log('edit callback for user:', user);
+                }
+            },
+            {
+                label: 'Delete',
+                callback: () => {
+                    console.log('delete callback for user:', user);
+                },
+                classes: ['color-danger']
+            }
+        ];
+        /* eslint-enable */
+    }
+
+    newUserModal() {
+        this.modalService.open({
+            component: 'rfUserModal',
+            resolve: { },
+            size: 'sm'
+        }).result.then((result) => {
+            // eslint-disable-next-line
+            console.log('user modal closed with value:', result);
+        });
+    }
+}
+
+const OrganizationUsersModule = angular.module('pages.organization.users', []);
+OrganizationUsersModule.controller('OrganizationUsersController', OrganizationUsersController);
+
+export default OrganizationUsersModule;

--- a/app-frontend/src/assets/styles/sass/_imports.scss
+++ b/app-frontend/src/assets/styles/sass/_imports.scss
@@ -83,7 +83,8 @@
 @import
   "pages/dashboard",
   "pages/datasources",
-  "pages/editor";
+  "pages/editor",
+  "pages/admin";
 
 /* * * *
  * Shame

--- a/app-frontend/src/assets/styles/sass/components/_dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_dropdown.scss
@@ -236,3 +236,31 @@
     }
   }
 }
+
+/*
+ * rf-dropdown classes
+*/
+.rf-dropdown {
+    width: 10em;
+    position: absolute;
+    bottom: 0;
+    transform: translateY(100%);
+    background: $white;
+    border: 1px solid $shade-light;
+    border-radius: 3px 0 3px 3px;
+    z-index: 100;
+
+    .rf-dropdown-item {
+        padding: 0.5em 1em;
+        cursor: pointer;
+        &:hover {
+            background: $off-white;
+        }
+        &:first-child {
+            padding-top: 1em;
+        }
+        &:last-child {
+            padding-bottom: 1em;
+        }
+    }
+}

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -1,0 +1,129 @@
+.admin-header {
+    display: flex;
+    flex-direction: row;
+    padding: 1em;
+    background: #eee;
+}
+
+.admin-logo {
+    border-radius: 3px;
+    background: #ddd; width: 3em;
+    height: 3em;
+}
+
+.admin-logo-name {
+    font-size: 3rem;
+    margin-left: 0.5em;
+}
+
+.admin-tabs {
+    display: flex;
+    flex-direction: row;
+    flex-basis: flex-start;
+    background: #eee;
+    padding: 0 1em 0 1em;
+    margin-right: 0.2em;
+    .admin-tab {
+        padding: 0.8em 1em;
+        cursor: pointer;
+        border-radius: 3px 3px 0 0;
+
+        &:hover {
+            background: #f5f5f5;
+        }
+        &.active {
+            cursor: default;
+            background: #fff;
+        }
+    }
+}
+
+.admin-users-content {
+    display: flex;
+    flex-direction: column;
+}
+
+.admin-table {
+    width: 100%;
+
+    td {
+        padding: 0.75em 1.5em;
+    }
+
+    tr:not(:last-child) {
+        border-bottom: 1px solid #ddd;
+    }
+
+    .actions {
+        width: 8em;
+        .rf-dropdown-container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: row;
+            align-items: center;
+            justify-content: flex-end;
+
+            .btn.active {
+                border-radius: 3px 3px 0 0;
+            }
+        }
+    }
+
+    .user-avatar {
+        width: 2.5em;
+        height: 2.5em;
+        background: #ddd;
+        border-radius: 3px;
+        margin-right: 1em;
+    }
+}
+
+.admin-team-table {
+    .name {
+        width: 20em;
+        overflow-x: hidden;
+    }
+
+    .users {
+        text-align: right;
+        display: flex;
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: flex-end;
+
+        .users-more {
+            padding: 0 1em;
+        }
+    }
+
+    .teams {
+        width: 13em;
+    }
+
+}
+
+.admin-user-table {
+    .teams {
+        width: 10em;
+    }
+
+    .username {
+        display: flex;
+        flex-direction: row;
+        align-items: center
+    }
+
+}
+
+.admin-users-actions {
+    display: flex;
+    flex-direction: row;
+    padding: 1em;
+}
+
+.user-search {
+    width: 15em;
+    margin-right: 0.5em;
+}


### PR DESCRIPTION
## Overview

Create organization management routes
Create rough pages with styling for user management and teams

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/4392704/36171438-ad838fe2-10d0-11e8-8c74-92aed7d70fee.png)
![image](https://user-images.githubusercontent.com/4392704/36171443-b2a6beae-10d0-11e8-82e8-4858fb80a164.png)


### Notes

Nothing is hooked up, This is just the rough-in for the various pages and routes

## Testing Instructions

 * Verify that the routes work
* Verify that I didn't break dropdowns elsewhere in the app
* Verify that dropdowns for the users / teams work as expected

Closes #2964
