### PR TITLE
Add property tests for ThumbnailDao

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -237,6 +237,11 @@ object Generators extends ArbitraryInstances {
     Thumbnail.Identified(id, organizationId, thumbnailSize, sideLength, sideLength, sceneId, url)
   }
 
+  private def thumbnailGen: Gen[Thumbnail] = for {
+    thumbnailIdentified <- thumbnailIdentifiedGen
+    userId <- nonEmptyStringGen
+  } yield { thumbnailIdentified.toThumbnail(userId) }
+
   private def sceneCreateGen: Gen[Scene.Create] = for {
     sceneId <- uuidGen map { Some(_) }
     organizationId <- uuidGen
@@ -310,6 +315,8 @@ object Generators extends ArbitraryInstances {
     implicit def arbSceneCreate: Arbitrary[Scene.Create] = Arbitrary { sceneCreateGen }
 
     implicit def arbListSceneCreate: Arbitrary[List[Scene.Create]] = Arbitrary { Gen.listOfN(3, sceneCreateGen) }
+
+    implicit def arbThumbnail: Arbitrary[Thumbnail] = Arbitrary { thumbnailGen }
 
     implicit def arbDatasourceCreate: Arbitrary[Datasource.Create] = Arbitrary { datasourceCreateGen }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -59,7 +59,7 @@ object SceneDao extends Dao[Scene] {
          data_footprint, metadata_files, ingest_location, cloud_cover,
          acquisition_date, sun_azimuth, sun_elevation, thumbnail_status,
          boundary_status, ingest_status
-      )""") ++ fr"""VALUES (
+      )""" ++ fr"""VALUES (
         ${scene.id}, ${scene.createdAt}, ${scene.createdBy}, ${scene.modifiedAt}, ${scene.modifiedBy}, ${scene.owner},
         ${scene.organizationId}, ${scene.ingestSizeBytes}, ${scene.visibility}, ${scene.tags},
         ${scene.datasource}, ${scene.sceneMetadata}, ${scene.name}, ${scene.tileFootprint},

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ThumbnailDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ThumbnailDao.scala
@@ -21,7 +21,13 @@ object ThumbnailDao extends Dao[Thumbnail] {
     FROM
   """ ++ tableF
 
-  def insertMany(thumbnails: Seq[Thumbnail]): ConnectionIO[Int] = {
+  def unsafeGetThumbnailById(thumbnailId: UUID): ConnectionIO[Thumbnail] =
+    query.filter(thumbnailId).select
+
+  def getThumbnailById(thumbnailId: UUID): ConnectionIO[Option[Thumbnail]] =
+    query.filter(thumbnailId).selectOption
+
+  def insertMany(thumbnails: List[Thumbnail]): ConnectionIO[Int] = {
     val insertSql = """
       INSERT INTO thumbnails (
         id, created_at, modified_at, organization_id, width_px,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -28,6 +28,15 @@ trait PropTestHelpers {
     } yield (org, user, project)
   }
 
+  def insertUserOrgScene(user: User.Create, org: Organization.Create, scene: Scene.Create) = {
+    for {
+      orgUserInsert <- insertUserAndOrg(user, org)
+      (dbOrg, dbUser) = orgUserInsert
+      dbDatasource <- unsafeGetRandomDatasource
+      scene <- SceneDao.insert(fixupSceneCreate(dbUser, dbOrg, dbDatasource, scene), dbUser)
+    } yield (dbOrg, dbUser, scene)
+  }
+
   def unsafeGetRandomDatasource: ConnectionIO[Datasource] =
     (DatasourceDao.selectF ++ fr"ORDER BY RANDOM() limit 1").query[Datasource].unique
 
@@ -75,4 +84,6 @@ trait PropTestHelpers {
     } yield ds
   }
 
+  def fixupThumbnail(org: Organization, scene: Scene.WithRelated, thumbnail: Thumbnail): Thumbnail =
+    thumbnail.copy(organizationId = org.id, sceneId = scene.id)
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
@@ -1,35 +1,94 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.{Organization, Thumbnail, ThumbnailSize}
+import com.azavea.rf.datamodel.Generators.Implicits._
+import com.azavea.rf.datamodel._
 import com.azavea.rf.database.Implicits._
 
 import doobie._, doobie.implicits._
 import cats._, cats.data._, cats.effect.IO
 import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 import java.util.UUID
 
 
-class ThumbnailDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ThumbnailDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
 
-  test("types") { check(ThumbnailDao.selectF.query[Thumbnail]) }
-
-  // This is a scene id from the development data. If this test starts failing for non-
-  // obvious reasons, it probably means this scene is no longer part of development
-  // data for some reason. This isn't ideal, but the notion of a "default" scene doesn't
-  // make too much sense, so it's something to get the tests to run for now.
-  val sceneId : UUID = UUID.fromString("a9ce69c2-f87e-4119-863d-d570afb53983")
-  val makeThumbnail = (org : Organization, thumbnailSize : ThumbnailSize) => {
-    Thumbnail.Create(
-      org.id,
-      thumbnailSize,
-      256,
-      256,
-      sceneId,
-      "https://url.com"
-    ).toThumbnail
+  test("list thumbnails") {
+    ThumbnailDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
   }
+
+  test("insert a thumbnail") {
+    check {
+      forAll {
+        (org: Organization.Create, user: User.Create, scene: Scene.Create, thumbnail: Thumbnail) => {
+          val thumbnailInsertIO = insertUserOrgScene(user, org, scene) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbScene: Scene.WithRelated) => {
+              ThumbnailDao.insert(fixupThumbnail(dbOrg, dbScene, thumbnail))
+            }
+          }
+          val insertedThumbnail = thumbnailInsertIO.transact(xa).unsafeRunSync
+
+          insertedThumbnail.widthPx == thumbnail.widthPx &&
+            insertedThumbnail.heightPx == thumbnail.heightPx &&
+            insertedThumbnail.url == thumbnail.url &&
+            insertedThumbnail.thumbnailSize == thumbnail.thumbnailSize
+        }
+      }
+    }
+  }
+
+  test("insert many thumbnails") {
+    check {
+      forAll {
+        (org: Organization.Create, user: User.Create, scene: Scene.Create, thumbnails: List[Thumbnail]) => {
+          val thumbnailsInsertIO = insertUserOrgScene(user, org, scene) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbScene: Scene.WithRelated) => {
+              ThumbnailDao.insertMany(thumbnails map { fixupThumbnail(dbOrg, dbScene, _) })
+            }
+          }
+          thumbnailsInsertIO.transact(xa).unsafeRunSync == thumbnails.length
+        }
+      }
+    }
+  }
+
+  test("update a thumbnail") {
+    check {
+      forAll {
+        (org: Organization.Create, user: User.Create, scene: Scene.Create, insertThumbnail: Thumbnail, updateThumbnail: Thumbnail) => {
+          val thumbnailInsertIO = insertUserOrgScene(user, org, scene) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbScene: Scene.WithRelated) => {
+              ThumbnailDao.insert(fixupThumbnail(dbOrg, dbScene, insertThumbnail))
+            }
+          }
+
+          val thumbnailUpdateWithThumbnailIO = thumbnailInsertIO flatMap {
+            (dbThumbnail: Thumbnail) => {
+              val withFks = updateThumbnail.copy(
+                id = dbThumbnail.id,
+                organizationId = dbThumbnail.organizationId,
+                sceneId = dbThumbnail.sceneId
+              )
+              ThumbnailDao.update(withFks, dbThumbnail.id) flatMap {
+                (affectedRows: Int) => {
+                  ThumbnailDao.unsafeGetThumbnailById(dbThumbnail.id) map { (affectedRows, _) }
+                }
+              }
+            }
+          }
+
+          val (affectedRows, updatedThumbnail) = thumbnailUpdateWithThumbnailIO.transact(xa).unsafeRunSync
+          affectedRows == 1 &&
+            updatedThumbnail.widthPx == updateThumbnail.widthPx &&
+            updatedThumbnail.heightPx == updateThumbnail.heightPx &&
+            updatedThumbnail.url == updateThumbnail.url &&
+            updatedThumbnail.thumbnailSize == updateThumbnail.thumbnailSize
+        }
+      }
+    }
+  }
+
 }
 


### PR DESCRIPTION
## Overview

This PR adds property tests for the ThumbnailDao

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * CI