### PR TITLE
Revert unintentional changes to Vagrantfile and db settings

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 8096
-    vb.cpus = 4
+    vb.cpus = 2
   end
 
   host_user = ENV.fetch("USER", "vagrant")

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/util/database.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/util/database.scala
@@ -5,15 +5,16 @@ import doobie.hikari.HikariTransactor
 import cats.effect.IO
 import doobie.hikari.implicits._
 import scala.concurrent.duration._
+import scala.util.Properties
 
 trait Config {
 //  private val config = ConfigFactory.load()
 //  private val databaseConfig = config.getConfig("db")
   val jdbcNoDBUrl = "jdbc:postgresql://database.service.rasterfoundry.internal/"
-  val jdbcDBName = "rasterfoundry"
+  val jdbcDBName = Properties.envOrElse("POSTGRES_DB", "rasterfoundry")
   val jdbcUrl = jdbcNoDBUrl + jdbcDBName
-  val dbUser = "rasterfoundry"
-  val dbPassword = "rasterfoundry"
+  val dbUser = Properties.envOrElse("POSTGRES_USER", "rasterfoundry")
+  val dbPassword = Properties.envOrElse("POSTGRES_PASSWORD", "rasterfoundry")
 }
 
 object RFTransactor extends Config {


### PR DESCRIPTION
## Overview

This PR reverts a change to the Vagrantfile that increased the number of CPUs to four
and fixes where we get database settings.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * don't
 * paired with @alkamin to confirm this works