### PR TITLE
Handle shape filters separately from other scene query params

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -106,12 +106,27 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
 
     val pageFragment: Fragment = Page(pageRequest)
     val queryFilters: List[Option[Fragment]] = makeFilters(List(sceneParams)).flatten
+
+    val shapeIO: ConnectionIO[Option[Shape]] =
+      sceneParams.sceneParams.shape match {
+        case Some(shapeId) => ShapeDao.getShapeById(shapeId, user)
+        case _ => (None : Option[Shape]).pure[ConnectionIO]
+      }
+
     val scenesIO: ConnectionIO[List[Scene]] =
-      (selectF ++ Fragments.whereAndOpt((query.ownerVisibilityFilterF(user) :: queryFilters): _*) ++ pageFragment)
-        .query[Scene]
-        .stream
-        .compile
-        .toList
+      shapeIO flatMap {
+        (shpO: Option[Shape]) => {
+          (selectF ++ Fragments.whereAndOpt(
+             ((shpO map { (shp: Shape) => fr"ST_Intersects(data_footprint, ${shp.geometry})" })
+                :: query.ownerVisibilityFilterF(user)
+                :: queryFilters): _*) ++ pageFragment)
+            .query[Scene]
+            .stream
+            .compile
+            .toList
+        }
+      }
+
     val withRelatedsIO: ConnectionIO[List[Scene.WithRelated]] = scenesIO flatMap { scenesToScenesWithRelated }
 
     for {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
@@ -113,11 +113,7 @@ trait Filterables extends RFMeta {
           statuses => Fragments.in(fr"ingest_status", statuses)
         }),
         (sceneParams.bboxPolygon, sceneParams.shape) match {
-          case (_, Some(shpId)) => Some(
-            fr"""
-            ST_Intersects(
-              data_footprint,
-              (SELECT geometry from shapes where id=${shpId}))""")
+          case (_, Some(shpId)) => None
           case (Some(bboxPolygons), _) => {
             val fragments = bboxPolygons.map(bbox =>
               fr"ST_Intersects(data_footprint, ${bbox})")


### PR DESCRIPTION
## Overview

This PR pre-fetches the geometry for a shape ID filter when using shape IDs to filter scenes.
When using a subquery, postgres got confused and didn't know how to use the `data_footprint`
index to run a reasonably quick query. In fact it was not reasonably quick enough that the 
API was timing out :cry:. By pre-fetching the geometry, we help postgres not be confused.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

There isn't really a local performance test that proves this will work in the wild. :man_shrugging: 

@notthatbreezy and I `EXPLAIN ANALYZE`d using a geom literal in the prod db to confirm that 
it would make the db use the index.

## Testing Instructions

 * draw a shape and use it to filter scenes to prove that I didn't ruin the sql
 * CI

Closes #3307
