### PR TITLE
Get more datasource information from scenes

### DIFF
--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -87,7 +87,7 @@ trait DatasourceRoutes extends Authentication
     } {
       rejectEmptyResponse {
         complete {
-          DatasourceDao.getDatasourceById(datasourceId, user).transact(xa).unsafeToFuture
+          DatasourceDao.getDatasourceById(datasourceId).transact(xa).unsafeToFuture
         }
       }
     }

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -173,7 +173,7 @@ trait DatasourceRoutes extends Authentication
          case true => complete(List("*"))
          case false =>
            onSuccess(
-             DatasourceDao.unsafeGetDatasourceById(datasourceId, user).transact(xa).unsafeToFuture
+             DatasourceDao.unsafeGetDatasourceById(datasourceId).transact(xa).unsafeToFuture
            ) { datasource =>
              datasource.owner == user.id match {
                case true => complete(List("*"))

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -108,7 +108,10 @@ trait SceneRoutes extends Authentication
           delete {
             deleteScenePermissions(sceneId)
           }
-        }
+        } ~
+          pathPrefix("datasource") {
+            pathEndOrSingleSlash { getSceneDatasource(sceneId) }
+          }
       }
     }
   }
@@ -272,6 +275,19 @@ trait SceneRoutes extends Authentication
     } {
       complete {
         AccessControlRuleDao.deleteByObject(ObjectType.Scene, sceneId).transact(xa).unsafeToFuture
+      }
+    }
+  }
+
+  def getSceneDatasource(sceneId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      SceneDao.query
+        .authorized(user, ObjectType.Scene, sceneId, ActionType.View)
+        .transact(xa)
+        .unsafeToFuture
+    } {
+      onSuccess(SceneDao.getSceneDatasource(sceneId).transact(xa).unsafeToFuture) { datasourceO =>
+        complete { datasourceO }
       }
     }
   }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Datasource.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Datasource.scala
