### PR TITLE
Add AoiDao property tests

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -279,6 +279,17 @@ object Generators extends ArbitraryInstances {
                  metadataFiles, images, thumbnails, ingestLocation, filterFields, statusFields)
   }
 
+  private def aoiGen: Gen[AOI] = for {
+    id <- uuidGen
+    timeField <- timestampIn2016Gen
+    organizationId <- uuidGen
+    userField <- nonEmptyStringGen
+    area <- projectedMultiPolygonGen3857
+    filters <- Gen.const(().asJson) // maybe this should be CombinedSceneQueryParams as json
+  } yield {
+    AOI(id, timeField, timeField, organizationId, userField, userField, userField, area, filters)
+  }
+
   private def datasourceCreateGen: Gen[Datasource.Create] = for {
     orgId <- uuidGen
     name <- nonEmptyStringGen
@@ -351,5 +362,7 @@ object Generators extends ArbitraryInstances {
     implicit def arbDatasourceCreate: Arbitrary[Datasource.Create] = Arbitrary { datasourceCreateGen }
 
     implicit def arbUploadCreate: Arbitrary[Upload.Create] = Arbitrary { uploadCreateGen }
+
+    implicit def arbAOI: Arbitrary[AOI] = Arbitrary { aoiGen }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
@@ -28,6 +28,12 @@ object AoiDao extends Dao[AOI] {
       FROM
     """ ++ tableF
 
+  def unsafeGetAoiById(id: UUID, user: User): ConnectionIO[AOI] =
+    query.ownerFilter(user).filter(id).select
+
+  def getAoiById(id: UUID, user: User): ConnectionIO[Option[AOI]] =
+    query.ownerFilter(user).filter(id).selectOption
+
   def updateAOI(aoi: AOI, id: UUID, user: User): ConnectionIO[Int] = {
     (fr"UPDATE" ++ tableF ++ fr"SET" ++ fr"""
         modified_at = NOW(),
@@ -40,14 +46,13 @@ object AoiDao extends Dao[AOI] {
   }
 
   def createAOI(aoi: AOI, projectId: UUID, user: User): ConnectionIO[AOI] = {
-    val id = UUID.randomUUID
     val ownerId = Ownership.checkOwner(user, Some(aoi.owner))
 
     val aoiCreate: ConnectionIO[AOI] = (fr"INSERT INTO" ++ tableF ++ fr"""
         (id, created_at, modified_at, organization_id,
         created_by, modified_by, owner, area, filters)
       VALUES
-        (${id}, NOW(), NOW(), ${user.organizationId},
+        (${aoi.id}, NOW(), NOW(), ${user.organizationId},
         ${user.id}, ${user.id}, ${ownerId}, ${aoi.area}, ${aoi.filters})
     """).update.withUniqueGeneratedKeys[AOI](
       "id", "created_at", "modified_at", "organization_id",

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
@@ -70,21 +70,10 @@ object AoiDao extends Dao[AOI] {
       )).query[AOI].list
   }
 
-  def deleteAOI(id: UUID, user: User): ConnectionIO[Int]={
-    val deleteAoiToProject = (
-      fr"DELETE FROM" ++ AoiToProjectDao.tableF ++ fr"WHERE aoi_id = ${id}"
+  def deleteAOI(id: UUID, user: User): ConnectionIO[Int]= {
+    (
+      fr"DELETE FROM" ++ tableF ++ Fragments.whereAndOpt(query.ownerFilterF(user), Some(fr"id = ${id}"))
     ).update.run
-
-    val deleteAoi = (
-      fr"DELETE FROM" ++ tableF ++ fr"WHERE id = ${id}"
-    ).update.run
-
-    val transaction = for {
-      _ <- deleteAoiToProject
-      del <- deleteAoi
-    } yield del
-
-    transaction
   }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -1,22 +1,132 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.AOI
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 
 import io.circe._
 import io.circe.syntax._
 import doobie._, doobie.implicits._
 import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
 import cats.syntax.either._
 import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import geotrellis.slick._
 import geotrellis.vector._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 
 
-class AoiDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
 
-  test("types") { check(AoiDao.selectF.query[AOI]) }
+  test("list AOIs") {
+    AoiDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+  }
+
+  test("insert an AOI") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, aoi: AOI) => {
+          val aoiInsertIO = insertUserOrgProject(user, org, project) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+              AoiDao.createAOI(fixupAoi(dbUser, dbOrg, aoi), dbProject.id, dbUser)
+            }
+          }
+          val insertedAoi = aoiInsertIO.transact(xa).unsafeRunSync
+
+          insertedAoi.area == aoi.area &&
+            insertedAoi.filters == aoi.filters
+        }
+      }
+    }
+  }
+
+  test("update an AOI") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, aoiInsert: AOI, aoiUpdate: AOI) => {
+          val aoiInsertWithOrgUserIO = insertUserOrgProject(user, org, project) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+              AoiDao.createAOI(fixupAoi(dbUser, dbOrg, aoiInsert), dbProject.id, dbUser) map {
+                (_, dbOrg, dbUser)
+              }
+            }
+          }
+
+          val aoiUpdateWithAoi = aoiInsertWithOrgUserIO flatMap {
+            case (dbAoi: AOI, dbOrg: Organization, dbUser: User) => {
+              val aoiId = dbAoi.id
+              val fixedUpUpdateAoi = fixupAoi(dbUser, dbOrg, aoiUpdate).copy(id = aoiId)
+              AoiDao.updateAOI(fixedUpUpdateAoi, aoiId, dbUser) flatMap {
+                (affectedRows: Int) => {
+                  AoiDao.unsafeGetAoiById(aoiId, dbUser) map { (affectedRows, _) }
+                }
+              }
+            }
+          }
+
+          val (affectedRows, updatedAoi) = aoiUpdateWithAoi.transact(xa).unsafeRunSync
+
+          affectedRows == 1 &&
+            updatedAoi.area == aoiUpdate.area &&
+            updatedAoi.filters == aoiUpdate.filters
+
+        }
+      }
+    }
+  }
+
+  test("delete an AOI") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, aoi: AOI) => {
+          val aoiDeleteIO = insertUserOrgProject(user, org, project) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+              AoiDao.createAOI(fixupAoi(dbUser, dbOrg, aoi), dbProject.id, dbUser) map {
+                (_, dbUser)
+              }
+            }
+          } flatMap {
+            case (dbAoi: AOI, dbUser: User) => {
+              AoiDao.deleteAOI(dbAoi.id, dbUser)
+            }
+          }
+
+          aoiDeleteIO.transact(xa).unsafeRunSync == 1
+
+        }
+      }
+    }
+  }
+
+  test("list AOIs for a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, aois: List[AOI]) => {
+          val aoisInsertWithProjectUserIO = insertUserOrgProject(user, org, project) flatMap {
+            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+              aois.traverse((aoi: AOI) => AoiDao.createAOI(fixupAoi(dbUser, dbOrg, aoi), dbProject.id, dbUser)) map {
+                (_, dbProject, dbUser)
+              }
+            }
+          }
+
+          val aoisForProject = aoisInsertWithProjectUserIO flatMap {
+            case (dbAois: List[AOI], dbProject: Project, dbUser: User) => {
+              AoiDao.listAOIs(dbProject.id, dbUser) map {
+                (dbAois, _)
+              }
+            }
+          }
+
+          val (dbAois, listedAois) = aoisForProject.transact(xa).unsafeRunSync
+          (dbAois.toSet map { (aoi: AOI) => aoi.area }) == (listedAois.toSet map { (aoi: AOI) => aoi.area })
+        }
+      }
+    }
+  }
+
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -98,4 +98,8 @@ trait PropTestHelpers {
       case _ => withoutProjectFixup
     }
   }
