### PR TITLE
Double planet thumbnail resolution

### DIFF
--- a/app-frontend/src/app/services/vendor/planetLabs.service.js
+++ b/app-frontend/src/app/services/vendor/planetLabs.service.js
@@ -10,6 +10,8 @@ export default (app) => {
             'ngInject';
             this.$log = $log;
             this.$http = $http;
+
+            this.thumbnailSize = '512';
         }
 
         sendHttpRequest(req) {
@@ -56,7 +58,7 @@ export default (app) => {
             let token = btoa(apiKey + ':');
             let req = {
                 'method': 'GET',
-                'url': link,
+                'url': link + '?width=' + this.thumbnailSize,
                 'headers': {
                     'Authorization': 'Basic ' + token,
                     'Content-Type': 'arraybuffer'


### PR DESCRIPTION
## Overview

This PR doubles the default planet thumbnail size from 256px to 512px since the previous thumbnails seem pretty blurry.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Notes

Planet states that for users who have download accesses, imagery thumbnails can be as high as 2048px. But I do not think we should load thumbnails higher than 512px.


## Testing Instructions

 * Go to browse planet imageries in a project
 * See if planet thumbnails are at a higher resolution as 512 x 512.

Closes #2994
