### PR TITLE
Allow platform admins to change a user's organization

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -375,11 +375,12 @@ trait PlatformRoutes extends Authentication
 
   def addUserToOrganization(platformId: UUID, orgId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      OrganizationDao.userIsAdmin(user, orgId).transact(xa).unsafeToFuture
+      PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
     } {
       entity(as[UserGroupRole.UserRole]) { ur =>
         complete {
-          OrganizationDao.setUserRole(user, ur.userId, orgId, ur.groupRole).transact(xa).unsafeToFuture
+          OrganizationDao.setUserOrganization(user, ur.userId, orgId, ur.groupRole)
+            .transact(xa).unsafeToFuture
         }
       }
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -88,6 +88,13 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
       .list
   }
 
+  def listByUserAndGroupType(user: User, groupType: GroupType) = {
+    query
+      .filter(fr"user_id = ${user.id}")
+      .filter(fr"group_type = ${groupType}")
+      .list
+  }
+
   // List roles that have been given to users for a group
   def listByGroup(groupType: GroupType, groupId: UUID): ConnectionIO[List[UserGroupRole]] = {
     query

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
@@ -180,4 +180,39 @@ class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTe
     }
   }
 
+  test("change a user's organization") {
+    check {
+      forAll{
+        (userCreate: User.Create, oldUserOrg: Organization.Create, oldUserGroupRole: GroupRole,
+         newUserOrg: Organization.Create, newUserGroupRole: GroupRole, platform: Platform) => {
+          val changeOrgIO = for {
+            insertedPlatform <- PlatformDao.create(platform)
+            dbNewOrg <- OrganizationDao.create(
+              newUserOrg.copy(platformId = insertedPlatform.id).toOrganization
+            )
+            orgAndUser <- insertUserAndOrg(
+              userCreate, oldUserOrg.copy(platformId = insertedPlatform.id), false
+            )
+            (dbOldOrg, dbUser) = orgAndUser
+            originalUserGroupRoles <- OrganizationDao.addUserRole(dbUser, dbUser.id, dbOldOrg.id, oldUserGroupRole)
+            updatedUserGroupRoles <- OrganizationDao.setUserOrganization(
+              dbUser, dbUser.id, dbNewOrg.id, newUserGroupRole
+            )
+            allUserGroupRoles <- UserGroupRoleDao.query.filter(fr"user_id = ${dbUser.id}").list
+          } yield { (dbOldOrg, dbNewOrg, originalUserGroupRoles, allUserGroupRoles) }
+          val (oldOrg, newOrg, oldRoles, newRoles) = changeOrgIO.transact(xa).unsafeRunSync
+          assert(newRoles.filter((ugr) => ugr.isActive == true).size == 2,
+                 "; There should be two active roles after changing orgs - platform and the new org"
+                 )
+          assert(newRoles.filter((ugr) => ugr.isActive == false).size == 1,
+                 "; There should be 1 inactive role after changing orgs - the old org"
+          )
+          assert(newRoles.size == 3, "; The user should have a total of 3 roles, one inactive and 2 active")
+          true
+        }
+
+      }
+    }
+  }
+
 }

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -7,7 +7,8 @@
     <h4 class="modal-title">
       Add users to team
     </h4>
