### PR TITLE
Fix page ordering when `DESC`

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/util/Page.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/util/Page.scala
@@ -47,11 +47,10 @@ object Page {
     val defaultSort: Fragment = pageRequest.sort.isEmpty match {
       case true => defaultOrderBy
       case false => {
-        val orderString = pageRequest.sort.values.head match {
-          case Order.Asc => "ASC"
-          case Order.Desc => "DESC"
+        pageRequest.sort.values.head match {
+          case Order.Asc => fr"id ASC"
+          case Order.Desc => fr"id DESC"
         }
-        fr"id ${orderString}"
       }
     }
     val orderBy =


### PR DESCRIPTION
## Overview

This PR makes a small fix for an issue that appears when a page request using a sorting of `DESC`. Our method of combining ordering fragments ended up sending a non-interpolated sql string to the database, so it contained a `?` instead of the interpolated sort direction.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Hit the 'Data' tab of the UI, the scenes should load

Closes #3199 
