### PR TITLE
Return and display approximate scene counts for many scenes

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -31,7 +31,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
 
     for {
       page <- paginatedQuery
-      count <- countQuery
+      count <- query.countIO
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count
@@ -114,12 +114,10 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
         .compile
         .toList
     val withRelatedsIO: ConnectionIO[List[Scene.WithRelated]] = scenesIO flatMap { scenesToScenesWithRelated }
-    val countIO: ConnectionIO[Int] =
-      (fr"SELECT count(*) FROM scenes" ++ Fragments.whereAndOpt(queryFilters: _*)).query[Int].unique
 
     for {
       page <- withRelatedsIO
-      count <- countIO
+      count <- query.countIO
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -166,7 +166,8 @@ export default (app) => {
                             resolve({
                                 scenes: response.results,
                                 hasNext,
-                                count: this.$filter('number')(response.count)
+                                count: response.count >= 10000 ?
+                                    'At least 10,000' : this.$filter('number')(response.count);
                             });
                         }, (error) => {
                             reject({


### PR DESCRIPTION
## Overview

This PR makes the backend stop counting database objects if it finds more than we feel like counting.
Right now, "how many we feel like counting" is 10,000.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * browse scenes to list them for a project
 * observe that you get "At least 10,000" for far out zooms
 * observe that the number is exact when you add some filters (note that bbox doesn't seem to affect anything though, see #3232 )

Closes #3108 
