### PR TITLE
Overzooming for Multiband Export

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -34,7 +34,7 @@ import geotrellis.spark.io.file._
 import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.s3._
 import geotrellis.spark.regrid._
-import geotrellis.spark.resample._
+import geotrellis.spark.resample.ZoomResample
 import geotrellis.spark.tiling._
 import geotrellis.vector.MultiPolygon
 import org.apache.hadoop.fs.Path
@@ -155,7 +155,7 @@ object Export extends SparkJob with Config with LazyLogging {
         if (requestedLayerId.zoom <= maxAvailableZoom)
           queryLayer(requestedQuery)
         else
-          queryLayer(maxQuery).resample(maxAvailableZoom, requestedLayerId.zoom)
+          ZoomResample(queryLayer(maxQuery), maxAvailableZoom, requestedLayerId.zoom)
 
       val md = query.metadata
 

--- a/app-backend/batch/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
+++ b/app-backend/batch/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
@@ -1,0 +1,147 @@
+package geotrellis.spark.resample
+
+import geotrellis.raster._
+import geotrellis.raster.resample._
+import geotrellis.spark._
+import geotrellis.spark.tiling._
+import geotrellis.util._
+import geotrellis.vector.Extent
+
+import org.apache.spark.rdd.RDD
+
+/*
+ * This is taken directly from GeoTrellis: https://github.com/locationtech/geotrellis/blob/master/spark/src/main/scala/geotrellis/spark/resample/ZoomResample.scala
+ *
+ * The reason for this is because the version of GT that Raster Foundry uses has a ZoomResample object
+ * that does not support MultibandTileLayerRDDs. Since that feature is needed, this object has been
+ * added for right now, but it can be removed once the version of GT is updated.
+ */
+
+object ZoomResample {
+  private def gridBoundsAtZoom(sourceZoom: Int, spatialKey: SpatialKey, targetZoom: Int): GridBounds = {
+    val SpatialKey(col, row) = spatialKey
+    val zoomDiff = targetZoom - sourceZoom
+    val factor = math.pow(2, zoomDiff).toInt
+    val (minCol, minRow) = (col * factor, row * factor)
+    val (maxCol, maxRow) = (((col + 1) * factor) - 1, ((row + 1) * factor) - 1)
+    GridBounds(minCol, minRow, maxCol, maxRow)
+  }
+
+  private def boundsAtZoom[K: SpatialComponent](sourceZoom: Int, bounds: Bounds[K], targetZoom: Int): Bounds[K] =
+    bounds match {
+      case KeyBounds(minKey, maxKey) =>
+        val min = {
+          val gb = gridBoundsAtZoom(sourceZoom, minKey.getComponent[SpatialKey], targetZoom)
+          minKey.setComponent(SpatialKey(gb.colMin, gb.rowMin))
+        }
+
+        val max = {
+          val gb = gridBoundsAtZoom(sourceZoom, maxKey.getComponent[SpatialKey], targetZoom)
+          maxKey.setComponent(SpatialKey(gb.colMax, gb.rowMax))
+        }
+        KeyBounds(min, max)
+      case EmptyBounds =>
+        EmptyBounds
+    }
+
+  /** Resamples a tile layer from a lower zoom level to a higher zoom level.
+    * The levels are based on the ZoomedLayoutScheme.
+    *
+    * @param       rdd              The RDD to be resampled.
+    * @param       sourceZoom       The zoom level of the rdd.
+    * @param       targetZoom       The zoom level we want to resample to.
+    * @param       targetGridBounds Optionally, a grid bounds in the target zoom level we want to filter by.
+    * @param       method           The resample method to use for resampling.
+    */
+  def apply[K: SpatialComponent, V <: CellGrid](
+    rdd: RDD[(K, V)] with Metadata[TileLayerMetadata[K]],
+    sourceZoom: Int,
+    targetZoom: Int,
+    targetGridBounds: Option[GridBounds] = None,
+    method: ResampleMethod = NearestNeighbor
+  )(implicit ev: V => TileResampleMethods[V]): RDD[(K, V)] with Metadata[TileLayerMetadata[K]] = {
+    require(sourceZoom < targetZoom, "This resample call requires that the target zoom level be greater than the source zoom level")
+    val tileSize = rdd.metadata.layout.tileLayout.tileCols
+    val targetLayoutDefinition =
+      ZoomedLayoutScheme.layoutForZoom(targetZoom, rdd.metadata.layout.extent, tileSize)
+    val targetMapTransform = targetLayoutDefinition.mapTransform
+    val sourceMapTransform = rdd.metadata.mapTransform
+    val (resampledRdd: RDD[(K, V)], md) =
+      targetGridBounds match {
+        case Some(tgb) =>
+          val resampleKeyBounds: KeyBounds[K] =
+            boundsAtZoom(sourceZoom, rdd.metadata.bounds, targetZoom).get
+
+          resampleKeyBounds.toGridBounds.intersection(tgb) match {
+            case Some(resampleGridBounds) => {
+              val resampled: RDD[(K, V)] = rdd.flatMap { case (key, tile) =>
+                val gbaz: Option[GridBounds] =
+                  gridBoundsAtZoom(sourceZoom, key.getComponent[SpatialKey], targetZoom)
+                    .intersection(resampleGridBounds)
+
+                gbaz.map { gb =>
+                  gb.coordsIter
+                    .map { case (col, row) =>
+                      val sourceExtent = sourceMapTransform.keyToExtent(key.getComponent[SpatialKey])
+                      val targetExtent = targetMapTransform.keyToExtent(col, row)
+                      val resampled = tile.resample(
+                        sourceExtent,
+                        RasterExtent(targetExtent, tileSize, tileSize),
+                        method
+                      )
+
+                      (key.setComponent(SpatialKey(col, row)), resampled)
+                    }
+                }.getOrElse(Iterator.empty)
+              }
+
+              val extent: Extent =
+                targetMapTransform(resampleGridBounds).intersection(rdd.metadata.extent) match {
+                  case Some(ex) => ex
+                  case None => throw new Exception
+                }
+
+              val md = rdd.metadata.copy(
+                layout = targetLayoutDefinition,
+                bounds = resampleKeyBounds.setSpatialBounds(resampleGridBounds),
+                extent = extent
+              )
+
+              (resampled, md)
+            }
+            case None => {
+              val md = rdd.metadata.copy(
+                layout = targetLayoutDefinition,
+                bounds = (EmptyBounds: Bounds[K])
+              )
+
+              (rdd.sparkContext.emptyRDD[(K, V)], md)
+            }
+          }
+        case None => {
+          val resampled: RDD[(K, V)] =
+            rdd
+              .flatMap { case (key, tile) =>
+                gridBoundsAtZoom(sourceZoom, key.getComponent[SpatialKey], targetZoom)
+                  .coordsIter
+                  .map { case (col, row) =>
+                    val sourceExtent = sourceMapTransform.keyToExtent(key.getComponent[SpatialKey])
+                    val targetExtent = targetMapTransform.keyToExtent(col, row)
+                    val resampled =
+                      tile.resample(sourceExtent, RasterExtent(targetExtent, tileSize, tileSize), method)
+                    (key.setComponent(SpatialKey(col, row)), resampled)
+                  }
+               }
+
+          val md = rdd.metadata.copy(
+            layout = targetLayoutDefinition,
+            bounds = boundsAtZoom(sourceZoom, rdd.metadata.bounds, targetZoom)
+          )
+
+          (resampled, md)
+        }
+      }
+
+    ContextRDD(resampledRdd, md)
+  }
+}


### PR DESCRIPTION
## Overview

This PR allows for overzooming when export `MultibandTileLayerRDD`s as GeoTiffs. With this new feature, it'll allow the exportation of layers even if the desired zoom level is greater than the max level of the layer.

### Checklist

- [x] Styleguide updated, if necessary
- [x] Swagger specification updated, if necessary
- [x] Symlinks from new migrations present or corrected for any new migrations
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This PR was not tested.

## Testing Instructions

I don't have a testing environment setup, so I'm unable to test to see if this feature works. Someone else will need to test this.