### PR TITLE
Use OpenJDK 8 JDK for Spark tasks

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM openjdk:8-jdk-slim
 
 ENV SPARK_VERSION 2.1.0
 ENV HADOOP_VERSION 2.7


### PR DESCRIPTION
## Overview

This assists troubleshooting efforts by including tools like `jmap` and `jstack` directly in the container image. Currently, the JRE does not make these tools available.

The image size difference between the two is roughly 40MB (244MB to 205MB).

Resolves https://github.com/azavea/raster-foundry-platform/issues/290

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

Ensure that `cibuild` completes successfully.
