### PR TITLE
Add first cut permissions modal

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -279,8 +279,7 @@ trait PlatformRoutes extends Authentication
 
   def listPlatformMembers(platformId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      // QUESTION: should this be open to members of the same platform?
-      PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
+      PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
     } {
       (withPagination & searchParams) { (page, searchParams) =>
         complete {

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -273,6 +273,9 @@ trait ProjectRoutes extends Authentication
                 traceName("list-project-permissions") {
                   listProjectPermissions(projectId)
                 }
+              } ~
+              delete {
+                deleteProjectPermissions(projectId)
               }
           } ~
           pathPrefix("actions") {
@@ -787,6 +790,16 @@ trait ProjectRoutes extends Authentication
             }
           }
         }
+      }
+    }
+  }
+
+  def deleteProjectPermissions(projectId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      ProjectDao.query.ownedBy(user, projectId).exists.transact(xa).unsafeToFuture
+    } {
+      complete {
+        AccessControlRuleDao.deleteByObject(ObjectType.Project, projectId).transact(xa).unsafeToFuture
       }
     }
   }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -104,6 +104,9 @@ trait SceneRoutes extends Authentication
             traceName("list-user-allowed-actions") {
               listUserSceneActions(sceneId)
             }
+          } ~
+          delete {
+            deleteScenePermissions(sceneId)
           }
         }
       }
@@ -259,6 +262,16 @@ trait SceneRoutes extends Authentication
             }
           }
         }
+      }
+    }
+  }
+
+  def deleteScenePermissions(sceneId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      SceneDao.query.ownedBy(user, sceneId).exists.transact(xa).unsafeToFuture
+    } {
+      complete {
+        AccessControlRuleDao.deleteByObject(ObjectType.Scene, sceneId).transact(xa).unsafeToFuture
       }
     }
   }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -85,6 +85,9 @@ trait ShapeRoutes extends Authentication
               } ~
               get {
                 listShapePermissions(shapeId)
+              } ~
+              delete {
+                deleteShapePermissions(shapeId)
               }
           } ~
           pathPrefix("actions") {
@@ -258,4 +261,13 @@ trait ShapeRoutes extends Authentication
     }
   }
 
+  def deleteShapePermissions(shapeId: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      ShapeDao.query.ownedBy(user, shapeId).exists.transact(xa).unsafeToFuture
+    } {
+      complete {
+        AccessControlRuleDao.deleteByObject(ObjectType.Shape, shapeId).transact(xa).unsafeToFuture
+      }
+    }
+  }
 }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -40,6 +40,11 @@ trait UserRoutes extends Authentication
 
   val userRoutes: Route = handleExceptions(userExceptionHandler) {
     pathPrefix("me") {
+      pathPrefix("teams") {
+        pathEndOrSingleSlash {
+          get { getUserTeams }
+        }
+      } ~
       pathPrefix("roles") {
         get { getUserRoles }
       } ~
@@ -123,6 +128,10 @@ trait UserRoutes extends Authentication
     }
   }
 
