### PR TITLE
 Add RF_DEPLOYMENT_ENVIRONMENT variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,9 +29,11 @@ node {
       if (env.BRANCH_NAME =~ /(release|hotfix)\//) {
         env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
         env.RF_DEPLOYMENT_BRANCH = 'master'
+        env.RF_DEPLOYMENT_ENVIRONMENT = "Production"
       } else {
         env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
         env.RF_DEPLOYMENT_BRANCH = 'develop'
+        env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
       }
 
       // Publish container images built and tested during `cibuild`


### PR DESCRIPTION
## Overview

Add `RF_DEPLOYMENT_ENVIRONMENT` variable, which is used when checking `desired_vcpus` for batch compute environments.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

 * see azavea/raster-foundry-deployment#137

Connects azavea/raster-foundry-platform#334
