### PR TITLE
Change acquisition date display to UTC

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
@@ -37,7 +37,7 @@
             {{$ctrl.datasource ? $ctrl.datasource.name : 'Loading datasource'}}
           </dd>
           <dt ng-repeat-start="(field, value) in $ctrl.scene.filterFields">
-            {{field}}
+            {{field === 'acquisitionDate' ? field + ' (UTC)' : field}}
           </dt>
           <dd ng-repeat-end>{{field !== 'acquisitionDate' ? value : $ctrl.accDateDisplay}}</dd>
           <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
@@ -37,7 +37,7 @@
             {{$ctrl.datasource ? $ctrl.datasource.name : 'Loading datasource'}}
           </dd>
           <dt ng-repeat-start="(field, value) in $ctrl.scene.filterFields">
-            {{field === 'acquisitionDate' ? field + ' (UTC)' : field}}
+            {{field}}
           </dt>
           <dd ng-repeat-end>{{field !== 'acquisitionDate' ? value : $ctrl.accDateDisplay}}</dd>
           <dt ng-if-start="$ctrl.scene.createdAt">Created Date</dt>

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -133,7 +133,7 @@ class SceneDetailModalController {
     }
 
     formatAcqDate(date) {
-        return date.length ? this.moment.utc(date).format('MM/DD/YYYY') : 'MM/DD/YYYY';
+        return date.length ? this.moment.utc(date).format('MM/DD/YYYY') + ' (UTC)' : 'MM/DD/YYYY';
     }
 
     openDatePickerModal(date) {

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -133,7 +133,7 @@ class SceneDetailModalController {
     }
 
     formatAcqDate(date) {
-        return date.length ? this.moment(date).format('MM/DD/YYYY') : 'MM/DD/YYYY';
+        return date.length ? this.moment.utc(date).format('MM/DD/YYYY') : 'MM/DD/YYYY';
     }
 
     openDatePickerModal(date) {

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -26,7 +26,7 @@
     <div>
       <span title="{{$ctrl.scene.name}}">
         <strong class="color-dark">
-          {{$ctrl.getReferenceDate() | date : 'mediumDate' : '+0000'}}
+          {{($ctrl.getReferenceDate() | date : 'mediumDate' : '+0000') + ' (UTC)'}}
         </strong>
       </span>
     </div>

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -26,7 +26,7 @@
     <div>
       <span title="{{$ctrl.scene.name}}">
         <strong class="color-dark">
-          {{$ctrl.getReferenceDate() | date}}
+          {{$ctrl.getReferenceDate() | date : 'mediumDate' : '+0000'}}
         </strong>
       </span>
     </div>


### PR DESCRIPTION
## Overview

This PR updates acquisition display to use UTC on scene detail modal and on scene item.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to a project and check if dates on scene item display and scene detail modal match what are returned from the request (all should be in UTC).

Closes #3052
