### PR TITLE
Add property tests for ProjectDao methods

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -148,7 +148,7 @@ lazy val apiDependencies = dbDependencies ++ migrationsDependencies ++
 )
 
 lazy val root = Project("root", file("."))
-  .aggregate(api, common, migrations, datamodel, batch, tile, tool, bridge)
+  .aggregate(api, db, common, migrations, datamodel, batch, tile, tool, bridge)
   .settings(commonSettings:_*)
 
 lazy val api = Project("api", file("api"))
@@ -223,7 +223,8 @@ lazy val datamodel = Project("datamodel", file("datamodel"))
       Dependencies.akkahttp,
       Dependencies.betterFiles,
       Dependencies.scalaCheck,
-      Dependencies.circeTest
+      Dependencies.circeTest,
+      "com.lonelyplanet" %% "akka-http-extensions" % "0.4.15" % "test",
     )
   })
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -80,8 +80,9 @@ object SceneDao extends Dao[Scene] {
       _ <- thumbnailInsert
       _ <- imageInsert
       _ <- bandInsert
-      sceneWithRelated <- SceneWithRelatedDao.getScene(sceneId, user)
-    } yield sceneWithRelated.get
+      // It's fine to do this unsafely, since we know we the prior insert succeeded
+      sceneWithRelated <- SceneWithRelatedDao.unsafeGetScene(sceneId, user)
+    } yield sceneWithRelated
   }
 
   def insertMaybe(sceneCreate: Scene.Create, user: User): ConnectionIO[Option[Scene.WithRelated]] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserDao.scala