-    <p>Select a users to add to the team.</p>
+    <p ng-if="!$ctrl.resolve.modalText">Select a users to add to the team.</p>
+    <p ng-if="$ctrl.resolve.modalText">{{$ctrl.resolve.modalText}}</p>
   </div>
   <div class="modal-body">
     <div class="text-right">

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -15,14 +15,16 @@ const AddUserModalComponent = {
 };
 
 class AddUserModalController {
-    constructor($log, $q, $scope, platformService, teamService) {
+    constructor($log, $q, $scope, platformService, organizationService, teamService) {
         'ngInject';
         this.$log = $log;
         this.$q = $q;
         this.$scope = $scope;
         this.platformService = platformService;
+        this.organizationService = organizationService;
         this.teamService = teamService;
         this.platformId = this.resolve.platformId;
+        this.organizationId = this.resolve.organizationId;
         this.selected = new Set();
     }
 
@@ -54,16 +56,30 @@ class AddUserModalController {
 
     fetchUsers(page = 1, search) {
         this.fetching = true;
-        this.platformService.getMembers(
-            this.platformId,
-            page - 1,
-            search && search.length ? search : null
-        ).then((response) => {
-            this.fetching = false;
-            this.updatePagination(response);
-            this.lastUserResult = response;
-            this.users = response.results;
-        });
+        if (this.resolve.adminView === 'organization') {
+            this.platformService.getMembers(
+                this.platformId,
+                page - 1,
+                search && search.length ? search : null
+            ).then((response) => {
+                this.fetching = false;
+                this.updatePagination(response);
+                this.lastUserResult = response;
+                this.users = response.results;
+            });
+        } else if (this.resolve.adminView === 'team') {
+            this.organizationService.getMembers(
+                this.platformId,
+                this.organizationId,
+                page - 1,
+                search && search.length ? search : null
+            ).then((response) => {
+                this.fetching = false;
+                this.updatePagination(response);
+                this.lastUserResult = response;
+                this.users = response.results;
+            });
+        }
     }
 
     toggleUserSelect(user) {
@@ -77,12 +93,21 @@ class AddUserModalController {
     addUsers() {
         delete this.error;
         let promises = this.selected.toArray().map((userId) => {
-            return this.teamService.addUser(
-                this.resolve.platformId,
-                this.resolve.organizationId,
-                this.resolve.teamId,
-                userId
-            );
+            if (this.resolve.adminView === 'team') {
+                return this.teamService.addUser(
+                    this.resolve.platformId,
+                    this.resolve.organizationId,
+                    this.resolve.teamId,
+                    userId
+                );
+            } else if (this.resolve.adminView === 'organization') {
+                return this.organizationService.addUser(
+                    this.resolve.platformId,
+                    this.resolve.organizationId,
+                    userId
+                );
+            }
+            throw new Error('Undefined admin view - cannot add users without a defined group');
         });
         this.$q.all(promises).then(() => {
             this.close();

--- a/app-frontend/src/app/pages/admin/admin.html
+++ b/app-frontend/src/app/pages/admin/admin.html
@@ -15,7 +15,7 @@
           <td>
             <button class="btn btn-primary "
                     ui-sref="admin.platform.users({platformId: platform.item.id})">
-              Manage
+              {{platform.role.groupRole === 'ADMIN' ? 'Manage' : 'View'}}
             </button>
           </td>
         </tr>
@@ -38,7 +38,7 @@
           <td>
             <button class="btn btn-primary"
                     ui-sref="admin.organization.users({organizationId: organization.item.id})">
-              Manage
+              {{organization.role.groupRole === 'ADMIN' ? 'Manage' : 'View'}}
             </button>
           </td>
         </tr>
@@ -62,7 +62,7 @@
           <td>
             <button class="btn btn-primary"
                     ui-sref="admin.team.users({teamId: team.item.id})">
-              Manage
+              {{team.role.groupRole === 'ADMIN' ? 'Manage' : 'View'}}
             </button>
           </td>
         </tr>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -1,7 +1,12 @@
 <div class="admin-users-content container column-stretch dashboard">
   <div class="admin-users-actions">
     <input type="text" class="form-control admin-search" placeholder="Search for users"
-           ng-model="$ctrl.search" ng-disabled="$ctrl.fetching">
+           ng-model="$ctrl.search">
+      <button type="button" class="btn btn-primary"
+              ng-click="$ctrl.addUserModal()"
+              ng-disabled="$ctrl.fetching">
+        Add User
+      </button>
   </div>
   <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching">
     <thead>
@@ -19,7 +24,7 @@
             <img class="avatar" ng-src="{{user.profileImageUri}}">
           </div>
           <div>
-            {{user.name}}
+            {{user.name || user.id}}
           </div>
         </td>
         <td class="emails">

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -87,14 +87,16 @@ class OrganizationUsersController {
         /* eslint-enable */
     }
 
-    newUserModal() {
+    addUserModal() {
         this.modalService.open({
-            component: 'rfUserModal',
-            resolve: { },
-            size: 'sm'
-        }).result.then((result) => {
-            // eslint-disable-next-line
-            console.log('user modal closed with value:', result);
+            component: 'rfAddUserModal',
+            resolve: {
+                platformId: () => this.organization.platformId,
+                organizationId: () => this.organization.id,
+                adminView: () => 'organization'
+            }
+        }).result.then(() => {
+            this.fetchUsers(1, this.search);
         });
     }
 }

--- a/app-frontend/src/app/pages/admin/team/users/users.js
+++ b/app-frontend/src/app/pages/admin/team/users/users.js
@@ -94,7 +94,8 @@ class TeamUsersController {
             resolve: {
                 platformId: () => this.platformId,
                 organizationId: () => this.organization.id,
-                teamId: () => this.team.id
+                teamId: () => this.team.id,
+                adminView: () => 'team'
             }
         }).result.then(() => {
             this.fetchUsers(1, this.search);

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -17,6 +17,17 @@ export default (app) => {
                             'organizations/:organizationId/members',
                         method: 'GET'
                     },
+                    addUser: {
+                        url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
+                            'organizations/:organizationId/members',
+                        method: 'POST',
+                        isArray: true
+                    },
+                    deactivateUser: {
+                        url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
+                            'organizations/:organizationId/members/:userId',
+                        method: 'DELETE'
+                    },
                     teams: {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
                             'organizations/:organizationId/teams',
@@ -42,6 +53,13 @@ export default (app) => {
                     organizationId: '@organizationId'
                 }
             );
+        }
+
+        addUser(platformId, organizationId, userId) {
+            return this.PlatformOrganization.addUser({platformId, organizationId}, {
+                userId,
+                groupRole: 'MEMBER'
+            }).$promise;
         }
 
         getOrganization(organizationId) {


### PR DESCRIPTION
## Overview

Allow platform admins to change a user's organization

### Checklist

~- [ ] Styleguide updated, if necessary~
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests


## Testing Instructions
 * Create a platform admin
* Create a user under an organization in that platform
* Change the user's organization by making a `POST` request to `/api/platform/{platformId}/organizations/{newOrganizationId}/members` containing `{userId: <user id>, groupRole: <user role>}`
* Verify that the roles have been updated appropriately - old org roles are deactivated, and the new org role exists
* Verify that the created tests make sense
Closes #3405 
Closes #3406 