### PR TITLE
Parameterize app name on raster and datasource pages.

### DIFF
--- a/app-frontend/src/app/pages/imports/datasources/list/list.html
+++ b/app-frontend/src/app/pages/imports/datasources/list/list.html
@@ -31,7 +31,7 @@
           title="You haven't created any datasources yet"
           class="panel panel-off-white">
           <div class="cta-flex-text">
-            You can create a new datasource by linking Raster Foundry with various kinds of imagery sources
+            You can create a new datasource by linking {{$ctrl.BUILDCONFIG.APP_NAME}} with various kinds of imagery sources
             like your computer, Amazon S3 Buckets, DropBox, and many other sources.
           </div>
           <div class="cta-button-row">

--- a/app-frontend/src/app/pages/imports/raster/raster.html
+++ b/app-frontend/src/app/pages/imports/raster/raster.html
@@ -25,11 +25,11 @@
           </p>
           <h5>What imagery sources am I limited to?</h5>
           <p class="font-size-small">
-            Raster Foundry can currently ingest multi or single band geotiffs.
+            {{$ctrl.BUILDCONFIG.APP_NAME}} can currently ingest multi or single band geotiffs.
           </p>
           <h5>What is a datasource?</h5>
           <p class="font-size-small">
-            Datasources are how Raster Foundry stores common information about scenes that share similar structure - typically metadata such as band information that is useful to carry across scenes.
+            Datasources are how {{$ctrl.BUILDCONFIG.APP_NAME}} stores common information about scenes that share similar structure - typically metadata such as band information that is useful to carry across scenes.
             <ul class="list-unstyled">
               <li><a href="#">View your datasources</a></li>
               <li><a href="#">Create a datasources</a></li>

--- a/app-frontend/src/app/pages/imports/raster/raster.module.js
+++ b/app-frontend/src/app/pages/imports/raster/raster.module.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 class RasterListController {
     constructor(authService, $uibModal) {
         'ngInject';
@@ -6,7 +7,7 @@ class RasterListController {
     }
 
     $onInit() {
-
+        this.BUILDCONFIG = BUILDCONFIG;
     }
 
     $onDestroy() {


### PR DESCRIPTION
## Overview

This PR parameterizes app name on raster and datasource pages under data tab.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- [X] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- ~Any new SQL strings have tests~

## Testing Instructions

 * Go to raster and datasources pages under data tab of the app -- check if "Raster Foundry" is still the app name.
 * Apply custom `overrides.js` file and check the above two pages -- see if the app name changes to the designated name.

Closes #3410 
