### PR TITLE
[Platforms] Add platform datamodel, DAO, DAOSpec, and Routes

### DIFF
--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -11,6 +11,7 @@ import com.azavea.rf.api.healthcheck._
 import com.azavea.rf.api.image.ImageRoutes
 import com.azavea.rf.api.maptoken.MapTokenRoutes
 import com.azavea.rf.api.organization.OrganizationRoutes
+import com.azavea.rf.api.platform.PlatformRoutes
 import com.azavea.rf.api.project.ProjectRoutes
 import com.azavea.rf.api.scene.SceneRoutes
 import com.azavea.rf.api.shape.ShapeRoutes
@@ -59,7 +60,8 @@ trait Router extends HealthCheckRoutes
   with FeatureFlagRoutes
   with ShapeRoutes
   with LicenseRoutes
-  with TeamRoutes {
+  with TeamRoutes
+  with PlatformRoutes {
 
   val settings = CorsSettings.defaultSettings.copy(
     allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE))
@@ -68,76 +70,76 @@ trait Router extends HealthCheckRoutes
     pathPrefix("healthcheck") {
       healthCheckRoutes
     } ~
-      pathPrefix("api") {
-        pathPrefix("projects") {
-          projectRoutes
-        } ~
-          pathPrefix("areas-of-interest") {
-            aoiRoutes
-          } ~
-          pathPrefix("images") {
-            imageRoutes
-          } ~
-          pathPrefix("organizations") {
-            organizationRoutes
-          } ~
-          pathPrefix("scenes") {
-            sceneRoutes
-          } ~
-          pathPrefix("thumbnails") {
-            thumbnailRoutes
-          } ~
-          pathPrefix("tokens") {
-            tokenRoutes
-          } ~
-          pathPrefix("users") {
-            userRoutes
-          } ~
-          pathPrefix("tools") {
-            toolRoutes
-          } ~
-          pathPrefix("tool-tags") {
-            toolTagRoutes
-          } ~
-          pathPrefix("tool-categories") {
-            toolCategoryRoutes
-          } ~
-          pathPrefix("tool-runs") {
-            toolRunRoutes
-          } ~
-          pathPrefix("datasources") {
-            datasourceRoutes
-          } ~
-          pathPrefix("map-tokens") {
-            mapTokenRoutes
-          } ~
-          pathPrefix("feed") {
-            feedRoutes
-          } ~
-          pathPrefix("uploads") {
-            uploadRoutes
-          } ~
-          pathPrefix("exports") {
-            exportRoutes
-          } ~
-          pathPrefix("shapes") {
-            shapeRoutes
-          } ~
-          pathPrefix("licenses") {
-            licenseRoutes
-          } ~
-          pathPrefix("teams") {
-            teamRoutes
-          }
+    pathPrefix("api") {
+      pathPrefix("projects") {
+        projectRoutes
       } ~
-      pathPrefix("config") {
-        configRoutes
+      pathPrefix("platforms") {
+        platformRoutes
       } ~
-      pathPrefix("feature-flags") {
-        featureFlagRoutes
+      pathPrefix("areas-of-interest") {
+        aoiRoutes
+      } ~
+      pathPrefix("images") {
+        imageRoutes
+      } ~
+      pathPrefix("organizations") {
+        organizationRoutes
+      } ~
+      pathPrefix("scenes") {
+        sceneRoutes
       } ~
       pathPrefix("thumbnails") {
-        thumbnailImageRoutes
+        thumbnailRoutes
+      } ~
+      pathPrefix("tokens") {
+        tokenRoutes
+      } ~
+      pathPrefix("users") {
+        userRoutes
+      } ~
+      pathPrefix("tools") {
+        toolRoutes
+      } ~
+      pathPrefix("tool-tags") {
+        toolTagRoutes
+      } ~
+      pathPrefix("tool-categories") {
+        toolCategoryRoutes
+      } ~
+      pathPrefix("tool-runs") {
+        toolRunRoutes
+      } ~
+      pathPrefix("datasources") {
+        datasourceRoutes
+      } ~
+      pathPrefix("map-tokens") {
+        mapTokenRoutes
+      } ~
+      pathPrefix("feed") {
+        feedRoutes
+      } ~
+      pathPrefix("uploads") {
+        uploadRoutes
+      } ~
+      pathPrefix("exports") {
+        exportRoutes
+      } ~
+      pathPrefix("shapes") {
+        shapeRoutes
+      } ~
+      pathPrefix("licenses") {
+        licenseRoutes
       }
+    } ~
+    pathPrefix("config") {
+      configRoutes
+    } ~
+    pathPrefix("feature-flags") {
+      featureFlagRoutes
+    } ~
+    pathPrefix("thumbnails") {
+      thumbnailImageRoutes
+    }
   }
 }

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -1,0 +1,109 @@
+package com.azavea.rf.api.platform
+
+import com.azavea.rf.common.{Authentication, UserErrorHandler, CommonHandlers}
+import com.azavea.rf.database.PlatformDao
+import com.azavea.rf.datamodel._
+import com.azavea.rf.database.filter.Filterables._
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import cats.effect.IO
+import cats.implicits._
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import io.circe._
+import kamon.akka.http.KamonTraceDirectives
+
+import scala.util.{Failure, Success}
+
+import java.util.UUID
+
+trait PlatformRoutes extends Authentication
+  with PaginationDirectives
+  with CommonHandlers
+  with KamonTraceDirectives
+  with UserErrorHandler {
+
+  val xa: Transactor[IO]
+
+  val platformRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get {
+        traceName("platforms-list") {
+          listPlatforms
+        }
+      } ~
+      post {
+        traceName("platforms-create") {
+          createPlatform
+        }
+      }
+    } ~
+    pathPrefix(JavaUUID) { platformId =>
+      pathEndOrSingleSlash {
+        get {
+          traceName("platforms-get") {
+            getPlatform(platformId)
+          }
+        } ~
+        put {
+          traceName("platforms-update") {
+            updatePlatform(platformId)
+          }
+        } ~
+        delete {
+          traceName("platforms-delete") {
+            deletePlatform(platformId)
+          }
+        }
+      }
+    }
+  }
+
+  // @TODO: most platform API interactions should be highly restricted -- only 'super-users' should
+  // be able to do list, create, update, delete. Non-super users can only get a platform if they belong to it.
+  def listPlatforms: Route = authenticate { user =>
+    (withPagination) { page =>
+      complete {
+        PlatformDao.query.page(page).transact(xa).unsafeToFuture
+      }
+    }
+  }
+
+  def createPlatform: Route = authenticate { user =>
+    entity(as[Platform.Create]) { platformToCreate =>
+      onComplete(PlatformDao.create(platformToCreate.toPlatform).transact(xa).unsafeToFuture) {
+        case Success(platform) => complete(platform)
+        case Failure(err) => complete((StatusCodes.InternalServerError, err.getMessage))
+      }
+    }
+  }
+
+  def getPlatform(platformId: UUID): Route = authenticate { user =>
+    rejectEmptyResponse {
+      complete {
+        PlatformDao.query.filter(platformId).selectOption.transact(xa).unsafeToFuture
+      }
+    }
+  }
+
+  def updatePlatform(platformId: UUID): Route = authenticate { user =>
+    entity(as[Platform]) { platformToUpdate =>
+      onComplete(PlatformDao.update(platformToUpdate, platformId, user).transact(xa).unsafeToFuture) {
+        case Success(count) => completeSingleOrNotFound(count)
+        case Failure(err) => complete((StatusCodes.InternalServerError, err.getMessage))
+      }
+    }
+  }
+
+  def deletePlatform(platformId: UUID): Route = authenticate { user =>
+    onComplete(PlatformDao.query.filter(platformId).delete.transact(xa).unsafeToFuture) {
+      case Success(count) => completeSingleOrNotFound(count)
+      case Failure(err) => complete((StatusCodes.InternalServerError, err.getMessage))
+    }
+  }
+}

