### PR TITLE
Add SceneWithRelatedDao property tests

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -28,7 +28,7 @@ object Generators extends ArbitraryInstances {
     Gen.nonEmptyListOf[Char](Gen.alphaChar).map(_.mkString)
 
   private def pageRequestGen: Gen[PageRequest] =
-    Gen.const(PageRequest(0, 20, Map("createdAt" -> Order.Desc)))
+    Gen.const(PageRequest(0, 20, Map("created_at" -> Order.Desc)))
 
   private def userRoleGen: Gen[UserRole] = Gen.oneOf(UserRoleRole, Viewer, Admin)
 
@@ -296,7 +296,7 @@ object Generators extends ArbitraryInstances {
     dataFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
     metadataFiles <- stringListGen
     images <- Gen.oneOf(1, 10) flatMap { Gen.listOfN(_, imageBandedGen) }
-    thumbnails <- Gen.oneOf(0, 2) flatMap { Gen.listOfN(_, thumbnailIdentifiedGen) }
+    thumbnails <- Gen.oneOf(1, 2) flatMap { Gen.listOfN(_, thumbnailIdentifiedGen) }
     ingestLocation <- Gen.oneOf(nonEmptyStringGen map { Some(_) }, Gen.const(None))
     filterFields <- sceneFilterFieldsGen
     statusFields <- sceneStatusFieldsGen
@@ -361,10 +361,15 @@ object Generators extends ArbitraryInstances {
     layerAttributes <- Gen.listOfN(10, layerAttributeGen)
   } yield layerAttributes map { _.copy(layerName = layerName) }
 
+  private def combinedSceneQueryParamsGen: Gen[CombinedSceneQueryParams] =
+    Gen.const(CombinedSceneQueryParams())
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
 
     implicit def arbPageRequest: Arbitrary[PageRequest] = Arbitrary { pageRequestGen }
+
+    implicit def arbCombinedSceneQueryParams: Arbitrary[CombinedSceneQueryParams] = Arbitrary { combinedSceneQueryParamsGen }
 
     implicit def arbAnnotationCreate: Arbitrary[Annotation.Create] = Arbitrary { annotationCreateGen }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -17,7 +17,6 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 
 import java.util.UUID
 
-// TODO: query for a single scene is bad here for some reason, fix it
 object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
   val tableName = "scenes"
 
@@ -136,7 +135,8 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
   def getScene(sceneId: UUID, user: User): ConnectionIO[Option[Scene.WithRelated]] = {
     val scenesO: ConnectionIO[Option[Scene]] = getSceneQ(sceneId, user).option
     scenesO map { _.toList } flatMap { scenesToScenesWithRelated(_) } map {
-      // guaranteed to be either 0 or 1 in the list based on .option above
+      // guaranteed to be either 0 or 1 in the list based on .option above, so no need to worry
+      // about losing information from lists with length > 1
       _.headOption
     }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/util/Page.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/util/Page.scala
@@ -47,11 +47,9 @@ object Page {
           val parsedExpr = sortExprConvertor(sortExpr)
           (parsedExpr, ord) match {
             case (Some(expr), Order.Asc) => {
-              println(s"ASC: ${expr}")
               Fragment.const(s"$expr ASC")
             }
             case (Some(expr), Order.Desc) => {
-              println(s"DESC: ${expr}")
               Fragment.const(s"$expr DESC")
             }
             case (_, _) => Fragment.empty

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -1,0 +1,116 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
+import com.azavea.rf.database.Implicits._
+
+import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+
+import doobie._, doobie.implicits._
+import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import org.scalacheck.Prop.{forAll, exists}
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import java.sql.Timestamp
+import java.time.LocalDate
+
+class SceneWithRelatedDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+  test("list scenes with related") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, page: PageRequest, csq: CombinedSceneQueryParams) => {
+          val sceneListIO = for {
+            orgAndUser <- insertUserAndOrg(user, org)
+            (dbOrg, dbUser) = orgAndUser
+            sceneList <- SceneWithRelatedDao.listScenes(page, csq, dbUser)
+          } yield sceneList
+
+          sceneListIO.transact(xa).unsafeRunSync.results.length >= 0
+        }
+      }
+    }
+  }
+
+  test("list scenes for a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, scenes: List[Scene.Create],
+         page: PageRequest, csq: CombinedSceneQueryParams) => {
+          val scenesInsertWithUserProjectIO = for {
+            orgUserProject <- insertUserOrgProject(user, org, project)
+            (dbOrg, dbUser, dbProject) = orgUserProject
+            datasource <- unsafeGetRandomDatasource
+            scenesInsert <- (scenes map { fixupSceneCreate(dbUser, dbOrg, datasource, _) }).traverse(
+              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+            )
+          } yield (scenesInsert, dbUser, dbProject)
+
+          val scenesListIO = scenesInsertWithUserProjectIO flatMap {
+            case (dbScenes: List[Scene.WithRelated], dbUser: User, dbProject: Project) => {
+              ProjectDao.addScenesToProject(dbScenes map { _.id }, dbProject.id, dbUser) flatMap {
+                _ => {
+                  SceneWithRelatedDao.listProjectScenes(dbProject.id, page, csq, dbUser) map {
+                    (paginatedResponse: PaginatedResponse[Scene.WithRelated]) => (dbScenes, paginatedResponse.results)
+                  }
+                }
+              }
+            }
+          }
+
+          val (insertedScenes, listedScenes) = scenesListIO.transact(xa).unsafeRunSync
+          val insertedIds = insertedScenes.toSet map { (scene: Scene.WithRelated) => scene.id }
+          val listedIds = listedScenes.toSet map { (scene: Scene.WithRelated) => scene.id }
+          insertedIds == listedIds
+        }
+      }
+    }
+  }
+
+  test("get scenes to ingest") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, scenes: List[Scene.Create]) => {
+          val scenesInsertWithUserProjectIO = for {
+            orgUserProject <- insertUserOrgProject(user, org, project)
+            (dbOrg, dbUser, dbProject) = orgUserProject
+            datasource <- unsafeGetRandomDatasource
+            scenesInsert <- (scenes map { fixupSceneCreate(dbUser, dbOrg, datasource, _) }).traverse(
+              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+            )
+          } yield (scenesInsert, dbUser, dbProject)
+
+          val scenesToIngestIO = scenesInsertWithUserProjectIO flatMap {
+            case (dbScenes: List[Scene.WithRelated], dbUser: User, dbProject: Project) => {
+              ProjectDao.addScenesToProject(dbScenes map { _.id }, dbProject.id, dbUser) flatMap {
+                _ => SceneWithRelatedDao.getScenesToIngest(dbProject.id) map {
+                  (ingestableScenes: List[Scene.WithRelated]) => {
+                    (dbScenes, ingestableScenes)
+                  }
+                }
+              }
+            }
+          }
+
+          val (insertedScenes, ingestableScenes) = scenesToIngestIO.transact(xa).unsafeRunSync
+          val ingestableScenesIds = ingestableScenes map { _.id }
+          val ingestableIdsFromInserted = insertedScenes.filter(
+            (scene: Scene.WithRelated) => {
+              val staleModified =
+                scene.modifiedAt.before(Timestamp.valueOf(LocalDate.now().atStartOfDay.plusDays(-1L)))
+              val ingestStatus = scene.statusFields.ingestStatus
+              (staleModified, ingestStatus) match {
+                case (true, IngestStatus.Ingesting) => true
+                case (false, IngestStatus.Ingesting) => false
+                case (_, IngestStatus.Ingested) => false
+                case (_, _) => true
+              }
+            }).map( _.id ).toSet
+          ingestableIdsFromInserted == ingestableScenesIds.toSet
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds property tests for the `SceneWithRelatedDao`

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I discovered in the process that json aggregation with no results from a related table becomes a `null` rather than an empty array -- I captured fallout from that in #3163 with more description of why that's bad.

I also realized that our return from adding scenes to a project is odd, which I captured in #3170.

## Testing Instructions

* Pay special attention to the logic in the test for scenes to ingest -- I believe that it correctly expresses what we want to happen, and it matches what _does_ happen, but it's the messiest part of the tests
 * CI
