### PR TITLE
Get all paginated datasources upon scene browse

### DIFF
--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -110,20 +110,23 @@ export default (app) => {
 
         getSources() {
             let deferred = this.$q.defer();
-            this.datasourceService.query({sort: 'name,asc'}).then((res) => {
-                let promises = _.times(Math.ceil(res.count / res.pageSize) + 1, (idx) => {
+
+            let promise = this.datasourceService.query({sort: 'name,asc'}).then((res) => {
+                let pageCount = Math.ceil(res.count / res.pageSize);
+
+                let promises = [promise].concat(_.times(pageCount, (idx) => {
                     return this.datasourceService
-                        .query({sort: 'name,asc', page: idx})
+                        .query({sort: 'name,asc', page: idx + 1})
                         .then(resp => resp, error => error);
-                });
+                }));
+
                 this.$q.all(promises).then((reps) => {
                     deferred.resolve(_.flatMap(reps, r => r.results));
-                }, (error) => {
-                    deferred.reject(error);
-                });
-            }, (err) => {
-                deferred.reject(err);
-            });
+                }, error => deferred.reject(error));
+
+                return res;
+            }, (err) => deferred.reject(err));
+
             return deferred.promise;
         }
 

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -107,15 +107,28 @@ export default (app) => {
         }
 
         getSources() {
-            return this.$q((resolve, reject) => {
-                this.datasourceService.query({
-                    sort: 'name,asc'
-                }).then(response => {
-                    resolve(response.results);
+            let deferred = this.$q.defer();
+            let datasourceService = this.datasourceService;
+
+            let getAllDatasources = function (page, sources) {
+                datasourceService.query({
+                    sort: 'name,asc',
+                    page: page,
+                    pageSize: 10
+                }).then((res) => {
+                    let results = sources.concat(res.results);
+                    if (res.hasNext) {
+                        getAllDatasources(page + 1, results);
+                    } else {
+                        deferred.resolve(results);
+                    }
                 }, (err) => {
-                    reject(err);
+                    deferred.reject(err);
                 });
-            });
+            };
+
+            getAllDatasources(0, []);
+            return deferred.promise;
         }
 
         /*


### PR DESCRIPTION
## Overview

This PR enables getting all paginated datasources upon scene browse.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to browse scenes in a project
 * Check if all datasources are listed in the filer pane.

Closes #3106
