### PR TITLE
Add most LayerAttributeDao tests

### DIFF
--- a/app-backend/common/src/main/scala/geotrellis/spark/io/postgres/PostgresAttributeStore.scala
+++ b/app-backend/common/src/main/scala/geotrellis/spark/io/postgres/PostgresAttributeStore.scala
@@ -49,14 +49,14 @@ class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(im
 
   def read[T: JsonFormat](layerId: LayerId, attributeName: String): T = {
     logger.debug(s"read($layerId-$attributeName)")
-    Await.result(LayerAttributeDao.getAttribute(layerId, attributeName).transact(xa).unsafeToFuture
+    Await.result(LayerAttributeDao.unsafeGetAttribute(layerId, attributeName).transact(xa).unsafeToFuture
       .map(_.value.noSpaces.parseJson.convertTo[T]), awaitTimeout)
   }
 
   def readAll[T: JsonFormat](attributeName: String): Map[LayerId, T] = {
     logger.debug(s"readAll($attributeName)")
     Await.result(
-      LayerAttributeDao.getAllAttributes(attributeName).transact(xa).unsafeToFuture.map {
+      LayerAttributeDao.listAllAttributes(attributeName).transact(xa).unsafeToFuture.map {
         _.map { attribute =>
           attribute.layerId -> attribute.value.noSpaces.parseJson.convertTo[T]
         }.toMap
@@ -78,7 +78,7 @@ class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(im
 
   def getHistogram[T: JsonFormat](layerId: LayerId): Future[Option[T]] = {
     logger.debug(s"getHistogram($layerId)")
-    LayerAttributeDao.getAttribute(layerId, "histogram").transact(xa).unsafeToFuture
+    LayerAttributeDao.unsafeGetAttribute(layerId, "histogram").transact(xa).unsafeToFuture
       .map { attribute =>
         Option(attribute.value.noSpaces.parseJson.convertTo[T])
       }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -347,6 +347,20 @@ object Generators extends ArbitraryInstances {
                   owner, visibility, projectId, source)
   }
 
+  private def layerAttributeGen: Gen[LayerAttribute] = for {
+    layerName <- nonEmptyStringGen
+    zoom <- Gen.choose(0, 30)
+    name <- nonEmptyStringGen
+    value <- Gen.const(().asJson)
+  } yield {
+    LayerAttribute(layerName, zoom, name, value)
+  }
+
+  private def layerAttributesWithSameLayerNameGen: Gen[List[LayerAttribute]] = for {
+    layerName <- nonEmptyStringGen
+    layerAttributes <- Gen.listOfN(10, layerAttributeGen)
+  } yield layerAttributes map { _.copy(layerName = layerName) }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
 
@@ -395,5 +409,11 @@ object Generators extends ArbitraryInstances {
     implicit def arbUploadCreate: Arbitrary[Upload.Create] = Arbitrary { uploadCreateGen }
 
     implicit def arbAOI: Arbitrary[AOI] = Arbitrary { aoiGen }
+
+    implicit def arbLayerAttribute: Arbitrary[LayerAttribute] = Arbitrary { layerAttributeGen }
+
+    implicit def arbListLayerAttribute: Arbitrary[List[LayerAttribute]] = Arbitrary {
+      layerAttributesWithSameLayerNameGen
+    }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
@@ -28,39 +28,24 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
       FROM
     """ ++ tableF
 
-  def getAttribute(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[LayerAttribute] = {
-    {
-      selectF ++ fr"""
-      WHERE
-        layer_name = ${layerId.name} AND
-        zoom = ${layerId.zoom} AND
-        name = ${attributeName}"""
-    }
-      .query[LayerAttribute]
-      .unique
+  def unsafeGetAttribute(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[LayerAttribute] = {
+    query
+      .filter(fr"name = ${attributeName}")
+      .filter(fr"zoom = ${layerId.zoom}")
+      .filter(fr"layer_name = ${layerId.name}")
+      .select
   }
 
-  def getAttributeOption(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[Option[LayerAttribute]] = {
-    {
-      selectF ++ fr"""
-      WHERE
-        layer_name = ${layerId.name} AND
-        zoom = ${layerId.zoom} AND
-        name = ${attributeName}"""
-    }
-      .query[LayerAttribute]
-      .option
+  def getAttribute(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[Option[LayerAttribute]] = {
+    query
+      .filter(fr"name = ${attributeName}")
+      .filter(fr"zoom = ${layerId.zoom}")
+      .filter(fr"layer_name = ${layerId.name}")
+      .selectOption
   }
 
-  def getAllAttributes(attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[List[LayerAttribute]] = {
-    {
-      selectF ++ fr"""
-        WHERE
-          name = ${attributeName}
-      """
-    }
-      .query[LayerAttribute]
-      .list
+  def listAllAttributes(attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[List[LayerAttribute]] = {
+    query.filter(fr"name = ${attributeName}").list
   }
 
   def insertLayerAttribute(layerAttribute: LayerAttribute)(implicit xa: Transactor[IO]): ConnectionIO[Int] = {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
@@ -1,28 +1,78 @@
 package com.azavea.rf.database
 
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.datamodel.LayerAttribute
 import com.azavea.rf.database.Implicits._
 
 import doobie._, doobie.implicits._
 import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
 import cats.syntax.either._
 import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
 import io.circe.syntax._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 
 
-class LayerAttributeDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class LayerAttributeDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig {
 
-  test("types") { check(LayerAttributeDao.selectF.query[LayerAttribute]) }
+  test("list all layer ids") {
+    LayerAttributeDao.layerIds.transact(xa).unsafeRunSync.length should be >= 0
+  }
 
-  test("insertion") {
-    val testLayerAttribute = LayerAttribute("testLayerAttr", 13, "testLayerName", ().asJson)
-    val transaction = LayerAttributeDao.insertLayerAttribute(testLayerAttribute)
+  test("get max zooms for layers") {
+    LayerAttributeDao.maxZoomsForLayers(Set.empty[String]).transact(xa).unsafeRunSync.length should be >= 0
+  }
 
-    val result = transaction.transact(xa).unsafeRunSync
+  // insertLayerAttribute
+  test("insert a layer attribute") {
+    check {
+      forAll {
+        (layerAttribute: LayerAttribute) => {
+          val layerId = layerAttribute.layerId
+          val attributeIO = LayerAttributeDao.insertLayerAttribute(layerAttribute) flatMap {
+            _ => LayerAttributeDao.unsafeGettAttribute(layerId, layerAttribute.name)
+          }
+          attributeIO.transact(xa).unsafeRunSync == layerAttribute
+        }
+      }
+    }
+  }
 
-    result shouldBe 1
+  // listAllAttributes
+  test("list layers for an attribute name") {
+    check {
+      forAll {
+        (layerAttributes: List[LayerAttribute]) => {
+          val attributesIO = layerAttributes.traverse(
+            (attr: LayerAttribute) => {
+              LayerAttributeDao.insertLayerAttribute(attr)
+            }
+          ) flatMap {
+            _ => LayerAttributeDao.listAllAttributes(layerAttributes.head.name)
+          }
+
+          attributesIO.transact(xa).unsafeRunSync.length ==
+            layerAttributes.filter(_.name == layerAttributes.head.name).length
+        }
+      }
+    }
+  }
+
+  // layerExists
+  test("check layer existence") {
+    check {
+      forAll {
+        (layerAttribute: LayerAttribute) => {
+          val layerId = layerAttribute.layerId
+          val attributesIO = LayerAttributeDao.insertLayerAttribute(layerAttribute) flatMap {
+            _ => LayerAttributeDao.layerExists(layerId)
+          }
+          attributesIO.transact(xa).unsafeRunSync
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Overview

This PR adds tests for the `LayerAttributeDao`.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~[ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

### Notes

I didn't test every method here since I'm unsure about some of the business logic and how some of the methods should be tested. Requesting review from @alkamin since he wrote this Dao and might have some specific ideas about what certain things were trying to accomplish.

## Testing Instructions

 * CI