### PR TITLE
Update admin UI permission and failure messages 

### DIFF
--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -11,67 +11,76 @@
     <p ng-if="$ctrl.resolve.modalText">{{$ctrl.resolve.modalText}}</p>
   </div>
   <div class="modal-body">
-    <div class="text-right">
-      <input type="text" class="form-control admin-search" placeholder="Search for users"
-             ng-model="$ctrl.search" ng-disabled="$ctrl.fetching && !$ctrl.search.length">
+    <div ng-if="$ctrl.hasPermission">
+      <div class="text-right">
+        <input type="text" class="form-control admin-search" placeholder="Search for users"
+               ng-model="$ctrl.search" ng-disabled="$ctrl.fetching && !$ctrl.search.length">
+        <p class="font-size-small"
+          ng-if="!$ctrl.searchString"
+        >
+         Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} users
+        </p>
+      </div>
+      <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
+        <thead>
+          <tr>
+            <td>Name</td>
+            <td>Email</td>
+            <td>Select</td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr ng-repeat="user in $ctrl.users track by $index">
+            <td class="username">
+              <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
+              <div class="user-avatar" ng-if="user.profileImageUri">
+                <img class="avatar" ng-src="{{user.profileImageUri}}">
+              </div>
+              <div>
+                {{user.name || user.email || user.id}}
+              </div>
+            </td>
+            <td class="emails" ng-class="{'color-light': !user.email}">
+              {{user.email || 'None'}}
+            </td>
+            <td class="actions">
+              <rf-toggle value="$ctrl.selected.has(user.id)" on-change="$ctrl.toggleUserSelect(user)">
+              </rf-toggle>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="table-loading" ng-if="$ctrl.fetching">
+        <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+      </div>
+      <!-- Pagination -->
+      <div class="list-group text-center"
+           ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
+        <ul uib-pagination
+            items-per-page="$ctrl.lastUserResult.pageSize"
+            total-items="$ctrl.pagination.count"
+            ng-model="$ctrl.currentPage"
+            max-size="4"
+            rotate="true"
+            boundary-link-numbers="true"
+            force-ellipses="true"
+            ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
+        </ul>
+      </div>
     </div>
-    <p class="font-size-small"
-       ng-if="!$ctrl.searchString"
-    >
-      Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} users
-    </p>
-    <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
-      <thead>
-        <tr>
-          <td>Name</td>
-          <td>Email</td>
-          <td>Select</td>
-        </tr>
-      </thead>
-      <tbody>
-        <tr ng-repeat="user in $ctrl.users track by $index">
-          <td class="username">
-            <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
-            <div class="user-avatar" ng-if="user.profileImageUri">
-              <img class="avatar" ng-src="{{user.profileImageUri}}">
-            </div>
-            <div>
-              {{user.name || user.email || user.id}}
-            </div>
-          </td>
-          <td class="emails" ng-class="{'color-light': !user.email}">
-            {{user.email || 'None'}}
-          </td>
-          <td class="actions">
-            <rf-toggle value="$ctrl.selected.has(user.id)" on-change="$ctrl.toggleUserSelect(user)">
-            </rf-toggle>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="table-loading" ng-if="$ctrl.fetching">
-      <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
-    </div>
-
-    <!-- Pagination -->
-    <div class="list-group text-center"
-         ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-      <ul uib-pagination
-          items-per-page="$ctrl.lastUserResult.pageSize"
-          total-items="$ctrl.pagination.count"
-          ng-model="$ctrl.currentPage"
-          max-size="4"
-          rotate="true"
-          boundary-link-numbers="true"
-          force-ellipses="true"
-          ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
-      </ul>
+    <div ng-if="!$ctrl.hasPermission">
+      <p>
+        {{$ctrl.permisionDeniedMsg}}
+        <a href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}} admin</a>.
+      </p>
     </div>
   </div>
   <div class="modal-footer">
     <span class="color-danger">{{$ctrl.error}}</span>
-    <button type="button" class="btn"
-            ng-click="$ctrl.addUsers()">
+    <button type="button"
+            class="btn"
+            ng-click="$ctrl.addUsers()"
+            ng-disabled="!$ctrl.hasPermission">
       Add users
     </button>
   </div>

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -71,7 +71,7 @@
     <div ng-if="!$ctrl.hasPermission">
       <p>
         {{$ctrl.permissionDeniedMsg}}
-        <a href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}} admin</a>.
+        <a href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}}</a>.
       </p>
     </div>
   </div>

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -71,7 +71,7 @@
     <div ng-if="!$ctrl.hasPermission">
       <p>
         {{$ctrl.permissionDeniedMsg}}