+
+  def getUserTeams: Route = authenticate { user =>
+    complete { TeamDao.teamsForUser(user).transact(xa).unsafeToFuture }
+  }
   def updateUserByEncodedAuthId(authIdEncoded: String): Route = authenticateRootMember { root =>
     entity(as[User]) { updatedUser =>
       onSuccess(UserDao.updateUser(updatedUser, authIdEncoded).transact(xa).unsafeToFuture()) {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -182,4 +182,6 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
     .query[String]
     .list
 
+  def deleteByObject(objectType: ObjectType, objectId: UUID): ConnectionIO[Int] =
+    listedByObject(objectType, objectId).delete
 }

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -1,0 +1,78 @@
+<div class="modal-header">
+  <span> Edit permissions for {{ $ctrl.objectName }} </span>
+  <button type="button" class="close" aria-label="Close"
+          ng-click="$ctrl.dismiss()">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
+
+<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.existing">
+  <div ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
+    <span class="permissions-object-key">
+      {{ key }}
+    </span>
+    <span class="permissions-object-marker" ng-repeat="actionType in $ctrl.actionTypes">
+      <input type="checkbox" name="{{ actionType }}" value="{{ actionType }}" ng-if="!row.includes(actionType)"
+             ng-click="$ctrl.togglePermission(actionType, key)">
+      <input type="checkbox" name="{{ actionType }}" value="{{ actionType }}" checked ng-if="row.includes(actionType)"
+             ng-click="$ctrl.togglePermission(actionType, key)">
+    </span>
+  </div>
+  <div class="new-permission-row">
+    <button class="btn btn-block" ng-click="$ctrl.setState('newPermission')">
+      Add a new permission
+    </button>
+  </div>
+</div>
+
+<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.newPermission"
+     ng-if="$ctrl.state === $ctrl.states.newPermission">
+  <div>Who would you like to grant permissions to?</div>
+  <select ng-model="$ctrl.newPermissionSubject"
+          ng-options="subjectType.name for subjectType in $ctrl.subjectTypes track by subjectType.id"></select>
+  <button class="btn btn-block" disabled ng-if="$ctrl.newPermissionSubject === null">Next </button>
+  <button class="btn btn-block"
+          ng-if="$ctrl.newPermissionSubject !== null"
+          ng-click="$ctrl.handleNewPermissionSubjectSelection()">Next</button>
+</div>
+
+<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.organizationSelect">
+</div>
+
+<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.teamSelect">
+  <div class="selectable-list-item" ng-repeat="team in $ctrl.teams"
+       ng-click="$ctrl.selectTeam(team)">
+    {{ team.name }}
+  </div>
+</div>
+
+<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.userSelect">
+  <rf-search on-search="$ctrl.searchUsers(value)" placeholder="Search for users" auto-focus="true"></rf-searcH>
+  <div class="selectable-list-item" ng-repeat="member in $ctrl.availableUsers"
+       ng-click="$ctrl.selectUser(user)">
+    {{ member.email }}
+  </div>
+</div>
+
+<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.createNewACR">
+  <div class="new-acr-confirmation"
+       ng-if="!['USER', 'EVERYONE'].includes($ctrl.newPermissionSubject.target)">
+    You are about to add <code>VIEW</code> permissions to the {{$ctrl.newPermissionSubject.target | lowercase }}
+    {{ $ctrl.selectedPermissionsTarget.name }}.
+    {{ $ctrl.affectedUsers }} user(s) will receive <code>VIEW</code> permissions. To add additional permissions,
+    toggle them on or off in the list of permissions grants.
+  </div>
+  <div class="new-acr-confirmation" ng-if="'USER' === $ctrl.newPermissionSubject">
+    You are about to give {{ $ctrl.selectedPermissionsTarget.name }} <code>VIEW</code> permissions. To add
+    additional permissions, toggle them on or off in the list of permissions grants.
+  </div>
+</div>
+
+<div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.createNewACR">
+  <button class="btn pull-right" ng-click="$ctrl.createNewACR()">Confirm</button>
+</div>
+
+<div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.existing">
+  <button class="btn pull-right" ng-click="$ctrl.updatePermissions()">Save</button>
+  <button class="btn pull-left" ng-click="$ctrl.close()">Cancel</button>
+</div>

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -44,9 +44,6 @@
           ng-click="$ctrl.handleNewPermissionSubjectSelection()">Next</button>
 </div>
 
-<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.organizationSelect">
-</div>
-
 <div class="modal-content" ng-if="$ctrl.state === $ctrl.states.teamSelect">
   <div class="selectable-list-item" ng-repeat="team in $ctrl.teams"
        ng-click="$ctrl.selectTeam(team)">
@@ -56,9 +53,9 @@
 
 <div class="modal-content" ng-if="$ctrl.state === $ctrl.states.userSelect">
   <rf-search on-search="$ctrl.searchUsers(value)" placeholder="Search for users" auto-focus="true"></rf-searcH>
-  <div class="selectable-list-item" ng-repeat="member in $ctrl.availableUsers"
+  <div class="selectable-list-item" ng-repeat="user in $ctrl.availableUsers track by user.email"
        ng-click="$ctrl.selectUser(user)">
-    {{ member.email }}
+    {{ user.email }}
   </div>
 </div>
 
@@ -70,7 +67,7 @@
     {{ $ctrl.affectedUsers }} user(s) will receive <code>VIEW</code> permissions. To add additional permissions,
     toggle them on or off in the list of permissions grants.
   </div>
-  <div class="new-acr-confirmation" ng-if="'USER' === $ctrl.newPermissionSubject">
+  <div class="new-acr-confirmation" ng-if="'USER' === $ctrl.newPermissionSubject.target">
     You are about to give {{ $ctrl.selectedPermissionsTarget.name }} <code>VIEW</code> permissions. To add
     additional permissions, toggle them on or off in the list of permissions grants.
   </div>

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -71,18 +71,12 @@
 
   <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.createNewACR">
     <div class="content">
-      <div class="new-acr-confirmation"
-           ng-if="!['USER', 'EVERYONE'].includes($ctrl.newPermissionSubject.target)">
-        You are about to add <code>VIEW</code> permissions to the {{$ctrl.newPermissionSubject.target | lowercase }}
-        {{ $ctrl.selectedPermissionsTarget.name }}.
-        {{ $ctrl.affectedUsers }} user(s) will receive <code>VIEW</code> permissions. To add additional permissions,
-        toggle them on or off in the list of permissions grants.
+      <div class="new-acr-confirmation" ng-if="!$ctrl.subjectType === 'EVERYONE'">
+        You are about to give <code>VIEW</code> permissions to {{$ctrl.newPermissionSubject.target | lowercase }}
+        {{ $ctrl.selectedPermissionsTarget.name }}. To add additional permissions, toggle them on or off in
+        the list of permissions grants.
       </div>
-      <div class="new-acr-confirmation" ng-if="'USER' === $ctrl.newPermissionSubject.target">
-        You are about to give {{ $ctrl.selectedPermissionsTarget.name }} <code>VIEW</code> permissions. To add
-        additional permissions, toggle them on or off in the list of permissions grants.
-      </div>
-      <div class="new-acr-confirmation" ng-if="'EVERYONE' === $ctrl.newPermissionSubject.target">
+      <div class="new-acr-confirmation" ng-if="'EVERYONE' === $ctrl.subjectType">
         You are about to give <em>everyone</em> <code>VIEW</code> permissions. To add
         additional permissions, toggle them on or off in the list of permissions grants.
       </div>

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -1,87 +1,110 @@
-<div class="modal-header">
-  <span> Edit permissions for {{ $ctrl.objectName }} </span>
-  <button type="button" class="close" aria-label="Close"
-          ng-click="$ctrl.dismiss()">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
 
-<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.existing">
-  <div class="permissions-table-header">
-    <span class="permission-target">
-      Grantee
-    </span>
-    <span class="permission-grant-col" ng-repeat="actionType in $ctrl.actionTypes">
-      {{ actionType }}
-    </span>
-  </div>
-  <div ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
-    <span class="permissions-object-key">
-      {{ key }}
-    </span>
-    <span class="permissions-object-marker" ng-repeat="actionType in $ctrl.actionTypes">
-      <input type="checkbox" name="{{ actionType }}" value="{{ actionType }}" ng-if="!row.includes(actionType)"
-             ng-click="$ctrl.togglePermission(actionType, key)">
-      <input type="checkbox" name="{{ actionType }}" value="{{ actionType }}" checked ng-if="row.includes(actionType)"
-             ng-click="$ctrl.togglePermission(actionType, key)">
-    </span>
-  </div>
-  <div class="new-permission-row">
-    <button class="btn btn-block" ng-click="$ctrl.setState('newPermission')">
-      Add a new permission
+<div class="modal-scrollable-body modal-sidebar-header">
+  <div class="modal-header">
+    <h4 class="modal-title">Permissions and Sharing</h4>
+    <button type="button" class="close" aria-label="Close"
+            ng-click="$ctrl.dismiss()">
+      <span aria-hidden="true">&times;</span>
     </button>
   </div>
-</div>
 
-<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.newPermission"
-     ng-if="$ctrl.state === $ctrl.states.newPermission">
-  <div>Who would you like to grant permissions to?</div>
-  <select ng-model="$ctrl.newPermissionSubject"
-          ng-options="subjectType.name for subjectType in $ctrl.subjectTypes track by subjectType.id"></select>
-  <button class="btn btn-block" disabled ng-if="$ctrl.newPermissionSubject === null">Next </button>
-  <button class="btn btn-block"
-          ng-if="$ctrl.newPermissionSubject !== null"
-          ng-click="$ctrl.handleNewPermissionSubjectSelection()">Next</button>
-</div>
-
-<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.teamSelect">
-  <div class="selectable-list-item" ng-repeat="team in $ctrl.teams"
-       ng-click="$ctrl.selectTeam(team)">
-    {{ team.name }}
+  <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.existing">
+    <div class="content">
+      <h4>{{$ctrl.objectName}}</h4>
+      <div class="dropdown btn-group selectable-list-item" uib-dropdown uib-dropdown-toggle ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
+        <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description !== null">
+          <span class="permissions-object-key font-600">
+            {{ key | limitTo:12}}
+          </span>
+          <span ng-if="row.length">Can</span>
+          <span ng-if="!row.length">Will no longer have access</span>
+          <span class="permissions-object-marker" ng-repeat="actionType in $ctrl.actionTypes">
+            <span ng-if="row.includes(actionType)">&nbsp;{{actionType}}</span>
+          </span>
+        </a>
+        <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description === null">
+          Use default val
+        </a>
+        <button type="button" class="btn dropdown-toggle">
+          <i class="icon-caret-down"></i>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+          <li role="menuitem" ng-repeat="actionType in $ctrl.actionTypes">
+            <rf-toggle value="row.includes(actionType)" on-change="$ctrl.togglePermission(actionType, key)">&nbsp;{{ actionType }}</rf-toggle>
+          </li>
+        </ul>
+      </div>
+      <div class="new-permission-row">
+        <button class="btn btn-block btn-secondary" ng-click="$ctrl.setState('newPermission')">
+          Add a new permission
+        </button>
+      </div>
+    </div>
   </div>
-</div>
 
-<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.userSelect">
-  <rf-search on-search="$ctrl.searchUsers(value)" placeholder="Search for users" auto-focus="true"></rf-searcH>
-  <div class="selectable-list-item" ng-repeat="user in $ctrl.availableUsers track by user.email"
-       ng-click="$ctrl.selectUser(user)">
-    {{ user.email }}
+  <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.newPermission">
+    <div class="content">
+      <div>Who would you like to grant permissions to?</div>
+      <select ng-model="$ctrl.newPermissionSubject"
+              ng-options="subjectType.name for subjectType in $ctrl.subjectTypes track by subjectType.id"></select>
+    </div>
   </div>
-</div>
 
-<div class="modal-content" ng-if="$ctrl.state === $ctrl.states.createNewACR">
-  <div class="new-acr-confirmation"
-       ng-if="!['USER', 'EVERYONE'].includes($ctrl.newPermissionSubject.target)">
-    You are about to add <code>VIEW</code> permissions to the {{$ctrl.newPermissionSubject.target | lowercase }}
-    {{ $ctrl.selectedPermissionsTarget.name }}.
-    {{ $ctrl.affectedUsers }} user(s) will receive <code>VIEW</code> permissions. To add additional permissions,
-    toggle them on or off in the list of permissions grants.
+  <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.teamSelect">
+    <div class="content">
+      <button class="btn btn-block selectable-list-item" ng-repeat="team in $ctrl.teams"
+           ng-click="$ctrl.selectTeam(team)">
+        {{ team.name }}
+      </button>
+    </div>
   </div>
-  <div class="new-acr-confirmation" ng-if="'USER' === $ctrl.newPermissionSubject.target">
-    You are about to give {{ $ctrl.selectedPermissionsTarget.name }} <code>VIEW</code> permissions. To add
-    additional permissions, toggle them on or off in the list of permissions grants.
-  </div>
-  <div class="new-acr-confirmation" ng-if="'EVERYONE' === $ctrl.newPermissionSubject.target">
-    You are about to give <em>everyone</em> <code>VIEW</code> permissions. To add
-    additional permissions, toggle them on or off in the list of permissions grants.
-  </div>
-</div>
 
-<div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.createNewACR">
-  <button class="btn pull-right" ng-click="$ctrl.createNewACR()">Confirm</button>
-</div>
+  <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.userSelect">
+    <div class="content">
+      <rf-search on-search="$ctrl.searchUsers(value)" placeholder="Search for users" auto-focus="true"></rf-searcH>
+      <button class="btn btn-block selectable-list-item" ng-repeat="user in $ctrl.availableUsers track by user.email"
+           ng-click="$ctrl.selectUser(user)">
+        {{ user.email }}
+      </button>
+    </div>
+  </div>
 
-<div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.existing">
-  <button class="btn pull-right" ng-click="$ctrl.updatePermissions()">Save</button>
-  <button class="btn pull-left" ng-click="$ctrl.close()">Cancel</button>
+  <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.createNewACR">
+    <div class="content">
+      <div class="new-acr-confirmation"
+           ng-if="!['USER', 'EVERYONE'].includes($ctrl.newPermissionSubject.target)">
+        You are about to add <code>VIEW</code> permissions to the {{$ctrl.newPermissionSubject.target | lowercase }}
+        {{ $ctrl.selectedPermissionsTarget.name }}.
+        {{ $ctrl.affectedUsers }} user(s) will receive <code>VIEW</code> permissions. To add additional permissions,
+        toggle them on or off in the list of permissions grants.
+      </div>
+      <div class="new-acr-confirmation" ng-if="'USER' === $ctrl.newPermissionSubject.target">
+        You are about to give {{ $ctrl.selectedPermissionsTarget.name }} <code>VIEW</code> permissions. To add
+        additional permissions, toggle them on or off in the list of permissions grants.
+      </div>
+      <div class="new-acr-confirmation" ng-if="'EVERYONE' === $ctrl.newPermissionSubject.target">
+        You are about to give <em>everyone</em> <code>VIEW</code> permissions. To add
+        additional permissions, toggle them on or off in the list of permissions grants.
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.newPermission">
+    <button class="btn pull-left" ng-click="$ctrl.setState('existing')">Back</button>
+    <button class="btn pull-right btn-primary" ng-click="$ctrl.handleNewPermissionSubjectSelection()">Next</button>
+  </div>
+
+  <div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.teamSelect || $ctrl.state === $ctrl.states.userSelect">
+    <button class="btn pull-left" ng-click="$ctrl.setState('newPermission')">Back</button>
+  </div>
+
+  <div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.createNewACR">
+    <button class="btn pull-left" ng-click="$ctrl.setState('newPermission')">Back</button>
+    <button class="btn pull-right btn-primary" ng-click="$ctrl.createNewACR()">Confirm</button>
+  </div>
+
+  <div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.existing">
+    <button class="btn pull-right btn-primary" ng-click="$ctrl.updatePermissions()">Save</button>
+    <button class="btn pull-left" ng-click="$ctrl.close()">Cancel</button>
+  </div>
 </div>

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -71,6 +71,10 @@
     You are about to give {{ $ctrl.selectedPermissionsTarget.name }} <code>VIEW</code> permissions. To add
     additional permissions, toggle them on or off in the list of permissions grants.
   </div>
+  <div class="new-acr-confirmation" ng-if="'EVERYONE' === $ctrl.newPermissionSubject.target">
+    You are about to give <em>everyone</em> <code>VIEW</code> permissions. To add
+    additional permissions, toggle them on or off in the list of permissions grants.
+  </div>
 </div>
 
 <div class="modal-footer" ng-if="$ctrl.state === $ctrl.states.createNewACR">

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -7,6 +7,14 @@
 </div>
 
 <div class="modal-content" ng-if="$ctrl.state === $ctrl.states.existing">
+  <div class="permissions-table-header">
+    <span class="permission-target">
+      Grantee
+    </span>
+    <span class="permission-grant-col" ng-repeat="actionType in $ctrl.actionTypes">
+      {{ actionType }}
+    </span>
+  </div>
   <div ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
     <span class="permissions-object-key">
       {{ key }}

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -83,16 +83,6 @@ class PermissionsModalController {
         )[0].groupId;
     }
 
-    countTeamMembers(team) {
-        return this.teamService.getMembers(
-            this.platformId, this.organizationId, team.id, 1, null
-        ).then(
-            (firstPage) => {
-                this.affectedUsers = firstPage.count;
-            }
-        );
-    }
-
     createNewACR() {
         switch (this.authTarget.objectType) {
         case 'scenes':
@@ -129,19 +119,11 @@ class PermissionsModalController {
 
     handleOrganizationSubjectSelection() {
         this.subjectType = 'ORGANIZATION';
-        this.organizationService.getMembers(
-            this.platformId, this.organizationId, 1, null
-        ).then(
-            (resp) => {
-                this.affectedUsers = resp.count;
+        this.organizationService.getOrganization(this.organizationId).then(
+            (organization) => {
+                this.selectedPermissionsTarget = organization;
+                this.setState('createNewACR');
             }
-        ).then(
-            this.organizationService.getOrganization(this.organizationId).then(
-                (organization) => {
-                    this.selectedPermissionsTarget = organization;
-                    this.setState('createNewACR');
-                }
-            )
         );
     }
 
@@ -161,7 +143,7 @@ class PermissionsModalController {
     }
 
     handleEveryoneSubjectSelection() {
-        this.subjectType = 'ALL';
+        this.subjectType = 'EVERYONE';
         this.setState('createNewACR');
     }
 
@@ -247,8 +229,8 @@ class PermissionsModalController {
                     (actionType) => {
                         return {
                             isActive: true,
-                            subjectType: key === 'Everyone' ? 'ALL' : key.split(' ')[0],
-                            subjectId: key === 'Everyone' ? null : key.split(' ')[1],
+                            subjectType: key === 'Everyone' ? 'PLATFORM' : key.split(' ')[0],
+                            subjectId: key === 'Everyone' ? this.platformId : key.split(' ')[1],
                             actionType: actionType
                         };
                     }

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -1,0 +1,264 @@
+import angular from 'angular';
+import permissionsModalTpl from './permissionsModal.html';
+import _ from 'lodash';
+
+const PermissionsModalComponent = {
+    templateUrl: permissionsModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'PermissionsModalController'
+};
+
+class PermissionsModalController {
+    constructor(authService, organizationService, permissionsService, platformService,
+                teamService, userService) {
+        'ngInject';
+
+        // services
+        this.authService = authService;
+        this.organizationService = organizationService;
+        this.permissionsService = permissionsService;
+        this.platformService = platformService;
+        this.teamService = teamService;
+        this.userService = userService;
+
+        // data
+        this.defaultActions = ['VIEW', 'EDIT', 'DELETE'];
+        this.newPermissionSubject = null;
+        this.subjectTypes = {
+            EVERYONE: {
+                name: 'Everyone',
+                target: 'EVERYONE',
+                id: 0
+            },
+            TEAM: {
+                name: 'One of my teams',
+                target: 'TEAM',
+                id: 1
+            },
+            USER: {
+                name: 'A user',
+                target: 'USER',
+                id: 2
+            },
+            ORGANIZATION: {
+                name: 'My organization',
+                target: 'ORGANIZATION',
+                id: 3
+            }
+        };
+        this.states = {
+            existing: 'EXISTINGPERMISSIONS',
+            newPermission: 'NEWPERMISSION',
+            choosePermissions: 'CHOOSEPERMISSIONS',
+            organizationSelect: 'ORGANIZATIONSELECT',
+            teamSelect: 'TEAMSELECT',
+            userSelect: 'USERSELECT',
+            createNewACR: 'CREATENEWACR'
+        };
+        this.state = this.states.existing;
+    }
+
+    $onInit() {
+        this.accessControlRules = [];
+        this.actionTypes = [...this.defaultActions, ...this.resolve.extraActions];
+        this.authTarget = {
+            objectType: this.resolve.objectType,
+            objectId: this.resolve.object.id
+        };
+
+        this.objectId = this.resolve.object.id;
+        this.objectName = this.resolve.objectName;
+
+        this.fetchPermissions();
+        this.allRoles = this.authService.getUserRoles();
+
+        this.organizationId = this.allRoles.filter(
+            (role) => role.groupType === 'ORGANIZATION'
+        )[0].groupId;
+        this.platformId = this.allRoles.filter(
+            (role) => role.groupType === 'PLATFORM'
+        )[0].groupId;
+    }
+
+    countTeamMembers(team) {
+        return this.teamService.getMembers(
+            this.platformId, this.organizationId, team.id, 1, null
+        ).then(
+            (firstPage) => {
+                this.affectedUsers = firstPage.count;
+            }
+        );
+    }
+
+    createNewACR() {
+        switch (this.authTarget.objectType) {
+        case 'scenes':
+            this.permissionsService.create(
+                this.authTarget,
+                {
+                    isActive: true,
+                    subjectType: this.subjectType,
+                    subjectId: this.selectedPermissionsTarget.id,
+                    actionType: 'VIEW'
+                }
+            ).then(
+                (accessControlRules) => {
+                    this.setAccessControlRuleRows(accessControlRules);
+                    this.setState('existing');
+                }
+            );
+            break;
+        default:
+            break;
+        }
+        return;
+    }
+
+    fetchPermissions() {
+        return this.permissionsService.query(this.authTarget).$promise.then(
+            (permissions) => {
+                this.setAccessControlRuleRows(permissions);
+            }
+        );
+    }
+
+    handleOrganizationSubjectSelection() {
+        this.subjectType = 'ORGANIZATION';
+        this.organizationService.getMembers(
+            this.platformId, this.organizationId, 1, null
+        ).then(
+            (resp) => {
+                this.affectedUsers = resp.count;
+            }
+        ).then(
+            this.organizationService.getOrganization(this.organizationId).then(
+                (organization) => {
+                    this.selectedPermissionsTarget = organization;
+                    this.setState('createNewACR');
+                }
+            )
+        );
+    }
+
+    handleTeamSubjectSelection() {
+        this.subjectType = 'TEAM';
+        this.userService.getTeams().then(
+            (teams) => {
+                this.teams = teams;
+                this.setState('teamSelect');
+            }
+        );
+    }
+
+    handleUserSubjectSelection() {
+        this.setState('userSelect');
+    }
+
+    handleNewPermissionSubjectSelection() {
+        switch (this.newPermissionSubject.target) {
+        case 'EVERYONE':
+            this.setState('choosePermissions');
+            this.subjectType = 'ALL';
+            break;
+        case 'ORGANIZATION':
+            this.handleOrganizationSubjectSelection();
+            break;
+        case 'TEAM':
+            this.handleTeamSubjectSelection();
+            break;
+        default:
+            this.handleUserSubjectSelection();
+        }
+    }
+
+    searchUsers(value) {
+        if (value && value.length >= 4) {
+            this.platformService.getMembers(
+                this.platformId, 1, value
+            ).then(
+                (resp) => {
+                    this.availableUsers = resp.results;
+                }
+            );
+        } else {
+            this.availableUsers = [];
+        }
+    }
+
+    selectTeam(team) {
+        this.selectedPermissionsTarget = team;
+        this.countTeamMembers(this.selectedPermissionsTarget);
+        this.setState('createNewACR');
+    }
+
+    selectUser(user) {
+        this.selectedPermissionsTarget = Object.assign(user, {name: user.email});
+        this.setState('createNewACR');
+    }
+
+    setAccessControlRuleRows(accessControlRules) {
+        this.accessControlRuleRows = _.mapValues(
+            _.groupBy(
+                accessControlRules,
+                (acr) => this.toTitle(acr.subjectType, acr.subjectId)
+            ),
+            (acrList) => _.map(acrList, (acr) => acr.actionType)
+        );
+    }
+
+    setState(newState) {
+        this.state = this.states[newState];
+    }
+
+    togglePermission(actionType, objectKey) {
+        const existingActions = this.accessControlRuleRows[objectKey];
+        const newRows = existingActions.includes(actionType) ?
+              existingActions.filter(action => action !== actionType) :
+              [...existingActions, actionType];
+        this.accessControlRuleRows[objectKey] = newRows;
+    }
+
+    toTitle(subjectType, subjectId) {
+        return subjectType === 'ALL' && subjectId === null ?
+            'Everyone' :
+            `${subjectType} ${subjectId}`;
+    }
+
+    updatePermissions() {
+        let rules = [];
+        for (let key in this.accessControlRuleRows) {
+            if (this.accessControlRuleRows.hasOwnProperty(key)) {
+                let transformed = _.map(
+                    this.accessControlRuleRows[key],
+                    (actionType) => {
+                        return {
+                            isActive: true,
+                            subjectType: key.split(' ')[0],
+                            subjectId: key.split(' ')[1],
+                            actionType: actionType
+                        };
+                    }
+                );
+                rules = [...rules, ...transformed];
+            }
+        }
+        this.permissionsService.update(
+            this.authTarget,
+            rules
+        ).then(
+            () => this.close()
+        );
+    }
+}
+
+const PermissionsModalModule = angular.module('components.permissions.permissionsModal', []);
+
+PermissionsModalModule.component('permissionsModal', PermissionsModalComponent);
+PermissionsModalModule.controller('PermissionsModalController', PermissionsModalController);
+
+export default PermissionsModalModule;

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -179,6 +179,7 @@ class PermissionsModalController {
         default:
             this.handleUserSubjectSelection();
         }
+        this.newPermissionSubject = null;
     }
 
     searchUsers(value) {

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -156,6 +156,7 @@ class PermissionsModalController {
     }
 
     handleUserSubjectSelection() {
+        this.subjectType = 'USER';
         this.setState('userSelect');
     }
 
@@ -179,10 +180,12 @@ class PermissionsModalController {
     searchUsers(value) {
         if (value && value.length >= 4) {
             this.platformService.getMembers(
-                this.platformId, 1, value
+                this.platformId, 0, value
             ).then(
                 (resp) => {
-                    this.availableUsers = resp.results;
+                    this.availableUsers = _.uniqBy(resp.results, (user) => {
+                        return user.email;
+                    });
                 }
             );
         } else {
@@ -199,6 +202,7 @@ class PermissionsModalController {
     selectUser(user) {
         this.selectedPermissionsTarget = Object.assign(user, {name: user.email});
         this.setState('createNewACR');
+        this.availableUsers = [];
     }
 
     setAccessControlRuleRows(accessControlRules) {

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -54,8 +54,6 @@ class PermissionsModalController {
         this.states = {
             existing: 'EXISTINGPERMISSIONS',
             newPermission: 'NEWPERMISSION',
-            choosePermissions: 'CHOOSEPERMISSIONS',
-            organizationSelect: 'ORGANIZATIONSELECT',
             teamSelect: 'TEAMSELECT',
             userSelect: 'USERSELECT',
             createNewACR: 'CREATENEWACR'
@@ -103,7 +101,9 @@ class PermissionsModalController {
                 {
                     isActive: true,
                     subjectType: this.subjectType,
-                    subjectId: this.selectedPermissionsTarget.id,
+                    subjectId: this.selectedPermissionsTarget ?
+                        this.selectedPermissionsTarget.id :
+                        null,
                     actionType: 'VIEW'
                 }
             ).then(
@@ -160,11 +160,15 @@ class PermissionsModalController {
         this.setState('userSelect');
     }
 
+    handleEveryoneSubjectSelection() {
+        this.subjectType = 'ALL';
+        this.setState('createNewACR');
+    }
+
     handleNewPermissionSubjectSelection() {
         switch (this.newPermissionSubject.target) {
         case 'EVERYONE':
-            this.setState('choosePermissions');
-            this.subjectType = 'ALL';
+            this.handleEveryoneSubjectSelection();
             break;
         case 'ORGANIZATION':
             this.handleOrganizationSubjectSelection();
@@ -242,8 +246,8 @@ class PermissionsModalController {
                     (actionType) => {
                         return {
                             isActive: true,
-                            subjectType: key.split(' ')[0],
-                            subjectId: key.split(' ')[1],
+                            subjectType: key === 'Everyone' ? 'ALL' : key.split(' ')[0],
+                            subjectId: key === 'Everyone' ? null : key.split(' ')[1],
                             actionType: actionType
                         };
                     }

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -256,12 +256,20 @@ class PermissionsModalController {
                 rules = [...rules, ...transformed];
             }
         }
-        this.permissionsService.update(
-            this.authTarget,
-            rules
-        ).then(
-            () => this.close()
-        );
+        if (rules.length) {
+            this.permissionsService.update(
+                this.authTarget,
+                rules
+            ).then(
+                () => this.close()
+            );
+        } else {
+            this.permissionsService.delete(
+                this.authTarget
+            ).then(
+                () => this.close()
+            );
+        }
     }
 }
 

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -31,6 +31,12 @@ class ImportListController {
         this.populateImportList(this.$state.params.page || 1);
         this.sceneActions = [
             {
+                label: 'Modify permissions',
+                onClick: this.shareModal.bind(this),
+                buttonClass: 'btn-danger',
+                iconClass: 'icon-download'
+            },
+            {
                 label: 'Download',
                 onClick: this.downloadModal.bind(this),
                 iconClass: 'icon-download'
@@ -95,6 +101,18 @@ class ImportListController {
             component: 'rfSceneDownloadModal',
             resolve: {
                 scene: () => scene
+            }
+        });
+    }
+
+    shareModal(scene) {
+        this.modalService.open({
+            component: 'permissionsModal',
+            resolve: {
+                object: () => scene,
+                objectType: () => 'scenes',
+                objectName: () => scene.name,
+                extraActions: () => []
             }
         });
     }

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -1,5 +1,8 @@
 /* eslint-disable */
 export default angular.module('index.components', [
+    // permission components
+    require('./components/permissions/permissionsModal.module.js').name,
+
     // scene components
     require('./components/scenes/importList/importList.module.js').name,
     require('./components/scenes/sceneItem/sceneItem.module.js').name,

--- a/app-frontend/src/app/services/auth/permissions.service.js
+++ b/app-frontend/src/app/services/auth/permissions.service.js
@@ -24,6 +24,9 @@ export default (app) => {
                         cache: false,
                         isArray: true,
                         transformRequest: (reqBody) => angular.toJson(reqBody.rules)
+                    },
+                    delete: {
+                        method: 'DELETE'
                     }
                 }
             );
@@ -44,6 +47,14 @@ export default (app) => {
                 Object.assign(
                     {rules: accessControlRuleCreates},
                     {objectType: objectType, objectId: objectId}
+                )
+            ).$promise;
+        }
+
+        delete({objectType, objectId}) {
+            return this.Permissions.delete(
+                Object.assign(
+                    { objectType, objectId }
                 )
             ).$promise;
         }

--- a/app-frontend/src/app/services/auth/permissions.service.js
+++ b/app-frontend/src/app/services/auth/permissions.service.js
@@ -1,0 +1,53 @@
+/* globals BUILDCONFIG */
+
+import angular from 'angular';
+
+export default (app) => {
+    class PermissionsService {
+        constructor($resource) {
+            this.Permissions = $resource(
+                `${BUILDCONFIG.API_HOST}/api/:objectType/:objectId/permissions`, {
+                    objectType: '@objectType',
+                    objectId: '@objectId'
+                }, {
+                    query: {
+                        method: 'GET',
+                        cache: false,
+                        isArray: true
+                    },
+                    create: {
+                        method: 'POST',
+                        isArray: true
+                    },
+                    update: {
+                        method: 'PUT',
+                        cache: false,
+                        isArray: true,
+                        transformRequest: (reqBody) => angular.toJson(reqBody.rules)
+                    }
+                }
+            );
+        }
+
+        query({objectType, objectId}) {
+            return this.Permissions.query({objectType: objectType, objectId: objectId});
+        }
+
+        create({objectType, objectId}, accessControlRuleCreate) {
+            return this.Permissions.create(
+                Object.assign(accessControlRuleCreate, {objectType: objectType, objectId: objectId})
+            ).$promise;
+        }
+
+        update({objectType, objectId}, accessControlRuleCreates) {
+            return this.Permissions.update(
+                Object.assign(
+                    {rules: accessControlRuleCreates},
+                    {objectType: objectType, objectId: objectId}
+                )
+            ).$promise;
+        }
+    }
+
+    app.service('permissionsService', PermissionsService);
+};

--- a/app-frontend/src/app/services/auth/user.service.js
+++ b/app-frontend/src/app/services/auth/user.service.js
@@ -29,6 +29,12 @@ export default (app) => {
                 update: {
                     method: 'PUT',
                     cache: false
+                },
+                getTeams: {
+                    url: `${BUILDCONFIG.API_HOST}/api/users/me/teams`,
+                    method: 'GET',
+                    cache: false,
+                    isArray: true
                 }
             });
         }
@@ -54,6 +60,10 @@ export default (app) => {
                     }, (err) => reject(err));
                 }, (err) => reject(err));
             });
+        }
+
+        getTeams() {
+            return this.User.getTeams().$promise;
         }
     }
 

--- a/app-frontend/src/app/services/services.module.js
+++ b/app-frontend/src/app/services/services.module.js
@@ -14,6 +14,7 @@ require('./auth/user.service')(shared);
 require('./auth/platform.service.js')(shared);
 require('./auth/organization.service.js')(shared);
 require('./auth/team.service.js')(shared);
+require('./auth/permissions.service.js')(shared);
 
 // settings
 require('./settings/config.provider')(shared);

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3040,3 +3040,21 @@ rf-reclassify-table {
   text-transform: uppercase;
   font-size: 1rem;
 }
+
+.permission-grant-item {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  margin-bottom: 0.5rem;
+  background: #fff;
+  display: flex;
+}
+
+.permissions-object-key {
+  margin-right: 1rem;
+  flex: 1;
+}
+
+.selectable-list-item {
+  margin-bottom: 0.5rem;
+  text-align: left;
+}

--- a/app-frontend/src/assets/styles/sass/components/_form.scss
+++ b/app-frontend/src/assets/styles/sass/components/_form.scss
@@ -203,6 +203,7 @@ input[type=radio] {
   .btn-link {
     border: none;
     position: absolute;
+    top: 0;
     right: 0;
     padding: 0.7em;
     color: $shade-light;


### PR DESCRIPTION
## Overview

This PR adds a barebones, ugly, unstyled permissions modal for adding permissions to first-class objects. It handles:

- [x] adding a new permission
- [x] updating permissions that are already defined
- [x] removing permissions
- [x] additional action types depending on context
- [x] sharing with a user's organization
- [x] sharing with teams a user is a member of
- [x] sharing with other users in a user's platform (blocked by #3452 but it should work)
- [x] sharing with everyone

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

### Notes

It's ugly I know I know there are classes in place to target for styling I'm sorry it's so ugly right now.

More importantly:

it doesn't really respect the designs we have, for two reasons. The first is that we didn't know they
existed when I started. The second is that, since our permissions are non-hierarchical and require
support for context-sensitive types of actions (annotating projects, downloading scenes...), the
single permission dropdown didn't really make sense as a strategy for creating grants. There's 
more work to be done here to work out how we're going to get everything tied together, but
this is a first cut.

Also I'm not sure about the `CONFIRM` workflow -- I think probably it's worth checking, since I think gmail makes you confirm that you intend to give someone permissions, and that's our inspiration to
some extent. But also it seems maybe cumbersome? Like I don't know if that's going to annoy people
or make them think that we're taking their data security seriously.

I'll rebase out the dumb button in the raster list before merging once we figure out how to get into
this context.

## Testing Instructions

 * make some teams and add your dev user to them ([these instructions](https://github.com/azavea/raster-foundry-platform/wiki/Managing-platforms-and-user-roles) may be helpful) 
 * go to your raster list area
 * click on the red download button (I just reused the icon because it's probably going away anyway)
 * add a new permission for teams or orgs
 * confirm that you want to add them
 * examine your new permissions table and confirm it respected your wishes
 * add more permissions and confirm results are what you'd expect

Closes #3384 
