### PR TITLE
Fix text in the organization add user modal

### DIFF
--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -5,9 +5,9 @@
       <span aria-hidden="true">&times;</span>
     </button>
     <h4 class="modal-title">
-      Add users to team
+      Add users
     </h4>
-    <p ng-if="!$ctrl.resolve.modalText">Select a users to add to the team.</p>
+    <p ng-if="!$ctrl.resolve.modalText">Select users to add to this {{$ctrl.resolve.adminView}}.</p>
     <p ng-if="$ctrl.resolve.modalText">{{$ctrl.resolve.modalText}}</p>
   </div>
   <div class="modal-body">
@@ -36,11 +36,11 @@
               <img class="avatar" ng-src="{{user.profileImageUri}}">
             </div>
             <div>
-              {{user.name}}
+              {{user.name || user.email || user.id}}
             </div>
           </td>
-          <td class="emails">
-            {{user.email}}
+          <td class="emails" ng-class="{'color-light': !user.email}">
+            {{user.email || 'None'}}
           </td>
           <td class="actions">
             <rf-toggle value="$ctrl.selected.has(user.id)" on-change="$ctrl.toggleUserSelect(user)">

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -22,7 +22,7 @@
         <td class="users">
           <div class="user-avatar"
                ng-repeat="user in team.fetchedUsers.results track by $index | limitTo : 5"
-               ng-attr-title="{{user.name}}"
+               ng-attr-title="{{user.name || user.email || user.id}}"
           >
             <img class="avatar" ng-src="{{user.profileImageUri}}">
           </div>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -24,17 +24,17 @@
             <img class="avatar" ng-src="{{user.profileImageUri}}">
           </div>
           <div>
-            {{user.name || user.id}}
+            {{user.name || user.email || user.id}}
           </div>
         </td>
-        <td class="emails">
-          {{user.email}}
+        <td class="emails" ng-class="{'color-light': !user.email}">
+          {{user.email || 'None'}}
         </td>
         <td class="roles">
           {{user.groupRole}}
         </td>
         <td class="teams">
-          {{user.teams.length}} Teams
+          In {{user.teams.length || 0}} teams
         </td>
         <td class="actions">
           <rf-dropdown data-options="user.options">

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -37,7 +37,7 @@
           <td class="users">
             <div class="user-avatar"
                  ng-repeat="user in organization.fetchedUsers.results track by user.id | limitTo : 5"
-                 ng-attr-title="{{user.name}}"
+                 ng-attr-title="{{user.name || user.email || user.id}}"
             >
               <img class="avatar" ng-src="{{user.profileImageUri}}">
             </div>

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -19,7 +19,7 @@
             <img class="avatar" ng-src="{{user.profileImageUri}}">
           </div>
           <div>
-            {{user.name}}
+            {{user.name || user.email || user.id}}
           </div>
         </td>
         <td class="emails">

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -23,7 +23,7 @@
             <img class="avatar" ng-src="{{user.profileImageUri}}">
           </div>
           <div>
-            {{user.name}}
+            {{user.name || user.email || user.id}}
           </div>
         </td>
         <td class="emails">

--- a/app-frontend/src/app/pages/admin/team/users/users.js
+++ b/app-frontend/src/app/pages/admin/team/users/users.js
@@ -106,7 +106,7 @@ class TeamUsersController {
         const modal = this.modalService.open({
             component: 'rfConfirmationModal',
             resolve: {
-                title: () => `Remove ${user.name} from this team?`,
+                title: () => `Remove ${user.name || user.email || user.id} from this team?`,
                 confirmText: () => 'Remove User',
                 cancelText: () => 'Cancel'
             }


### PR DESCRIPTION
## Overview
Fix user identifiers in a couple places

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/40812148-46b76a82-6502-11e8-8927-627e34264df8.png)


## Testing Instructions

 * Verify that places where users are shown, identifiers default to name, then fallback to email and finally ID
* Verify that the organization view's "add user" modal now mentions organizations instead of teams.

Closes #3445