@@ -20,13 +20,21 @@ case class Datasource(
   extras: Json,
   bands: Json,
   licenseName: Option[String]
-)
+) {
+  def toThin: Datasource.Thin = Datasource.Thin(this.name, this.id)
+}
 
 object Datasource {
 
   def tupled = (Datasource.apply _).tupled
 
   def create = Create.apply _
+
+  @JsonCodec
+  case class Thin (
+    name: String,
+    id: UUID
+  )
 
   @JsonCodec
   case class Create (

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -76,7 +76,8 @@ case class Scene(
 
   def withRelatedFromComponents(
     images: List[Image.WithRelated],
-    thumbnails: List[Thumbnail]
+    thumbnails: List[Thumbnail],
+    datasource: Datasource
   ): Scene.WithRelated = Scene.WithRelated(
     this.id,
     this.createdAt,
@@ -87,7 +88,7 @@ case class Scene(
     this.ingestSizeBytes,
     this.visibility,
     this.tags,
-    this.datasource,
+    datasource.toThin,
     this.sceneMetadata,
     this.name,
     this.tileFootprint,
@@ -166,7 +167,7 @@ object Scene {
     ingestSizeBytes: Int,
     visibility: Visibility,
     tags: List[String],
-    datasource: UUID,
+    datasource: Datasource.Thin,
     sceneMetadata: Json,
     name: String,
     tileFootprint: Option[Projected[MultiPolygon]],
@@ -190,7 +191,7 @@ object Scene {
         ingestSizeBytes,
         visibility,
         tags,
-        datasource,
+        datasource.id,
         sceneMetadata,
         name,
         tileFootprint,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
@@ -29,17 +29,11 @@ object DatasourceDao extends Dao[Datasource] {
       FROM
     """ ++ tableF
 
-  def unsafeGetDatasourceById(datasourceId: UUID, user: User): ConnectionIO[Datasource] = {
-    (selectF ++ Fragments.whereAnd(fr"id = ${datasourceId}"))
-      .query[Datasource]
-      .unique
-  }
+  def unsafeGetDatasourceById(datasourceId: UUID): ConnectionIO[Datasource] =
+    query.filter(datasourceId).select
 
-  def getDatasourceById(datasourceId: UUID, user: User): ConnectionIO[Option[Datasource]] = {
-    (selectF ++ Fragments.whereAnd(fr"id = ${datasourceId}"))
-      .query[Datasource]
-      .option
-  }
+  def getDatasourceById(datasourceId: UUID): ConnectionIO[Option[Datasource]] =
+    query.filter(datasourceId).selectOption
 
   def listDatasources(page: PageRequest, params: DatasourceQueryParameters, user: User): ConnectionIO[PaginatedResponse[Datasource]] = {
     DatasourceDao.query.filter(params)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -39,11 +39,16 @@ object SceneDao extends Dao[Scene] with LazyLogging {
     FROM
   """ ++ tableF
 
-  def getSceneById(id: UUID, user: User): ConnectionIO[Option[Scene]] =
+  def getSceneById(id: UUID): ConnectionIO[Option[Scene]] =
     query.filter(id).selectOption
 
-  def unsafeGetSceneById(id: UUID, user: User): ConnectionIO[Scene] =
+  def unsafeGetSceneById(id: UUID): ConnectionIO[Scene] =
     query.filter(id).select
+
+  def getSceneDatasource(sceneId: UUID): ConnectionIO[Datasource] =
+    unsafeGetSceneById(sceneId) flatMap {
+      (scene: Scene) => DatasourceDao.unsafeGetDatasourceById(scene.datasource)
+    }
 
   def insert(sceneCreate: Scene.Create, user: User): ConnectionIO[Scene.WithRelated] = {
     val scene = sceneCreate.toScene(user)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -26,7 +26,9 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
 
     val projectFilterFragment = fr"id IN (SELECT scene_id FROM scenes_to_projects WHERE project_id = ${projectId})"
     val queryFilters = makeFilters(List(sceneParams)).flatten ++ List(Some(projectFilterFragment))
-    val paginatedQuery = listQuery(queryFilters, Some(pageRequest)).query[Scene.WithRelated].list
+    val paginatedQuery = SceneDao.query.filter(queryFilters).list(pageRequest.offset, pageRequest.limit) flatMap {
+      (scenes: List[Scene]) => scenesToScenesWithRelated(scenes)
+    }
 
     for {
       page <- paginatedQuery
@@ -61,6 +63,14 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
     )
   }
 
+  def getScenesDatasources(datasourceIds: List[UUID]): ConnectionIO[List[Datasource]] =
+    datasourceIds.toNel match {
+      case Some(ids) => {
+        DatasourceDao.query.filter(Fragments.in(fr"id", ids)).list
+      }
+      case _ => List.empty[Datasource].pure[ConnectionIO]
+    }
+
   def getScenesImages(sceneIds: List[UUID]): ConnectionIO[List[Image.WithRelated]] =
     sceneIds.toNel match {
       case Some(ids) =>
@@ -79,24 +89,28 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
         List.empty[Thumbnail].pure[ConnectionIO]
     }
 
+  // We know the datasources list head exists because of the foreign key relationship
+  @SuppressWarnings(Array("TraversableHead"))
   def scenesToScenesWithRelated(scenes: List[Scene]): ConnectionIO[List[Scene.WithRelated]] = {
     // "The astute among you will note that we don’t actually need a monad to do this;
     // an applicative functor is all we need here."
     // let's roll, doobie
-    val componentsIO: ConnectionIO[(List[Image.WithRelated], List[Thumbnail])] = {
+    val componentsIO: ConnectionIO[(List[Image.WithRelated], List[Thumbnail], List[Datasource])] = {
       val thumbnails = getScenesThumbnails(scenes map { _.id  })
       val images = getScenesImages(scenes map { _.id })
-      (images, thumbnails).tupled
+      val datasources = getScenesDatasources(scenes map { _.datasource })
+      (images, thumbnails, datasources).tupled
     }
 
     componentsIO map {
-      case (images, thumbnails) => {
+      case (images, thumbnails, datasources) => {
         val groupedThumbs = thumbnails.groupBy(_.sceneId)
         val groupedIms = images.groupBy(_.scene)
         scenes map { scene: Scene =>
           scene.withRelatedFromComponents(
             groupedIms.getOrElse(scene.id, List.empty[Image.WithRelated]),
-            groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail])
+            groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail]),
+            datasources.filter(_.id == scene.datasource).head
           )
         }
       }
@@ -104,15 +118,16 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
   }
 
   def sceneToSceneWithRelated(scene: Scene): ConnectionIO[Scene.WithRelated] = {
-    val componentsIO: ConnectionIO[(List[Image.WithRelated], List[Thumbnail])] = {
+    val componentsIO: ConnectionIO[(List[Image.WithRelated], List[Thumbnail], Datasource)] = {
       val thumbnails = getScenesThumbnails(List(scene.id))
       val images = getScenesImages(List(scene.id))
-      (images, thumbnails).tupled
+      val datasource = DatasourceDao.unsafeGetDatasourceById(scene.datasource)
+      (images, thumbnails, datasource).tupled
     }
 
     componentsIO map {
-      case (images, thumbnails) => {
-        scene.withRelatedFromComponents(images, thumbnails)
+      case (images, thumbnails, datasource) => {
+        scene.withRelatedFromComponents(images, thumbnails, datasource)
       }
     }
   }
@@ -153,107 +168,9 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
         """),
       Some(fr"scenes.id IN (SELECT scene_id FROM scenes_to_projects WHERE project_id = ${projectId})")
     )
-    listQuery(fragments, None).query[Scene.WithRelated].list
-  }
-
-  def listQuery(fragments: List[Option[Fragment]], page: Option[PageRequest]): Fragment = {
-      fr"""WITH
-        scenes_q AS (
-          SELECT *, coalesce(acquisition_date, created_at) as acquisition_date_sort
-          FROM scenes""" ++ Fragments.whereAndOpt(fragments: _*) ++
-        fr"""
-        ), images_q AS (
-          SELECT * FROM images WHERE images.scene IN (SELECT id FROM scenes_q)
-        ), thumbnails_q AS (
-          SELECT * FROM thumbnails WHERE thumbnails.scene IN (SELECT id FROM scenes_q)
-        ), bands_q AS (
-          SELECT * FROM bands WHERE image_id IN (SELECT id FROM images_q)
-        )
-      SELECT scenes_q.id,
-             scenes_q.created_at,
-             scenes_q.created_by,
-             scenes_q.modified_at,
-             scenes_q.modified_by,
-             scenes_q.owner,
-             scenes_q.ingest_size_bytes,
-             scenes_q.visibility,
-             scenes_q.tags,
-             scenes_q.datasource,
-             scenes_q.scene_metadata,
-             scenes_q.name,
-             scenes_q.tile_footprint,
-             scenes_q.data_footprint,
-             scenes_q.metadata_files,
-             images_with_bands.j :: jsonb AS images,
-             coalesce(tnails.thumbnails, '[]') :: jsonb,
-             scenes_q.ingest_location,
-             scenes_q.cloud_cover,
-             scenes_q.acquisition_date,
-             scenes_q.sun_azimuth,
-             scenes_q.sun_elevation,
-             scenes_q.thumbnail_status,
-             scenes_q.boundary_status,
-             scenes_q.ingest_status,
-             scenes_q.scene_type
-      FROM scenes_q
-      LEFT JOIN (
-        SELECT
-          scene,
-          json_agg (
-            json_build_object(
-              'id', i.id,
-              'createdAt', to_char(i.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-              'modifiedAt', to_char(i.modified_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-              'createdBy', i.created_by,
-              'modifiedBy', i.modified_by,
-              'owner', i.owner,
-              'rawDataBytes', i.raw_data_bytes,
-              'visibility', i.visibility,
-              'filename', i.filename,
-              'sourceUri', i.sourceuri,
-              'scene', i.scene,
-              'imageMetadata', i.image_metadata,
-              'resolutionMeters', i.resolution_meters,
-              'metadataFiles', i.metadata_files,
-              'bands', b.bands
-            )
-          ) AS j
-        FROM images_q AS i
-        LEFT JOIN (
-          SELECT
-            image_id,
-            json_agg(
-              json_build_object(
-                'id', b.id,
-                'image', b.image_id,
-                'name', b.name,
-                'number', b.number,
-                'wavelength', b.wavelength
-              )
-            ) AS bands
-            FROM bands_q AS b
-            GROUP BY image_id
-          ) AS b ON i.id = b.image_id
-        GROUP BY scene
-      ) AS images_with_bands ON scenes_q.id = images_with_bands.scene
-      LEFT JOIN (
-        SELECT
-          scene,
-          json_agg(
-            json_build_object(
-              'id', t.id,
-              'createdAt', to_char(t.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-              'modifiedAt', to_char(t.modified_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-              'widthPx', t.width_px,
-              'heightPx', t.height_px,
-              'sceneId', t.scene,
-              'url', t.url,
-              'thumbnailSize', t.thumbnail_size
-            )
-          ) AS thumbnails
-        FROM thumbnails_q AS t
-        GROUP BY scene
-      ) AS tnails ON scenes_q.id = tnails.scene""" ++ Page(page)
+    SceneDao.query.filter(fragments).list flatMap {
+      (scenes: List[Scene]) => scenesToScenesWithRelated(scenes)
+    }
   }
 
   def makeFilters[T](myList: List[T])(implicit filterable: Filterable[Scene.WithRelated, T]) = {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DataSourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DataSourceDaoSpec.scala
@@ -47,7 +47,7 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
             dsInsert <- fixupDatasource(dsCreate, userInsert)
-            dsGet <- DatasourceDao.getDatasourceById(dsInsert.id, userInsert)
+            dsGet <- DatasourceDao.getDatasourceById(dsInsert.id)
           } yield dsGet
           val getDs = getDsIO.transact(xa).unsafeRunSync
           getDs.get.name === dsCreate.name
@@ -64,7 +64,7 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
             dsInsert <- fixupDatasource(dsCreate, userInsert)
-            dsGetUnsafe <- DatasourceDao.unsafeGetDatasourceById(dsInsert.id, userInsert)
+            dsGetUnsafe <- DatasourceDao.unsafeGetDatasourceById(dsInsert.id)
           } yield dsGetUnsafe
           val getDsUnsafe = getDsUnsafeIO.transact(xa).unsafeRunSync
           getDsUnsafe.name === dsCreate.name

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
@@ -94,7 +94,7 @@ class SceneDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
                 .copy(id = dbScene.id)
               SceneDao.update(fixedUpUpdateScene, sceneId, dbUser) flatMap {
                 case (affectedRows: Int, shouldKickoffIngest: Boolean) => {
-                  SceneDao.unsafeGetSceneById(sceneId, dbUser) map { (affectedRows, _, shouldKickoffIngest) }
+                  SceneDao.unsafeGetSceneById(sceneId) map { (affectedRows, _, shouldKickoffIngest) }
                 }
               }
             }

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
@@ -45,7 +45,7 @@
           <dt ng-if-start="$ctrl.scene.modifiedAt">Modified Date</dt>
           <dd ng-if-end>{{$ctrl.scene.modifiedAt | date}}</dd>
           <dt ng-if-start="$ctrl.scene.datasource">Datasource</dt>
-          <dd ng-if-end>{{$ctrl.scene.datasource}}</dd>
+          <dd ng-if-end>{{$ctrl.scene.datasource.name}}</dd>
           <dt>Visibility</dt>
           <dd>{{$ctrl.scene.visibility}}</dd>
           <dt ng-repeat-start="(field, value) in $ctrl.scene.statusFields">

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -31,8 +31,7 @@
       </span>
     </div>
     <div>
-      <span ng-attr-title="{{$ctrl.datasource}}">
-            {{$ctrl.datasource ? $ctrl.datasource.name : 'Loading datasource'}}</span>
+      <span>{{$ctrl.datasource ? $ctrl.datasource.name : 'Loading datasource'}}</span>
     </div>
   </div>
   <div class="list-group-right">

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -17,8 +17,7 @@ const SceneItemComponent = {
 
 class SceneItemController {
     constructor(
-        $scope, $attrs,
-        thumbnailService, mapService, datasourceService, modalService
+        $scope, $attrs, thumbnailService, mapService, modalService
     ) {
         'ngInject';
 
@@ -32,19 +31,9 @@ class SceneItemController {
         this.isDraggable = $attrs.hasOwnProperty('draggable');
         this.isPreviewable = $attrs.hasOwnProperty('previewable');
         this.isClickable = $attrs.hasOwnProperty('clickable');
-        this.datasourceService = datasourceService;
         this.modalService = modalService;
         this.$scope = $scope;
-    }
-
-    $onInit() {
-        this.$scope.$watch('$ctrl.scene.datasource', () => {
-            if (this.repository) {
-                this.repository.service.getDatasource(this.scene).then((datasource) => {
-                    this.datasource = datasource;
-                });
-            }
-        });
+        this.datasource = this.scene.datasource;
     }
 
     $onChanges(changes) {
@@ -53,9 +42,6 @@ class SceneItemController {
         }
         if (changes.repository && changes.repository.currentValue) {
             this.repository = changes.repository.currentValue;
-            this.repository.service.getDatasource(this.scene).then((datasource) => {
-                this.datasource = datasource;
-            });
             this.repository.service.getThumbnail(this.scene).then((thumbnail) => {
                 this.thumbnail = thumbnail;
             });

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -202,30 +202,7 @@ export default (app) => {
         }
 
         getDatasource(scene) {
-            return this.$q((resolve, reject) => {
-                if (this.datasourceCache.has(scene.datasource)) {
-                    let datasource = this.datasourceCache.get(scene.datasource);
-                    if (datasource.then) {
-                        datasource.then((d) => {
-                            resolve(d);
-                        });
-                    } else {
-                        resolve(datasource);
-                    }
-                } else {
-                    this.datasourceCache = this.datasourceCache.set(
-                        scene.datasource,
-                        this.datasourceService
-                            .get(scene.datasource)
-                            .then((datasource) => {
-                                resolve(datasource);
-                                return datasource;
-                            }, (err) => {
-                                reject(err);
-                            })
-                    );
-                }
-            });
+            return this.$q((resolve) => resolve(scene.datasource));
         }
 
 

--- a/app-frontend/src/app/services/scenes/scene.service.js
+++ b/app-frontend/src/app/services/scenes/scene.service.js
@@ -36,6 +36,14 @@ export default (app) => {
                         params: {
                             id: '@id'
                         }
+                    },
+                    datasource: {
+                        method: 'GET',
+                        url: `${BUILDCONFIG.API_HOST}/api/scenes/:id/datasource`,
+                        cache: true,
+                        params: {
+                            id: '@id'
+                        }
                     }
                 }
             );
@@ -139,6 +147,10 @@ export default (app) => {
 
         getDownloadableImages(scene) {
             return this.Scene.download({id: scene.id}).$promise;
+        }
+
+        datasource({id}) {
+            return this.Scene.datasource({id: id}).$promise;
         }
     }
 


### PR DESCRIPTION
## Overview

This PR gets datasource names from a reduced datasource object on scenes and adds a
`/scene/<id>/datasource` endpoint for fetching a datasource using scene authorization.

### Checklist

- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated (raster-foundry/raster-foundry-api-spec#17)
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

This doesn't solve the problem of what happens if someone only transitively has permission to view
scenes through a project that's shared with them. I'm considering that out-of-scope for this issue.

Also this turned out to be underestimated, since we didn't appreciate the surface area of "where do
we need to get datasource permissions right?".

## Testing Instructions

 * Browse scenes and confirm you can still see scene datasources
 * Try to run an analysis and note that you get datasources successfully without making a thousand requests for datasources

Closes azavea/raster-foundry-platform#335
