### PR TITLE
Fix hasNext calculations for scenes

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -242,7 +242,7 @@ object ProjectDao extends Dao[Project] {
       countResponse <- (countClause ++ sceneQuery).query[Int].unique
     } yield {
       val hasPrevious = page.offset > 0
-      val hasNext = (page.offset * page.limit) + 1 < countResponse
+      val hasNext = ((page.offset + 1) * page.limit) < countResponse
       PaginatedResponse[UUID](countResponse, hasPrevious, hasNext, page.offset, page.limit, pageResponse)
     }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -101,7 +101,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
       count <- countIO
     } yield {
       val hasPrevious = pageRequest.offset > 0
-      val hasNext = (pageRequest.offset * pageRequest.limit) + 1 < count
+      val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count
       PaginatedResponse[Scene.WithRelated](count, hasPrevious, hasNext, pageRequest.offset, pageRequest.limit, page)
     }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -34,7 +34,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
       count <- countQuery
     } yield {
       val hasPrevious = pageRequest.offset > 0
-      val hasNext = (pageRequest.offset * pageRequest.limit) + 1 < count
+      val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count
 
       PaginatedResponse[Scene.WithRelated](count, hasPrevious, hasNext, pageRequest.offset, pageRequest.limit, page)
     }


### PR DESCRIPTION
## Overview

This PR changes the math in calculating `hasNext` to be correct:

Consider a response with 100 results. If we asked for page 4, twenty scenes at a time, then the pages are:

- `0 -> [0, 20)`
- `1 -> [21, 40)`
- `2 -> [41, 60)`
- `3 -> [61, 80)`
- `4 -> [81, 100)`

so we know that there isn't actually a next page. However, `offset * limit + 1 = 4 * 20 + 1 = 81`, which is definitely less than 100, so we would have returned `true` for hasNext. That's a simple math error to fix, so this PR fixes it.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * list some scenes in a small enough area that the count is small (I've found that New Hampshire with default filters is pretty good for this, in the dev environment)
 * keep clicking "load more" until you've reached enough scenes that `hasNext` should be false
 * note that the button is disabled

Closes #3105
