### PR TITLE
Add checklist item to PR template for APP_NAME templating

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Brief description of what this PR does, and why it is needed.
 - [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
 - [ ] Symlinks from new migrations present or corrected for any new migrations
 - [ ] PR has a name that won't get you publicly shamed for vagueness
+- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
 
 ### Demo
 


### PR DESCRIPTION
Trivial.

Adds an item to our PR checklist to ensure we don't forget to use the `BUILDCONFIG.APP_NAME` variable in our templates.