### PR TITLE
Signed requests should never send a HEAD request

### DIFF
--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -53,6 +53,9 @@ memcached {
   enabled = true
   enabled = ${?MEMCACHED_ENABLED}
 
+  keySize = 250
+  keySize = ${?MEMCACHED_KEY_SIZE}
+
   localCache.enabled = true
   localCache.enabled = ${?MEMCACHED_LOCAL_CACHE_ENABLED}
 

--- a/app-backend/common/src/main/scala/Config.scala
+++ b/app-backend/common/src/main/scala/Config.scala
@@ -46,6 +46,9 @@ object Config {
     lazy val enabled: Boolean =
       memcachedConfig.getBoolean("enabled")
 
+    lazy val keySize: Int =
+      memcachedConfig.getInt("keySize")
+
     lazy val localCacheEnabled: Boolean =
       memcachedConfig.getBoolean("localCache.enabled")
 

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -3,6 +3,7 @@ package com.azavea.rf.common.utils
 import com.azavea.rf.common.cache._
 import com.azavea.rf.common.cache.kryo._
 import com.azavea.rf.common.{Config => CommonConfig}
+
 import geotrellis.vector._
 import geotrellis.raster._
 import geotrellis.raster.crop._
@@ -15,9 +16,6 @@ import geotrellis.util._
 import geotrellis.proj4._
 import geotrellis.spark.tiling._
 
-import scala.util.Properties
-import scala.math
-import scala.util.Try
 import scala.concurrent._
 import cats.data._
 import cats.implicits._
@@ -35,7 +33,7 @@ object CogUtils {
 
   /** Read GeoTiff from URI while caching the header bytes in memcache */
   def fromUri(uri: String)(implicit ec: ExecutionContext): OptionT[Future, GeoTiff[MultibandTile]] = {
-    val cacheKey = s"cog-header-${uri}"
+    val cacheKey = s"cog-header-${URIUtils.withNoParams(uri)}"
     val cacheSize = 1<<18
 
     rfCache.cachingOptionT(cacheKey, doCache = cacheConfig.tool.enabled) {
@@ -53,7 +51,7 @@ object CogUtils {
   }
 
   def fetch(uri: String, zoom: Int, x: Int, y: Int)(implicit ec: ExecutionContext): OptionT[Future, MultibandTile] =
-    rfCache.cachingOptionT(s"cog-tile-${zoom}-${x}-${y}-${uri}")(
+    rfCache.cachingOptionT(s"cog-tile-${zoom}-${x}-${y}-${URIUtils.withNoParams(uri)}")(
       CogUtils.fromUri(uri).mapFilter { tiff =>
         val transform = Proj4Transform(tiff.crs, WebMercator)
         val inverseTransform = Proj4Transform(WebMercator, tiff.crs)

--- a/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
+++ b/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
@@ -1,34 +1,47 @@
 package com.azavea.rf.common.utils
 
 import com.typesafe.scalalogging.LazyLogging
-import geotrellis.proj4.{LatLng, WebMercator}
-import geotrellis.slick.Projected
-import geotrellis.vector.{Extent, Point, Polygon}
-import geotrellis.util.{ FileRangeReader, RangeReader }
+import geotrellis.util.{FileRangeReader, RangeReader}
 import geotrellis.spark.io.s3.util.S3RangeReader
 import geotrellis.spark.io.s3.AmazonS3Client
 import geotrellis.spark.io.http.util.HttpRangeReader
 
-import com.amazonaws.services.s3.AmazonS3URI
 import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3Client => AWSAmazonS3Client}
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import org.apache.http.client.utils.URLEncodedUtils
 
-import scala.util.Try
+import java.nio.file.Paths
+import java.nio.charset.Charset
 import java.net.URI
 import java.net.URL
 
 
 object RangeReaderUtils extends LazyLogging {
   def fromUri(uri: String): Option[RangeReader] = {
-    import java.nio.file._
-
     val javaUri = new URI(uri)
+
+    /**
+      * Links can be signed for instance via HMAC-SHA,
+      * it means that request signature can be specific at least to the METHOD
+      * (GET and HEAD requests would have different auth signature)
+      *
+      * AWS S3 would return 403 as each METHOD has a different signature,
+      * see: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+      *
+      * In all cases there are some query params force GET method usage
+      */
+    val noQueryParams =
+      URLEncodedUtils.parse(uri, Charset.forName("UTF-8")).isEmpty
+
     javaUri.getScheme match {
       case "file" | null =>
         Some(FileRangeReader(Paths.get(javaUri).toFile))
 
-      case "http" | "https" =>
+      case "http" | "https" if noQueryParams =>
         Some(HttpRangeReader(new URL(uri)))
+
+      case "http" | "https" =>
+        Some(new HttpRangeReader(new URL(uri), false))
 
       case "s3" =>
         val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))

--- a/app-backend/common/src/main/scala/utils/URIUtils.scala
+++ b/app-backend/common/src/main/scala/utils/URIUtils.scala
@@ -1,0 +1,19 @@
+package com.azavea.rf.common.utils
+
+import java.net.URI
+
+object URIUtils {
+  def withNoParams(uri: URI): URI =
+    new URI(
+      uri.getScheme,
+      uri.getAuthority,
+      uri.getPath,
+      null, // Ignore the query part of the input url
+      uri.getFragment
+    )
+
+
+  def withNoParams(str: String): String =
+    withNoParams(new URI(str)).toString
+
+}


### PR DESCRIPTION
## Overview

AWS generates a hmac-sha signature to auth queries, however this signature is based on `METHOD`, time, and other params. It means that `GET` query and `HEAD` query can't have the same signature.
[By default `HttpRangeReader` would send a `HEAD` request](https://github.com/locationtech/geotrellis/blob/master/spark/src/main/scala/geotrellis/spark/io/http/util/HttpRangeReader.scala#L38-L42)

See: https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

I suggest to remark in docs that `URL` should be for `GET` request and in all cases we have extra get params in URLs - use only `GET` requests.

## Testing Instructions

* Get a signed URL (for instance: https://raster-prediction-api-dev-andrew.s3.amazonaws.com/uploads/a6009b46-e5ff-42ee-bb07-1f61f2704050/1-x-upload.tif?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIHFVQ2CL73CVLHFQ%2F20180605%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20180605T191932Z&X-Amz-Expires=604799&X-Amz-SignedHeaders=host&X-Amz-Signature=3645c60ff097e20067616dc07f1530cc39bfd47dcb8c5e927205d0624b513c82)
* Go through the UI and try and upload it

![image](https://user-images.githubusercontent.com/4929546/41310347-ebd05660-6e89-11e8-85d0-7cb185fd4803.png)

This PR also introduces `MEMCACHED_KEY_SIZE` env variable support, which defines max possible keys size. The current logic is just to take a substring of the key, but may be it's a waste of memory and it makes sense just to encode all keys into `MD5` or `SHA1`. However this can be discussed.

Closes #3461
