### PR TITLE
Eagerly insert scenes and flip csv date order

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -93,17 +93,6 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
   // Getting the image size is the only place where the s3 object
   // is required to exist -- so handle the missing object by returning
   // a -1 for the image's size
-  protected def sizeFromPath(tifPath: String, productId: String): Int = {
-    val path = s"c1/${getLandsatPath(productId)}/$tifPath"
-    logger.info(s"Getting object size for path: $path")
-    Try(
-      s3Client.getObject(landsat8Config.bucketName, path).getObjectMetadata.getContentLength.toInt
-    ) match {
-      case Success(size) => size
-      case Failure(_) => -1
-    }
-  }
-
   protected def createThumbnails(sceneId: UUID, productId: String): List[Thumbnail.Identified] = {
     val path = getLandsatUrl(productId)
     val smallUrl = s"$path/${productId}_thumb_small.jpg"
@@ -236,7 +225,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
         ).map {
         case (resolution, tiffPath, band) =>
           Image.Banded(
-            rawDataBytes = sizeFromPath(tiffPath, productId),
+            rawDataBytes = 0,
             visibility = Visibility.Public,
             filename = tiffPath,
             sourceUri = s"${getLandsatUrl(productId)}/${tiffPath}",


### PR DESCRIPTION
## Overview

We previously assumed that recent scenes would be
at the top of the csv, so that if we had a run of several rows where the row's date was before the
start date, that indicated we were past the block of rows that we cared about. Sometime recently
though (who knows when), the order seems to have been flipped, so our threshold for rows before
the start date was always happening before we found any rows that we actually cared about. With this
PR, we now check for runs of scenes with dates _greater than the end date_. The downside is that
we now have to traverse the entire csv to get to the rows we care about.

This PR also borrows the eager insertion strategy from Sentinel-2 import, so that if anything goes
wrong we still get to insert some scenes.

Finally, it also gives up on calculating object size for every image to create. It takes forever and we don't use it and also no one seems to care. We should probably just drop that column.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * 2017-07-01 is in the Collection 1 era, so the importer should work on it. Open up a console in the `batch` project, then:

```scala
import com.azavea.rf.batch.landsat8.ImportLandsat8C1
import com.azavea.rf.database.util.RFTransactor.xa
import java.time.LocalDate
ImportLandsat8C1(LocalDate.parse("2017-07-01")).run
```
 * it'll take a while, since it has to get to that section of the csv, which is really far in, but it should succeed eventually

Closes azavea/raster-foundry-platform#337