### PR TITLE
Disable Failed Retries for Ingests from API

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -173,8 +173,6 @@ object SceneDao extends Dao[Scene] {
             scene.statusFields.ingestStatus match {
               case IngestStatus.ToBeIngested =>
                 (n, true)
-              case IngestStatus.Failed =>
-                (n, true)
               case IngestStatus.Ingesting =>
                 (n, ts.getTime < now.getTime - (24 hours).toMillis)
               case _ =>


### PR DESCRIPTION
## Overview

This prevents a scenario where retrying ingests can cause a large
number of jobs to be kicked off because the status was updated to
failed. This change makes it so that in cases where the status is
updated to failed we do not automatically kick off another job and
assume that manual intervention or external retries will handle the
failure.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

I think testing should be optional for this because it's pretty small and there is a test to verify behavior ... but if you desire to test this
 * Update a scene from the API with its ingest status set to `FAILED` and verify that log output shows ingest would not be kicked off
 * Update a scene from the API with its ingest status set to 'TOBEINGESTED' and verify that log output shows that ingest would be kicked off

Closes #3336 
