### PR TITLE
Update export definition on an export when we create it

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -46,7 +46,10 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
       exportDef <- ExportDao.getExportDefinition(export, user)
       x <- {
         writeExportDefToS3(exportDef, bucket, key)
-        val updatedExport = export.copy(exportStatus = ExportStatus.Exporting)
+        val updatedExport = export.copy(
+          exportStatus = ExportStatus.Exporting,
+          exportOptions = exportDef.asJson
+        )
         ExportDao.update(updatedExport, exportId, user)
       }
     } yield {


### PR DESCRIPTION
## Overview

This PR makes it so that exports know where their files live.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Rebuild your batch jar
 * Create an export
 * Get your export id
 * Run `rf export <export id>` in your batch jar
 * Try to download your export
 * Observe that you can

Closes #3293 
