### PR TITLE
Use BUILDCONFIG logo on share page

### DIFF
--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -1,5 +1,7 @@
-import logoAsset from '../../../assets/images/logo-raster-foundry.png';
-/* global L */
+/* global BUILDCONFIG, L */
+const ASSETLOGO = BUILDCONFIG.LOGOURL || BUILDCONFIG.LOGOFILE ?
+    require(`../../../assets/images/${BUILDCONFIG.LOGOFILE}`) :
+    require('../../../assets/images/raster-foundry-logo.svg');
 
 export default class ShareController {
     constructor( // eslint-disable-line max-params
@@ -8,7 +10,7 @@ export default class ShareController {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
-        this.logoAsset = logoAsset;
+        this.logoAsset = ASSETLOGO;
         this.authService = authService;
         this.projectService = projectService;
         this.mapUtilsService = mapUtilsService;


### PR DESCRIPTION
## Overview

This PR uses logo in `BUILDCONFIG` on the share page.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to `/share/projectid` and see if it the logo specified in `BUILDCONFIG` shows up (`raster-foundry-logo.svg` in our case)

Closes #3049
