### PR TITLE
Better parallelize sentinel2 import

### DIFF
--- a/app-backend/api/build.sbt
+++ b/app-backend/api/build.sbt
@@ -4,9 +4,6 @@ initialCommands in console := """
   |import com.azavea.rf.api.utils.Config
   |import com.azavea.rf.api._
   |import com.azavea.rf.datamodel._
-  |import com.azavea.rf.database.Database
-  |import com.azavea.rf.database.ExtendedPostgresDriver.api._
-  |import com.azavea.rf.database.tables._
   |import io.circe._
   |import io.circe.syntax._
   |import java.util.UUID

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -19,14 +19,16 @@ import org.postgresql.util.PSQLException
 import java.security.InvalidParameterException
 import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import java.util.UUID
+import java.util.concurrent.Executors
 
-import cats.effect.IO
+import cats.effect.{IO, Timer}
+import cats.implicits._
 import com.azavea.rf.common.RollbarNotifier
 import doobie.{ConnectionIO, Fragment, Fragments}
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 
-import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 
 case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))(implicit val xa: Transactor[IO]) extends Job {
@@ -34,6 +36,8 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
   // To resolve an ambiguous implicit
   import doobie.free.connection.AsyncConnectionIO
   import ImportSentinel2._
+  val cachedThreadPool = Executors.newCachedThreadPool()
+  val SceneCreationIOContext = ExecutionContext.fromExecutor(cachedThreadPool)
 
   val name = ImportSentinel2.name
 
@@ -94,17 +98,15 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
     val keyPath: String = s"$tilePath/preview.jpg"
     val thumbnailUrl = s"${sentinel2Config.baseHttpPath}$keyPath"
 
-    if (!isUriExists(thumbnailUrl)) Nil
-    else
-      Thumbnail.Identified(
-        id = None,
-        organizationId = UUID.fromString(landsat8Config.organization),
-        thumbnailSize  = ThumbnailSize.Square,
-        widthPx        = 343,
-        heightPx       = 343,
-        sceneId        = sceneId,
-        url            = thumbnailUrl
-      ) :: Nil
+    Thumbnail.Identified(
+      id = None,
+      organizationId = UUID.fromString(landsat8Config.organization),
+      thumbnailSize  = ThumbnailSize.Square,
+      widthPx        = 343,
+      heightPx       = 343,
+      sceneId        = sceneId,
+      url            = thumbnailUrl
+    ) :: Nil
   }
 
   def getSentinel2Products(date: LocalDate): List[URI] = {
@@ -117,134 +119,140 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       ).toList
   }
 
-  def getExistingScenes(date: LocalDate, datasourceUUID: UUID): ConnectionIO[List[String]] = {
-    SceneDao.query.filter(
+  def getExistingScenes(date: LocalDate, datasourceUUID: UUID): List[String] = {
+    logger.info("Getting scenes that already exist in the database")
+    val scenesConnIO = SceneDao.query.filter(
       Fragments.and(fr"datasource = ${datasourceUUID} :: uuid", fr"date(acquisition_date) = date(${date}) :: date")
     ).list map { (scenes: List[Scene]) => scenes map { _.name } }
+    scenesConnIO.transact(xa).unsafeRunSync
   }
 
   /** Because it makes scenes -- get it? */
-  def riot(existingScenes: List[String], scenePath: String, datasourceUUID: UUID): Option[Scene.Create] = {
-      val sceneId = UUID.randomUUID()
-      val images = List(10f, 20f, 60f).map(createImages(sceneId, scenePath.some, _)).reduce(_ ++ _)
-      val thumbnails = createThumbnails(sceneId, scenePath)
-      val sceneName = s"S2 ${scenePath}"
-      if (existingScenes.contains(sceneName)) {
-        logger.info(s"Skipping scene creation. Scene already exists: ${scenePath} - ${sceneName}")
-        None
-      } else {
-        logger.info(s"Starting scene creation: ${scenePath}- ${sceneName}")
-        val tileinfo =
-          s3Client
-            .getObject(sentinel2Config.bucketName, s"${scenePath}/tileInfo.json")
-            .getObjectContent
-            .toJson
-            .getOrElse(Json.Null)
-        logger.info(s"Getting scene metadata for ${scenePath}")
-        val sceneMetadata: Map[String, String] = getSceneMetadata(tileinfo)
-        val datasourcePrefix = "S2"
-        logger.info(s"${datasourcePrefix} - Extracting polygons for ${scenePath}")
-        val tileFootprint = multiPolygonFromJson(tileinfo, "tileGeometry", sentinel2Config.targetProjCRS)
-        val dataFootprint = multiPolygonFromJson(tileinfo, "tileDataGeometry", sentinel2Config.targetProjCRS)
-        val awsBase = s"https://${sentinel2Config.bucketName}.s3.amazonaws.com"
-        val metadataFiles = List(
-          s"$awsBase/$scenePath/tileInfo.json",
-          s"$awsBase/$scenePath/metadata.xml",
-          s"$awsBase/$scenePath/productInfo.json"
-        )
-        val cloudCover = sceneMetadata.get("dataCoveragePercentage").map(_.toFloat)
-        val acquisitionDate = sceneMetadata.get("timeStamp").map { dt =>
-          new java.sql.Timestamp(
-            ZonedDateTime
-              .parse(dt)
-              .toInstant
-              .getEpochSecond * 1000l
-          )
-        }
-        logger.info(s"${datasourcePrefix} - Creating scene case class ${scenePath}")
-        Scene.Create(
-          id = sceneId.some,
-          organizationId = sentinel2Config.organizationUUID,
-          ingestSizeBytes = 0,
-          visibility = Visibility.Public,
-          tags = List("Sentinel-2", "JPEG2000"),
-          datasource = datasourceUUID,
-          sceneMetadata = sceneMetadata.asJson,
-          name = sceneName,
-          owner = systemUser.some,
-          tileFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| tileFootprint).map {
-            case (code, mp) => Projected(mp, code)
-          },
-          dataFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| dataFootprint).map {
-            case (code, mp) => Projected(mp, code)
-          },
-          metadataFiles = metadataFiles,
-          images = images,
-          thumbnails = createThumbnails(sceneId, scenePath),
-          ingestLocation = None,
-          filterFields = SceneFilterFields(
-            cloudCover = cloudCover,
-            acquisitionDate = acquisitionDate
-          ),
-          statusFields = SceneStatusFields(
-            thumbnailStatus = JobStatus.Success,
-            boundaryStatus = JobStatus.Success,
-            ingestStatus = IngestStatus.NotIngested
-          ),
-          sceneType = SceneType.Avro.some
-        ).some
-      }
+  def riot(scenePath: String, datasourceUUID: UUID, user: User): IO[Scene.WithRelated] = {
+    logger.info(s"Attempting to import ${scenePath}")
+    val sceneId = UUID.randomUUID()
+    val images = List(10f, 20f, 60f).map(createImages(sceneId, scenePath.some, _)).reduce(_ ++ _)
+    val thumbnails = createThumbnails(sceneId, scenePath)
+    val sceneName = s"S2 ${scenePath}"
+    logger.info(s"Starting scene creation: ${scenePath}- ${sceneName}")
+    logger.info(s"Getting tile info for ${scenePath}")
+    val tileinfo =
+      s3Client
+        .getObject(sentinel2Config.bucketName, s"${scenePath}/tileInfo.json")
+        .getObjectContent
+        .toJson
+        .getOrElse(Json.Null)
+    logger.info(s"Getting scene metadata for ${scenePath}")
+    val sceneMetadata: Map[String, String] = getSceneMetadata(tileinfo)
+    val datasourcePrefix = "S2"
+    logger.info(s"${datasourcePrefix} - Extracting polygons for ${scenePath}")
+    val tileFootprint = multiPolygonFromJson(tileinfo, "tileGeometry", sentinel2Config.targetProjCRS)
+    val dataFootprint = multiPolygonFromJson(tileinfo, "tileDataGeometry", sentinel2Config.targetProjCRS)
+    val awsBase = s"https://${sentinel2Config.bucketName}.s3.amazonaws.com"
+    val metadataFiles = List(
+      s"$awsBase/$scenePath/tileInfo.json",
+      s"$awsBase/$scenePath/metadata.xml",
+      s"$awsBase/$scenePath/productInfo.json"
+    )
+    val cloudCover = sceneMetadata.get("dataCoveragePercentage").map(_.toFloat)
+    val acquisitionDate = sceneMetadata.get("timeStamp").map { dt =>
+      new java.sql.Timestamp(
+        ZonedDateTime
+          .parse(dt)
+          .toInstant
+          .getEpochSecond * 1000l
+      )
+    }
+    logger.info(s"${datasourcePrefix} - Creating scene case class ${scenePath}")
+    val sceneCreate = Scene.Create(
+      id = sceneId.some,
+      organizationId = sentinel2Config.organizationUUID,
+      ingestSizeBytes = 0,
+      visibility = Visibility.Public,
+      tags = List("Sentinel-2", "JPEG2000"),
+      datasource = datasourceUUID,
+      sceneMetadata = sceneMetadata.asJson,
+      name = sceneName,
+      owner = systemUser.some,
+      tileFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| tileFootprint).map {
+        case (code, mp) => Projected(mp, code)
+      },
+      dataFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| dataFootprint).map {
+        case (code, mp) => Projected(mp, code)
+      },
+      metadataFiles = metadataFiles,
+      images = images,
+      thumbnails = createThumbnails(sceneId, scenePath),
+      ingestLocation = None,
+      filterFields = SceneFilterFields(
+        cloudCover = cloudCover,
+        acquisitionDate = acquisitionDate
+      ),
+      statusFields = SceneStatusFields(
+        thumbnailStatus = JobStatus.Success,
+        boundaryStatus = JobStatus.Success,
+        ingestStatus = IngestStatus.NotIngested
+      ),
+      sceneType = SceneType.Avro.some
+    )
+
+    SceneDao.insert(sceneCreate, user).transact(xa)
   }
 
-  def findScenes(date: LocalDate, keys: List[URI], user: User, datasourceUUID: UUID): ConnectionIO[List[Scene.WithRelated]] = {
-    val scenesIo: ConnectionIO[List[Scene.Create]] = getExistingScenes(date, datasourceUUID) map {
-      case (names: List[String]) => {
-        keys map {
-          (uri:URI) => {
-            for {
-              json <- s3Client.getObject(uri.getHost, uri.getPath.tail).getObjectContent.toJson
-              tilesJson <- json.hcursor.downField("tiles").as[List[Json]].toOption
-            } yield {
-              tilesJson.flatMap { tileJson =>
-                tileJson.hcursor.downField("path").as[String].toOption.map {
-                  scenePath => riot(names, scenePath, datasourceUUID)
-                }
-              }.flatten
-            }
-          }.foldLeft(List.empty[Scene.Create])(_ combine _)
-        }
-      }.flatten
-    }
-
-    logger.info(s"Inserting scenes for ${date}")
-
-    scenesIo flatMap {
-      (sceneList: List[Scene.Create]) => {
-        sceneList.traverse({ SceneDao.insert(_, user) })
+  def insertSceneFromURI(uri: URI, existingSceneNames: List[String], datasourceUUID: UUID, user: User): List[IO[Scene.WithRelated]] = {
+    val json: Option[Json] = s3Client.getObject(uri.getHost, uri.getPath.tail).getObjectContent.toJson
+    val tilesJson: Option[List[Json]] = json flatMap { _.hcursor.downField("tiles").as[List[Json]].toOption }
+    val paths: List[String] = tilesJson match {
+      case None => List.empty[String]
+      case Some(jsons) => {
+        jsons flatMap { _.hcursor.downField("path").as[String].toOption }
       }
     }
+    logger.info(s"Found ${paths.length} tiles for ${uri}")
+    paths.filter( (path: String) => !(existingSceneNames contains path) ) map { riot(_, datasourceUUID, user) }
+  }
+
+  def findScenes(date: LocalDate, keys: List[URI], user: User, datasourceUUID: UUID): IO[List[Scene.WithRelated]] = {
+    logger.info("Finding scenes to import")
+    val sceneNames = getExistingScenes(date, datasourceUUID)
+    val ios = keys flatMap{
+      (uri: URI) => {
+        insertSceneFromURI(uri, sceneNames, datasourceUUID, user) map {
+          IO.shift(SceneCreationIOContext) *> _
+        }
+      }
+    }
+    ios.sequence
   }
 
   def run: Unit = {
     logger.info(s"Importing Sentinel 2 scenes for ${startDate}")
     val keys = getSentinel2Products(startDate)
-    val scenesIO:ConnectionIO[List[Scene.WithRelated]] =
-      UserDao.getUserById(systemUser) flatMap { (mbUser: Option[User]) =>
+    val scenesIO:IO[List[Scene.WithRelated]] =
+      UserDao.getUserById(systemUser).transact(xa) flatMap { (mbUser: Option[User]) =>
         mbUser match {
-          case Some(u) =>
+          case Some(u) => {
             findScenes(startDate, keys, u, sentinel2Config.datasourceUUID)
-          case None =>
+          }
+          case None => {
+            logger.error("yup the database was borked")
             throw new Exception(s"${systemUser} could not be found -- probably the database is borked")
+          }
         }
       }
     try {
-      scenesIO.transact(xa).unsafeRunSync
+      val withLength = scenesIO map {
+        (scenes: List[Scene.WithRelated]) => logger.info(s"Inserted ${scenes.length} scenes")
+      }
+      withLength.unsafeRunSync
       logger.info("Scenes imported successfully")
       stop
+      cachedThreadPool.shutdown()
     } catch {
       case (e: Throwable) => {
         sendError(e)
         stop
+        cachedThreadPool.shutdown()
         sys.exit(1)
       }
     }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -83,6 +83,7 @@ case class S3(
     val objectRequest = (new ListObjectsRequest)
       .withBucketName(s3bucket)
       .withPrefix(s3prefix)
+      .withMaxKeys(1000)
 
     // Avoid digging into a deeper directory
     if (!recursive) objectRequest.withDelimiter("/")

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -260,7 +260,8 @@ lazy val batch = Project("batch", file("batch"))
       Dependencies.scaffeine,
       Dependencies.mamlJvm,
       Dependencies.mamlSpark,
-      Dependencies.auth0
+      Dependencies.auth0,
+      Dependencies.catsEffect
     )
   })
   .settings(assemblyShadeRules in assembly := Seq(

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -54,6 +54,7 @@ object Dependencies {
   val circeTest               = "io.circe"                    %% "circe-testing"                        % Version.circe % "test"
   val akkaCirceJson           = "de.heikoseeberger"           %% "akka-http-circe"                   % Version.akkaCirceJson
   val catsCore                = "org.typelevel"               %% "cats-core"                         % Version.cats
+  val catsEffect              = "org.typelevel"               %% "cats-effect"                       % Version.catsEffect
   val gatlingHighcharts       = "io.gatling.highcharts"        % "gatling-charts-highcharts"         % Version.gatling
   val gatlingTest             = "io.gatling"                   % "gatling-test-framework"            % Version.gatling % "test,it"
   val gatlingApp              = "io.gatling"                   % "gatling-app"                       % Version.gatling % "test,it"

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -32,6 +32,7 @@ object Version {
   val circe              = "0.9.1"
   val akkaCirceJson      = "1.20.0-RC1"
   val cats               = "1.0.1"
+  val catsEffect         = "0.10"
   val gatling            = "2.2.4"
   val scalajHttp         = "2.3.0"
   val ficus              = "1.4.0"


### PR DESCRIPTION
## Overview

This PR uses a `ParSeq` to fan out work for importing sentinel 2 scenes across cores.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This solution makes me kind of sad, but it works. It was supposed to be possible to `IO.shift *> otherIO`
our way to having whatever IO we wanted off the main thread. I was under the impression that that
would also allow us to shift IOs off of the shifted threads. That never really seemed to work. What
happened instead was that, when I shifted off the `main` thread, everything wound up running on the
same shifted thread. I'm not sure why that happened.

It may be time soon to look through Paul Cleary's scala pet store (https://github.com/pauljamescleary/scala-pet-store/blob/master/build.sbt) to get more familiarity with some of the things that work with the
fancier parts of the cats ecosystem, if we ever want to do this right :tm:

Also I'm leaving a few commits in for now that will get rebased out so I can link to them in discussion with @echeipesh 

## Testing Instructions

 * Open up a batch shell
 *
```scala
import com.azavea.rf.database.util.RFTransactor.xa
import com.azavea.rf.batch.sentinel2.ImportSentinel2
ImportSentinel2().run
```
 * things should be running on several workers

Closes azavea/raster-foundry-platform#332
