### PR TITLE
Fix sql queries and stop actor system in Sentinel 2 import

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -124,7 +124,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
   }
 
   /** Because it makes scenes -- get it? */
-  def riot(existingScenes: List[UUID], scenePath: String, datasourceUUID: UUID): Option[Scene.Create] = {
+  def riot(existingScenes: List[String], scenePath: String, datasourceUUID: UUID): Option[Scene.Create] = {
       val sceneId = UUID.randomUUID()
       val images = List(10f, 20f, 60f).map(createImages(sceneId, scenePath.some, _)).reduce(_ ++ _)
       val thumbnails = createThumbnails(sceneId, scenePath)
@@ -197,7 +197,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
 
   def findScenes(date: LocalDate, keys: List[URI], user: User, datasourceUUID: UUID): ConnectionIO[List[Scene.WithRelated]] = {
     val scenesIo: ConnectionIO[List[Scene.Create]] = getExistingScenes(date, datasourceUUID) map {
-      case (ids: List[UUID]) => {
+      case (names: List[String]) => {
         keys map {
           (uri:URI) => {
             for {
@@ -206,7 +206,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
             } yield {
               tilesJson.flatMap { tileJson =>
                 tileJson.hcursor.downField("path").as[String].toOption.map {
-                  scenePath => riot(ids, scenePath, datasourceUUID)
+                  scenePath => riot(names, scenePath, datasourceUUID)
                 }
               }.flatten
             }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -36,8 +36,6 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
 
   val name = ImportSentinel2.name
 
-  type SceneName = String
-
   /** Get S3 client per each call */
   def s3Client = S3(region = sentinel2Config.awsRegion)
 
@@ -119,14 +117,14 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       ).toList
   }
 
-  def getExistingScenes(date: LocalDate, datasourceUUID: UUID): ConnectionIO[List[SceneName]] = {
-    val idsQuery =
-      sql" select id from scenes where date(acquisition_date) = ${date} and datasource_id = ${datasourceUUID}"
-    idsQuery.query[SceneName].stream.compile.toList
+  def getExistingScenes(date: LocalDate, datasourceUUID: UUID): ConnectionIO[List[UUID]] = {
+    SceneDao.query.filter(
+      Fragments.and(fr"datasource = ${datasourceUUID} :: uuid", fr"date(acquisition_date) = date(${date}) :: date")
+    ).list map { (scenes: List[Scene]) => scenes map { _.id } }
   }
 
   /** Because it makes scenes -- get it? */
-  def riot(existingScenes: List[SceneName], scenePath: String, datasourceUUID: UUID): Option[Scene.Create] = {
+  def riot(existingScenes: List[UUID], scenePath: String, datasourceUUID: UUID): Option[Scene.Create] = {
       val sceneId = UUID.randomUUID()
       val images = List(10f, 20f, 60f).map(createImages(sceneId, scenePath.some, _)).reduce(_ ++ _)
       val thumbnails = createThumbnails(sceneId, scenePath)
@@ -199,9 +197,9 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
 
   def findScenes(date: LocalDate, keys: List[URI], user: User, datasourceUUID: UUID): ConnectionIO[List[Scene.WithRelated]] = {
     val scenesIo: ConnectionIO[List[Scene.Create]] = getExistingScenes(date, datasourceUUID) map {
-      case ids: List[SceneName] => {
+      case (ids: List[UUID]) => {
         keys map {
-          uri:URI => {
+          (uri:URI) => {
             for {
               json <- s3Client.getObject(uri.getHost, uri.getPath.tail).getObjectContent.toJson
               tilesJson <- json.hcursor.downField("tiles").as[List[Json]].toOption
@@ -219,8 +217,10 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
 
     logger.info(s"Inserting scenes for ${date}")
 
-    scenesIo flatMap { sceneList: List[Scene.Create] =>
-      sceneList.traverse({ SceneDao.insert(_, user) })
+    scenesIo flatMap {
+      (sceneList: List[Scene.Create]) => {
+        sceneList.traverse({ SceneDao.insert(_, user) })
+      }
     }
   }
 
@@ -236,8 +236,16 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
             throw new Exception(s"${systemUser} could not be found -- probably the database is borked")
         }
       }
-    scenesIO.transact(xa).unsafeRunSync
-    logger.info("Scenes imported successfully")
+    try {
+      scenesIO.transact(xa).unsafeRunSync
+      logger.info("Scenes imported successfully")
+      stop
+    } catch {
+      case (e: Throwable) => {
+        sendError(e)
+        stop
+      }
+    }
   }
 }
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -117,10 +117,10 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       ).toList
   }
 
-  def getExistingScenes(date: LocalDate, datasourceUUID: UUID): ConnectionIO[List[UUID]] = {
+  def getExistingScenes(date: LocalDate, datasourceUUID: UUID): ConnectionIO[List[String]] = {
     SceneDao.query.filter(
       Fragments.and(fr"datasource = ${datasourceUUID} :: uuid", fr"date(acquisition_date) = date(${date}) :: date")
-    ).list map { (scenes: List[Scene]) => scenes map { _.id } }
+    ).list map { (scenes: List[Scene]) => scenes map { _.name } }
   }
 
   /** Because it makes scenes -- get it? */


### PR DESCRIPTION
## Overview

This PR explicitly stops the `ActorSystem` in both success and failure cases and fixes some
sql bugs in the Sentinel-2 import job.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * add a `.take(5)` to `getSentinel2Products`
 * run `assembly` for the `batch` subproject
 * count the scenes in your db
 * run the the `import_sentinel2` job (the recursive key listing part takes more than a minute but it's necessary) for `2018-10-29` (because you shouldn't already have those dates in your db)
 * count the scenes in your db again
 * note that there are 5 more

Closes #3243 
