### PR TITLE
Enable scene re-ordering in the UI

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -7,7 +7,8 @@
   <div class="item-img-container">
     <rf-status-tag entity-type="scene"
                    ng-if="$ctrl.scene.statusFields.ingestStatus"
-                   status="$ctrl.scene.statusFields.ingestStatus"></rf-status-tag>
+                   status="$ctrl.scene.statusFields.ingestStatus"
+                   ng-class="{'on-drag': $ctrl.isDraggable}"></rf-status-tag>
     <img ng-attr-src="{{$ctrl.thumbnail}}"
          ng-if="$ctrl.thumbnail"
          class="rounded-img item-img">

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -1,5 +1,7 @@
 <div class="list-group-item has-action {{$ctrl.isDisabled ? 'is-disabled' : ''}}">
-  <div ng-if="$ctrl.isDraggable" ui-tree-handle>
+  <div title="Drag to reorder this scene"
+       ng-if="$ctrl.isDraggable"
+       ui-tree-handle>
     <i class="icon-gripper"></i>
   </div>
   <div class="item-img-container">

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -20,24 +20,18 @@ class SceneItemController {
       $scope, $attrs,
       thumbnailService, mapService, datasourceService) {
         'ngInject';
+
+        this.$scope = $scope;
+        this.$parent = $scope.$parent.$ctrl;
+
+        this.isDraggable = $attrs.hasOwnProperty('draggable');
+
         this.thumbnailService = thumbnailService;
         this.mapService = mapService;
-        this.isDraggable = $attrs.hasOwnProperty('draggable');
         this.datasourceService = datasourceService;
-        this.$scope = $scope;
     }
 
     $onInit() {
-        if (this.isDraggable) {
-            Object.assign(this.$scope.$parent.$treeScope.$callbacks, {
-                dragStart: function () {
-                    this.mapService.disableFootprints = true;
-                },
-                dragStop: function () {
-                    this.mapService.disableFootprints = false;
-                }
-            });
-        }
         this.$scope.$watch('$ctrl.scene.datasource', () => {
             if (this.repository) {
                 this.repository.service.getDatasource(this.scene).then((datasource) => {

--- a/app-frontend/src/app/index.vendor.js
+++ b/app-frontend/src/app/index.vendor.js
@@ -36,6 +36,7 @@ import 'mathjs';
 import 'angular-uuid4';
 import 'angular-hotkeys';
 import 'ui-select';
+import 'angular-ui-tree';
 
 // local scripts
 // import '../assets/js/...';

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -2,6 +2,7 @@ import angular from 'angular';
 import {Map, Set} from 'immutable';
 import ProjectActions from '_redux/actions/project-actions';
 import AnnotationActions from '_redux/actions/annotation-actions';
+import _ from 'lodash';
 
 class ProjectsEditController {
     constructor( // eslint-disable-line max-params
@@ -127,9 +128,9 @@ class ProjectsEditController {
                     (scene) => scene.statusFields.ingestStatus !== 'INGESTED'
                 ));
 
-                this.sceneList = this.orderedSceneId.map((id) => {
+                this.sceneList = _.uniqBy(this.orderedSceneId.map((id) => {
                     return allScenes.filter(s => s.id === id)[0];
-                });
+                }), 'id');
                 for (const scene of this.sceneList) {
                     let scenelayer = this.layerService.layerFromScene(scene, this.projectId);
                     this.sceneLayers = this.sceneLayers.set(scene.id, scenelayer);

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -44,8 +44,8 @@
   </div>
 </div>
 <div class="sidebar-scrollable"
-     data-empty-placeholder-enabled="false"
-     ui-tree="$ctrl.treeOptions">
+     ui-tree="$ctrl.treeOptions"
+     data-empty-placeholder-enabled="false">
   <div
     class="list-group"
     ng-model="$ctrl.$parent.sceneList"
@@ -56,7 +56,7 @@
         ng-click="$ctrl.openSceneDetailModal(scene)"
         ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
         ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
-        ng-repeat="scene in $ctrl.$parent.sceneList track by $index"
+        ng-repeat="scene in $ctrl.$parent.sceneList track by scene.id"
         ui-tree-node
         draggable>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -43,15 +43,22 @@
     </div>
   </div>
 </div>
-<div class="sidebar-scrollable">
-  <div class="list-group">
+<div class="sidebar-scrollable"
+     data-empty-placeholder-enabled="false"
+     ui-tree="$ctrl.treeOptions">
+  <div
+    class="list-group"
+    ng-model="$ctrl.$parent.sceneList"
+    ui-tree-nodes>
     <rf-scene-item
         scene="scene"
         repository="$ctrl.repository"
         ng-click="$ctrl.openSceneDetailModal(scene)"
         ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
         ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
-        ng-repeat="scene in $ctrl.$parent.sceneList track by scene.id">
+        ng-repeat="scene in $ctrl.$parent.sceneList track by $index"
+        ui-tree-node
+        draggable>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>
       </button>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -1,8 +1,5 @@
 import angular from 'angular';
 
-require('angular-ui-tree/dist/angular-ui-tree.min.css');
-require('angular-ui-tree/dist/angular-ui-tree.min.js');
-
 class ProjectsScenesController {
     constructor( // eslint-disable-line max-params
         $log, $state, $scope, modalService, projectService, RasterFoundryRepository

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -1,3 +1,4 @@
+/* globals document */
 import angular from 'angular';
 
 class ProjectsScenesController {
@@ -20,10 +21,23 @@ class ProjectsScenesController {
         // eslint-disable-next-line
         let thisItem = this;
         this.treeOptions = {
+            dragStart: function (e) {
+                thisItem.onSceneDragStart(e);
+            },
             dropped: function (e) {
                 thisItem.onSceneDropped(e.source.nodesScope.$modelValue);
             }
         };
+    }
+
+    onSceneDragStart(e) {
+        this.setDragPlaceholderHeight(e);
+    }
+
+    setDragPlaceholderHeight(e) {
+        const ele = angular.element(document.querySelector('.list-group-item'));
+        const placeholder = angular.element(e.elements.placeholder);
+        placeholder.css('height', ele.css('height'));
     }
 
     onSceneDropped(orderedScenes) {

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -1,11 +1,14 @@
 import angular from 'angular';
+
+require('angular-ui-tree/dist/angular-ui-tree.min.css');
+require('angular-ui-tree/dist/angular-ui-tree.min.js');
+
 class ProjectsScenesController {
     constructor( // eslint-disable-line max-params
         $log, $state, $scope, modalService, projectService, RasterFoundryRepository
     ) {
         'ngInject';
         this.$log = $log;
-        this.$state = $state;
         this.modalService = modalService;
         this.projectId = $state.params.projectid;
         this.$parent = $scope.$parent.$ctrl;
@@ -14,6 +17,21 @@ class ProjectsScenesController {
             name: 'Raster Foundry',
             service: RasterFoundryRepository
         };
+    }
+
+    $onInit() {
+        // eslint-disable-next-line
+        let thisItem = this;
+        this.treeOptions = {
+            dropped: function (e) {
+                thisItem.onSceneDropped(e.source.nodesScope.$modelValue);
+            }
+        };
+    }
+
+    onSceneDropped(orderedScenes) {
+        let orderedSceneIds = orderedScenes.map(s => s.id);
+        this.updateSceneOrder(orderedSceneIds);
     }
 
     removeSceneFromProject(scene, $event) {
@@ -51,9 +69,15 @@ class ProjectsScenesController {
             }
         });
     }
+
+    updateSceneOrder(orderedSceneIds) {
+        this.projectService.updateSceneOrder(this.projectId, orderedSceneIds).then(() => {
+            this.$parent.layerFromProject();
+        });
+    }
 }
 
-const ProjectsScenesModule = angular.module('pages.projects.edit.scenes', []);
+const ProjectsScenesModule = angular.module('pages.projects.edit.scenes', ['ui.tree']);
 
 ProjectsScenesModule.controller(
     'ProjectsScenesController', ProjectsScenesController

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -149,7 +149,6 @@ export default (app) => {
                     updateSceneOrder: {
                         method: 'PUT',
                         url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/order/`,
-                        cache: false,
                         params: {
                             projectId: '@projectId'
                         }

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -137,6 +137,22 @@ export default (app) => {
                             projectId: '@projectId',
                             sceneId: '@sceneId'
                         }
+                    },
+                    sceneOrder: {
+                        method: 'GET',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/order/`,
+                        cache: false,
+                        params: {
+                            projectId: '@projectId'
+                        }
+                    },
+                    updateSceneOrder: {
+                        method: 'PUT',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/order/`,
+                        cache: false,
+                        params: {
+                            projectId: '@projectId'
+                        }
                     }
                 }
             );
@@ -496,6 +512,17 @@ export default (app) => {
 
         getProjectAois(projectId) {
             return this.Project.projectAois({projectId: projectId}).$promise;
+        }
+
+        getSceneOrder(projectId) {
+            return this.Project.sceneOrder({projectId: projectId}).$promise;
+        }
+
+        updateSceneOrder(projectId, sceneIds) {
+            return this.Project.updateSceneOrder(
+                {projectId: projectId},
+                sceneIds
+            ).$promise;
         }
     }
 

--- a/app-frontend/src/assets/styles/sass/components/_list-group.scss
+++ b/app-frontend/src/assets/styles/sass/components/_list-group.scss
@@ -38,9 +38,9 @@
 }
 
 
-/* 
+/*
  * Status: deprecated
- * Currently only used on download modal 
+ * Currently only used on download modal
 */
 .list-group-subitem {
   padding: 1.5rem;
@@ -163,4 +163,15 @@
   @include respond-to('sm-up') {
     //max-width: 275px;
   }
+}
+
+.angular-ui-tree-placeholder {
+    background: lighten($brand-tertiary, 35%);
+    border: 2px dashed $brand-tertiary;
+    width: 40rem;
+    position: relative;
+}
+
+rf-scene-item {
+    display: block;
 }

--- a/app-frontend/src/assets/styles/sass/components/_tags.scss
+++ b/app-frontend/src/assets/styles/sass/components/_tags.scss
@@ -31,6 +31,10 @@
     left: 1rem;
     top: 2rem;
   }
+
+  .on-drag & {
+    left: 4rem;
+  }
 }
 
 .grey-tag {


### PR DESCRIPTION
## Overview

This PR updates the following on the scenes page in a project:

- Make the order of scene items on the sidebar respect the real overlay sequence of scenes on the map
- Enable re-ordering of scenes by dragging scene sidebar item handles. The map reflects the new sequence.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

The scene overlaid on others was the one in the middle. This reorders the scene so that it comes to the bottom of all scenes.

![reorder](https://raw.githubusercontent.com/aaronxsu/MyData/master/gifs/rf-pr-gifs/reorder.gif)

## Testing Instructions

 * Go to a project with overlaying scenes
 * Check if the sidebar items reflect the true scene overlay sequence
 * Re-order scene items and see if the map gets updated
 * Make sure other pages using the scene item component that should not have this re-ordering feature are not affected.

Closes #2299
