### PR TITLE
Annotation shapefile export

### DIFF
--- a/app-backend/api/src/main/scala/exports/package.scala
+++ b/app-backend/api/src/main/scala/exports/package.scala
@@ -51,7 +51,7 @@ package object exports extends Config {
       val now = new Timestamp(new Date().getTime)
 
       if (!S3.doesObjectExist(bucket, s"${key}/RFUploadAccessTestFile")) {
-        S3.putObject(
+        S3.putObjectString(
           dataBucket,
           s"${key}/RFUploadAccessTestFile",
           s"Allow Upload Access for RF: ${key} at ${now.toString}"

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -9,7 +9,7 @@ import com.azavea.rf.batch.util._
 import com.azavea.rf.batch.util.conf._
 import com.azavea.rf.datamodel._
 import com.azavea.rf.tool.ast.MapAlgebraAST
-import com.azavea.rf.common.S3.putObject
+import com.azavea.rf.common.S3.putObjectString
 
 import com.azavea.maml.serve._
 import com.azavea.maml.eval._
@@ -265,7 +265,7 @@ object Export extends SparkJob with Config with LazyLogging {
       }
 
       logger.info(s"Writing status into the ${params.statusBucket}/${exportDef.id}")
-      putObject(
+      putObjectString(
         params.statusBucket,
         exportDef.id.toString,
         ExportStatus.Exported
@@ -274,7 +274,7 @@ object Export extends SparkJob with Config with LazyLogging {
       case t: Throwable =>
         logger.info(s"Writing status into the ${params.statusBucket}/${exportDef.id}")
         logger.error(t.stackTraceString)
-        putObject(
+        putObjectString(
           params.statusBucket,
           exportDef.id.toString,
           ExportStatus.Failed

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
@@ -9,7 +9,7 @@ import com.azavea.rf.batch.ingest.json._
 import com.azavea.rf.batch.ingest.model._
 import com.azavea.rf.batch.util._
 import com.azavea.rf.batch.util.conf.Config
-import com.azavea.rf.common.S3.putObject
+import com.azavea.rf.common.S3.putObjectString
 import com.azavea.rf.datamodel.IngestStatus
 
 import geotrellis.raster._
@@ -325,7 +325,7 @@ object Ingest extends SparkJob with LazyLogging with Config {
     try {
       ingestDefinition.layers.foreach(ingestLayer(params, _))
       if (params.testRun) ingestDefinition.layers.foreach(Validation.validateCatalogEntry)
-      putObject(
+      putObjectString(
         params.statusBucket,
         ingestDefinition.id.toString,
         IngestStatus.Ingested
@@ -333,7 +333,7 @@ object Ingest extends SparkJob with LazyLogging with Config {
     } catch {
       case t: Throwable =>
         logger.error(t.stackTraceString)
-        putObject(
+        putObjectString(
           params.statusBucket,
           ingestDefinition.id.toString,
           IngestStatus.Failed

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -28,6 +28,7 @@ lazy val commonSettings = Seq(
   externalResolvers := Seq(
     "Geotoolkit Repo" at "http://maven.geotoolkit.org",
     "Open Source Geospatial Foundation Repo" at "http://download.osgeo.org/webdav/geotools/",
+    "imageio-ext Repository" at "http://maven.geo-solutions.it",
     DefaultMavenRepository,
     Resolver.sonatypeRepo("snapshots"),
     Resolver.bintrayRepo("azavea", "maven"),
@@ -193,10 +194,13 @@ lazy val datamodel = Project("datamodel", file("datamodel"))
     libraryDependencies ++= loggingDependencies ++ Seq(
       Dependencies.geotrellisSlick % "provided",
       Dependencies.geotrellisRaster,
+      Dependencies.geotrellisGeotools,
+      Dependencies.geotools,
       Dependencies.circeCore,
       Dependencies.circeGenericExtras,
       Dependencies.akka,
-      Dependencies.akkahttp
+      Dependencies.akkahttp,
+      Dependencies.betterFiles
     )
   })
 

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -152,10 +152,12 @@ package object S3 {
   def listObjects(listObjectsRequest: ListObjectsRequest): ObjectListing =
     client.listObjects(listObjectsRequest)
 
-  def putObject(bucket: String, key: String, contents: String): String = {
+  def putObjectString(bucket: String, key: String, contents: String): String = {
     client.putObject(bucket, key, contents)
     contents
   }
+
+  def putObject(bucket: String, key: String, file: File) = client.putObject(bucket, key, file)
 
   def doesObjectExist(bucket: String, key: String): Boolean =
     client.doesObjectExist(bucket, key)

--- a/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Annotations.scala
+++ b/app-backend/database/src/main/scala/com/azavea/rf/database/tables/Annotations.scala
@@ -89,6 +89,16 @@ object Annotations extends TableQuery(tag => new Annotations(tag)) with LazyLogg
     )
   }
 
+  def listAllAnnotations(projectId: UUID, user: User)(implicit database: DB) = {
+    val filteredAnnotations = Annotations
+      .filter(_.owner === user.id)
+      .filter(_.projectId === projectId)
+
+    database.db.run{
+      filteredAnnotations.result
+    }
+  }
+
   /** Insert a Annotation given a create case class with a user
     *
     * @param annotationToCreate Annotation.Create object to use to create full Annotation

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -1,14 +1,33 @@
 package com.azavea.rf.datamodel
 
-import java.util.UUID
+import java.util.{UUID, Map => JMap, HashMap => JHashMap}
 import java.sql.Timestamp
 
+import scala.collection.JavaConverters._
+
+import better.files._
 import io.circe._
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras._
 
 import geotrellis.slick.Projected
 import geotrellis.vector.Geometry
+import geotrellis.vector._
+import geotrellis.proj4.CRS
+import geotrellis.geotools._
+import geotrellis.proj4.{LatLng, WebMercator}
+
+import com.vividsolutions.jts.{geom => jts}
+
+import org.geotools.data.{DataUtilities, DefaultTransaction}
+import org.geotools.data.shapefile.{ShapefileDataStore, ShapefileDataStoreFactory}
+import org.geotools.data.simple.{SimpleFeatureCollection, SimpleFeatureStore}
+import org.geotools.feature.{DefaultFeatureCollection, DefaultFeatureCollections}
+import org.geotools.feature.simple.{SimpleFeatureTypeBuilder, SimpleFeatureBuilder}
+import org.opengis.feature.simple.{SimpleFeature, SimpleFeatureType}
+import org.geotools.referencing.crs.DefaultGeographicCRS
+
+import com.typesafe.scalalogging.LazyLogging
 
 @JsonCodec
 case class Annotation(
@@ -148,4 +167,115 @@ object Annotation {
             )
         }
     }
+}
+
+object AnnotationShapefileService extends LazyLogging {
+
+  def annotationsToShapefile(annotations: Seq[Annotation]): File = {
+
+    val annotationFeatures = annotations.map(this.createSimpleFeature).flatten
+
+    val featureCollection = new DefaultFeatureCollection()
+    annotationFeatures.foreach(
+      feature => {
+        val x = featureCollection.add(feature)
+      }
+    )
+
+    val zipfile = File.newTemporaryFile("export", ".zip")
+
+    File.usingTemporaryDirectory() { directory =>
+      this.createShapefiles(featureCollection, directory)
+      directory.zipTo(destination = zipfile)
+    }
+    zipfile
+  }
+
+  // TODO: Update this to use GeoTrellis's build in conversion once the id bug is fixed:
+  //       https://github.com/locationtech/geotrellis/issues/2575
+  def createSimpleFeature(annotation: Annotation): Option[SimpleFeature] = {
+    annotation.geometry match {
+      case Some(geometry) =>
+        val geom = geometry.geom
+        val geometryField = "the_geom"
+        val sftb = (new SimpleFeatureTypeBuilder).minOccurs(1).maxOccurs(1).nillable(false)
+
+        sftb.setName("Annotaion")
+        geom match {
+          case pt: Point => sftb.add(geometryField, classOf[jts.Point])
+          case ln: Line => sftb.add(geometryField, classOf[jts.LineString])
+          case pg: Polygon => sftb.add(geometryField, classOf[jts.Polygon])
+          case mp: MultiPoint => sftb.add(geometryField, classOf[jts.MultiPoint])
+          case ml: MultiLine => sftb.add(geometryField, classOf[jts.MultiLineString])
+          case mp: MultiPolygon => sftb.add(geometryField, classOf[jts.MultiPolygon])
+          case  g: Geometry => throw new Exception(s"Unhandled Geotrellis Geometry $g")
+        }
+        sftb.setDefaultGeometry(geometryField)
+
+        val data = Seq(
+          ("id", annotation.id),
+          ("label", annotation.label),
+          ("desc", annotation.description.getOrElse("")),
+          ("machinegen", annotation.machineGenerated.getOrElse(false)),
+          ("confidence", annotation.confidence.getOrElse(0)),
+          ("quality", annotation.quality.getOrElse("UNSURE").toString)
+        )
+
+        data.foreach({ case (key, value) => sftb
+                          .minOccurs(1).maxOccurs(1).nillable(false)
+                          .add(key, value.getClass)
+                     })
+
+        val sft = sftb.buildFeatureType
+        val sfb = new SimpleFeatureBuilder(sft)
+
+        geom match {
+          case Point(pt) => sfb.add(pt)
+          case Line(ln) => sfb.add(ln)
+          case Polygon(pg) => sfb.add(pg)
+          case MultiPoint(mp) => sfb.add(mp)
+          case MultiLine(ml) => sfb.add(ml)
+          case MultiPolygon(mp) => sfb.add(mp)
+          case g: Geometry => throw new Exception(s"Unhandled Geotrellis Geometry $g")
+        }
+        data.foreach({ case (key, value) => sfb.add(value) })
+
+        Some(sfb.buildFeature(annotation.id.toString))
+      case _ =>
+        None
+    }
+  }
+
+  def createShapefiles(featureCollection: DefaultFeatureCollection, directory: File) = {
+    val shapeFile = directory / "shapefile.shp"
+
+    val dataStoreFactory = new ShapefileDataStoreFactory()
+
+    val params = new JHashMap[String, java.io.Serializable]()
+    params.put("url", shapeFile.url)
+    params.put("create spatial index", true)
+
+    val newDataStore = dataStoreFactory
+      .createNewDataStore(params)
+      .asInstanceOf[ShapefileDataStore]
+    newDataStore.createSchema(featureCollection.getSchema)
+    newDataStore.forceSchemaCRS(DefaultGeographicCRS.WGS84)
+
+    val transaction = new DefaultTransaction("create")
+    val typeName = newDataStore.getTypeNames.head
+
+    newDataStore.getFeatureSource(typeName) match {
+      case featureStore: SimpleFeatureStore =>
+        featureStore.setTransaction(transaction)
+        try {
+          featureStore.addFeatures(featureCollection)
+          transaction.commit()
+        } catch {
+          case default: Throwable =>
+            transaction.rollback()
+        } finally {
+          transaction.close()
+        }
+    }
+  }
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -57,6 +57,9 @@ case class User(
 
   def getDefaultExportSource(export: Export, dataBucket: String): URI =
     new URI(s"s3://$dataBucket/user-exports/${URLEncoder.encode(id, "UTF-8")}/${export.id}")
+
+  def getDefaultAnnotationShapefileSource(dataBucket: String): URI =
+    new URI(s"s3://$dataBucket/user-exports/${URLEncoder.encode(id, "UTF-8")}/annotations/${UUID.randomUUID}/annotations.zip")
 }
 
 object User {

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -18,6 +18,8 @@ object Dependencies {
   val geotrellisVector        = "org.locationtech.geotrellis" %% "geotrellis-vector"                 % Version.geotrellis
   val geotrellisUtil          = "org.locationtech.geotrellis" %% "geotrellis-util"                   % Version.geotrellis
   val geotrellisShapefile     = "org.locationtech.geotrellis" %% "geotrellis-shapefile"              % Version.geotrellis
+  val geotrellisGeotools      = "org.locationtech.geotrellis" %% "geotrellis-geotools"               % Version.geotrellis
+  val geotools                = "org.geotools"                 % "gt-shapefile"                      % Version.geotools
   val spark                   = "org.apache.spark"            %% "spark-core"                        % Version.spark % "provided"
   val sparkCore               = "org.apache.spark"            %% "spark-core"                        % Version.spark
   val hadoopAws               = "org.apache.hadoop"            % "hadoop-aws"                        % Version.hadoop

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -3,6 +3,7 @@ object Version {
   val akka               = "2.5.6"
   val akkaHttp           = "10.1.0-RC1"
   val geotrellis         = "1.2.1-SNAPSHOT"
+  val geotools           = "17.1"
   val hikariCP           = "3.2.0"
   val postgres           = "42.1.1"
   val scala              = "2.11.11"

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -828,6 +828,26 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
+  /projects/{uuid}/annotations/shapefile:
+    x-resource: Projects
+    get:
+      summary: Get a shapefile containing all annotations on this project
+      parameters:
+        - $ref: '#/parameters/uuid'
+      tags:
+        - Imagery
+      responses:
+        307:
+          description: redirect to a signed s3 download URL
+        404:
+          description: The UUID parameter does not refer to a project  or the user does not have access to the project it refers to.
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error.
+          schema:
+            $ref: '#/definitions/Error'
+
   /projects/{uuid}/annotations/{uuid2}:
     x-resouce: Projects
     get:


### PR DESCRIPTION
## Overview

Add project annotations shapefile endpoint

Endpoint returns a redirect to a signed aws s3 link to a zipped shapefile collection

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] Swagger specification updated, if necessary
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo
```
curl -L -X GET \
http://localhost:9100/api/projects/cf78c056-16dc-44fb-9bc9-ad7a276ee3db/annotations/shapefile \
-H 'Authorization: Bearer ${token}' \
-H 'Cache-Control: no-cache' \
--output annotations.zip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   606  100   606    0     0   1446      0 --:--:-- --:--:-- --:--:--  1446
100  1589  100  1589    0     0   3197      0 --:--:-- --:--:-- --:--:--  3197
```

### Notes
Discovered https://github.com/locationtech/geotrellis/issues/2576 and https://github.com/locationtech/geotrellis/issues/2575 while implementing. We should update the code to use the geotrellis functions once they are fixed

## Testing Instructions

 * make a curl request similar to the demo request on a project with annotations
* Verify that the shapefile is valid and makes sense
* You can use http://mapshaper.org/ to test shapefiles if you don't want to open qgis

Closes #2967 
