### PR TITLE
Allow adding MODIS scenes to projects

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UploadType.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/UploadType.scala
@@ -19,6 +19,7 @@ object UploadType {
     case "S3" => S3
     case "LOCAL" => Local
     case "PLANET" => Planet
+    case "MODIS_USGS" => Modis
   }
 
   implicit val uploadTypeEncoder: Encoder[UploadType] =

--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -3,20 +3,22 @@ import axios from 'axios';
 
 export default (app) => {
     class CMRRepository {
-        constructor($q) {
+        constructor($q, authService, uploadService) {
             this.$q = $q;
             this.previewOnMap = false;
+            this.authService = authService;
+            this.uploadService = uploadService;
         }
 
         initDatasources() {
             this.datasources = [{
-                name: 'MODIS/Aqua',
-                uuid: '73b24c83-1da9-4118-ae3f-ac601d1b701b',
+                name: 'MYD09A1: MODIS/Aqua ',
+                uuid: '755735945-9da5-47c3-8ae4-572b5e11205b',
                 id: 'MYD09A1',
                 default: true
             }, {
-                name: 'MODIS/Terra',
-                uuid: '73b24c83-1da9-4118-ae3f-ac601d1b701b',
+                name: 'MOD09A1: MODIS/Terra',
+                uuid: 'a11b768b-d869-476e-a1ed-0ac3205ed761',
                 id: 'MOD09A1'
             }];
         }
@@ -80,7 +82,7 @@ export default (app) => {
         }
 
         getScenePermissions() {
-            return [];
+            return ['download'];
         }
 
         /*
@@ -113,8 +115,8 @@ export default (app) => {
                         }).then(response => {
                             page += 1;
                             resolve({
-                                scenes: response.data.feed.entry.map(
-                                    this.incomingSceneAdapter.bind(this)
+                                scenes: response.data.feed.entry.map(s =>
+                                    this.incomingSceneAdapter(s, filters.datasource)
                                 ),
                                 hasNext: true,
                                 count: 'Unknown'
@@ -159,7 +161,7 @@ export default (app) => {
         }
 
         // Transform a single scene
-        incomingSceneAdapter(scene) {
+        incomingSceneAdapter(scene, datasource) {
             return {
                 id: scene.id,
                 createdAt: scene.time_start,
@@ -167,7 +169,7 @@ export default (app) => {
                 modifiedAt: scene.time_start,
                 modifiedBy: 'nasa',
                 owner: 'nasa',
-                datasource: scene.dataset_id,
+                datasource: datasource,
                 sceneMetadata: scene,
                 name: scene.title,
                 tileFootprint: {
@@ -185,13 +187,33 @@ export default (app) => {
             };
         }
 
+        sceneToUploadObject(scene, projectId, user) {
+            const dataRel = 'http://esipfed.org/ns/fedsearch/1.1/data#';
+            const dataHref = scene.sceneMetadata.links.find(l => l.rel === dataRel).href;
+            return {
+                files: [dataHref],
+                fileType: 'GEOTIFF',
+                uploadType: 'MODIS_USGS',
+                datasource: this.datasources.find(d => d.id === scene.datasource).uuid,
+                uploadStatus: 'UPLOADED',
+                visibility: 'PRIVATE',
+                organizationId: user.organizationId,
+                projectId,
+                metadata: {}
+            };
+        }
+
         /*
           Returns a function which creates an import using the given scenes
           returns: (scenes) => Future(success, failure)
         */
-        addToProject() {
-            // @TODO: Implement
-            throw Error('Not implemented');
+        addToProject(projectId, scenes) {
+            return this.authService.getCurrentUser().then(user => {
+                const uploads = scenes.map(s => this.sceneToUploadObject(s, projectId, user));
+                return this.$q.all(
+                    uploads.map(u => this.uploadService.create(u))
+                );
+            });
         }
     }
 

--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -10,22 +10,6 @@ export default (app) => {
 
         initDatasources() {
             this.datasources = [{
-                name: 'Landsat 1-5 MSS',
-                uuid: '02e8ffdb-d20d-4a50-9a12-23a9b3cf7f0d',
-                id: 'Landsat_MSS'
-            }, {
-                name: 'Landsat 4-5 TM',
-                uuid: '5ea52134-ab8e-4dd4-93bb-461bdac9dcaa',
-                id: 'Landsat4-5_TM_C1'
-            }, {
-                name: 'Landsat 7 ETM',
-                uuid: 'fa364cbb-c742-401e-8815-d69d0f042382',
-                id: 'Landsat7_ETM_Plus_C1'
-            }, {
-                name: 'Landsat 8 OLI TIRS',
-                uuid: '697a0b91-b7a8-446e-842c-97cda155554d',
-                id: 'Landsat_8_OLI_TIRS_C1'
-            }, {
                 name: 'MODIS/Aqua',
                 uuid: '73b24c83-1da9-4118-ae3f-ac601d1b701b',
                 id: 'MYD09A1',
@@ -55,7 +39,7 @@ export default (app) => {
             return [{
                 param: 'datasource',
                 label: 'Imagery Collection',
-                type: 'searchSelect',
+                type: 'search-select',
                 getSources: this.getSources.bind(this)
             }, {
                 params: {


### PR DESCRIPTION
## Overview

This PR makes mostly front-end changes that allow users to select MODIS scenes through CMR and add them to a project. Previously, only browsing the scenes was possible.

An upload object is created for each scene.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Notes

I'd like to get this merged to staging and do some tests there to make sure that datasource IDs are aligned.

## Testing Instructions

 * Browse MODIS scenes through the CMR repo
 * Select some and add them to scenes

Closes #3318
Closes #3380
