### PR TITLE
Add sharing endpoints to projects

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -268,6 +268,11 @@ trait ProjectRoutes extends Authentication
                 traceName("add-project-permission") {
                   addPermission(projectId)
                 }
+              } ~
+              get {
+                traceName("list-project-permissions") {
+                  listPermissions(projectId)
+                }
               }
           }
       }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -749,4 +749,14 @@ trait ProjectRoutes extends Authentication
       }
     }
   }
+
+  def listPermissions(projectId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      ProjectDao.ownedBy(projectId, user).transact(xa).unsafeToFuture
+    } {
+      complete {
+        AccessControlRuleDao.listByObject(ObjectType.Project, projectId).transact(xa).unsafeToFuture
+      }
+    }
+  }
 }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -72,191 +72,205 @@ trait ProjectRoutes extends Authentication
           listProjects
         }
       } ~
-      post {
-        traceName("projects-create") {
-          createProject
+        post {
+          traceName("projects-create") {
+            createProject
+          }
         }
-      }
     } ~
-    pathPrefix(JavaUUID) { projectId =>
-      pathEndOrSingleSlash {
-        get {
-          traceName("projects-detail") {
-            getProject(projectId)
-          }
-        } ~
-        put {
-          traceName("projects-update") {
-            updateProject(projectId)
-          }
-        } ~
-        delete {
-          traceName("projects-delete") {
-            deleteProject(projectId) }
-        }
-      } ~
-      pathPrefix("labels") {
+      pathPrefix(JavaUUID) { projectId =>
         pathEndOrSingleSlash {
           get {
-            traceName("project-list-labels") {
-              listLabels(projectId)
-            }
-          }
-        }
-      } ~
-      pathPrefix("annotations") {
-        pathEndOrSingleSlash {
-          get {
-            traceName("projects-list-annotations") {
-              listAnnotations(projectId)
+            traceName("projects-detail") {
+              getProject(projectId)
             }
           } ~
-          post {
-            traceName("projects-create-annotations") {
-              createAnnotation(projectId)
-            }
-          } ~
-            delete {
-              traceName("projects-delete-annotations") {
-                deleteProjectAnnotations(projectId)
-              }
-            }
-        } ~
-        pathPrefix("shapefile") {
-          get {
-            traceName("project-annotations-shapefile") {
-              exportAnnotationShapefile(projectId)
-            }
-          }
-        } ~
-        pathPrefix(JavaUUID) { annotationId =>
-          pathEndOrSingleSlash {
-            get {
-              traceName("projects-get-annotation") {
-                getAnnotation(projectId, annotationId)
-              }
-            } ~
             put {
-              traceName("projects-update-annotation") {
-                updateAnnotation(projectId, annotationId)
+              traceName("projects-update") {
+                updateProject(projectId)
               }
             } ~
             delete {
-              traceName("projects-delete-annotation") {
-                deleteAnnotation(projectId, annotationId)
+              traceName("projects-delete") {
+                deleteProject(projectId) }
+            }
+        } ~
+          pathPrefix("labels") {
+            pathEndOrSingleSlash {
+              get {
+                traceName("project-list-labels") {
+                  listLabels(projectId)
+                }
               }
             }
-          }
-        }
-      } ~
-      pathPrefix("areas-of-interest") {
-        pathEndOrSingleSlash {
-          get {
-            traceName("projects-list-areas-of-interest") {
-              listAOIs(projectId)
-            }
           } ~
-          post {
-            traceName("projects-create-areas-of-interest") {
-              createAOI(projectId)
-            }
-          }
-        }
-      } ~
-      pathPrefix("scenes") {
-        pathEndOrSingleSlash {
-          get {
-            traceName("project-list-scenes") {
-              listProjectScenes(projectId)
-            }
-          } ~
-          post {
-            traceName("project-add-scenes-list") {
-              addProjectScenes(projectId)
-            }
-          } ~
-          put {
-            traceName("project-update-scenes-list") {
-              updateProjectScenes(projectId)
-            }
-          } ~
-          delete {
-            traceName("project-delete-scenes-list") {
-              deleteProjectScenes(projectId)
-            }
-          }
-        } ~
-        pathPrefix("bulk-add-from-query") {
-          pathEndOrSingleSlash {
-            post {
-              traceName("project-add-scenes-from-query") {
-                addProjectScenesFromQueryParams(projectId)
+          pathPrefix("annotations") {
+            pathEndOrSingleSlash {
+              get {
+                traceName("projects-list-annotations") {
+                  listAnnotations(projectId)
+                }
+              } ~
+                post {
+                  traceName("projects-create-annotations") {
+                    createAnnotation(projectId)
+                  }
+                } ~
+                delete {
+                  traceName("projects-delete-annotations") {
+                    deleteProjectAnnotations(projectId)
+                  }
+                }
+            } ~
+              pathPrefix("shapefile") {
+                get {
+                  traceName("project-annotations-shapefile") {
+                    exportAnnotationShapefile(projectId)
+                  }
+                }
+              } ~
+              pathPrefix(JavaUUID) { annotationId =>
+                pathEndOrSingleSlash {
+                  get {
+                    traceName("projects-get-annotation") {
+                      getAnnotation(projectId, annotationId)
+                    }
+                  } ~
+                    put {
+                      traceName("projects-update-annotation") {
+                        updateAnnotation(projectId, annotationId)
+                      }
+                    } ~
+                    delete {
+                      traceName("projects-delete-annotation") {
+                        deleteAnnotation(projectId, annotationId)
+                      }
+                    }
+                }
               }
-            }
-          }
-        } ~
-        pathPrefix("accept") {
-          post {
-            traceName("project-accept-scenes-list") {
-              acceptScenes(projectId)
-            }
-          }
-        } ~
-        pathPrefix(JavaUUID) { sceneId =>
-          pathPrefix("accept") {
-            post {
-              traceName("project-accept-scene") {
-                acceptScene(projectId, sceneId)
-              }
-            }
-          }
-        }
-      } ~
-      pathPrefix("mosaic") {
-        pathEndOrSingleSlash {
-          get {
-            traceName("project-get-mosaic-definition") {
-              getProjectMosaicDefinition(projectId)
-            }
-          }
-        } ~
-        pathPrefix(JavaUUID) { sceneId =>
-          get {
-            traceName("project-get-scene-color-corrections") {
-              getProjectSceneColorCorrectParams(projectId, sceneId)
+          } ~
+          pathPrefix("areas-of-interest") {
+            pathEndOrSingleSlash {
+              get {
+                traceName("projects-list-areas-of-interest") {
+                  listAOIs(projectId)
+                }
+              } ~
+                post {
+                  traceName("projects-create-areas-of-interest") {
+                    createAOI(projectId)
+                  }
+                }
             }
           } ~
-          put {
-            traceName("project-set-scene-color-corrections") {
-              setProjectSceneColorCorrectParams(projectId, sceneId)
-            }
-          }
-        } ~
-        pathPrefix("bulk-update-color-corrections") {
-          pathEndOrSingleSlash {
-            post {
-              traceName("project-bulk-update-color-corrections") {
-                setProjectScenesColorCorrectParams(projectId)
+          pathPrefix("scenes") {
+            pathEndOrSingleSlash {
+              get {
+                traceName("project-list-scenes") {
+                  listProjectScenes(projectId)
+                }
+              } ~
+                post {
+                  traceName("project-add-scenes-list") {
+                    addProjectScenes(projectId)
+                  }
+                } ~
+                put {
+                  traceName("project-update-scenes-list") {
+                    updateProjectScenes(projectId)
+                  }
+                } ~
+                delete {
+                  traceName("project-delete-scenes-list") {
+                    deleteProjectScenes(projectId)
+                  }
+                }
+            } ~
+              pathPrefix("bulk-add-from-query") {
+                pathEndOrSingleSlash {
+                  post {
+                    traceName("project-add-scenes-from-query") {
+                      addProjectScenesFromQueryParams(projectId)
+                    }
+                  }
+                }
+              } ~
+              pathPrefix("accept") {
+                post {
+                  traceName("project-accept-scenes-list") {
+                    acceptScenes(projectId)
+                  }
+                }
+              } ~
+              pathPrefix(JavaUUID) { sceneId =>
+                pathPrefix("accept") {
+                  post {
+                    traceName("project-accept-scene") {
+                      acceptScene(projectId, sceneId)
+                    }
+                  }
+                }
               }
-            }
-          }
-        }
-      } ~
-      pathPrefix("order") {
-        pathEndOrSingleSlash {
-          get {
-            traceName("projects-get-scene-order") {
-              listProjectSceneOrder(projectId)
+          } ~
+          pathPrefix("mosaic") {
+            pathEndOrSingleSlash {
+              get {
+                traceName("project-get-mosaic-definition") {
+                  getProjectMosaicDefinition(projectId)
+                }
+              }
+            } ~
+              pathPrefix(JavaUUID) { sceneId =>
+                get {
+                  traceName("project-get-scene-color-corrections") {
+                    getProjectSceneColorCorrectParams(projectId, sceneId)
+                  }
+                } ~
+                  put {
+                    traceName("project-set-scene-color-corrections") {
+                      setProjectSceneColorCorrectParams(projectId, sceneId)
+                    }
+                  }
+              } ~
+              pathPrefix("bulk-update-color-corrections") {
+                pathEndOrSingleSlash {
+                  post {
+                    traceName("project-bulk-update-color-corrections") {
+                      setProjectScenesColorCorrectParams(projectId)
+                    }
+                  }
+                }
+              }
+          } ~
+          pathPrefix("order") {
+            pathEndOrSingleSlash {
+              get {
+                traceName("projects-get-scene-order") {
+                  listProjectSceneOrder(projectId)
+                }
+              } ~
+                put {
+                  traceName("projects-set-scene-order") {
+                    setProjectSceneOrder(projectId)
+                  }
+                }
             }
           } ~
-          put {
-            traceName("projects-set-scene-order") {
-              setProjectSceneOrder(projectId)
-            }
+          pathPrefix("permissions") {
+            pathEndOrSingleSlash {
+              put {
+                traceName("replace-project-permissions") {
+                  replacePermissions(projectId)
+                }
+              }
+            } ~
+              post {
+                traceName("add-project-permission") {
+                  addPermission(projectId)
+                }
+              }
           }
-        }
       }
-    }
   }
 
   def listProjects: Route = authenticate { user =>
@@ -703,6 +717,34 @@ trait ProjectRoutes extends Authentication
 
         onSuccess(ProjectDao.deleteScenesFromProject(sceneIds.toList, projectId).transact(xa).unsafeToFuture()) {
           _ => complete(StatusCodes.NoContent)
+        }
+      }
+    }
+  }
+
+  def addPermission(projectId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      ProjectDao.ownedBy(projectId, user).transact(xa).unsafeToFuture
+    } {
+      entity(as[AccessControlRule.Create]) { acrCreate =>
+        complete {
+          AccessControlRuleDao.createWithResults(
+            acrCreate.toAccessControlRule(user, ObjectType.Project, projectId)
+          ).transact(xa).unsafeToFuture
+        }
+      }
+    }
+  }
+
+  def replacePermissions(projectId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      ProjectDao.ownedBy(projectId, user).transact(xa).unsafeToFuture
+    } {
+      entity(as[List[AccessControlRule.Create]]) { acrCreates =>
+        complete {
+          AccessControlRuleDao.replaceWithResults(
+            user, ObjectType.Project, projectId, acrCreates
+          ).transact(xa).unsafeToFuture
         }
       }
     }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
@@ -9,45 +9,41 @@ import io.circe.syntax._
 
 @JsonCodec
 case class AccessControlRule(
-    id: UUID,
-    createdAt: Timestamp,
-    createdBy: String,
-    modifiedAt: Timestamp,
-    modifiedBy: String,
-    isActive: Boolean,
-    objectType: ObjectType,
-    objectId: UUID,
-    subjectType: SubjectType,
-    subjectId: Option[String],
-    actionType: ActionType
+  id: UUID,
+  createdAt: Timestamp,
+  createdBy: String,
+  isActive: Boolean,
+  objectType: ObjectType,
+  objectId: UUID,
+  subjectType: SubjectType,
+  subjectId: Option[String],
+  actionType: ActionType
 )
 
 object AccessControlRule {
-    def create = Create.apply _
-    def tupled = (AccessControlRule.apply _).tupled
+  def create = Create.apply _
+  def tupled = (AccessControlRule.apply _).tupled
 
-    case class Create(
-        objectType: ObjectType,
-        objectId: UUID,
-        subjectType: SubjectType,
-        subjectId: Option[String],
-        actionType: ActionType
-    ) {
-        def toAccessControlRule(user: User): AccessControlRule = {
-            val now = new Timestamp((new java.util.Date()).getTime())
-            AccessControlRule(
-                UUID.randomUUID(),
-                now, // createdAt
-                user.id, // createdBy
-                now, // modifiedAt
-                user.id, // modifiedBy
-                true, // isActive
-                objectType,
-                objectId,
-                subjectType,
-                subjectId,
-                actionType
-            )
-        }
+  @JsonCodec
+  case class Create(
+    isActive: Boolean,
+    subjectType: SubjectType,
+    subjectId: Option[String],
+    actionType: ActionType
+  ) {
+    def toAccessControlRule(user: User, objectType: ObjectType, objectId: UUID): AccessControlRule = {
+      val now = new Timestamp((new java.util.Date()).getTime())
+      AccessControlRule(
+        UUID.randomUUID(),
+        now, // createdAt
+        user.id, // createdBy
+        isActive,
+        objectType,
+        objectId,
+        subjectType,
+        subjectId,
+        actionType
+      )
     }
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -285,4 +285,8 @@ object ProjectDao extends Dao[Project] {
       scenesAdded <- addScenesToProject(scenes.map(_.id), projectId, user)
     } yield scenesAdded
   }
+
+  def ownedBy(projectId: UUID, user: User): ConnectionIO[Boolean] = {
+    query.filter(projectId).filter(fr"owner = ${user.id}").exists
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -42,8 +42,8 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
             )
             _ <- AccessControlRuleDao.create(
               AccessControlRule.Create(
-                ObjectType.Project, project.id, SubjectType.All, None, ActionType.View
-              ).toAccessControlRule(user1)
+                true, SubjectType.All, None, ActionType.View
+              ).toAccessControlRule(user1, ObjectType.Project, project.id)
             )
             user1Authorized <- ProjectDao.query.authorized(user1, ObjectType.Project, project.id, ActionType.View)
             user2Authorized <- ProjectDao.query.authorized(user2, ObjectType.Project, project.id, ActionType.View)
@@ -84,8 +84,8 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
             project <- ProjectDao.insertProject(fixupProjectCreate(user1, org1, projectCreate), user1)
             _ <- AccessControlRuleDao.create(
               AccessControlRule.Create(
-                ObjectType.Project, project.id, SubjectType.Platform, Some(platform1.id.toString), ActionType.View
-              ).toAccessControlRule(user1)
+                true, SubjectType.Platform, Some(platform1.id.toString), ActionType.View
+              ).toAccessControlRule(user1, ObjectType.Project, project.id)
             )
             user1Authorized <- ProjectDao.query.authorized(user1, ObjectType.Project, project.id, ActionType.View)
             user2Authorized <- ProjectDao.query.authorized(user2, ObjectType.Project, project.id, ActionType.View)
@@ -116,8 +116,8 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
             project <- ProjectDao.insertProject(fixupProjectCreate(user1, org1, projectCreate), user1)
             _ <- AccessControlRuleDao.create(
               AccessControlRule.Create(
-                ObjectType.Project, project.id, SubjectType.Organization, Some(org1.id.toString), ActionType.View
-              ).toAccessControlRule(user1)
+                true, SubjectType.Organization, Some(org1.id.toString), ActionType.View
+              ).toAccessControlRule(user1, ObjectType.Project, project.id)
             )
             user1Authorized <- ProjectDao.query.authorized(user1, ObjectType.Project, project.id, ActionType.View)
             user2Authorized <- ProjectDao.query.authorized(user2, ObjectType.Project, project.id, ActionType.View)

--- a/app-backend/migrations/src_migrations/main/scala/207.scala
+++ b/app-backend/migrations/src_migrations/main/scala/207.scala
@@ -53,8 +53,6 @@ object M207 {
         id UUID PRIMARY KEY NOT NULL,
         created_at TIMESTAMP NOT NULL,
         created_by VARCHAR(255) REFERENCES users(id) NOT NULL,
-        modified_at TIMESTAMP NOT NULL,
-        modified_by VARCHAR(255) REFERENCES users(id) NOT NULL,
         is_active BOOLEAN DEFAULT true NOT NULL,
         object_type object_type NOT NULL,
         object_id UUID NOT NULL,


### PR DESCRIPTION
## Overview

This PR adds endpoints for managing access to projects.

### Checklist

- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated (raster-foundry/raster-foundry-api-spec#12)
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

ACRs are immutable now :tada:, which also let us simplify the model some.

## Testing Instructions

Here's an example post body you can send and edit for below:

```json
{
  "actionType": "VIEW",
  "subjectType": "ALL",
  "subjectId": null,
  "isActive": true
}
```

 * login to your frontend and get a token
 * find a project id you have access to
 * `POST` the ACR above to `/api/projects/<id>/permissions`
 * check out the permission that came back and confirm it matches what you created
 * log in as a different user
 * verify you can see the project
 * `POST` another one, but with a different action type
 * check out that you get both of them back
 * `PUT` only one permission in a json list to the same endpoint
 * verify that it's the only thing that comes back
 * `GET` the same endpoint
 * verify that what you get back matches what you got back a minute ago
 * grab a token for the other user you logged in as
 * try to do anything to the permissions
 * confirm that you're not authorized to do so

Closes #3348 