--- a/app-backend/api/src/main/scala/platform/package.scala
+++ b/app-backend/api/src/main/scala/platform/package.scala
@@ -1,0 +1,3 @@
+package com.azavea.rf.api
+
+package object platform

--- a/app-backend/common/src/main/scala/CommonHandlers.scala
+++ b/app-backend/common/src/main/scala/CommonHandlers.scala
@@ -1,13 +1,30 @@
 package com.azavea.rf.common
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.{RequestContext, RouteResult}
 import akka.http.scaladsl.server.{StandardRoute, ExceptionHandler}
-import akka.http.scaladsl.server.directives.RouteDirectives
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.{RouteDirectives, FutureDirectives, CompleteOrRecoverWithMagnet}
 import io.circe._
 import cats.syntax.show
 
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 trait CommonHandlers extends RouteDirectives {
+  def completeWithOneOrFail(
+    future: ⇒ Future[Int]
+  ): RequestContext => Future[RouteResult] =
+    FutureDirectives.onComplete(future) {
+      case Success(count) => completeSingleOrNotFound(count)
+      case Failure(err) => failWith(err)
+    }
+
+  def completeOrFail(
+    magnet: CompleteOrRecoverWithMagnet
+  ): RequestContext => Future[RouteResult] =
+    FutureDirectives.completeOrRecoverWith(magnet)(failWith)
+
   def completeSingleOrNotFound(count: Int): StandardRoute = count match {
     case 1 => complete(StatusCodes.NoContent)
     case 0 => complete(StatusCodes.NotFound)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
@@ -1,0 +1,40 @@
+package com.azavea.rf.datamodel
+
+import java.util.UUID
+import java.sql.Timestamp
+
+import io.circe._
+import io.circe.generic.JsonCodec
+import io.circe.syntax._
+
+@JsonCodec
+case class Platform(
+    id: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    modifiedBy: String,
+    name: String,
+    settings: Json
+)
+
+object Platform {
+    def create = Create.apply _
+    def tupled = (Platform.apply _).tupled
+
+    @JsonCodec
+    case class Create(name: String, user: User, settings: Json = "{}".asJson) {
+        def toPlatform: Platform = {
+            val now = new Timestamp((new java.util.Date()).getTime())
+            Platform(
+                UUID.randomUUID(),
+                now,
+                user.id,
+                now,
+                user.id,
+                name,
+                settings
+            )
+        }
+    }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
@@ -28,10 +28,10 @@ object Platform {
             val now = new Timestamp((new java.util.Date()).getTime())
             Platform(
                 UUID.randomUUID(),
-                now,
-                user.id,
-                now,
-                user.id,
+                now, // createdAt
+                user.id, // createdBy
+                now, // modifiedAt
+                user.id, // modifiedBy
                 name,
                 settings
             )

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -1,0 +1,49 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.datamodel.{Platform, User}
+
+import doobie._, doobie.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import doobie.util.transactor.Transactor
+import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import io.circe._
+
+import java.util.UUID
+
+object PlatformDao extends Dao[Platform] {
+    val tableName = "platforms"
+
+    val selectF = sql"""
+        SELECT
+            id, created_at, created_by, modified_at, modified_by, name, settings
+        FROM
+    """ ++ tableF
+
+    def create(platform: Platform): ConnectionIO[Platform] = {
+        println(platform)
+        (fr"INSERT INTO" ++ tableF ++ fr"""(
+                id, created_at, created_by,
+                modified_at, modified_by, name,
+                settings
+            )
+            VALUES (
+                ${platform.id}, ${platform.createdAt}, ${platform.createdBy},
+                ${platform.modifiedAt}, ${platform.modifiedBy}, ${platform.name},
+                ${platform.settings}
+            )
+        """).update.withUniqueGeneratedKeys[Platform](
+            "id", "created_at", "created_by", "modified_at", "modified_by", "name", "settings"
+        )
+    }
+
+    def update(platform: Platform, id: UUID, user: User): ConnectionIO[Int] = {
+        (fr"UPDATE" ++ tableF ++ fr"""SET
+            name = ${platform.name},
+            modified_at = NOW(),
+            modified_by = ${user.id},
+            settings = ${platform.settings}
+            where id = ${id}
+        """).update.run
+    }
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -12,38 +12,37 @@ import io.circe._
 import java.util.UUID
 
 object PlatformDao extends Dao[Platform] {
-    val tableName = "platforms"
+  val tableName = "platforms"
 
-    val selectF = sql"""
-        SELECT
-            id, created_at, created_by, modified_at, modified_by, name, settings
-        FROM
-    """ ++ tableF
+  val selectF = sql"""
+    SELECT
+      id, created_at, created_by, modified_at, modified_by, name, settings
+    FROM
+  """ ++ tableF
 
-    def create(platform: Platform): ConnectionIO[Platform] = {
-        println(platform)
-        (fr"INSERT INTO" ++ tableF ++ fr"""(
-                id, created_at, created_by,
-                modified_at, modified_by, name,
-                settings
-            )
-            VALUES (
-                ${platform.id}, ${platform.createdAt}, ${platform.createdBy},
-                ${platform.modifiedAt}, ${platform.modifiedBy}, ${platform.name},
-                ${platform.settings}
-            )
-        """).update.withUniqueGeneratedKeys[Platform](
-            "id", "created_at", "created_by", "modified_at", "modified_by", "name", "settings"
+  def create(platform: Platform): ConnectionIO[Platform] = {
+    (fr"INSERT INTO" ++ tableF ++ fr"""(
+          id, created_at, created_by,
+          modified_at, modified_by, name,
+          settings
         )
-    }
+        VALUES (
+          ${platform.id}, ${platform.createdAt}, ${platform.createdBy},
+          ${platform.modifiedAt}, ${platform.modifiedBy}, ${platform.name},
+          ${platform.settings}
+        )
+    """).update.withUniqueGeneratedKeys[Platform](
+      "id", "created_at", "created_by", "modified_at", "modified_by", "name", "settings"
+    )
+  }
 
-    def update(platform: Platform, id: UUID, user: User): ConnectionIO[Int] = {
-        (fr"UPDATE" ++ tableF ++ fr"""SET
-            name = ${platform.name},
-            modified_at = NOW(),
-            modified_by = ${user.id},
-            settings = ${platform.settings}
-            where id = ${id}
-        """).update.run
-    }
+  def update(platform: Platform, id: UUID, user: User): ConnectionIO[Int] = {
+      (fr"UPDATE" ++ tableF ++ fr"""SET
+        name = ${platform.name},
+        modified_at = NOW(),
+        modified_by = ${user.id},
+        settings = ${platform.settings}
+        where id = ${id}
+      """).update.run
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -20,18 +20,20 @@ object PlatformDao extends Dao[Platform] {
     FROM
   """ ++ tableF
 
+  def createF(platform: Platform) = fr"INSERT INTO" ++ tableF ++ fr"""(
+        id, created_at, created_by,
+        modified_at, modified_by, name,
+        settings
+      )
+      VALUES (
+        ${platform.id}, ${platform.createdAt}, ${platform.createdBy},
+        ${platform.modifiedAt}, ${platform.modifiedBy}, ${platform.name},
+        ${platform.settings}
+      )
+  """
+
   def create(platform: Platform): ConnectionIO[Platform] = {
-    (fr"INSERT INTO" ++ tableF ++ fr"""(
-          id, created_at, created_by,
-          modified_at, modified_by, name,
-          settings
-        )
-        VALUES (
-          ${platform.id}, ${platform.createdAt}, ${platform.createdBy},
-          ${platform.modifiedAt}, ${platform.modifiedBy}, ${platform.name},
-          ${platform.settings}
-        )
-    """).update.withUniqueGeneratedKeys[Platform](
+    createF(platform).update.withUniqueGeneratedKeys[Platform](
       "id", "created_at", "created_by", "modified_at", "modified_by", "name", "settings"
     )
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -39,10 +39,6 @@ class PlatformDaoSpec extends FunSuite with Matchers with IOChecker with DBTestC
         result.name shouldBe "test platform"
     }
 
-    test("insertion types") {
-        createPlatform.map(p => check(PlatformDao.createF(p).query[Platform]))
-    }
-
     test("update") {
         val transaction = for {
             usr <- defaultUserQ

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -1,0 +1,60 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.datamodel.Platform
+import com.azavea.rf.database.Implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.syntax.either._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import doobie.scalatest.imports._
+import org.scalatest._
+import io.circe._
+import io.circe.syntax._
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class PlatformDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+
+    def createPlatform: ConnectionIO[Platform] = {
+        val platformName = "test platform"
+        for {
+            usr <- defaultUserQ
+            create <- PlatformDao.create(Platform.Create(platformName, usr).toPlatform)
+        } yield create
+    }
+
+    test("insertion") {
+        val transaction = for {
+            platformIn <- createPlatform
+            platformOut <- PlatformDao.query.filter(platformIn.id).selectQ.unique
+        } yield platformOut
+
+        val result = transaction.transact(xa).unsafeRunSync
+        result.name shouldBe "test platform"
+    }
+
+    test("insertion types") { check(PlatformDao.selectF.query[Platform]) }
+
+    test("update") {
+        val transaction = for {
+            usr <- defaultUserQ
+            platformIn <- createPlatform
+            platformUpdate <- PlatformDao.update(platformIn, platformIn.id, usr)
+        } yield platformUpdate
+
+        transaction.transact(xa).unsafeRunSync shouldBe 1
+    }
+
+    test("delete") {
+        val transaction = for {
+            platformIn <- createPlatform
+            platformDelete <- PlatformDao.query.filter(platformIn.id).delete
+        } yield platformDelete
+
+        transaction.transact(xa).unsafeRunSync shouldBe 1
+    }
+}


### PR DESCRIPTION
## Overview

Note that this is a PR against the platform branch.

This PR adds a datamodel, DAO, DAO tests, and routes for platforms.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated, if necessary~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

You'll need this sql snippet, which is in place of making a migration. We'll need to formulate a plan to address migrations on our long running feature branches.

```sql
CREATE TABLE platforms (
    id UUID PRIMARY KEY NOT NULL,
    created_at TIMESTAMP NOT NULL,
    created_by VARCHAR(255) REFERENCES users(id) NOT NULL,
    modified_at TIMESTAMP NOT NULL,
    modified_by VARCHAR(255) REFERENCES users(id) NOT NULL,
    name TEXT NOT NULL,
    settings JSONB NOT NULL default '{}'
);
```
## Testing Instructions

 * Run the above SQL manually
 * Make sure it compiles
 * `db/test`

Closes #3089
