### PR TITLE
Disable white-balance correction

### DIFF
--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -238,9 +238,10 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
     val md: Future[Seq[MosaicDefinition]] = mosaicDefinition(projectId, Option(polygonBbox))
     OptionT(
       mergeTiles(
-        colorCorrectTiles(
+        // This seems to cause issues -- disabled
+        // colorCorrectTiles(
           renderForBbox(md, Some(polygonBbox), zoom, Some(s"${zoom}-${col}-${row}"))
-        )
+        // )
       )
     )
   }


### PR DESCRIPTION
## Overview

Going to merge once this passes, it's a trivial change that _actually_ disables the white-balance. This will resolve the mis-colored individual tiles which occurred after the doobie refactor.