### PR TITLE
Let scene detail modal persist when date picker modal is opened

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -146,7 +146,7 @@ class SceneDetailModalController {
                         selectedDay: this.moment(date)
                     })
                 }
-            }).result.then(selectedDay => {
+            }, false).result.then(selectedDay => {
                 this.updateAcquisitionDate(selectedDay);
             });
     }


### PR DESCRIPTION
## Overview

This PR lets the scene detail modal persist under edit mode when acquisition date picker is opened.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

 * Go to Data -> Raster and view details of one of your uploaded scenes
 * Edit the metadata and change the acquisition date -- the scene detail modal should persist after the date modal is opened.

Closes #3139 
