### PR TITLE
Show emails only when user proves some commonality with others

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -19,6 +19,7 @@ import doobie.postgres.implicits._
 import io.circe._
 import kamon.akka.http.KamonTraceDirectives
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 
 import java.util.UUID

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -89,6 +89,7 @@ object User {
 
   def create = Create.apply _
 
+
   @JsonCodec
   case class WithGroupRole (
     id: String,


### PR DESCRIPTION
## Overview

This PR limits the scope of when the API returns email addresses in user lists:

- if a user has proven commonality with the users they're listing, then emails are returned. This covers listing users in a non-default organization, or listing users in teams (see notes)
- if a user hasn't proven commonality with the users they're listing, then emails are not returned. This covers listing users in the default organization, and listing users in a platform

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

It isn't obvious what should happen with listing users in teams. A team of users not in the public org
can be created on that public organization, in which case, I have no idea what commonality that
proves. It might make sense not to allow creating teams on the public organization for that reason. I'm
not sure.

Also, there's a better implementation where users' emails are hidden conditionally on a per-user basis.
That's more complicated, so I'm starting with the blunt force instrument and we can refine from here.

Double also, I tried doing this initially with an `implicit val foo: Encoder[User.WithGroupRole]` closer
to where results were returned, but that turned out to be more complicated than I expected, so I killed
it in favor of `paginatedResponse.copy( <nerf emails> )`.

## Testing Instructions

 * have an admin user in the dev platform
 * list users in the contexts mentioned in the overview
 * confirm results
 * try to think of cases where the results would not be what we want them to be

Closes azavea/raster-foundry-platform#350
