### PR TITLE
Add authorization to all project endpoints

### DIFF
--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -83,7 +83,7 @@ trait MapTokenRoutes extends Authentication
   }
 
   def deleteMapToken(mapTokenId: UUID): Route = authenticate { user =>
-    onSuccess(MapTokenDao.query.ownerFilter(user).filter(fr"id = ${mapTokenId}").delete.transact(xa).unsafeToFuture) {
+    onSuccess(MapTokenDao.query.ownerFilter(user).filter(mapTokenId).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -119,7 +119,7 @@ trait SceneRoutes extends Authentication
   }
 
   def deleteScene(sceneId: UUID): Route = authenticate { user =>
-    onSuccess(SceneDao.query.filter(fr"id = ${sceneId}").ownerFilter(user).delete.transact(xa).unsafeToFuture) {
+    onSuccess(SceneDao.query.filter(sceneId).ownerFilter(user).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -129,7 +129,7 @@ trait ShapeRoutes extends Authentication
   def getShape(shapeId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
-        ShapeDao.query.filter(fr"id = ${shapeId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture().map {
+        ShapeDao.query.filter(shapeId).ownerFilter(user).selectOption.transact(xa).unsafeToFuture().map {
           _ map { _.toGeoJSONFeature }
         }
       }
@@ -156,7 +156,7 @@ trait ShapeRoutes extends Authentication
   }
 
   def deleteShape(shapeId: UUID): Route = authenticate { user =>
-    onSuccess(ShapeDao.query.filter(fr"id = ${shapeId}").ownerFilter(user).delete.transact(xa).unsafeToFuture) {
+    onSuccess(ShapeDao.query.filter(shapeId).ownerFilter(user).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -61,7 +61,7 @@ trait ToolTagRoutes extends Authentication
 
   def getToolTag(toolTagId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete(ToolTagDao.query.ownerFilter(user).filter(fr"id = ${toolTagId}").select.transact(xa).unsafeToFuture)
+      complete(ToolTagDao.query.ownerFilter(user).filter(toolTagId).select.transact(xa).unsafeToFuture)
     }
   }
 
@@ -76,7 +76,7 @@ trait ToolTagRoutes extends Authentication
   }
 
   def deleteToolTag(toolTagId: UUID): Route = authenticate { user =>
-    onSuccess(ToolTagDao.query.ownerFilter(user).filter(fr"id = ${toolTagId}").delete.transact(xa).unsafeToFuture()) {
+    onSuccess(ToolTagDao.query.ownerFilter(user).filter(toolTagId).delete.transact(xa).unsafeToFuture()) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -122,7 +122,7 @@ trait ThumbnailRoutes extends Authentication
   }
 
   def deleteThumbnail(thumbnailId: UUID): Route = authenticate { user =>
-    onSuccess(ThumbnailDao.query.ownerFilter(user).filter(fr"id = ${thumbnailId}").delete.transact(xa).unsafeToFuture) {
+    onSuccess(ThumbnailDao.query.ownerFilter(user).filter(thumbnailId).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -75,7 +75,7 @@ trait ToolRunRoutes extends Authentication
 
   def getToolRun(runId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete(ToolRunDao.query.filter(fr"id = ${runId}").selectOption.transact(xa).unsafeToFuture)
+      complete(ToolRunDao.query.filter(runId).selectOption.transact(xa).unsafeToFuture)
     }
   }
 
@@ -90,7 +90,7 @@ trait ToolRunRoutes extends Authentication
   }
 
   def deleteToolRun(runId: UUID): Route = authenticate { user =>
-    onSuccess(ToolRunDao.query.filter(fr"id = ${runId}").ownerFilter(user).delete.transact(xa).unsafeToFuture) {
+    onSuccess(ToolRunDao.query.filter(runId).ownerFilter(user).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -87,7 +87,7 @@ trait ToolRoutes extends Authentication
 
   def getToolSources(toolId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      onSuccess(ToolDao.query.filter(fr"id = ${toolId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture) { maybeTool =>
+      onSuccess(ToolDao.query.filter(toolId).ownerFilter(user).selectOption.transact(xa).unsafeToFuture) { maybeTool =>
         val sources = maybeTool.map(_.definition.as[MapAlgebraAST].valueOr(throw _).sources)
         complete(sources)
       }
@@ -114,7 +114,7 @@ trait ToolRoutes extends Authentication
 
   def getTool(toolId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
-      complete(ToolDao.query.filter(fr"id = ${toolId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture)
+      complete(ToolDao.query.filter(toolId).ownerFilter(user).selectOption.transact(xa).unsafeToFuture)
     }
   }
 
@@ -129,7 +129,7 @@ trait ToolRoutes extends Authentication
   }
 
   def deleteTool(toolId: UUID): Route = authenticate { user =>
-    onSuccess(ToolDao.query.filter(fr"id = ${toolId}").ownerFilter(user).delete.transact(xa).unsafeToFuture) {
+    onSuccess(ToolDao.query.filter(toolId).ownerFilter(user).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -64,7 +64,7 @@ trait UploadRoutes extends Authentication
   def getUpload(uploadId: UUID): Route = authenticate { user =>
     rejectEmptyResponse {
       complete {
-        UploadDao.query.filter(fr"id = ${uploadId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture
+        UploadDao.query.filter(uploadId).ownerFilter(user).selectOption.transact(xa).unsafeToFuture
       }
     }
   }
@@ -108,7 +108,7 @@ trait UploadRoutes extends Authentication
       authorize(user.isInRootOrSameOrganizationAs(updateUpload)) {
         onSuccess {
           val x = for {
-            u <- UploadDao.query.filter(fr"id = ${uploadId}").ownerFilter(user).selectOption
+            u <- UploadDao.query.filter(uploadId).ownerFilter(user).selectOption
             c <- UploadDao.update(updateUpload, uploadId, user)
           } yield {
             (u, c) match {
@@ -129,14 +129,14 @@ trait UploadRoutes extends Authentication
   }
 
   def deleteUpload(uploadId: UUID): Route = authenticate { user =>
-    onSuccess(UploadDao.query.filter(fr"id = ${uploadId}").ownerFilter(user).delete.transact(xa).unsafeToFuture) {
+    onSuccess(UploadDao.query.filter(uploadId).ownerFilter(user).delete.transact(xa).unsafeToFuture) {
       completeSingleOrNotFound
     }
   }
 
   def getUploadCredentials(uploadId: UUID): Route = authenticate { user =>
     extractTokenHeader { jwt =>
-      onSuccess(UploadDao.query.filter(fr"id = ${uploadId}").ownerFilter(user).selectOption.transact(xa).unsafeToFuture) {
+      onSuccess(UploadDao.query.filter(uploadId).ownerFilter(user).selectOption.transact(xa).unsafeToFuture) {
         case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
         case None => complete(StatusCodes.NotFound)
       }

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -115,7 +115,7 @@ object Auth0UserService extends Config with LazyLogging{
       auth0User <- requestAuth0User(userId, bearerToken)
     } yield auth0User
     query.flatMap { auth0User =>
-      UserDao.query.filter(fr"id = ${userId}").selectOption.transact(xa).unsafeToFuture().map { user =>
+      UserDao.filterById(userId).selectOption.transact(xa).unsafeToFuture().map { user =>
         user match {
           case Some(user: User) =>
             UserWithOAuth(user, auth0User)

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -115,7 +115,7 @@ object Auth0UserService extends Config with LazyLogging{
       auth0User <- requestAuth0User(userId, bearerToken)
     } yield auth0User
     query.flatMap { auth0User =>
-      UserDao.filterById(userId).selectOption.transact(xa).unsafeToFuture().map { user =>
+      UserDao.getUserById(userId).transact(xa).unsafeToFuture().map { user =>
         user match {
           case Some(user: User) =>
             UserWithOAuth(user, auth0User)

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -72,7 +72,7 @@ trait UserRoutes extends Authentication
   def createUser: Route = authenticateRootMember { root =>
     entity(as[User.Create]) { newUser =>
       onSuccess(UserDao.create(newUser).transact(xa).unsafeToFuture()) { createdUser =>
-        onSuccess(UserDao.query.filter(fr"id = ${createdUser.id}").selectOption.transact(xa).unsafeToFuture()) {
+        onSuccess(UserDao.filterById(createdUser.id).selectOption.transact(xa).unsafeToFuture()) {
           case Some(user) => complete((StatusCodes.Created, user))
           case None => throw new IllegalStateException("Unable to create user")
         }
@@ -134,7 +134,7 @@ trait UserRoutes extends Authentication
     rejectEmptyResponse {
       val authId = URLDecoder.decode(authIdEncoded, "US_ASCII")
       if (user.isInRootOrganization || user.id == authId) {
-        complete(UserDao.query.filter(fr"id = ${authId}").select.transact(xa).unsafeToFuture())
+        complete(UserDao.filterById(authId).select.transact(xa).unsafeToFuture())
       } else {
         complete(StatusCodes.NotFound)
       }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -72,7 +72,7 @@ trait UserRoutes extends Authentication
   def createUser: Route = authenticateRootMember { root =>
     entity(as[User.Create]) { newUser =>
       onSuccess(UserDao.create(newUser).transact(xa).unsafeToFuture()) { createdUser =>
-        onSuccess(UserDao.filterById(createdUser.id).selectOption.transact(xa).unsafeToFuture()) {
+        onSuccess(UserDao.getUserById(createdUser.id).transact(xa).unsafeToFuture()) {
           case Some(user) => complete((StatusCodes.Created, user))
           case None => throw new IllegalStateException("Unable to create user")
         }
@@ -134,7 +134,7 @@ trait UserRoutes extends Authentication
     rejectEmptyResponse {
       val authId = URLDecoder.decode(authIdEncoded, "US_ASCII")
       if (user.isInRootOrganization || user.id == authId) {
-        complete(UserDao.filterById(authId).select.transact(xa).unsafeToFuture())
+        complete(UserDao.unsafeGetUserById(authId).transact(xa).unsafeToFuture())
       } else {
         complete(StatusCodes.NotFound)
       }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -91,8 +91,8 @@ case class CreateExportDef(exportId: UUID, region: Option[String] = None)(implic
     logger.info("Starting export process...")
 
     val processingExport = for {
-      user <- UserDao.query.filter(fr"id = ${systemUser}").select
-      export <- ExportDao.query.filter(fr"id = ${exportId}").select
+      user <- UserDao.filterById(systemUser).select
+      export <- ExportDao.query.filter(exportId).select
       exportDef <- ExportDao.getExportDefinition(export, user)
       _ <- {
         writeExportDefToS3(exportDef)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -91,7 +91,7 @@ case class CreateExportDef(exportId: UUID, region: Option[String] = None)(implic
     logger.info("Starting export process...")
 
     val processingExport = for {
-      user <- UserDao.filterById(systemUser).select
+      user <- UserDao.unsafeGetUserById(systemUser)
       export <- ExportDao.query.filter(exportId).select
       exportDef <- ExportDao.getExportDefinition(export, user)
       _ <- {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -268,7 +268,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
   def run: Unit = {
     logger.info("Importing scenes...")
 
-    val userQuery = UserDao.filterById(systemUser).select
+    val userQuery = UserDao.unsafeGetUserById(systemUser)
     val insertedScenes = for {
       user <- userQuery
       scenes <- scenesFromCsv(user)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -268,7 +268,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
   def run: Unit = {
     logger.info("Importing scenes...")
 
-    val userQuery = UserDao.query.filter(fr"id = ${systemUser}").select
+    val userQuery = UserDao.filterById(systemUser).select
     val insertedScenes = for {
       user <- userQuery
       scenes <- scenesFromCsv(user)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/Notification.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/Notification.scala
@@ -37,7 +37,7 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
 
   def getSceneOwner(sceneId: UUID): ConnectionIO[String] = {
     for {
-      scene <- SceneDao.query.filter(fr"id = ${sceneId}").select
+      scene <- SceneDao.query.filter(sceneId).select
     } yield scene.owner
   }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -1,7 +1,13 @@
 package com.azavea.rf.database
 
 import com.azavea.rf.database.Implicits._
-import com.azavea.rf.datamodel.{AccessControlRule, ActionType, ObjectType, SubjectType, User}
+import com.azavea.rf.datamodel.{
+  AccessControlRule,
+  ActionType,
+  ObjectType,
+  SubjectType,
+  User
+}
 
 import doobie._, doobie.implicits._
 import doobie.postgres._, doobie.postgres.implicits._
@@ -12,9 +18,9 @@ import io.circe._
 import java.util.UUID
 
 object AccessControlRuleDao extends Dao[AccessControlRule] {
-    val tableName = "access_control_rules"
+  val tableName = "access_control_rules"
 
-    val selectF = fr"""
+  val selectF = fr"""
         SELECT
             id, created_at, created_by,
             modified_at, modified_by, is_active,
@@ -23,8 +29,8 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
         FROM
     """ ++ tableF
 
-    def createF(ac: AccessControlRule) =
-        fr"INSERT INTO" ++ tableF ++ fr"""(
+  def createF(ac: AccessControlRule) =
+    fr"INSERT INTO" ++ tableF ++ fr"""(
             id, created_at, created_by,
             modified_at, modified_by, is_active,
             object_type, object_id, subject_type,
@@ -37,70 +43,86 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
         )
         """
 
-    def create(ac: AccessControlRule): ConnectionIO[AccessControlRule] = {
-        val objectDao = ac.objectType match {
-            case ObjectType.Project => ProjectDao
-            case ObjectType.Scene => SceneDao
-            case ObjectType.Datasource => DatasourceDao
-            case ObjectType.Shape => ShapeDao
-            case ObjectType.Workspace => throw new Exception("Workspaces not yet supported")
-            case ObjectType.Template => throw new Exception("Templates not yet supported")
-            case ObjectType.Analysis => throw new Exception("Analyses not yet supported")
+  def create(ac: AccessControlRule): ConnectionIO[AccessControlRule] = {
+    val objectDao = ac.objectType match {
+      case ObjectType.Project    => ProjectDao
+      case ObjectType.Scene      => SceneDao
+      case ObjectType.Datasource => DatasourceDao
+      case ObjectType.Shape      => ShapeDao
+      case ObjectType.Workspace =>
+        throw new Exception("Workspaces not yet supported")
+      case ObjectType.Template =>
+        throw new Exception("Templates not yet supported")
+      case ObjectType.Analysis =>
+        throw new Exception("Analyses not yet supported")
+    }
+
+    val isValidObject = objectDao.query.filter(ac.objectId).exists
+
+    // These validity checks need to be done individually because of varying id types
+
+    val isValidSubject = (ac.subjectType, ac.subjectId) match {
+      case (SubjectType.All, _) => true.pure[ConnectionIO]
+      case (SubjectType.Platform, Some(sid)) =>
+        PlatformDao.query.filter(UUID.fromString(sid)).exists
+      case (SubjectType.Organization, Some(sid)) =>
+        OrganizationDao.query.filter(UUID.fromString(sid)).exists
+      case (SubjectType.Team, Some(sid)) =>
+        OrganizationDao.query.filter(UUID.fromString(sid)).exists
+      case (SubjectType.User, Some(sid)) =>
+        UserDao.filterById(sid).exists
+      case _ => throw new Exception("Subject id required and but not provided")
+    }
+
+    val create = createF(ac).update.withUniqueGeneratedKeys[AccessControlRule](
+      "id",
+      "created_at",
+      "created_by",
+      "modified_at",
+      "modified_by",
+      "is_active",
+      "object_type",
+      "object_id",
+      "subject_type",
+      "subject_id",
+      "action_type"
+    )
+
+    for {
+      isValidObject <- isValidObject
+      isValidSubject <- isValidSubject
+      createAC <- {
+        if (isValidObject && isValidSubject) create
+        else {
+          val errSB = new StringBuilder("Invalid access control object")
+          if (!isValidObject) errSB.append(", invalid object")
+          if (!isValidSubject) errSB.append(", invalid subject")
+          throw new Exception(errSB.toString)
         }
+      }
+    } yield createAC
+  }
 
-        val isValidObject = objectDao.query.filter(ac.objectId).exists
+  def getOption(id: UUID): ConnectionIO[Option[AccessControlRule]] = {
+    query.filter(id).selectOption
+  }
 
-        // These validity checks need to be done individually because of varying id types
+  // List rules that a given subject has applied to it
+  def listBySubject(
+      subjectType: SubjectType,
+      subjectId: String): ConnectionIO[List[AccessControlRule]] = {
+    query
+      .filter(fr"subject_type = ${subjectType}")
+      .filter(fr"subject_id = ${subjectId}")
+      .list
+  }
 
-        val isValidSubject = (ac.subjectType, ac.subjectId) match {
-            case (SubjectType.All, _) => true.pure[ConnectionIO]
-            case (SubjectType.Platform, Some(sid)) => PlatformDao.query.filter(UUID.fromString(sid)).exists
-            case (SubjectType.Organization, Some(sid)) => OrganizationDao.query.filter(UUID.fromString(sid)).exists
-            case (SubjectType.Team, Some(sid)) => OrganizationDao.query.filter(UUID.fromString(sid)).exists
-            case (SubjectType.User, Some(sid)) => UserDao.query.filter(fr"id = ${sid}").exists
-            case _ => throw new Exception("Subject id required and but not provided")
-        }
-
-        val create = createF(ac).update.withUniqueGeneratedKeys[AccessControlRule](
-            "id", "created_at", "created_by",
-            "modified_at", "modified_by", "is_active",
-            "object_type", "object_id", "subject_type",
-            "subject_id", "action_type"
-        )
-
-        for {
-            isValidObject <- isValidObject
-            isValidSubject <- isValidSubject
-            createAC <- {
-                if (isValidObject && isValidSubject) create
-                else {
-                    val errSB = new StringBuilder("Invalid access control object")
-                    if (!isValidObject) errSB.append(", invalid object")
-                    if (!isValidSubject) errSB.append(", invalid subject")
-                    throw new Exception(errSB.toString)
-                }
-            }
-        } yield createAC
-    }
-
-    def getOption(id: UUID): ConnectionIO[Option[AccessControlRule]] = {
-        query.filter(id).selectOption
-    }
-
-    // List rules that a given subject has applied to it
-    def listBySubject(subjectType: SubjectType, subjectId: String): ConnectionIO[List[AccessControlRule]] = {
-        query
-            .filter(fr"subject_type = ${subjectType}")
-            .filter(fr"subject_id = ${subjectId}")
-            .list
-    }
-
-    def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
-        (fr"UPDATE" ++ tableF ++ fr""" SET
-              is_active = false,
-              modified_at = NOW(),
-              modified_by = ${user.id}
-            WHERE id = ${id}
-        """).update.run
-    }
+  def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
+    (fr"UPDATE" ++ tableF ++ fr""" SET
+        is_active = false,
+        modified_at = NOW(),
+        modified_by = ${user.id}
+      WHERE id = ${id}
+    """).update.run
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -79,7 +79,7 @@ object ExportDao extends Dao[Export] {
     }
 
     val dropboxToken = for {
-      user <- UserDao.query.filter(fr"id = ${export.owner}").selectOption
+      user <- UserDao.filterById(export.owner).selectOption
     } yield {
       user.flatMap(_.dropboxCredential.token)
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -79,7 +79,7 @@ object ExportDao extends Dao[Export] {
     }
 
     val dropboxToken = for {
-      user <- UserDao.filterById(export.owner).selectOption
+      user <- UserDao.getUserById(export.owner)
     } yield {
       user.flatMap(_.dropboxCredential.token)
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ImageDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ImageDao.scala
@@ -23,7 +23,7 @@ object ImageDao extends Dao[Image] {
     SELECT
       id, created_at, modified_at, organization_id, created_by, modified_by,
       owner, raw_data_bytes, visibility, filename, sourceuri, scene,
-      image_metadata, resolution_meters, metadata_files FROM """ ++ tableF 
+      image_metadata, resolution_meters, metadata_files FROM """ ++ tableF
 
   def create(
     image: Image,
@@ -93,7 +93,7 @@ object ImageDao extends Dao[Image] {
 
   // delete images
   def deleteImage(id: UUID, user: User): ConnectionIO[Int] = {
-    this.query.filter(fr"owner = ${user.id}").filter(fr"id = ${id}").delete
+    this.query.filter(fr"owner = ${user.id}").filter(id).delete
   }
 
   // get image

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -131,7 +131,7 @@ object ProjectDao extends Dao[Project] {
     for {
       _ <- aoiDeleteQuery.update.run
       _ <- aoiToProjectDelete.update.run
-      projectDeleteCount <- query.filter(fr"id = ${id}").delete
+      projectDeleteCount <- query.filter(id).delete
     } yield projectDeleteCount
   }
 
@@ -235,7 +235,7 @@ object ProjectDao extends Dao[Project] {
   }
 
   def listProjectSceneOrder(projectId: UUID, page: PageRequest, user: User): ConnectionIO[PaginatedResponse[UUID]] = {
-    val projectQuery = query.filter(fr"id = ${projectId}").filter(ownerEditFilter(user)).select
+    val projectQuery = query.filter(projectId).filter(ownerEditFilter(user)).select
     val selectClause = fr"SELECT scene_id "
     val countClause = fr"SELECT count(*) "
     val sceneQuery = fr"FROM scenes_to_projects INNER JOIN scenes ON scene_id = scenes.id WHERE project_id = ${projectId}"

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -61,4 +61,51 @@ object TeamDao extends Dao[Team] {
         "name", "settings"
       )
   }
+
+  def userIsAdminF(user: User, teamId: UUID) = {
+    fr"""
+      SELECT (
+        SELECT count(id) > 0
+        FROM """ ++ UserGroupRoleDao.tableF ++ fr"""
+        WHERE
+          user_id = ${user.id} AND
+          group_type = ${GroupType.Team.toString}::group_type AND
+          group_role = ${GroupRole.Admin.toString}::group_role AND
+          group_id = ${teamId} AND
+          is_active = true
+        LIMIT 1
+      ) OR (
+        SELECT count(ugr.id) > 0
+        FROM""" ++ OrganizationDao.tableF ++ fr"""o
+        JOIN""" ++ tableF ++ fr"""t
+          ON t.organization_id = o.id
+        JOIN""" ++ UserGroupRoleDao.tableF ++ fr"""ugr
+          ON ugr.group_id = o.id
+        WHERE
+          t.id = ${teamId} AND
+          ugr.user_id = ${user.id} AND
+          ugr.group_role = ${GroupRole.Admin.toString}::group_role AND
+          ugr.group_type = ${GroupType.Platform.toString}::group_type AND
+          ugr.is_active = true
+      ) OR (
+        SELECT count(ugr.id) > 0
+        FROM""" ++ PlatformDao.tableF ++ fr"""AS p
+        JOIN""" ++ OrganizationDao.tableF ++ fr"""o
+          ON o.platform_id = p.id
+        JOIN""" ++ tableF ++ fr"""t
+          ON t.organization_id = o.id
+        JOIN""" ++ UserGroupRoleDao.tableF ++ fr"""ugr
+          ON ugr.group_id = p.id
+        WHERE
+          t.id = ${teamId} AND
+          ugr.user_id = ${user.id} AND
+          ugr.group_role = ${GroupRole.Admin.toString}::group_role AND
+          ugr.group_type = ${GroupType.Platform.toString}::group_type AND
+          ugr.is_active = true
+      )
+    """
+  }
+
+  def userIsAdmin(user: User, teamId: UUID) =
+    userIsAdminF(user, teamId).query[Boolean].option.map(_.getOrElse(false))
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -85,7 +85,7 @@ object TeamDao extends Dao[Team] {
           t.id = ${teamId} AND
           ugr.user_id = ${user.id} AND
           ugr.group_role = ${GroupRole.Admin.toString}::group_role AND
-          ugr.group_type = ${GroupType.Platform.toString}::group_type AND
+          ugr.group_type = ${GroupType.Organization.toString}::group_type AND
           ugr.is_active = true
       ) OR (
         SELECT count(ugr.id) > 0

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserDao.scala
@@ -28,12 +28,16 @@ object UserDao extends Dao[User] {
     FROM
   """ ++ tableF
 
+  def filterById(id: String) = {
+    query.filter(fr"id = ${id}")
+  }
+
   def unsafeGetUserById(id: String): ConnectionIO[User] = {
-    query.filter(fr"id = ${id}").select
+    filterById(id).select
   }
 
   def getUserById(id: String): ConnectionIO[Option[User]] = {
-    query.filter(fr"id = ${id}").selectOption
+    filterById(id).selectOption
   }
 
   def createUserWithAuthId(id: String): ConnectionIO[User] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -1,7 +1,7 @@
 package com.azavea.rf.database
 
 import com.azavea.rf.database.Implicits._
-import com.azavea.rf.datamodel.{UserGroupRole, GroupType, User}
+import com.azavea.rf.datamodel.{UserGroupRole, GroupType, User, GroupRole}
 
 import doobie._, doobie.implicits._
 import doobie.postgres._, doobie.postgres.implicits._
@@ -12,84 +12,99 @@ import io.circe._
 import java.util.UUID
 
 object UserGroupRoleDao extends Dao[UserGroupRole] {
-    val tableName = "user_group_roles"
+  val tableName = "user_group_roles"
 
-    val selectF = fr"""
-        SELECT
-            id, created_at, created_by,
-            modified_at, modified_by, is_active,
-            user_id, group_type, group_id, group_role
-        FROM
+  val selectF =
+    fr"""
+      SELECT
+        id, created_at, created_by,
+        modified_at, modified_by, is_active,
+        user_id, group_type, group_id, group_role
+      FROM
     """ ++ tableF
 
-    def createF(ugr: UserGroupRole) =
-        fr"INSERT INTO" ++ tableF ++ fr"""(
-            id, created_at, created_by,
-            modified_at, modified_by, is_active,
-            user_id, group_type, group_id, group_role
-        ) VALUES (
-            ${ugr.id}, ${ugr.createdAt}, ${ugr.createdBy},
-            ${ugr.modifiedAt}, ${ugr.modifiedBy}, ${ugr.isActive},
-            ${ugr.userId}, ${ugr.groupType}, ${ugr.groupId}, ${ugr.groupRole}
-        )
-        """
+  def createF(ugr: UserGroupRole) =
+    fr"INSERT INTO" ++ tableF ++ fr"""(
+        id, created_at, created_by,
+        modified_at, modified_by, is_active,
+        user_id, group_type, group_id, group_role
+      ) VALUES (
+          ${ugr.id}, ${ugr.createdAt}, ${ugr.createdBy},
+          ${ugr.modifiedAt}, ${ugr.modifiedBy}, ${ugr.isActive},
+          ${ugr.userId}, ${ugr.groupType}, ${ugr.groupId}, ${ugr.groupRole}
+      )
+    """
 
-    // We don't want to support changes to roles beyond deactivation and promotion
-    def updateF(ugr: UserGroupRole, id: UUID, user: User) =
-        fr"UPDATE" ++ tableF ++ fr"""SET
-            modified_at = NOW(),
-            modified_by = ${user.id},
-            is_active = ${ugr.isActive},
-            group_role = ${ugr.groupRole}
-            where id = ${id}
-          """
+  // We don't want to support changes to roles beyond deactivation and promotion
+  def updateF(ugr: UserGroupRole, id: UUID, user: User) =
+    fr"UPDATE" ++ tableF ++ fr"""SET
+      modified_at = NOW(),
+      modified_by = ${user.id},
+      is_active = ${ugr.isActive},
+      group_role = ${ugr.groupRole}
+      where id = ${id}
+    """
 
-    def create(ugr: UserGroupRole): ConnectionIO[UserGroupRole] = {
-        val isValidGroup = ugr.groupType match {
-            case GroupType.Platform => PlatformDao.query.filter(ugr.groupId).exists
-            case GroupType.Organization => OrganizationDao.query.filter(ugr.groupId).exists
-            case GroupType.Team => TeamDao.query.filter(ugr.groupId).exists
-        }
-
-        val create = createF(ugr).update.withUniqueGeneratedKeys[UserGroupRole](
-            "id", "created_at", "created_by",
-            "modified_at", "modified_by", "is_active",
-            "user_id", "group_type", "group_id", "group_role"
-        )
-
-        for {
-            isValid <- isValidGroup
-            createUGR <- {
-                if (isValid) create
-                else throw new Exception(s"Invalid group: ${ugr.groupType}(${ugr.groupId})")
-            }
-        } yield createUGR
+  def create(ugr: UserGroupRole): ConnectionIO[UserGroupRole] = {
+    val isValidGroup = ugr.groupType match {
+      case GroupType.Platform => PlatformDao.query.filter(ugr.groupId).exists
+      case GroupType.Organization =>
+        OrganizationDao.query.filter(ugr.groupId).exists
+      case GroupType.Team => TeamDao.query.filter(ugr.groupId).exists
     }
 
-    def getOption(id: UUID): ConnectionIO[Option[UserGroupRole]] = {
-        query.filter(id).selectOption
-    }
+    val create = createF(ugr).update.withUniqueGeneratedKeys[UserGroupRole](
+      "id",
+      "created_at",
+      "created_by",
+      "modified_at",
+      "modified_by",
+      "is_active",
+      "user_id",
+      "group_type",
+      "group_id",
+      "group_role"
+    )
 
-    // List roles that a given user has been granted
-    def listByUser(user: User): ConnectionIO[List[UserGroupRole]] = {
-        query.filter(fr"user_id = ${user.id}").list
-    }
+    for {
+      isValid <- isValidGroup
+      createUGR <- {
+        if (isValid) create
+        else
+          throw new Exception(
+            s"Invalid group: ${ugr.groupType}(${ugr.groupId})")
+      }
+    } yield createUGR
+  }
 
-    // List roles that have been given to users for a group
-    def listByGroup(groupType: GroupType, groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
-        query.filter(fr"group_type = ${groupType}").filter(fr"group_id = ${groupId}").list
-    }
+  def getOption(id: UUID): ConnectionIO[Option[UserGroupRole]] = {
+    query.filter(id).selectOption
+  }
 
-    // @TODO: ensure a user cannot demote (or promote?) themselves
-    def update(ugr: UserGroupRole, id: UUID, user: User): ConnectionIO[Int] =
-        updateF(ugr, id, user).update.run
+  // List roles that a given user has been granted
+  def listByUser(user: User): ConnectionIO[List[UserGroupRole]] = {
+    query.filter(fr"user_id = ${user.id}").list
+  }
 
-    def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
-        (fr"UPDATE" ++ tableF ++ fr""" SET
-              is_active = false,
-              modified_at = NOW(),
-              modified_by = ${user.id}
-            WHERE id = ${id}
-        """).update.run
-    }
+  // List roles that have been given to users for a group
+  def listByGroup(groupType: GroupType,
+                  groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
+    query
+      .filter(fr"group_type = ${groupType}")
+      .filter(fr"group_id = ${groupId}")
+      .list
+  }
+
+  // @TODO: ensure a user cannot demote (or promote?) themselves
+  def update(ugr: UserGroupRole, id: UUID, user: User): ConnectionIO[Int] =
+    updateF(ugr, id, user).update.run
+
+  def deactivate(id: UUID, user: User): ConnectionIO[Int] = {
+    (fr"UPDATE" ++ tableF ++ fr""" SET
+        is_active = false,
+        modified_at = NOW(),
+        modified_by = ${user.id}
+      WHERE id = ${id}
+    """).update.run
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -27,10 +27,10 @@ trait DBTestConfig {
 
   val defaultPlatformId = UUID.fromString("31277626-968b-4e40-840b-559d9c67863c")
 
-  val defaultUserQ = UserDao.query.filter(fr"id = 'default'").selectQ.unique
-  val rootOrgQ = OrganizationDao.query.filter(fr" id = ${UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")}").selectQ.unique
-  val changeDetectionProjQ = ProjectDao.query.filter(fr"id = ${UUID.fromString("30fd336a-d360-4c9f-9f99-bb7ac4b372c4")}").selectQ.unique
-  val defaultPlatformQ = PlatformDao.query.filter(fr"id = ${defaultPlatformId}").selectQ.unique
+  val defaultUserQ = UserDao.filterById("default").selectQ.unique
+  val rootOrgQ = OrganizationDao.query.filter(UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")).selectQ.unique
+  val changeDetectionProjQ = ProjectDao.query.filter(UUID.fromString("30fd336a-d360-4c9f-9f99-bb7ac4b372c4")).selectQ.unique
+  val defaultPlatformQ = PlatformDao.query.filter(defaultPlatformId).selectQ.unique
 
 
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -27,11 +27,8 @@ trait DBTestConfig {
 
   val defaultPlatformId = UUID.fromString("31277626-968b-4e40-840b-559d9c67863c")
 
-  val defaultUserQ = UserDao.filterById("default").selectQ.unique
+  val defaultUserQ = UserDao.unsafeGetUserById("default")
   val rootOrgQ = OrganizationDao.query.filter(UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")).selectQ.unique
-  val changeDetectionProjQ = ProjectDao.query.filter(UUID.fromString("30fd336a-d360-4c9f-9f99-bb7ac4b372c4")).selectQ.unique
   val defaultPlatformQ = PlatformDao.query.filter(defaultPlatformId).selectQ.unique
-
-
 }
 

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -101,7 +101,7 @@ trait TileAuthentication extends Authentication
       case Some(token) => {
         val userId = token.owner.toString
         val userFromId = rfCache.caching(s"user-$userId-token-$mapToken") {
-          UserDao.filterById(userId).selectOption.transact(xa).unsafeToFuture
+          UserDao.getUserById(userId).transact(xa).unsafeToFuture
         }
         onSuccess(userFromId).flatMap {
           case Some(user) => provide(user)

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -101,7 +101,7 @@ trait TileAuthentication extends Authentication
       case Some(token) => {
         val userId = token.owner.toString
         val userFromId = rfCache.caching(s"user-$userId-token-$mapToken") {
-          UserDao.query.filter(fr"id=${userId}").selectOption.transact(xa).unsafeToFuture
+          UserDao.filterById(userId).selectOption.transact(xa).unsafeToFuture
         }
         onSuccess(userFromId).flatMap {
           case Some(user) => provide(user)


### PR DESCRIPTION
## Overview

This PR does a few things so looking at it by commit would likely be best:

 - 36965e7: cleans up our use of fragments in filters. We had a lot of manual ID lookups that could be replaced by the standard `id: UUID` filter. In addition, I added a method to the user DAO to lookup users by id `filterById(id: String)` to streamline user lookups by id.

- 4518be9: adds two authorization filters to the base DAO. One filter is by object type, intended for listing. The other is by object type and id, for verifying authorization of a single object. This commit also adds a convenience function for chaining together the typical sequence of methods for cleaner repeated use.

- 643a9f0: adds authorization checks to all project endpoints. This uses akka's `authorizeAsync` to make a call to the DB to verify the operation is authorized.

- (new) b14984b: adds `userIsAdmin` methods to `teamDao`, `organizationDao`, and `platformDao` to allow adding user-role based authorization to endpoints. The methods aren't used anywhere yet. Admin roles cascade down: the admin of an organization is also an admin of any teams within that organization. An admin of a Platform is also an admin of any organization within the Platform.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

### Notes

The two authorization filters have different SQL patterns:

- **authorizing for lists** centers on an `IN` clause where we filter out objects by id if they are not in the list of objects that the user is authorized to do the specified action on. If the user owns the object, they are automatically authorized to do any action, otherwise, a corresponding `access_control_rule` must grant authorization.

- **authorizing for a get** uses a `WHERE <boolean>` filter. We build up the boolean value by checking for object ownership of that specific object and then any corresponding `access_control_rule`s.

## Testing Instructions

The SQL needed to test is below. The SQL (or migration) from the base branch should have already been run before running the SQL below. What it does:
 - adds a test team
 - adds the user to the Raster Foundry platform (through `user_group_roles`)
 - adds the user to the public organization (through `user_group_roles`)
 - adds the user to the test team (through `user_group_roles`)
 - adds five projects, each with names that indicate permissions
 - adds the various `access_control_rules` for the projects

After _that_, attempt various actions **as the dev user** with each project and verify that they following matrix of allowed/disallowed actions is correct:

| Project Name                  | Can View In List | Can View Individually | Can Edit | Can Delete |
|-------------------------------|------------------|-----------------------|----------|------------|
| ALL - View Only               | YES              | YES                   | NO       | NO         |
| PLATFORM - View Only          | YES              | YES                   | NO       | NO         |
| ORG - View and Edit           | YES              | YES                   | YES      | NO         |
| TEAM - View and Edit          | YES              | YES                   | YES      | NO         |
| USER - View, Edit, and Delete | YES              | YES                   | YES      | YES        |

A recommended sequence for each project might be:
 - (can view in list) is the project visible on the list page?
 - (can view individually) when I open the project can I see it's name?
 - (can edit) can I change the name of the project?
 - (can delete) when I go back to the project page, can I delete the project?

There are many other things to try as well.

After that, the user role methods can be tested using the REPL inside the db project. Based on the SQL below, all calls to `userIsAdmin` should return false. Further testing can be done by modifying the `user_group_role` objects that are in the big SQL chunk to be ADMINs.

```scala
val devUser = UserDao.filterById("auth0|59318a9d2fbbca3e16bcfc92").selectOption.transact(xa).unsafeRunSync.get

PlatformDao.userIsAdmin(devUser, java.util.UUID.fromString("31277626-968b-4e40-840b-559d9c67863c")).transact(xa).unsafeRunSync

OrganizationDao.userIsAdmin(devUser, java.util.UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")).transact(xa).unsafeRunSync

TeamDao.userIsAdmin(devUser, java.util.UUID.fromString("f53a67bb-2b0d-484a-90d9-115b78a2cd28")).transact(xa).unsafeRunSync
```



```sql
INSERT INTO teams VALUES (
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    NOW(),
    'default',
    NOW(),
    'default',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'Test team',
    '{}'
);

INSERT INTO user_group_roles VALUES (
    '03580e75-00b2-4682-a3e1-5401a96793cf',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'PLATFORM',
    '31277626-968b-4e40-840b-559d9c67863c',
    'MEMBER'
), (
    '42a5cbd4-dc12-41a9-8111-ca473a7d304e',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'ORGANIZATION',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'MEMBER'
), (
    '25f52de8-cc7b-487e-96f2-44d51e1f2f40',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'TEAM',
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    'MEMBER'
);

INSERT INTO projects VALUES (
    'c767576a-9da9-44b3-94c0-4f2736895b0d',
    NOW(),
    NOW(),
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'default',
    'default',
    'ALL - View only',
    '',
    '',
    'PRIVATE',
    '{}',
    false,
    NULL,
    'PRIVATE',
    false,
    604800000,
    NOW(),
    'default',
    false,
    NULL
), (
    'eebc9d3d-150d-4390-81e5-e1260d178771',
    NOW(),
    NOW(),
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'default',
    'default',
    'PLATFORM - View only',
    '',
    '',
    'PRIVATE',
    '{}',
    false,
    NULL,
    'PRIVATE',
    false,
    604800000,
    NOW(),
    'default',
    false,
    NULL
), (
    '442adf17-3e84-4c79-a354-070d9398c59a',
    NOW(),
    NOW(),
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'default',
    'default',
    'ORG - View and Edit',
    '',
    '',
    'PRIVATE',
    '{}',
    false,
    NULL,
    'PRIVATE',
    false,
    604800000,
    NOW(),
    'default',
    false,
    NULL
), (
    'f9881704-1f12-437c-a5cb-37ea2c495d8b',
    NOW(),
    NOW(),
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'default',
    'default',
    'TEAM - View and Edit',
    '',
    '',
    'PRIVATE',
    '{}',
    false,
    NULL,
    'PRIVATE',
    false,
    604800000,
    NOW(),
    'default',
    false,
    NULL
), (
    'a2c9b52f-6b03-4f8d-bfa1-0595baff342f',
    NOW(),
    NOW(),
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'default',
    'default',
    'USER - View, Edit, and Delete',
    '',
    '',
    'PRIVATE',
    '{}',
    false,
    NULL,
    'PRIVATE',
    false,
    604800000,
    NOW(),
    'default',
    false,
    NULL
);

INSERT INTO access_control_rules VALUES (
    'd89efe65-22b2-416d-a9ad-037bbbb9d261',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'c767576a-9da9-44b3-94c0-4f2736895b0d',
    'ALL',
    '',
    'VIEW'
), (
    '50fc8148-9ca9-468c-b522-e6165f7ff049',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'eebc9d3d-150d-4390-81e5-e1260d178771',
    'PLATFORM',
    '31277626-968b-4e40-840b-559d9c67863c',
    'VIEW'
), (
    '7c66cec0-2bf7-4a82-acc8-5f069e308425',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    '442adf17-3e84-4c79-a354-070d9398c59a',
    'ORGANIZATION',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'VIEW'
), (
    'ae2fd08e-7af0-405f-8413-6b5e0bf8948d',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    '442adf17-3e84-4c79-a354-070d9398c59a',
    'ORGANIZATION',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'EDIT'
), (
    '5624e870-a88d-4247-8bdf-b7778f599396',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'f9881704-1f12-437c-a5cb-37ea2c495d8b',
    'TEAM',
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    'VIEW'
), (
    '397929e3-7b94-43e9-be4c-78fd5510bfb0',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'f9881704-1f12-437c-a5cb-37ea2c495d8b',
    'TEAM',
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    'EDIT'
),(
    'd9b35020-206a-4b39-b5a3-4731ca64b575',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'a2c9b52f-6b03-4f8d-bfa1-0595baff342f',
    'USER',
    'auth0|59318a9d2fbbca3e16bcfc92',
    'VIEW'
), (
    '297a5506-65bf-43c9-a008-4d8746ce5a6c',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'a2c9b52f-6b03-4f8d-bfa1-0595baff342f',
    'USER',
    'auth0|59318a9d2fbbca3e16bcfc92',
    'EDIT'
), (
    '79c754fc-c4d2-4f39-b6a2-43d119889151',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'PROJECT',
    'a2c9b52f-6b03-4f8d-bfa1-0595baff342f',
    'USER',
    'auth0|59318a9d2fbbca3e16bcfc92',
    'DELETE'
);
```

Closes #3093
