### PR TITLE
Separately run mg init and ignore errors

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -47,7 +47,9 @@ then
 
         echo "Preparing the database for testing"
         docker-compose \
-            run --rm api-server ";mg init;mg update;mg apply"
+            run --rm api-server "mg init" || true
+        docker-compose \
+            run --rm api-server ";mg update;mg apply"
 
         echo "Executing Scala test suite"
         docker-compose \


### PR DESCRIPTION
## Overview

This PR run `mg init` separately in testing setup and ignores errors if it fails (e.g., due to
`__migrations__` already existing in the db). The reason for running it separately is shared
`postgres` container state across develop builds, since it's off the same branch, which causes
the build to happen against a database that has already been initialized for forklift. The correct
solution is in #3230 but it's more time-consuming.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

CI is pretty much guaranteed to pass on this branch except for unrelated issues, so the real test is against develop -- the testing instructions below replicate the `develop` branch build scenario, where migration initialization runs against an already-initialized database.

## Testing Instructions

 * Kill everything in `scripts/test` except updating scala deps, database prep, and running scala tests
 * `./scripts/test`
 * watch the error happen for `mg init` and the tests proceed anyway
