### PR TITLE
Enable copy confirmation on sharing buttons

### DIFF
--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.html
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.html
@@ -33,8 +33,10 @@
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.shareUrl}}" readonly>
           <button class="btn btn-link"
-                  clipboard text="$ctrl.shareUrl">
-            Copy
+                  clipboard text="$ctrl.shareUrl"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.shareUrl, 'page')">
+                  <span ng-show="$ctrl.copyType !== 'page'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'page'"></span>
           </button>
           <button class="btn btn-primary"
                   ng-click="$ctrl.openProjectShare()">
@@ -47,16 +49,22 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.standard}}" readonly>
-          <button clipboard text="$ctrl.tileLayerUrls.standard" class="btn btn-link">
-            Copy
+          <button class="btn btn-link"
+                  clipboard text="$ctrl.tileLayerUrls.standard"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.standard, 'zxy')">
+                  <span ng-show="$ctrl.copyType !== 'zxy'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'zxy'"></span>
           </button>
         </div>
         <label for="tile-link">ArcGIS Tile Layer URL</label>
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.arcGIS}}" readonly>
-          <button clipboard text="$ctrl.tileLayerUrls.arcGIS" class="btn btn-link">
-            Copy
+          <button class="btn btn-link"
+                  clipboard text="$ctrl.tileLayerUrls.arcGIS"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.arcGIS, 'arcGIS')">
+                  <span ng-show="$ctrl.copyType !== 'arcGIS'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'arcGIS'"></span>
           </button>
         </div>
       </div>
@@ -66,8 +74,10 @@
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.mapToken.id}}" readonly>
           <button class="btn btn-link"
-                  clipboard text="$ctrl.mapToken.id">
-            Copy
+                  clipboard text="$ctrl.mapToken.id"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.mapToken.id, 'token')">
+                  <span ng-show="$ctrl.copyType !== 'token'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'token'"></span>
           </button>
         </div>
       </div>
@@ -79,16 +89,22 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.standard}}" readonly>
-          <button clipboard text="$ctrl.tileLayerUrls.standard" class="btn btn-link">
-            Copy
+          <button class="btn btn-link"
+                  clipboard text="$ctrl.tileLayerUrls.standard"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.standard, 'zxy')">
+                  <span ng-show="$ctrl.copyType !== 'zxy'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'zxy'"></span>
           </button>
         </div>
         <label for="tile-link">ArcGIS Tile Layer URL</label>
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.arcGIS}}" readonly>
-          <button clipboard text="$ctrl.tileLayerUrls.arcGIS" class="btn btn-link">
-            Copy
+          <button class="btn btn-link"
+                  clipboard text="$ctrl.tileLayerUrls.arcGIS"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.arcGIS, 'arcGIS')">
+                  <span ng-show="$ctrl.copyType !== 'arcGIS'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'arcGIS'"></span>
           </button>
         </div>
         <label>Token</label>
@@ -96,8 +112,10 @@
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.analysisToken}}" readonly>
           <button class="btn btn-link"
-                  clipboard text="$ctrl.analysisToken">
-            Copy
+                  clipboard text="$ctrl.analysisToken"
+                  ng-click="$ctrl.onCopyClick($event, $ctrl.analysisToken, 'token')">
+                  <span ng-show="$ctrl.copyType !== 'token'">Copy</span>
+                  <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'token'"></span>
           </button>
         </div>
       </div>

--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.html
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.html
@@ -32,7 +32,7 @@
           <label for="tile-link" class="sr-only">URL</label>
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.shareUrl}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal-first"
                   clipboard text="$ctrl.shareUrl"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.shareUrl, 'page')">
                   <span ng-show="$ctrl.copyType !== 'page'">Copy</span>
@@ -49,7 +49,7 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.standard}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal"
                   clipboard text="$ctrl.tileLayerUrls.standard"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.standard, 'zxy')">
                   <span ng-show="$ctrl.copyType !== 'zxy'">Copy</span>
@@ -60,7 +60,7 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.arcGIS}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal"
                   clipboard text="$ctrl.tileLayerUrls.arcGIS"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.arcGIS, 'arcGIS')">
                   <span ng-show="$ctrl.copyType !== 'arcGIS'">Copy</span>
@@ -73,7 +73,7 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.mapToken.id}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal"
                   clipboard text="$ctrl.mapToken.id"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.mapToken.id, 'token')">
                   <span ng-show="$ctrl.copyType !== 'token'">Copy</span>
@@ -89,7 +89,7 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.standard}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal"
                   clipboard text="$ctrl.tileLayerUrls.standard"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.standard, 'zxy')">
                   <span ng-show="$ctrl.copyType !== 'zxy'">Copy</span>
@@ -100,7 +100,7 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                   value="{{$ctrl.tileLayerUrls.arcGIS}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal"
                   clipboard text="$ctrl.tileLayerUrls.arcGIS"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.arcGIS, 'arcGIS')">
                   <span ng-show="$ctrl.copyType !== 'arcGIS'">Copy</span>
