### PR TITLE
Add support for lat long coordinates in map search

### DIFF
--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.module.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.module.js
@@ -261,11 +261,15 @@ class MapContainerController {
                 component: 'rfMapSearchModal',
                 resolve: { }
             }).result.then(location => {
-                const mapView = location.mapView;
-                this.map.fitBounds([
-                    [mapView.bottomRight.latitude, mapView.bottomRight.longitude],
-                    [mapView.topLeft.latitude, mapView.topLeft.longitude]
-                ]);
+                if (location.coords) {
+                    this.map.setView(location.coords, 11);
+                } else {
+                    const mapView = location.mapView;
+                    this.map.fitBounds([
+                        [mapView.bottomRight.latitude, mapView.bottomRight.longitude],
+                        [mapView.topLeft.latitude, mapView.topLeft.longitude]
+                    ]);
+                }
             });
     }
 


### PR DESCRIPTION
## Overview

This PR adds handling of geographic coordinates (lat long) in the map search.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

![image](https://user-images.githubusercontent.com/2442245/41391898-514bbe26-6f6b-11e8-804a-4c66c3bf5c90.png)

## Testing Instructions

 * Enter coordinates and things that aren't coordinates and make sure that the search detects coordinates properly.
 * Make sure the map view changes and goes to where to told it to

Closes #3327 
