### PR TITLE
Various front-end cleanup items

### DIFF
--- a/app-frontend/src/app/components/common/navBar/navBar.controller.js
+++ b/app-frontend/src/app/components/common/navBar/navBar.controller.js
@@ -47,11 +47,11 @@ export default class NavBarController {
             this.currentUgrPromise = this.authService.fetchUserRoles().then(res => {
                 let isPlatOrgAdmin = res.filter((ugr) => {
                     return ugr.groupType === 'PLATFORM' &&
-                           ugr.groupRole === 'ADMIN' &&
-                           ugr.isActive ||
-                              ugr.groupType === 'ORGANIZATION' &&
-                              ugr.groupRole === 'ADMIN' &&
-                              ugr.isActive;
+                        ugr.groupRole === 'ADMIN' &&
+                        ugr.isActive ||
+                        ugr.groupType === 'ORGANIZATION' &&
+                        ugr.groupRole === 'ADMIN' &&
+                        ugr.isActive;
                 }).length;
                 this.showAdmin = isPlatOrgAdmin || isSuperuser;
             });

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -2,12 +2,10 @@
   <div ng-if="$ctrl.errorMsg">
     <p>
       {{$ctrl.errorMsg}}
-      <a ng-href="mailto:{{$ctrl.orgAdminEmail}}">organization admin</a>.
     </p>
   </div>
   <div ng-if="!$ctrl.errorMsg">
     <div class="admin-users-actions">
-      <input type="text" class="form-control admin-search" placeholder="Search for teams" ng-disabled="$ctrl.fetching">
       <div class="actions-right">
         <button type="button" class="btn btn-primary"
                 ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
@@ -17,37 +15,38 @@
     </div>
   </div>
   <table class="admin-table admin-team-table" ng-if="!$ctrl.fetching">
-    <thead>
-      <tr>
-        <td>Name</td>
-        <td class="users">Users</td>
-        <td>Actions</td>
-      </tr>
-    </thead>
     <tbody>
       <tr ng-repeat="team in $ctrl.teams track by team.id">
         <td class="name">
-          {{team.name}}
-        </td>
-        <td class="users">
-          <div class="user-avatar"
-               ng-repeat="user in team.fetchedUsers.results track by $index | limitTo : 5"
-               ng-attr-title="{{user.name || user.email || user.id}}"
-          >
-            <img class="avatar" ng-src="{{user.profileImageUri}}">
-          </div>
-          <a class="users-more" title="View team details"
+          <a title="View team details"
              ui-sref="admin.team.users({teamId: team.id})">
-            <ng-pluralize count="team.fetchedUsers.count"
-                          when="{'0': ' No team members',
-                                 '1': ' View 1 team member',
-                                 'other': ' View {} team members'}"
-
-            >
-            </ng-pluralize>
+            {{team.name}}
           </a>
         </td>
-        <td class="teams" ng-if="!team.fetchedUsers">
+        <td class="users">
+          <div class="user-group-avatars">
+            <div class="avatar user-avatar image-placeholder"
+                 ng-if="!user.profileImageUri"
+                 ng-repeat-start="user in team.fetchedUsers.results track by $index | limitTo : 5">
+            </div>
+            <div class="user-avatar"
+                 ng-if="user.profileImageUri"
+                 ng-repeat-end>
+              <img class="avatar"
+                   ng-src="{{user.profileImageUri}}"
+                   ng-attr-title="{{user.name || user.email || user.id}}">
+            </div>
+          </div>
+          &nbsp;
+          <ng-pluralize count="team.fetchedUsers.count"
+                        when="{'0': ' No members',
+                               '1': ' 1 member',
+                               'other': '{} members'}"
+
+          >
+          </ng-pluralize>
+        </td>
+        <td class="users" ng-if="!team.fetchedUsers">
           <a class="users-more" title="View team details"
              ui-sref="admin.team.users({teamId: team.id})">
             Counting members...
@@ -55,7 +54,7 @@
         </td>
         <td class="actions">
           <rf-dropdown data-options="team.options" ng-if="team.showOptions">
-            <span class="icon-caret-down"></span>
+            <span class="icon-edit"></span>
           </rf-dropdown>
         </td>
       </tr>

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -8,10 +8,12 @@
   <div ng-if="!$ctrl.errorMsg">
     <div class="admin-users-actions">
       <input type="text" class="form-control admin-search" placeholder="Search for teams" ng-disabled="$ctrl.fetching">
