### PR TITLE
Get subject name in sharing modal.

### DIFF
--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -19,12 +19,12 @@
       </div>
       <div class="dropdown btn-group selectable-list-item" uib-dropdown uib-dropdown-toggle ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
         <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description !== null">
-          <span class="permissions-object-key font-600">
+          <span class="permissions-object-key font-600 text-none">
             {{ $ctrl.subjectNameObj[key]  || 'Loading' }}
           </span>
-          <span ng-if="row.length">Can</span>
-          <span ng-if="!row.length">Will no longer have access</span>
-          <span class="permissions-object-marker" ng-repeat="actionType in $ctrl.actionTypes">
+          <span class="text-none" ng-if="row.length">Can</span>
+          <span class="text-none" ng-if="!row.length">Will no longer have access</span>
+          <span class="permissions-object-marker text-lowercase" ng-repeat="actionType in $ctrl.actionTypes">
             <span ng-if="row.includes(actionType)">&nbsp;{{actionType}}</span>
           </span>
         </a>
@@ -35,8 +35,10 @@
           <i class="icon-edit"></i>
         </button>
         <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-          <li role="menuitem" ng-repeat="actionType in $ctrl.actionTypes">
-            <rf-toggle value="row.includes(actionType)" on-change="$ctrl.togglePermission(actionType, key)">&nbsp;{{ actionType }}</rf-toggle>
+          <li role="menuitem" ng-repeat="actionType in $ctrl.actionTypes" class="dropdown-list-item">
+            <rf-toggle value="row.includes(actionType)" on-change="$ctrl.togglePermission(actionType, key)">
+              <span class="titlecase">&nbsp;{{ actionType }}</span>
+            </rf-toggle>
           </li>
         </ul>
       </div>

--- a/app-frontend/src/app/components/permissions/permissionsModal.html
+++ b/app-frontend/src/app/components/permissions/permissionsModal.html
@@ -20,7 +20,7 @@
       <div class="dropdown btn-group selectable-list-item" uib-dropdown uib-dropdown-toggle ng-repeat="(key, row) in $ctrl.accessControlRuleRows">
         <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.description !== null">
           <span class="permissions-object-key font-600">
