### PR TITLE
Use Rollbar Java SDK for exception reporting

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -177,7 +177,8 @@ lazy val common = Project("common", file("common"))
     Dependencies.chill,
     Dependencies.catsCore,
     Dependencies.awsBatchSdk,
-    Dependencies.awsStsSdk
+    Dependencies.awsStsSdk,
+    Dependencies.rollbar
   )})
 
 lazy val db = Project("db", file("db"))

--- a/app-backend/common/src/main/scala/Rollbar.scala
+++ b/app-backend/common/src/main/scala/Rollbar.scala
@@ -1,123 +1,35 @@
 package com.azavea.rf.common
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model._
-import akka.stream.{ActorMaterializer, Materializer}
+import com.rollbar.notifier.Rollbar
+import com.rollbar.notifier.config.ConfigBuilder
 import com.typesafe.scalalogging.LazyLogging
-import spray.json.DefaultJsonProtocol._
-import spray.json._
-
-import scala.collection.mutable
-
 
 trait RollbarNotifier extends LazyLogging {
 
-  implicit val system: ActorSystem
-  implicit val materializer: Materializer
-
-
-  val rollbarApiToken = sys.env.get("ROLLBAR_SERVER_TOKEN") match {
+  val rollbarApiToken: String = sys.env.get("ROLLBAR_SERVER_TOKEN") match {
     case Some(t) => t
     case _ =>
       throw new RuntimeException("Rollbar API token must be present to notify rollbar")
   }
 
-  val url = "https://api.rollbar.com/api/1/item/"
-
-  val environment = sys.env.get("ENVIRONMENT") match {
+  val environment: String = sys.env.get("ENVIRONMENT") match {
     case Some(env) => env
     case _ => "staging"
   }
 
-  def buildRollbarPayload(e: Throwable): JsObject = JsObject(
-    "access_token" -> this.rollbarApiToken.toJson,
-    "data" -> JsObject(
-      "environment" -> this.environment.toJson,
-      "body" -> JsObject(
-        "trace_chain" -> {
-          val traces = mutable.ListBuffer.empty[JsObject]
-          var thr = e
-          do {
-            traces += createTrace(thr)
-            thr = thr.getCause
-          } while (thr != null)
-
-          JsArray(traces.toVector)
-        }
-      )
-    )
-  )
-
-  def buildRollbarPayload(s: String): JsObject = JsObject(
-    "access_token" -> this.rollbarApiToken.toJson,
-    "data" -> JsObject(
-      "environment" -> this.environment.toJson,
-      "body" -> JsObject(
-        "message" -> JsObject("body" -> JsString(s))
-      )
-    )
-  )
-
-  @SuppressWarnings(Array("CatchException"))
-  def createTrace(throwable: Throwable): JsObject = {
-    val frames = throwable.getStackTrace.map { element =>
-      val lineNo = if (element.getLineNumber > 0) Seq("lineno" -> element.getLineNumber.toJson) else Nil
-      val frame = Seq(
-        "class_name" -> element.getClassName.toJson,
-        "filename" -> element.getFileName.toJson,
-        "method" -> element.getMethodName.toJson
-      ) ++ lineNo
-      JsObject(Map(frame: _*))
-    }
-
-    val raw = try {
-      val baos = new ByteArrayOutputStream()
-      val ps = new PrintStream(baos)
-      throwable.printStackTrace(ps)
-      ps.close()
-      baos.close()
-      Some(baos.toString("UTF-8"))
-    } catch {
-      case e: Exception => {
-        logger.debug("Exception printing stack trace.", e)
-        None
-      }
-    }
-
-    JsObject(
-      "frames" -> JsArray(frames.toVector),
-      "exception" -> JsObject(
-        "class" -> throwable.getClass.getCanonicalName.toJson,
-        "message" -> (throwable.getMessage match {
-          case null => "".toJson
-          case _ => throwable.getMessage.toJson
-        })
-      ),
-      "raw" -> raw.toJson
-    )
-  }
+  val rollbarClient: Rollbar = Rollbar.init(
+    ConfigBuilder.withAccessToken(rollbarApiToken)
+      .language("scala")
+      .environment(environment)
+      .build())
 
   def sendError(e: Throwable): Unit = {
-    val payload = this.buildRollbarPayload(e)
-    sendError(payload)
+    if (this.environment != "development")
+      rollbarClient.error(e)
   }
 
   def sendError(s: String): Unit = {
-    val payload = this.buildRollbarPayload(s)
-    sendError(payload)
-  }
-
-  def sendError(payload: JsObject): Unit = {
-    if (this.environment != "development") {
-      Http().singleRequest(
-        HttpRequest(HttpMethod("POST", false, false, RequestEntityAcceptance.Expected),
-          uri = this.url,
-          entity = HttpEntity(ContentTypes.`application/json`,
-            payload.toString))
-      )
-    }
+    if (this.environment != "development")
+      rollbarClient.error(s)
   }
 }

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -79,4 +79,5 @@ object Dependencies {
   val doobiePostgres          = "org.tpolecat"                %% "doobie-postgres"                   % Version.doobie
   val doobieSpecs             = "org.tpolecat"                %% "doobie-specs2"                     % Version.doobie
   val doobieScalatest         = "org.tpolecat"                %% "doobie-scalatest"                  % Version.doobie
+  val rollbar                 = "com.rollbar"                  % "rollbar-java"                      % Version.rollbar
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -49,4 +49,5 @@ object Version {
   val slickMigrationAPI  = "0.4.0"
   val betterFiles        = "3.4.0"
   val doobie             = "0.5.0-M14"
+  val rollbar            = "1.0.1"
 }


### PR DESCRIPTION
## Overview

Instead of maintaining stacktrace assembly and reporting logic, depend on the Rollbar Java SDK to do it for us. Also, attempt to maintain the existing `RollbarNotifier` abstraction—just instantiate the SDK client inside of `RollbarNotifier`.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

Update `ROLLBAR_SERVER_TOKEN` in `.env` and attempt to trigger a `sendError()` in the project.

To help make things easier, I generated Rollbar entries using this branch already, which you can inspect at:

- https://rollbar.com/Azavea/RasterFoundry/items/4674/
- https://rollbar.com/Azavea/RasterFoundry/items/4675/