-        <a href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}}</a>.
+        <a ng-href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}}</a>.
       </p>
     </div>
   </div>

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -70,7 +70,7 @@
     </div>
     <div ng-if="!$ctrl.hasPermission">
       <p>
-        {{$ctrl.permisionDeniedMsg}}
+        {{$ctrl.permissionDeniedMsg}}
         <a href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}} admin</a>.
       </p>
     </div>

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -68,7 +68,7 @@ class AddUserModalController {
                 this.lastUserResult = response;
                 this.users = response.results;
             }, (error) => {
-                this.permisionDenied(error, 'organization');
+                this.permissionDenied(error, 'organization');
             });
         } else if (this.resolve.adminView === 'team') {
             this.organizationService.getMembers(
@@ -121,12 +121,12 @@ class AddUserModalController {
         });
     }
 
-    permisionDenied(err, subject) {
+    permissionDenied(err, subject) {
         this.fetching = false;
         this.hasPermission = false;
         this.subject = subject;
         this.adminEmail = 'example@email.com';
-        this.permisionDeniedMsg = `${err.data}. Please contact `;
+        this.permissionDeniedMsg = `${err.data}. Please contact `;
     }
 }
 

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -68,7 +68,8 @@ class AddUserModalController {
                 this.lastUserResult = response;
                 this.users = response.results;
             }, (error) => {
-                this.permissionDenied(error, 'organization');
+                // platform admins or super users are allowed to list platform users
+                this.permissionDenied(error, 'platform admin');
             });
         } else if (this.resolve.adminView === 'team') {
             this.organizationService.getMembers(

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -69,7 +69,7 @@ class AddUserModalController {
                 this.users = response.results;
             }, (error) => {
                 // platform admins or super users are allowed to list platform users
-                this.permissionDenied(error, 'platform admin');
+                this.permissionDenied(error, 'platform admin', 'example@email.com');
             });
         } else if (this.resolve.adminView === 'team') {
             this.organizationService.getMembers(
@@ -78,10 +78,13 @@ class AddUserModalController {
                 page - 1,
                 search && search.length ? search : null
             ).then((response) => {
+                this.hasPermission = true;
                 this.fetching = false;
                 this.updatePagination(response);
                 this.lastUserResult = response;
                 this.users = response.results;
+            }, (error) => {
+                this.permissionDenied(error, 'organization admin', 'example@email.com');
             });
         }
     }
@@ -122,11 +125,11 @@ class AddUserModalController {
         });
     }
 
-    permissionDenied(err, subject) {
+    permissionDenied(err, subject, adminEmail) {
         this.fetching = false;
         this.hasPermission = false;
         this.subject = subject;
-        this.adminEmail = 'example@email.com';
+        this.adminEmail = adminEmail;
         this.permissionDeniedMsg = `${err.data}. Please contact `;
     }
 }

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -62,10 +62,13 @@ class AddUserModalController {
                 page - 1,
                 search && search.length ? search : null
             ).then((response) => {
+                this.hasPermission = true;
                 this.fetching = false;
                 this.updatePagination(response);
                 this.lastUserResult = response;
                 this.users = response.results;
+            }, (error) => {
+                this.permisionDenied(error, 'organization');
             });
         } else if (this.resolve.adminView === 'team') {
             this.organizationService.getMembers(
@@ -116,6 +119,14 @@ class AddUserModalController {
             this.error = err.data;
             this.$log.error('Error adding users to team:', err);
         });
+    }
+
+    permisionDenied(err, subject) {
+        this.fetching = false;
+        this.hasPermission = false;
+        this.subject = subject;
+        this.adminEmail = 'example@email.com';
+        this.permisionDeniedMsg = `${err.data}. Please contact `;
     }
 }
 

--- a/app-frontend/src/app/components/settings/organizationModal/organizationModal.html
+++ b/app-frontend/src/app/components/settings/organizationModal/organizationModal.html
@@ -9,21 +9,32 @@
     ></span>
   </div>
   <div class="modal-body">
-    <form name="$ctrl.form" class="form-group">
-      <label>
-        Organization name
-        <input
-            type="text"
-            class="form-control"
-            name="name"
-            ng-model="name"
-        >
-      </label>
-    </form>
+    <div ng-if="$ctrl.permissionDenied.isDenied">
+      <p>
+        {{$ctrl.permissionDenied.message}}
+        <a ng-href="mailto:{{$ctrl.permissionDenied.adminEmail}}">{{$ctrl.permissionDenied.subject}}</a>.
+      </p>
+    </div>
+    <div ng-if="!$ctrl.permissionDenied.isDenied">
+      <form name="$ctrl.form" class="form-group">
+        <label>
+          Organization name
+          <input
+              type="text"
+              class="form-control"
+              name="name"
+              ng-model="name"
+          >
+        </label>
+      </form>
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-light" ng-click="$ctrl.dismiss()">Cancel</button>
-    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()">Add</button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      ng-click="$ctrl.onAdd()"
+      ng-if="!$ctrl.permissionDenied.isDenied">Add</button>
   </div>
 </div>