-            {{ key | limitTo:12}}
+            {{ $ctrl.subjectNameObj[key]  || 'Loading' }}
           </span>
           <span ng-if="row.length">Can</span>
           <span ng-if="!row.length">Will no longer have access</span>

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -194,30 +194,28 @@ class PermissionsModalController {
 
     setSubjectNames(keysArr) {
         keysArr.forEach((key) => {
-            if (key === 'Everyone') {
+            let type = key.split(' ')[0];
+            let id = key.split(' ')[1];
+            if (key === 'Everyone' || type === 'PLATFORM') {
                 this.subjectNameObj[key] = 'Everyone';
-            } else {
-                let type = key.split(' ')[0];
-                let id = key.split(' ')[1];
-                if (type === 'ORGANIZATION' && id) {
-                    this.organizationService.getOrganization(id).then(resp => {
-                        this.subjectNameObj[key] = resp.name;
-                    }, () => {
-                        this.subjectNameObj[key] = 'NULL';
-                    });
-                } else if (type === 'USER' && id) {
-                    this.userService.getUserById(id).then(resp => {
-                        this.subjectNameObj[key] = resp.name;
-                    }, () => {
-                        this.subjectNameObj[key] = 'NULL';
-                    });
-                } else if (type === 'TEAM' && id) {
-                    this.teamService.getTeam(id).then(resp => {
-                        this.subjectNameObj[key] = resp.name;
-                    }, () => {
-                        this.subjectNameObj[key] = 'NULL';
-                    });
-                }
+            } else if (type === 'ORGANIZATION' && id) {
+                this.organizationService.getOrganization(id).then(resp => {
+                    this.subjectNameObj[key] = `${type} - ${resp.name}`;
+                }, () => {
+                    this.subjectNameObj[key] = type;
+                });
+            } else if (type === 'USER' && id) {
+                this.userService.getUserById(id).then(resp => {
+                    this.subjectNameObj[key] = `${type} - ${resp.name}`;
+                }, () => {
+                    this.subjectNameObj[key] = type;
+                });
+            } else if (type === 'TEAM' && id) {
+                this.teamService.getTeam(id).then(resp => {
+                    this.subjectNameObj[key] = `${type} - ${resp.name}`;
+                }, () => {
+                    this.subjectNameObj[key] = type;
+                });
             }
         });
     }

--- a/app-frontend/src/app/components/permissions/permissionsModal.module.js
+++ b/app-frontend/src/app/components/permissions/permissionsModal.module.js
@@ -63,6 +63,7 @@ class PermissionsModalController {
 
     $onInit() {
         this.accessControlRules = [];
+        this.subjectNameObj = {};
         this.actionTypes = [...this.defaultActions, ...this.resolve.extraActions];
         this.authTarget = {
             permissionsBase: this.resolve.permissionsBase,
@@ -191,6 +192,36 @@ class PermissionsModalController {
         this.availableUsers = [];
     }
 
+    setSubjectNames(keysArr) {
+        keysArr.forEach((key) => {
+            if (key === 'Everyone') {
+                this.subjectNameObj[key] = 'Everyone';
+            } else {
+                let type = key.split(' ')[0];
+                let id = key.split(' ')[1];
+                if (type === 'ORGANIZATION' && id) {
+                    this.organizationService.getOrganization(id).then(resp => {
+                        this.subjectNameObj[key] = resp.name;
+                    }, () => {
+                        this.subjectNameObj[key] = 'NULL';
+                    });
+                } else if (type === 'USER' && id) {
+                    this.userService.getUserById(id).then(resp => {
+                        this.subjectNameObj[key] = resp.name;
+                    }, () => {
+                        this.subjectNameObj[key] = 'NULL';
+                    });
+                } else if (type === 'TEAM' && id) {
+                    this.teamService.getTeam(id).then(resp => {
+                        this.subjectNameObj[key] = resp.name;
+                    }, () => {
+                        this.subjectNameObj[key] = 'NULL';
+                    });
+                }
+            }
+        });
+    }
+
     setAccessControlRuleRows(accessControlRules) {
         this.accessControlRuleRows = _.mapValues(
             _.groupBy(
@@ -199,6 +230,7 @@ class PermissionsModalController {
             ),
             (acrList) => _.map(acrList, (acr) => acr.actionType)
         );
+        this.setSubjectNames(Object.keys(this.accessControlRuleRows));
     }
 
     setState(newState) {

--- a/app-frontend/src/app/services/auth/user.service.js
+++ b/app-frontend/src/app/services/auth/user.service.js
@@ -65,6 +65,10 @@ export default (app) => {
         getTeams() {
             return this.User.getTeams().$promise;
         }
+
+        getUserById(id) {
+            return this.UserMetadata.get({userid: id}).$promise;
+        }
     }
 
     app.service('userService', UserService);

--- a/app-frontend/src/assets/styles/sass/base/_typography.scss
+++ b/app-frontend/src/assets/styles/sass/base/_typography.scss
@@ -78,6 +78,10 @@ p, .p {
   text-transform: lowercase;
 }
 
+.text-none {
+  text-transform: none;
+}
+
 .text-center {
   text-align: center !important;
 }


### PR DESCRIPTION
## Overview

This PR gets subject name of ACR record based on id in the sharing modal

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

This is a pure frontend solution to let the modal display subject name instead of type + id.

## Testing Instructions
 
* Make dev user an admin.
 * Go to raster import page and click on the sharing modal button.
 * Assign some permissions if you have not done so.
 * Check if subject names are displayed instead of the types in the list of granted permission.

Closes #3457  (kind of...)
Closes https://github.com/azavea/raster-foundry-platform/issues/346 