### PR TITLE
Add COG/MODIS upload handling

### DIFF
--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -105,6 +105,9 @@ trait Router extends HealthCheckRoutes
       pathPrefix("datasources") {
         datasourceRoutes
       } ~
+      pathPrefix("thumbnails") {
+        thumbnailImageRoutes
+      } ~
       pathPrefix("map-tokens") {
         mapTokenRoutes
       } ~

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -120,7 +120,26 @@ trait SceneRoutes extends Authentication
 
   def createScene: Route = authenticate { user =>
     entity(as[Scene.Create]) { newScene =>
-      onSuccess(SceneDao.insert(newScene, user).transact(xa).unsafeToFuture) { scene =>
+
+      val tileFootprint = (newScene.sceneType, newScene.ingestLocation, newScene.tileFootprint) match {
+        case (Some(SceneType.COG), Some(ingestLocation), None) => {
+          logger.info(s"Generating Footprint for Newly Added COG")
+          CogUtils.getTiffExtent(ingestLocation)
+        }
+        case _ => {
+          logger.info("Not generating footprint, already exists")
+          None
+        }
+      }
+
+      val dataFootprint = (tileFootprint, newScene.dataFootprint) match {
+        case (Some(tf), None) => tileFootprint
+        case _ => newScene.dataFootprint
+      }
+
+      val updatedScene = newScene.copy(dataFootprint = dataFootprint, tileFootprint = tileFootprint)
+
+      onSuccess(SceneDao.insert(updatedScene, user).transact(xa).unsafeToFuture) { scene =>
         if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested) kickoffSceneIngest(scene.id)
         complete((StatusCodes.Created, scene))
       }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -93,6 +93,7 @@ trait UploadRoutes extends Authentication
           else throw new IllegalStateException("Planet upload must specify some ids")
         }
         case (UploadType.Local, _) => newUpload
+        case (UploadType.Modis, _) => newUpload
         case _ => throw new IllegalStateException("Unsupported import type")
       }
 


### PR DESCRIPTION
## Overview

Adds functionality that was accidentally rebased over

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] PR has a name that won't get you publicly shamed for vagueness~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Testing

#### Modis
 - Create a project
 - Attempt to add MODIS scenes, should not fail

#### COGs
 - Create a project
 - Add a COG scene (use 4 band planetscope) when given the opportunity (remote: http://radiant-nasa-iserv.s3-us-west-2.amazonaws.com/2014/02/06/IP0201402061342550633S03899E/IP0201402061342550633S03899E-COG.tif)
 - Browse project/scene - verify it has a data footprint

#### Refresh Tokens
 - Get a refresh token
 - Use refresh token to get a JWT (`POST` `{refreshToken: <>}` to `/api/tokens/`)
 - Use returned JWT to request `/api/projects/` - should not error

Closes #3466