### PR TITLE
Update .gitignore to handle .envrc files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ api-server/.ensime_cache/*
 .sbt/
 
 /.env
+/.envrc
 
 .node_modules
 dist/


### PR DESCRIPTION
This is used with direnv

Trivial.