### PR TITLE
Fix listing of project AOIs

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -381,7 +381,7 @@ trait ProjectRoutes extends Authentication
   def listAOIs(projectId: UUID): Route = authenticate { user =>
     withPagination { page =>
       complete {
-        AoiDao.query.filter(fr"project_id = ${projectId}").page(page).transact(xa).unsafeToFuture
+        AoiDao.listAOIs(projectId, user, page).transact(xa).unsafeToFuture
       }
     }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -78,7 +78,7 @@ object Dao {
     }
 
     /** Provide a list of responses within the PaginatedResponse wrapper */
-    def page(pageRequest: PageRequest): ConnectionIO[PaginatedResponse[Model]] = {
+    def page(pageRequest: PageRequest, selectF: Fragment = selectF, countF: Fragment = countF): ConnectionIO[PaginatedResponse[Model]] = {
       for {
         page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest)).query[Model].list
         count <- (countF ++ Fragments.whereAndOpt(filters: _*)).query[Int].unique

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -10,6 +10,7 @@ import doobie._, doobie.implicits._
 import cats._, cats.data._, cats.effect.IO
 import cats.implicits._
 import cats.syntax.either._
+import com.lonelyplanet.akka.http.extensions.PageRequest
 import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import geotrellis.slick._
@@ -115,14 +116,14 @@ class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig 
 
           val aoisForProject = aoisInsertWithProjectUserIO flatMap {
             case (dbAois: List[AOI], dbProject: Project, dbUser: User) => {
-              AoiDao.listAOIs(dbProject.id, dbUser) map {
+              AoiDao.listAOIs(dbProject.id, dbUser, PageRequest(0, 1000, Map.empty)) map {
                 (dbAois, _)
               }
             }
           }
 
           val (dbAois, listedAois) = aoisForProject.transact(xa).unsafeRunSync
-          (dbAois.toSet map { (aoi: AOI) => aoi.area }) == (listedAois.toSet map { (aoi: AOI) => aoi.area })
+          (dbAois.toSet map { (aoi: AOI) => aoi.area }) == (listedAois.results.toSet map { (aoi: AOI) => aoi.area })
         }
       }
     }


### PR DESCRIPTION
## Overview

This PR adjusts the base Dao `page` method to handle overriding the fragments used for selection and counting which allows more complex queries (such as joins) to be paged.

This method is then used to ensure that project AOIs can be listed and paged.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Create an AOI project
 * Select 'Browse for Imagery'
 * See that the controls for AOI parameters are visible
 * See that a request to the aoi endpoint resulted in a paged response

Closes #3182
