### PR TITLE
Platform route cleanup

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -277,7 +277,7 @@ trait PlatformRoutes extends Authentication
       UserDao.isSuperUser(user).transact(xa).unsafeToFuture
     } {
       completeWithOneOrFail {
-        PlatformDao.delete(platformId).transact(xa).unsafeToFuture
+        ???
       }
     }
   }
@@ -359,10 +359,8 @@ trait PlatformRoutes extends Authentication
     authorizeAsync {
       PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
     } {
-      rejectEmptyResponse {
-        complete {
-          ???
-        }
+      completeWithOneOrFail {
+        ???
       }
     }
   }
@@ -448,7 +446,7 @@ trait PlatformRoutes extends Authentication
       TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
     } {
       completeWithOneOrFail {
-        TeamDao.query.filter(teamId).delete.transact(xa).unsafeToFuture
+        ???
       }
     }
   }

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -47,24 +47,19 @@ trait PlatformRoutes extends Authentication
     } ~
     pathPrefix(JavaUUID) { platformId =>
       pathEndOrSingleSlash {
-        validate (
-          PlatformDao.validatePath(platformId).transact(xa).unsafeRunSync,
-          "Resource path invalid"
-        ) {
-          get {
-            traceName("platforms-get") {
-              getPlatform(platformId)
-            }
-          } ~
-          put {
-            traceName("platforms-update") {
-              updatePlatform(platformId)
-            }
-          } ~
-          delete {
-            traceName("platforms-delete") {
-              deletePlatform(platformId)
-            }
+        get {
+          traceName("platforms-get") {
+            getPlatform(platformId)
+          }
+        } ~
+        put {
+          traceName("platforms-update") {
+            updatePlatform(platformId)
+          }
+        } ~
+        delete {
+          traceName("platforms-delete") {
+            deletePlatform(platformId)
           }
         }
       } ~

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -80,13 +80,32 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
 
 
   def userIsMemberF(user: User, organizationId: UUID ) = fr"""
-    SELECT count(id) > 0
-      FROM """ ++ UserGroupRoleDao.tableF ++ fr"""
+    SELECT (
+        SELECT is_superuser
+        FROM """ ++ UserDao.tableF ++ fr"""
+        WHERE id = ${user.id}
+      ) OR (
+        SELECT count(id) > 0
+        FROM """ ++ UserGroupRoleDao.tableF ++ fr"""
+        WHERE
+          user_id = ${user.id} AND
+          group_type = ${GroupType.Organization.toString}::group_type AND
+          group_id = ${organizationId} AND
+          is_active = true
+      ) OR (
+      SELECT count(ugr.id) > 0
+      FROM""" ++ PlatformDao.tableF ++ fr"""AS p
+      JOIN""" ++ tableF ++ fr"""o
+        ON o.platform_id = p.id
+      JOIN""" ++ UserGroupRoleDao.tableF ++ fr"""ugr
+        ON ugr.group_id = p.id
       WHERE
-        user_id = ${user.id} AND
-        group_type = ${GroupType.Organization.toString}::group_type AND
-        group_id = ${organizationId} AND
-        is_active = true
+        o.id = ${organizationId} AND
+        ugr.user_id = ${user.id} AND
+        ugr.group_role = ${GroupRole.Admin.toString}::group_role AND
+        ugr.group_type = ${GroupType.Platform.toString}::group_type AND
+        ugr.is_active = true
+    )
   """
 
   def userIsMember(user: User, organizationId: UUID): ConnectionIO[Boolean] =

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -114,19 +114,13 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
         FROM """ ++ tableF ++ fr""" ugr
         JOIN """ ++ UserDao.tableF ++ fr""" u
           ON u.id = ugr.user_id
-        WHERE
-          ugr.group_type = ${groupType} AND
-          ugr.group_id = ${groupId} AND
-          ugr.is_active
       """
 
     val cf =
       fr"""SELECT count(ugr.id)
-        FROM """ ++ tableF ++ fr""" ugr
-        WHERE
-          ugr.group_type = ${groupType} AND
-          ugr.group_id = ${groupId} AND
-          ugr.is_active
+        FROM """ ++ tableF ++ fr"""AS ugr
+        JOIN """ ++ UserDao.tableF ++ fr""" u
+          ON u.id = ugr.user_id
       """
 
       query

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -114,13 +114,19 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
         FROM """ ++ tableF ++ fr""" ugr
         JOIN """ ++ UserDao.tableF ++ fr""" u
           ON u.id = ugr.user_id
+        WHERE
+          ugr.group_type = ${groupType} AND
+          ugr.group_id = ${groupId} AND
+          ugr.is_active
       """
 
     val cf =
       fr"""SELECT count(ugr.id)
         FROM """ ++ tableF ++ fr""" ugr
-        JOIN """ ++ UserDao.tableF ++ fr""" u
-          ON u.id = ugr.user_id
+        WHERE
+          ugr.group_type = ${groupType} AND
+          ugr.group_id = ${groupId} AND
+          ugr.is_active
       """
 
       query


### PR DESCRIPTION
## Overview

This PR addresses some small issues with the platform routes.

6922c12
This makes `userIsMember` of Team and Organization DAOs take cascading admin roles into account. For example, an admin role in a platform satisfies a check for membership of a child organization.

cb0f85a + 35a0a98
This enforces checks on platform level routes that the platform must exist.

09f292b
This makes listing of users within a group take the `is_active` flag of the `UserGroupRole` into account, only returning users with an active role.

1ec672b
We have not properly implemented delete methods (see issues #3282 and #3379). This removes any functionality that was incorrect in favor of code that will throw.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [x] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~

## Notes

Right now, the validate directive returns 400s for incorrect URL paths. An issue exists to correct this: #3382

## Testing Instructions

You'll need some stubbed data (see below)

  * Any DELETE requests to platforms, orgs, or teams should throw unimplemented errors
  * Add and deactivate a user role for a group. Calling  the `listMembers` method for that group should not contain the user with that role
  * Try calling any platform routes with an incorrect platform id, it shouldn't work
  * Add an organization admin role for your user and make sure that you have the id of a team in that org that your user is not a member or admin of (explicitly). Calling the `userIsAdmin` method of the `TeamDao` with that team should return true (there is SQL for this below)

SQL
```sql
INSERT INTO teams VALUES (
    'f53a67bb-2b0d-484a-90d9-115b78a2cd28',
    NOW(),
    'default',
    NOW(),
    'default',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'Test team',
    '{}'
);

INSERT INTO user_group_roles VALUES (
    '42a5cbd4-dc12-41a9-8111-ca473a7d304e',
    NOW(),
    'default',
    NOW(),
    'default',
    true,
    'auth0|59318a9d2fbbca3e16bcfc92',
    'ORGANIZATION',
    'dfac6307-b5ef-43f7-beda-b9f208bb7726',
    'ADMIN'
);
```

Closes #3339 
Closes #3357
