### PR TITLE
Add scaffeine local cache to tile-server to improve cache performance

### DIFF
--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -44,6 +44,12 @@ memcached {
   enabled = true
   enabled = ${?MEMCACHED_ENABLED}
 
+  localCache.enabled = true
+  localCache.enabled = ${?MEMCACHED_LOCAL_CACHE_ENABLED}
+
+  localCache.size = 20
+  localCache.size = ${?MEMCACHED_LOCAL_CACHE_SIZE}
+
   layerAttributes.enabled = true
   layerAttributes.enabled = ${?MEMCACHED_LAYER_ATTRIBUTES}
 

--- a/app-backend/common/src/main/scala/Config.scala
+++ b/app-backend/common/src/main/scala/Config.scala
@@ -46,6 +46,12 @@ object Config {
     lazy val enabled: Boolean =
       memcachedConfig.getBoolean("enabled")
 
+    lazy val localCacheEnabled: Boolean =
+      memcachedConfig.getBoolean("localCache.enabled")
+
+    lazy val localCacheSize: Int =
+      memcachedConfig.getInt("localCache.size")
+
     object layerAttributes {
       lazy val enabled: Boolean =
         memcachedConfig.getBoolean("layerAttributes.enabled")

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -54,7 +54,7 @@ trait TileAuthentication extends Authentication
     onSuccess(
       ProjectDao.query
         .filter(id)
-        .filter(fr"visibility=${Visibility.Public.toString}")
+        .filter(fr"visibility=${Visibility.Public.toString}::visibility")
         .selectOption.transact(xa).unsafeToFuture
     ).flatMap {
       case Some(_) => provide(true)


### PR DESCRIPTION
## Overview

This PR adds a quick eviction in-memory cache to the tile-server. This allows us to keep track of expensive operations so that we can prevent duplicate cache lookups from missing and repeating the same operations (at least some of the time).

This local cache sits in front of our memcached client and can be disabled independently.

In addition, this PR fixes an error that was occurring in the doobie refactored tile-authentication process by explicitly casting to the `visibility` PG enum.

There are two variables that may need to be tuned:
  - the `AWAIT` time (currently 25ms)
  - the eviction time (currently 30s after write) -- we'll need to be careful with this one to avoid a too large cache

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 Compare tile-loading times (especially on cache misses, you could enable debug logs to see the messages) with the local cache disabled/enabled from here https://github.com/raster-foundry/raster-foundry/compare/feature/ak/local-tile-cache?expand=1#diff-62dae0c7d225eb2f5f536a3906985a70R40

Closes #3087
