### PR TITLE
Add property tests for ShapeDao

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -183,7 +183,6 @@ object Generators extends ArbitraryInstances {
       resolutionMeters, metadataFiles, bands
     )
   )
-
   private def imageGen: Gen[Image] = for {
     imCreate <- imageCreateGen
     user <- userGen

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -75,7 +75,7 @@ object SceneDao extends Dao[Scene] {
     val sceneWithRelatedquery = SceneWithRelatedDao.query.filter(scene.id).select
 
     for {
-      sceneId <- sceneInsert
+      sceneId <- sceneInsertId
       _ <- thumbnailInsert
       _ <- imageInsert
       _ <- bandInsert

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -79,8 +79,9 @@ object SceneDao extends Dao[Scene] {
       _ <- thumbnailInsert
       _ <- imageInsert
       _ <- bandInsert
+      // It's fine to do this unsafely, since we know we the prior insert succeeded
       sceneWithRelated <- SceneWithRelatedDao.unsafeGetScene(sceneId, user)
-    } yield { sceneWithRelated }
+    } yield sceneWithRelated
   }
 
   def insertMaybe(sceneCreate: Scene.Create, user: User): ConnectionIO[Option[Scene.WithRelated]] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -75,13 +75,12 @@ object SceneDao extends Dao[Scene] {
     val sceneWithRelatedquery = SceneWithRelatedDao.query.filter(scene.id).select
 
     for {
-      sceneId <- sceneInsertId
+      sceneId <- sceneInsert
       _ <- thumbnailInsert
       _ <- imageInsert
       _ <- bandInsert
-      // It's fine to do this unsafely, since we know we the prior insert succeeded
       sceneWithRelated <- SceneWithRelatedDao.unsafeGetScene(sceneId, user)
-    } yield sceneWithRelated
+    } yield { sceneWithRelated }
   }
 
   def insertMaybe(sceneCreate: Scene.Create, user: User): ConnectionIO[Option[Scene.WithRelated]] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ShapeDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ShapeDao.scala
@@ -26,6 +26,12 @@ object ShapeDao extends Dao[Shape] {
     FROM
   """ ++ tableF
 
+  def unsafeGetShapeById(shapeId: UUID, user: User): ConnectionIO[Shape] =
+    query.filter(shapeId).ownerFilter(user).select
+
+  def getShapeById(shapeId: UUID, user: User): ConnectionIO[Option[Shape]] =
+    query.filter(shapeId).ownerFilter(user).selectOption
+
   def insertShapes(shapes: Seq[Shape.Create], user: User): ConnectionIO[Seq[Shape.GeoJSON]] = {
     val insertSql = """
        INSERT INTO shapes

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -59,6 +59,20 @@ trait PropTestHelpers {
     )
   }
 