@@ -111,7 +111,7 @@
         <div class="form-group all-in-one">
           <input id="tile-link" type="text" class="form-control"
                  value="{{$ctrl.analysisToken}}" readonly>
-          <button class="btn btn-link"
+          <button class="btn btn-link btn-copy-modal"
                   clipboard text="$ctrl.analysisToken"
                   ng-click="$ctrl.onCopyClick($event, $ctrl.analysisToken, 'token')">
                   <span ng-show="$ctrl.copyType !== 'token'">Copy</span>

--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.module.js
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.module.js
@@ -171,10 +171,6 @@ class ProjectPublishModalController {
     onCopyClick(e, url, type) {
         if (url && url.length) {
             this.copyType = type;
-            angular.element(e.currentTarget).css({
-                width: angular.element(e.currentTarget).prop('offsetWidth'),
-                height: angular.element(e.currentTarget).prop('offsetHeight')
-            });
             this.$timeout(() => {
                 delete this.copyType;
             }, 1000);

--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.module.js
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.module.js
@@ -13,16 +13,21 @@ const ProjectPublishModalComponent = {
 };
 
 class ProjectPublishModalController {
-    constructor($q, projectService, $log, tokenService, authService, $window, $state) {
+    constructor(
+        $q, $log, $window, $state, $timeout,
+        projectService, tokenService, authService
+    ) {
         'ngInject';
+
+        this.$q = $q;
+        this.$log = $log;
+        this.$window = $window;
+        this.$state = $state;
+        this.$timeout = $timeout;
 
         this.authService = authService;
         this.projectService = projectService;
-        this.$log = $log;
         this.tokenService = tokenService;
-        this.$q = $q;
-        this.$window = $window;
-        this.$state = $state;
     }
 
     $onInit() {
@@ -160,6 +165,19 @@ class ProjectPublishModalController {
                     }
                 );
             }
+        }
+    }
+
+    onCopyClick(e, url, type) {
+        if (url && url.length) {
+            this.copyType = type;
+            angular.element(e.currentTarget).css({
+                width: angular.element(e.currentTarget).prop('offsetWidth'),
+                height: angular.element(e.currentTarget).prop('offsetHeight')
+            });
+            this.$timeout(() => {
+                delete this.copyType;
+            }, 1000);
         }
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
@@ -22,7 +22,7 @@
     <div class="list-group-item sidebar-actions-group">
       <label>Share Page</label>
       <div class="list-group-right btn-group">
-        <button class="btn btn-default"
+        <button class="btn btn-default btn-copy-page"
                 clipboard text="$ctrl.shareUrl"
                 ng-click="$ctrl.onCopyClick($event, $ctrl.shareUrl, 'page')">
           <span ng-show="$ctrl.copyType !== 'page'">Copy</span>
@@ -37,7 +37,7 @@
     <div class="list-group-item sidebar-actions-group">
       <label>ZXY Tile Layer URL</label>
       <div class="list-group-right btn-group">
-        <button class="btn btn-default"
+        <button class="btn btn-default btn-copy-page"
                 clipboard text="$ctrl.tileLayerUrls.standard"
                 ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.standard, 'zxy')">
           <span ng-show="$ctrl.copyType !== 'zxy'">Copy</span>
@@ -48,7 +48,7 @@
     <div class="list-group-item sidebar-actions-group">
       <label>ArcGIS Tile Layer URL</label>
       <div class="list-group-right btn-group">
-        <button class="btn btn-default"
+        <button class="btn btn-default btn-copy-page"
                 clipboard text="$ctrl.tileLayerUrls.arcGIS"
                 ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.arcGIS, 'arcGIS')">
           <span ng-show="$ctrl.copyType !== 'arcGIS'">Copy</span>
@@ -59,7 +59,7 @@
     <div class="list-group-item sidebar-actions-group">
       <label>Map Token</label>
       <div class="list-group-right btn-group">
-        <button class="btn btn-default"
+        <button class="btn btn-default btn-copy-page"
                 clipboard text="$ctrl.mapToken.id"
                 ng-click="$ctrl.onCopyClick($event, $ctrl.mapToken.id, 'token')">
           <span ng-show="$ctrl.copyType !== 'token'">Copy</span>

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
@@ -23,8 +23,10 @@
       <label>Share Page</label>
       <div class="list-group-right btn-group">
         <button class="btn btn-default"
-                clipboard text="$ctrl.shareUrl">
-          Copy
+                clipboard text="$ctrl.shareUrl"
+                ng-click="$ctrl.onCopyClick($event, $ctrl.shareUrl, 'page')">
+          <span ng-show="$ctrl.copyType !== 'page'">Copy</span>
+          <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'page'"></span>
         </button>
         <button class="btn btn-default"
                 ng-click="$ctrl.onSharePageOpen()">
@@ -35,24 +37,33 @@
     <div class="list-group-item sidebar-actions-group">
       <label>ZXY Tile Layer URL</label>
       <div class="list-group-right btn-group">
-        <button clipboard text="$ctrl.tileLayerUrls.standard" class="btn btn-default">
-          Copy
+        <button class="btn btn-default"
+                clipboard text="$ctrl.tileLayerUrls.standard"
+                ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.standard, 'zxy')">
+          <span ng-show="$ctrl.copyType !== 'zxy'">Copy</span>
+          <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'zxy'"></span>
         </button>
       </div>
     </div>
     <div class="list-group-item sidebar-actions-group">
       <label>ArcGIS Tile Layer URL</label>
       <div class="list-group-right btn-group">
