### PR TITLE
Extend upload credential timeout to an hour

### DIFF
--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -51,7 +51,7 @@ object CredentialsService extends Config with LazyLogging {
     stsRequest.setRoleArn(scopedUploadRoleArn)
     stsRequest.setRoleSessionName(s"upload${uploadId}")
     stsRequest.setWebIdentityToken(jwt)
-    stsRequest.setDurationSeconds(900)
+    stsRequest.setDurationSeconds(3600)
 
     val stsCredentials = stsClient.assumeRoleWithWebIdentity(stsRequest).getCredentials
 

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -51,6 +51,8 @@ object CredentialsService extends Config with LazyLogging {
     stsRequest.setRoleArn(scopedUploadRoleArn)
     stsRequest.setRoleSessionName(s"upload${uploadId}")
     stsRequest.setWebIdentityToken(jwt)
+    // Sessions for AWS account owners are restricted to a maximum of 3600 seconds. Longer durations seemed to give 501.
+    // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/securitytoken/model/GetSessionTokenRequest.html
     stsRequest.setDurationSeconds(3600)
 
     val stsCredentials = stsClient.assumeRoleWithWebIdentity(stsRequest).getCredentials


### PR DESCRIPTION
## Overview

This PR extends upload credential timeout from 15 minutes to an hour (max, restricted for AWS account owners, [read more here](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/securitytoken/model/GetSessionTokenRequest.html)).

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

Closes #2981 
