### PR TITLE
Kickoff ingests after adding scenes to projects everywhere

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -511,7 +511,7 @@ trait ProjectRoutes extends Authentication
             }
           }
           ingestsKickoff.transact(xa).unsafeRunAsync(
-            (result: Either[Throwable, Unit]) => {
+            (result: Either[Throwable, List[Unit]]) => {
               result match {
                 case Left(error) => sendError(error)
                 case _ => ()

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -16,7 +16,7 @@ import cats.implicits._
 import com.azavea.rf.api.scene._
 import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 import com.azavea.rf.api.utils.Config
-import com.azavea.rf.common.{Authentication, CommonHandlers, UserErrorHandler}
+import com.azavea.rf.common.{Authentication, CommonHandlers, RollbarNotifier, UserErrorHandler}
 import com.azavea.rf.common.AWSBatch
 import com.azavea.rf.common.S3._
 import com.azavea.rf.database._
@@ -57,6 +57,7 @@ trait ProjectRoutes extends Authentication
     with CommonHandlers
     with AWSBatch
     with UserErrorHandler
+    with RollbarNotifier
     with KamonTraceDirectives
     with LazyLogging {
 
@@ -502,7 +503,23 @@ trait ProjectRoutes extends Authentication
   def addProjectScenesFromQueryParams(projectId: UUID): Route = authenticate { user =>
     entity(as[CombinedSceneQueryParams]) { combinedSceneQueryParams =>
       onSuccess(ProjectDao.addScenesToProjectFromQuery(combinedSceneQueryParams, projectId, user).transact(xa).unsafeToFuture()) {
-        scenesAdded => complete((StatusCodes.Created, scenesAdded))
+        scenesAdded => {
+          val ingestsKickoff = SceneWithRelatedDao.getScenesToIngest(projectId) map {
+            (toIngest: List[Scene.WithRelated]) => {
+              logger.info(s"Kicking off ${toIngest.length} scene ingests from query parameter add")
+              toIngest map { (scene: Scene.WithRelated) => kickoffSceneIngest(scene.id) }
+            }
+          }
+          ingestsKickoff.transact(xa).unsafeRunAsync(
+            (result: Either[Throwable, Unit]) => {
+              result match {
+                case Left(error) => sendError(error)
+                case _ => ()
+              }
+            }
+          )
+          complete((StatusCodes.Created, scenesAdded))
+        }
       }
     }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -284,7 +284,5 @@ object ProjectDao extends Dao[Project] {
       scenes <- SceneDao.query.filter(sceneParams).list
       scenesAdded <- addScenesToProject(scenes.map(_.id), projectId, user)
     } yield scenesAdded
-
   }
-
 }


### PR DESCRIPTION
## Overview

This PR adds ingest kickoffs after adding scenes to projects in updating AOIs and in
adding scenes to a project from a query.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

The handling to kickoff ingests when adding scenes from query parameters is a little bit different from
the handling when posting IDs correctly. I _think_ it's the case that we don't want to send a failure
response on adding scenes to a project when we fail to kickoff ingests for those scenes. Possibly we do
though, since it means that users can't add scenes to a project without those scenes also having
ingests kicked off successfully. I'm not sure.

## Testing Instructions

 * ???

Closes azavea/raster-foundry-platform#218
