### PR TITLE
Use correct image and thumbnail source uris

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -227,6 +227,14 @@ object ReadStacFeature extends Config with LazyLogging {
     Projected(poly, 3857)
   }
 
+  // PNGs for stac features must be referenced at radiant-nasa-iserv.s3.amazonaws.com/... instead of
+  // at s3.amazonaws.com/bucket/...
+  private def createThumbnailUrl(thumbnailPath: URI, rootUri: URI): URI = {
+    val base = new URI(s"https://${rootUri.getHost}.s3.amazonaws.com")
+    val path = combineUris(thumbnailPath, new URI(rootUri.getPath.dropWhile(_ == '/')))
+    combineUris(path, base)
+  }
+
   protected def thumbnailFromLink(link: stac.Link, sceneId: UUID, rootUri: URI): Option[Thumbnail.Identified] = {
     // fetch thumbnail, get width/height
     try {
@@ -241,7 +249,7 @@ object ReadStacFeature extends Config with LazyLogging {
              widthPx = thumb.getWidth,
              heightPx = thumb.getHeight,
              sceneId = sceneId,
-             url = link.href
+             url = createThumbnailUrl(new URI(link.href), rootUri).toString
            ))
     } catch {
       case e: Exception =>

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -230,7 +230,13 @@ object ReadStacFeature extends Config with LazyLogging {
   // PNGs for stac features must be referenced at radiant-nasa-iserv.s3.amazonaws.com/... instead of
   // at s3.amazonaws.com/bucket/...
   private def createThumbnailUrl(thumbnailPath: URI, rootUri: URI): URI = {
-    val base = new URI(s"https://${rootUri.getHost}.s3.amazonaws.com")
+    val base = new URI(
+      rootUri.getScheme match {
+        case "s3" => s"https://${rootUri.getHost}.s3.amazonaws.com"
+        case "http" | "https" => s"https://${rootUri.getHost}"
+        case _ => ""
+      }
+    )
     val path = combineUris(thumbnailPath, new URI(rootUri.getPath.dropWhile(_ == '/')))
     combineUris(path, base)
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -141,7 +141,7 @@ object ReadStacFeature extends Config with LazyLogging {
       thumbnails = thumbnailLinks.map(thumbnailFromLink(_, sceneId, rootUri)).flatten.toList,
       ingestLocation = None,
       filterFields = SceneFilterFields(
-        cloudCover = None,
+        cloudCover = Some(0), // required for search in the frontend
         sunAzimuth = None,
         sunElevation = None,
         acquisitionDate = Some(feature.properties.start)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
@@ -73,16 +73,17 @@ package object util extends LazyLogging {
       throw new IllegalArgumentException(s"Resource at $uri is not valid")
   }
 
+  def combineUris(targetName: URI, prefix: URI): URI = {
+    targetName.getScheme match {
+      case "file" | "http" | "https" | "s3" => targetName
+      case _ => if (prefix.toString.endsWith("/")) new URI(prefix.toString + targetName.toString)
+                else new URI(prefix.toString + "/" + targetName.toString)
+    }
+  }
+
   /** Converts URI's into input streams, branching on URI type. Handles relative URIs given a root URI */
   def getStream(uri: URI, rootUri: URI): InputStream = {
-    uri.getScheme match {
-      case "file" | "http" | "https" | "s3" =>
-        getStream(uri)
-      case _ =>
-        // relative routes with a root uri
-        val prefix = if (rootUri.toString.last != '/') rootUri.toString + '/' else rootUri.toString
-        getStream((new URI(prefix + uri)).normalize)
-    }
+    getStream(combineUris(uri, rootUri).normalize)
   }
 
   /** Use a provided URI to get an array of bytes */


### PR DESCRIPTION
## Overview

This PR makes the batch jar's `read_stac_feature` command work. The problem with it
previously was that it didn't construct fully-qualified image source URIs, so ingests failed
when we tried to point to a local file.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * reassemble your batch jar
 * `./scripts/console batch bash`
 * make yourself a nice rgb datasource
 * `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main read_stac_feature -p <a path in s3 to a stac feature json> -d <the id of the datasource you made>
 * from the db, find the id of the scene you just created: `select id, name. created_at from scenes order by created_at desc limit 1;`
 * ingest your scene (make sure your server is running): `rf ingest-scene --local --ignore-previous <your scene id>`
 * navigate to the area where your scene is -- plopping the `<item>.json` into geojson.io can help with this
 * filter to the datasource you created and confirm that your scene has a thumbnail and has tiles

Helps with azavea/raster-foundry-platform#300
