### PR TITLE
Fix user filter - Don't default to organizational sharing

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
@@ -28,7 +28,7 @@ trait Filterables extends RFMeta {
   implicit val permissionsFilter = Filterable[Any, User] { user: User =>
     val filter =
       if (!user.isInRootOrganization) {
-        Some(fr"(organization_id = ${user.organizationId} OR owner = ${user.id})")
+        Some(fr"owner = ${user.id}")
       } else {
         None
       }


### PR DESCRIPTION
## Overview

This change removes a clause in a filter that allowed users to see anything within their organization.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Better sharing granularity is a concern for the platforms feature.


## Testing Instructions

 * Can you list projects that aren't owned by you (you shouldn't be able to)

Closes #3095