-      <button type="button" class="btn btn-primary"
-              ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
-        New Team
-      </button>
+      <div class="actions-right">
+        <button type="button" class="btn btn-primary"
+                ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
+          New Team
+        </button>
+      </div>
     </div>
   </div>
   <table class="admin-table admin-team-table" ng-if="!$ctrl.fetching">

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -114,22 +114,23 @@ class OrganizationTeamsController {
     itemsForTeam(team) {
         /* eslint-disable */
         return [
+            // {
+            //     label: 'Edit',
+            //     callback: () => {
+            //         this.$state.go('admin.team.users', {teamId: team.id});
+            //     },
+            //     classes: []
+            // },
             {
-                label: 'Edit',
-                callback: () => {
-                    this.$state.go('admin.team.users', {teamId: team.id});
-                },
-                classes: []
-            },
-            {
-                label: 'Add to team...',
+                label: 'Add User',
                 callback: () => {
                     this.modalService.open({
                         component: 'rfAddUserModal',
                         resolve: {
-                            platformId: () => this.platformId,
-                            organizationId: () => this.organizationId,
-                            teamId: () => team.id
+                            platformId: () => this.organization.platformId,
+                            organizationId: () => this.organization.id,
+                            teamId: () => team.id,
+                            adminView: () => 'organization'
                         }
                     }).result.then(() => {
                         this.teamService

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -2,13 +2,11 @@
   <div ng-if="$ctrl.errorMsg">
     <p>
       {{$ctrl.errorMsg}}
-      <a ng-href="mailto:{{$ctrl.platAdminEmail}}">platform admin</a>.
     </p>
   </div>
   <div ng-if="!$ctrl.errorMsg">
     <div class="admin-users-actions">
-      <input type="text" class="form-control admin-search" placeholder="Search for users"
-             ng-model="$ctrl.search">
+      <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
       <div class="actions-right">
         <button type="button" class="btn btn-primary"
                 ng-click="$ctrl.addUserModal()"
@@ -19,20 +17,12 @@
     </div>
   </div>
   <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching">
-    <thead>
-      <tr>
-        <td>Name</td>
-        <td>Email</td>
-        <td>Role</td>
-        <td>Teams</td>
-      </tr>
-    </thead>
     <tbody>
       <tr ng-repeat="user in $ctrl.users track by $index">
         <td class="username">
-          <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
-          <div class="user-avatar" ng-if="user.profileImageUri">
-            <img class="avatar" ng-src="{{user.profileImageUri}}">
+          <div class="avatar user-avatar image-placeholder" ng-if="!user.profileImageUri"></div>
+          <div ng-if="user.profileImageUri">
+            <img class="avatar user-avatar" ng-src="{{user.profileImageUri}}">
           </div>
           <div>
             {{user.name || user.email || user.id}}
@@ -46,13 +36,12 @@
                     ng-model="user.groupRole"
                     ng-disabled="$ctrl.disabled"
                     ng-change="$ctrl.updateUserGroupRole(user)"
+                    ng-if="$ctrl.currentPlatUgr.groupRole === 'ADMIN' || $ctrl.currentOrgUgr.groupRole === 'ADMIN'"
             >
               <option value="ADMIN">Admin</option>
               <option value="MEMBER">Member</option>
             </select>
-        </td>
-        <td class="teams">
-          In {{user.teams.length || 0}} teams
+            <span ng-if="!$ctrl.currentPlatUgr.groupRole === 'ADMIN' && !$ctrl.currentOrgUgr.groupRole === 'ADMIN'">{{user.groupRole}}</span>
         </td>
       </tr>
     </tbody>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -25,7 +25,6 @@
         <td>Email</td>
         <td>Role</td>
         <td>Teams</td>
-        <td>Options</td>
       </tr>
     </thead>
     <tbody>
@@ -43,15 +42,17 @@
           {{user.email || 'None'}}
         </td>
         <td class="roles titlecase">
-          {{user.groupRole}}
+            <select class="form-control"
+                    ng-model="user.groupRole"
+                    ng-disabled="$ctrl.disabled"
+                    ng-change="$ctrl.updateUserGroupRole(user)"
+            >
+              <option value="ADMIN">Admin</option>
+              <option value="MEMBER">Member</option>
+            </select>
         </td>
         <td class="teams">
           In {{user.teams.length || 0}} teams
-        </td>
-        <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions">
-            <span class="icon-caret-down"></span>
-          </rf-dropdown>
         </td>
       </tr>
     </tbody>

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -14,7 +14,7 @@ class OrganizationUsersController {
 
         this.platAdminEmail = 'example@email.com';
 
-        let debouncedSearch = _.debounce(
+        this.debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,
             {leading: false, trailing: true}
@@ -29,7 +29,7 @@ class OrganizationUsersController {
                 this.currentUserPromise = this.$scope.$parent.$ctrl.currentUserPromise;
                 this.currentUgrPromise = this.$scope.$parent.$ctrl.currentUgrPromise;
                 this.getUserAndUgrs();
-                this.$scope.$watch('$ctrl.search', debouncedSearch);
+                this.fetchUsers(1, '');
             }
         });
     }
@@ -105,19 +105,19 @@ class OrganizationUsersController {
     itemsForUser(user) {
         /* eslint-disable */
         return [
-            // {
-            //     label: 'Edit',
-            //     callback: () => {
-            //         console.log('edit callback for user:', user);
-            //     }
-            // }
-            // {
-            //     label: 'Delete',
-            //     callback: () => {
-            //         console.log('delete callback for user:', user);
-            //     },
-            //     classes: ['color-danger']
-            // }
+            {
+                label: 'Edit',
+                callback: () => {
+                    console.log('edit callback for user:', user);
+                }
+            },
+            {
+                label: 'Delete',
+                callback: () => {
+                    console.log('delete callback for user:', user);
+                },
+                classes: ['color-danger']
+            }
         ];
         /* eslint-enable */
     }

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -64,6 +64,16 @@ class OrganizationUsersController {
         };
     }
 
+    updateUserGroupRole(user) {
+        this.organizationService.setUserRole(
+            this.organization.platformId,
+            this.organization.id,
+            user
+        ).catch(() => {
+            this.fetchUsers(this.pagination.currentPage, this.search);
+        });
+    }
+
     fetchUsers(page = 1, search) {
         const platformId = this.organization.platformId;
         const organizationId = this.organization.id;
@@ -95,12 +105,12 @@ class OrganizationUsersController {
     itemsForUser(user) {
         /* eslint-disable */
         return [
-            {
-                label: 'Edit',
-                callback: () => {
-                    console.log('edit callback for user:', user);
-                }
-            }
+            // {
+            //     label: 'Edit',
+            //     callback: () => {
+            //         console.log('edit callback for user:', user);
+            //     }
+            // }
             // {
             //     label: 'Delete',
             //     callback: () => {

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -1,12 +1,6 @@
 <ui-view>
   <div class="admin-users-content container column-stretch">
     <div class="admin-users-actions">
-      <input type="text"
-             class="form-control admin-search"
-             placeholder="Search for organizations"
-             ng-model="$ctrl.search"
-             ng-disabled="$ctrl.fetching"
-      >
       <div class="actions-right">
         <button type="button" class="btn btn-primary"
                 ng-click="$ctrl.newOrgModal()"
@@ -19,42 +13,42 @@
       <tbody>
         <tr ng-repeat="organization in $ctrl.organizations track by $index">
           <td class="name">
-            <div class="placeholder-avatar"></div>
+              <div class="avatar user-avatar image-placeholder" ng-if="!organization.logoUri"></div>
+              <div ng-if="organization.logoUri">
+                <img class="avatar user-avatar" ng-src="{{organization.logoUri}}">
+              </div>
             <div>
-              {{organization.name}}
+              <a ui-sref="admin.organization.users({organizationId: organization.id})">{{organization.name}}</a>
             </div>
-          </td>
-          <td class="email">
-            {{organization.email}}
           </td>
           <td class="users">
-            <div class="user-avatar"
-                 ng-repeat="user in organization.fetchedUsers.results track by $index | limitTo : 5"
-                 ng-attr-title="{{user.name || user.email || user.id}}"
-            >
-              <img class="avatar" ng-src="{{user.profileImageUri}}">
+            <div class="user-group-avatars">
+              <div class="avatar user-avatar image-placeholder"
+                   ng-if="!user.profileImageUri"
+                   ng-repeat-start="user in organization.fetchedUsers.results track by $index | limitTo : 5">
+              </div>
+              <div class="user-avatar"
+                   ng-if="user.profileImageUri"
+                   ng-repeat-end>
+                <img class="avatar"
+                     ng-src="{{user.profileImageUri}}"
+                     ng-attr-title="{{user.name || user.email || user.id}}">
+              </div>
             </div>
-            <div>
-              <a class="users-more" title="View organization details"
-                 ui-sref="admin.organization.users({organizationId: organization.id})">
-                <ng-pluralize count="organization.fetchedUsers.count"
-                              when="{'0': ' No members',
-                                     '1': ' View 1 member',
-                                     'other': ' View {} more members'}"
+            &nbsp;
+            <ng-pluralize count="organization.fetchedUsers.count"
+                          when="{'0': 'No members',
+                                 '1': '1 member',
+                                 'other': '{} members'}"
 
-                >
-                </ng-pluralize>
-              </a>
-            </div>
+            >
+            </ng-pluralize>
           </td>
           <td>{{ organization.isActive ? "Active" : "Deactivated"}}</td>
-          <td class="actions">
-            <div ng-if="organization.showOptions">
-              <a ui-sref="admin.organization.users({organizationId: organization.id})">View page</a>
-              <rf-dropdown data-options="organization.options">
-                <span class="icon-caret-down"></span>
-              </rf-dropdown>
-            </div>
+          <td class="actions" ng-if="organization.showOptions">
+            <rf-dropdown data-options="organization.options">
+              <span class="icon-edit"></span>
+            </rf-dropdown>
           </td>
         </tr>
       </tbody>

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -28,11 +28,6 @@
           <td class="roles titlecase">
             {{user.groupRole}}
           </td>
-          <td class="actions">
-            <rf-dropdown data-options="user.options">
-              <span class="icon-caret-down"></span>
-            </rf-dropdown>
-          </td>
         </tr>
       </tbody>
     </table>

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -7,16 +7,15 @@
   </div>
   <div ng-if="!$ctrl.errorMsg">
     <div class="admin-users-actions">
-      <input type="text" class="form-control admin-search" placeholder="Search for users"
-             ng-model="$ctrl.search" ng-disabled="$ctrl.fetching">
+      <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
     </div>
     <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
       <tbody>
         <tr ng-repeat="user in $ctrl.users track by $index">
           <td class="username">
-            <div class="placeholder-avatar" ng-if="!user.profileImageUri"></div>
-            <div class="user-avatar" ng-if="user.profileImageUri">
-              <img class="avatar" ng-src="{{user.profileImageUri}}">
+            <div class="avatar user-avatar image-placeholder" ng-if="!user.profileImageUri"></div>
+            <div ng-if="user.profileImageUri">
+              <img class="avatar user-avatar" ng-src="{{user.profileImageUri}}">
             </div>
             <div>
               {{user.name || user.email || user.id}}

--- a/app-frontend/src/app/pages/admin/platform/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/platform/users/users.module.js
@@ -15,13 +15,13 @@ class PlatformUsersController {
         this.fetching = true;
         this.platAdminEmail = 'example@email.com';
 
-        let debouncedSearch = _.debounce(
+        this.debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,
             {leading: false, trailing: true}
         );
 
-        this.$scope.$watch('$ctrl.search', debouncedSearch);
+        this.fetchUsers(1, '');
     }
 
     onSearch(search) {

--- a/app-frontend/src/app/pages/admin/team/team.html
+++ b/app-frontend/src/app/pages/admin/team/team.html
@@ -1,7 +1,5 @@
 <div class="container-admin-header">
   <div class="admin-header">
-    <div class="admin-logo">
-    </div>
     <div class="admin-logo-text" ng-if="!$ctrl.fetching">
       <h1 class="admin-logo-name h3">
         {{$ctrl.team.name}}

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -2,10 +2,12 @@
   <div class="admin-users-actions">
     <input type="text" class="form-control admin-search" placeholder="Search for users"
            ng-model="$ctrl.search" ng-disabled="$ctrl.fetching">
-    <button type="button" class="btn btn-primary"
-            ng-click="$ctrl.addUser()" ng-disabled="$ctrl.fetching">
-      Add users
-    </button>
+    <div class="actions-right">
+      <button type="button" class="btn btn-primary"
+              ng-click="$ctrl.addUser()" ng-disabled="$ctrl.fetching">
+        Add users
+      </button>
+    </div>
   </div>
   <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
     <tbody>
@@ -23,7 +25,14 @@
           {{user.email}}
         </td>
         <td class="roles titlecase">
-          {{user.groupRole}}
+            <select class="form-control"
+                    ng-model="user.groupRole"
+                    ng-disabled="$ctrl.disabled"
+                    ng-change="$ctrl.updateUserGroupRole(user)"
+            >
+              <option value="ADMIN">Admin</option>
+              <option value="MEMBER">Member</option>
+            </select>
         </td>
         <td class="actions">
           <rf-dropdown data-options="user.options" ng-if="user.showOptions">

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -1,7 +1,6 @@
 <div class="admin-users-content container column-stretch">
   <div class="admin-users-actions">
-    <input type="text" class="form-control admin-search" placeholder="Search for users"
-           ng-model="$ctrl.search" ng-disabled="$ctrl.fetching">
+      <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
     <div class="actions-right">
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.addUser()" ng-disabled="$ctrl.fetching">
@@ -27,16 +26,17 @@
         <td class="roles titlecase">
             <select class="form-control"
                     ng-model="user.groupRole"
-                    ng-disabled="$ctrl.disabled"
                     ng-change="$ctrl.updateUserGroupRole(user)"
+                    ng-if="$ctrl.isAdmin"
             >
               <option value="ADMIN">Admin</option>
               <option value="MEMBER">Member</option>
             </select>
+            <span ng-if="!$ctrl.isAdmin">{{user.groupRole}}</span>
         </td>
         <td class="actions">
           <rf-dropdown data-options="user.options" ng-if="user.showOptions">
-            <span class="icon-caret-down"></span>
+            <span class="icon-edit"></span>
           </rf-dropdown>
         </td>
       </tr>

--- a/app-frontend/src/app/pages/admin/team/users/users.js
+++ b/app-frontend/src/app/pages/admin/team/users/users.js
@@ -48,6 +48,17 @@ class TeamUsersController {
         });
     }
 
+    updateUserGroupRole(user) {
+        this.teamService.setUserRole(
+            this.organization.platformId,
+            this.organization.id,
+            this.team.id,
+            user
+        ).catch(() => {
+            this.fetchUsers(this.pagination.currentPage, this.search);
+        });
+    }
+
     matchUrgRole(urg, role = 'ADMIN') {
         return urg && urg.groupRole === role;
     }
@@ -95,12 +106,12 @@ class TeamUsersController {
     itemsForUser(user) {
         /* eslint-disable */
         return [
-            {
-                label: 'Edit',
-                callback: () => {
-                    console.log('edit callback for user:', user);
-                }
-            },
+            // {
+            //     label: 'Edit',
+            //     callback: () => {
+            //         console.log('edit callback for user:', user);
+            //     }
+            // },
             {
                 label: 'Remove',
                 callback: () => {

--- a/app-frontend/src/app/pages/admin/team/users/users.js
+++ b/app-frontend/src/app/pages/admin/team/users/users.js
@@ -22,15 +22,15 @@ class TeamUsersController {
             this.organization = organization;
             this.platformId = organization.platformId;
 
-            let debouncedSearch = _.debounce(
+            this.debouncedSearch = _.debounce(
                 this.onSearch.bind(this),
                 500,
                 {leading: false, trailing: true}
             );
 
-            this.getUserAndUgrs();
-
-            this.$scope.$watch('$ctrl.search', debouncedSearch);
+            this.getUserAndUgrs().then(() => {
+                this.fetchUsers(1, '');
+            });
         });
     }
 
@@ -38,13 +38,14 @@ class TeamUsersController {
         this.authService.getCurrentUser().then(resp => {
             this.currentUser = resp;
         });
-        this.authService.fetchUserRoles().then(resp => {
+        return this.authService.fetchUserRoles().then(resp => {
             this.currentTeamUgr = resp.filter(ugr => ugr.groupId === this.team.id)[0];
             this.currentOrgUgr = resp.filter(ugr => ugr.groupId === this.organization.id)[0];
             this.currentPlatUgr = resp.filter(ugr => ugr.groupId === this.platformId)[0];
-            this.isAdmin = this.matchUrgRole(this.currentPlatUgr) ||
-                this.matchUrgRole(this.currentOrgUgr) ||
-                this.matchUrgRole(this.currentTeamUgr);
+            this.isAdmin =
+                this.matchUgrRole(this.currentPlatUgr) ||
+                this.matchUgrRole(this.currentOrgUgr) ||
+                this.matchUgrRole(this.currentTeamUgr);
         });
     }
 
@@ -59,7 +60,7 @@ class TeamUsersController {
         });
     }
 
-    matchUrgRole(urg, role = 'ADMIN') {
+    matchUgrRole(urg, role = 'ADMIN') {
         return urg && urg.groupRole === role;
     }
 

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -74,6 +74,16 @@ export default (app) => {
             }).$promise;
         }
 
+        setUserRole(platformId, organizationId, user) {
+            return this.PlatformOrganization.addUser({
+                platformId,
+                organizationId
+            }, {
+                userId: user.id,
+                groupRole: user.groupRole
+            }).$promise;
+        }
+
         getOrganization(organizationId) {
             return this.Organization.get({organizationId}).$promise;
         }

--- a/app-frontend/src/app/services/auth/team.service.js
+++ b/app-frontend/src/app/services/auth/team.service.js
@@ -60,6 +60,17 @@ export default (app) => {
             }).$promise;
         }
 
+        setUserRole(platformId, organizationId, teamId, user) {
+            return this.Team.addUser({
+                platformId,
+                organizationId,
+                teamId
+            }, {
+                userId: user.id,
+                groupRole: user.groupRole
+            }).$promise;
+        }
+
         removeUser(platformId, organizationId, teamId, userId) {
             return this.Team.removeUser({platformId, organizationId, teamId, userId}).$promise;
         }

--- a/app-frontend/src/assets/styles/sass/components/_avatar.scss
+++ b/app-frontend/src/assets/styles/sass/components/_avatar.scss
@@ -3,6 +3,8 @@
   line-height: 1;
   vertical-align: middle;
   border-radius: $border-radius-base;
+  object-fit: contain;
+  object-position: center;
   height: 25px;
   width: 25px;
 

--- a/app-frontend/src/assets/styles/sass/components/_dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_dropdown.scss
@@ -246,7 +246,7 @@
  * rf-dropdown classes
 */
 .rf-dropdown {
-    width: 10em;
+    min-width: 10em;
     position: absolute;
     bottom: 0;
     transform: translateY(100%);
@@ -256,6 +256,7 @@
     z-index: 100;
 
     .rf-dropdown-item {
+        text-align: left;
         padding: 0.5em 1em;
         cursor: pointer;
         &:hover {

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -7,7 +7,6 @@
 
 .admin-logo {
     border-radius: 3px;
-    background: $gray-lightest;
     width: 4em;
     height: 4em;
     margin-right: 1.4rem;
@@ -124,8 +123,8 @@
     }
 
     .placeholder-avatar {
-        width: 2.5em;
-        height: 2.5em;
+        width: 2.5rem;
+        height: 2.5rem;
         background: #ddd;
         border-radius: 3px;
         margin-right: 1em;
@@ -142,8 +141,8 @@
         text-align: right;
         display: flex;
         flex-direction: row;
-        justify-content: flex-end;
-        align-items: flex-end;
+        justify-content: center;
+        align-items: center;
 
         .users-more {
             padding: 0 1em;
@@ -184,20 +183,28 @@
     }
 
     .users {
-        width: 20em;
-        * {
-            display: inline-block;
-        }
+        min-width: 20em;
+        overflow: hidden;
+        white-space: nowrap;
     }
 
     .actions {
         width: 13em;
+        text-align: right;
         a {
             margin-right: 1em;
         }
         a, rf-dropdown {
             display: inline-block;
         }
+    }
+}
+
+.user-group-avatars {
+    display: inline-block;
+    .user-avatar {
+        display: inline-block;
+        margin-right: 0.25rem;
     }
 }
 


### PR DESCRIPTION
## Overview

This PR does a bunch of things to polish the admin UI:

- allow platform admins to change organization logos
- remove headers as per design from various admin list pages
- remove non-functional elements — search on orgs, teams and various dropdown options
- use existing search component instead of plain inputs
- make team and org name links to those pages, remove ‘View page’ links and member count links (they went to the same place but the name was previously not a link)
- use a different icon for the dropdown (edit instead of a caret since the button has no text)
- make user avatars the same size whether or not an avatar is available, use existing placeholder class
- move header actions to the right as per design
- unify copy
- allow org and platform admins to change user roles on organizations
- allow org, platform, and team admins to change user roles on teams
- use organization logo on organization listing page
- remove placeholder logo for teams (teams do not have logos currently)

Some things this does not fix:
- there are still no empty list call-to-actions
- trying to add users from the organization's team list page does not work


I opted to remove a lot of non-functional things rather than make them all work as they can be addressed in separate issues. The priority here was not to present non-functional UI components.

## Testing Instructions

* Make sure you have a user that is a platform admin
* Go through each page of the admin area and ensure that _everything_ (other than the two things listed above) works:
    - platform user list
    - platform org list
    - org user list
    - org team list
    - team user list

Closes #3471