### PR TITLE
Annotation export as shapefile and project annotation api bug fix

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AnnotationDao.scala
@@ -30,12 +30,6 @@ object AnnotationDao extends Dao[Annotation] {
       FROM
     """ ++ tableF
 
-  def listAnnotationsForProject(projectId: UUID, user: User): ConnectionIO[List[Annotation]] = {
-    (selectF ++ Fragments.whereAndOpt(fr"project_id = ${projectId}".some, query.ownerFilterF(user)))
-      .query[Annotation]
-      .stream.compile.toList
-  }
-
   def insertAnnotations(
     annotations: List[Annotation.Create],
     projectId: UUID,
@@ -79,4 +73,3 @@ object AnnotationDao extends Dao[Annotation] {
   }
 
 }
-

--- a/app-frontend/src/app/pages/projects/edit/annotate/export/export.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/export/export.html
@@ -8,15 +8,25 @@
   </div>
   <div class="list-group">
     <div class="list-group-item">
+      <label>Export Format:</lable>
+      <select class="form-control"
+              ng-init="$ctrl.exportType = 'GeoJSON'"
+              ng-model="$ctrl.exportType">
+        <option value="GeoJSON">GeoJSON</option>
+        <option value="Shapefile" ng-if="$ctrl.hasShapefile">Shapefile</option>
+      </select>
+    </div>
+    <div class="list-group-item" ng-if="$ctrl.exportType === 'GeoJSON'">
       <input type="text"
              ng-model="$ctrl.fileName"
              class="form-control"
              placeholder="File Name">
     </div>
-    <div class="list-group-item" ng-if="$ctrl.fileName">
+    <div class="list-group-item">
       <button class="btn btn-primary btn-block"
               type="button"
-              ng-click="$ctrl.onExportClick($event)">
+              ng-click="$ctrl.onExportClick($event)"
+              ng-disabled="$ctrl.exportType === 'GeoJSON' && !$ctrl.fileName">
         Export
       </button>
     </div>

--- a/app-frontend/src/app/pages/projects/edit/annotate/export/export.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/export/export.module.js
@@ -4,13 +4,16 @@ import {annotationsToFeatureCollection} from '_redux/annotation-utils';
 
 class AnnotateExportController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $scope, $ngRedux
+        $log, $state, $scope, $ngRedux,
+        projectService
     ) {
         'ngInject';
         this.$log = $log;
         this.$state = $state;
         this.$scope = $scope;
         this.$parent = $scope.$parent.$ctrl;
+
+        this.projectService = projectService;
 
         let unsubscribe = $ngRedux.connect(
             this.mapStateToThis
@@ -26,12 +29,26 @@ class AnnotateExportController {
 
     $onInit() {
         this.visibleAnnotations = this.$parent.visibleAnnotations;
+        this.projectService.getAnnotationShapefile(this.$state.params.projectid).then(
+            (res) => {
+                this.shapefileDlUri = res.data;
+                this.hasShapefile = true;
+            },
+            (err) => {
+                this.hasShapefile = false;
+                this.$log.error(err);
+            }
+        );
     }
 
     onAnnotationsDownload(e, annotationData) {
         let href = `data:text/json;charset=utf-8,${encodeURI(JSON.stringify(annotationData))}`;
         let dl = angular.element(`<a href="${href}"
             download="${this.fileName}.geojson"></a>`);
+        if (this.exportType === 'Shapefile' && this.shapefileDlUri) {
+            href = this.shapefileDlUri;
+            dl = angular.element(`<a href="${href}"></a>`);
+        }
         angular.element(e.target).parent().append(dl);
         dl[0].click();
         dl.remove();

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -523,6 +523,13 @@ export default (app) => {
                 sceneIds
             ).$promise;
         }
+
+        getAnnotationShapefile(projectId) {
+            return this.$http({
+                method: 'GET',
+                url: `${BUILDCONFIG.API_HOST}/api/projects/${projectId}/annotations/shapefile`
+            });
+        }
     }
 
     app.service('projectService', ProjectService);


### PR DESCRIPTION
## Overview

This PR:
* updates backend support for annotation export as zipped shapefile
* enables frontend to export project annotations as geojson or zipped shapefile
* fixes a backend bug so that project id filter is applied when getting project specific annotations

### Checklist

~Styleguide updated, if necessary~
~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Check in your annotation and non-annotation projects and see if annotations are in the correct projects
 * In a project with annotations, check to see if you can download them in either geojson or shapefile format, load them in GIS software/tool to make sure the data are correct 

Closes #3117 and #3118 
