### PR TITLE
Display ownership information with projects

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -297,6 +297,7 @@ trait ProjectRoutes extends Authentication
           .authQuery(user, ObjectType.Project)
           .filter(projectQueryParameters)
           .page(page)
+          .flatMap(ProjectDao.projectsToProjectsWithRelated)
           .transact(xa).unsafeToFuture
       }
     }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -136,6 +136,13 @@ object User {
     }
   }
 
+  @JsonCodec
+  case class Thin(
+    id: String,
+    name: String,
+    profileImageUri: String
+  )
+
   case class JwtFields(
     id: String,
     email: String,

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -136,13 +136,6 @@ object User {
     }
   }
 
-  @JsonCodec
-  case class Thin(
-    id: String,
-    name: String,
-    profileImageUri: String
-  )
-
   case class JwtFields(
     id: String,
     email: String,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -260,7 +260,7 @@ object ProjectDao extends Dao[Project] {
   }
 
   def deleteScenesFromProject(sceneIds: List[UUID], projectId: UUID): ConnectionIO[Int] = {
-    val f:Option[Fragment] = sceneIds.toNel.map(Fragments.in(fr"scene_id", _))
+    val f:Option[Fragment] = sceneIds.toList.toNel.map(Fragments.in(fr"scene_id", _))
     val deleteQuery = fr"DELETE FROM scenes_to_projects" ++
       Fragments.whereAndOpt(f, Some(fr"project_id = ${projectId}"))
     deleteQuery.update.run
@@ -273,4 +273,38 @@ object ProjectDao extends Dao[Project] {
       scenesAdded <- addScenesToProject(scenes.map(_.id), projectId, user)
     } yield scenesAdded
   }
+
+  // head is safe here, because we're looking up users from the ids in projects, and the map was
+  // build from those same ids.
+  // throwing the exception is also safe, since the foreign key from project owners to users requires
+  // that every project's owner is a key in the resulting list of users
+  @SuppressWarnings(Array("TraversableHead"))
+  def projectsToProjectsWithRelated(projectsPage: PaginatedResponse[Project]): ConnectionIO[PaginatedResponse[Project.WithUser]] =
+    projectsPage.results.toList.toNel match {
+      case Some(nelProjects) => {
+        val usersIO: ConnectionIO[List[User.Thin]] =
+          (fr"select id, name, profile_image_uri from users where" ++
+             Fragments.in(fr"id", nelProjects map { _.owner }))
+            .query[User.Thin]
+            .list
+        usersIO map {
+          (users: List[User.Thin]) => {
+            val groupedUsers = users.groupBy(_.id)
+            val withUsers =
+              projectsPage.results map {
+                (project: Project) => Project.WithUser(
+                  project,
+                  groupedUsers.get(project.owner).getOrElse(
+                    throw new Exception("Somehow, a user id was lost to the aether")
+                  ).head
+                )
+              }
+            projectsPage.copy(results = withUsers)
+          }
+        }
+      }
+      case _ => {
+        projectsPage.copy(results = List.empty[Project.WithUser]).pure[ConnectionIO]
+      }
+    }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -294,7 +294,8 @@ object ProjectDao extends Dao[Project] {
               projectsPage.results map {
                 (project: Project) => Project.WithUser(
                   project,
-                  groupedUsers.get(project.owner).getOrElse(
+                  groupedUsers.getOrElse(
+                    project.owner,
                     throw new Exception("Somehow, a user id was lost to the aether")
                   ).head
                 )

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -45,6 +45,15 @@
         </div>
       </a>
     </div>
+
+    <div class="project-ownership">
+      <div ng-if="$ctrl.project.owner.profileImageUri">
+        <img class="avatar user-avatar pull-left" src="{{ $ctrl.project.owner.profileImageUri }}" />
+      </div>
+      <div class="font-600">
+        Modified on {{ $ctrl.project.modifiedAt | date }}
+      </div>
+    </div>
   </ng-container>
 
   <ng-container ng-if="$ctrl.slim">

--- a/app-frontend/src/assets/styles/sass/components/_project-item.scss
+++ b/app-frontend/src/assets/styles/sass/components/_project-item.scss
@@ -77,3 +77,7 @@
   border-radius: $border-radius-base;
   overflow: hidden;
 }
+
+.project-ownership {
+  margin: 0.5rem 0 0;
+}


### PR DESCRIPTION
## Overview

This PR modifies the projects list endpoint to include extra user information: id, name, and a url
for the user's profile image. It uses this information in the frontend to display information about
who owns a project that a user can see.

### Checklist

- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated (raster-foundry/raster-foundry-api-spec#22)
- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://user-images.githubusercontent.com/5702984/41553356-8b321904-72ff-11e8-8779-e90febedba8f.png)

### Notes

@jfrankl said to take out the user's name because names are long and it might mess things up.

## Testing Instructions

 * bring up your server and frontend
 * list projects
 * confirm it matches designs, within scope of the linked issue

Closes #3526 