-

--- a/app-frontend/src/app/components/settings/organizationModal/organizationModal.module.js
+++ b/app-frontend/src/app/components/settings/organizationModal/organizationModal.module.js
@@ -14,6 +14,7 @@ const OrganizationModalComponent = {
 
 class OrganizationModalController {
     constructor() {
+        this.permissionDenied = this.resolve.permissionDenied;
     }
 
     onAdd() {

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.html
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.html
@@ -9,13 +9,13 @@
     ></span>
   </div>
   <div class="modal-body">
-    <div ng-if="$ctrl.permissionDenied">
+    <div ng-if="$ctrl.permissionDenied.isDenied">
       <p>
         {{$ctrl.permissionDenied.message}}
-        <a href="mailto:{{$ctrl.permissionDenied.adminEmail}}">organization admin</a>.
+        <a href="mailto:{{$ctrl.permissionDenied.adminEmail}}">{{$ctrl.permissionDenied.subject}}</a>.
       </p>
     </div>
-    <div ng-if="!$ctrl.permissionDenied">
+    <div ng-if="!$ctrl.permissionDenied.isDenied">
       <form name="$ctrl.form" class="form-group">
         <label>
           Team name
@@ -31,6 +31,6 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-light" ng-click="$ctrl.dismiss()">Cancel</button>
-    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()" ng-if="!$ctrl.permissionDenied">Add</button>
+    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()" ng-if="!$ctrl.permissionDenied.isDenied">Add</button>
   </div>
 </div>

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.html
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.html
@@ -9,21 +9,28 @@
     ></span>
   </div>
   <div class="modal-body">
-    <form name="$ctrl.form" class="form-group">
-      <label>
-        Team name
-        <input
-            type="text"
-            class="form-control"
-            name="name"
-            ng-model="name"
-        >
-      </label>
-    </form>
+    <div ng-if="$ctrl.permissionDenied">
+      <p>
+        {{$ctrl.permissionDenied.message}}
+        <a href="mailto:{{$ctrl.permissionDenied.adminEmail}}">organization admin</a>.
+      </p>
+    </div>
+    <div ng-if="!$ctrl.permissionDenied">
+      <form name="$ctrl.form" class="form-group">
+        <label>
+          Team name
+          <input
+              type="text"
+              class="form-control"
+              name="name"
+              ng-model="name"
+          >
+        </label>
+      </form>
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-light" ng-click="$ctrl.dismiss()">Cancel</button>
-    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()">Add</button>
+    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()" ng-if="!$ctrl.permissionDenied">Add</button>
   </div>
 </div>
-

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.html
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.html
@@ -12,7 +12,7 @@
     <div ng-if="$ctrl.permissionDenied.isDenied">
       <p>
         {{$ctrl.permissionDenied.message}}
-        <a href="mailto:{{$ctrl.permissionDenied.adminEmail}}">{{$ctrl.permissionDenied.subject}}</a>.
+        <a ng-href="mailto:{{$ctrl.permissionDenied.adminEmail}}">{{$ctrl.permissionDenied.subject}}</a>.
       </p>
     </div>
     <div ng-if="!$ctrl.permissionDenied.isDenied">

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.module.js
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.module.js
@@ -14,6 +14,8 @@ const TeamModalComponent = {
 
 class TeamModalController {
     constructor() {
+        this.permissionDenied = this.resolve.permissionDenied;
+        console.log(this.permissionDenied);
     }
 
     onAdd() {

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.module.js
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.module.js
@@ -15,7 +15,6 @@ const TeamModalComponent = {
 class TeamModalController {
     constructor() {
         this.permissionDenied = this.resolve.permissionDenied;
-        console.log(this.permissionDenied);
     }
 
     onAdd() {

--- a/app-frontend/src/app/pages/admin/organization/organization.module.js
+++ b/app-frontend/src/app/pages/admin/organization/organization.module.js
@@ -1,10 +1,14 @@
 import angular from 'angular';
 
 class OrganizationController {
-    constructor($stateParams, organizationService) {
+    constructor(
+      $stateParams,
+      organizationService, authService) {
         'ngInject';
         this.$stateParams = $stateParams;
+
         this.organizationService = organizationService;
+        this.authService = authService;
         this.fetching = true;
     }
 
@@ -14,6 +18,8 @@ class OrganizationController {
             .then((organization) => {
                 this.organization = organization;
                 this.fetching = false;
+                this.currentUserPromise = this.authService.getCurrentUser().then();
+                this.currentUgrPromise = this.authService.fetchUserRoles().then();
             });
     }
 }

--- a/app-frontend/src/app/pages/admin/organization/organization.module.js
+++ b/app-frontend/src/app/pages/admin/organization/organization.module.js
@@ -18,9 +18,9 @@ class OrganizationController {
             .then((organization) => {
                 this.organization = organization;
                 this.fetching = false;
-                this.currentUserPromise = this.authService.getCurrentUser().then();
-                this.currentUgrPromise = this.authService.fetchUserRoles().then();
             });
+        this.currentUserPromise = this.authService.getCurrentUser().then();
+        this.currentUgrPromise = this.authService.fetchUserRoles().then();
     }
 }
 

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -38,16 +38,13 @@
           </a>
         </td>
         <td class="teams" ng-if="!team.fetchedUsers">
-
           <a class="users-more" title="View team details"
              ui-sref="admin.team.users({teamId: team.id})">
             Counting members...
           </a>
         </td>
         <td class="actions">
-          <rf-dropdown
-              data-options="team.options"
-          >
+          <rf-dropdown data-options="team.options" ng-if="team.showOptions">
             <span class="icon-caret-down"></span>
           </rf-dropdown>
         </td>

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -1,73 +1,80 @@
 <div class="admin-users-content container column-stretch dashboard">
-  <div class="admin-users-actions">
-    <input type="text" class="form-control admin-search" placeholder="Search for teams" ng-disabled="$ctrl.fetching">
-    <button type="button" class="btn btn-primary"
-            ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
-      New Team
-    </button>
+  <div ng-if="$ctrl.errorMsg">
+    <p>
+      {{$ctrl.errorMsg}}
+      <a ng-href="mailto:{{$ctrl.orgAdminEmail}}">organization admin</a>.
+    </p>
   </div>
-  <table class="admin-table admin-team-table" ng-if="!$ctrl.fetching">
-    <thead>
-      <tr>
-        <td>Name</td>
-        <td class="users">Users</td>
-        <td>Actions</td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr ng-repeat="team in $ctrl.teams track by team.id">
-        <td class="name">
-          {{team.name}}
-        </td>
-        <td class="users">
-          <div class="user-avatar"
-               ng-repeat="user in team.fetchedUsers.results track by $index | limitTo : 5"
-               ng-attr-title="{{user.name || user.email || user.id}}"
-          >
-            <img class="avatar" ng-src="{{user.profileImageUri}}">
-          </div>
-          <a class="users-more" title="View team details"
-             ui-sref="admin.team.users({teamId: team.id})">
-            <ng-pluralize count="team.fetchedUsers.count"
-                          when="{'0': ' No team members',
-                                 '1': ' View 1 team member',
-                                 'other': ' View {} team members'}"
-
+  <div ng-if="!$ctrl.errorMsg">
+    <div class="admin-users-actions">
+      <input type="text" class="form-control admin-search" placeholder="Search for teams" ng-disabled="$ctrl.fetching">
+      <button type="button" class="btn btn-primary"
+              ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
+        New Team
+      </button>
+    </div>
+    <table class="admin-table admin-team-table" ng-if="!$ctrl.fetching">
+      <thead>
+        <tr>
+          <td>Name</td>
+          <td class="users">Users</td>
+          <td>Actions</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="team in $ctrl.teams track by team.id">
+          <td class="name">
+            {{team.name}}
+          </td>
+          <td class="users">
+            <div class="user-avatar"
+                 ng-repeat="user in team.fetchedUsers.results track by $index | limitTo : 5"
+                 ng-attr-title="{{user.name || user.email || user.id}}"
             >
-            </ng-pluralize>
-          </a>
-        </td>
-        <td class="teams" ng-if="!team.fetchedUsers">
-          <a class="users-more" title="View team details"
-             ui-sref="admin.team.users({teamId: team.id})">
-            Counting members...
-          </a>
-        </td>
-        <td class="actions">
-          <rf-dropdown data-options="team.options" ng-if="team.showOptions">
-            <span class="icon-caret-down"></span>
-          </rf-dropdown>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+              <img class="avatar" ng-src="{{user.profileImageUri}}">
+            </div>
+            <a class="users-more" title="View team details"
+               ui-sref="admin.team.users({teamId: team.id})">
+              <ng-pluralize count="team.fetchedUsers.count"
+                            when="{'0': ' No team members',
+                                   '1': ' View 1 team member',
+                                   'other': ' View {} team members'}"
 
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+              >
+              </ng-pluralize>
+            </a>
+          </td>
+          <td class="teams" ng-if="!team.fetchedUsers">
+            <a class="users-more" title="View team details"
+               ui-sref="admin.team.users({teamId: team.id})">
+              Counting members...
+            </a>
+          </td>
+          <td class="actions">
+            <rf-dropdown data-options="team.options" ng-if="team.showOptions">
+              <span class="icon-caret-down"></span>
+            </rf-dropdown>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="table-loading" ng-if="$ctrl.fetching">
+      <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+    </div>
+    <!-- Pagination -->
+    <div class="list-group text-center"
+          ng-show="!$ctrl.loading && $ctrl.lastTeamResult && $ctrl.pagination.show && !$ctrl.errorMsg">
+      <ul uib-pagination
+          items-per-page="$ctrl.lastTeamResult.pageSize"
+          total-items="$ctrl.pagination.count"
+          ng-model="$ctrl.currentPage"
+          max-size="4"
+          rotate="true"
+          boundary-link-numbers="true"
+          force-ellipses="true"
+          ng-change="$ctrl.fetchTeams($ctrl.currentPage, $ctrl.search)">
+      </ul>
+    </div>
+    <!-- Pagination -->
   </div>
-  <!-- Pagination -->
-  <div class="list-group text-center"
-        ng-show="!$ctrl.loading && $ctrl.lastTeamResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastTeamResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchTeams($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
 </div>

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -38,7 +38,6 @@ class OrganizationTeamsController {
         });
         this.authService.fetchUserRoles().then((resp) => {
             this.currentUgr = resp.filter(ugr => ugr.groupId === this.organizationId)[0];
-            this.$log.log(this.currentUgr);
         }, (err) => {
             this.$log.error(err);
         });
@@ -163,8 +162,10 @@ class OrganizationTeamsController {
         if (!(this.currentUser.isActive &&
             (this.currentUser.isSuperuser || this.currentUgr.groupRole === 'ADMIN'))) {
             permissionDenied = {
+                isDenied: true,
                 adminEmail: 'example@email.com',
-                message: 'You do not have access to this operation. Please contact '
+                message: 'You do not have access to this operation. Please contact ',
+                subject: 'organization admin'
             };
         }
         this.modalService.open({

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -14,6 +14,8 @@ class OrganizationTeamsController {
         this.teamService = teamService;
         this.authService = authService;
 
+        this.orgAdminEmail = 'example@email.com';
+
         let debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,
@@ -102,6 +104,9 @@ class OrganizationTeamsController {
                             });
                     }
                 );
+            }, (error) => {
+                this.fetching = false;
+                this.errorMsg = `${error.data}. Please contact `;
             });
     }
 

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -1,68 +1,75 @@
 <div class="admin-users-content container column-stretch dashboard">
-  <div class="admin-users-actions">
-    <input type="text" class="form-control admin-search" placeholder="Search for users"
-           ng-model="$ctrl.search">
+  <div ng-if="$ctrl.errorMsg">
+    <p>
+      {{$ctrl.errorMsg}}
+      <a ng-href="mailto:{{$ctrl.platAdminEmail}}">platform admin</a>.
+    </p>
+  </div>
+  <div ng-if="!$ctrl.errorMsg">
+    <div class="admin-users-actions">
+      <input type="text" class="form-control admin-search" placeholder="Search for users"
+             ng-model="$ctrl.search">
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.addUserModal()"
               ng-disabled="$ctrl.fetching">
         Add User
       </button>
+    </div>
+    <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching">
+      <thead>
+        <tr>
+          <td>Name</td>
+          <td>Email</td>
+          <td>Role</td>
+          <td>Teams</td>
+          <td>Options</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="user in $ctrl.users track by $index">
+          <td class="username">
+            <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
+            <div class="user-avatar" ng-if="user.profileImageUri">
+              <img class="avatar" ng-src="{{user.profileImageUri}}">
+            </div>
+            <div>
+              {{user.name || user.email || user.id}}
+            </div>
+          </td>
+          <td class="emails" ng-class="{'color-light': !user.email}">
+            {{user.email || 'None'}}
+          </td>
+          <td class="roles">
+            {{user.groupRole}}
+          </td>
+          <td class="teams">
+            In {{user.teams.length || 0}} teams
+          </td>
+          <td class="actions">
+            <rf-dropdown data-options="user.options" ng-if="user.showOptions">
+              <span class="icon-caret-down"></span>
+            </rf-dropdown>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="table-loading" ng-if="$ctrl.fetching">
+      <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+    </div>
+    <!-- Pagination -->
+    <div class="list-group text-center"
+          ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
+      <ul uib-pagination
+          items-per-page="$ctrl.lastUserResult.pageSize"
+          total-items="$ctrl.pagination.count"
+          ng-model="$ctrl.currentPage"
+          max-size="4"
+          rotate="true"
+          boundary-link-numbers="true"
+          force-ellipses="true"
+          ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
+      </ul>
+    </div>
+    <!-- Pagination -->
   </div>
-  <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching">
-    <thead>
-      <tr>
-        <td>Name</td>
-        <td>Email</td>
-        <td>Role</td>
-        <td>Teams</td>
-        <td>Options</td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr ng-repeat="user in $ctrl.users track by $index">
-        <td class="username">
-          <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
-          <div class="user-avatar" ng-if="user.profileImageUri">
-            <img class="avatar" ng-src="{{user.profileImageUri}}">
-          </div>
-          <div>
-            {{user.name || user.email || user.id}}
-          </div>
-        </td>
-        <td class="emails" ng-class="{'color-light': !user.email}">
-          {{user.email || 'None'}}
-        </td>
-        <td class="roles">
-          {{user.groupRole}}
-        </td>
-        <td class="teams">
-          In {{user.teams.length || 0}} teams
-        </td>
-        <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions">
-            <span class="icon-caret-down"></span>
-          </rf-dropdown>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
-  </div>
-
-  <!-- Pagination -->
-  <div class="list-group text-center"
-        ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastUserResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
 </div>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -14,6 +14,8 @@
         <td>Name</td>
         <td>Email</td>
         <td>Role</td>
+        <td>Teams</td>
+        <td>Options</td>
       </tr>
     </thead>
     <tbody>
@@ -37,7 +39,7 @@
           In {{user.teams.length || 0}} teams
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions">
             <span class="icon-caret-down"></span>
           </rf-dropdown>
         </td>

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -4,12 +4,13 @@ import _ from 'lodash';
 class OrganizationUsersController {
     constructor(
         $scope, $stateParams,
-        modalService, organizationService
+        modalService, organizationService, authService
     ) {
         this.$scope = $scope;
         this.$stateParams = $stateParams;
         this.modalService = modalService;
         this.organizationService = organizationService;
+        this.authService = authService;
         this.fetching = true;
 
         let debouncedSearch = _.debounce(
@@ -25,6 +26,12 @@ class OrganizationUsersController {
                 this.organization = organization;
                 this.$scope.$watch('$ctrl.search', debouncedSearch);
             }
+        });
+    }
+
+    $onInit() {
+        this.authService.getCurrentUser().then(resp => {
+            this.currentUser = resp;
         });
     }
 
@@ -56,14 +63,15 @@ class OrganizationUsersController {
                 this.lastUserResult = response;
                 this.users = response.results;
 
-                this.users.forEach(
-                    (user) => Object.assign(
-                        user, {
-                            options: {
-                                items: this.itemsForUser(user)
-                            }
-                        }
-                    ));
+                this.users.forEach((user) => {
+                    Object.assign(user, {
+                        options: {
+                            items: this.itemsForUser(user)
+                        },
+                        showOptions: user.isActive && (user.id === this.currentUser.id ||
+                            user.isSuperuser || user.groupRole === 'ADMIN')
+                    });
+                });
             });
     }
 

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -3,12 +3,11 @@ import _ from 'lodash';
 
 class OrganizationUsersController {
     constructor(
-        $scope, $stateParams, $log,
+        $scope, $stateParams,
         modalService, organizationService
     ) {
         this.$scope = $scope;
         this.$stateParams = $stateParams;
-        this.$log = $log;
         this.modalService = modalService;
         this.organizationService = organizationService;
         this.fetching = true;
@@ -78,15 +77,13 @@ class OrganizationUsersController {
                 let isAdmin = this.currentPlatUgr && this.currentPlatUgr.groupRole === 'ADMIN' ||
                     this.currentOrgUgr && this.currentOrgUgr.groupRole === 'ADMIN';
 
-                this.users.forEach((user) => {
-                    Object.assign(user, {
-                        options: {
-                            items: this.itemsForUser(user)
-                        },
-                        showOptions: user.isActive && (user.id === this.currentUser.id ||
-                            user.isSuperuser || isAdmin)
-                    });
-                });
+                this.users.forEach(user => Object.assign(user, {
+                    options: {
+                        items: this.itemsForUser(user)
+                    },
+                    showOptions: user.isActive && (user.id === this.currentUser.id ||
+                        user.isSuperuser || isAdmin)
+                }));
             });
     }
 

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -3,11 +3,12 @@ import _ from 'lodash';
 
 class OrganizationUsersController {
     constructor(
-        $scope, $stateParams,
+        $scope, $stateParams, $log,
         modalService, organizationService, authService
     ) {
         this.$scope = $scope;
         this.$stateParams = $stateParams;
+        this.$log = $log;
         this.modalService = modalService;
         this.organizationService = organizationService;
         this.authService = authService;
@@ -24,6 +25,7 @@ class OrganizationUsersController {
                 this.orgWatch();
                 delete this.orgWatch;
                 this.organization = organization;
+                this.organizationId = this.organization.id;
                 this.$scope.$watch('$ctrl.search', debouncedSearch);
             }
         });
@@ -32,6 +34,11 @@ class OrganizationUsersController {
     $onInit() {
         this.authService.getCurrentUser().then(resp => {
             this.currentUser = resp;
+        });
+        this.authService.fetchUserRoles().then((resp) => {
+            this.currentUgr = resp.filter(ugr => ugr.groupId === this.organizationId)[0];
+        }, (err) => {
+            this.$log.error(err);
         });
     }
 
@@ -69,7 +76,7 @@ class OrganizationUsersController {
                             items: this.itemsForUser(user)
                         },
                         showOptions: user.isActive && (user.id === this.currentUser.id ||
-                            user.isSuperuser || user.groupRole === 'ADMIN')
+                            user.isSuperuser || this.currentUgr.groupRole === 'ADMIN')
                     });
                 });
             });

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -12,6 +12,8 @@ class OrganizationUsersController {
         this.organizationService = organizationService;
         this.fetching = true;
 
+        this.platAdminEmail = 'example@email.com';
+
         let debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,
@@ -84,6 +86,9 @@ class OrganizationUsersController {
                     showOptions: user.isActive && (user.id === this.currentUser.id ||
                         user.isSuperuser || isAdmin)
                 }));