+  def fixupShapeCreate(user: User, org: Organization, shapeCreate: Shape.Create): Shape.Create =
+    shapeCreate.copy(owner = Some(user.id), organizationId = org.id)
+
+  def fixupShapeGeoJSON(user: User, org: Organization, shape: Shape, shapeGeoJSON: Shape.GeoJSON): Shape.GeoJSON =
+    shapeGeoJSON.copy(
+      id = shape.id,
+      properties = shapeGeoJSON.properties.copy(
+        createdBy = user.id,
+        modifiedBy = user.id,
+        owner = user.id,
+        organizationId = org.id
+      )
+    )
+
   def fixupImageBanded(ownerId: String, orgId: UUID, sceneId: UUID, image: Image.Banded): Image.Banded = {
     image.copy(
       owner = Some(ownerId),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
@@ -1,6 +1,7 @@
 package com.azavea.rf.database
 
 import com.azavea.rf.datamodel.{User, Organization, Shape}
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 
 import doobie._, doobie.implicits._
@@ -9,32 +10,94 @@ import cats.syntax.either._
 import cats.syntax.option._
 import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 
 import geotrellis.slick.Projected
 import geotrellis.vector.{MultiPolygon, Polygon, Point}
 
 
-class ShapeDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ShapeDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
 
-  test("types") { check(ShapeDao.selectF.query[Shape]) }
-  test("insertion") {
-    val testPoly = Projected(MultiPolygon(Polygon(Point(1, 0), Point(1, 1), Point(0, 1), Point(1, 0))), 3857)
-    val someShapes = (user : User, org : Organization) => Seq(
-      Shape.Create(None, org.id, "Good shape", None, None),
-      Shape.Create(None, org.id, "Great shape", "A great shape".some, testPoly.some),
-      Shape.Create(user.id.some, org.id, "Best shape", "The best shape".some, testPoly.some)
-    )
-    val transaction = for {
-      user <- defaultUserQ
-      org <- rootOrgQ
-      shapes = someShapes(user, org)
-      shapesIn <- ShapeDao.insertShapes(shapes, user)
-    } yield (shapesIn)
+  test("list shapes") {
+    ShapeDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+  }
 
-    val result = transaction.transact(xa).unsafeRunSync
+  test("insert shapes") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, shapes: Seq[Shape.Create]) => {
+          val shapeInsertIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              ShapeDao.insertShapes(shapes map {fixupShapeCreate(dbUser, dbOrg, _)}, dbUser)
+            }
+          }
+          shapeInsertIO.transact(xa).unsafeRunSync.length == shapes.length
+        }
+      }
+    }
+  }
 
-    result.length shouldBe 3
+  test("update a shape") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, shapeInsert: Shape.Create, shapeUpdate: Shape.GeoJSON) => {
+          val shapeInsertWithUserAndOrgIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              ShapeDao.insertShapes(List(shapeInsert) map {fixupShapeCreate(dbUser, dbOrg, _)}, dbUser) map {
+                (shapes: Seq[Shape.GeoJSON]) => (shapes.head.toShape, dbUser, dbOrg)
+              }
+            }
+          }
+          val updateWithShapeIO = shapeInsertWithUserAndOrgIO flatMap {
+            case (insertShape: Shape, dbUser: User, dbOrg: Organization) => {
+              ShapeDao.updateShape(fixupShapeGeoJSON(dbUser, dbOrg, insertShape, shapeUpdate), insertShape.id, dbUser) flatMap {
+                (affectedRows: Int) => {
+                  ShapeDao.unsafeGetShapeById(insertShape.id, dbUser) map { (affectedRows, _) }
+                }
+              }
+            }
+          }
+
+          val (affectedRows, updatedShape) = updateWithShapeIO.transact(xa).unsafeRunSync
+
+          val shapeUpdateShape = shapeUpdate.toShape
+
+          affectedRows == 1 &&
+            updatedShape.name == shapeUpdateShape.name &&
+            updatedShape.description == shapeUpdateShape.description &&
+            updatedShape.geometry == shapeUpdateShape.geometry
+
+        }
+      }
+    }
+  }
+
+  test("get a shape by id") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, shape: Shape.Create) => {
+          val shapeInsertWithUserIO = insertUserAndOrg(user, org) flatMap {
+            case (dbOrg: Organization, dbUser: User) => {
+              ShapeDao.insertShapes(List(shape) map {fixupShapeCreate(dbUser, dbOrg, _)}, dbUser) map {
+                (_, dbUser)
+              }
+            }
+          }
+
+          val shapeByIdIO = shapeInsertWithUserIO flatMap {
+            case (shapes: List[Shape], dbUser: User) => {
+              // safe because we just put it there -- errors here mean insert is broken
+              val insertedShape = shapes.head.toShape
+              ShapeDao.getShapeById(insertedShape.id, dbUser) map { _.get == insertedShape }
+            }
+          }
+
+          shapeByIdIO.transact(xa).unsafeRunSync
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

This PR adds property tests for the ShapeDao.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

I rebased the anchor branch on develop because there were merge conflicts so there are some unrelated changes here -- safe to focus on the ShapeDaoSpec and Generators changes

## Testing Instructions

 * CI