### PR TITLE
Fix Hanging postgres metadata write

### DIFF
--- a/app-backend/batch/src/main/resources/log4j.properties
+++ b/app-backend/batch/src/main/resources/log4j.properties
@@ -2,4 +2,4 @@ log4j.rootLogger=WARN, A1
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
 log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%d [%t] %-5p %c -  %m%n
-#log4j.logger.org.apache.http.wire=DEBUG
+log4j.logger.com.azavea.shaded.amazonaws.services.s3=ERROR

--- a/app-backend/batch/src/main/resources/logback.xml
+++ b/app-backend/batch/src/main/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache.http.wire" level="info" additivity="false">
+        <appender-ref ref="stdout" />
+    </logger>
+
+    <root level="${APP_SERVER_LOG_LEVEL:-info}">
+        <appender-ref ref="stdout"/>
+    </root>
+
+</configuration>

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/Notification.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/Notification.scala
@@ -31,7 +31,7 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
 
   def getSceneConsumers(sceneId: UUID): ConnectionIO[List[String]] = {
     for {
-      projects <- ProjectDao.query.filter(fr"id IN (SELECT project_id FROM scenes_to_projects WHERE scene_id = ${sceneId}").list
+      projects <- ProjectDao.query.filter(fr"id IN (SELECT project_id FROM scenes_to_projects WHERE scene_id = ${sceneId})").list
     } yield projects.map(_.owner)
   }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
@@ -49,11 +49,14 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
   }
 
   def insertLayerAttribute(layerAttribute: LayerAttribute)(implicit xa: Transactor[IO]): ConnectionIO[Int] = {
+    // This insert includes conflict handling, because if we re-ingest a scene, its layerattributes should already
+    // be in the db.
     val insertStatement = fr"INSERT into" ++ tableF ++
       fr"""
           (layer_name, zoom, name, value)
       VALUES
           (${layerAttribute.layerName}, ${layerAttribute.zoom}, ${layerAttribute.name}, ${layerAttribute.value})
+      ON CONFLICT (layer_name, zoom, name) DO UPDATE set value = ${layerAttribute.value}
       """
     insertStatement.update.run
   }

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -226,9 +226,11 @@ def metadata_to_postgres(uri, scene_id):
         scene_id
     ]
     logger.debug('Bash command to store metadata: %s', ' '.join(bash_cmd))
-    subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
+    running_cmd = subprocess.Popen(bash_cmd)
+    running_cmd.communicate()
     logger.info('Successfully completed metadata postgres write for scene %s', scene_id)
     return True
+
 
 def notify_for_scene_ingest_status(scene_id):
     """Notify users that are using this scene as well as the scene owner that
@@ -245,5 +247,6 @@ def notify_for_scene_ingest_status(scene_id):
         'notify_ingest_status',
         scene_id
     ]
-    subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
+    running_process = subprocess.Popen(bash_cmd)
+    running_process.communicate()
     return True


### PR DESCRIPTION
## Overview

This PR fixes a few miscellaneous bugs that were making ingests fail for different reasons.

- replaced use of `stdout=PIPE` with `Popen(...).communicate()` (usage of `PIPE` is [strongly discouraged](https://docs.python.org/2/library/subprocess.html#using-the-subprocess-module)
- fixed a sql bug in the notification job
- added conflict handling to the sql for writing layer metadata
- suppress some annoying logging

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

To pick a scene that's small enough to ingest locally, get the id from your database using:

```sql
select scenes.name, scenes.id from (scenes inner join datasources on scenes.datasource = datasources.id) where datasources.name = 'UAV - 3 Band';
```

I think they're both of an acceptably small size

 * Give your vm 12gb of RAM
 * Rebuild the batch jar
 * bring up your server
 * console in to the batch container
 * after your server is up: `rf ingest-scene --local --ignore-previous <scene id>`

Closes #3216 