+            }, (error) => {
+                this.fetching = false;
+                this.errorMsg = `${error.data}. Please contact `;
             });
     }
 

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -36,8 +36,8 @@
           </td>
           <td class="users">
             <div class="user-avatar"
-                 ng-repeat="user in organization.fetchedUsers.results track by user.id | limitTo : 5"
-                 ng-attr-title="{{user.name || user.email || user.id}}"
+                 ng-repeat="user in organization.fetchedUsers.results track by $index | limitTo : 5"
+                 ng-attr-title="{{user.name}}"
             >
               <img class="avatar" ng-src="{{user.profileImageUri}}">
             </div>
@@ -56,10 +56,12 @@
           </td>
           <td>{{ organization.isActive ? "Active" : "Deactivated"}}</td>
           <td class="actions">
-            <a ui-sref="admin.organization.users({organizationId: organization.id})">View page</a>
-            <rf-dropdown data-options="organization.options">
-              <span class="icon-caret-down"></span>
-            </rf-dropdown>
+            <div ng-if="organization.showOptions">
+              <a ui-sref="admin.organization.users({organizationId: organization.id})">View page</a>
+              <rf-dropdown data-options="organization.options">
+                <span class="icon-caret-down"></span>
+              </rf-dropdown>
+            </div>
           </td>
         </tr>
       </tbody>

