### PR TITLE
Attempt to suppress Scapegoat OOM errors

### DIFF
--- a/app-backend/.jvmopts
+++ b/app-backend/.jvmopts
@@ -1,0 +1,3 @@
+-Xms512m
+-Xmx3g
+-Xss2m

--- a/app-backend/project/build.properties
+++ b/app-backend/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.1.4

--- a/app-backend/sbt
+++ b/app-backend/sbt
@@ -2,15 +2,17 @@
 #
 # A more capable sbt runner, coincidentally also called sbt.
 # Author: Paul Phillips <paulp@improving.org>
+# https://github.com/paulp/sbt-extras
 
 set -o pipefail
 
-declare -r sbt_release_version="0.13.13"
-declare -r sbt_unreleased_version="0.13.13"
+declare -r sbt_release_version="0.13.16"
+declare -r sbt_unreleased_version="0.13.16"
 
-declare -r latest_212="2.12.1"
-declare -r latest_211="2.11.8"
-declare -r latest_210="2.10.6"
+declare -r latest_213="2.13.0-M2"
+declare -r latest_212="2.12.4"
+declare -r latest_211="2.11.12"
+declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"
 declare -r latest_28="2.8.2"
 
@@ -27,7 +29,7 @@ declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory
 declare sbt_jar sbt_dir sbt_create sbt_version sbt_script sbt_new
 declare sbt_explicit_version
 declare verbose noshare batch trace_level
-declare sbt_saved_stty debugUs
+declare debugUs
 
 declare java_cmd="java"
 declare sbt_launch_dir="$HOME/.sbt/launchers"
@@ -43,19 +45,21 @@ echoerr () { echo >&2 "$@"; }
 vlog ()    { [[ -n "$verbose" ]] && echoerr "$@"; }
 die ()     { echo "Aborting: $@" ; exit 1; }
 
-# restore stty settings (echo in particular)
-onSbtRunnerExit() {
-  [[ -n "$sbt_saved_stty" ]] || return
-  vlog ""
-  vlog "restoring stty: $sbt_saved_stty"
-  stty "$sbt_saved_stty"
-  unset sbt_saved_stty
-}
+setTrapExit () {
+  # save stty and trap exit, to ensure echo is re-enabled if we are interrupted.
+  export SBT_STTY="$(stty -g 2>/dev/null)"
 
-# save stty and trap exit, to ensure echo is re-enabled if we are interrupted.
-trap onSbtRunnerExit EXIT
-sbt_saved_stty="$(stty -g 2>/dev/null)"
-vlog "Saved stty: $sbt_saved_stty"
+  # restore stty settings (echo in particular)
+  onSbtRunnerExit() {
+    [ -t 0 ] || return
+    vlog ""
+    vlog "restoring stty: $SBT_STTY"
+    stty "$SBT_STTY"
+  }
+
+  vlog "saving stty: $SBT_STTY"
+  trap onSbtRunnerExit EXIT
+}
 
 # this seems to cover the bases on OSX, and someone will
 # have to tell me about the others.
@@ -228,8 +232,13 @@ execRunner () {
     vlog ""
   }
 
-  [[ -n "$batch" ]] && exec </dev/null
-  exec "$@"
+  setTrapExit
+
+  if [[ -n "$batch" ]]; then
+    "$@" < /dev/null
+  else
+    "$@"
+  fi
 }
 
 jar_url ()  { make_url "$1"; }
@@ -251,9 +260,9 @@ download_url () {
   echoerr "    To  $jar"
 
   mkdir -p "${jar%/*}" && {
-    if which curl >/dev/null; then
+    if command -v curl > /dev/null 2>&1; then
       curl --fail --silent --location "$url" --output "$jar"
-    elif which wget >/dev/null; then
+    elif command -v wget > /dev/null 2>&1; then
       wget -q -O "$jar" "$url"
     fi
   } && [[ -r "$jar" ]]
@@ -320,6 +329,7 @@ runner with the -x option.
   -210                      use $latest_210
   -211                      use $latest_211
   -212                      use $latest_212
+  -213                      use $latest_213
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
   -binary-version <version> use the specified scala version when searching for dependencies
@@ -358,7 +368,7 @@ process_args () {
   }
   while [[ $# -gt 0 ]]; do
     case "$1" in
-          -h|-help) usage; exit 1 ;;
+          -h|-help) usage; exit 0 ;;
                 -v) verbose=true && shift ;;
                 -d) addSbt "--debug" && shift ;;
                 -w) addSbt "--warn"  && shift ;;
@@ -399,7 +409,8 @@ process_args () {
               -210) setScalaVersion "$latest_210" && shift ;;
               -211) setScalaVersion "$latest_211" && shift ;;
               -212) setScalaVersion "$latest_212" && shift ;;
-               new) sbt_new=true && sbt_explicit_version="$sbt_release_version"  && addResidual "$1" && shift ;;
+              -213) setScalaVersion "$latest_213" && shift ;;
+               new) sbt_new=true && : ${sbt_explicit_version:=$sbt_release_version} && addResidual "$1" && shift ;;
                  *) addResidual "$1" && shift ;;
     esac
   done


### PR DESCRIPTION
## Overview

Attempt to suppress Scapegoat OOM errors by:

- Updating `sbt` to the most recent patch release
- Updating `sbt-extras` script to its most recent version
- Increasing maximum heap size for the `sbt` JVM

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

When executing the `sbt-extras` script at the root of the top level `app-backend` directory, use `ps` to ensure that its default JVM options are being overridden:

```bash
$ cd app-backend
$ ./sbt compile
```

As that's running, use another terminal session to execute `ps`:

```bash
$ ps aux | grep java
hector           66124 219.9  1.3  9020244 225588 s003  R+   12:23AM   0:03.23 /usr/bin/java -Xms512m -Xmx3g -Xss2m -Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy -jar /Users/hector/.sbt/launchers/1.1.4/sbt-launch.jar compile
```

Note that the default options of `-Xms512m -Xmx1536m -Xss2m` are not present. Instead, the default options supplied in `.jvmopts` are being used.

Also, ensure that CI build complete successfully, since they were failing due to OOM.