### PR TITLE
Use Spark Local for Exports

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -41,16 +41,6 @@ landsat8 {
   bucketName       = "landsat-pds"
 }
 
-export-def {
-  awsRegion   = "us-east-1"
-  bucketName  = "export-definitions"
-  awsDataproc = "dataproc.rasterfoundry.com."
-  sparkJarS3  = "s3://rasterfoundry-global-artifacts-us-east-1/batch"
-  sparkJar    = ${?BATCH_JAR_PATH}
-  sparkClass  = "com.azavea.rf.batch.export.spark.Export"
-  sparkMemory = "2G"
-}
-
 sentinel2 {
   # Public Organization UUID in Raster Foundry
   organization = "dfac6307-b5ef-43f7-beda-b9f208bb7726"

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
@@ -7,7 +7,7 @@ import scala.util._
 object CommandLine {
   case class Params(
     jobDefinition: URI = new URI(""),
-    statusBucket: String = "rasterfoundry-dataproc-export-status-us-east-1"
+    statusURI: URI = new URI("")
   )
 
   // Used for reading text in as URI
@@ -25,8 +25,8 @@ object CommandLine {
       .text("The location of the json which defines an ingest job")
       .required
 
-    opt[String]('b',"statusBucket")
-      .action( (s, conf) => conf.copy(statusBucket = s) )
-      .text("S3 bucket to write status jsons to")
+    opt[URI]('b',"statusURI")
+      .action( (s, conf) => conf.copy(statusURI = s) )
+      .text("S3 URI to write status jsons to")
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -5,9 +5,6 @@ import java.util.UUID
 import cats.data._
 import cats.effect.IO
 import cats.implicits._
-import com.amazonaws.{AmazonServiceException, SdkClientException}
-import com.amazonaws.services.elasticmapreduce.AmazonElasticMapReduceClientBuilder
-import com.amazonaws.services.elasticmapreduce.model.{AddJobFlowStepsRequest, AddJobFlowStepsResult, HadoopJarStepConfig, StepConfig}
 import com.azavea.rf.batch._
 import com.azavea.rf.batch.util._
 import com.azavea.rf.database.Implicits._
@@ -16,118 +13,51 @@ import com.azavea.rf.database.{ExportDao, UserDao}
 import com.azavea.rf.datamodel._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
-import org.xbill.DNS._
 import doobie._
 import doobie.implicits._
 import doobie.postgres._
 import doobie.postgres.implicits._
 
-import scala.collection.JavaConverters._
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
 import scala.util._
 
-case class CreateExportDef(exportId: UUID, region: Option[String] = None)(implicit val xa: Transactor[IO]) extends Job {
+case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit val xa: Transactor[IO]) extends Job {
   val name = CreateExportDef.name
 
   /** Get S3 client per each call */
-  def s3Client = S3(region = region)
+  def s3Client = S3(region = None)
 
-  protected def writeExportDefToS3(exportDef: ExportDefinition): Unit = {
-    logger.info(s"Uploading export definition ${exportDef.id.toString} to S3 at ${exportDefConfig.bucketName}")
+  protected def writeExportDefToS3(exportDef: ExportDefinition, bucket: String, key: String): Unit = {
+    logger.info(s"Uploading export definition ${exportDef.id.toString} to S3 at s3://${bucket}/${key}")
 
-    val uri = getExportURI(exportDef)
     try {
-      s3Client.putObject(uri, s"${exportDef.id.toString}.json", exportDef.asJson.toString)
+      s3Client.putObject(bucket, key, exportDef.asJson.toString)
     } catch {
       case e: Throwable => {
-        logger.error(s"Failed to put export defintion ${exportDef.id} => ${uri}")
+        logger.error(s"Failed to put export definition ${exportDef.id} => ${bucket}/${key}")
         throw e
       }
     }
   }
 
-  def getExportURI(exportDefinition: ExportDefinition): String = {
-    s"rasterfoundry-development-data-us-east-1/${exportDefConfig.bucketName}"
-  }
-
-  protected def getClusterId() = {
-    val dnsLookup = new Lookup(exportDefConfig.awsDataproc, Type.TXT, DClass.IN)
-    dnsLookup.run()
-    val clusterId = dnsLookup.getAnswers().map(_.rdataToString).head.replace("\"", "")
-    clusterId
-  }
-
-  protected def startExportEmrJob(exportDef: ExportDefinition, exportDefUri: String): AddJobFlowStepsResult = {
-    val jarStep = new HadoopJarStepConfig()
-    jarStep.setJar(jarPath)
-    jarStep.setArgs(
-      List(
-        "/usr/bin/spark-submit", "--master", "yarn", "--deploy-mode",
-        "cluster", "--conf", "spark.yarn.submit.waitAppCompletion=false",
-        "--class", exportDefConfig.sparkClass, "--driver-memory", exportDefConfig.sparkMemory,
-        s"${exportDefConfig.sparkJarS3}/${exportDefConfig.sparkJar}",
-        "-j", s"s3://${exportDefUri}/${exportDef.id}.json"
-      ).asJava
-    )
-
-    val steps = new StepConfig()
-    steps.setName(s"export-${exportDef.id}")
-    steps.setActionOnFailure("CONTINUE")
-    steps.setHadoopJarStep(jarStep)
-
-    val jobSteps = new AddJobFlowStepsRequest()
-    jobSteps.setJobFlowId(getClusterId())
-    jobSteps.setSteps(List(steps).asJava)
-
-    val emrClient = AmazonElasticMapReduceClientBuilder.standard().withCredentials(s3Client.credentialsProviderChain).build()
-    emrClient.addJobFlowSteps(jobSteps)
-  }
-
-  def updateExportStatus(export: Export, status: ExportStatus): Export =
-    export.copy(exportStatus = status)
-
   def run: Unit = {
-    logger.info("Starting export process...")
-
-    val processingExport = for {
+    val exportDefinitionWrite = for {
       user <- UserDao.query.filter(fr"id = ${systemUser}").select
       export <- ExportDao.query.filter(fr"id = ${exportId}").select
       exportDef <- ExportDao.getExportDefinition(export, user)
-      _ <- {
-        writeExportDefToS3(exportDef)
-        ExportDao.update(updateExportStatus(export, ExportStatus.Exporting), exportId, user)
+      x <- {
+        writeExportDefToS3(exportDef, bucket, key)
+        val updatedExport = export.copy(exportStatus = ExportStatus.Exporting)
+        ExportDao.update(updatedExport, exportId, user)
       }
     } yield {
-      val uri = getExportURI(exportDef)
-      try {
-        startExportEmrJob(exportDef, uri)
-        val exportStarted = updateExportStatus(export, ExportStatus.Exporting)
-        ExportDao.update(exportStarted, exportId, user)
-        exportStarted
-      } catch {
-        case e: Throwable => {
-          logger.error(s"An error occurred during export ${export.id}. Skipping...")
-          logger.error(e.stackTraceString)
-          sendError(e)
-          val exportFailed = updateExportStatus(export, ExportStatus.Failed)
-          ExportDao.update(exportFailed, exportId, user)
-          exportFailed
-        }
-      }
+      logger.info(s"Wrote export definition: ${x}")
     }
 
-    processingExport.transact(xa).unsafeToFuture onComplete {
+    exportDefinitionWrite.transact(xa).unsafeToFuture onComplete {
       case Success(export) => {
-        if (export.exportStatus == ExportStatus.Failed) {
-          logger.error("Export job failed to send to cluster; status not updated")
-          sendError("Export job failed to send to cluster; status not updated")
-          stop
-          sys.exit(1)
-        } else {
-          logger.info("Export job sent to cluster and status updated")
-          stop
-        }
+        logger.info("Successfully wrote export definition")
+        stop
+        sys.exit(0)
       }
       case Failure(e) => {
         logger.error(e.stackTraceString)
@@ -146,10 +76,9 @@ object CreateExportDef {
     implicit val xa = RFTransactor.xa
 
     val job = args.toList match {
-      case List(exportId, region) => CreateExportDef(UUID.fromString(exportId), Some(region))
-      case List(exportId) => CreateExportDef(UUID.fromString(exportId))
+      case List(exportId, bucket, key) => CreateExportDef(UUID.fromString(exportId), bucket, key)
       case _ =>
-        throw new IllegalArgumentException("Argument could not be parsed to UUID")
+        throw new IllegalArgumentException("Argument could not be parsed to UUID and URI")
     }
 
     job.run

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -64,6 +64,11 @@ case class S3(
   def putObject(s3bucket: String, s3Key: String, content: String): PutObjectResult =
     client.putObject(s3bucket, s3Key, content)
 
+  def putObject(uri: URI, content: String): PutObjectResult = {
+    val s3uri = new AmazonS3URI(uri)
+    client.putObject(s3uri.getBucket, s3uri.getKey, content)
+  }
+
   /** List the keys to files found within a given bucket */
   def listKeys(url: String, ext: String, recursive: Boolean): Array[URI] = {
     val S3InputFormat.S3UrlRx(_, _, bucket, prefix) = url

--- a/app-backend/common/src/main/scala/AWSBatch.scala
+++ b/app-backend/common/src/main/scala/AWSBatch.scala
@@ -67,6 +67,6 @@ trait AWSBatch extends RollbarNotifier with LazyLogging {
   def kickoffProjectExport(exportId: UUID): Unit = {
     val jobDefinition = awsbatchConfig.exportJobName
     val jobName = s"$jobDefinition-$exportId"
-    submitJobRequest(jobDefinition, awsbatchConfig.jobQueue, Map("exportId" -> s"$exportId"), jobName)
+    submitJobRequest(jobDefinition, awsbatchConfig.ingestJobQueue, Map("exportId" -> s"$exportId"), jobName)
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -58,8 +58,7 @@ object ExportDao extends Dao[Export] {
   }
 
   def update(export: Export, id: UUID, user: User): ConnectionIO[Int] = {
-    (fr"""
-      UPDATE ${tableName} SET
+    (fr"UPDATE" ++ tableF ++ fr"SET" ++ fr"""
         modified_at = NOW(),
         modified_by = ${user.id},
         export_status = ${export.exportStatus},

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -23,49 +23,70 @@ def export(export_id):
     Args:
         export_id (str): ID of export job to process
     """
-    start_emr_export(export_id)
-    wait_for_status(export_id)
+    export_uri = create_export_definition(export_id)
+    try:
+        status_uri = run_export(export_uri, export_id)
+    finally:
+        wait_for_status(export_id, status_uri)
 
 
-def start_emr_export(export_id):
-    """Start process of EMR export
+def create_export_definition(export_id):
+    """Create an export definition
 
     Args:
-        export_id (str): ID of export object
+        export_id (str): ID of export job to process
     """
-    bash_cmd = 'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main create_export_def {0}'.format(export_id)
-    cmd = subprocess.Popen(bash_cmd, shell=True, stdout=subprocess.PIPE)
-    step_id = ''
-    for line in cmd.stdout:
-        logger.info(line.strip())
-        if 'StepId:' in line:
-            step_id = line.replace('StepId:', '').strip()
+    bucket = os.getenv('DATA_BUCKET')
+    key = 'export-definitions/{}'.format(export_id)
+    logger.info('Creating export definition for %s', export_id)
+    command = ['java', '-cp',
+               '/opt/raster-foundry/jars/rf-batch.jar',
+               'com.azavea.rf.batch.Main', 'create_export_def',
+               export_id, bucket, key]
+    logger.info('Running Command %s', ' '.join(command))
+    subprocess.check_call(command)
 
-    logger.info('Launched export creation process, watching for updates...')
-    is_success = wait_for_emr_success(step_id, get_cluster_id())
-    return is_success
+    logger.info('Created export definition for %s', export_id)
+    return 's3://{}/{}'.format(bucket, key)
 
 
-def wait_for_status(export_id):
+def run_export(export_s3_uri, export_id):
+    """Run spark export
+
+    Args:
+        export_s3_uri (str): location of job definition
+        export_id (str): ID of export job to process
+
+    """
+    export_cores = os.getenv('LOCAL_INGEST_CORES', 32)
+    export_memory = os.getenv('LOCAL_INGEST_MEM_GB', 48)
+    status_uri = 's3://{}/export-statuses/{}'.format(os.getenv('DATA_BUCKET'), export_id)
+
+    command = ['spark-submit',
+               '--master', 'local[{}]'.format(export_cores),
+               '--driver-memory', '{}g'.format(export_memory),
+               '--class', 'com.azavea.rf.batch.export.spark.Export',
+               '/opt/raster-foundry/jars/rf-batch.jar',
+               '-j', export_s3_uri, '-b', status_uri
+    ]
+    subprocess.check_call(command)
+    logger.info('Finished exporting %s in spark local', export_s3_uri)
+    return status_uri
+
+
+def wait_for_status(export_id, status_uri):
     """Wait for a result from the Spark job
 
     Args:
+        status_uri (str): location of job status URI
         export_id (str): run command to wait for status of export
     """
 
-    bash_cmd = 'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main check_export_status {0}'.format(export_id)
+    bash_cmd = ['java', '-cp', '/opt/raster-foundry/jars/rf-batch.jar',
+                'com.azavea.rf.batch.Main',
+                'check_export_status',
+                export_id, status_uri]
+
     logger.info('Updating %s\'s export status after successful EMR status', export_id)
-    cmd = subprocess.Popen(bash_cmd, shell=True, stdout=subprocess.PIPE)
-    for line in cmd.stdout:
-        logger.info(line.strip())
-
-    # Wait until process terminates (without using cmd.wait())
-    while cmd.poll() is None:
-        time.sleep(0.5)
-
-    if cmd.returncode == 0:
-        logger.info('Successfully completed export %s', export_id)
-        return True
-    else:
-        logger.error('Something went wrong with export: %s', export_id)
-        raise Exception('Export failed for {}'.format(export_id))
+    subprocess.check_call(bash_cmd)
+    logger.info('Successfully completed export %s', export_id)


### PR DESCRIPTION
## Overview

This commit adjusts how exports are run by no longer relying on a permanent EMR cluster to be running. A few things happen here:
 - Code to submit EMR jobs in the batch CLI is removed
 - Code to run a local spark job is added to the `rf` client
 - Export jobs now run in the "ingest" queue in AWS
 - The location of job statuses is made more explicit

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [ ] Add an issue to rename "ingest" environment variables/queues to "spark"
- [x] Add an issue to remove usages of "status" json's in S3 to track status
- [x] Add an issue to remove/take-down spark EMR cluster

### Demo


### Notes

Some things are left for later tasks at this point:
 - Status JSONs are still used, there is a little bit of infrastructure there that I did not want to mess with -- mostly the problem is we do not use our own python client for the batch stuff, which makes using the API for new things (like updating/querying export definitions) kind of a pain -- so that stays for now. If this is deemed OK, I'm going to add an issue to deal with this
 - There are a few places where I hijacked the "ingest" queue and "ingest" settings for spark jobs. I think we should rename the "ingest" queue to be the "spark" queue (or something more innocuous like high cpu/high mem)

## Testing Instructions

 * Rebuild batch jar and batch docker container
```
./scripts/console api-server ./sbt
project batch
assembly
```

```
docker-compose build batch
```
 * Create an export of a small scene in development and get its ID (either from the request or a SQL query)
 * With the ID of the export run the following:
```
./scripts/console batch "rf export <export-id>"
```
 * Wait for export to succeed

Closes #3217