--- a/app-frontend/src/app/pages/admin/platform/platform.module.js
+++ b/app-frontend/src/app/pages/admin/platform/platform.module.js
@@ -1,10 +1,11 @@
 import angular from 'angular';
 
 class PlatformController {
-    constructor($stateParams, platformService) {
+    constructor($stateParams, platformService, authService) {
         'ngInject';
         this.$stateParams = $stateParams;
         this.platformService = platformService;
+        this.authService = authService;
         this.fetching = true;
     }
 
@@ -15,6 +16,8 @@ class PlatformController {
                 this.platform = platform;
                 this.fetching = false;
             });
+        this.currentUserPromise = this.authService.getCurrentUser().then();
+        this.currentUgrPromise = this.authService.fetchUserRoles().then();
     }
 }
 

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -1,58 +1,65 @@
 <div class="admin-users-content container column-stretch dashboard">
-  <div class="admin-users-actions">
-    <input type="text" class="form-control admin-search" placeholder="Search for users"
-           ng-model="$ctrl.search" ng-disabled="$ctrl.fetching">
+  <div ng-if="$ctrl.errrorMsg">
+    <p>
+      {{$ctrl.errrorMsg}}
+      <a ng-href="mailto:{{$ctrl.platAdminEmail}}">platform admin</a>.
+    </p>
   </div>
