### PR TITLE
Upgrade aws-cli version

### DIFF
--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -1,5 +1,5 @@
 ---
-aws_cli_version: "1.14.36"
+aws_cli_version: "1.14.64"
 
 docker_version: "17.*"
 docker_compose_version: "1.16.*"


### PR DESCRIPTION
## Overview

AWS templated push commands for ECR require a more recent version of the AWS CLI
than we install currently. To facilitate using the VM and keeping everyone's
versions of things consistent, we should upgrade to a version that understands
the commands in ECR push instructions.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Try to `sudo pip install awscli=={the updated version}` inside the vm
 * Afterward, try the AWS ECR `get-login` command in `View push commands` in ECR
 * It shouldn't fail while complaining about not understanding `--no-include-email`