### PR TITLE
Use a fresh platform in OrganizationDao tests

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Organization.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Organization.scala
@@ -25,7 +25,7 @@ object Organization {
     name: String,
     platformId: UUID
   ) {
-    def toOrganization(): Organization = {
+    def toOrganization: Organization = {
       val id = java.util.UUID.randomUUID()
       val now = new Timestamp((new java.util.Date()).getTime())
       Organization(id, now, now, name, platformId)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UserGroupRole.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UserGroupRole.scala
@@ -30,17 +30,16 @@ object UserGroupRole {
         userToAdd: User,
         groupType: GroupType,
         groupId: UUID,
-        groupRole: GroupRole,
-        creator: User
+        groupRole: GroupRole
     ) {
-        def toUserGroupRole: UserGroupRole = {
+        def toUserGroupRole(user: User): UserGroupRole = {
             val now = new Timestamp((new java.util.Date()).getTime())
             UserGroupRole(
                 UUID.randomUUID(),
                 now, // createdAt
-                creator.id, // createdBy
+                user.id, // createdBy
                 now, // modifiedAt
-                creator.id, // modifiedBy
+                user.id, // modifiedBy
                 true, // always default isActive to true
                 userToAdd.id, // user that is being given the group role
                 groupType,

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -38,6 +38,14 @@ object Generators extends ArbitraryInstances {
 
   private def userRoleGen: Gen[UserRole] = Gen.oneOf(UserRoleRole, Viewer, Admin)
 
+  private def groupTypeGen: Gen[GroupType] = Gen.oneOf(
+    GroupType.Platform, GroupType.Organization, GroupType.Team
+  )
+
+  private def groupRoleGen: Gen[GroupRole] = Gen.oneOf(
+    GroupRole.Admin, GroupRole.Member
+  )
+
   private def annotationQualityGen: Gen[AnnotationQuality] = Gen.oneOf(
     AnnotationQuality.Yes, AnnotationQuality.No, AnnotationQuality.Miss, AnnotationQuality.Unsure
   )
@@ -388,6 +396,13 @@ object Generators extends ArbitraryInstances {
     settings <- Gen.const(().asJson)
   } yield { Platform.Create(platformName, settings) }
 
+  private def userGroupRoleCreateGen: Gen[UserGroupRole.Create] = for {
+    user <- userGen
+    groupType <- groupTypeGen
+    groupId <- uuidGen
+    groupRole <- groupRoleGen
+  } yield { UserGroupRole.Create(user, groupType, groupId, groupRole) }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
 
@@ -450,5 +465,7 @@ object Generators extends ArbitraryInstances {
     implicit def arbTeam: Arbitrary[Team] = Arbitrary { teamGen }
 
     implicit def arbPlatformCreate: Arbitrary[Platform.Create] = Arbitrary { platformCreateGen }
+
+    implicit def arbUserGroupRoleCreate: Arbitrary[UserGroupRole.Create] = Arbitrary { userGroupRoleCreateGen }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -12,18 +12,18 @@ import io.circe._
 import java.util.UUID
 
 object UserGroupRoleDao extends Dao[UserGroupRole] {
-    val tableName = "user_group_roles"
+  val tableName = "user_group_roles"
 
-    val selectF = fr"""
-        SELECT
-            id, created_at, created_by,
-            modified_at, modified_by, is_active,
-            user_id, group_type, group_id, group_role
-        FROM
+  val selectF = fr"""
+      SELECT
+        id, created_at, created_by,
+        modified_at, modified_by, is_active,
+        user_id, group_type, group_id, group_role
+      FROM
     """ ++ tableF
 
-    def createF(ugr: UserGroupRole) =
-        fr"INSERT INTO" ++ tableF ++ fr"""(
+  def createF(ugr: UserGroupRole) =
+    fr"INSERT INTO" ++ tableF ++ fr"""(
             id, created_at, created_by,
             modified_at, modified_by, is_active,
             user_id, group_type, group_id, group_role
@@ -34,62 +34,68 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
         )
         """
 
-    // We don't want to support changes to roles beyond deactivation and promotion
-    def updateF(ugr: UserGroupRole, id: UUID, user: User) =
-        fr"UPDATE" ++ tableF ++ fr"""SET
-            modified_at = NOW(),
-            modified_by = ${user.id},
-            is_active = ${ugr.isActive},
-            group_role = ${ugr.groupRole}
-            where id = ${id}
-          """
+  // We don't want to support changes to roles beyond deactivation and promotion
+  def updateF(ugr: UserGroupRole, id: UUID, user: User) =
+    fr"UPDATE" ++ tableF ++ fr"""SET
+          modified_at = NOW(),
+          modified_by = ${user.id},
+          is_active = ${ugr.isActive},
+          group_role = ${ugr.groupRole}
+          where id = ${id}
+        """
 
-    def create(ugr: UserGroupRole): ConnectionIO[UserGroupRole] = {
-        val isValidGroup = ugr.groupType match {
-            case GroupType.Platform => PlatformDao.query.filter(ugr.groupId).exists
-            case GroupType.Organization => OrganizationDao.query.filter(ugr.groupId).exists
-            case GroupType.Team => TeamDao.query.filter(ugr.groupId).exists
-        }
+  def getUserGroupRoleById(ugrId: UUID, user: User): ConnectionIO[Option[UserGroupRole]] =
+    query.filter(ugrId).filter(fr"user_id = ${user.id}").selectOption
 
-        val create = createF(ugr).update.withUniqueGeneratedKeys[UserGroupRole](
-            "id", "created_at", "created_by",
-            "modified_at", "modified_by", "is_active",
-            "user_id", "group_type", "group_id", "group_role"
-        )
+  def unsafeGetUserGroupRoleById(ugrId: UUID, user: User): ConnectionIO[UserGroupRole] =
+    query.filter(ugrId).filter(fr"user_id = ${user.id}").select
 
-        for {
-            isValid <- isValidGroup
-            createUGR <- {
-                if (isValid) create
-                else throw new Exception(s"Invalid group: ${ugr.groupType}(${ugr.groupId})")
-            }
-        } yield createUGR
+  def create(ugr: UserGroupRole): ConnectionIO[UserGroupRole] = {
+    val isValidGroupIO = ugr.groupType match {
+      case GroupType.Platform => PlatformDao.query.filter(ugr.groupId).exists
+      case GroupType.Organization => OrganizationDao.query.filter(ugr.groupId).exists
+      case GroupType.Team => TeamDao.query.filter(ugr.groupId).exists
     }
 
-    def getOption(id: UUID): ConnectionIO[Option[UserGroupRole]] = {
-        query.filter(id).selectOption
-    }
+    val create = createF(ugr).update.withUniqueGeneratedKeys[UserGroupRole](
+      "id", "created_at", "created_by",
+      "modified_at", "modified_by", "is_active",
+      "user_id", "group_type", "group_id", "group_role"
+    )
 
-    // List roles that a given user has been granted
-    def listByUser(user: User): ConnectionIO[List[UserGroupRole]] = {
-        query.filter(fr"user_id = ${user.id}").list
-    }
+    for {
+      isValid <- isValidGroupIO
+      createUGR <- {
+        if (isValid) create
+        else throw new Exception(s"Invalid group: ${ugr.groupType}(${ugr.groupId})")
+      }
+    } yield createUGR
+  }
 
-    // List roles that have been given to users for a group
-    def listByGroup(groupType: GroupType, groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
-        query.filter(fr"group_type = ${groupType}").filter(fr"group_id = ${groupId}").list
-    }
+  def getOption(id: UUID): ConnectionIO[Option[UserGroupRole]] = {
+    query.filter(id).selectOption
+  }
 
-    // @TODO: ensure a user cannot demote (or promote?) themselves
-    def update(ugr: UserGroupRole, id: UUID, user: User): ConnectionIO[Int] =
-        updateF(ugr, id, user).update.run
+  // List roles that a given user has been granted
+  def listByUser(user: User): ConnectionIO[List[UserGroupRole]] = {
+    query.filter(fr"user_id = ${user.id}").list
+  }
 
-    def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
-        (fr"UPDATE" ++ tableF ++ fr""" SET
-              is_active = false,
-              modified_at = NOW(),
-              modified_by = ${user.id}
+  // List roles that have been given to users for a group
+  def listByGroup(groupType: GroupType, groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
+    query.filter(fr"group_type = ${groupType}").filter(fr"group_id = ${groupId}").list
+  }
+
+  // @TODO: ensure a user cannot demote (or promote?) themselves
+  def update(ugr: UserGroupRole, id: UUID, user: User): ConnectionIO[Int] =
+    updateF(ugr, id, user).update.run
+
+  def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
+    (fr"UPDATE" ++ tableF ++ fr""" SET
+          is_active = false,
+          modified_at = NOW(),
+          modified_by = ${user.id}
             WHERE id = ${id}
         """).update.run
-    }
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -119,4 +119,12 @@ trait PropTestHelpers {
 
   def fixupTeam(teamCreate: Team.Create, org: Organization, user: User): Team =
     teamCreate.copy(organizationId = org.id).toTeam(user)
+
+  def fixupUserGroupRole(user: User, organization: Organization, team: Team, platform: Platform, ugrCreate: UserGroupRole.Create): UserGroupRole.Create = {
+    ugrCreate.groupType match {
+      case GroupType.Platform => ugrCreate.copy(groupId = platform.id, userToAdd = user)
+      case GroupType.Organization => ugrCreate.copy(groupId = organization.id, userToAdd = user)
+      case GroupType.Team => ugrCreate.copy(groupId = team.id, userToAdd = user)
+    }
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -1,74 +1,143 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.{UserGroupRole, GroupType, GroupRole}
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 import doobie._
 import doobie.implicits._
 import cats._
 import cats.data._
 import cats.effect.IO
+import cats.implicits._
 import cats.syntax.either._
 import doobie.postgres._
 import doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
+import org.scalatest.prop.Checkers
 import io.circe._
 import io.circe.syntax._
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class UserGroupRoleDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
 
-    def createUserGroupRole: ConnectionIO[UserGroupRole] = {
-        for {
-            platform <- defaultPlatformQ
-            usr <- defaultUserQ
-            create <- {
-                val ugr = UserGroupRole.Create(
-                    usr,
-                    GroupType.Platform,
-                    platform.id,
-                    GroupRole.Member,
-                    usr
-                )
-                UserGroupRoleDao.create(ugr.toUserGroupRole)
+  test("list user group roles") {
+    UserGroupRoleDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+  }
+
+  test("insert a user group role") {
+    check {
+      forAll {
+        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
+         platformCreate: Platform.Create, ugrCreate: UserGroupRole.Create) => {
+          val insertUgrIO = for {
+            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+            (insertedOrg, insertedUser) = orgAndUser
+            teamAndPlatform <- (
+              TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(insertedUser)),
+              PlatformDao.create(platformCreate.toPlatform(insertedUser))
+            ).tupled
+            (insertedTeam, insertedPlatform) = teamAndPlatform
+            insertedUgr <- UserGroupRoleDao.create(
+              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
+                .toUserGroupRole(insertedUser)
+            )
+          } yield { insertedUgr }
+
+          val insertedUgr = insertUgrIO.transact(xa).unsafeRunSync
+
+          insertedUgr.userId == userCreate.id &&
+            insertedUgr.groupType == ugrCreate.groupType &&
+            insertedUgr.groupRole == ugrCreate.groupRole &&
+            insertedUgr.modifiedBy == userCreate.id &&
+            insertedUgr.createdBy == userCreate.id
+        }
+      }
+    }
+  }
+
+  test("update a user group role") {
+    check {
+      forAll {
+        (userCreate: User.Create, manager: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
+         platformCreate: Platform.Create, ugrCreate: UserGroupRole.Create, ugrUpdate: UserGroupRole.Create) => {
+          val insertUgrWithRelationsIO = for {
+            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+            (insertedOrg, insertedUser) = orgAndUser
+            managerUser <- UserDao.create(manager.copy(organizationId = insertedOrg.id))
+            teamAndPlatform <- (
+              TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(managerUser)),
+              PlatformDao.create(platformCreate.toPlatform(managerUser))
+            ).tupled
+            (insertedTeam, insertedPlatform) = teamAndPlatform
+            insertedUgr <- UserGroupRoleDao.create(
+              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
+                .toUserGroupRole(managerUser)
+            )
+          } yield (insertedUgr, insertedUser, managerUser, insertedOrg, insertedTeam, insertedPlatform)
+
+          val updateUgrWithUpdatedAndAffectedRowsIO = insertUgrWithRelationsIO flatMap {
+            case (dbUgr: UserGroupRole, dbMember: User, dbAdmin: User, dbOrg: Organization, dbTeam: Team, dbPlatform: Platform) => {
+              val fixedUpUgrUpdate = fixupUserGroupRole(dbMember, dbOrg, dbTeam, dbPlatform, ugrUpdate)
+                .toUserGroupRole(dbAdmin)
+              UserGroupRoleDao.update(fixedUpUgrUpdate, dbUgr.id, dbAdmin) flatMap {
+                (affectedRows: Int) => {
+                  UserGroupRoleDao.unsafeGetUserGroupRoleById(dbUgr.id, dbMember) map { (affectedRows, _) }
+                }
+              }
             }
-        } yield create
+          }
+
+          val (affectedRows, updatedUgr) = updateUgrWithUpdatedAndAffectedRowsIO.transact(xa).unsafeRunSync
+          // isActive should always be true since it doesn't exist on UserGroupRole.Creates and is set
+          // to true when those are turned into UserGroupRoles
+          affectedRows == 1 &&
+            updatedUgr.isActive == true &&
+            updatedUgr.modifiedBy == manager.id &&
+            (updatedUgr.groupType == ugrUpdate.groupType) == (ugrUpdate.groupType == ugrCreate.groupType) &&
+            updatedUgr.groupRole == ugrUpdate.groupRole
+        }
+      }
     }
+  }
 
-    test("read types") { check(UserGroupRoleDao.selectF.query[UserGroupRole]) }
+  test("deactivate a user group role") {
+    check {
+      forAll {
+        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create, platformCreate: Platform.Create, ugrCreate: UserGroupRole.Create) => {
+          val insertUgrWithUserIO = for {
+            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+            (insertedOrg, insertedUser) = orgAndUser
+            teamAndPlatform <- (
+              TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(insertedUser)),
+              PlatformDao.create(platformCreate.toPlatform(insertedUser))
+            ).tupled
+            (insertedTeam, insertedPlatform) = teamAndPlatform
+            insertedUgr <- UserGroupRoleDao.create(
+              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
+                .toUserGroupRole(insertedUser)
+            )
+          } yield (insertedUgr, insertedUser)
 
-    test("insertion") {
-        val transaction = for {
-            ugrIn <- createUserGroupRole
-            ugrOut <- UserGroupRoleDao.getOption(ugrIn.id)
-        } yield ugrOut
+          val deactivateWithDeactivatedUgrIO = insertUgrWithUserIO flatMap {
+            case (dbUgr: UserGroupRole, dbUser: User) => {
+              UserGroupRoleDao.deactivate(dbUgr.id, dbUser) flatMap {
+                (affectedRows: Int) => {
+                  UserGroupRoleDao.unsafeGetUserGroupRoleById(dbUgr.id, dbUser) map { (affectedRows, _) }
+                }
+              }
+            }
+          }
 
-        val result = transaction.transact(xa).unsafeRunSync
-        result.get.groupType shouldBe GroupType.Platform
+          val (affectedRows, updatedUgr) = deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
+          affectedRows == 1 &&
+            updatedUgr.isActive == false &&
+            updatedUgr.modifiedBy == userCreate.id &&
+            updatedUgr.groupType == ugrCreate.groupType &&
+            updatedUgr.groupRole == ugrCreate.groupRole
+        }
+      }
     }
-
-    test("update") {
-        val transaction = for {
-            usr <- defaultUserQ
-            ugrIn <- createUserGroupRole
-            ugrUpdate <- UserGroupRoleDao.update(ugrIn.copy(groupRole = GroupRole.Admin), ugrIn.id, usr)
-            ugrOut <- UserGroupRoleDao.getOption(ugrIn.id)
-        } yield ugrOut
-
-        val result = transaction.transact(xa).unsafeRunSync
-        result.get.groupRole shouldBe GroupRole.Admin
-    }
-
-    test("deactivation") {
-        val transaction = for {
-            usr <- defaultUserQ
-            ugrIn <- createUserGroupRole
-            ugrDeactivated <- UserGroupRoleDao.deactivate(ugrIn.id, usr)
-            ugrOut <- UserGroupRoleDao.getOption(ugrIn.id)
-        } yield ugrOut
-
-        val result = transaction.transact(xa).unsafeRunSync
-        result.get.isActive shouldBe false
-    }
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds a platform to the database before adding an organization in OrganizationDao tests.
It uses that platform to prove we can insert organizations under new platforms.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

...I'm not sure what else was supposed to happen here -- there wasn't too much going on that adding
the platform id seems like it would affect. Was there more to this card?

Also there's a commit in here from #3267 since there's stuff in there that I thought might be useful here. I'm not certain that's correct but feel free just to look at 7ce0ea2

## Testing Instructions

 * `testOnly *OrganizationDaoSpec`

Closes #3225 

Closes #3267 
