### PR TITLE
Move authorization query to inner join

### DIFF
--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -60,8 +60,9 @@ trait DatasourceRoutes extends Authentication
   def listDatasources: Route = authenticate { user =>
     (withPagination & datasourceQueryParams) { (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
       complete {
-        DatasourceDao.query.filter(datasourceParams)
-          .authorize(user, ObjectType.Datasource, ActionType.View)
+        DatasourceDao
+          .authQuery(user, ObjectType.Datasource)
+          .filter(datasourceParams)
           .page(page)
           .transact(xa).unsafeToFuture
       }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -281,8 +281,9 @@ trait ProjectRoutes extends Authentication
   def listProjects: Route = authenticate { user =>
     (withPagination & projectQueryParameters) { (page, projectQueryParameters) =>
       complete {
-        ProjectDao.query.filter(projectQueryParameters)
-          .authorize(user, ObjectType.Project, ActionType.View)
+        ProjectDao
+          .authQuery(user, ObjectType.Project)
+          .filter(projectQueryParameters)
           .page(page)
           .transact(xa).unsafeToFuture
       }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -129,8 +129,9 @@ trait ShapeRoutes extends Authentication
   def listShapes: Route = authenticate { user =>
     (withPagination & shapeQueryParams) { (page: PageRequest, queryParams: ShapeQueryParameters) =>
       complete {
-        ShapeDao.query.filter(queryParams)
-          .authorize(user, ObjectType.Shape, ActionType.View)
+        ShapeDao
+          .authQuery(user, ObjectType.Shape)
+          .filter(queryParams)
           .page(page)
           .transact(xa).unsafeToFuture().map { p => {
             fromPaginatedResponseToGeoJson[Shape, Shape.GeoJSON](p)

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -67,9 +67,9 @@ trait ToolRunRoutes extends Authentication
   def listToolRuns: Route = authenticate { user =>
     (withPagination & toolRunQueryParameters) { (page, runParams) =>
       complete {
-        ToolRunDao.query
+        ToolRunDao
+          .authQuery(user, ObjectType.Analysis)
           .filter(runParams)
-          .authorize(user, ObjectType.Analysis, ActionType.View)
           .page(page)
           .transact(xa).unsafeToFuture
       }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -121,9 +121,9 @@ trait ToolRoutes extends Authentication
   def listTools: Route = authenticate { user =>
     (withPagination & combinedToolQueryParams) { (page, combinedToolQueryParameters) =>
       complete {
-        ToolDao.query
+        ToolDao
+          .authQuery(user, ObjectType.Template)
           .filter(combinedToolQueryParameters)
-          .authorize(user, ObjectType.Template, ActionType.View)
           .page(page)
           .transact(xa).unsafeToFuture
       }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -86,10 +86,10 @@ case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) ex
       val alreadyCheckedFilter: Option[Fragment] = Some(fr"created_at > ${lastChecked}")
       val acquisitionFilter: Option[Fragment] = Some(fr"acquisition_date > ${startTime}")
       val areaFilter: Option[Fragment] = Some(fr"st_intersects(data_footprint, ${geom})")
-      SceneWithRelatedDao.query
+      SceneWithRelatedDao
+        .authQuery(user, ObjectType.Scene)
         .filter(geom)
         .filter(queryParams.getOrElse(CombinedSceneQueryParams()))
-        .authorize(user, ObjectType.Scene, ActionType.View)
         .list
         .map { (scenes: List[Scene.WithRelated]) => scenes map { _.id } }
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
@@ -76,7 +76,7 @@ object AoiDao extends Dao[AOI] {
     query.filter(fr"project_id = ${projectId}").page(page)
 
   def listAuthorizedAois(user: User, aoiQueryParams: AoiQueryParameters, page: PageRequest): ConnectionIO[PaginatedResponse[AOI]] = {
-    val authedProjectsIO = ProjectDao.query.authorize(user, ObjectType.Project, ActionType.View).list
+    val authedProjectsIO = ProjectDao.authQuery(user, ObjectType.Project).list
     for {
       authedProjects <- authedProjectsIO
       authedProjectIdsF = (authedProjects map { _.id }).toNel map {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -30,6 +30,32 @@ abstract class Dao[Model: Composite] extends Filterables {
   /** Begin construction of a complex, filtered query */
   def query: Dao.QueryBuilder[Model] = Dao.QueryBuilder[Model](selectF, tableF, List.empty)
 
+  def authQuery(user: User, objectType: ObjectType): Dao.QueryBuilder[Model] =
+    Dao.QueryBuilder[Model](selectF, tableF ++ authTableF(user, objectType), List.empty)
+
+  def authTableF(user: User, objectType: ObjectType): Fragment =
+    fr"""INNER JOIN (
+      SELECT id as object_id FROM""" ++ tableF ++ fr"""WHERE owner = ${user.id}
+
+      UNION ALL
+
+      SELECT acr.object_id
+      FROM access_control_rules acr
+      WHERE acr.object_type = ${objectType}
+        AND acr.action_type = ${ActionType.View.toString}::action_type
+        AND -- Match if the ACR is an ALL or per user
+        (acr.subject_type = 'ALL' OR (acr.subject_type = 'USER' AND acr.subject_id = ${user.id}))
+
+      UNION ALL -- Collect objects the user has access to for group permissions
+
+      SELECT acr.object_id
+      FROM access_control_rules acr
+      JOIN user_group_roles ugr ON acr.subject_type::text = ugr.group_type::text
+      AND acr.subject_id::text = ugr.group_id::text
+      WHERE ugr.user_id = ${user.id}
+       AND acr.object_type = ${objectType}
+       AND acr.action_type = ${ActionType.View.toString}::action_type) as object_ids ON""" ++
+      Fragment.const(s"${tableName}.id") ++ fr"= object_ids.object_id"
 }
 
 object Dao {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -31,7 +31,7 @@ abstract class Dao[Model: Composite] extends Filterables {
   def query: Dao.QueryBuilder[Model] = Dao.QueryBuilder[Model](selectF, tableF, List.empty)
 
   def authQuery(user: User, objectType: ObjectType): Dao.QueryBuilder[Model] =
-    Dao.QueryBuilder[Model](selectF ++ authTableF(user, objectType), tableF ++ authTableF(user, objectType), List.empty, tableName)
+    Dao.QueryBuilder[Model](selectF ++ authTableF(user, objectType), tableF ++ authTableF(user, objectType), List.empty)
 
   def authTableF(user: User, objectType: ObjectType): Fragment =
     fr"""INNER JOIN (

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -31,7 +31,7 @@ abstract class Dao[Model: Composite] extends Filterables {
   def query: Dao.QueryBuilder[Model] = Dao.QueryBuilder[Model](selectF, tableF, List.empty)
 
   def authQuery(user: User, objectType: ObjectType): Dao.QueryBuilder[Model] =
-    Dao.QueryBuilder[Model](selectF, tableF ++ authTableF(user, objectType), List.empty)
+    Dao.QueryBuilder[Model](selectF ++ authTableF(user, objectType), tableF ++ authTableF(user, objectType), List.empty, tableName)
 
   def authTableF(user: User, objectType: ObjectType): Fragment =
     fr"""INNER JOIN (

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/MapTokenDao.scala
@@ -66,8 +66,9 @@ object MapTokenDao extends Dao[MapToken] {
   } yield { authTuple._1 || authTuple._2 }
 
   def listAuthorizedMapTokens(user: User, mapTokenParams: CombinedMapTokenQueryParameters, page: PageRequest): ConnectionIO[PaginatedResponse[MapToken]] = {
-    val authedProjectsIO = ProjectDao.query.authorize(user, ObjectType.Project, ActionType.View).list
-    val authedAnalysesIO = ToolRunDao.query.authorize(user, ObjectType.Analysis, ActionType.View).list
+    val authedProjectsIO = ProjectDao.authQuery(user, ObjectType.Project).list
+    val authedAnalysesIO = ToolRunDao.authQuery(user, ObjectType.Analysis).list
+
     for {
       projAndAnalyses <- (authedProjectsIO, authedAnalysesIO).tupled
       (authedProjects, authedAnalyses) = projAndAnalyses

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -45,10 +45,10 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
       case _ => None.pure[ConnectionIO]
     }
     sceneSearchBuilder = {
-      SceneDao.query
+      SceneDao
+        .authQuery(user, ObjectType.Scene)
         .filter(shapeO map { _.geometry })
         .filter(sceneParams)
-        .authorize(user, ObjectType.Scene, ActionType.View)
     }
     scenes <- sceneSearchBuilder.list(pageRequest.offset, pageRequest.limit)
     withRelateds <- scenesToScenesWithRelated(scenes)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -71,10 +71,10 @@ trait PropTestHelpers {
   // We assume the Scene.Create has an id, since otherwise thumbnails have no idea what scene id to use
   def fixupSceneCreate(user: User, datasource: Datasource, sceneCreate: Scene.Create): Scene.Create = {
     sceneCreate.copy(
-      owner = None,
+      owner = Some(user.id),
       datasource = datasource.id,
       images = sceneCreate.images map {
-        _.copy(scene = sceneCreate.id.get, owner = None)
+        _.copy(scene = sceneCreate.id.get, owner = Some(user.id))
       },
       thumbnails = sceneCreate.thumbnails map {
         _.copy(sceneId = sceneCreate.id.get)


### PR DESCRIPTION
## Overview

This PR moves auth logic into an `INNER JOIN` and out of a subquery.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

### Notes

New strings are exercised in the `SceneWithRelatedDaoSpec`

This still needs migrations.

## Testing Instructions

 * Log in to the app
 * List projects
 * Note that you see the correct projects and that you don't see a nice 400 line stack trace from invalid sql