### PR TITLE
Use S3 client instead of hadoop writer for S3 exports

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -64,6 +64,9 @@ case class S3(
   def putObject(s3bucket: String, s3Key: String, content: String): PutObjectResult =
     client.putObject(s3bucket, s3Key, content)
 
+  def putObject(putObjectRequest: PutObjectRequest): PutObjectResult =
+    client.putObject(putObjectRequest)
+
   def putObject(uri: URI, content: String): PutObjectResult = {
     val s3uri = new AmazonS3URI(uri)
     client.putObject(s3uri.getBucket, s3uri.getKey, content)


### PR DESCRIPTION
## Overview

There was an issue with how credentials were being supplied once the
export moved away from EMR. This fixes the problem by using an S3
client directly for writes to S3.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

 * rebuild batch jar
 * Go to project and create a new export
 * run export in batch containter `./scripts/console batch "rf export <export-id-from-created-export>"
 * Go to project export and file should be properly populated for download

Closes https://github.com/azavea/raster-foundry-platform/issues/302
