### PR TITLE
Docker cron-task should run daily

### DIFF
--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -54,7 +54,7 @@
   cron:
     name: "docker-prune"
     user: "{{ jenkins_name }}"
-    special_time: "hourly"
+    special_time: "daily"
     job: docker system prune -af
     state: "present"
   changed_when: False


### PR DESCRIPTION
## Overview

Configure the docker prune cron job to run daily, instead of hourly. Addresses a race condition where images build in CI get pruned before they can be deployed. 

### Checklist

- [ x ] Styleguide updated, if necessary
- [ x ] Swagger specification updated, if necessary
- [ x ] Symlinks from new migrations present or corrected for any new migrations
- [ x ] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions
Run `ansible-playbook` against Jenkins, ensure no changes are necessary aside from the `Disable security for login` task.

```bash
$ ansible-playbook -vv  -i deployment/ansible/inventory deployment/ansible/raster-foundry-jenkins.yml
```
Closes #XXX
