### PR TITLE
Fix credential empty string handling

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -49,11 +49,11 @@ object Credential {
     }
 
   def fromString(s: String) = {
-    applyWithNonEmptyString(Some(s))(Credential.apply)
+    Credential.apply(Some(s))
   }
 
-  def fromStringO(s: Option[String]) = {
-    applyWithNonEmptyString(s)(Credential.apply)
+  def fromStringO(s: Option[String]) =
+    Credential.apply(s)
   }
 }
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -52,7 +52,7 @@ object Credential {
     Credential.apply(Some(s))
   }
 
-  def fromStringO(s: Option[String]) =
+  def fromStringO(s: Option[String]) = {
     Credential.apply(s)
   }
 }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -25,7 +25,10 @@ object Generators extends ArbitraryInstances {
     Gen.oneOf(0, 15) flatMap { Gen.listOfN(_, nonEmptyStringGen) }
 
   private def nonEmptyStringGen: Gen[String] =
-    Gen.nonEmptyListOf[Char](Gen.alphaChar).map(_.mkString)
+    Gen.nonEmptyListOf[Char](Gen.alphaChar) map { _.mkString }
+
+  private def possiblyEmptyStringGen: Gen[String] =
+    Gen.containerOf[List, Char](Gen.alphaChar) map { _.mkString }
 
   private def pageRequestGen: Gen[PageRequest] =
     Gen.const(PageRequest(0, 20, Map("created_at" -> Order.Desc)))
@@ -39,7 +42,7 @@ object Generators extends ArbitraryInstances {
   private def visibilityGen: Gen[Visibility] = Gen.oneOf(
     Visibility.Public, Visibility.Organization, Visibility.Private)
 
-  private def credentialGen: Gen[Credential] = nonEmptyStringGen map { Credential.fromString }
+  private def credentialGen: Gen[Credential] = possiblyEmptyStringGen flatMap { Credential.fromString }
 
   // This is fine not to test the max value --
   private def rawDataBytesGen: Gen[Long] = Gen.choose(0L, 100000L)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/meta/CirceJsonbMeta.scala
@@ -21,7 +21,7 @@ trait CirceJsonbMeta {
   implicit val credentialMeta: Meta[Credential] =
     Meta.other[String]("text").xmap[Credential](
       a => {
-        if (a.length == 0) Credential(None) else Credential.fromString(a)
+        Credential.fromString(a)
       },
       a => a.token.getOrElse("").toString
     )


### PR DESCRIPTION
## Overview

This PR allows empty strings to be passed as Credentials.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

## Testing Instructions

 * Run `db/tests` as generators were changed (or check CI)
 * PUT a user object with empty credential strings and see that it succeeds -- the easiest way to do this might be through the UI... Settings -> Third Party Connections

Closes #3178
