### PR TITLE
Restore unintentionally removed migration config

### DIFF
--- a/app-backend/migrations/src/main/resources/application.conf
+++ b/app-backend/migrations/src/main/resources/application.conf
@@ -2,5 +2,23 @@ migrations {
   unhandled_location = "./migrations/src_migrations/main/scala"
   handled_location = "./migrations/src/main/scala/migrations"
   migration_object = "RFMigrations"
-  include file("./database/src/main/resources/reference.conf")
+  slick {
+    driver = "slick.driver.PostgresDriver$"
+    db {
+      driver = org.postgresql.Driver
+      url = "jdbc:postgresql://database.service.rasterfoundry.internal/"
+      url = ${?POSTGRES_URL}
+      name = "rasterfoundry"
+      name = ${?POSTGRES_NAME}
+      user = "rasterfoundry"
+      user = ${?POSTGRES_USER}
+      password = "rasterfoundry"
+      password = ${?POSTGRES_PASSWORD}
+    }
+
+    threads = 8
+    threads = ${?SLICK_THREADS}
+    queueSize = 1000
+    queueSize = ${?SLICK_QUEUE_SIZE}
+  }
 }


### PR DESCRIPTION
## Overview

We accidentally removed some essential configuration for migrations. Somehow we didn't feel the effects of this until someone did a fresh setup thanks to caching.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

Is there a cleaner way? Probably.

## Testing Instructions

 * Before checking out the PR, clear target directories and attempt `mg update` and `mg apply`. It should not work
* After checking this out and reloading the project, attempt `mg update` and `mg apply` again. It should work.
