### PR TITLE
Add scene dao tests

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -44,6 +44,12 @@ object SceneDao extends Dao[Scene] {
     FROM
   """ ++ tableF
 
+  def getSceneById(id: UUID, user: User): ConnectionIO[Option[Scene]] =
+    query.filter(id).ownerFilter(user).selectOption
+
+  def unsafeGetSceneById(id: UUID, user: User): ConnectionIO[Scene] =
+    query.filter(id).ownerFilter(user).select
+
   def insert(sceneCreate: Scene.Create, user: User): ConnectionIO[Scene.WithRelated] = {
     val scene = sceneCreate.toScene(user)
     val thumbnails = sceneCreate.thumbnails.map(_.toThumbnail(user.id))
@@ -144,6 +150,9 @@ object SceneDao extends Dao[Scene] {
       datasource = ${scene.datasource},
       scene_metadata = ${scene.sceneMetadata},
       name = ${scene.name},
+      data_footprint = ${scene.dataFootprint},
+      tile_footprint = ${scene.tileFootprint},
+      ingest_location = ${scene.ingestLocation},
       cloud_cover = ${scene.filterFields.cloudCover},
       acquisition_date = ${scene.filterFields.acquisitionDate},
       sun_azimuth = ${scene.filterFields.sunAzimuth},

--- a/app-backend/db/src/test/resources/logback-test.xml
+++ b/app-backend/db/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+    <pattern>%-5level %logger{0}: %msg%n</pattern>
+  </encoder> 
+  </appender>
+
+	<logger name="geotrellis.vector.io" level="info" additivity="false">
+		<appender-ref ref="STDOUT" />
+	</logger>
+
+	<root level="debug">
+		<appender-ref ref="STDOUT" />
+	</root>
+
+</configuration>

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
@@ -1,16 +1,119 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.Scene
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 
 import doobie._, doobie.implicits._
 import cats._, cats.data._, cats.effect.IO
 import cats.syntax.either._
 import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 
 
-class SceneDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
-  test("selection types") { check(SceneDao.selectF.query[Scene]) }
+class SceneDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+  test("list scenes") {
+    SceneDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+  }
+
+  test("insert a scene") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, scene: Scene.Create) => {
+          val sceneInsertIO = for {
+            orgAndUser <- insertUserAndOrg(user, org)
+            (dbOrg, dbUser) = orgAndUser
+            datasource <- unsafeGetRandomDatasource
+            sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser, dbOrg, datasource, scene), dbUser)
+          } yield sceneInsert
+          val insertedScene = sceneInsertIO.transact(xa).unsafeRunSync
+
+          insertedScene.visibility == scene.visibility &&
+            insertedScene.tags == scene.tags &&
+            insertedScene.sceneMetadata == scene.sceneMetadata &&
+            insertedScene.name == scene.name &&
+            insertedScene.tileFootprint == scene.tileFootprint &&
+            insertedScene.dataFootprint == scene.dataFootprint &&
+            insertedScene.metadataFiles == scene.metadataFiles &&
+            insertedScene.ingestLocation == scene.ingestLocation &&
+            insertedScene.filterFields == scene.filterFields &&
+            insertedScene.statusFields == scene.statusFields
+        }
+      }
+    }
+  }
+
+  test("maybe insert a scene") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, scene: Scene.Create) => {
+          val sceneInsertIO = for {
+            orgAndUser <- insertUserAndOrg(user, org)
+            (dbOrg, dbUser) = orgAndUser
+            datasource <- unsafeGetRandomDatasource
+            sceneInsert <- SceneDao.insertMaybe(fixupSceneCreate(dbUser, dbOrg, datasource, scene), dbUser)
+          } yield sceneInsert
+          val insertedSceneO = sceneInsertIO.transact(xa).unsafeRunSync
+          // our expectation is that this should succeed so this should be safe -- if it fails that indicates
+          // something else was wrong
+          val insertedScene = insertedSceneO.get
+
+          insertedScene.visibility == scene.visibility &&
+            insertedScene.tags == scene.tags &&
+            insertedScene.sceneMetadata == scene.sceneMetadata &&
+            insertedScene.name == scene.name &&
+            insertedScene.tileFootprint == scene.tileFootprint &&
+            insertedScene.dataFootprint == scene.dataFootprint &&
+            insertedScene.metadataFiles == scene.metadataFiles &&
+            insertedScene.ingestLocation == scene.ingestLocation &&
+            insertedScene.filterFields == scene.filterFields &&
+            insertedScene.statusFields == scene.statusFields
+        }
+      }
+    }
+  }
+
+  test("update a scene") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, insertScene: Scene.Create, updateScene: Scene.Create) => {
+          val sceneInsertWithUserOrgDatasourceIO = for {
+            orgAndUser <- insertUserAndOrg(user, org)
+            (dbOrg, dbUser) = orgAndUser
+            datasource <- unsafeGetRandomDatasource
+            sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser, dbOrg, datasource, insertScene), dbUser)
+          } yield (sceneInsert, dbUser, dbOrg, datasource)
+
+          val sceneUpdateWithSceneIO = sceneInsertWithUserOrgDatasourceIO flatMap {
+            case (dbScene: Scene.WithRelated, dbUser: User, dbOrg: Organization, dbDatasource: Datasource) => {
+              val sceneId = dbScene.id
+              val fixedUpUpdateScene = fixupSceneCreate(dbUser, dbOrg, dbDatasource, updateScene)
+                .toScene(dbUser)
+                .copy(id = dbScene.id)
+              SceneDao.update(fixedUpUpdateScene, sceneId, dbUser) flatMap {
+                case (affectedRows: Int, _) => {
+                  SceneDao.unsafeGetSceneById(sceneId, dbUser) map { (affectedRows, _) }
+                }
+              }
+            }
+          }
+
+          val (affectedRows, updatedScene) = sceneUpdateWithSceneIO.transact(xa).unsafeRunSync
+
+          affectedRows == 1 &&
+            updatedScene.visibility == updateScene.visibility &&
+            updatedScene.tags == updateScene.tags &&
+            updatedScene.sceneMetadata == updateScene.sceneMetadata &&
+            updatedScene.name == updateScene.name &&
+            updatedScene.tileFootprint == updateScene.tileFootprint &&
+            updatedScene.dataFootprint == updateScene.dataFootprint &&
+            updatedScene.ingestLocation == updateScene.ingestLocation &&
+            updatedScene.filterFields == updateScene.filterFields &&
+            updatedScene.statusFields == updateScene.statusFields
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds property tests for the SceneDao. It also tells geotrellis vector WKT logging to chill out. It also fixes a bug or two about updating scenes. See the notes.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Update behavior was a little odd. There are three fields that weren't update-able that I feel like at least maybe should be:

- `ingest_location` -- we have to be able to set this. It's necessary. This was definitely a bug.
- `tile_footprint`/`data_footprint` -- we might miscalculate these and want to provide correction later
- `metadata_files` -- I can imagine users wanting to provide this for scenes that they upload

I modified the `SceneDao.update` method so that the first two can be updated. The third I skipped because the `Meta` for `List[String]` wasn't cooperating and I was getting a sql error. We should make explicit choices about these though, rather than "the choice that happened to be convenient while I was overhauling testing".

## Testing Instructions

 * CI