### PR TITLE
Fix anti-meridian artifacts on scene footprints

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -230,7 +230,7 @@ class ProjectsEditController {
             }
         });
         this.getMap().then((map) => {
-            map.setGeojson('footprint', styledGeojson);
+            map.setGeojson('footprint', styledGeojson, {rectify: true});
         });
     }
 

--- a/app-frontend/src/app/services/map/map.service.js
+++ b/app-frontend/src/app/services/map/map.service.js
@@ -244,8 +244,16 @@ class MapWrapper {
     }
 
     shouldRectifyBounds(bounds, beforeArea, afterArea) {
+        // NOTE: This magic number was tested to work with MODIS imagery, which is the largest
+        //       that we've worked with so far. The largest I saw was around 10, so 30
+        //       is a conservative guess that should cover everything that matters.
+        //       Essentially, this boils down to checking if
+        //       the middle of a polygon that may cross the anti-meridian is 30 degrees or
+        //       less off center. In order for a scene to not trigger rectification, it
+        //       would need to cover 60+ degrees of longitude
+        const differenceThreshold = 30;
         return bounds &&
-              Math.abs(bounds.getEast() + bounds.getWest()) < 30 &&
+              Math.abs(bounds.getEast() + bounds.getWest()) < differenceThreshold &&
               afterArea < beforeArea;
     }
 

--- a/app-frontend/src/app/services/map/map.service.js
+++ b/app-frontend/src/app/services/map/map.service.js
@@ -216,6 +216,12 @@ class MapWrapper {
         if (allOptions.onEachFeature) {
             allOptions.onEachFeature(geojson, layer);
         }
+
+        if (options && options.rectify) {
+            // TODO: if rectified, needs to duplicate the polygon on the other side of the map
+            this.rectifyLayerCoords(layer);
+        }
+
         this._geoJsonLayerGroup.addLayer(layer);
         if (this._geoJsonMap.has(id)) {
             this._geoJsonMap = this._geoJsonMap.set(
@@ -225,6 +231,36 @@ class MapWrapper {
             this._geoJsonMap = this._geoJsonMap.set(id, [layer]);
         }
         return this;
+    }
+
+    rectifyCoords(latlongs) {
+        return latlongs.map((multipolygon) => {
+            return multipolygon.map((polygon) => {
+                return polygon.map((cord) => {
+                    return {lng: cord.lng > 0 ? cord.lng - 360 : cord.lng, lat: cord.lat};
+                });
+            });
+        });
+    }
+
+    shouldRectifyBounds(bounds, beforeArea, afterArea) {
+        return bounds &&
+              Math.abs(bounds.getEast() + bounds.getWest()) < 30 &&
+              afterArea < beforeArea;
+    }
+
+    rectifyLayerCoords(currentLayer) {
+        const bounds = currentLayer.getBounds && currentLayer.getBounds();
+
+        const currentArea = L.GeometryUtil.geodesicArea(currentLayer.getLatLngs()[0][0]);
+
+        const latlongs = currentLayer.getLatLngs();
+        const newCoords = this.rectifyCoords(latlongs);
+        const rectifiedArea = L.GeometryUtil.geodesicArea(newCoords[0][0]);
+
+        if (this.shouldRectifyBounds(bounds, currentArea, rectifiedArea)) {
+            currentLayer.setLatLngs(newCoords);
+        }
     }
 
     /** Update a geojson layer. Overwrites current contents
@@ -517,14 +553,16 @@ class MapWrapper {
                 }
                 this.setGeojson(
                     'thumbnail',
-                    footprintGeojson
+                    footprintGeojson,
+                    {rectify: true}
                 );
             });
         } else if (scene.dataFootprint) {
             this.deleteLayers('thumbnail');
             this.setGeojson(
                 'thumbnail',
-                footprintGeojson
+                footprintGeojson,
+                {rectify: true}
             );
         }
         return this;

--- a/docs/architecture/adr-0022-anti-meridian-artifacts.md
+++ b/docs/architecture/adr-0022-anti-meridian-artifacts.md
@@ -1,0 +1,54 @@
+# Anti-meridian artifacts
+
+## Observation
+Polygons which cross the anti-meridian are ambiguous. 
+There are various heuristics to determine what the best to display them is, 
+but none of them are correct in all cases.  
+Fixing a polygon has multiple solutions and they're all relatively easy to 
+implement, but determining which polygons need to be fixed is a less straightforward question.
+
+## Possible solutions
+None of these address every possible case since it is a mathematically ambiguous problem.
+Each heuristic makes a compromise somewhere.
+
+### Smallest area
+Calculate the area of the polygon two ways - one in which the polygon crosses the anti-meridian, 
+and the other in which it wraps around in the other direction. Assume that the smaller one is correct.
+
+#### Advantages
+Relatively simple to implement, and most likely to be correct for all imagery
+
+#### Disadvantages
+Any polygons which cover more than half of the world horizontally will be shown as wrapping around the world in the wrong direction.
+Most imagery that we handle does not cover such a wide area, as imagery providers tend to chop up their imagery for easier processing.
+
+### Degree difference threshold
+calculation: Abs(westmost coord + eastmost coord) < degree threshold
+
+#### Advantages
+- Only affects polygons which are close to the meridian
+ 
+#### Disadvantages
+- Doesn't fix polygons which are outside the threshold.
+- Can have false positives on small polygons which are close to the anti-meridian
+- threshold must be tuned to the expected size of the polygons - can't deal with large and small polygons equally well
+
+### Assume that no polygons cross the anti-meridian
+
+#### Advantages
+- Easy
+- assume that all polygon sources will split into multipolygons instead of crossing the anti-meridian
+#### Disadvantages
+Doesn't actually address the problem since we can't choose where our polygons are coming from
+
+### Combine Smallest area and Degree difference threshold
+Also only apply to thumbnails
+#### Advantages
+- Is somewhat better that each of the solutions individually
+- Avoids issue with small polygons near the anti-meridian
+
+#### Disadvantages
+- Still has issues with very large polygons, but now both the eastmost and westmost points must be relatively near the anti-meridian.
+
+## Proposal
+Go with the hybrid smallest area and degree difference approach for now, and only apply it to scene footprints. We don't currently support any imagery sources that cover wide swaths of the globe, so this should be good enough as a temporary solution.


### PR DESCRIPTION
## Overview

Fix warped scene footprints on the anti-meridian

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

![image](https://user-images.githubusercontent.com/4392704/41252047-fe003c98-6d89-11e8-9f8e-9130158c6908.png)

### Notes

While fixing this, I found a couple other issues that should be handled in another issue:
- When moving the map over the anti-meridian, the search queries only show results for the side of the anti-meridian that the center of the map is on. Anything which actually crosses the anti-meridian is considered to be on the right side of the it for search purposes.
- Thumbnails that cross the anti-meridian are  also broken, being placed on the meridian instead. They require a similar fix

## Testing Instructions

 * In the project scene browse view, verify that scenes which cross the anti-meridian no longer have a warped polygon
* Verify that scenes which cross the meridian are not warped (common regression for this kind of fix)
* Review the ADR
Closes https://github.com/raster-foundry/raster-foundry/issues/3419
