### PR TITLE
[Platforms] Add team datamodel, dao, and routes

### DIFF
--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -23,9 +23,10 @@ import com.azavea.rf.api.tooltag.ToolTagRoutes
 import com.azavea.rf.api.uploads.UploadRoutes
 import com.azavea.rf.api.user.UserRoutes
 import com.azavea.rf.api.utils.Config
+import com.azavea.rf.api.license.LicenseRoutes
+import com.azavea.rf.api.team.TeamRoutes
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
 import ch.megard.akka.http.cors.scaladsl.settings._
-import com.azavea.rf.api.license.LicenseRoutes
 
 import scala.collection.immutable.Seq
 
@@ -57,7 +58,8 @@ trait Router extends HealthCheckRoutes
   with Config
   with FeatureFlagRoutes
   with ShapeRoutes
-  with LicenseRoutes {
+  with LicenseRoutes
+  with TeamRoutes {
 
   val settings = CorsSettings.defaultSettings.copy(
     allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE))
@@ -123,6 +125,9 @@ trait Router extends HealthCheckRoutes
           } ~
           pathPrefix("licenses") {
             licenseRoutes
+          } ~
+          pathPrefix("teams") {
+            teamRoutes
           }
       } ~
       pathPrefix("config") {

--- a/app-backend/api/src/main/scala/team/Routes.scala
+++ b/app-backend/api/src/main/scala/team/Routes.scala
@@ -1,0 +1,89 @@
+package com.azavea.rf.api.team
+
+import com.azavea.rf.common.{Authentication, CommonHandlers, UserErrorHandler}
+import com.azavea.rf.database.TeamDao
+import com.azavea.rf.database.filter.Filterables._
+import com.azavea.rf.datamodel._
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.StatusCodes
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+import io.circe._
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import java.util.UUID
+
+import cats.effect.IO
+
+import doobie.util.transactor.Transactor
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import doobie.Fragments.in
+import doobie.postgres._
+import doobie.postgres.implicits._
+
+
+/**
+  * Routes for Organizations
+  */
+trait TeamRoutes extends Authentication
+    with PaginationDirectives
+    with CommonHandlers
+    with UserErrorHandler {
+
+  val xa: Transactor[IO]
+
+  val teamRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listTeams } ~
+      post { createTeam }
+    } ~
+    pathPrefix(JavaUUID) { teamId =>
+      get { getTeam(teamId) } ~
+      put { updateTeam(teamId) } ~
+      delete { deleteTeam(teamId) }
+    }
+  }
+
+  def listTeams: Route = authenticate { user =>
+    withPagination { page =>
+      complete {
+        TeamDao.query.page(page).transact(xa).unsafeToFuture
+      }
+    }
+  }
+
+  def createTeam: Route = authenticate { user =>
+    entity(as[Team.Create]) { newTeam =>
+      authorize(user.isInRootOrSameOrganizationAs(newTeam)) {
+        onSuccess(TeamDao.createTeam(newTeam, user).transact(xa).unsafeToFuture()) { team =>
+          complete(StatusCodes.Created, team)
+        }
+      }
+    }
+  }
+
+  def getTeam(teamId: UUID): Route = authenticate { user =>
+    rejectEmptyResponse {
+      complete {
+        TeamDao.getTeamById(teamId).transact(xa).unsafeToFuture
+      }
+    }
+  }
+
+  def updateTeam(teamId: UUID): Route = authenticate { user =>
+    entity(as[Team]) { updatedTeam =>
+      authorize(user.isInRootOrSameOrganizationAs(updatedTeam)) {
+        onSuccess(TeamDao.updateTeam(updatedTeam, teamId, user).transact(xa).unsafeToFuture()) { team =>
+          complete(StatusCodes.OK, team)
+        }
+      }
+    }
+  }
+
+  def deleteTeam(teamId: UUID): Route = authenticate { user =>
+    onSuccess(TeamDao.deleteTeam(teamId, user).transact(xa).unsafeToFuture) {
+      completeSingleOrNotFound
+    }
+  }
+
+}

