### PR TITLE
Coordinate doobie output from find aoi projects and cli input

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -43,7 +43,9 @@ case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job {
         .to[List]
     }
 
-    aoiProjectsToUpdate.transact(xa).unsafeRunSync.foreach(println)
+    aoiProjectsToUpdate.transact(xa).unsafeRunSync.foreach(
+      (projectId: UUID) => println(s"Project to update: ${projectId}")
+    )
   }
 }
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -43,6 +43,7 @@ case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job {
         .to[List]
     }
 
+    // TODO: this stdout-based process communication _extremely_ brittle. See #3263
     aoiProjectsToUpdate.transact(xa).unsafeRunSync.foreach(
       (projectId: UUID) => println(s"Project to update: ${projectId}")
     )

--- a/app-tasks/rf/src/rf/commands/find_aoi_projects.py
+++ b/app-tasks/rf/src/rf/commands/find_aoi_projects.py
@@ -27,13 +27,14 @@ def find_aoi_projects_to_update():
     """Find AOI projects to check for updates and return their IDs to process"""
     logger.info('Finding AOI projects to check for updates')
 
-    bash_cmd = 'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main find_aoi_projects'
-    cmd = subprocess.Popen(bash_cmd, shell=True, stdout=subprocess.PIPE)
-    projects = ['']
-    for line in cmd.stdout:
-        logger.info(line.strip())
-        if 'ProjectIds:' in line:
-            projects = [p.strip() for p in line.replace('ProjectIds:', '').strip().split(',')]
+    bash_cmd = ['java', '-cp', '/opt/raster-foundry/jars/rf-batch.jar',
+                'com.azavea.rf.batch.Main', 'find_aoi_projects']
+    cmd = subprocess.Popen(bash_cmd, stdout=subprocess.PIPE)
+    (stdout, stderr) = cmd.communicate()
+    projects = [
+        x.strip().lstrip('Project to update: ') for x in stdout.split('\n') if
+        x.startswith('Project to update: ')
+    ]
     return projects
 
 

--- a/app-tasks/rf/src/rf/commands/find_aoi_projects.py
+++ b/app-tasks/rf/src/rf/commands/find_aoi_projects.py
@@ -31,6 +31,9 @@ def find_aoi_projects_to_update():
                 'com.azavea.rf.batch.Main', 'find_aoi_projects']
     cmd = subprocess.Popen(bash_cmd, stdout=subprocess.PIPE)
     (stdout, stderr) = cmd.communicate()
+    # Note: this is _extremely_ brittle, and relies on specific strings being printed
+    # somewhere where the scala compiler doesn't know it needs to care about a message's text
+    # See #3263
     projects = [
         x.strip().lstrip('Project to update: ') for x in stdout.split('\n') if
         x.startswith('Project to update: ')
@@ -44,13 +47,13 @@ def kickoff_aoi_project_update_checks(project_ids):
     Args:
         project_ids (List[str]): list of project ids to process
     """
+    logger.info('Found projects to check for updates: %s', project_ids)
 
     if ENVIRONMENT.lower() not in ['staging', 'production']:
         logger.warn('Skipping kicking off AOI updates because in environment %s', ENVIRONMENT)
         return
 
     client = boto3.client('batch')
-    logger.info('Found projects to check for updates: %s', project_ids)
 
     for project_id in project_ids:
         parameters = {'projectId': project_id}


### PR DESCRIPTION
## Overview

This PR fixes a bad job submission bug where the python client tries
to submit an empty string as a project id.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

The bug came from the refactor of the `find_aoi_projects` job. The specific content of the logging
output turned out to be important since the python client is doing string filtering on what it finds in
stdout, which I didn't notice when I refactored it originally.

## Testing Instructions

 * set all of the projects in your dev db to have `is_aoi_project = true`
 * run `batch/assembly`
 * throw an `info` statement into `find_aoi_projects_to_update`
 * rebuild your `batch` container
 * console in to your `batch` container
 * `rf find-aoi-projects`
