### PR TITLE
Fix creating EVERYONE permissions

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -108,10 +108,10 @@ trait SceneRoutes extends Authentication
               listUserSceneActions(sceneId)
             }
           }
-        } ~
-          pathPrefix("datasource") {
-            pathEndOrSingleSlash { getSceneDatasource(sceneId) }
-          }
+        }
+      } ~
+      pathPrefix("datasource") {
+        pathEndOrSingleSlash { getSceneDatasource(sceneId) }
       }
     }
   }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -96,6 +96,9 @@ trait SceneRoutes extends Authentication
           traceName("list-scene-permissions") {
             listScenePermissions(sceneId)
           }
+        } ~
+        delete {
+          deleteScenePermissions(sceneId)
         }
       } ~
       pathPrefix("actions") {
@@ -104,9 +107,6 @@ trait SceneRoutes extends Authentication
             traceName("list-user-allowed-actions") {
               listUserSceneActions(sceneId)
             }
-          } ~
-          delete {
-            deleteScenePermissions(sceneId)
           }
         } ~
           pathPrefix("datasource") {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -37,7 +37,7 @@ abstract class Dao[Model: Composite] extends Filterables {
     fr"""INNER JOIN (
       SELECT id as object_id FROM""" ++ tableF ++ fr"""WHERE owner = ${user.id}
 
-      UNION ALL
+      UNION
 
       SELECT acr.object_id
       FROM access_control_rules acr
@@ -46,7 +46,7 @@ abstract class Dao[Model: Composite] extends Filterables {
         AND -- Match if the ACR is an ALL or per user
         (acr.subject_type = 'ALL' OR (acr.subject_type = 'USER' AND acr.subject_id = ${user.id}))
 
-      UNION ALL -- Collect objects the user has access to for group permissions
+      UNION -- Collect objects the user has access to for group permissions
 
       SELECT acr.object_id
       FROM access_control_rules acr

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -1,7 +1,8 @@
 
 <div class="modal-scrollable-body modal-sidebar-header">
   <div class="modal-header">
-    <h4 class="modal-title">Permissions and Sharing</h4>
+    <h4 class="modal-title">Permissions</h4>
+    <h6 class="modal-title" ng-attr-title="{{$ctrl.objectName}}">{{$ctrl.objectName}}</h6>
     <button type="button" class="close" aria-label="Close"
             ng-click="$ctrl.dismiss()">
       <span aria-hidden="true">&times;</span>
@@ -10,7 +11,6 @@
 
   <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.existing">
     <div class="content">
-      <h4>{{$ctrl.objectName}}</h4>
       <div class="dropdown btn-group selectable-list-item" uib-dropdown uib-dropdown-toggle ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
         <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description !== null">
           <span class="permissions-object-key font-600">
@@ -34,11 +34,21 @@
           </li>
         </ul>
       </div>
-      <div class="new-permission-row">
+      <div class="new-permission-row" ng-if="!$ctrl.showShowNonIdealState()">
         <button class="btn btn-block btn-secondary" ng-click="$ctrl.setState('newPermission')">
           Add a new permission
         </button>
       </div>
+      <rf-call-to-action-item
+        title="No permissions are currently configured"
+        class="panel panel-off-white"
+        ng-if="$ctrl.showShowNonIdealState()">
+        <p class="pb-25">
+          Without any permissions, only you will be able to see or interact with <span class="font-600">{{ $ctrl.objectName }}</span>.
+        </p>
+
+        <a class="btn btn-primary" ng-click="$ctrl.setState('newPermission')">Add a new permission</a>
+      </rf-call-to-action-item>
     </div>
   </div>
 

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -71,12 +71,12 @@
 
   <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.createNewACR">
     <div class="content">
-      <div class="new-acr-confirmation" ng-if="!$ctrl.subjectType === 'EVERYONE'">
+      <div class="new-acr-confirmation" ng-if="$ctrl.subjectType !== 'PLATFORM'">
         You are about to give <code>VIEW</code> permissions to {{$ctrl.newPermissionSubject.target | lowercase }}
         {{ $ctrl.selectedPermissionsTarget.name }}. To add additional permissions, toggle them on or off in
         the list of permissions grants.
       </div>
-      <div class="new-acr-confirmation" ng-if="'EVERYONE' === $ctrl.subjectType">
+      <div class="new-acr-confirmation" ng-if="$ctrl.subjectType === 'PLATFORM'">
         You are about to give <em>everyone</em> <code>VIEW</code> permissions. To add
         additional permissions, toggle them on or off in the list of permissions grants.
       </div>

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -11,6 +11,12 @@
 
   <div class="modal-body" ng-if="$ctrl.state === $ctrl.states.existing">
     <div class="content">
+      <div class="dashboard-header" ng-if="!$ctrl.showShowNonIdealState()">
+        <div class="flex-fill"></div>
+        <button class="btn btn-primary" ng-click="$ctrl.setState('newPermission')">
+          Add Permission
+        </button>
+      </div>
       <div class="dropdown btn-group selectable-list-item" uib-dropdown uib-dropdown-toggle ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
         <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description !== null">
           <span class="permissions-object-key font-600">
@@ -26,7 +32,7 @@
           Use default val
         </a>
         <button type="button" class="btn dropdown-toggle">
-          <i class="icon-caret-down"></i>
+          <i class="icon-edit"></i>
         </button>
         <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
           <li role="menuitem" ng-repeat="actionType in $ctrl.actionTypes">
@@ -34,11 +40,7 @@
           </li>
         </ul>
       </div>
-      <div class="new-permission-row" ng-if="!$ctrl.showShowNonIdealState()">
-        <button class="btn btn-block btn-secondary" ng-click="$ctrl.setState('newPermission')">
-          Add a new permission
-        </button>
-      </div>
+
       <rf-call-to-action-item
         title="No permissions are currently configured"
         class="panel panel-off-white"

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -65,7 +65,7 @@ class PermissionsModalController {
         this.accessControlRules = [];
         this.actionTypes = [...this.defaultActions, ...this.resolve.extraActions];
         this.authTarget = {
-            objectType: this.resolve.objectType,
+            permissionsBase: this.resolve.permissionsBase,
             objectId: this.resolve.object.id
         };
 
@@ -84,29 +84,22 @@ class PermissionsModalController {
     }
 
     createNewACR() {
-        switch (this.authTarget.objectType) {
-        case 'scenes':
-            this.permissionsService.create(
-                this.authTarget,
-                {
-                    isActive: true,
-                    subjectType: this.subjectType,
-                    subjectId: this.selectedPermissionsTarget ?
-                        this.selectedPermissionsTarget.id :
-                        null,
-                    actionType: 'VIEW'
-                }
-            ).then(
-                (accessControlRules) => {
-                    this.setAccessControlRuleRows(accessControlRules);
-                    this.setState('existing');
-                }
-            );
-            break;
-        default:
-            break;
-        }
-        return;
+        return this.permissionsService.create(
+            this.authTarget,
+            {
+                isActive: true,
+                subjectType: this.subjectType,
+                subjectId: this.subjectType === 'PLATFORM' ?
+                    this.platformId :
+                    this.selectedPermissionsTarget.id,
+                actionType: 'VIEW'
+            }
+        ).then(
+            (accessControlRules) => {
+                this.setAccessControlRuleRows(accessControlRules);
+                this.setState('existing');
+            }
+        );
     }
 
     fetchPermissions() {
@@ -143,7 +136,7 @@ class PermissionsModalController {
     }
 
     handleEveryoneSubjectSelection() {
-        this.subjectType = 'EVERYONE';
+        this.subjectType = 'PLATFORM';
         this.setState('createNewACR');
     }
 

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -83,6 +83,10 @@ class PermissionsModalController {
         )[0].groupId;
     }
 
+    showShowNonIdealState() {
+        return !Object.keys(this.accessControlRuleRows).length || true;
+    }
+
     createNewACR() {
         return this.permissionsService.create(
             this.authTarget,
@@ -175,7 +179,6 @@ class PermissionsModalController {
 
     selectTeam(team) {
         this.selectedPermissionsTarget = team;
-        this.countTeamMembers(this.selectedPermissionsTarget);
         this.setState('createNewACR');
     }
 

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -84,7 +84,10 @@ class PermissionsModalController {
     }
 
     showShowNonIdealState() {
-        return !Object.keys(this.accessControlRuleRows).length || true;
+        if (this.accessControlRuleRows) {
+            return !Object.keys(this.accessControlRuleRows).length;
+        }
+        return true;
     }
 
     createNewACR() {

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
@@ -83,6 +83,19 @@ export default class ProjectItemController {
             }
         });
     }
+
+    shareModal(project) {
+        this.modalService.open({
+            component: 'permissionsModal',
+            resolve: {
+                object: () => project,
+                objectType: () => 'projects',
+                objectName: () => project.name,
+                extraActions: () => ['ANNOTATE']
+            }
+        });
+    }
+
     deleteModal() {
         const modal = this.modalService.open({
             component: 'rfConfirmationModal',

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
@@ -89,7 +89,7 @@ export default class ProjectItemController {
             component: 'permissionsModal',
             resolve: {
                 object: () => project,
-                objectType: () => 'projects',
+                permissionsBase: () => 'projects',
                 objectName: () => project.name,
                 extraActions: () => ['ANNOTATE']
             }

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -7,7 +7,11 @@
     <div class="project-actions">
       <a href ng-click="$ctrl.publishModal()">
         <i class="icon-share"></i>
-        <span class="sr-only">Share</span>
+        <span class="sr-only">Publish</span>
+      </a>
+      <a href ng-click="$ctrl.shareModal($ctrl.project)">
+        <i class="icon-key"></i>
+        <span class="sr-only">Permissions</span>
       </a>
       <a href class="color-danger" ng-click="$ctrl.deleteModal()">
         <i class="icon-trash"></i>

--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.html
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.html
@@ -4,13 +4,12 @@
       <span aria-hidden="true">&times;</span>
     </button>
     <h4 class="modal-title">
-      Publish {{$ctrl.resolve.templateTitle ? 'Analysis - ' + $ctrl.resolve.templateTitle : 'Project - ' + $ctrl.resolve.project.name}}
+      Publishing
     </h4>
-    <p>Publish or export your {{$ctrl.resolve.templateTitle ? 'analysis' : 'project'}}</p>
+    <h6 class="modal-title" ng-attr-title="{{$ctrl.resolve.templateTitle ? $ctrl.resolve.templateTitle : $ctrl.resolve.project.name}}">{{$ctrl.resolve.templateTitle ? $ctrl.resolve.templateTitle : $ctrl.resolve.project.name}}</h6>
   </div>
   <div class="modal-body">
     <div class="content" ng-show="$ctrl.shareUrl">
-      <h4>Sharing</h4>
       <div class="form-group">
         <label>Map Visibility</label>
         <div class="form-group">
@@ -27,7 +26,7 @@
         </div>
       </div>
       <div class="form-group">
-        <label>Share Page</label>
+        <label>Published Page</label>
         <div class="form-group all-in-one">
           <label for="tile-link" class="sr-only">URL</label>
           <input id="tile-link" type="text" class="form-control"

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -110,7 +110,7 @@ class ImportListController {
             component: 'permissionsModal',
             resolve: {
                 object: () => scene,
-                objectType: () => 'scenes',
+                permissionsBase: () => 'scenes',
                 objectName: () => scene.name,
                 extraActions: () => []
             }

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -33,8 +33,7 @@ class ImportListController {
             {
                 label: 'Modify permissions',
                 onClick: this.shareModal.bind(this),
-                buttonClass: 'btn-danger',
-                iconClass: 'icon-download'
+                iconClass: 'icon-key'
             },
             {
                 label: 'Download',

--- a/app-frontend/src/app/pages/admin/admin.html
+++ b/app-frontend/src/app/pages/admin/admin.html
@@ -15,7 +15,7 @@
             <tbody>
               <tr ng-repeat="platform in $ctrl.platforms track by $index">
                 <td>{{platform.item.name }}</td>
-                <td>{{platform.role.groupRole}}</td>
+                <td class="titlecase">{{platform.role.groupRole}}</td>
                 <td>
                   <button class="btn btn-primary "
                           ui-sref="admin.platform.users({platformId: platform.item.id})">
@@ -44,7 +44,7 @@
             <tbody>
               <tr ng-repeat="organization in $ctrl.organizations track by $index">
                 <td>{{organization.item.name}}</td>
-                <td>{{organization.role.groupRole}}</td>
+                <td class="titlecase">{{organization.role.groupRole}}</td>
                 <td>
                   <button class="btn btn-primary"
                           ui-sref="admin.organization.users({organizationId: organization.item.id})">
@@ -73,7 +73,7 @@
             <tbody>
               <tr ng-repeat="team in $ctrl.teams track by $index">
                 <td>{{team.item.name}}</td>
-                <td>{{team.role.groupRole}}</td>
+                <td class="titlecase">{{team.role.groupRole}}</td>
                 <td>
                   <button class="btn btn-primary"
                           ui-sref="admin.team.users({teamId: team.item.id})">

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -42,7 +42,7 @@
         <td class="emails" ng-class="{'color-light': !user.email}">
           {{user.email || 'None'}}
         </td>
-        <td class="roles">
+        <td class="roles titlecase">
           {{user.groupRole}}
         </td>
         <td class="teams">

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -99,12 +99,14 @@ class PlatformOrganizationsController {
 
     itemsForOrg(organization) {
         /* eslint-disable */
-        let actions = [{
-            label: 'Manage',
-            callback: () => {
-                this.$state.go('.detail.features', {orgId: organization.id});
-            }
-        }];
+        let actions = [
+            // {
+            //     label: 'Manage',
+            //     callback: () => {
+            //         this.$state.go('.detail.features', {orgId: organization.id});
+            //     }
+            // }
+        ];
         if (organization.isActive) {
             actions.push({
                 label: 'Deactivate',

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -25,7 +25,7 @@
           <td class="emails">
             {{user.email}}
           </td>
-          <td class="roles">
+          <td class="roles titlecase">
             {{user.groupRole}}
           </td>
           <td class="actions">

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -22,7 +22,7 @@
         <td class="emails">
           {{user.email}}
         </td>
-        <td class="roles">
+        <td class="roles titlecase">
           {{user.groupRole}}
         </td>
         <td class="actions">

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -45,7 +45,13 @@
        ui-sref-active="active"
        data-title="Share">
       <i class="icon-share"></i>
-      <span>Share</span>
+      <span>Publish</span>
+    </a>
+    <a href
+       ng-click="$ctrl.openShareModal()"
+       data-title="Share">
+      <i class="icon-key"></i>
+      <span>Permissions</span>
     </a>
     </nav>
   </div>

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -277,6 +277,18 @@ class ProjectsEditController {
         });
     }
 
+    openShareModal() {
+        this.modalService.open({
+            component: 'permissionsModal',
+            resolve: {
+                object: () => this.project,
+                objectType: () => 'projects',
+                objectName: () => this.project.name,
+                extraActions: () => ['ANNOTATE']
+            }
+        });
+    }
+
     openExportModal() {
         this.getMap().then(m => {
             return m.map.getZoom();

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -282,7 +282,7 @@ class ProjectsEditController {
             component: 'permissionsModal',
             resolve: {
                 object: () => this.project,
-                objectType: () => 'projects',
+                permissionsBase: () => 'projects',
                 objectName: () => this.project.name,
                 extraActions: () => ['ANNOTATE']
             }

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
@@ -1,7 +1,7 @@
 <div class="sidebar-overlay" ng-show="$ctrl.drawing"></div>
 <div class="sidebar-static">
   <div class="sidebar-header">
-    <h5 class="sidebar-title">Sharing</h5>
+    <h5 class="sidebar-title">Linking</h5>
   </div>
 </div>
 <div class="sidebar-scrollable">
@@ -20,7 +20,7 @@
       </div>
     </div>
     <div class="list-group-item sidebar-actions-group">
-      <label>Share Page</label>
+      <label>Published Page</label>
       <div class="list-group-right btn-group">
         <button class="btn btn-default btn-copy-page"
                 clipboard text="$ctrl.shareUrl"

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.html
@@ -1,7 +1,7 @@
 <div class="sidebar-overlay" ng-show="$ctrl.drawing"></div>
 <div class="sidebar-static">
   <div class="sidebar-header">
-    <h5 class="sidebar-title">Linking</h5>
+    <h5 class="sidebar-title">Publish</h5>
   </div>
 </div>
 <div class="sidebar-scrollable">

--- a/app-frontend/src/app/services/auth/permissions.service.js
+++ b/app-frontend/src/app/services/auth/permissions.service.js
@@ -6,8 +6,8 @@ export default (app) => {
     class PermissionsService {
         constructor($resource) {
             this.Permissions = $resource(
-                `${BUILDCONFIG.API_HOST}/api/:objectType/:objectId/permissions`, {
-                    objectType: '@objectType',
+                `${BUILDCONFIG.API_HOST}/api/:permissionsBase/:objectId/permissions`, {
+                    permissionsBase: '@permissionsBase',
                     objectId: '@objectId'
                 }, {
                     query: {
@@ -32,29 +32,29 @@ export default (app) => {
             );
         }
 
-        query({objectType, objectId}) {
-            return this.Permissions.query({objectType: objectType, objectId: objectId});
+        query({permissionsBase, objectId}) {
+            return this.Permissions.query({permissionsBase, objectId});
         }
 
-        create({objectType, objectId}, accessControlRuleCreate) {
+        create({permissionsBase, objectId}, accessControlRuleCreate) {
             return this.Permissions.create(
-                Object.assign(accessControlRuleCreate, {objectType: objectType, objectId: objectId})
+                Object.assign(accessControlRuleCreate, {permissionsBase, objectId})
             ).$promise;
         }
 
-        update({objectType, objectId}, accessControlRuleCreates) {
+        update({permissionsBase, objectId}, accessControlRuleCreates) {
             return this.Permissions.update(
                 Object.assign(
                     {rules: accessControlRuleCreates},
-                    {objectType: objectType, objectId: objectId}
+                    {permissionsBase, objectId}
                 )
             ).$promise;
         }
 
-        delete({objectType, objectId}) {
+        delete({permissionsBase, objectId}) {
             return this.Permissions.delete(
                 Object.assign(
-                    { objectType, objectId }
+                    { permissionsBase, objectId }
                 )
             ).$promise;
         }

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3058,3 +3058,10 @@ rf-reclassify-table {
   margin-bottom: 0.5rem;
   text-align: left;
 }
+
+.titlecase {
+  text-transform: lowercase;
+  &:first-letter {
+    text-transform: uppercase;
+  }
+}

--- a/app-frontend/src/assets/styles/sass/components/_modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_modal.scss
@@ -104,6 +104,8 @@
 .modal-title {
   margin: 0;
   line-height: 1.8;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 // Modal body

--- a/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
@@ -99,21 +99,6 @@ def make_tif_image_copy(image):
     return copied
 
 
-def copy_scene(scene):
-    """Create a copy of this scene with images converted to tifs in s3
-
-    Args:
-        scene (Scene): scene to copy images from
-
-    Return:
-        Scene: the copied scene with substitute images
-    """
-
-    copied = Scene.from_dict(scene.to_dict())
-    copied.images = [make_tif_image_copy(image) for image in scene.images]
-    return copied
-
-
 def get_source(image, extent):
     """Construct source for a Sentinel-2 image
     Args:
@@ -187,7 +172,7 @@ def create_sentinel2_ingest(scene):
         Ingest
     """
 
-    copied = copy_scene(scene)
+    scene.images = [make_tif_image_copy(image) for image in scene.images]
     layer = get_sentinel2_layer(copied)
     id = copied.id
     return Ingest(id, [layer])


### PR DESCRIPTION
## Overview

This PR fixes what the permissions modal thinks `EVERYONE` means, scoping it
to the user's platform instead of to all users everywhere in the universe (possibly
even using DIFFERENT APPLICATIONS). It also fixes a duplication issue resulting
from how we constructed the auth query.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

## Testing Instructions

 * list your rasters
 * add some permissions
 * for everyone!
 * for specific entities!
 * nothing should be weird

Helps with azavea/raster-foundry-platform#346