--- a/app-backend/api/src/main/scala/team/package.scala
+++ b/app-backend/api/src/main/scala/team/package.scala
@@ -1,0 +1,5 @@
+package com.azavea.rf.api
+
+import com.azavea.rf.datamodel._
+
+package object team

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Team.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Team.scala
@@ -1,0 +1,49 @@
+package com.azavea.rf.datamodel
+
+import java.util.UUID
+import java.sql.Timestamp
+
+import io.circe._
+import io.circe.generic.JsonCodec
+import io.circe.syntax._
+
+@JsonCodec
+case class Team(
+  id: UUID,
+  createdAt: java.sql.Timestamp,
+  createdBy: String,
+  modifiedAt: java.sql.Timestamp,
+  modifiedBy: String,
+  organizationId: UUID,
+  name: String,
+  settings: Json
+)
+
+object Team {
+  def tupled = (Team.apply _).tupled
+
+  def create = Create.apply _
+
+  @JsonCodec
+  case class Create (
+    organizationId: UUID,
+    name: String,
+    settings: Json = "{}".asJson
+  ) {
+    def toTeam(user: User): Team = {
+      val id = java.util.UUID.randomUUID()
+      val now = new Timestamp((new java.util.Date()).getTime())
+
+      Team(
+        id,
+        now, // createdAt
+        user.id, // createdBy
+        now, // modifiedAt
+        user.id, // modifiedBy
+        this.organizationId,
+        this.name,
+        this.settings
+      )
+    }
+  }
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -1,0 +1,83 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.datamodel._
+
+import doobie._, doobie.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+
+import cats._, cats.data._, cats.effect.IO, cats.implicits._
+
+import java.util.{Date, UUID}
+import java.sql.Timestamp
+
+import scala.concurrent.Future
+
+object TeamDao extends Dao[Team] {
+  val tableName = "teams"
+
+  val selectF = sql"""
+    SELECT
+      id, created_at, created_by, modified_at, modified_by, organization_id,
+      name, settings
+    FROM
+  """ ++ tableF
+
+  def create(
+    team: Team
+  ): ConnectionIO[Team] = {
+    (fr"INSERT INTO" ++ tableF ++ fr"""
+      (id, created_at, created_by, modified_at, modified_by, organization_id,
+      name, settings)
+    VALUES
+      (${team.id}, ${team.createdAt}, ${team.createdBy}, ${team.modifiedAt},
+      ${team.modifiedBy}, ${team.organizationId}, ${team.name}, ${team.settings})
+    """)
+    .update
+    .withUniqueGeneratedKeys[Team](
+      "id", "created_at", "created_by", "modified_at", "modified_by", "organization_id",
+      "name", "settings"
+    )
+  }
+
+  def createTeam(
+    teamCreate: Team.Create,
+    user: User
+  ): ConnectionIO[Team] = {
+    val team = teamCreate.toTeam(user)
+    this.create(team)
+  }
+
+  def getTeamById(teamID: UUID): ConnectionIO[Team] = {
+    (selectF ++ fr"WHERE id = ${teamID}").query[Team].unique
+  }
+
+  def updateTeam(
+    team: Team,
+    id: UUID,
+    user: User
+  ): ConnectionIO[Team] = {
+    val now = new Timestamp((new java.util.Date()).getTime())
+    val updateQuery =
+      fr"UPDATE" ++ this.tableF ++
+      fr"SET" ++ fr"""
+      modified_at = ${now},
+      modified_by = ${user.id},
+      name = ${team.name}
+      settings = ${team.settings}
+      """ ++
+      fr"WHERE id = ${id}"
+    updateQuery
+      .update
+      .withUniqueGeneratedKeys[Team](
+        "id", "created_at", "created_by", "modified_at", "modified_by", "organization_id",
+        "name", "settings"
+      )
+  }
+
+  def deleteTeam(id: UUID, user: User): ConnectionIO[Int] = {
+    (fr"DELETE FROM " ++ this.tableF ++ fr" WHERE id = ${id}")
+      .update
+      .run
+  }
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -40,19 +40,7 @@ object TeamDao extends Dao[Team] {
     )
   }
 
-  def createTeam(
-    teamCreate: Team.Create,
-    user: User
-  ): ConnectionIO[Team] = {
-    val team = teamCreate.toTeam(user)
-    this.create(team)
-  }
-
-  def getTeamById(teamID: UUID): ConnectionIO[Team] = {
-    (selectF ++ fr"WHERE id = ${teamID}").query[Team].unique
-  }
-
-  def updateTeam(
+  def update(
     team: Team,
     id: UUID,
     user: User
@@ -60,24 +48,17 @@ object TeamDao extends Dao[Team] {
     val now = new Timestamp((new java.util.Date()).getTime())
     val updateQuery =
       fr"UPDATE" ++ this.tableF ++
-      fr"SET" ++ fr"""
-      modified_at = ${now},
-      modified_by = ${user.id},
-      name = ${team.name}
-      settings = ${team.settings}
-      """ ++
-      fr"WHERE id = ${id}"
+      fr"""
+      SET modified_at = ${now},
+          modified_by = ${user.id},
+          name = ${team.name}
+          settings = ${team.settings}
+      WHERE id = ${id}"""
     updateQuery
       .update
       .withUniqueGeneratedKeys[Team](
         "id", "created_at", "created_by", "modified_at", "modified_by", "organization_id",
         "name", "settings"
       )
-  }
-
-  def deleteTeam(id: UUID, user: User): ConnectionIO[Int] = {
-    (fr"DELETE FROM " ++ this.tableF ++ fr" WHERE id = ${id}")
-      .update
-      .run
   }
 }


### PR DESCRIPTION
## Overview

**This is a PR against the `feature/platforms` branch.**

This PR adds data model, DAO, and routes for teams.


### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

### Notes

Will write property tests for this PR when pairing on #3077 

### Testing Instructions


**Updates on April 4th:**

SQL snippet for creating the team table for testing purposes:

```sql
CREATE TABLE teams (
    id UUID PRIMARY KEY NOT NULL,
    created_at TIMESTAMP NOT NULL,
    created_by VARCHAR(255) REFERENCES users(id) NOT NULL,
    modified_at TIMESTAMP NOT NULL,
    modified_by VARCHAR(255) REFERENCES users(id) NOT NULL,
    organization_id UUID REFERENCES organizations(id) NOT NULL,
    name text NOT NULL,
    settings JSONB NOT NULL default '{}');
```

Closes #3091 
