### PR TITLE
Add user search to platform/org/team members endpoint

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -4,6 +4,7 @@ import com.azavea.rf.common.{Authentication, UserErrorHandler, CommonHandlers}
 import com.azavea.rf.database.{PlatformDao, OrganizationDao, TeamDao, UserDao, UserGroupRoleDao}
 import com.azavea.rf.datamodel._
 import com.azavea.rf.database.filter.Filterables._
+import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
@@ -27,7 +28,7 @@ trait PlatformRoutes extends Authentication
   with CommonHandlers
   with KamonTraceDirectives
   with UserErrorHandler
-  with PlatformQueryParameterDirective {
+  with QueryParametersCommon {
 
   val xa: Transactor[IO]
 
@@ -270,9 +271,9 @@ trait PlatformRoutes extends Authentication
     authorizeAsync {
       PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
     } {
-      withPagination { page =>
+      (withPagination & searchParams) { (page, searchParams) =>
         complete {
-          PlatformDao.listMembers(platformId, page).transact(xa).unsafeToFuture
+          PlatformDao.listMembers(platformId, page, searchParams).transact(xa).unsafeToFuture
         }
       }
     }
@@ -354,9 +355,9 @@ trait PlatformRoutes extends Authentication
     authorizeAsync {
       OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
     } {
-      withPagination { page =>
+      (withPagination & searchParams) { (page, searchParams) =>
         complete {
-          OrganizationDao.listMembers(orgId, page).transact(xa).unsafeToFuture
+          OrganizationDao.listMembers(orgId, page, searchParams).transact(xa).unsafeToFuture
         }
       }
     }
@@ -438,9 +439,9 @@ trait PlatformRoutes extends Authentication
     authorizeAsync {
       OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
     } {
-      withPagination { page =>
+      (withPagination & searchParams) { (page, searchParams) =>
         complete {
-          TeamDao.listMembers(teamId, page).transact(xa).unsafeToFuture
+          TeamDao.listMembers(teamId, page, searchParams).transact(xa).unsafeToFuture
         }
       }
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -62,8 +62,8 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
      """).update.run
   }
 
-  def listMembers(organizationId: UUID, page: PageRequest): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
-    UserGroupRoleDao.listUsersByGroup(GroupType.Organization, organizationId, page)
+  def listMembers(organizationId: UUID, page: PageRequest, searchParams: SearchQueryParameters): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
+    UserGroupRoleDao.listUsersByGroup(GroupType.Organization, organizationId, page, searchParams)
 
 
   def validatePath(platformId: UUID,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -39,8 +39,8 @@ object PlatformDao extends Dao[Platform] {
   def listPlatforms(page: PageRequest) =
     query.page(page)
 
-  def listMembers(platformId: UUID, page: PageRequest): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
-    UserGroupRoleDao.listUsersByGroup(GroupType.Platform, platformId, page)
+  def listMembers(platformId: UUID, page: PageRequest, searchParams: SearchQueryParameters): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
+    UserGroupRoleDao.listUsersByGroup(GroupType.Platform, platformId, page, searchParams)
 
   def create(platform: Platform): ConnectionIO[Platform] = {
     createF(platform).update.withUniqueGeneratedKeys[Platform](

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -79,8 +79,8 @@ object TeamDao extends Dao[Team] {
         is_active = true
   """
 
-  def listMembers(teamId: UUID, page: PageRequest): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
-    UserGroupRoleDao.listUsersByGroup(GroupType.Team, teamId, page)
+  def listMembers(teamId: UUID, page: PageRequest, searchParams: SearchQueryParameters): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
+    UserGroupRoleDao.listUsersByGroup(GroupType.Team, teamId, page, searchParams)
 
   def validatePath(platformId: UUID,
                    organizationId: UUID,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filters.scala
@@ -67,10 +67,10 @@ object Filters {
     List(
       searchParams.search.map(valueToMatch => {
         Fragment.const(
-          cols.map(col => {
+          "(" ++ cols.map(col => {
             val namePattern: String = "'%" + valueToMatch.toUpperCase() + "%'"
             s"UPPER($col) LIKE $namePattern"
-          }).mkString(" OR ")
+          }).mkString(" OR ") ++ ")"
         )
       })
     )

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -70,7 +70,11 @@ class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBT
               fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
                 .toUserGroupRole(managerUser)
             )
-            usersInGroup <- UserGroupRoleDao.listUsersByGroup(insertedUgr.groupType, insertedUgr.groupId, page)
+            usersInGroup <- UserGroupRoleDao.listUsersByGroup(
+              insertedUgr.groupType,
+              insertedUgr.groupId,
+              page,
+              SearchQueryParameters(Some("")))
           } yield (usersInGroup)
 
           val usersInGroup = insertUgrWithRelationsIO.transact(xa).unsafeRunSync


### PR DESCRIPTION
## Overview

This PR:
* adds user search to platform/org/team members endpoints by user name or email
* updates the property test for `listUsersByGroup` in `UserGroupRoleDao`

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Testing Instructions

 * Load development data and run migrations if neccessary
 * Run below sql to create records to test:
```sql
INSERT INTO teams VALUES (
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    NOW(),
    'default',
    NOW(),
    'default',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'Test team',
    '{}'
);

INSERT INTO user_group_roles VALUES (
    '03580e75-00b2-4682-a3e1-5401a96793cf',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'PLATFORM',
    '31277626-968b-4e40-840b-559d9c67863c',
    'ADMIN'
), (
    '42a5cbd4-dc12-41a9-8111-ca473a7d304e',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'ORGANIZATION',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'ADMIN'
), (
    '25f52de8-cc7b-487e-96f2-44d51e1f2f40',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'TEAM',
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    'ADMIN'
);
```
 * Login to frontend and grab a token
 * Send `GET` requests to the below endpoints:
      - `api/platforms/31277626-968b-4e40-840b-559d9c67863c/members?search=ras`
      - `api/platforms/31277626-968b-4e40-840b-559d9c67863c/organizations/dfac6307-b5ef-43f7-beda-b9f208bb7726/members?search=ras`
      - `api/platforms/31277626-968b-4e40-840b-559d9c67863c/organizations/dfac6307-b5ef-43f7-beda-b9f208bb7726/teams/f53a67bb-2b0d-484a-90d9-115b78a2cd28/members?search=ras`
 * Delete the above test records:
```sql
DELETE FROM teams
WHERE id = 'f53a67bb-2b0d-484a-90d9-115b78a2cd28';

DELETE FROM user_group_roles
WHERE id IN (
  '03580e75-00b2-4682-a3e1-5401a96793cf',
  '42a5cbd4-dc12-41a9-8111-ca473a7d304e',
  '25f52de8-cc7b-487e-96f2-44d51e1f2f40'
);
```

Closes #455 
