### PR TITLE
Use Sid repositories for installing GDAL

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -7,8 +7,8 @@ ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 COPY rf/requirements.txt /tmp/
 RUN set -ex \
     && gdalDeps=' \
-       gdal-bin \
-       python-gdal \
+       gdal-bin/sid \
+       python-gdal/sid \
        python-pip \
        python-setuptools \
        python-dev \
@@ -16,6 +16,7 @@ RUN set -ex \
        build-essential \
        imagemagick \
     ' \
+    && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends ${gdalDeps} wget \
     && pip install --no-cache-dir \


### PR DESCRIPTION
## Overview

We previously removed Sid because of a package problem. That seems to have resolved itself on its own (this build should work fine). We didn't press the issue any harder because we were unaware of code that depended on GDAL 2.2.x, but we use new arguments for GDAL polygonize.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

 * `docker-compose build batch`
 * `./scripts/console batch "gdalinfo --version"`
 * Verify 2.2.4 is installed