-        <button clipboard text="$ctrl.tileLayerUrls.arcGIS" class="btn btn-default">
-          Copy
+        <button class="btn btn-default"
+                clipboard text="$ctrl.tileLayerUrls.arcGIS"
+                ng-click="$ctrl.onCopyClick($event, $ctrl.tileLayerUrls.arcGIS, 'arcGIS')">
+          <span ng-show="$ctrl.copyType !== 'arcGIS'">Copy</span>
+          <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'arcGIS'"></span>
         </button>
       </div>
     </div>
     <div class="list-group-item sidebar-actions-group">
       <label>Map Token</label>
       <div class="list-group-right btn-group">
-        <button clipboard text="$ctrl.mapToken.id" class="btn btn-default">
-          Copy
+        <button class="btn btn-default"
+                clipboard text="$ctrl.mapToken.id"
+                ng-click="$ctrl.onCopyClick($event, $ctrl.mapToken.id, 'token')">
+          <span ng-show="$ctrl.copyType !== 'token'">Copy</span>
+          <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'token'"></span>
         </button>
       </div>
     </div>

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.module.js
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.module.js
@@ -48,13 +48,15 @@ const urlMappings = {
 
 class SharingController {
     constructor(
-        $log, $state, $window,
+        $log, $state, $window, $timeout,
         projectService, projectEditService, tokenService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
         this.$window = $window;
+        this.$timeout = $timeout;
+
         this.projectService = projectService;
         this.projectEditService = projectEditService;
         this.tokenService = tokenService;
@@ -157,6 +159,19 @@ class SharingController {
     onSharePageOpen() {
         if (this.project) {
             this.$window.open(this.shareUrl, '_blank');
+        }
+    }
+
+    onCopyClick(e, url, type) {
+        if (url && url.length) {
+            this.copyType = type;
+            angular.element(e.currentTarget).css({
+                width: angular.element(e.currentTarget).prop('offsetWidth'),
+                height: angular.element(e.currentTarget).prop('offsetHeight')
+            });
+            this.$timeout(() => {
+                delete this.copyType;
+            }, 1000);
         }
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.module.js
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.module.js
@@ -165,10 +165,6 @@ class SharingController {
     onCopyClick(e, url, type) {
         if (url && url.length) {
             this.copyType = type;
-            angular.element(e.currentTarget).css({
-                width: angular.element(e.currentTarget).prop('offsetWidth'),
-                height: angular.element(e.currentTarget).prop('offsetHeight')
-            });
             this.$timeout(() => {
                 delete this.copyType;
             }, 1000);

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3028,3 +3028,7 @@ rf-reclassify-table {
     float: right;
   }
 }
+
+.copy-confirmation {
+  font-size: 2rem;
+}

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -375,3 +375,24 @@
     transform: translateY(-50%);
   }
 }
+
+/*
+Copy button on project share modal
+*/
+.btn-copy-modal {
+  width: 99.47px;
+  height: 38px;
+}
+
+.btn-copy-modal-first {
+  width: 73.92px;
+  height: 38px;
+}
+
+/*
+Copy button on project share page
+*/
+.btn-copy-page {
+  width: 77.47px;
+  height: 32px;
+}

--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_button.scss
@@ -31,7 +31,7 @@
   @include button-states($shade-light, $white);
 }
 
-/* 
+/*
  * Makes three main buttons
  * types look the identical
  */
@@ -132,4 +132,21 @@
 
 .btn-square {
   padding: 1rem;
+}
+
+/*
+Copy button on project share modal
+*/
+.btn-copy-modal,
+.btn-copy-modal-first {
+  width: 99.47px;
+  height: 39px;
+}
+
+/*
+Copy button on project share page
+*/
+.btn-copy-page {
+  width: 77.47px;
+  height: 29px;
 }


### PR DESCRIPTION
## Overview

This PR enables showing a check mark on the copy button when an URL exists and is successfully copied to the clip board.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

![edit](https://user-images.githubusercontent.com/16109558/37484565-4a22653a-285f-11e8-8352-2ff403afcb67.gif)

![share](https://user-images.githubusercontent.com/16109558/37484569-4e2ce4ac-285f-11e8-8ab8-674b82f3b3e5.gif)


## Testing Instructions

 * Go to the sharing page of a project and copy share links
 * Go to the project list page, open the project share modal, copy the share links

Closes #3062 
