### PR TITLE
Fix sql and bash cmd in update-aoi-projects

### DIFF
--- a/app-tasks/rf/src/rf/commands/update_aoi_project.py
+++ b/app-tasks/rf/src/rf/commands/update_aoi_project.py
@@ -18,9 +18,12 @@ def update_aoi_project(project_id):
         project_id (str): ID of project to check for new scenes to add
     """
 
-    bash_cmd = 'java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main update_aoi_project {0}'.format(project_id)
+    bash_cmd = [
+        'java', '-cp', '/opt/raster-foundry/jars/rf-batch.jar',
+        'com.azavea.rf.batch.Main', 'update_aoi_project', project_id
+    ]
 
-    exit_code = subprocess.call([bash_cmd], shell=True)
+    exit_code = subprocess.call(bash_cmd)
     logger.info('Checking whether %s has updated scenes available', project_id)
     is_success = exit_code == 0
 


### PR DESCRIPTION
## Overview

This PR makes `update-aoi-projects` work.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

It's probably the case that the python file didn't _need_ to change per se,
but I couldn't really see a reason to use `shell=True` and splitting it into the list
form made it more readable for me when I was making sure I was running the
right java command in testing.

## Testing Instructions

 * reassemble your batch jar and rebuild your batch container
 * Bring up your server and frontend and make yourself a nice new AOI project
 * Get that project's id
 * `./scripts/console batch bash`
 * `rf update-aoi-project <project id>`

Closes #3271 
