### PR TITLE
More frontend fixes

### DIFF
--- a/app-frontend/src/app/pages/admin/organization/organization.html
+++ b/app-frontend/src/app/pages/admin/organization/organization.html
@@ -1,21 +1,18 @@
 <div class="container-admin-header">
   <div class="admin-header">
-    <div class="admin-logo image-placeholder editable-image"
-         ng-if="$ctrl.fetching"
-    ></div>
+    <div class="admin-logo image-placeholder" ng-if="!$ctrl.orgLogoUri.length && !$ctrl.isSuperOrAdmin || $ctrl.fetching"></div>
     <div class="admin-logo image-placeholder editable-image-placeholder"
-         ng-if="!$ctrl.orgLogoUri.length && $ctrl.isSuperOrAdmin"
+         ng-if="!$ctrl.orgLogoUri.length && $ctrl.isSuperOrAdmin && !$ctrl.fetching"
          ng-click="$ctrl.addLogoModal()"
     ></div>
     <div class="admin-logo editable-image-always"
-         ng-if="$ctrl.orgLogoUri.length && $ctrl.isSuperOrAdmin"
+         ng-if="$ctrl.orgLogoUri.length && $ctrl.isSuperOrAdmin && !$ctrl.fetching"
          ng-click="$ctrl.addLogoModal()"
     >
       <img ng-attr-src="{{$ctrl.orgLogoUri}}">
     </div>
-    <div class="admin-logo image-placeholder" ng-if="($ctrl.fetching || !$ctrl.orgLogoUri.length) && !$ctrl.isSuperOrAdmin"></div>
     <div class="admin-logo"
-         ng-if="$ctrl.orgLogoUri.length && !$ctrl.isSuperOrAdmin">
+         ng-if="$ctrl.orgLogoUri.length && !$ctrl.isSuperOrAdmin && !$ctrl.fetching">
       <img ng-attr-src="{{$ctrl.orgLogoUri}}">
     </div>
     <div class="admin-logo-text" ng-if="!$ctrl.fetching">

--- a/app-frontend/src/app/pages/admin/organization/organization.html
+++ b/app-frontend/src/app/pages/admin/organization/organization.html
@@ -1,10 +1,13 @@
 <div class="container-admin-header">
   <div class="admin-header">
     <div class="admin-logo image-placeholder editable-image"
-         ng-if="($ctrl.fetching || !$ctrl.orgLogoUri.length) && $ctrl.isSuperOrAdmin"
+         ng-if="$ctrl.fetching"
+    ></div>
+    <div class="admin-logo image-placeholder editable-image-placeholder"
+         ng-if="!$ctrl.orgLogoUri.length && $ctrl.isSuperOrAdmin"
          ng-click="$ctrl.addLogoModal()"
     ></div>
-    <div class="admin-logo editable-image"
+    <div class="admin-logo editable-image-always"
          ng-if="$ctrl.orgLogoUri.length && $ctrl.isSuperOrAdmin"
          ng-click="$ctrl.addLogoModal()"
     >

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -4,16 +4,30 @@
       {{$ctrl.errorMsg}}
     </p>
   </div>
-  <div ng-if="!$ctrl.errorMsg">
-    <div class="admin-users-actions">
-      <div class="actions-right">
-        <button type="button" class="btn btn-primary"
-                ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
-          New Team
-        </button>
-      </div>
+  <div class="admin-users-actions" ng-if="!$ctrl.errorMsg && $ctrl.teams.length">
+    <div class="actions-right">
+      <button type="button" class="btn btn-primary"
+              ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
+        Create Team
+      </button>
     </div>
   </div>
+  <rf-call-to-action-item
+    title="No teams have been formed yet"
+    class="panel panel-off-white"
+    ng-if="!$ctrl.teams.length && !$ctrl.fetching">
+    <p class="pb-25">
+      The {{$ctrl.organization.name}} organization does not have any teams yet.
+      You can use teams to organize users and make sharing common data even easier.
+      When you form teams, they'll be shown here.
+    </p>
+
+    <button type="button" class="btn btn-primary"
+            ng-click="$ctrl.newTeamModal()"
+    >
+      Create Team
+    </button>
+  </rf-call-to-action-item>
   <table class="admin-table admin-team-table" ng-if="!$ctrl.fetching">
     <tbody>
       <tr ng-repeat="team in $ctrl.teams track by team.id">
@@ -40,7 +54,7 @@
           </div>
           &nbsp;
           <ng-pluralize count="team.fetchedUsers.count"
-                        when="{'0': ' No members',
+                        when="{'0': ' No members yet',
                                '1': ' 1 member',
                                'other': '{} members'}"
 

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -4,19 +4,32 @@
       {{$ctrl.errorMsg}}
     </p>
   </div>
-  <div ng-if="!$ctrl.errorMsg">
-    <div class="admin-users-actions">
-      <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
-      <div class="actions-right">
-        <button type="button" class="btn btn-primary"
-                ng-click="$ctrl.addUserModal()"
-                ng-disabled="$ctrl.fetching">
-          Add User
-        </button>
-      </div>
+  <div class="admin-users-actions" ng-if="!$ctrl.errorMsg && $ctrl.users.length">
+    <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true" disabled="$ctrl.fetching || !$ctrl.users.length"></rf-search>
+    <div class="actions-right">
+      <button type="button" class="btn btn-primary"
+              ng-click="$ctrl.addUserModal()"
+              ng-disabled="$ctrl.fetching">
+        Add Users
+      </button>
     </div>
   </div>
