### PR TITLE
Fix excessive scene queries from hasNext

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -104,7 +104,6 @@ object Dao {
 
     def countIO: ConnectionIO[Int] = {
       val countQuery = countF ++ Fragments.whereAndOpt(filters: _*)
-      println(countQuery)
       val over10000IO: ConnectionIO[Boolean] =
         (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 10000") ++ fr")")
           .query[Boolean]

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -103,10 +103,10 @@ object Dao {
     }
 
     def countIO: ConnectionIO[Int] = {
-      // obviously I _wanted_ to call this over9000io, but alas
       val countQuery = countF ++ Fragments.whereAndOpt(filters: _*)
+      println(countQuery)
       val over10000IO: ConnectionIO[Boolean] =
-        (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 1000") ++ fr")")
+        (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 10000") ++ fr")")
           .query[Boolean]
           .unique
       over10000IO flatMap {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -31,7 +31,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
 
     for {
       page <- paginatedQuery
-      count <- query.countIO
+      count <- query.filter(Fragments.and(queryFilters.flatten.toSeq: _*)).countIO
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count


### PR DESCRIPTION
## Overview

This PR makes it so that loading the projects page doesn't fire off hundreds of scenes requests per project by default.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Go to the projects list page
 * Observe that you don't make hundreds of scenes requests

Closes #3266 