@@ -38,7 +38,7 @@ object UserDao extends Dao[User] {
 
   def createUserWithAuthId(id: String): ConnectionIO[User] = {
     for {
-      org <- OrganizationDao.query.filter(fr"name = 'PUBLIC'").select
+      org <- OrganizationDao.query.filter(fr"name = 'Public'").select
       user <- {
         val newUser = User.Create(id, org.id)
         create(newUser)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -14,41 +14,6 @@ import java.util.UUID
 
 class AnnotationDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
 
-  test("insertion") {
-
-    val testLabels = ("Label 1", "label 2")
-
-    val testAnnotation1 = Annotation.Create(
-      None,
-      testLabels._1,
-      None,
-      None,
-      None,
-      None,
-      None
-    )
-    val testAnnotation2 = Annotation.Create(
-      None,
-      testLabels._2,
-      None,
-      None,
-      None,
-      None,
-      None
-    )
-
-    val transaction = for {
-      usr <- defaultUserQ
-      org <- rootOrgQ
-      proj <- changeDetectionProjQ
-      annotationsIn <- AnnotationDao.insertAnnotations(List(testAnnotation1, testAnnotation2), proj.id, usr)
-    } yield annotationsIn
-
-    val result = transaction.transact(xa).unsafeRunSync
-
-    result.length shouldBe 2
-  }
-
   test("types") { check(AnnotationDao.selectF.query[Annotation]) }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -17,23 +17,6 @@ import org.scalatest._
 
 class AoiDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
 
-  test("insertion") {
-    val testPoly = Projected(MultiPolygon(Polygon(Point(1, 0), Point(1, 1), Point(0, 1), Point(1, 0))), 3857)
-
-    val transaction = for {
-      usr <- defaultUserQ
-      org <- rootOrgQ
-      proj <- changeDetectionProjQ
-      aoiIn <- {
-        val aoi = AOI.Create(org.id, testPoly, List(1,2).asJson, Some(usr.id)).toAOI(usr)
-        AoiDao.createAOI(aoi, proj.id, usr)
-      }
-    } yield aoiIn
-
-    val result : AOI = transaction.transact(xa).unsafeRunSync
-    result.area shouldBe testPoly
-  }
-
   test("types") { check(AoiDao.selectF.query[AOI]) }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -27,7 +27,6 @@ trait DBTestConfig {
 
   val defaultUserQ = UserDao.query.filter(fr"id = 'default'").selectQ.unique
   val rootOrgQ = OrganizationDao.query.filter(fr" id = ${UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")}").selectQ.unique
-  val changeDetectionProjQ = ProjectDao.query.filter(fr"id = ${UUID.fromString("30fd336a-d360-4c9f-9f99-bb7ac4b372c4")}").selectQ.unique
 
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
@@ -15,23 +15,6 @@ import io.circe.syntax._
 
 class ExportDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
 
-  test("insertion") {
-    val testStatus = ExportStatus.NotExported
-
-    val transaction = for {
-      usr <- defaultUserQ
-      org <- rootOrgQ
-      proj <- changeDetectionProjQ
-      exportIn <- ExportDao.insert(
-        Export.Create(org.id, Some(proj.id), testStatus, ExportType.Dropbox, Visibility.Public, Some(usr.id), None, JsonObject.empty.asJson).toExport(usr), usr
-      )
-      exportOut <- ExportDao.query.filter(fr"id = ${exportIn.id}").selectQ.unique
-    } yield exportOut
-
-    val result = transaction.transact(xa).unsafeRunSync
-    result.exportStatus shouldBe testStatus
-  }
-
   test("types") { check(ExportDao.selectF.query[Export]) }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
@@ -13,21 +13,6 @@ import org.scalatest._
 
 class MapTokenDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig{
 
-  test("insertion") {
-    val testName = "maptoken name"
-
-    val transaction = for {
-      usr <- defaultUserQ
-      org <- rootOrgQ
-      proj <- changeDetectionProjQ
-      mapTokenIn <- MapTokenDao.create(usr, Some(usr.id), org.id, testName, Some(proj.id), None)
-      mapTokenOut <- MapTokenDao.query.filter(fr"id = ${mapTokenIn.id}").selectQ.unique
-    } yield mapTokenOut
-
-    val result = transaction.transact(xa).unsafeRunSync
-    result.name shouldBe testName
-  }
-
   test("types") { check(MapTokenDao.selectF.query[MapToken]) }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -3,79 +3,255 @@ package com.azavea.rf.database
 import java.sql.Timestamp
 
 import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 import doobie._
 import doobie.implicits._
 import cats._
 import cats.data._
 import cats.effect.IO
-import cats.syntax.either._
+import cats.implicits._
+import cats.syntax._
 import doobie.postgres._
 import doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 import io.circe._
 import io.circe.syntax._
+import com.lonelyplanet.akka.http.extensions.PageRequest
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ProjectDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ProjectDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
 
-  def createProject: ConnectionIO[Project] = {
-    val testName = "test project name"
-
-    for {
-      usr <- defaultUserQ
-      org <- rootOrgQ
-      projectIn <- {
-        val projectCreate = Project.Create(org.id, testName, "description",
-          Visibility.Public, Visibility.Public, true, 123L, Some(usr.id), List("tags"), false, None
-        )
-        ProjectDao.insertProject(projectCreate, usr)
+  // insertProject
+  test("insert a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create) => {
+          val projInsertIO = insertUserAndOrg(user, org) flatMap {
+            case (org: Organization, user: User) => {
+              ProjectDao.insertProject(fixupProjectCreate(user, org, project), user)
+            }
+          }
+          val insertedProject = projInsertIO.transact(xa).unsafeRunSync
+          insertedProject.name == project.name &&
+            insertedProject.description == project.description &&
+            insertedProject.visibility == project.visibility &&
+            insertedProject.tileVisibility == project.tileVisibility &&
+            insertedProject.isAOIProject == project.isAOIProject &&
+            insertedProject.aoiCadenceMillis == project.aoiCadenceMillis &&
+            insertedProject.tags == project.tags &&
+            insertedProject.isSingleBand == project.isSingleBand &&
+            insertedProject.singleBandOptions == project.singleBandOptions
+        }
       }
-    } yield {
-      println(s"Created Project with ID: ${projectIn.id}")
-      projectIn
     }
   }
 
-  test("insertion") {
-    val transaction = for {
-      projectIn <- createProject
-      projectOut <- ProjectDao.query.filter(fr"id = ${projectIn.id}").selectQ.unique
-    } yield projectOut
+  // updateProject
+  test("update a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, insertProject: Project.Create, updateProject: Project.Create) => {
+          val projInsertWithUserAndOrgIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              ProjectDao.insertProject(fixupProjectCreate(dbUser, dbOrg, insertProject), dbUser) map {
+                (_, dbUser, dbOrg)
+              }
+            }
+          }
+          val updateProjectWithUpdatedIO = projInsertWithUserAndOrgIO flatMap {
+            case (dbProject: Project, dbUser: User, dbOrg: Organization) => {
+              val fixedUpUpdateProject = fixupProjectCreate(dbUser, dbOrg, updateProject).toProject(dbUser)
+              ProjectDao.updateProject(fixedUpUpdateProject, dbProject.id, dbUser) flatMap {
+                (affectedRows: Int) => {
+                  ProjectDao.unsafeGetProjectById(dbProject.id, Some(dbUser)) map {
+                    (affectedRows, _)
+                  }
+                }
+              }
+            }
+          }
 
-    val result = transaction.transact(xa).unsafeRunSync
-    result.name shouldBe "test project name"
-  }
+          val (affectedRows, updatedProject) = updateProjectWithUpdatedIO.transact(xa).unsafeRunSync
 
-  test("insertion types") { check(ProjectDao.selectF.query[Project]) }
-
-  test("update") {
-    val transaction = for {
-      user <- defaultUserQ
-      projectIn <- createProject
-      projectUpdate <- {
-        val updateQuery = ProjectDao.updateProjectQ(projectIn, projectIn.id, user)
-        check(updateQuery)
-        updateQuery.run
+          affectedRows == 1 &&
+            updatedProject.owner == user.id &&
+            updatedProject.name == updateProject.name &&
+            updatedProject.description == updateProject.description &&
+            updatedProject.visibility == updateProject.visibility &&
+            updatedProject.tileVisibility == updateProject.tileVisibility &&
+            updatedProject.isAOIProject == updateProject.isAOIProject &&
+            updatedProject.aoiCadenceMillis == updateProject.aoiCadenceMillis &&
+            updatedProject.tags == updateProject.tags &&
+            updatedProject.isSingleBand == updateProject.isSingleBand &&
+            updatedProject.singleBandOptions == updateProject.singleBandOptions
+        }
       }
-    } yield projectUpdate
-
-    val result = transaction.transact(xa).unsafeRunSync
-    result shouldBe 1
+    }
   }
 
-  test("delete") {
-    val transaction = for {
-      user <- defaultUserQ
-      projectIn <- createProject
-      projectDelete <- ProjectDao.deleteProject(projectIn.id, user)
-    } yield projectDelete
+  // deleteProject
+  test("delete a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create) => {
+          val projInsertWithUserIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              ProjectDao.insertProject(fixupProjectCreate(dbUser, dbOrg, project), dbUser) map {
+                (_, dbUser)
+              }
+            }
+          }
 
-    val result = transaction.transact(xa).unsafeRunSync
-    result shouldBe 1
+          val projDeleteIO = projInsertWithUserIO flatMap {
+            case (dbProject: Project, dbUser: User) => {
+              ProjectDao.deleteProject(dbProject.id, dbUser) flatMap {
+                _ => ProjectDao.getProjectById(dbProject.id, Some(dbUser))
+              }
+            }
+          }
+
+          projDeleteIO.transact(xa).unsafeRunSync == None
+        }
+      }
+    }
   }
 
