### PR TITLE
Set max classfile name length

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -21,6 +21,7 @@ lazy val commonSettings = Seq(
     "-language:postfixOps",
     "-language:existentials",
     "-language:experimental.macros",
+    "-Xmax-classfile-name", "100",
     "-Ypartial-unification",
     "-Ypatmat-exhaust-depth", "100"
   ),


### PR DESCRIPTION
## Overview

This PR overrides the default max classfile name length for the scala compiler from 255 (probably) to 100. It's necessary for `cipublish` to succeed, probably.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * not really testable except in a develop branch cipublish, but:
 * `./scripts/console api-server ./sbt`
 * `project db`
 * `test:compile`
 * check the longest filename under `app-backend/db/target/scala-2.11/test-classes/com/azavea/rf/database/`
 * it should be under 100
