### PR TITLE
[Platforms] Add datamodels, DAO, and spec for access-control-rules

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
@@ -1,0 +1,54 @@
+package com.azavea.rf.datamodel
+
+import java.util.UUID
+import java.sql.Timestamp
+
+import io.circe._
+import io.circe.generic.JsonCodec
+import io.circe.syntax._
+
+@JsonCodec
+case class AccessControlRule(
+    id: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    modifiedBy: String,
+    isActive: Boolean,
+    objectType: ObjectType,
+    objectId: UUID,
+    subjectType: SubjectType,
+    subjectId: Option[String],
+    actionType: ActionType
+)
+
+object AccessControlRule {
+    def create = Create.apply _
+    def tupled = (AccessControlRule.apply _).tupled
+
+    case class Create(
+        objectType: ObjectType,
+        objectId: UUID,
+        subjectType: SubjectType,
+        subjectId: Option[String],
+        actionType: ActionType,
+        user: User
+    ) {
+        def toAccessControlRule: AccessControlRule = {
+            val now = new Timestamp((new java.util.Date()).getTime())
+            AccessControlRule(
+                UUID.randomUUID(),
+                now, // createdAt
+                user.id, // createdBy
+                now, // modifiedAt
+                user.id, // modifiedBy
+                true, // isActive
+                objectType,
+                objectId,
+                subjectType,
+                subjectId,
+                actionType
+            )
+        }
+    }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ActionType.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ActionType.scala
@@ -1,0 +1,31 @@
+package com.azavea.rf.datamodel
+
+import io.circe._
+import cats.syntax.either._
+
+sealed abstract class ActionType(val repr: String) {
+    override def toString = repr
+}
+
+object ActionType {
+    case object View extends ActionType("VIEW")
+    case object Edit extends ActionType("EDIT")
+    case object Deactivate extends ActionType("DEACTIVATE")
+    case object Delete extends ActionType("DELETE")
+
+    def fromString(s: String): ActionType = s.toUpperCase match {
+        case "VIEW" => View
+        case "EDIT" => Edit
+        case "DEACTIVATE" => Deactivate
+        case "DELETE" => Delete
+        case _ => throw new Exception(s"Invalid ActionType: ${s}")
+    }
+
+    implicit val ActionTypeEncoder: Encoder[ActionType] =
+        Encoder.encodeString.contramap[ActionType](_.toString)
+
+    implicit val ActionTypeDecoder: Decoder[ActionType] =
+        Decoder.decodeString.emap { s =>
+            Either.catchNonFatal(fromString(s)).leftMap(gt => "ActionType")
+        }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ObjectType.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ObjectType.scala
@@ -1,0 +1,37 @@
+package com.azavea.rf.datamodel
+
+import io.circe._
+import cats.syntax.either._
+
+sealed abstract class ObjectType(val repr: String) {
+    override def toString = repr
+}
+
+object ObjectType {
+    case object Project extends ObjectType("PROJECT")
+    case object Scene extends ObjectType("SCENE")
+    case object Datasource extends ObjectType("DATASOURCE")
+    case object Shape extends ObjectType("SHAPE")
+    case object Workspace extends ObjectType("WORKSPACE")
+    case object Template extends ObjectType("TEMPLATE")
+    case object Analysis extends ObjectType("ANALYSIS")
+
+    def fromString(s: String): ObjectType = s.toUpperCase match {
+        case "PROJECT" => Project
+        case "SCENE" => Scene
+        case "DATASOURCE" => Datasource
+        case "SHAPE" => Shape
+        case "WORKSPACE" => Workspace
+        case "TEMPLATE" => Template
+        case "ANALYSIS" => Analysis
+        case _ => throw new Exception(s"Invalid ObjectType: ${s}")
+    }
+
+    implicit val ObjectTypeEncoder: Encoder[ObjectType] =
+        Encoder.encodeString.contramap[ObjectType](_.toString)
+
+    implicit val ObjectTypeDecoder: Decoder[ObjectType] =
+        Decoder.decodeString.emap { s =>
+            Either.catchNonFatal(fromString(s)).leftMap(gt => "ObjectType")
+        }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SubjectType.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SubjectType.scala
@@ -1,0 +1,33 @@
+package com.azavea.rf.datamodel
+
+import io.circe._
+import cats.syntax.either._
+
+sealed abstract class SubjectType(val repr: String) {
+    override def toString = repr
+}
+
+object SubjectType {
+    case object All extends SubjectType("ALL")
+    case object Platform extends SubjectType("PLATFORM")
+    case object Organization extends SubjectType("ORGANIZATION")
+    case object Team extends SubjectType("TEAM")
+    case object User extends SubjectType("USER")
+
+    def fromString(s: String): SubjectType = s.toUpperCase match {
+        case "ALL" => All
+        case "PLATFORM" => Platform
+        case "ORGANIZATION" => Organization
+        case "TEAM" => Team
+        case "USER" => User
+        case _ => throw new Exception(s"Invalid SubjectType: ${s}")
+    }
+
+    implicit val SubjectTypeEncoder: Encoder[SubjectType] =
+        Encoder.encodeString.contramap[SubjectType](_.toString)
+
+    implicit val SubjectTypeDecoder: Decoder[SubjectType] =
+        Decoder.decodeString.emap { s =>
+            Either.catchNonFatal(fromString(s)).leftMap(gt => "SubjectType")
+        }
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -1,0 +1,106 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.datamodel.{AccessControlRule, ActionType, ObjectType, SubjectType, User}
+
+import doobie._, doobie.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import doobie.util.transactor.Transactor
+import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import io.circe._
+
+import java.util.UUID
+
+object AccessControlRuleDao extends Dao[AccessControlRule] {
+    val tableName = "access_control_rules"
+
+    val selectF = fr"""
+        SELECT
+            id, created_at, created_by,
+            modified_at, modified_by, is_active,
+            object_type, object_id, subject_type,
+            subject_id, action_type
+        FROM
+    """ ++ tableF
+
+    def createF(ac: AccessControlRule) =
+        fr"INSERT INTO" ++ tableF ++ fr"""(
+            id, created_at, created_by,
+            modified_at, modified_by, is_active,
+            object_type, object_id, subject_type,
+            subject_id, action_type
+        ) VALUES (
+            ${ac.id}, ${ac.createdAt}, ${ac.createdBy},
+            ${ac.modifiedAt}, ${ac.modifiedBy}, ${ac.isActive},
+            ${ac.objectType}, ${ac.objectId}, ${ac.subjectType},
+            ${ac.subjectId}, ${ac.actionType}
+        )
+        """
+
+    def create(ac: AccessControlRule): ConnectionIO[AccessControlRule] = {
+        val objectDao = ac.objectType match {
+            case ObjectType.Project => ProjectDao
+            case ObjectType.Scene => SceneDao
+            case ObjectType.Datasource => DatasourceDao
+            case ObjectType.Shape => ShapeDao
+            case ObjectType.Workspace => throw new Exception("Workspaces not yet supported")
+            case ObjectType.Template => throw new Exception("Templates not yet supported")
+            case ObjectType.Analysis => throw new Exception("Analyses not yet supported")
+        }
+
+        val isValidObject = objectDao.query.filter(ac.objectId).exists
+
+        // These validity checks need to be done individually because of varying id types
+
+        val isValidSubject = (ac.subjectType, ac.subjectId) match {
+            case (SubjectType.All, _) => true.pure[ConnectionIO]
+            case (SubjectType.Platform, Some(sid)) => PlatformDao.query.filter(UUID.fromString(sid)).exists
+            case (SubjectType.Organization, Some(sid)) => OrganizationDao.query.filter(UUID.fromString(sid)).exists
+            case (SubjectType.Team, Some(sid)) => OrganizationDao.query.filter(UUID.fromString(sid)).exists
+            case (SubjectType.User, Some(sid)) => UserDao.query.filter(fr"id = ${sid}").exists
+            case _ => throw new Exception("Subject id required and but not provided")
+        }
+
+        val create = createF(ac).update.withUniqueGeneratedKeys[AccessControlRule](
+            "id", "created_at", "created_by",
+            "modified_at", "modified_by", "is_active",
+            "object_type", "object_id", "subject_type",
+            "subject_id", "action_type"
+        )
+
+        for {
+            isValidObject <- isValidObject
+            isValidSubject <- isValidSubject
+            createAC <- {
+                if (isValidObject && isValidSubject) create
+                else {
+                    val errSB = new StringBuilder("Invalid access control object")
+                    if (!isValidObject) errSB.append(", invalid object")
+                    if (!isValidSubject) errSB.append(", invalid subject")
+                    throw new Exception(errSB.toString)
+                }
+            }
+        } yield createAC
+    }
+
+    def getOption(id: UUID): ConnectionIO[Option[AccessControlRule]] = {
+        query.filter(id).selectOption
+    }
+
+    // List rules that a given subject has applied to it
+    def listBySubject(subjectType: SubjectType, subjectId: String): ConnectionIO[List[AccessControlRule]] = {
+        query
+            .filter(fr"subject_type = ${subjectType}")
+            .filter(fr"subject_id = ${subjectId}")
+            .list
+    }
+
+    def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
+        (fr"UPDATE" ++ tableF ++ fr""" SET
+              is_active = false,
+              modified_at = NOW(),
+              modified_by = ${user.id}
+            WHERE id = ${id}
+        """).update.run
+    }
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -44,6 +44,7 @@ object Dao {
 
     val countF = fr"SELECT count(*) FROM" ++ tableF
     val deleteF = fr"DELETE FROM" ++ tableF
+    val existF = fr"SELECT 1 FROM" ++ tableF
 
     /** Add another filter to the query being constructed */
     def filter[M >: Model, T](thing: T)(implicit filterable: Filterable[M, T]): QueryBuilder[Model] =
@@ -147,8 +148,11 @@ object Dao {
         .run
     }
 
-    def exists(id: UUID): ConnectionIO[Boolean] = {
-      list(0, 1).map(!_.isEmpty)
+    def exists: ConnectionIO[Boolean] = {
+      (existF ++ Fragments.whereAndOpt(filters: _*) ++ fr"LIMIT 1")
+        .query[Int]
+        .list
+        .map(!_.isEmpty)
     }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -46,9 +46,9 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
 
     def create(ugr: UserGroupRole): ConnectionIO[UserGroupRole] = {
         val isValidGroup = ugr.groupType match {
-            case GroupType.Platform => PlatformDao.query.exists(ugr.groupId)
-            case GroupType.Organization => OrganizationDao.query.exists(ugr.groupId)
-            case GroupType.Team => TeamDao.query.exists(ugr.groupId)
+            case GroupType.Platform => PlatformDao.query.filter(ugr.groupId).exists
+            case GroupType.Organization => OrganizationDao.query.filter(ugr.groupId).exists
+            case GroupType.Team => TeamDao.query.filter(ugr.groupId).exists
         }
 
         val create = createF(ugr).update.withUniqueGeneratedKeys[UserGroupRole](
@@ -79,7 +79,7 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
     def listByGroup(groupType: GroupType, groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
         query.filter(fr"group_type = ${groupType}").filter(fr"group_id = ${groupId}").list
     }
-    
+
     // @TODO: ensure a user cannot demote (or promote?) themselves
     def update(ugr: UserGroupRole, id: UUID, user: User): ConnectionIO[Int] =
         updateF(ugr, id, user).update.run

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/meta/EnumMeta.scala
@@ -47,5 +47,14 @@ trait EnumMeta {
 
   implicit val groupTypeMeta: Meta[GroupType] =
     pgEnumString("group_type", GroupType.fromString, _.repr)
+
+  implicit val subjectTypeMeta: Meta[SubjectType] =
+    pgEnumString("subject_type", SubjectType.fromString, _.repr)
+
+  implicit val objectTypeMeta: Meta[ObjectType] =
+    pgEnumString("object_type", ObjectType.fromString, _.repr)
+
+  implicit val actionTypeMeta: Meta[ActionType] =
+    pgEnumString("action_type", ActionType.fromString, _.repr)
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AccessControlRuleDaoSpac.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AccessControlRuleDaoSpac.scala
@@ -1,0 +1,67 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.datamodel.{AccessControlRule, ActionType, ObjectType, SubjectType}
+import com.azavea.rf.database.Implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.syntax.either._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import doobie.scalatest.imports._
+import org.scalatest._
+import io.circe._
+import io.circe.syntax._
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AccessControlRuleDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+
+    def createAccessControlRule: ConnectionIO[AccessControlRule] = {
+        for {
+            platform <- defaultPlatformQ
+            usr <- defaultUserQ
+            project <- changeDetectionProjQ
+            create <- {
+                val acr = AccessControlRule.Create(
+                    ObjectType.Project,
+                    project.id,
+                    SubjectType.User,
+                    Some(usr.id),
+                    ActionType.View,
+                    usr
+                )
+                val acrM = acr.toAccessControlRule
+                AccessControlRuleDao.create(acr.toAccessControlRule)
+            }
+        } yield create
+    }
+
+    test("read types") { check(AccessControlRuleDao.selectF.query[AccessControlRule]) }
+
+    test("insertion") {
+        val transaction = for {
+            acrIn <- createAccessControlRule
+            acrOut <- AccessControlRuleDao.getOption(acrIn.id)
+        } yield acrOut
+
+        val result = transaction.transact(xa).unsafeRunSync
+        result.get.objectType shouldBe ObjectType.Project
+        result.get.subjectType shouldBe SubjectType.User
+        result.get.actionType shouldBe ActionType.View
+    }
+
+    test("deactivation") {
+        val transaction = for {
+            usr <- defaultUserQ
+            acrIn <- createAccessControlRule
+            acrDeactivated <- AccessControlRuleDao.deactivate(acrIn.id, usr)
+            acrOut <- AccessControlRuleDao.getOption(acrIn.id)
+        } yield acrOut
+
+        val result = transaction.transact(xa).unsafeRunSync
+        result.get.isActive shouldBe false
+    }
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -21,12 +21,8 @@ class UserGroupRoleDaoSpec extends FunSuite with Matchers with IOChecker with DB
 
     def createUserGroupRole: ConnectionIO[UserGroupRole] = {
         for {
-            platform <- {
-                defaultPlatformQ
-            }
-            usr <- {
-                defaultUserQ
-            }
+            platform <- defaultPlatformQ
+            usr <- defaultUserQ
             create <- {
                 val ugr = UserGroupRole.Create(
                     usr,


### PR DESCRIPTION
## Overview

This PR adds data-models for:
  - `ObjectType`
  - `SubjectType`
  - `ActionType`
  - `AccessControlRule`

It also adds a DAO and DAO spec for the access control rules.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

Necessary SQL (in addition to anchor branch SQL):
```sql
CREATE TYPE object_type AS ENUM ('PROJECT', 'SCENE', 'DATASOURCE', 'SHAPE', 'WORKSPACE', 'TEMPLATE', 'ANALYSIS');
CREATE TYPE subject_type AS ENUM ('ALL', 'PLATFORM', 'ORGANIZATION', 'TEAM', 'USER');
CREATE TYPE action_type AS ENUM ('VIEW', 'EDIT', 'DEACTIVATE', 'DELETE');

CREATE TABLE access_control_rules (
    id UUID PRIMARY KEY NOT NULL,
    created_at TIMESTAMP NOT NULL,
    created_by VARCHAR(255) REFERENCES users(id) NOT NULL,
    modified_at TIMESTAMP NOT NULL,
    modified_by VARCHAR(255) REFERENCES users(id) NOT NULL,
    is_active BOOLEAN DEFAULT true NOT NULL,
    object_type object_type NOT NULL,
    object_id UUID NOT NULL,
    subject_type subject_type NOT NULL,
    subject_id text,
    action_type action_type NOT NULL
);

```

 * db/test

Closes #3092
