### PR TITLE
Add quiet option to scripts/server

### DIFF
--- a/scripts/server
+++ b/scripts/server
@@ -21,6 +21,11 @@ then
     then
         docker-compose -f "${DIR}/../docker-compose.yml" \
                        -f "${DIR}/../docker-compose.metrics.yml" up
+    elif [ "${1:-}" = "--quiet" ]
+    then
+        shift
+        docker-compose up -d && \
+            docker-compose logs -f --tail 20 api-server "$@"
     else
         docker-compose up --remove-orphans
     fi


### PR DESCRIPTION
## Overview

This PR adds a `--quiet` option to `scripts/server` that by default
only prints `api-server` logs instead of every log from every service since the beginning
of time and until the heat death of the universe. Logs from additional services can be
specified by passing service names as arguments after `--quiet`.

Example usage:

```bash
# prints tailed logs from api-server only
$ ./scripts/server --quiet
...
# prints tailed logs from nginx-api and api-server
$ ./scripts/server --quiet nginx-api
```

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I think the logs are too loud by a lot on startup, but this also solves a different problem, where you,
for example, want to restart the api server and don't want to kill everything else (like when
the db project has to recompile, and the tile server project doesn't need to care, and you just
want to leave that running, but you `scripts/server`ed and ctrl+c-ing that process will kill everything
and you forget for a minute that you can `docker-compose stop` in another terminal).

## Testing Instructions

 * try the example usage things and also any other service combinations you want
