### PR TITLE
Fix broken planet thumbnails.

### DIFF
--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@turf/area": "^4.7.3",
-    "@turf/distance": "^4.7.3",
     "@turf/bbox": "^4.7.3",
     "@turf/bbox-polygon": "^4.7.3",
+    "@turf/distance": "^4.7.3",
     "angular": "~1.5.8",
     "angular-animate": "~1.5.8",
     "angular-aria": "~1.5.8",

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -8,7 +8,7 @@
   </div>
   <div class="item-img-container"
        ng-class="{'previewable': $ctrl.isPreviewable}"
-       ng-click="$ctrl.isPreviewable && $ctrl.openSceneDetailModal()"
+       ng-click="$ctrl.isPreviewable && $ctrl.openSceneDetailModal($event)"
   >
     <rf-status-tag entity-type="scene"
                    ng-if="$ctrl.scene.statusFields.ingestStatus"

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -87,7 +87,8 @@ class SceneItemController {
         return false;
     }
 
-    openSceneDetailModal() {
+    openSceneDetailModal(e) {
+        e.stopPropagation();
         this.modalService.open({
             component: 'rfSceneDetailModal',
             resolve: {

--- a/app-frontend/src/app/pages/admin/platform/organizations/detail/detail.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/detail/detail.module.js
@@ -2,7 +2,7 @@ import angular from 'angular';
 
 class PlatformOrganizationDetailController {
     constructor() {
-        
+
     }
 }
 

--- a/app-frontend/src/app/services/scenes/planetRepository.service.js
+++ b/app-frontend/src/app/services/scenes/planetRepository.service.js
@@ -56,6 +56,7 @@ export default (app) => {
                         reject();
                     });
                 }
+                this.thumbnailSize = 512;
             });
         }
 
@@ -232,7 +233,7 @@ export default (app) => {
         getThumbnail(scene, trim = false) {
             return this.$q((resolve, reject) => {
                 this.planetLabsService.getThumbnail(
-                    this.planetToken, scene.thumbnails[0].url
+                    this.planetToken, scene.thumbnails[0].url, this.thumbnailSize
                 ).then((response) => {
                     let thumbnail = `data:image/png;base64,${response}`;
                     if (trim) {
@@ -250,7 +251,7 @@ export default (app) => {
             });
         }
 
-        // assumes thumbnail is 256x256, which is true for planet thumbnails
+        // assumes thumbnail is 512x512, which is true for planet thumbnails
         trimThumbnail(thumbnail) {
             function rowBlank(imageData, width, y) {
                 for (let x = 0; x < width; x = x + 1) {
@@ -271,8 +272,8 @@ export default (app) => {
             }
 
             return this.$q((resolve, reject) => {
-                const width = 256;
-                const height = 256;
+                const width = this.thumbnailSize;
+                const height = this.thumbnailSize;
                 const canvas = document.createElement('canvas');
                 canvas.width = width;
                 canvas.height = height;

--- a/app-frontend/src/app/services/scenes/planetRepository.service.js
+++ b/app-frontend/src/app/services/scenes/planetRepository.service.js
@@ -14,6 +14,7 @@ export default (app) => {
             this.permissionSource = ' from planet.com';
             this.skipThumbnailClipping = true;
             this.previewOnMap = true;
+            this.thumbnailSize = 512;
         }
 
         initRepository() {
@@ -56,7 +57,6 @@ export default (app) => {
                         reject();
                     });
                 }
-                this.thumbnailSize = 512;
             });
         }
 
@@ -251,7 +251,7 @@ export default (app) => {
             });
         }
 
-        // assumes thumbnail is 512x512, which is true for planet thumbnails
+        // Assumes the dimensions stored in `this.thumbnailSize` are correct
         trimThumbnail(thumbnail) {
             function rowBlank(imageData, width, y) {
                 for (let x = 0; x < width; x = x + 1) {

--- a/app-frontend/src/app/services/vendor/planetLabs.service.js
+++ b/app-frontend/src/app/services/vendor/planetLabs.service.js
@@ -10,8 +10,6 @@ export default (app) => {
             'ngInject';
             this.$log = $log;
             this.$http = $http;
-
-            this.thumbnailSize = '512';
         }
 
         sendHttpRequest(req) {
@@ -54,11 +52,12 @@ export default (app) => {
             return this.sendHttpRequest(req);
         }
 
-        getThumbnail(apiKey, link) {
+
+        getThumbnail(apiKey, link, size) {
             let token = btoa(apiKey + ':');
             let req = {
                 'method': 'GET',
-                'url': link + '?width=' + this.thumbnailSize,
+                'url': link + '?width=' + size,
                 'headers': {
                     'Authorization': 'Basic ' + token,
                     'Content-Type': 'arraybuffer'
@@ -69,8 +68,8 @@ export default (app) => {
             return this.$http(req).then(
                 (response) => {
                     let arr = new Uint8Array(response.data);
-                    let raw = String.fromCharCode.apply(null, arr);
-                    return btoa(raw);
+                    let rawString = this.uint8ToString(arr);
+                    return btoa(rawString);
                 },
                 (error) => {
                     return error;
@@ -197,6 +196,15 @@ export default (app) => {
                     'config': _.compact(config.concat([permissionFilter, geometryFilter]))
                 }
             };
+        }
+
+        uint8ToString(u8a) {
+            const CHUNK_SZ = 0x8000;
+            let result = [];
+            for (let i = 0; i < u8a.length; i += CHUNK_SZ) {
+                result.push(String.fromCharCode.apply(null, u8a.subarray(i, i + CHUNK_SZ)));
+            }
+            return result.join('');
         }
     }
 


### PR DESCRIPTION
## Overview

This PR:
- Fixes broken planet thumbnails.
- Deals with larger unit8arrays from planet thumbnail pngs since the resolution now is higher which resulted in `RangeError : Maximum call stack size exceeded` error in some cases using the original unit8arrays to string method.
- Stop click propagation on scene item details.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to a project and browse scenes from planet repository.
 * Check if thumbnails are displayed correctly on the sidebar, map, and detail modal map.
 * Click on the detail button from scene sidebar, make sure it does not trigger scene selection.

Closes [raster-foundry-platform issue #272](https://github.com/azavea/raster-foundry-platform/issues/272)
