### PR TITLE
Endpoints for listing user-specific actions on objects

### DIFF
--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -162,19 +162,23 @@ trait DatasourceRoutes extends Authentication
     }
 
   def listUserDatasourceActions(datasourceId: UUID): Route = authenticate { user =>
-    onSuccess(
-      DatasourceDao.getDatasourceById(datasourceId, user).transact(xa).unsafeToFuture
-    ) { datasourceO =>
-      datasourceO match {
-        case Some(datasource) =>
-          if (user.isSuperuser || datasource.owner == user.id) {
-            complete(List("*"))
-          } else {
-            complete {
-              AccessControlRuleDao.listUserActions(user, ObjectType.Datasource, datasourceId).transact(xa).unsafeToFuture
+    authorizeAsync {
+      DatasourceDao.query.authorized(user, ObjectType.Datasource, datasourceId, ActionType.View)
+        .transact(xa).unsafeToFuture
+    } { onSuccess(
+        DatasourceDao.getDatasourceById(datasourceId, user).transact(xa).unsafeToFuture
+      ) { datasourceO =>
+        datasourceO match {
+          case Some(datasource) =>
+            if (user.isSuperuser || datasource.owner == user.id) {
+              complete(List("*"))
+            } else {
+              complete {
+                AccessControlRuleDao.listUserActions(user, ObjectType.Datasource, datasourceId).transact(xa).unsafeToFuture
+              }
             }
-          }
-        case _ => complete(StatusCodes.NoContent)
+          case _ => complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -166,18 +166,14 @@ trait DatasourceRoutes extends Authentication
       DatasourceDao.query.authorized(user, ObjectType.Datasource, datasourceId, ActionType.View)
         .transact(xa).unsafeToFuture
     } { onSuccess(
-        DatasourceDao.getDatasourceById(datasourceId, user).transact(xa).unsafeToFuture
-      ) { datasourceO =>
-        datasourceO match {
-          case Some(datasource) =>
-            if (user.isSuperuser || datasource.owner == user.id) {
-              complete(List("*"))
-            } else {
-              complete {
-                AccessControlRuleDao.listUserActions(user, ObjectType.Datasource, datasourceId).transact(xa).unsafeToFuture
-              }
-            }
-          case _ => complete(StatusCodes.NoContent)
+        DatasourceDao.unsafeGetDatasourceById(datasourceId, user).transact(xa).unsafeToFuture
+      ) { datasource =>
+        if (user.isSuperuser || datasource.owner == user.id) {
+          complete(List("*"))
+        } else {
+          complete {
+            AccessControlRuleDao.listUserActions(user, ObjectType.Datasource, datasourceId).transact(xa).unsafeToFuture
+          }
         }
       }
     }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -774,18 +774,14 @@ trait ProjectRoutes extends Authentication
       ProjectDao.query.authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa).unsafeToFuture
     } { onSuccess(
-        ProjectDao.getProjectById(projectId, Some(user)).transact(xa).unsafeToFuture
-      ) { projectO =>
-        projectO match {
-          case Some(project) =>
-            if (user.isSuperuser || project.owner == user.id) {
-              complete(List("*"))
-            } else {
-              complete {
-                AccessControlRuleDao.listUserActions(user, ObjectType.Project, projectId).transact(xa).unsafeToFuture
-              }
-            }
-          case _ => complete(StatusCodes.NoContent)
+        ProjectDao.unsafeGetProjectById(projectId, Some(user)).transact(xa).unsafeToFuture
+      ) { project =>
+        if (user.isSuperuser || project.owner == user.id) {
+          complete(List("*"))
+        } else {
+          complete {
+            AccessControlRuleDao.listUserActions(user, ObjectType.Project, projectId).transact(xa).unsafeToFuture
+          }
         }
       }
     }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -278,7 +278,7 @@ trait ProjectRoutes extends Authentication
           pathPrefix("actions") {
             pathEndOrSingleSlash {
               get {
-                traceName("list-user-allowed actions") {
+                traceName("list-user-allowed-actions") {
                   listUserProjectActions(projectId)
                 }
               }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -769,8 +769,11 @@ trait ProjectRoutes extends Authentication
       }
     }
 
-    def listUserProjectActions(projectId: UUID): Route = authenticate { user =>
-      onSuccess(
+  def listUserProjectActions(projectId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      ProjectDao.query.authorized(user, ObjectType.Project, projectId, ActionType.View)
+        .transact(xa).unsafeToFuture
+    } { onSuccess(
         ProjectDao.getProjectById(projectId, Some(user)).transact(xa).unsafeToFuture
       ) { projectO =>
         projectO match {
@@ -786,5 +789,6 @@ trait ProjectRoutes extends Authentication
         }
       }
     }
+  }
 
 }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -246,18 +246,14 @@ trait SceneRoutes extends Authentication
       SceneWithRelatedDao.query.authorized(user, ObjectType.Scene, sceneId, ActionType.View)
         .transact(xa).unsafeToFuture
     } { onSuccess(
-        SceneWithRelatedDao.getScene(sceneId, user).transact(xa).unsafeToFuture
-      ) { sceneO =>
-        sceneO match {
-          case Some(sceneWithRelated) =>
-            if (user.isSuperuser || sceneWithRelated.owner == user.id) {
-              complete(List("*"))
-            } else {
-              complete {
-                AccessControlRuleDao.listUserActions(user, ObjectType.Scene, sceneId).transact(xa).unsafeToFuture
-              }
-            }
-          case _ => complete(StatusCodes.NoContent)
+        SceneWithRelatedDao.unsafeGetScene(sceneId, user).transact(xa).unsafeToFuture
+      ) { scene =>
+        if (user.isSuperuser || scene.owner == user.id) {
+          complete(List("*"))
+        } else {
+          complete {
+            AccessControlRuleDao.listUserActions(user, ObjectType.Scene, sceneId).transact(xa).unsafeToFuture
+          }
         }
       }
     }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -242,19 +242,23 @@ trait SceneRoutes extends Authentication
   }
 
   def listUserSceneActions(sceneId: UUID): Route = authenticate { user =>
-    onSuccess(
-      SceneWithRelatedDao.getScene(sceneId, user).transact(xa).unsafeToFuture
-    ) { sceneO =>
-      sceneO match {
-        case Some(sceneWithRelated) =>
-          if (user.isSuperuser || sceneWithRelated.owner == user.id) {
-            complete(List("*"))
-          } else {
-            complete {
-              AccessControlRuleDao.listUserActions(user, ObjectType.Scene, sceneId).transact(xa).unsafeToFuture
+    authorizeAsync {
+      SceneWithRelatedDao.query.authorized(user, ObjectType.Scene, sceneId, ActionType.View)
+        .transact(xa).unsafeToFuture
+    } { onSuccess(
+        SceneWithRelatedDao.getScene(sceneId, user).transact(xa).unsafeToFuture
+      ) { sceneO =>
+        sceneO match {
+          case Some(sceneWithRelated) =>
+            if (user.isSuperuser || sceneWithRelated.owner == user.id) {
+              complete(List("*"))
+            } else {
+              complete {
+                AccessControlRuleDao.listUserActions(user, ObjectType.Scene, sceneId).transact(xa).unsafeToFuture
+              }
             }
-          }
-        case _ => complete(StatusCodes.NoContent)
+          case _ => complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -165,7 +165,7 @@ trait SceneRoutes extends Authentication
   def getDownloadUrl(sceneId: UUID): Route = authenticate { user =>
     authorizeAsync {
       SceneWithRelatedDao.query
-        .authorized(user, ObjectType.Scene, sceneId, ActionType.View)
+        .authorized(user, ObjectType.Scene, sceneId, ActionType.Download)
         .transact(xa)
         .unsafeToFuture
     } {

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -101,7 +101,7 @@ trait SceneRoutes extends Authentication
       pathPrefix("actions") {
         pathEndOrSingleSlash {
           get {
-            traceName("list-user-allowed actions") {
+            traceName("list-user-allowed-actions") {
               listUserSceneActions(sceneId)
             }
           }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -241,18 +241,14 @@ trait ShapeRoutes extends Authentication
       ShapeDao.query.authorized(user, ObjectType.Shape, shapeId, ActionType.View)
         .transact(xa).unsafeToFuture
     } { onSuccess(
-        ShapeDao.getShapeById(shapeId).transact(xa).unsafeToFuture
-      ) { shapeO =>
-        shapeO match {
-          case Some(shape) =>
-            if (user.isSuperuser || shape.owner == user.id) {
-              complete(List("*"))
-            } else {
-              complete {
-                AccessControlRuleDao.listUserActions(user, ObjectType.Shape, shapeId).transact(xa).unsafeToFuture
-              }
-            }
-          case _ => complete(StatusCodes.NoContent)
+        ShapeDao.unsafeGetShapeById(shapeId).transact(xa).unsafeToFuture
+      ) { shape =>
+        if (user.isSuperuser || shape.owner == user.id) {
+          complete(List("*"))
+        } else {
+          complete {
+            AccessControlRuleDao.listUserActions(user, ObjectType.Shape, shapeId).transact(xa).unsafeToFuture
+          }
         }
       }
     }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -237,19 +237,23 @@ trait ShapeRoutes extends Authentication
     }
 
   def listUserShapeActions(shapeId: UUID): Route = authenticate { user =>
-    onSuccess(
-      ShapeDao.getShapeById(shapeId).transact(xa).unsafeToFuture
-    ) { shapeO =>
-      shapeO match {
-        case Some(shape) =>
-          if (user.isSuperuser || shape.owner == user.id) {
-            complete(List("*"))
-          } else {
-            complete {
-              AccessControlRuleDao.listUserActions(user, ObjectType.Shape, shapeId).transact(xa).unsafeToFuture
+    authorizeAsync {
+      ShapeDao.query.authorized(user, ObjectType.Shape, shapeId, ActionType.View)
+        .transact(xa).unsafeToFuture
+    } { onSuccess(
+        ShapeDao.getShapeById(shapeId).transact(xa).unsafeToFuture
+      ) { shapeO =>
+        shapeO match {
+          case Some(shape) =>
+            if (user.isSuperuser || shape.owner == user.id) {
+              complete(List("*"))
+            } else {
+              complete {
+                AccessControlRuleDao.listUserActions(user, ObjectType.Shape, shapeId).transact(xa).unsafeToFuture
+              }
             }
-          }
-        case _ => complete(StatusCodes.NoContent)
+          case _ => complete(StatusCodes.NoContent)
+        }
       }
     }
   }

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -176,18 +176,14 @@ trait ToolRunRoutes extends Authentication
       ToolRunDao.query.authorized(user, ObjectType.Analysis, analysisId, ActionType.View)
         .transact(xa).unsafeToFuture
     } { onSuccess(
-        ToolRunDao.query.filter(analysisId).selectOption.transact(xa).unsafeToFuture
-      ) { analysisO =>
-        analysisO match {
-          case Some(analysis) =>
-            if (user.isSuperuser || analysis.owner == user.id) {
-              complete(List("*"))
-            } else {
-              complete {
-                AccessControlRuleDao.listUserActions(user, ObjectType.Analysis, analysisId).transact(xa).unsafeToFuture
-              }
-            }
-          case _ => complete(StatusCodes.NoContent)
+        ToolRunDao.query.filter(analysisId).select.transact(xa).unsafeToFuture
+      ) { analysis =>
+        if (user.isSuperuser || analysis.owner == user.id) {
+          complete(List("*"))
+        } else {
+          complete {
+            AccessControlRuleDao.listUserActions(user, ObjectType.Analysis, analysisId).transact(xa).unsafeToFuture
+          }
         }
       }
     }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -241,18 +241,14 @@ trait ToolRoutes extends Authentication
       ToolDao.query.authorized(user, ObjectType.Template, templateId, ActionType.View)
         .transact(xa).unsafeToFuture
     } { onSuccess(
-        ToolDao.query.filter(templateId).selectOption.transact(xa).unsafeToFuture
-      ) { templateO =>
-        templateO match {
-          case Some(template) =>
-            if (user.isSuperuser || template.owner == user.id) {
-              complete(List("*"))
-            } else {
-              complete {
-                AccessControlRuleDao.listUserActions(user, ObjectType.Template, templateId).transact(xa).unsafeToFuture
-              }
-            }
-          case _ => complete(StatusCodes.NoContent)
+        ToolDao.query.filter(templateId).select.transact(xa).unsafeToFuture
+      ) { template =>
+        if (user.isSuperuser || template.owner == user.id) {
+          complete(List("*"))
+        } else {
+          complete {
+            AccessControlRuleDao.listUserActions(user, ObjectType.Template, templateId).transact(xa).unsafeToFuture
+          }
         }
       }
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -156,4 +156,33 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
       is_active = false
     """ ++ Fragments.whereAnd(fr"subject_type = ${subjectType}", fr"subject_id = ${subjectId}")).update.run
   }
+
+  def listUserActionsF(user: User, objectType: ObjectType, objectId: UUID): Fragment = {
+    fr"""
+    SELECT DISTINCT action_type
+    FROM access_control_rules
+    WHERE
+      is_active = true
+      AND
+      object_type = ${objectType}
+      AND
+      UUID(object_id) = ${objectId}
+      AND (
+        subject_type = 'ALL'
+        OR
+        subject_id IN (
+          SELECT text(group_id)
+          FROM user_group_roles
+          WHERE user_id = ${user.id}
+        )
+        OR
+        subject_id = ${user.id}
+      )
+    """
+
+  }
+
+  def listUserActions(user: User, objectType: ObjectType, objectId: UUID): ConnectionIO[List[String]] =
+    listUserActionsF(user, objectType, objectId).query[String].list
+
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -157,7 +157,7 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
     """ ++ Fragments.whereAnd(fr"subject_type = ${subjectType}", fr"subject_id = ${subjectId}")).update.run
   }
 
-  def listUserActionsF(user: User, objectType: ObjectType, objectId: UUID): Fragment = {
+  def listUserActions(user: User, objectType: ObjectType, objectId: UUID): ConnectionIO[List[String]] =
     fr"""
     SELECT DISTINCT action_type
     FROM access_control_rules
@@ -179,10 +179,7 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
         subject_id = ${user.id}
       )
     """
-
-  }
-
-  def listUserActions(user: User, objectType: ObjectType, objectId: UUID): ConnectionIO[List[String]] =
-    listUserActionsF(user, objectType, objectId).query[String].list
+    .query[String]
+    .list
 
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -192,7 +192,7 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
     }
   }
 
-  test("listing user actions granted by organization membership should return an empty list") {
+  test("listing user actions granted by platform membership should return an empty list") {
     check {
       forAll {
         (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
@@ -261,6 +261,35 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
           val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
           listUserActions.length == 3 &&
             listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty
+        }
+      }
+    }
+  }
+
+  test("listing user actions with deactivated ACR should return an empty list") {
+    check {
+      forAll {
+        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
+          val listUserActionsIO = for {
+            dbPlatform <- PlatformDao.create(platform)
+            orgUser <- insertUserAndOrg(userCreate, orgCreate.copy(platformId=dbPlatform.id))
+            (org, user) = orgUser
+            project <- ProjectDao.insertProject(fixupProjectCreate(user, projectCreate), user)
+            acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
+              AccessControlRule.Create(true, SubjectType.User, Some(user.id.toString()), _).toAccessControlRule(
+                user, ObjectType.Project, project.id)
+            }
+            numCreatedAcrs <- AccessControlRuleDao.createMany(acrs)
+            numDetactivatedAcrs <- AccessControlRuleDao.deactivateBySubject(SubjectType.User, user.id.toString())
+            listOfActions <- AccessControlRuleDao.listUserActions(user, ObjectType.Project, project.id)
+          } yield (numCreatedAcrs, numDetactivatedAcrs, listOfActions)
+
+          val (numCreatedAcrs, numDetactivatedAcrs, listOfActions) = listUserActionsIO.transact(xa).unsafeRunSync
+          listOfActions.isEmpty
+          assert(listOfActions.isEmpty, "; List of permitted actions should be empty when an ACR is deactivated.")
+          assert(numCreatedAcrs == 3, "; Number of created ACRs should be 3.")
+          assert(numDetactivatedAcrs == 3, "; Number of deactivated ACRs should be 3.")
+          true
         }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -185,8 +185,10 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
           } yield listOfActions
 
           val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
-          listUserActions.length == 3 &&
-            listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty
+
+          assert(listUserActions.length == 3, "; List of permitted actions should be 3")
+          assert(listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty, "; List of permitted actions should intersect with what was provided")
+          true
         }
       }
     }
@@ -234,8 +236,10 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
           } yield listOfActions
 
           val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
-          listUserActions.length == 3 &&
-            listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty
+
+          assert(listUserActions.length == 3, "; List of permitted actions should be 3")
+          assert(listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty, "; List of permitted actions should intersect with what was provided")
+          true
         }
       }
     }
@@ -259,8 +263,10 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
           } yield listOfActions
 
           val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
-          listUserActions.length == 3 &&
-            listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty
+
+          assert(listUserActions.length == 3, "; List of permitted actions should be 3")
+          assert(listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty, "; List of permitted actions should intersect with what was provided")
+          true
         }
       }
     }


### PR DESCRIPTION
## Overview

This PR:
  * adds methods in `AccessControlRuleDao` and objects' endpoints for listing user-specific actions on objects
  * adds property tests for these new SQL (**Updated on Jun. 4th**)
  * changes download scene action check from `VIEW` to `DOWNLOAD`

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (**Updated on June 4th:**)

### Notes
- [X] `PROJECT`
- [X] `SCENE`
- [X] `DATASOURCE`
- [X] `SHAPE`
- [ ] `WORKSPACE` - not implemented since there is no such thing in the develop branch yet, _TODO_ in the future
- [X] `TEMPLATE` (tool)
- [X] `ANALYSIS` (tool-run)

## Testing Instructions

 * Open a sql shell and do the following (**Updated on Jun. 4th**):
```sql
INSERT INTO 
access_control_rules
(id, created_at, created_by, is_active, object_type, object_id, subject_type, subject_id, action_type)
VALUES
    (
      'eae0b97a-72b1-449a-ab78-73065f66b302',
      now(),
      'default',
      true,
      'TEMPLATE',
      '6c9f3c72-0552-4a6d-adee-b1a350375a85',
      'PLATFORM',
      '31277626-968b-4e40-840b-559d9c67863c',
      'VIEW'),
    (
      'cb67cb45-e8fe-4538-89c2-170c0bc376eb',
      now(),
      'default',
      true,
      'TEMPLATE',
      '6c9f3c72-0552-4a6d-adee-b1a350375a85',
      'ORGANIZATION',
      'dfac6307-b5ef-43f7-beda-b9f208bb7726',
      'VIEW'),
    (
      'ada31394-ab62-41cc-9a0b-eb88fe5b8e5a',
      now(),
      'default',
      true,
      'TEMPLATE',
      '6c9f3c72-0552-4a6d-adee-b1a350375a85',
      'ORGANIZATION',
      'dfac6307-b5ef-43f7-beda-b9f208bb7726',
      'EDIT'),
    (
      '92abc4c1-38a6-4991-8f1e-dc21fc053959',
      now(),
      'default',
      true,
      'TEMPLATE',
      '6c9f3c72-0552-4a6d-adee-b1a350375a85',
      'USER',
      'auth0|59318a9d2fbbca3e16bcfc92',
      'DELETE');
```
 * Log in as a dev user and grab a token
 * `GET` to `.../api/tools/6c9f3c72-0552-4a6d-adee-b1a350375a85/actions` -- you should see `["VIEW", "EDIT","DELETE"]` as returned results. (**Updated on Jun. 4th**)
 * Change the dev user to `superuser` in the db, make the above request, and you should see `["*"]` as returned results
 * Change the owner of tool/template `6c9f3c72-0552-4a6d-adee-b1a350375a85` from `default` to dev user id, and you should see `["*"]` as returned results
 * Generate other test cases as you see fit
 * Delete the generated records from above:  (**Updated on Jun. 4th**):
```sql
DELETE FROM access_control_rules WHERE id IN (
  'eae0b97a-72b1-449a-ab78-73065f66b302',
  'cb67cb45-e8fe-4538-89c2-170c0bc376eb',
  'ada31394-ab62-41cc-9a0b-eb88fe5b8e5a',
  '92abc4c1-38a6-4991-8f1e-dc21fc053959'
);
```

Closes #3371 
Closes https://github.com/azavea/raster-foundry-platform/issues/341
