### PR TITLE
Progress toward working async workflows

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -102,7 +102,7 @@ trait SceneRoutes extends Authentication
   def getScene(sceneId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
-        SceneWithRelatedDao.query.filter(user).filter(sceneId).selectOption.transact(xa).unsafeToFuture
+        SceneWithRelatedDao.getScene(sceneId, user).transact(xa).unsafeToFuture
       }
     }
   }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -12,6 +12,7 @@ import java.util.UUID
 
 import cats.effect.IO
 
+import scala.util.{Success, Failure}
 import scala.concurrent.ExecutionContext.Implicits.global
 import doobie.util.transactor.Transactor
 import cats.implicits._
@@ -134,10 +135,23 @@ trait UploadRoutes extends Authentication
   }
 
   def getUploadCredentials(uploadId: UUID): Route = authenticate { user =>
-    extractTokenHeader { jwt =>
-      onSuccess(UploadDao.query.filter(fr"id = ${uploadId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture) {
-        case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
-        case None => complete(StatusCodes.NotFound)
+    extractTokenHeader {
+      jwt => {
+        println(s"${jwt}")
+        (UploadDao.query.filter(fr"id = ${uploadId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture) onComplete {
+          case Success(Some(_)) => {
+            println("Upload result: found an upload")
+            complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
+          }
+          case Success(None) => {
+            println("Upload result: didn't find an upload")
+            complete(StatusCodes.NotFound)
+          }
+          case Failure(_) => {
+            println("Upload result: what the hell dude")
+            complete(StatusCodes.NoContent)
+          }
+        }
       }
     }
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -25,7 +25,7 @@ case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job {
     val aoiProjectsToUpdate: ConnectionIO[List[UUID]] = {
 
       // get ids only
-      val baseSelect: Fragment = sql"select id from projects"
+      val baseSelect: Fragment = sql"select id from projects "
 
       //  check to make sure the project is an aoi project
       val isAoi: Option[Fragment] = fr"is_aoi_project=true".some

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -40,8 +40,7 @@ case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job {
 
       (baseSelect ++ Fragments.whereAndOpt(isAoi, nowGtLastCheckedPlusCadence))
         .query[UUID]
-        .stream
-        .compile.toList
+        .to[List]
     }
 
     aoiProjectsToUpdate.transact(xa).unsafeRunSync.foreach(println)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -21,7 +21,7 @@ import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 import cats.effect.IO
-import doobie.{ConnectionIO, Fragment}
+import doobie.{ConnectionIO, Fragment, Fragments}
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/BandDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/BandDao.scala
@@ -37,17 +37,12 @@ object BandDao extends Dao[Band] {
   }
 
   def createMany(bands: List[Band]): ConnectionIO[Int] = {
-    (fr"INSERT INTO" ++ tableF ++ fr"(id, image_id, name, number, wavelength) VALUES" ++
-       bands.foldLeft(fr"")(
-         (query: Fragment, band: Band) => {
-           query.toString().isEmpty() match {
-             case true =>
-               fr"(${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})"
-             case false =>
-               query ++ fr", (${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})"
-           }
-         })
-    ).update.run
+    val bandRowsFragment: Fragment = (bands map {
+      band: Band => fr"(${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})"
+    }).intercalate(fr",")
+    val insertFragment:Fragment =
+      fr"INSERT INTO" ++ tableF ++ fr"(id, image_id, name, number, wavelength) VALUES" ++ bandRowsFragment
+    insertFragment.update.run
   }
 }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -133,13 +133,13 @@ object SceneDao extends Dao[Scene] {
     val now = new Date()
 
     val lastModifiedIO: ConnectionIO[Timestamp] =
-      (sql"select modified_at from scenes" ++ Fragments.whereAndOpt(ownerEditFilter(user), idFilter))
+      (fr"select modified_at from scenes" ++ Fragments.whereAndOpt(ownerEditFilter(user), idFilter))
         .query[Timestamp]
         .unique
     val updateIO: ConnectionIO[Int] = (sql"""
     UPDATE scenes
     SET
-      modified_at = ${now}, // now
+      modified_at = ${now},
       modified_by = ${user.id},
       visibility = ${scene.visibility},
       tags = ${scene.tags},
@@ -152,7 +152,7 @@ object SceneDao extends Dao[Scene] {
       sun_elevation = ${scene.filterFields.sunElevation},
       thumbnail_status = ${scene.statusFields.thumbnailStatus},
       boundary_status = ${scene.statusFields.boundaryStatus},
-      ingest_status = ${scene.statusFields.boundaryStatus}
+      ingest_status = ${scene.statusFields.ingestStatus}
     """ ++ Fragments.whereAndOpt(ownerEditFilter(user), idFilter))
       .update
       .run

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -52,7 +52,7 @@ object SceneDao extends Dao[Scene] {
       sceneCreate.images(ind).bands map { bd => bd.toBand(im.id) }
     }
 
-    val sceneInsert = fr"""
+    val sceneInsert = (Fragment.const(s"""
       INSERT INTO ${tableName} (
          id, created_at, created_by, modified_at, modified_by, owner,
          organization_id, ingest_size_bytes, visibility, tags,
@@ -60,7 +60,7 @@ object SceneDao extends Dao[Scene] {
          data_footprint, metadata_files, ingest_location, cloud_cover,
          acquisition_date, sun_azimuth, sun_elevation, thumbnail_status,
          boundary_status, ingest_status
-      ) VALUES (
+      )""") ++ fr"""VALUES (
         ${scene.id}, ${scene.createdAt}, ${scene.createdBy}, ${scene.modifiedAt}, ${scene.modifiedBy}, ${scene.owner},
         ${scene.organizationId}, ${scene.ingestSizeBytes}, ${scene.visibility}, ${scene.tags},
         ${scene.datasource}, ${scene.sceneMetadata}, ${scene.name}, ${scene.tileFootprint},
@@ -68,7 +68,7 @@ object SceneDao extends Dao[Scene] {
         ${scene.filterFields.acquisitionDate}, ${scene.filterFields.sunAzimuth}, ${scene.filterFields.sunElevation},
         ${scene.statusFields.thumbnailStatus}, ${scene.statusFields.boundaryStatus}, ${scene.statusFields.ingestStatus}
       )
-    """.update.run
+    """).update.run
 
 
     val thumbnailInsert = ThumbnailDao.insertMany(thumbnails)
@@ -93,7 +93,7 @@ object SceneDao extends Dao[Scene] {
       sceneCreate.images(ind).bands map { bd => bd.toBand(im.id) }
     }
 
-    val sceneInsert = fr"""
+    val sceneInsert = (Fragment.const(s"""
       INSERT INTO ${tableName} (
          id, created_at, created_by, modified_at, modified_by, owner,
          organization_id, ingest_size_bytes, visibility, tags,
@@ -101,7 +101,7 @@ object SceneDao extends Dao[Scene] {
          data_footprint, metadata_files, ingest_location, cloud_cover,
          acquisition_date, sun_azimuth, sun_elevation, thumbnail_status,
          boundary_status, ingest_status
-      ) VALUES (
+      )""") ++ fr"""VALUES (
         ${scene.id}, ${scene.createdAt}, ${scene.createdBy}, ${scene.modifiedAt}, ${scene.modifiedBy}, ${scene.owner},
         ${scene.organizationId}, ${scene.ingestSizeBytes}, ${scene.visibility}, ${scene.tags},
          ${scene.datasource}, ${scene.sceneMetadata}, ${scene.name}, ${scene.tileFootprint},
@@ -109,7 +109,7 @@ object SceneDao extends Dao[Scene] {
         ${scene.filterFields.acquisitionDate}, ${scene.filterFields.sunAzimuth}, ${scene.filterFields.sunElevation},
         ${scene.statusFields.thumbnailStatus}, ${scene.statusFields.boundaryStatus}, ${scene.statusFields.ingestStatus}
       )
-    """.update.run
+    """).update.run
 
 
     val thumbnailInsert = ThumbnailDao.insertMany(thumbnails)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     image: raster-foundry-batch
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
-      - ./app-backend/batch/target/scala-2.11/rf-batch.jar:/opt/raster-foundry/jars/rf-batch.jar
+      - ./app-backend/batch/target/scala-2.11/:/opt/raster-foundry/jars/
       - $HOME/.aws:/root/.aws:ro
     build:
       context: ./app-tasks
@@ -101,6 +101,8 @@ services:
       - LOCAL_INGEST_CORES=2
       - LOCAL_INGEST_MEM_GB=4
     command: rf
+    links:
+      - postgres:database.service.rasterfoundry.internal
 
   tile-server:
     image: openjdk:8-jre


### PR DESCRIPTION
## Overview

This PR includes changes to Daos to facilitate getting the batch subproject working. On this branch, Landsat 8 import, Sentinel 2 import, ingest, and finding AOI projects are all confirmed working. Processing uploads is untestable locally because something is wrong with fetching temporary AWS credentials. Exports and updating AOI projects are untested for separate reasons, see notes.

The goal of merging this is to get scheduled import jobs functioning again, rather than to be done fixing the batch subproject.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification updated, if necessary~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~PR has a name that won't get you publicly shamed for vagueness~

### Notes

This task turned out to be "Track down a bunch of SQL errors that we should catch in tests." There's a separate card for adding property-based tests to the `db` project so that we'll be able to exercise the
sql we've written without having to do it through the app. I'm sticking a fork in more work to fix the batch
subproject until we've completed that, since there's currently no guarantee that fixes I've made so far
won't be broken again.

## Testing Instructions

 * beef up your vm and restart it (I did 6 cpus and 8gb of ram)
 * nerf your landsat import to only create a few scenes
 * find the ID for your uploaded tif
 * `batch/assembly`
 * from the `batch` container, run the `rf` commands for the workflows I've claimed work (I'll tell you some inputs to try)

Closes #3070 
