### PR TITLE
Add property tests for band and image daos

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -213,6 +213,7 @@ lazy val datamodel = Project("datamodel", file("datamodel"))
   .settings({
     libraryDependencies ++= loggingDependencies ++ Seq(
       Dependencies.geotrellisSlick % "provided",
+      Dependencies.geotrellisVectorTestkit,
       Dependencies.geotrellisRaster,
       Dependencies.geotrellisGeotools,
       Dependencies.geotools,
@@ -221,7 +222,8 @@ lazy val datamodel = Project("datamodel", file("datamodel"))
       Dependencies.akka,
       Dependencies.akkahttp,
       Dependencies.betterFiles,
-      Dependencies.scalaCheck
+      Dependencies.scalaCheck,
+      Dependencies.circeTest
     )
   })
 

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -2,6 +2,13 @@ package com.azavea.rf.datamodel
 
 import com.azavea.rf.datamodel._
 
+import geotrellis.slick.Projected
+import geotrellis.vector.{MultiPolygon, Point, Polygon}
+import geotrellis.vector.testkit.Rectangle
+
+import io.circe.Json
+import io.circe.testing.ArbitraryInstances
+
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 
@@ -9,46 +16,195 @@ import java.sql.Timestamp
 import java.time.LocalDate
 import java.util.UUID
 
