### PR TITLE
Preview scenes by clicking the thumbnail, select by clicking

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -96,11 +96,13 @@ module.exports = function (_path) {
             modulesDirectories: ['node_modules'],
             alias: {
                 _appRoot: path.join(_path, 'src', 'app'),
-                _images: path.join(_path, 'src', 'app', 'assets', 'images'),
-                _stylesheets: path.join(_path, 'src', 'app', 'assets', 'styles'),
-                _scripts: path.join(_path, 'src', 'app', 'assets', 'js'),
+                _stylesheets: path.join(_path, 'src', 'assets', 'styles'),
                 _api: path.join(_path, 'src', 'app', 'api'),
-                _redux: path.join(_path, 'src', 'app', 'redux')
+                _redux: path.join(_path, 'src', 'app', 'redux'),
+                _assets: path.join(_path, 'src', 'assets'),
+                _scripts: path.join(_path, 'src', 'assets', 'js'),
+                _images: path.join(_path, 'src', 'assets', 'images'),
+                _font: path.join(_path, 'src', 'assets', 'font')
             }
         },
 

--- a/app-frontend/src/app/components/scenes/importList/importList.html
+++ b/app-frontend/src/app/components/scenes/importList/importList.html
@@ -6,9 +6,9 @@
 </div>
 <div class="list-group">
   <rf-scene-item
+      previewable
       scene="scene"
       repository="$ctrl.repository"
-      ng-click="$ctrl.viewSceneDetail(scene)"
       ng-repeat="scene in $ctrl.importList track by scene.id">
     <div class="btn-group" ng-if="$ctrl.sceneActions && $ctrl.sceneActions.length">
       <button type="button"

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -83,16 +83,6 @@ class ImportListController {
         });
     }
 
