### PR TITLE
Install python-requests via apt to fix broken pip install

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex \
        python-pip \
        python-setuptools \
        python-dev \
+       python-requests \
        build-essential \
        imagemagick \
     ' \


### PR DESCRIPTION
## Overview

A new debian package release for python-pip seems to have broken the
install due to a missing install of python-requests. This fixes the
problem by explicitly installing requests.

Without this patch the following error is seen when trying to call `pip` at all:

```
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    from pip import main
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 21, in <module>
    from pip._vendor.requests.packages.urllib3.exceptions import DependencyWarning
ImportError: No module named requests.packages.urllib3.exceptions
```

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

If jenkins succeeds then this works, I'll merge once that is done