-  <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching">
+  <rf-call-to-action-item
+    title="No users are in this organization yet"
+    class="panel panel-off-white"
+    ng-if="!$ctrl.users.length && !$ctrl.fetching">
+    <p class="pb-25">
+      The {{$ctrl.organization.name}} organization does not have any users yet.
+      When it does, they'll be shown here.
+    </p>
+
+    <button type="button" class="btn btn-primary"
+            ng-click="$ctrl.addUserModal()"
+    >
+      Add Users
+    </button>
+  </rf-call-to-action-item>
+  <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching && $ctrl.users.length">
     <tbody>
       <tr ng-repeat="user in $ctrl.users track by $index">
         <td class="username">

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -1,14 +1,29 @@
 <div class="admin-users-content container column-stretch">
-  <div class="admin-users-actions">
+  <div class="admin-users-actions" ng-if="$ctrl.users.length">
       <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
     <div class="actions-right">
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.addUser()" ng-disabled="$ctrl.fetching">
-        Add users
+        Add Users
       </button>
     </div>
   </div>
-  <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
+  <rf-call-to-action-item
+    title="No users are in this team yet"
+    class="panel panel-off-white"
+    ng-if="!$ctrl.users.length && !$ctrl.fetching">
+    <p class="pb-25">
+      The {{$ctrl.team.name}} team does not have any users yet.
+      When it does, they'll be shown here.
+    </p>
+
+    <button type="button" class="btn btn-primary"
+            ng-click="$ctrl.addUser()"
+    >
+      Add Users
+    </button>
+  </rf-call-to-action-item>
+  <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching && $ctrl.users.length">
     <tbody>
       <tr ng-repeat="user in $ctrl.users track by $index">
         <td class="username">

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -38,29 +38,6 @@ div.image-placeholder {
   }
 }
 
-.editable-image {
-  $background: rgba(0,0,0,0.7);
-  position: relative;
-  border: 1px solid rgba(0, 0, 0, 0);
-  cursor: pointer;
-  &:hover {
-    border: 1px solid $background;
-  }
-  &:hover:before {
-    font-size: 1.1rem;
-    position: absolute;
-    padding: 2px 0px;
-    text-align: center;
-    background: $background;
-    color: #fff;
-    content: 'Change';
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 1000;
-  }
-}
-
 .editable-image-placeholder,
 .editable-image-always {
   $background: rgba(0,0,0,0.7);

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -39,19 +39,21 @@ div.image-placeholder {
 }
 
 .editable-image {
+  $background: rgba(0,0,0,0.7);
   position: relative;
-  border: 1px solid rgba($brand-primary, 0);
+  border: 1px solid rgba(0, 0, 0, 0);
   cursor: pointer;
   &:hover {
-    border: 1px solid $brand-primary;
+    border: 1px solid $background;
   }
   &:hover:before {
+    font-size: 1.1rem;
     position: absolute;
-    padding: 2px 12px;
+    padding: 2px 0px;
     text-align: center;
-    background: $brand-primary;
+    background: $background;
     color: #fff;
-    content: 'Edit';
+    content: 'Change';
     bottom: 0;
     left: 0;
     right: 0;
@@ -59,6 +61,35 @@ div.image-placeholder {
   }
 }
 
+.editable-image-placeholder,
+.editable-image-always {
+  $background: rgba(0,0,0,0.7);
+  position: relative;
+  cursor: pointer;
+  &::before {
+    font-size: 1.1rem;
+    overflow: hidden;
+    position: absolute;
+    padding: 2px 0px;
+    text-align: center;
+    background: $background;
+    color: #fff;
+    content: 'Upload';
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    border-radius: 0 0 $border-radius-base $border-radius-base;
+  }
+}
+
+.editable-image-placeholder::before {
+  content: 'Upload';
+}
+
+.editable-image-always::before {
+  content: 'Change';
+}
 
 /*
  * /browse/

--- a/app-frontend/src/assets/styles/sass/components/_project-item.scss
+++ b/app-frontend/src/assets/styles/sass/components/_project-item.scss
@@ -1,6 +1,6 @@
 .panel.project-item {
   border-radius: $border-radius-base;
-  
+
   .panel-body {
     padding: 1rem;
   }
@@ -14,7 +14,7 @@
   overflow: hidden;
   max-width: 100%;
   text-overflow: ellipsis;
-  padding-right: 6rem;
+  padding-right: 8.5rem;
 
   &:after {
     content: attr(data-title);
@@ -39,7 +39,7 @@
 }
 
 .project-status {
-  
+
   .inline-tag {
     text-indent: 0;
     top: 50%;

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -7,8 +7,8 @@
 
 .admin-logo {
     border-radius: 3px;
-    width: 4em;
-    height: 4em;
+    width: 6em;
+    height: 6em;
     margin-right: 1.4rem;
     position: relative;
 


### PR DESCRIPTION
## Overview

- fixes padding on long project names -- the name does not overlap the buttons now
- editable logos are now indicated even when the user is not hovering as long as the user is authorized to do so
- empty lists in the platform admin section are now hidden and in their place is a call to action item to explain and prompt the user to add the first item

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests

### Demo

![image](https://user-images.githubusercontent.com/2442245/41377202-580260d6-6f29-11e8-8c9f-6bfd94a681fb.png)

## Testing Instructions

 * make sure the things I said I changed were actually changed

Closes #3528 
Closes #3487