-object Generators {
+object Generators extends ArbitraryInstances {
 
-  def nonEmptyStringGen: Gen[String] =
+  private def nonEmptyStringGen: Gen[String] =
     Gen.nonEmptyListOf[Char](Arbitrary.arbChar.arbitrary).map(_.mkString)
 
-  def userRoleGen: Gen[UserRole] = Gen.oneOf(UserRoleRole, Viewer, Admin)
+  private def stringWithoutNullBytes: Gen[String] = arbitrary[String] suchThat { ! _.contains('\u0000') }
 
-  def uuidGen: Gen[UUID] = Gen.delay(UUID.randomUUID)
+  private def userRoleGen: Gen[UserRole] = Gen.oneOf(UserRoleRole, Viewer, Admin)
 
-  def timestampIn2016Gen: Gen[Timestamp] = for {
+  private def visibilityGen: Gen[Visibility] = Gen.oneOf(
+    Visibility.Public, Visibility.Organization, Visibility.Private)
+
+  private def uuidGen: Gen[UUID] = Gen.delay(UUID.randomUUID)
+
+  private def jobStatusGen: Gen[JobStatus] = Gen.oneOf(
+    JobStatus.Uploading, JobStatus.Success, JobStatus.Failure, JobStatus.PartialFailure,
+    JobStatus.Queued, JobStatus.Processing
+  )
+
+  private def ingestStatusGen: Gen[IngestStatus] = Gen.oneOf(
+    IngestStatus.NotIngested, IngestStatus.ToBeIngested, IngestStatus.Ingesting,
+    IngestStatus.Ingested, IngestStatus.Failed
+  )
+
+  private def thumbnailSizeGen: Gen[ThumbnailSize] = Gen.oneOf(
+    ThumbnailSize.Small, ThumbnailSize.Large, ThumbnailSize.Square
+  )
+
+  private def timestampIn2016Gen: Gen[Timestamp] = for {
     year <- Gen.const(2016)
     month <- Gen.choose(1, 12)
     day <- Gen.choose(1, 28) // for safety
   } yield { Timestamp.valueOf(LocalDate.of(year, month, day).atStartOfDay) }
 
-  def organizationCreateGen: Gen[Organization.Create] = for {
+  private def organizationGen: Gen[Organization] = for {
     name <- arbitrary[String]
   } yield (Organization.Create(name))
 
   def organizationGen: Gen[Organization] = organizationCreateGen map { _.toOrganization }
 
-  def userCreateGen: Gen[User.Create] = for {
+  private def userCreateGen: Gen[User.Create] = for {
     id <- arbitrary[String]
     org <- organizationGen
     role <- userRoleGen
   } yield { User.Create(id, org.id, role) }
 
-  def userGen: Gen[User] = userCreateGen map { _.toUser }
+  private def userGen: Gen[User] = userCreateGen map { _.toUser }
 
-  def credentialGen: Gen[Credential] = nonEmptyStringGen map { Credential.fromString }
+  private def credentialGen: Gen[Credential] = nonEmptyStringGen map { Credential.fromString }
+
+  private def bandIdentifiedGen: Gen[Band.Identified] = for {
+    name <- stringWithoutNullBytes
+    number <- arbitrary[Int]
+    wavelength <- Gen.listOfN(2, arbitrary[Int]) map { _.sorted }
+    imageId <- uuidGen
+  } yield { Band.Identified(None, imageId, name, number, wavelength) }
+
+  private def bandCreateGen: Gen[Band.Create] = for {
+    name <- stringWithoutNullBytes
+    number <- arbitrary[Int]
+    wavelength <- Gen.listOfN(2, arbitrary[Int]) map { _.sorted }
+  } yield { Band.Create(name, number, wavelength) }
+
+  private def bandGen: Gen[Band] = bandIdentifiedGen map { _.toBand }
+
+  private def imageCreateGen: Gen[Image.Create] = for {
+    orgId <- uuidGen
+    rawDataBytes <- arbitrary[Long]
+    visibility <- visibilityGen
+    filename <- stringWithoutNullBytes
+    sourceUri <- stringWithoutNullBytes
+    scene <- uuidGen
+    imageMetadata <- arbitrary[Json]
+    owner <- arbitrary[Option[String]]
+    resolutionMeters <- arbitrary[Float]
+    metadataFiles <- Gen.containerOf[List, String](stringWithoutNullBytes)
+  } yield (
+    Image.Create(
+      orgId, rawDataBytes, visibility, filename, sourceUri, scene, imageMetadata,
+      owner, resolutionMeters, metadataFiles
+    )
+  )
+
+  private def imageBandedGen: Gen[Image.Banded] = for {
+    orgId <- uuidGen
+    rawDataBytes <- arbitrary[Long]
+    visibility <- visibilityGen
+    filename <- stringWithoutNullBytes
+    sourceUri <- stringWithoutNullBytes
+    scene <- uuidGen
+    imageMetadata <- arbitrary[Json]
+    owner <- arbitrary[Option[String]]
+    resolutionMeters <- arbitrary[Float]
+    metadataFiles <- Gen.containerOf[List, String](stringWithoutNullBytes)
+    bands <- Gen.containerOf[Seq, Band.Create](bandCreateGen)
+  } yield (
+    Image.Banded(
+      orgId, rawDataBytes, visibility, filename, sourceUri, owner, scene, imageMetadata,
+      resolutionMeters, metadataFiles, bands
+    )
+  )
+
+  // generate up to a 50km/side polygon with bounds in EPSG:3857 bounds
+  private def polygonGen3857: Gen[Polygon] = for {
+    width <- Gen.choose(100, 50000)
+    height <- Gen.choose(100, 50000)
+    centerX <- Gen.choose(-2E7, 2E7)
+    centerY <- Gen.choose(-2E7, 2E7)
+  } yield {
+    Rectangle().withWidth(width).withHeight(height).setCenter(Point(centerX, centerY)).build()
+  }
+
+  private def multiPolygonGen3857: Gen[MultiPolygon] = for {
+    polygons <- Gen.nonEmptyListOf[Polygon](polygonGen3857)
+  } yield (MultiPolygon(polygons))
+
+  def projectedMultiPolygonGen3857: Gen[Projected[MultiPolygon]] =
+    multiPolygonGen3857 map { Projected(_, 3857) }
+
+  private def sceneFilterFieldsGen: Gen[SceneFilterFields] = for {
+    cloudCover <- Gen.frequency((1, None), (10, arbitrary[Float] map { Some(_) }))
+    acquisitionDate <- Gen.frequency((1, None), (10, timestampIn2016Gen map { Some(_) }))
+    sunAzimuth <- Gen.frequency((1, None), (10, Gen.choose(0f, 360f) map { Some(_) }))
+    sunElevation <- Gen.frequency((1, None), (10, Gen.choose(0f, 90f) map { Some(_) }))
+  } yield { SceneFilterFields(cloudCover, acquisitionDate, sunAzimuth, sunElevation) }
+
+  private def sceneStatusFieldsGen: Gen[SceneStatusFields] = for {
+    thumbnailStatus <- jobStatusGen
+    boundaryStatus <- jobStatusGen
+    ingestStatus <- ingestStatusGen
+  } yield { SceneStatusFields(thumbnailStatus, boundaryStatus, ingestStatus) }
+
+  private def thumbnailIdentifiedGen: Gen[Thumbnail.Identified] = for {
+    id <- uuidGen map { Some(_) }
+    organizationId <- uuidGen
+    thumbnailSize <- thumbnailSizeGen
+    sideLength <- Gen.choose(200, 1000)
+    sceneId <- uuidGen
+    url <- nonEmptyStringGen
+  } yield {
+    Thumbnail.Identified(id, organizationId, thumbnailSize, sideLength, sideLength, sceneId, url)
+  }
+
+  private def sceneCreateGen: Gen[Scene.Create] = for {
+    sceneId <- uuidGen map { Some(_) }
+    organizationId <- uuidGen
+    ingestSizeBytes <- arbitrary[Int]
+    visibility <- visibilityGen
+    tags <- Gen.containerOf[List, String](stringWithoutNullBytes)
+    datasource <- uuidGen
+    sceneMetadata <- arbitrary[Json]
+    name <- stringWithoutNullBytes
+    owner <- arbitrary[Option[String]]
+    tileFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
+    dataFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
+    metadataFiles <- Gen.containerOf[List, String](stringWithoutNullBytes)
+    images <- Gen.containerOf[List, Image.Banded](imageBandedGen)
+    thumbnails <- Gen.containerOf[List, Thumbnail.Identified](thumbnailIdentifiedGen)
+    ingestLocation <- Gen.oneOf(stringWithoutNullBytes map { Some(_) }, Gen.delay(None))
+    filterFields <- sceneFilterFieldsGen
+    statusFields <- sceneStatusFieldsGen
+  } yield {
+    Scene.Create(sceneId, organizationId, ingestSizeBytes, visibility, tags,
+                 datasource, sceneMetadata, name, owner, tileFootprint, dataFootprint,
+                 metadataFiles, images, thumbnails, ingestLocation, filterFields, statusFields)
+  }
+
+  private def imageGen: Gen[Image] = for {
+    imCreate <- imageCreateGen
+    user <- userGen
+  } yield (imCreate.toImage(user))
 
   object Implicits {
-    implicit def arbOrganizationCreate: Arbitrary[Organization.Create] = Arbitrary { organizationCreateGen }
+    implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
 
     implicit def arbOrganization: Arbitrary[Organization] = Arbitrary { organizationGen }
 
-    implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
+    implicit def arbOrganizationCreate: Arbitrary[Organization.Create] = Arbitrary { organizationCreateGen }
 
     implicit def arbUserCreate: Arbitrary[User.Create] = Arbitrary { userCreateGen }
 
     implicit def arbUser: Arbitrary[User] = Arbitrary { userGen }
+
+    implicit def arbBand: Arbitrary[Band] = Arbitrary { bandGen }
+
+    implicit def arbImage: Arbitrary[Image] = Arbitrary { imageGen }
+
+    implicit def arbImageCreate: Arbitrary[Image.Create] = Arbitrary { imageCreateGen }
+
+    implicit def arbImageBanded: Arbitrary[Image.Banded] = Arbitrary { imageBandedGen }
   }
 }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -79,7 +79,7 @@ object Generators extends ArbitraryInstances {
   private def organizationGen: Gen[Organization] = organizationCreateGen map { _.toOrganization }
 
   private def userCreateGen: Gen[User.Create] = for {
-    id <- arbitrary[String]
+    id <- nonEmptyStringGen
     org <- organizationGen
     role <- userRoleGen
   } yield { User.Create(id, org.id, role) }
@@ -141,7 +141,7 @@ object Generators extends ArbitraryInstances {
   private def imageGen: Gen[Image] = for {
     imCreate <- imageCreateGen
     user <- userGen
-  } yield (imCreate.toImage(user))
+  } yield (imCreate.copy(owner=Some(user.id)).toImage(user))
 
   private def sceneFilterFieldsGen: Gen[SceneFilterFields] = for {
     cloudCover <- Gen.frequency((1, None), (10, Gen.choose(0.0f, 1.0f) map { Some(_) }))

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -8,6 +8,7 @@ import geotrellis.vector.testkit.Rectangle
 
 import io.circe.Json
 import io.circe.testing.ArbitraryInstances
+import io.circe.syntax._
 
 import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
@@ -19,14 +20,17 @@ import java.util.UUID
 object Generators extends ArbitraryInstances {
 
   private def nonEmptyStringGen: Gen[String] =
-    Gen.nonEmptyListOf[Char](Arbitrary.arbChar.arbitrary).map(_.mkString)
-
-  private def stringWithoutNullBytes: Gen[String] = arbitrary[String] suchThat { ! _.contains('\u0000') }
+    Gen.nonEmptyListOf[Char](Gen.alphaChar).map(_.mkString)
 
   private def userRoleGen: Gen[UserRole] = Gen.oneOf(UserRoleRole, Viewer, Admin)
 
   private def visibilityGen: Gen[Visibility] = Gen.oneOf(
     Visibility.Public, Visibility.Organization, Visibility.Private)
+
+  private def credentialGen: Gen[Credential] = nonEmptyStringGen map { Credential.fromString }
+
+  // This is fine not to test the max value --
+  private def rawDataBytesGen: Gen[Long] = Gen.choose(0L, 100000L)
 
   private def uuidGen: Gen[UUID] = Gen.delay(UUID.randomUUID)
 
@@ -50,73 +54,6 @@ object Generators extends ArbitraryInstances {
     day <- Gen.choose(1, 28) // for safety
   } yield { Timestamp.valueOf(LocalDate.of(year, month, day).atStartOfDay) }
 
-  private def organizationGen: Gen[Organization] = for {
-    name <- arbitrary[String]
-  } yield (Organization.Create(name))
-
-  def organizationGen: Gen[Organization] = organizationCreateGen map { _.toOrganization }
-
-  private def userCreateGen: Gen[User.Create] = for {
-    id <- arbitrary[String]
-    org <- organizationGen
-    role <- userRoleGen
-  } yield { User.Create(id, org.id, role) }
-
-  private def userGen: Gen[User] = userCreateGen map { _.toUser }
-
-  private def credentialGen: Gen[Credential] = nonEmptyStringGen map { Credential.fromString }
-
-  private def bandIdentifiedGen: Gen[Band.Identified] = for {
-    name <- stringWithoutNullBytes
-    number <- arbitrary[Int]
-    wavelength <- Gen.listOfN(2, arbitrary[Int]) map { _.sorted }
-    imageId <- uuidGen
-  } yield { Band.Identified(None, imageId, name, number, wavelength) }
-
-  private def bandCreateGen: Gen[Band.Create] = for {
-    name <- stringWithoutNullBytes
-    number <- arbitrary[Int]
-    wavelength <- Gen.listOfN(2, arbitrary[Int]) map { _.sorted }
-  } yield { Band.Create(name, number, wavelength) }
-
-  private def bandGen: Gen[Band] = bandIdentifiedGen map { _.toBand }
-
-  private def imageCreateGen: Gen[Image.Create] = for {
-    orgId <- uuidGen
-    rawDataBytes <- arbitrary[Long]
-    visibility <- visibilityGen
-    filename <- stringWithoutNullBytes
-    sourceUri <- stringWithoutNullBytes
-    scene <- uuidGen
-    imageMetadata <- arbitrary[Json]
-    owner <- arbitrary[Option[String]]
-    resolutionMeters <- arbitrary[Float]
-    metadataFiles <- Gen.containerOf[List, String](stringWithoutNullBytes)
-  } yield (
-    Image.Create(
-      orgId, rawDataBytes, visibility, filename, sourceUri, scene, imageMetadata,
-      owner, resolutionMeters, metadataFiles
-    )
-  )
-
-  private def imageBandedGen: Gen[Image.Banded] = for {
-    orgId <- uuidGen
-    rawDataBytes <- arbitrary[Long]
-    visibility <- visibilityGen
-    filename <- stringWithoutNullBytes
-    sourceUri <- stringWithoutNullBytes
-    scene <- uuidGen
-    imageMetadata <- arbitrary[Json]
-    owner <- arbitrary[Option[String]]
-    resolutionMeters <- arbitrary[Float]
-    metadataFiles <- Gen.containerOf[List, String](stringWithoutNullBytes)
-    bands <- Gen.containerOf[Seq, Band.Create](bandCreateGen)
-  } yield (
-    Image.Banded(
-      orgId, rawDataBytes, visibility, filename, sourceUri, owner, scene, imageMetadata,
-      resolutionMeters, metadataFiles, bands
-    )
-  )
 
   // generate up to a 50km/side polygon with bounds in EPSG:3857 bounds
   private def polygonGen3857: Gen[Polygon] = for {
@@ -129,14 +66,85 @@ object Generators extends ArbitraryInstances {
   }
 
   private def multiPolygonGen3857: Gen[MultiPolygon] = for {
-    polygons <- Gen.nonEmptyListOf[Polygon](polygonGen3857)
+    polygons <- Gen.listOfN[Polygon](1, polygonGen3857)
   } yield (MultiPolygon(polygons))
 
   def projectedMultiPolygonGen3857: Gen[Projected[MultiPolygon]] =
     multiPolygonGen3857 map { Projected(_, 3857) }
 
+  private def organizationCreateGen: Gen[Organization.Create] = for {
+    name <- arbitrary[String]
+  } yield (Organization.Create(name))
+
+  private def organizationGen: Gen[Organization] = organizationCreateGen map { _.toOrganization }
+
+  private def userCreateGen: Gen[User.Create] = for {
+    id <- arbitrary[String]
+    org <- organizationGen
+    role <- userRoleGen
+  } yield { User.Create(id, org.id, role) }
+
+  private def userGen: Gen[User] = userCreateGen map { _.toUser }
+
+  private def bandIdentifiedGen: Gen[Band.Identified] = for {
+    name <- nonEmptyStringGen
+    number <- Gen.choose(1, 15)
+    wavelength <- Gen.listOfN(2, Gen.choose(1, 50000)) map { _.sorted }
+    imageId <- uuidGen
+  } yield { Band.Identified(None, imageId, name, number, wavelength) }
+
+  private def bandCreateGen: Gen[Band.Create] = for {
+    name <- nonEmptyStringGen
+    number <- Gen.choose(1, 15)
+    wavelength <- Gen.listOfN(2, Gen.choose(1, 50000)) map { _.sorted }
+  } yield { Band.Create(name, number, wavelength) }
+
+  private def bandGen: Gen[Band] = bandIdentifiedGen map { _.toBand }
+
+  private def imageCreateGen: Gen[Image.Create] = for {
+    orgId <- uuidGen
+    rawDataBytes <- rawDataBytesGen
+    visibility <- visibilityGen
+    filename <- nonEmptyStringGen
+    sourceUri <- nonEmptyStringGen
+    scene <- uuidGen
+    imageMetadata <- Gen.const(().asJson)
+    owner <- arbitrary[Option[String]]
+    resolutionMeters <- Gen.choose(0.25f, 1000f)
+    metadataFiles <- Gen.containerOf[List, String](nonEmptyStringGen)
+  } yield (
+    Image.Create(
+      orgId, rawDataBytes, visibility, filename, sourceUri, scene, imageMetadata,
+      owner, resolutionMeters, metadataFiles
+    )
+  )
+
+  private def imageBandedGen: Gen[Image.Banded] = for {
+    orgId <- uuidGen
+    rawDataBytes <- rawDataBytesGen
+    visibility <- visibilityGen
+    filename <- nonEmptyStringGen
+    sourceUri <- nonEmptyStringGen
+    scene <- uuidGen
+    imageMetadata <- Gen.const(().asJson)
+    owner <- arbitrary[Option[String]]
+    resolutionMeters <- Gen.choose(0.25f, 1000f)
+    metadataFiles <- Gen.containerOf[List, String](nonEmptyStringGen)
+    bands <- Gen.nonEmptyContainerOf[Seq, Band.Create](bandCreateGen)
+  } yield (
+    Image.Banded(
+      orgId, rawDataBytes, visibility, filename, sourceUri, owner, scene, imageMetadata,
+      resolutionMeters, metadataFiles, bands
+    )
+  )
+
+  private def imageGen: Gen[Image] = for {
+    imCreate <- imageCreateGen
+    user <- userGen
+  } yield (imCreate.toImage(user))
+
   private def sceneFilterFieldsGen: Gen[SceneFilterFields] = for {
-    cloudCover <- Gen.frequency((1, None), (10, arbitrary[Float] map { Some(_) }))
+    cloudCover <- Gen.frequency((1, None), (10, Gen.choose(0.0f, 1.0f) map { Some(_) }))
     acquisitionDate <- Gen.frequency((1, None), (10, timestampIn2016Gen map { Some(_) }))
     sunAzimuth <- Gen.frequency((1, None), (10, Gen.choose(0f, 360f) map { Some(_) }))
     sunElevation <- Gen.frequency((1, None), (10, Gen.choose(0f, 90f) map { Some(_) }))
@@ -162,19 +170,19 @@ object Generators extends ArbitraryInstances {
   private def sceneCreateGen: Gen[Scene.Create] = for {
     sceneId <- uuidGen map { Some(_) }
     organizationId <- uuidGen
-    ingestSizeBytes <- arbitrary[Int]
+    ingestSizeBytes <- Gen.const(0)
     visibility <- visibilityGen
-    tags <- Gen.containerOf[List, String](stringWithoutNullBytes)
+    tags <- Gen.containerOf[List, String](nonEmptyStringGen)
     datasource <- uuidGen
-    sceneMetadata <- arbitrary[Json]
-    name <- stringWithoutNullBytes
+    sceneMetadata <- Gen.const(().asJson)
+    name <- nonEmptyStringGen
     owner <- arbitrary[Option[String]]
     tileFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
     dataFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
-    metadataFiles <- Gen.containerOf[List, String](stringWithoutNullBytes)
-    images <- Gen.containerOf[List, Image.Banded](imageBandedGen)
-    thumbnails <- Gen.containerOf[List, Thumbnail.Identified](thumbnailIdentifiedGen)
-    ingestLocation <- Gen.oneOf(stringWithoutNullBytes map { Some(_) }, Gen.delay(None))
+    metadataFiles <- Gen.containerOf[List, String](nonEmptyStringGen)
+    images <- Gen.nonEmptyContainerOf[List, Image.Banded](imageBandedGen)
+    thumbnails <- Gen.nonEmptyContainerOf[List, Thumbnail.Identified](thumbnailIdentifiedGen)
+    ingestLocation <- Gen.oneOf(nonEmptyStringGen map { Some(_) }, Gen.delay(None))
     filterFields <- sceneFilterFieldsGen
     statusFields <- sceneStatusFieldsGen
   } yield {
@@ -182,11 +190,6 @@ object Generators extends ArbitraryInstances {
                  datasource, sceneMetadata, name, owner, tileFootprint, dataFootprint,
                  metadataFiles, images, thumbnails, ingestLocation, filterFields, statusFields)
   }
-
-  private def imageGen: Gen[Image] = for {
-    imCreate <- imageCreateGen
-    user <- userGen
-  } yield (imCreate.toImage(user))
 
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
@@ -206,5 +209,7 @@ object Generators extends ArbitraryInstances {
     implicit def arbImageCreate: Arbitrary[Image.Create] = Arbitrary { imageCreateGen }
 
     implicit def arbImageBanded: Arbitrary[Image.Banded] = Arbitrary { imageBandedGen }
+
+    implicit def arbSceneCreate: Arbitrary[Scene.Create] = Arbitrary { sceneCreateGen }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/BandDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/BandDao.scala
@@ -25,17 +25,6 @@ object BandDao extends Dao[Band] {
       FROM
     """ ++ tableF
 
-  def create(band: Band): ConnectionIO[Band] = {
-    val id = UUID.randomUUID
-    (fr"INSERT INTO" ++ tableF ++ fr"""
-        (id, image_id, name, number, wavelength)
-      VALUES
-        (${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})
-    """).update.withUniqueGeneratedKeys[Band](
-      "id", "image_id", "name", "number", "wavelength"
-    )
-  }
-
   def createMany(bands: List[Band]): ConnectionIO[Int] = {
     (fr"INSERT INTO" ++ tableF ++ fr"(id, image_id, name, number, wavelength) VALUES" ++
        bands.foldLeft(fr"")(

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/BandDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/BandDao.scala
@@ -26,17 +26,18 @@ object BandDao extends Dao[Band] {
     """ ++ tableF
 
   def createMany(bands: List[Band]): ConnectionIO[Int] = {
-    (fr"INSERT INTO" ++ tableF ++ fr"(id, image_id, name, number, wavelength) VALUES" ++
-       bands.foldLeft(fr"")(
-         (query: Fragment, band: Band) => {
-           query.toString().isEmpty() match {
-             case true =>
-               fr"(${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})"
-             case false =>
-               query ++ fr", (${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})"
-           }
-         })
-    ).update.run
+    val bandFragments: List[Fragment] = bands map {
+      (band: Band) => fr"(${band.id}, ${band.image}, ${band.name}, ${band.number}, ${band.wavelength})"
+    }
+    val insertFragment = fr"INSERT INTO" ++ tableF ++ fr"(id, image_id, name, number, wavelength) VALUES" ++ {
+      bandFragments.toNel match {
+        case Some(fragments) =>
+          fragments.intercalate(fr",")
+        case None =>
+          throw new IllegalArgumentException("Can't insert bands from an empty list")
+      }
+    }
+    insertFragment.update.run
   }
 }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ImageDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ImageDao.scala
@@ -24,6 +24,7 @@ object ImageDao extends Dao[Image] {
       id, created_at, modified_at, organization_id, created_by, modified_by,
       owner, raw_data_bytes, visibility, filename, sourceuri, scene,
       image_metadata, resolution_meters, metadata_files FROM """ ++ tableF 
+
   def create(
     image: Image,
     user: User

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ImageDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ImageDao.scala
@@ -79,7 +79,7 @@ object ImageDao extends Dao[Image] {
         fr"""
           modified_at = ${now},
           modified_by = ${user.id},
-          rawDataBytes = ${image.rawDataBytes},
+          raw_data_bytes = ${image.rawDataBytes},
           visibility = ${image.visibility},
           filename = ${image.filename},
           sourceuri = ${image.sourceUri},
@@ -87,8 +87,7 @@ object ImageDao extends Dao[Image] {
           image_metadata = ${image.imageMetadata},
           resolution_meters = ${image.resolutionMeters},
           metadata_files = ${image.metadataFiles}
-          where id = ${id} AND owner = ${user.id}
-      """
+      """ ++ Fragments.whereAndOpt(query.ownerFilterF(user), fr"id = ${id}".some)
     updateQuery.update.run
   }
 
@@ -99,7 +98,12 @@ object ImageDao extends Dao[Image] {
 
   // get image
   def getImage(id: UUID, user: User): ConnectionIO[Option[Image]] = {
-    this.query.filter(fr"owner = ${user.id} OR owner = 'default'").selectOption
+    this.query.filter(id).ownerFilter(user).selectOption
+  }
+
+  // get an image assuming it's present
+  def unsafeGetImage(id: UUID, user: User): ConnectionIO[Image] = {
+    this.query.filter(id).ownerFilter(user).select
   }
 }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -17,10 +17,11 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 
 import java.util.UUID
 
+// TODO: query for a single scene is bad here for some reason, fix it
 object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
   val tableName = "scenes"
 
-  val selectF = SceneDao.selectF 
+  val selectF = SceneDao.selectF
 
   def listProjectScenes(projectId: UUID, pageRequest: PageRequest, sceneParams: CombinedSceneQueryParams, user: User): ConnectionIO[PaginatedResponse[Scene.WithRelated]] = {
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
@@ -1,6 +1,7 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.Band
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 
 import doobie._, doobie.implicits._
@@ -13,24 +14,14 @@ import org.scalatest._
 import java.util.UUID
 
 
-class BandDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+/** We only need to test the list query, since insertion is checked when creating a
+  * scene from a Scene.Create
+  */
+class BandDaoSpec extends FunSuite with Matchers with DBTestConfig {
 
-  test("insertion") {
-    val testName = "Some Test Name"
-
-    val transaction = for {
-      img <- ImageDao.query.listQ(1).unique
-      bandIn <- {
-        val band = Band(UUID.randomUUID(), img.id, testName, 123, List(1, 2, 3))
-        BandDao.create(band)
-      }
-      bandOut <- BandDao.query.filter(fr"id = ${bandIn.id}").selectQ.unique
-    } yield bandOut
-
-    val result = transaction.transact(xa).unsafeRunSync
-    result.name shouldBe testName
+  // list bands
+  test("list bands") {
+    BandDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
   }
-
-  test("types") { check(BandDao.selectF.query[Band]) }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.database
 import java.sql.Timestamp
 
 import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 import doobie._
 import doobie.implicits._
@@ -13,35 +14,51 @@ import cats.syntax.either._
 import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.scalatest.imports._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 import io.circe._
 import io.circe.syntax._
 import java.util.UUID
 
 
-class ImageDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+/** We only need to test inserting a single image and listing images because inserting
+  *  many is tested in inserting a scene from a Scene.Create
+  */
+class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
 
-  test("insertion") {
-    val testFileList = List("file1", "typo")
-
-    val transaction = for {
-      usr <- defaultUserQ
-      org <- rootOrgQ
-      proj <- changeDetectionProjQ
-      scene <- SceneDao.query.filter(fr"id = ${UUID.fromString("a9ce69c2-f87e-4119-863d-d570afb53983")}").selectQ.unique
-      imageIn <- {
-        val now = new Timestamp((new java.util.Date()).getTime())
-        val image = Image(UUID.randomUUID(), now, now, org.id, usr.id, usr.id, usr.id, 123456L, Visibility.Public, "filename", "http://sourceUri", scene.id,
-          List(1, 2).asJson, 15.0.toFloat, testFileList)
-        ImageDao.create(image, usr)
-      }
-      imageOut <- ImageDao.query.filter(fr"id = ${imageIn.id}").selectQ.unique
-    } yield imageOut
-
-    val result = transaction.transact(xa).unsafeRunSync
-    result.metadataFiles shouldBe testFileList
+  test("insert a single image") {
+    check {
+      forAll(
+        (user: User.Create, org: Organization.Create, scene: Scene.Create, image: Image.Banded) => {
+          val sceneInsertIO = for {
+            orgAndUser <- insertUserAndOrg(user, org)
+            (insertedOrg, insertedUser) = orgAndUser
+            insertedScene <- SceneDao.insert(fixupSceneCreate(insertedUser, insertedOrg, scene), insertedUser)
+          } yield (insertedScene, insertedUser)
+          val imageInsertIO = sceneInsertIO flatMap {
+            case (swr: Scene.WithRelated, dbUser: User) => {
+              ImageDao.insertImage(
+                image.copy(scene = swr.id, organizationId = swr.organizationId, owner = Some(swr.owner)),
+                dbUser
+              )
+            }
+          }
+          val insertedImage = imageInsertIO.transact(xa).unsafeRunSync.get
+          insertedImage.rawDataBytes == image.rawDataBytes &&
+            insertedImage.visibility == image.visibility &&
+            insertedImage.filename == image.filename &&
+            insertedImage.sourceUri == image.sourceUri &&
+            insertedImage.imageMetadata == image.imageMetadata &&
+            insertedImage.resolutionMeters == image.resolutionMeters &&
+            insertedImage.metadataFiles == image.metadataFiles
+        }
+      )
+    }
   }
 
-  test("types") { check(ImageDao.selectF.query[Image]) }
+  test("list images") {
+    ImageDao.query.list.transact(xa).unsafeRunSync
+  }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
@@ -34,7 +34,10 @@ class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
           val sceneInsertIO = for {
             orgAndUser <- insertUserAndOrg(user, org)
             (insertedOrg, insertedUser) = orgAndUser
-            insertedScene <- SceneDao.insert(fixupSceneCreate(insertedUser, insertedOrg, scene), insertedUser)
+            datasource <- unsafeGetRandomDatasource
+            insertedScene <- SceneDao.insert(
+              fixupSceneCreate(insertedUser, insertedOrg, datasource, scene), insertedUser
+            )
           } yield (insertedScene, insertedUser)
           val imageInsertIO = sceneInsertIO flatMap {
             case (swr: Scene.WithRelated, dbUser: User) => {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -1,0 +1,30 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.datamodel._
+
+import doobie.ConnectionIO
+
+trait PropTestHelpers {
+
+  def insertUserAndOrg(user: User.Create, org: Organization.Create): ConnectionIO[(Organization, User)] = {
+    for {
+      orgInsert <- OrganizationDao.createOrganization(org)
+      userInsert <- UserDao.create(user.copy(organizationId = orgInsert.id))
+    } yield (orgInsert, userInsert)
+  }
+
+  // We assume the Scene.Create has an id, since otherwise thumbnails have no idea what scene id to use
+  def fixupSceneCreate(user: User, org: Organization, sceneCreate: Scene.Create): Scene.Create = {
+    sceneCreate.copy(
+      organizationId = org.id,
+      owner = Some(user.id),
+      images = sceneCreate.images map {
+        _.copy(organizationId = org.id, scene = sceneCreate.id.get, owner = Some(user.id))
+      },
+      thumbnails = sceneCreate.thumbnails map {
+        _.copy(organizationId = org.id, sceneId = sceneCreate.id.get)
+      }
+    )
+  }
+
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -6,6 +6,8 @@ import com.azavea.rf.datamodel._
 import doobie._
 import doobie.implicits._
 
+import java.util.UUID
+
 trait PropTestHelpers {
 
   def insertUserAndOrg(user: User.Create, org: Organization.Create): ConnectionIO[(Organization, User)] = {
@@ -22,14 +24,31 @@ trait PropTestHelpers {
   def fixupSceneCreate(user: User, org: Organization, datasource: Datasource, sceneCreate: Scene.Create): Scene.Create = {
     sceneCreate.copy(
       organizationId = org.id,
-      owner = Some(user.id),
+      owner = None,
       datasource = datasource.id,
       images = sceneCreate.images map {
-        _.copy(organizationId = org.id, scene = sceneCreate.id.get, owner = Some(user.id))
+        _.copy(organizationId = org.id, scene = sceneCreate.id.get, owner = None)
       },
       thumbnails = sceneCreate.thumbnails map {
         _.copy(organizationId = org.id, sceneId = sceneCreate.id.get)
       }
+    )
+  }
+
+  def fixupImageBanded(ownerId: String, orgId: UUID, sceneId: UUID, image: Image.Banded): Image.Banded = {
+    image.copy(
+      owner = Some(ownerId),
+      organizationId = orgId,
+      scene = sceneId
+    )
+  }
+
+  def fixupImage(ownerId: String, orgId: UUID, sceneId: UUID, image: Image): Image = {
+    image.copy(
+      createdBy = ownerId,
+      owner = ownerId,
+      organizationId = orgId,
+      scene = sceneId
     )
   }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -1,8 +1,10 @@
 package com.azavea.rf.database
 
+import com.azavea.rf.database.Implicits._
 import com.azavea.rf.datamodel._
 
-import doobie.ConnectionIO
+import doobie._
+import doobie.implicits._
 
 trait PropTestHelpers {
 
@@ -13,11 +15,15 @@ trait PropTestHelpers {
     } yield (orgInsert, userInsert)
   }
 
+  def unsafeGetRandomDatasource: ConnectionIO[Datasource] =
+    (DatasourceDao.selectF ++ fr"ORDER BY RANDOM() limit 1").query[Datasource].unique
+
   // We assume the Scene.Create has an id, since otherwise thumbnails have no idea what scene id to use
-  def fixupSceneCreate(user: User, org: Organization, sceneCreate: Scene.Create): Scene.Create = {
+  def fixupSceneCreate(user: User, org: Organization, datasource: Datasource, sceneCreate: Scene.Create): Scene.Create = {
     sceneCreate.copy(
       organizationId = org.id,
       owner = Some(user.id),
+      datasource = datasource.id,
       images = sceneCreate.images map {
         _.copy(organizationId = org.id, scene = sceneCreate.id.get, owner = Some(user.id))
       },

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -17,8 +17,6 @@ import scala.util.Random
 
 class UserDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig {
 
-  val randomUserFragment = UserDao.selectF ++ fr"ORDER BY RANDOM() LIMIT 1"
-
   // create
   test("inserting users") {
     check(

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -16,6 +16,7 @@ object Dependencies {
   val geotrellisRasterTestkit = "org.locationtech.geotrellis" %% "geotrellis-raster-testkit"         % Version.geotrellis
   val geotrellisSlick         = "org.locationtech.geotrellis" %% "geotrellis-slick"                  % Version.geotrellis
   val geotrellisVector        = "org.locationtech.geotrellis" %% "geotrellis-vector"                 % Version.geotrellis
+  val geotrellisVectorTestkit = "org.locationtech.geotrellis" %% "geotrellis-vector-testkit"         % Version.geotrellis % "test"
   val geotrellisUtil          = "org.locationtech.geotrellis" %% "geotrellis-util"                   % Version.geotrellis
   val geotrellisShapefile     = "org.locationtech.geotrellis" %% "geotrellis-shapefile"              % Version.geotrellis
   val geotrellisGeotools      = "org.locationtech.geotrellis" %% "geotrellis-geotools"               % Version.geotrellis
@@ -50,6 +51,7 @@ object Dependencies {
   val circeGenericExtras      = "io.circe"                    %% "circe-generic-extras"              % Version.circe
   val circeParser             = "io.circe"                    %% "circe-parser"                      % Version.circe
   val circeOptics             = "io.circe"                    %% "circe-optics"                      % Version.circe
+  val circeTest               = "io.circe"                    %% "circe-testing"                        % Version.circe % "test"
   val akkaCirceJson           = "de.heikoseeberger"           %% "akka-http-circe"                   % Version.akkaCirceJson
   val catsCore                = "org.typelevel"               %% "cats-core"                         % Version.cats
   val gatlingHighcharts       = "io.gatling.highcharts"        % "gatling-charts-highcharts"         % Version.gatling


### PR DESCRIPTION
## Overview

This PR adds property tests for image and band database interactions that aren't tested by inserting scenes (to avoid duplicative testing).

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I discovered a few weird behaviors in running these tests that I opened issues for or will just note here:

- `ingestSizeBytes` has a pretty low max because it's just an int (#3137)
- there's no REST API information that would help someone understand why inserting an image without bands would fail (#3136)
- `circe`'s `arbitrary[Json]` generation is garbage and I couldn't figure out how to configure it to make it not produce values that make postgres barf

Also there's some debug logging from geotrellis that makes it print a bunch of multipolygon WKTs. Sorry.

## Testing Instructions

 * `testOnly com.azavea.rf.database.BandDaoSpec com.azavea.rf.database.ImageDaoSpec`