### PR TITLE
[Platforms] Add property tests for teamDao

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -370,6 +370,19 @@ object Generators extends ArbitraryInstances {
   private def combinedSceneQueryParamsGen: Gen[CombinedSceneQueryParams] =
     Gen.const(CombinedSceneQueryParams())
 
+  private def teamCreateGen: Gen[Team.Create] = for {
+    orgId <- uuidGen
+    name <- nonEmptyStringGen
+    settings <- Gen.const(().asJson)
+  } yield Team.Create(orgId, name, settings)
+
+  private def teamGen: Gen[Team] = for {
+    user <- userGen
+    teamCreate <- teamCreateGen
+  } yield {
+    teamCreate.toTeam(user)
+  }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
 
@@ -426,5 +439,9 @@ object Generators extends ArbitraryInstances {
     implicit def arbListLayerAttribute: Arbitrary[List[LayerAttribute]] = Arbitrary {
       layerAttributesWithSameLayerNameGen
     }
+
+    implicit def arbTeamCreate: Arbitrary[Team.Create] = Arbitrary { teamCreateGen }
+
+    implicit def arbTeam: Arbitrary[Team] = Arbitrary { teamGen }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -51,7 +51,7 @@ object TeamDao extends Dao[Team] {
       fr"""
       SET modified_at = ${now},
           modified_by = ${user.id},
-          name = ${team.name}
+          name = ${team.name},
           settings = ${team.settings}
       WHERE id = ${id}"""
     updateQuery

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -116,4 +116,7 @@ trait PropTestHelpers {
   def fixupAoi(user: User, org: Organization, aoi: AOI): AOI = {
     aoi.copy(organizationId = org.id, owner = user.id, createdBy = user.id, modifiedBy = user.id)
   }
+
+  def fixupTeam(teamCreate: Team.Create, org: Organization, user: User): Team =
+    teamCreate.copy(organizationId = org.id).toTeam(user)
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -1,0 +1,77 @@
+package com.azavea.rf.database
+
+import java.sql.Timestamp
+
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
+import com.azavea.rf.database.Implicits._
+import doobie._
+import doobie.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.syntax.either._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatest.prop.Checkers
+import io.circe._
+import io.circe.syntax._
+import java.util.UUID
+
+class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+
+  test("creating a team") {
+    check {
+      forAll (
+        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create) => {
+          val createTeamIO = for {
+            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
+            (orgInsert, userInsert) = orgAndUserInsert
+            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+          } yield (teamInsert, orgInsert)
+
+          val (createdTeam, org) = createTeamIO.transact(xa).unsafeRunSync
+
+          createdTeam.name == teamCreate.name &&
+            createdTeam.organizationId == org.id &&
+            createdTeam.settings == teamCreate.settings
+        }
+      )
+    }
+  }
+
+  test("updating a team"){
+    check {
+      forAll (
+        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create, teamUpdate: Team.Create) => {
+          val createTeamIO = for {
+            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
+            (orgInsert, userInsert) = orgAndUserInsert
+            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+          } yield (teamInsert, orgInsert, userInsert)
+
+          val updateTeamIO = createTeamIO flatMap {
+            case (team: Team, org: Organization, user: User) => {
+              TeamDao.update(
+                fixupTeam(teamUpdate, org, user),
+                team.id,
+                user
+              ) map {
+                (_, org)
+              }
+            }
+          }
+
+          val (updatedTeam, org) = updateTeamIO.transact(xa).unsafeRunSync
+
+          updatedTeam.name == teamUpdate.name &&
+            updatedTeam.settings == teamUpdate.settings &&
+            updatedTeam.organizationId == org.id
+        }
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR adds property tests for `teamDao`.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

 * `mg update`, `mg apply`
 * `./scripts/console api-server ./sbt`
 * `project db`
 * `testOnly *TeamDaoSpec`

Closes #3224