+
+  def fixupAoi(user: User, org: Organization, aoi: AOI): AOI = {
+    aoi.copy(organizationId = org.id, owner = user.id, createdBy = user.id, modifiedBy = user.id)
+  }
 }

--- a/app-backend/migrations/src_migrations/main/scala/103.scala
+++ b/app-backend/migrations/src_migrations/main/scala/103.scala
@@ -11,6 +11,9 @@ ALTER TABLE users ALTER COLUMN dropbox_credential SET NOT NULL;
 ALTER TABLE users ALTER COLUMN planet_credential SET DEFAULT '';
 UPDATE users SET planet_credential = '' WHERE planet_credential IS NULL;
 ALTER TABLE users ALTER COLUMN planet_credential SET NOT NULL;
+
+ALTER TABLE aois_to_projects DROP CONSTRAINT aois_to_projects_aoi_id_fkey;
+ALTER TABLE aois_to_projects ADD CONSTRAINT aois_to_projects_aoi_id_fkey FOREIGN KEY (aoi_id) REFERENCES aois(id) ON DELETE CASCADE;
 """
   ))
 }


### PR DESCRIPTION
## Overview

This PR adds AoiDao property tests and fixes two bugs -- one was related to deletes, which weren't
filtering to AOIs a user could see. The other was related to creating AOIs, which was failing to thread
through the actual ID of the created AOI properly.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * CI