### PR TITLE
Restore Landsat 8 to Landsat 8 C1 import redirection

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
@@ -296,13 +296,13 @@ object ImportLandsat8 {
      case List(date, threshold) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date), threshold.toInt)
      case List(date) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date))
      case List(date, threshold) => throw new NotImplementedError(
-       "pre-May 1, 2016 import did not deserve to make the trip to the valley beyond"
+       "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
      )
      case List(date) => throw new NotImplementedError(
-       "pre-May 1, 2016 import did not deserve to make the trip to the valley beyond"
+       "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
      )
      case _ =>  throw new NotImplementedError(
-       "pre-May 1, 2016 import did not deserve to make the trip to the valley beyond"
+       "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
      )
    }
 


### PR DESCRIPTION
## Overview

Our batch processes try to invoke the `import_landsat8` job, which used to redirect to `import_landsat8_c1`. That was removed when I was fixing the batch subproject to get things
to work. This restores it.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * attempt to run the batch jar `import_landsat8` job for a date in the `c1` era
 * note that you don't instantly fail for having unimplemented methods
 * observe that the most recent direct run of `import_landsat8_c1` succeeded
