### PR TITLE
Allow deactivating teams

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -386,13 +386,13 @@ trait PlatformRoutes extends Authentication
     }
   }
 
-  def listTeams(platformId: UUID, orgId: UUID): Route = authenticate { user =>
+  def listTeams(platformId: UUID, organizationId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
+      OrganizationDao.userIsMember(user, organizationId).transact(xa).unsafeToFuture
     } {
       withPagination { page =>
         complete {
-          TeamDao.query.filter(fr"organization_id = ${orgId}").page(page).transact(xa).unsafeToFuture
+          TeamDao.listOrgTeams(organizationId, page).transact(xa).unsafeToFuture
         }
       }
     }
@@ -442,7 +442,7 @@ trait PlatformRoutes extends Authentication
       TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
     } {
       completeWithOneOrFail {
-        ???
+        TeamDao.deactivate(teamId).transact(xa).unsafeToFuture
       }
     }
   }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -46,6 +46,16 @@ object Generators extends ArbitraryInstances {
     GroupRole.Admin, GroupRole.Member
   )
 
+  private def subjectTypeGen: Gen[SubjectType] = Gen.oneOf(
+    SubjectType.All, SubjectType.Platform, SubjectType.Organization, SubjectType.Team, SubjectType.User
+  )
+
+  private def actionTypeGen: Gen[ActionType] = Gen.oneOf(
+    ActionType.View, ActionType.Edit, ActionType.Deactivate, ActionType.Delete, ActionType.Annotate,
+    ActionType.Export, ActionType.Download
+  )
+
+
   private def annotationQualityGen: Gen[AnnotationQuality] = Gen.oneOf(
     AnnotationQuality.Yes, AnnotationQuality.No, AnnotationQuality.Miss, AnnotationQuality.Unsure
   )
@@ -415,6 +425,12 @@ object Generators extends ArbitraryInstances {
     teamCreate.toTeam(user)
   }
 
+  private def accessControlRuleCreateGen: Gen[AccessControlRule.Create] = for {
+    subjectType <- subjectTypeGen
+    subjectId <- uuidGen
+    actionType <- actionTypeGen
+  } yield { AccessControlRule.Create(true, subjectType, Some(subjectId.toString()), actionType) }
+
   private def userGroupRoleCreateGen: Gen[UserGroupRole.Create] = for {
     user <- userGen
     groupType <- groupTypeGen
@@ -514,6 +530,10 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbUserJwtFields: Arbitrary[User.JwtFields] = Arbitrary {
       userJwtFieldsGen
+    }
+
+    implicit def arbAccessControlRule : Arbitrary[AccessControlRule.Create] = Arbitrary {
+      accessControlRuleCreateGen
     }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -157,4 +157,16 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
 
   def listByObject(objectType: ObjectType, objectId: UUID): ConnectionIO[List[AccessControlRule]] =
     listedByObject(objectType, objectId).list
+
+  def deactivateBySubject(subjectType: SubjectType, subjectId: String): ConnectionIO[Int] = {
+    (fr"UPDATE" ++ tableF ++ fr"""SET
+      is_active = false
+    """ ++ Fragments.whereAnd(fr"subject_type = ${subjectType}", fr"subject_id = ${subjectId}")).update.run
+  }
+
+  def deactivateByObject(objectType: ObjectType, objectId: UUID): ConnectionIO[Int] = {
+    (fr"UPDATE" ++ tableF ++ fr"""SET
+      is_active = false
+    """ ++ Fragments.whereAnd(fr"object_type = ${objectType}", fr"object_id = ${objectId}")).update.run
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -156,10 +156,4 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
       is_active = false
     """ ++ Fragments.whereAnd(fr"subject_type = ${subjectType}", fr"subject_id = ${subjectId}")).update.run
   }
-
-  def deactivateByObject(objectType: ObjectType, objectId: UUID): ConnectionIO[Int] = {
-    (fr"UPDATE" ++ tableF ++ fr"""SET
-      is_active = false
-    """ ++ Fragments.whereAnd(fr"object_type = ${objectType}", fr"object_id = ${objectId}")).update.run
-  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -1,14 +1,7 @@
 package com.azavea.rf.database
 
 import com.azavea.rf.database.Implicits._
-import com.azavea.rf.datamodel.{
-  AccessControlRule,
-  ActionType,
-  ObjectType,
-  SubjectType,
-  User
-}
-
+import com.azavea.rf.datamodel._
 import doobie._, doobie.implicits._
 import doobie.postgres._, doobie.postgres.implicits._
 import doobie.util.transactor.Transactor

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -215,4 +215,10 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
       "group_role"
     ).compile.toList
   }
+
+  def deactivateByGroup(groupType: GroupType, groupId: UUID) = {
+    (fr"UPDATE" ++ tableF ++ fr"""SET
+        is_active = false
+        """ ++ Fragments.whereAnd(fr"group_type = ${groupType}", fr"group_id = ${groupId}")).update.run
+  }
 }

--- a/app-frontend/src/app/services/auth/team.service.js
+++ b/app-frontend/src/app/services/auth/team.service.js
@@ -82,6 +82,10 @@ export default (app) => {
                 )
                 .$promise;
         }
+
+        deactivateTeam(platformId, organizationId, teamId) {
+            return this.PlatformTeam.delete({platformId, organizationId, teamId}).$promise;
+        }
     }
 
     app.service('teamService', TeamService);


### PR DESCRIPTION
## Overview

Hook up all buttons in the action menu of the organization teams list: edit, add to team, and delete

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Demo
![image](https://user-images.githubusercontent.com/4392704/40495339-f6cdf30a-5f44-11e8-89f4-cc915c464fa3.png)

## Testing Instructions
* Give your user platform or org admin:
 `insert into user_group_roles (id, created_at, created_by, modified_at, modified_by, is_active, user_id, group_type, group_id, group_role) values (uuid_generate_v4(), now(), 'default', now(), 'default', true, 'auth0|59318a9d2fbbca3e16bcfc92', 'PLATFORM', '31277626-968b-4e40-840b-559d9c67863c', 'ADMIN');`
* Create a new team under your organization and add yourself to it
* Create an access control rule which references the team using psql
* Delete the team, and verify that the ACR and all user group roles referencing the team are deactivated
* Verify that the teams endpoint respect `is_active` on teams
Closes #3379 
