### PR TITLE
Use parent scope's project when opening scene import modal

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -63,7 +63,7 @@ class ProjectsScenesController {
         this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
-                project: () => this.project
+                project: () => this.$parent.project
             }
         });
     }


### PR DESCRIPTION
## Overview

...for projects

This PR uses the edit module's `project` to get a project in the scene import modal, which
was for some reason broken by the passage of time.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * open dev tools in your browser
 * try to create an upload in a project
 * observe that `projectId` is in the request