+  // list projects
+  test("list projects") {
+    ProjectDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+  }
+
+  // add scenes to a project
+  // also exercises createScenesToProject
+  test("add scenes to a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, scenes: List[Scene.Create], project: Project.Create) => {
+          val projAndScenesInsertWithUserIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              val scenesInsertIO = unsafeGetRandomDatasource flatMap {
+                (dbDatasource: Datasource) => {
+                  scenes.traverse(
+                    (scene: Scene.Create) => {
+                      SceneDao.insert(fixupSceneCreate(dbUser, dbOrg, dbDatasource, scene), dbUser)
+                    }
+                  )
+                }
+              }
+              val projectInsertIO = ProjectDao.insertProject(fixupProjectCreate(dbUser, dbOrg, project), dbUser)
+              (projectInsertIO, scenesInsertIO, dbUser.pure[ConnectionIO]).tupled
+            }
+          }
+
+          val addScenesIO = projAndScenesInsertWithUserIO flatMap {
+            case (dbProject: Project, dbScenes: List[Scene.WithRelated], dbUser: User) => {
+              ProjectDao.addScenesToProject(
+                // this.get is safe because the arbitrary instance only produces NELs
+                (dbScenes map {_.id}).toNel.get,
+                dbProject.id,
+                dbUser
+              )
+            }
+          }
+          addScenesIO.transact(xa).unsafeRunSync == scenes.length
+        }
+      }
+    }
+  }
+
+  // listProjectSceneOrder
+  test("list project scenes order") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, scenes: List[Scene.Create], project: Project.Create, pageRequest: PageRequest) => {
+          val projAndScenesInsertWithUserIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              val scenesInsertIO = unsafeGetRandomDatasource flatMap {
+                (dbDatasource: Datasource) => {
+                  scenes.traverse(
+                    (scene: Scene.Create) => {
+                      SceneDao.insert(fixupSceneCreate(dbUser, dbOrg, dbDatasource, scene), dbUser)
+                    }
+                  )
+                }
+              }
+              val projectInsertIO = ProjectDao.insertProject(fixupProjectCreate(dbUser, dbOrg, project), dbUser)
+              (projectInsertIO, scenesInsertIO, dbUser.pure[ConnectionIO]).tupled
+            }
+          }
+
+          val addScenesWithProjectAndUserAndScenesIO = projAndScenesInsertWithUserIO flatMap {
+            case (dbProject: Project, dbScenes: List[Scene.WithRelated], dbUser: User) => {
+              ProjectDao.addScenesToProject(dbScenes map { _.id }, dbProject.id, dbUser) map {
+                _ => (dbProject, dbUser, dbScenes)
+              }
+            }
+          }
+
+          val listAddedSceneIDsIO = addScenesWithProjectAndUserAndScenesIO flatMap {
+            case (dbProject: Project, dbUser: User, dbScenes: List[Scene.WithRelated]) => {
+              ProjectDao.listProjectSceneOrder(dbProject.id, pageRequest, dbUser) map {
+                (resp: PaginatedResponse[UUID]) => (resp.results, dbScenes map { _.id })
+              }
+            }
+          }
+          val (foundScenes, createdScenes) = listAddedSceneIDsIO.transact(xa).unsafeRunSync
+          foundScenes.toSet == createdScenes.toSet
+        }
+      }
+    }
+  }
+
+  // deleteScenesFromProject
+  test("delete scenes from a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, scenes: List[Scene.Create], project: Project.Create, pageRequest: PageRequest) => {
+          val projAndScenesInsertWithUserIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              val scenesInsertIO = unsafeGetRandomDatasource flatMap {
+                (dbDatasource: Datasource) => {
+                  scenes.traverse(
+                    (scene: Scene.Create) => {
+                      SceneDao.insert(fixupSceneCreate(dbUser, dbOrg, dbDatasource, scene), dbUser)
+                    }
+                  )
+                }
+              }
+              val projectInsertIO = ProjectDao.insertProject(fixupProjectCreate(dbUser, dbOrg, project), dbUser)
+              (projectInsertIO, scenesInsertIO, dbUser.pure[ConnectionIO]).tupled
+            }
+          }
+
+          val addAndDeleteScenesWithProjectAndUserIO = projAndScenesInsertWithUserIO flatMap {
+            case (dbProject: Project, dbScenes: List[Scene.WithRelated], dbUser: User) => {
+              val sceneIds = dbScenes map {_.id}
+              ProjectDao.addScenesToProject(
+                // this.get is safe because the arbitrary instance only produces NELs
+                (dbScenes map {_.id}).toNel.get, dbProject.id, dbUser) flatMap {
+                _ => ProjectDao.deleteScenesFromProject(dbScenes map {_.id}, dbProject.id) map {
+                  _ => (dbProject, dbUser)
+                }
+              }
+            }
+          }
+
+          val listAddedSceneIDsIO = addAndDeleteScenesWithProjectAndUserIO flatMap {
+            case (dbProject: Project, dbUser: User) => {
+              ProjectDao.listProjectSceneOrder(dbProject.id, pageRequest, dbUser) map {
+                (resp: PaginatedResponse[UUID]) => resp.results
+              }
+            }
+          }
+
+          listAddedSceneIDsIO.transact(xa).unsafeRunSync == List()
+        }
+      }
+    }
+  }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -20,6 +20,10 @@ trait PropTestHelpers {
   def unsafeGetRandomDatasource: ConnectionIO[Datasource] =
     (DatasourceDao.selectF ++ fr"ORDER BY RANDOM() limit 1").query[Datasource].unique
 
+  def fixupProjectCreate(user: User, org: Organization, proj: Project.Create): Project.Create = {
+    proj.copy(organizationId = org.id, owner = Some(user.id))
+  }
+
   // We assume the Scene.Create has an id, since otherwise thumbnails have no idea what scene id to use
   def fixupSceneCreate(user: User, org: Organization, datasource: Datasource, sceneCreate: Scene.Create): Scene.Create = {
     sceneCreate.copy(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
@@ -31,23 +31,5 @@ class ThumbnailDaoSpec extends FunSuite with Matchers with IOChecker with DBTest
       "https://url.com"
     ).toThumbnail
   }
-
-  test("insertion") {
-    val transaction = for {
-      org <- rootOrgQ
-      user <- defaultUserQ
-      smallThumbnail = makeThumbnail(org, ThumbnailSize.Small)
-      largeThumbnail = makeThumbnail(org, ThumbnailSize.Large)
-      squareThumbnail = makeThumbnail(org, ThumbnailSize.Square)
-      resultSmall <- ThumbnailDao.insert(smallThumbnail)
-      resultLarge <- ThumbnailDao.insert(largeThumbnail)
-      resultSquare <- ThumbnailDao.insert(squareThumbnail)
-    } yield (resultSmall, resultLarge, resultSquare)
-
-    val (small, large, square) = transaction.transact(xa).unsafeRunSync
-    small.thumbnailSize shouldBe ThumbnailSize.Small
-    large.thumbnailSize shouldBe ThumbnailSize.Large
-    square.thumbnailSize shouldBe ThumbnailSize.Square
-  }
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -45,6 +45,10 @@ then
         docker-compose \
             run --rm --no-deps api-server scapegoat
 
+        echo "Preparing the database for testing"
+        docker-compose \
+            run --rm api-server ";mg init;mg update;mg apply"
+
         echo "Executing Scala test suite"
         docker-compose \
             run --rm api-server test


### PR DESCRIPTION
## Overview

This PR adds property tests and fixes for bugs discovered while adding property tests for the `ProjectDao`.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

There's a `DO NOT MERGE` commit in here for explicitly running migrations before scala tests
execute. I'd like to figure out how to handle that appropriately and have added a checklist item in #3134 
to get rid of or refactor that step. It's included here to prove / verify that ProjectDao tests work in CI.

A separate PR will address unrelated testing failures

## Testing Instructions

 * CI