-    viewSceneDetail(scene) {
-        this.modalService.open({
-            component: 'rfSceneDetailModal',
-            resolve: {
-                scene: () => scene,
-                repository: () => this.repository
-            }
-        });
-    }
-
     importModal() {
         this.modalService.open({
             component: 'rfSceneImportModal',

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -1,10 +1,15 @@
-<div class="list-group-item has-action {{$ctrl.isDisabled ? 'is-disabled' : ''}}">
+<div class="list-group-item"
+     ng-class="{'disabled': $ctrl.isDisabled,
+                'clickable': $ctrl.isClickable}">
   <div title="Drag to reorder this scene"
        ng-if="$ctrl.isDraggable"
        ui-tree-handle>
     <i class="icon-gripper"></i>
   </div>
-  <div class="item-img-container">
+  <div class="item-img-container"
+       ng-class="{'previewable': $ctrl.isPreviewable}"
+       ng-click="$ctrl.isPreviewable && $ctrl.openSceneDetailModal()"
+  >
     <rf-status-tag entity-type="scene"
                    ng-if="$ctrl.scene.statusFields.ingestStatus"
                    status="$ctrl.scene.statusFields.ingestStatus"

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -17,8 +17,9 @@ const SceneItemComponent = {
 
 class SceneItemController {
     constructor(
-      $scope, $attrs,
-      thumbnailService, mapService, datasourceService) {
+        $scope, $attrs,
+        thumbnailService, mapService, datasourceService, modalService
+    ) {
         'ngInject';
 
         this.$scope = $scope;
@@ -28,7 +29,12 @@ class SceneItemController {
 
         this.thumbnailService = thumbnailService;
         this.mapService = mapService;
+        this.isDraggable = $attrs.hasOwnProperty('draggable');
+        this.isPreviewable = $attrs.hasOwnProperty('previewable');
+        this.isClickable = $attrs.hasOwnProperty('clickable');
         this.datasourceService = datasourceService;
+        this.modalService = modalService;
+        this.$scope = $scope;
     }
 
     $onInit() {
@@ -79,6 +85,16 @@ class SceneItemController {
             return true;
         }
         return false;
+    }
+
+    openSceneDetailModal() {
+        this.modalService.open({
+            component: 'rfSceneDetailModal',
+            resolve: {
+                scene: () => this.scene,
+                repository: () => this.repository
+            }
+        });
     }
 }
 

--- a/app-frontend/src/app/components/vectors/shapeItem/shapeItem.html
+++ b/app-frontend/src/app/components/vectors/shapeItem/shapeItem.html
@@ -1,4 +1,6 @@
-<div class="list-group-item has-action {{$ctrl.isDisabled ? 'is-disabled' : ''}}">
+<div class="list-group-item"
+     ng-class="{'disabled': $ctrl.isDisabled,
+                'clickable': $ctrl.isClickable}">
   <div class="list-group-overflow">
     <div>
       <span title="{{$ctrl.shape.properties.name}}">

--- a/app-frontend/src/app/components/vectors/shapeItem/shapeItem.module.js
+++ b/app-frontend/src/app/components/vectors/shapeItem/shapeItem.module.js
@@ -11,7 +11,10 @@ const ShapeItemComponent = {
 };
 
 class ShapeItemController {
-    constructor() {}
+    constructor($attrs) {
+        this.isPreviewable = $attrs.hasOwnProperty('previewable');
+        this.isClickable = $attrs.hasOwnProperty('clickable');
+    }
     $postLink() {
         this.shapeJson = JSON.stringify(this.shape);
     }

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -174,8 +174,8 @@ export default class ProjectsAdvancedColorController {
                 map.setGeojson(scene.id, this.sceneService.getStyledFootprint(scene));
             });
         } else {
-            this.selectedScenes.delete(scene.id);
-            this.selectedLayers.delete(scene.id);
+            this.selectedScenes = this.selectedScenes.delete(scene.id);
+            this.selectedLayers = this.selectedLayers.delete(scene.id);
             this.getMap().then((map) => {
                 map.deleteGeojson(scene.id);
             });

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.html
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.html
@@ -30,6 +30,9 @@
   <div class="sidebar-scrollable">
     <div class="list-group">
       <rf-scene-item
+          previewable
+          clickable
+          ng-click="$ctrl.setSelected(scene, !$ctrl.isSelected(scene))"
           scene="scene"
           repository="$ctrl.repository"
           selected="$ctrl.isSelected(scene)"

--- a/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.html
+++ b/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.html
@@ -54,12 +54,12 @@
 </div>
 <div class="sidebar-scrollable list-group">
   <rf-scene-item
+      previewable
       scene="scene"
       repository="$ctrl.repository"
       is-disabled="$ctrl.isInProject(scene)"
       on-select="$ctrl.setSelected(scene, selected)"
       class="selectable"
-      ng-click="$ctrl.openSceneDetailModal(scene)"
       ng-mouseenter="$ctrl.setHoveredScene(scene)"
       ng-mouseleave="$ctrl.removeHoveredScene()"
       ng-repeat="scene in $ctrl.pendingSceneList track by scene.id">

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.html
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.html
@@ -78,14 +78,16 @@
 </div>
 <div class="sidebar-scrollable list-group" ng-if="$ctrl.sceneList.length">
   <rf-scene-item
+      previewable
+      clickable
       scene="scene"
       repository="$ctrl.currentRepository"
       selected="$ctrl.isSelected(scene)"
       is-disabled="$ctrl.isInProject(scene)"
       on-select="$ctrl.setSelected(scene, selected)"
-      ng-click="$ctrl.openSceneDetailModal(scene)"
       ng-mouseenter="$ctrl.setHoveredScene(scene)"
       ng-mouseleave="$ctrl.removeHoveredScene()"
+      ng-click="$ctrl.setSelected(scene, !$ctrl.isSelected(scene))"
       ng-repeat="scene in $ctrl.sceneList track by scene.id">
   </rf-scene-item>
   <img ng-attr-src="{{$ctrl.base64Uri}}">

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -301,16 +301,6 @@ class ProjectsSceneBrowserController {
         this.selectNoScenes();
         this.$state.go('projects.edit.scenes');
     }
-
-    openSceneDetailModal(scene) {
-        this.modalService.open({
-            component: 'rfSceneDetailModal',
-            resolve: {
-                scene: () => scene,
-                repository: () => this.currentRepository
-            }
-        });
-    }
 }
 
 const ProjectsSceneBrowserModule = angular.module('pages.projects.edit.browse', []);

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -51,14 +51,14 @@
     ng-model="$ctrl.$parent.sceneList"
     ui-tree-nodes>
     <rf-scene-item
+        previewable
+        draggable
         scene="scene"
         repository="$ctrl.repository"
-        ng-click="$ctrl.openSceneDetailModal(scene)"
         ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
         ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
         ng-repeat="scene in $ctrl.$parent.sceneList track by scene.id"
-        ui-tree-node
-        draggable>
+        ui-tree-node>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>
       </button>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -59,19 +59,6 @@ class ProjectsScenesController {
         );
     }
 
-    openSceneDetailModal(scene) {
-        this.$parent.removeHoveredScene();
-
-        this.modalService.open({
-            component: 'rfSceneDetailModal',
-            resolve: {
-                scene: () => scene,
-                repository: () => this.repository
-            }
-        });
-    }
-
-
     openImportModal() {
         this.modalService.open({
             component: 'rfSceneImportModal',

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -476,10 +476,14 @@ rf-project-editor .leaflet-tile {
   }
 }
 
-.list-group-item.is-disabled {
-  opacity: 0.5;
+.list-group-item {
+    &.disabled {
+        opacity: 0.5;
+    }
+    &.clickable {
+        cursor: pointer;
+    }
 }
-
 .checkbox-container {
   height: 2rem;
   width: 2rem;

--- a/app-frontend/src/assets/styles/sass/components/_image.scss
+++ b/app-frontend/src/assets/styles/sass/components/_image.scss
@@ -25,6 +25,24 @@
     border: 1px solid $border-color-default;
     display: flex;
     justify-content: center;
+
+    &.previewable {
+        cursor: zoom-in;
+
+        &:hover:before {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+
+            content: "Details";
+
+            color: $white;
+            background: $brand-primary;
+
+            padding: 0.5em;
+            border-radius: 3px;
+        }
+    }
 }
 
 .item-img {


### PR DESCRIPTION
## Overview
Add previewable attribute to sceneItems
Add clickable attribute to sceneItems (just adds styling)
Fix some webpack path aliases
Adjust styling of sceneItem to make preview action more clear
Fix some classes being conditionally defined outside of an ng-class on the class property

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/4392704/36920984-90cc464c-1e30-11e8-9935-600af4d62913.png)
![image](https://user-images.githubusercontent.com/4392704/36921039-d0e0fe8a-1e30-11e8-9a33-68b55ffa50ab.png)


## Testing Instructions

 * Verify that hovering scene thumbnails shows "Details" text, and clicking brings up the preview modal
* Verify that clicking the scene item in the views that allow selecting now selects the scene instead of bringing up the modal
* Verify that 

Closes https://github.com/raster-foundry/raster-foundry/issues/3006
