### PR TITLE
Use rasterio warp module to warp modis tifs

### DIFF
--- a/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
+++ b/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
@@ -53,7 +53,6 @@ def create_geotiffs(modis_path, output_directory):
     pre_warp_output_path = os.path.join(pre_warp_directory, 'B.tif')
     combined_tif_filepath = os.path.join(output_directory, 'combined-tif.tif')
     warped_tif_path = os.path.join(output_directory, 'warped-combined.tif')
-    cropped_tif_path = os.path.join(output_directory, 'cropped-warped.tif')
     cog_filename = '.'.join(os.path.basename(modis_path).split('.')[:-1]) + '.tif'
     cog_tif_filepath = os.path.join(output_directory, cog_filename)
 
@@ -67,10 +66,10 @@ def create_geotiffs(modis_path, output_directory):
                      '-separate']
 
     # Generate overviews
-    overview_command = ['gdaladdo', cropped_tif_path, '2', '4', '8', '16', '32']
+    overview_command = ['gdaladdo', warped_tif_path, '2', '4', '8', '16', '32']
 
     # Create final tif with overviews
-    translate_cog_command = ['gdal_translate', warped_tif_path, '-a_nodata', '0',
+    translate_cog_command = ['gdal_translate', warped_tif_path, '-a_nodata', '-28672',
                              '-co', 'TILED=YES', '-co', 'COMPRESS=LZW', '-co', 'COPY_SRC_OVERVIEWS=YES',
                              cog_tif_filepath]
 

--- a/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
+++ b/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
@@ -70,8 +70,9 @@ def create_geotiffs(modis_path, output_directory):
     overview_command = ['gdaladdo', cropped_tif_path, '2', '4', '8', '16', '32']
 
     # Create final tif with overviews
-    translate_cog_command = ['gdal_translate', warped_tif_path, '-co', 'TILED=YES',
-                             '-co', 'COMPRESS=LZW', '-co', 'COPY_SRC_OVERVIEWS=YES', cog_tif_filepath]
+    translate_cog_command = ['gdal_translate', warped_tif_path, '-a_nodata', '0',
+                             '-co', 'TILED=YES', '-co', 'COMPRESS=LZW', '-co', 'COPY_SRC_OVERVIEWS=YES',
+                             cog_tif_filepath]
 
     logger.info('Creating tifs for Subdatasets: %s', ' '.join(translate_command))
     subprocess.check_call(translate_command)


### PR DESCRIPTION
## Overview

This PR uses rasterio's `warp` module to perform the warp instead of `gdalwarp` plus a bunch
of command line options.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Not clear whether we want to set nodata or not. I feel like we probably do, so I added that into the
final translation step in a separate commit, but I can remove if we don't want to for some reason.

## Testing Instructions

 * call `warp_tif` on the path to your `combined.tif`, writing output somewhere convenient
 * compare results in qgis

Closes #3421 