-  <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
-    <thead>
-      <tr>
-        <td>Name</td>
-        <td>Email</td>
-        <td>Role</td>
-      </tr>
-    </thead>
-    <tbody>
-      <tr ng-repeat="user in $ctrl.users track by $index">
-        <td class="username">
-          <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
-          <div class="user-avatar" ng-if="user.profileImageUri">
-            <img class="avatar" ng-src="{{user.profileImageUri}}">
-          </div>
-          <div>
-            {{user.name || user.email || user.id}}
-          </div>
-        </td>
-        <td class="emails">
-          {{user.email}}
-        </td>
-        <td class="roles">
-          {{user.groupRole}}
-        </td>
-        <td class="actions">
-          <rf-dropdown data-options="user.options">
-            <span class="icon-caret-down"></span>
-          </rf-dropdown>
-        </td>
-      </tr>
-    </tbody>
-  </table>
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+  <div ng-if="!$ctrl.errrorMsg">
+    <div class="admin-users-actions">
+      <input type="text" class="form-control admin-search" placeholder="Search for users"
+             ng-model="$ctrl.search" ng-disabled="$ctrl.fetching">
+    </div>
+    <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
+      <thead>
+        <tr>
+          <td>Name</td>
+          <td>Email</td>
+          <td>Role</td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-repeat="user in $ctrl.users track by $index">
+          <td class="username">
+            <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
+            <div class="user-avatar" ng-if="user.profileImageUri">
+              <img class="avatar" ng-src="{{user.profileImageUri}}">
+            </div>
+            <div>
+              {{user.name || user.email || user.id}}
+            </div>
+          </td>
+          <td class="emails">
+            {{user.email}}
+          </td>
+          <td class="roles">
+            {{user.groupRole}}
+          </td>
+          <td class="actions">
+            <rf-dropdown data-options="user.options">
+              <span class="icon-caret-down"></span>
+            </rf-dropdown>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="table-loading" ng-if="$ctrl.fetching">
+      <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+    </div>
+    <!-- Pagination -->
+    <div class="list-group text-center"
+          ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
+      <ul uib-pagination
+          items-per-page="$ctrl.lastUserResult.pageSize"
+          total-items="$ctrl.pagination.count"
+          ng-model="$ctrl.currentPage"
+          max-size="4"
+          rotate="true"
+          boundary-link-numbers="true"
+          force-ellipses="true"
+          ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
+      </ul>
+    </div>
+    <!-- Pagination -->
   </div>
