### PR TITLE
Implement addUser and removeUser dao functions for org and team

### DIFF
--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -74,5 +74,5 @@ trait OrganizationRoutes extends Authentication
     }
   }
 
-  // @TODO: There is no delete functionality as we most likely will want to instead deactivate platforms
+  // @TODO: There is no delete functionality as we most likely will want to instead deactivate organizations
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UserGroupRole.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UserGroupRole.scala
@@ -25,6 +25,12 @@ object UserGroupRole {
     def create = Create.apply _
     def tupled = (UserGroupRole.apply _).tupled
 
+    case class UserGroup(
+      userId: String,
+      groupType: GroupType,
+      groupId: UUID
+    )
+
     @JsonCodec
     case class Create(
         userToAdd: User,

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -470,5 +470,7 @@ object Generators extends ArbitraryInstances {
     implicit def arbPlatformCreate: Arbitrary[Platform.Create] = Arbitrary { platformCreateGen }
 
     implicit def arbUserGroupRoleCreate: Arbitrary[UserGroupRole.Create] = Arbitrary { userGroupRoleCreateGen }
+
+    implicit def arbGroupRoleCreate: Arbitrary[GroupRole] = Arbitrary { groupRoleGen }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -14,9 +14,10 @@ import java.util.UUID
 import java.sql.Timestamp
 
 import scala.concurrent.Future
+import com.typesafe.scalalogging.LazyLogging
 
 
-object OrganizationDao extends Dao[Organization] {
+object OrganizationDao extends Dao[Organization] with LazyLogging {
 
   val tableName = "organizations"
 
@@ -86,4 +87,47 @@ object OrganizationDao extends Dao[Organization] {
 
   def userIsAdmin(user: User, organizationId: UUID) =
     userIsAdminF(user, organizationId).query[Boolean].option.map(_.getOrElse(false))
+
+  def getOrgPlatformId(organizationId: UUID): ConnectionIO[UUID] = {
+    (fr"SELECT platform_id FROM " ++ tableF ++ fr"WHERE id = ${organizationId}").query[UUID].unique
+  }
+
+  def addUserRole(user: User, subject: User, organizationId: UUID, userRole: GroupRole): ConnectionIO[UserGroupRole] = {
+    val userGroupRoleCreate = UserGroupRole.Create(
+      subject, GroupType.Organization, organizationId, userRole
+    )
+    UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(user))
+  }
+
+  def setUserRole(user: User, subject: User, organizationId: UUID, userRole: GroupRole):
+      ConnectionIO[List[UserGroupRole]] = {
+    for {
+      orgRoles <- OrganizationDao.deactivateUserRoles(
+        user, subject, organizationId
+      ).flatMap(
+        (deactivatedRoles) => {
+          OrganizationDao.addUserRole(user, subject, organizationId, userRole)
+            .map((role) => deactivatedRoles ++ List(role))
+        }
+      )
+      platformId <- getOrgPlatformId(organizationId)
+      platformRoles <- UserGroupRoleDao
+      .listUserGroupRoles(GroupType.Platform, platformId, subject)
+      .flatMap(
+        (roles: List[UserGroupRole]) => roles match {
+          case Nil =>
+            PlatformDao.setUserRole(user, subject, platformId, GroupRole.Member)
+          case roles =>
+            List.empty[UserGroupRole].pure[ConnectionIO]
+        }
+      )
+    } yield (platformRoles ++ orgRoles)
+  }
+
+  def deactivateUserRoles(user: User, removedUser: User, organizationId: UUID): ConnectionIO[List[UserGroupRole]] = {
+    val userGroup = UserGroupRole.UserGroup(
+      removedUser.id, GroupType.Organization, organizationId
+    )
+    UserGroupRoleDao.deactivateUserGroupRoles(userGroup, user)
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -79,4 +79,23 @@ object PlatformDao extends Dao[Platform] {
   def delete(platformId: UUID): ConnectionIO[Int] =
     PlatformDao.query.filter(platformId).delete
 
+  def addUserRole(user: User, subject: User, platformId: UUID, userRole: GroupRole): ConnectionIO[UserGroupRole] = {
+    val userGroupRoleCreate = UserGroupRole.Create(
+      subject, GroupType.Platform, platformId, userRole
+    )
+    UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(user))
+  }
+
+  def setUserRole(user: User, subject: User, platformId: UUID, userRole: GroupRole):
+      ConnectionIO[List[UserGroupRole]] = {
+    deactivateUserRoles(user, subject, platformId)
+      .flatMap(updatedRoles =>
+        addUserRole(user, subject, platformId, userRole).map((ugr: UserGroupRole) => updatedRoles ++ List(ugr))
+      )
+  }
+
+  def deactivateUserRoles(user: User, subject: User, platformId: UUID): ConnectionIO[List[UserGroupRole]] = {
+    val userGroup = UserGroupRole.UserGroup(subject.id, GroupType.Platform, platformId)
+    UserGroupRoleDao.deactivateUserGroupRoles(userGroup, user)
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -119,4 +119,22 @@ object TeamDao extends Dao[Team] {
   def delete(teamId: UUID): ConnectionIO[Int] =
     TeamDao.query.filter(teamId).delete
 
+  def addUserRole(user: User, subject: User, teamId: UUID, userRole: GroupRole): ConnectionIO[UserGroupRole] = {
+    val userGroupRoleCreate = UserGroupRole.Create(
+      subject, GroupType.Team, teamId, userRole
+    )
+    UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(user))
+  }
+
+  def setUserRole(user: User, subject: User, teamId: UUID, userRole: GroupRole): ConnectionIO[List[UserGroupRole]] = {
+    deactivateUserRoles(user, subject, teamId).flatMap(
+      deactivatedUserRoles => addUserRole(user, subject, teamId, userRole)
+        .map(deactivatedUserRoles ++ List(_))
+    )
+  }
+
+  def deactivateUserRoles(user: User, subject: User, teamId: UUID): ConnectionIO[List[UserGroupRole]] = {
+    val userGroup = UserGroupRole.UserGroup(subject.id, GroupType.Team, teamId)
+    UserGroupRoleDao.deactivateUserGroupRoles(userGroup, user)
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -80,12 +80,28 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
 
   // List roles that a given user has been granted
   def listByUser(user: User): ConnectionIO[List[UserGroupRole]] = {
-    query.filter(fr"user_id = ${user.id}").list
+    query
+      .filter(fr"user_id = ${user.id}")
+      .filter(fr"is_active = true")
+      .list
   }
 
   // List roles that have been given to users for a group
   def listByGroup(groupType: GroupType, groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
-    query.filter(fr"group_type = ${groupType}").filter(fr"group_id = ${groupId}").list
+    query
+      .filter(fr"group_type = ${groupType}")
+      .filter(fr"group_id = ${groupId}")
+      .filter(fr"is_active = true")
+      .list
+  }
+
+  // List a user's roles in a group
+  def listUserGroupRoles(groupType: GroupType, groupId: UUID, user: User): ConnectionIO[List[UserGroupRole]] = {
+    query.filter(fr"group_type = ${groupType}")
+      .filter(fr"group_id = ${groupId}")
+      .filter(fr"user_id = ${user.id}")
+      .filter(fr"is_active = true")
+      .list
   }
 
   // @TODO: ensure a user cannot demote (or promote?) themselves
@@ -99,5 +115,30 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
           modified_by = ${user.id}
             WHERE id = ${id}
         """).update.run
+  }
+
+  def deactivateUserGroupRoles(ugr: UserGroupRole.UserGroup, user: User): ConnectionIO[List[UserGroupRole]] = {
+    (fr"UPDATE" ++ tableF ++ fr"""SET
+        modified_at = NOW(),
+        modified_by = ${user.id},
+        is_active = false
+        """ ++ Fragments.whereAnd(
+      fr"user_id = ${ugr.userId}",
+      fr"group_type = ${ugr.groupType}",
+      fr"group_id = ${ugr.groupId}",
+      fr"is_active = true"
+     )
+    ).update.withGeneratedKeys[UserGroupRole](
+      "id",
+      "created_at",
+      "created_by",
+      "modified_at",
+      "modified_by",
+      "is_active",
+      "user_id",
+      "group_type",
+      "group_id",
+      "group_role"
+    ).compile.toList
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.{Organization, Platform, User}
+import com.azavea.rf.datamodel.{Organization, Platform, User, GroupRole, GroupType}
 import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 import doobie._
@@ -97,6 +97,94 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
 
           val (rowsAffected, platformById) = deletePlatformWithPlatformIO.transact(xa).unsafeRunSync
           rowsAffected == 1 && platformById == None
+        }
+      }
+    }
+  }
+
+  test("add a user role") {
+    check {
+      forAll{
+        (
+          userCreate: User.Create, orgCreate: Organization.Create, platformCreate: Platform.Create,
+          userRole: GroupRole
+        ) => {
+          val addPlatformRoleWithPlatformIO = for {
+            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+                                          (org, dbUser) = orgAndUser
+            insertedPlatform <- PlatformDao.create(platformCreate.toPlatform(dbUser))
+            insertedUserGroupRole <- PlatformDao.addUserRole(dbUser, dbUser, insertedPlatform.id, userRole)
+            byIdUserGroupRole <- UserGroupRoleDao.getOption(insertedUserGroupRole.id)
+          } yield { (insertedPlatform, byIdUserGroupRole) }
+
+          val (dbPlatform, dbUserGroupRole) = addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
+          dbUserGroupRole match {
+            case Some(ugr) =>
+              assert(ugr.isActive, "; Added role should be active")
+              assert(ugr.groupType == GroupType.Platform, "; Added role should be for a Platform")
+              assert(ugr.groupId == dbPlatform.id, "; Added role should be for the correct Platform")
+              assert(ugr.groupRole == userRole, "; Added role should have the correct role")
+              true
+            case _ => false
+          }
+        }
+      }
+    }
+  }
+
+  test("replace a user's roles") {
+    check {
+      forAll{
+        (
+          userCreate: User.Create, orgCreate: Organization.Create, platformCreate: Platform.Create,
+          userRole: GroupRole
+        ) => {
+          val setPlatformRoleIO = for {
+            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+            (org, dbUser) = orgAndUser
+            insertedPlatform <- PlatformDao.create(platformCreate.toPlatform(dbUser))
+            originalUserGroupRole <- PlatformDao.addUserRole(dbUser, dbUser, insertedPlatform.id, userRole)
+            updatedUserGroupRoles <- PlatformDao.setUserRole(dbUser, dbUser, insertedPlatform.id, userRole)
+          } yield { (insertedPlatform, originalUserGroupRole, updatedUserGroupRoles ) }
+
+          val (dbPlatform, dbOldUGR, dbNewUGRs) = setPlatformRoleIO.transact(xa).unsafeRunSync
+
+          assert(dbNewUGRs.filter((ugr) => ugr.isActive == true).size == 1,
+                 "; Updated UGRs should have one set to active")
+          assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
+                 "; Updated UGRs should have one set to inactive")
+          assert(dbNewUGRs.filter((ugr) => ugr.id == dbOldUGR.id && ugr.isActive == false).size == 1,
+                 "; Old UGR should be set to inactive")
+          assert(dbNewUGRs.filter((ugr) => ugr.id != dbOldUGR.id && ugr.isActive == true).size == 1,
+                 "; New UGR should be set to active")
+          assert(dbNewUGRs.size == 2, "; Update should have old and new UGRs")
+          true
+        }
+      }
+    }
+  }
+
+  test("deactivate a user's roles") {
+    check {
+      forAll{
+        (
+          userCreate: User.Create, orgCreate: Organization.Create, platformCreate: Platform.Create,
+          userRole: GroupRole
+        ) => {
+          val setPlatformRoleIO = for {
+            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+            (org, dbUser) = orgAndUser
+            insertedPlatform <- PlatformDao.create(platformCreate.toPlatform(dbUser))
+            originalUserGroupRole <- PlatformDao.addUserRole(dbUser, dbUser, insertedPlatform.id, userRole)
+            updatedUserGroupRoles <- PlatformDao.deactivateUserRoles(dbUser, dbUser, insertedPlatform.id)
+          } yield { (insertedPlatform, originalUserGroupRole, updatedUserGroupRoles ) }
+
+          val (dbPlatform, dbOldUGR, dbNewUGRs) = setPlatformRoleIO.transact(xa).unsafeRunSync
+
+          assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
+                 "; The updated UGR should be inactive")
+          assert(dbNewUGRs.size == 1, "; There should only be a single UGR updated")
+          true
         }
       }
     }


### PR DESCRIPTION
## Overview
Adding a user more than once deactivates any actives roles for that groupId and
creates a new one with the specified role.

Removing a user deactivates any active roles for that groupId

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Create / Update tests for Dao functions

### Notes
Instead of updating roles, we deactivate the old role and create a new one to preserve an audit trail.

## Testing Instructions

* Stuff should compile
* Verify that the queries make sense
* Verify that tests make sense


Closes #3282 
Closes #3284