### PR TITLE
Fix scene visibility filtering

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -61,6 +61,14 @@ object Dao {
       }
     }
 
+    def ownerVisibilityFilterF(user: User): Option[Fragment] = {
+      if (user.isInRootOrganization) {
+        None
+      } else {
+        Some(fr"((organization_id = ${user.organizationId} AND visibility = 'ORGANIZATION' :: visibility) OR owner = ${user.id} OR visibility = 'PUBLIC' :: visibility)")
+      }
+    }
+
     def ownerFilter[M >: Model](user: User)(implicit filterable: Filterable[M, Option[Fragment]]): QueryBuilder[Model] = {
       this.copy(filters = filters ++ filterable.toFilters(ownerFilterF(user)))
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -27,7 +27,6 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
     val projectFilterFragment = fr"id IN (SELECT scene_id FROM scenes_to_projects WHERE project_id = ${projectId})"
     val queryFilters = makeFilters(List(sceneParams)).flatten ++ List(Some(projectFilterFragment))
     val paginatedQuery = listQuery(queryFilters, Some(pageRequest)).query[Scene.WithRelated].list
-    val countQuery = (fr"SELECT count(*) FROM scenes" ++ Fragments.whereAndOpt(queryFilters: _*)).query[Int].unique
 
     for {
       page <- paginatedQuery
@@ -108,7 +107,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
     val pageFragment: Fragment = Page(pageRequest)
     val queryFilters: List[Option[Fragment]] = makeFilters(List(sceneParams)).flatten
     val scenesIO: ConnectionIO[List[Scene]] =
-      (selectF ++ Fragments.whereAndOpt(queryFilters: _*) ++ pageFragment)
+      (selectF ++ Fragments.whereAndOpt((query.ownerVisibilityFilterF(user) :: queryFilters): _*) ++ pageFragment)
         .query[Scene]
         .stream
         .compile

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -30,7 +30,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
 
     for {
       page <- paginatedQuery
-      count <- query.filter(Fragments.and(queryFilters.flatten.toSeq: _*)).countIO
+      count <- query.filter(projectFilterFragment).countIO
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count
@@ -116,7 +116,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
 
     for {
       page <- withRelatedsIO
-      count <- query.countIO
+      count <- query.filter(Fragments.and((query.ownerVisibilityFilterF(user) :: queryFilters).flatten.toSeq: _*)).countIO
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count


### PR DESCRIPTION
## Overview

This PR updates the base `Dao` to include a `ownerVisibilityFilterF` attribute, that filters on
ownership or public visibility.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This makes it so that scenes and datasources both respect public visibility, and so that nothing else
cares (nothing except datasources cared before). Per offline discussion, that's what we want -- everything is locked down basically except those two types of data, and finer-grained permissions
control will continue over on #3130 

## Testing Instructions

 * before pulling down this branch, set all of your scenes to private
 * browse for some scenes
 * observe that you see them, which is bad
 * check out this branch
 * do the same browse
 * note that you don't see scenes anymore
 * set all of your scenes to public
 * query for some scenes
 * ch-ch-ch-check 'em out

Closes #3274