-
-  <!-- Pagination -->
-  <div class="list-group text-center"
-        ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastUserResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
 </div>

--- a/app-frontend/src/app/pages/admin/platform/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/platform/users/users.module.js
@@ -6,12 +6,14 @@ class PlatformUsersController {
         $scope, $stateParams,
         modalService, platformService
     ) {
+        this.$scope = $scope;
+        this.$stateParams = $stateParams;
+
         this.modalService = modalService;
         this.platformService = platformService;
-        this.$stateParams = $stateParams;
-        this.$scope = $scope;
         // check if has permissions for platform page
         this.fetching = true;
+        this.platAdminEmail = 'example@email.com';
 
         let debouncedSearch = _.debounce(
             this.onSearch.bind(this),
@@ -52,14 +54,16 @@ class PlatformUsersController {
             this.lastUserResult = response;
             this.users = response.results;
 
-            this.users.forEach(
-                (user) => Object.assign(
-                    user, {
-                        options: {
-                            items: this.itemsForUser(user)
-                        }
+            this.users.forEach(user => {
+                Object.assign(user, {
+                    options: {
+                        items: this.itemsForUser(user)
                     }
-                ));
+                });
+            });
+        }, (error) => {
+            this.fetching = false;
+            this.errrorMsg = `${error.data}. Please contact `;
         });
     }
 

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -34,7 +34,7 @@
           {{user.groupRole}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions">
             <span class="icon-caret-down"></span>
           </rf-dropdown>
         </td>

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -13,6 +13,7 @@
         <td>Name</td>
         <td>Email</td>
         <td>Role</td>
+        <td>Actions</td>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Overview

This PR updates admin UI permissions and failure messages on platform, organization, and team pages.

~Marked as WIP since platform related pages have not been touched yet.~

**Updates on Jun. 4th:**
 * Finish platform related pages and remove WIP tag

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

~Platform related pages have not been updated yet.~


## Testing Instructions

 * Log in as a dev user.
 * In a sql shell, update dev user's roles in the public organization, Raster Foundry platform, teams, etc. in the `user_group_roles` table.
 * Navigate through all admin pages as you switch the dev user's role `ADMIN/MEMBER` on platform/org/team levels, check if the authorized/not authorized behaviors are correctly reflected on the frontend and if useful info is shown upon authentication failures.

Closes #3431 
