### PR TITLE
Use AWS batch job attempt to fail early after retries

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
@@ -42,8 +42,6 @@ import org.apache.spark.rdd._
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import scala.util.Properties
-
 import java.io.File
 import java.net.URI
 import java.util.UUID
@@ -327,13 +325,6 @@ object Ingest extends SparkJob with RollbarNotifier with Config {
     implicit def asS3Payload(status: IngestStatus): String = S3IngestStatus(sceneId, status).asJson.noSpaces
 
     try {
-      Properties.envOrElse("AWS_BATCH_JOB_ATTEMPT", "1") match {
-        case "3" => {
-          logger.error("Failing early due to previous failures. See prior attempts' logs")
-          throw new Exception("Suspicious repeated ingest failures")
-        }
-        case _ => ()
-      }
       ingestDefinition.layers.foreach(ingestLayer(params, _))
       if (params.testRun) ingestDefinition.layers.foreach(Validation.validateCatalogEntry)
       putObjectString(

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
@@ -342,13 +342,15 @@ object Ingest extends SparkJob with RollbarNotifier with Config {
         IngestStatus.Ingested
       )
     } catch {
-      case t: Throwable =>
+      case t: Throwable => {
         sendError(t)
         putObjectString(
           params.statusBucket,
           ingestDefinition.id.toString,
           IngestStatus.Failed
         )
+        throw t
+      }
     } finally {
       sc.stop
     }

--- a/app-tasks/rf/src/rf/cli.py
+++ b/app-tasks/rf/src/rf/cli.py
@@ -3,6 +3,7 @@
 """Console script for Raster Foundry"""
 
 import logging
+import os
 
 import click
 
@@ -17,6 +18,10 @@ from .commands import (
 logger = logging.getLogger('rf')
 
 
+if os.getenv('AWS_BATCH_JOB_ATTEMPT', '') == '3':
+    raise Exception('Failing async task early after suspicious repeated failures')
+
+
 @click.group()
 @click.option('--verbose/--quiet')
 def run(verbose):
@@ -26,6 +31,7 @@ def run(verbose):
         logger.debug('VERBOSE logging enabled')
     else:
         logger.setLevel(logging.INFO)
+
 
 run.add_command(export)
 run.add_command(process_upload)


### PR DESCRIPTION
## Overview

When batch jobs fail without being able to update scene ingest status, they can
leave scenes stuck in ingesting forever. This change makes it so that on the
third attempt, the batch job exits early, before it can get to a state where it
might run out of memory or have some other fatal error.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * confirm the env variable matches the variable from https://docs.aws.amazon.com/batch/latest/userguide/job_retries.html

Closes azavea/raster-foundry-deployment#119

Closes #3176 
