### PR TITLE
Make organization and team names editable for admins

### DIFF
--- a/app-frontend/src/app/pages/admin/organization/organization.html
+++ b/app-frontend/src/app/pages/admin/organization/organization.html
@@ -16,9 +16,35 @@
       <img ng-attr-src="{{$ctrl.orgLogoUri}}">
     </div>
     <div class="admin-logo-text" ng-if="!$ctrl.fetching">
-      <h1 class="admin-logo-name h3">
+      <h1 class="admin-logo-name h3"
+          ng-if="!$ctrl.isEditOrgName">
         {{$ctrl.organization.name}}
+        <button class="btn btn-tiny btn-admin-name-edit-small"
+                type="button"
+                ng-click="$ctrl.toggleOrgNameEdit()"
+                ng-if="$ctrl.isSuperOrAdmin">
+          <span class="icon-pencil"></span>
+        </button>
       </h1>
+      <div ng-if="$ctrl.isEditOrgName">
+        <form class="inline-form" ng-submit="$ctrl.finishOrgNameEdit()">
+          <div class="form-group all-in-one form-admin-name-edit-header">
+            <input id="name"
+                   type="text"
+                   class="form-control"
+                   ng-attr-placeholder="{{$ctrl.organization.name}}"
+                   ng-model="$ctrl.nameBuffer">
+            <button class="btn btn-link flex-last node-header-eidt-group">
+              <span class="sr-only">Save</span>
+              <span class="icon-save node-label-name"</span>
+            </button>
+            <button type="button" class="btn btn-link node-header-eidt-group" ng-click="$ctrl.toggleOrgNameEdit()">
+              <span class="sr-only">Cancel</span>
+              <span class="icon-cancel node-label-name"></span>
+            </button>
+          </div>
+        </form>
+      </div>
       <div>
         Organization Management
       </div>

--- a/app-frontend/src/app/pages/admin/organization/organization.html
+++ b/app-frontend/src/app/pages/admin/organization/organization.html
@@ -32,7 +32,7 @@
             <input id="name"
                    type="text"
                    class="form-control"
-                   ng-attr-placeholder="{{$ctrl.organization.name}}"
+                   ng-init="$ctrl.nameBuffer = $ctrl.organization.name"
                    ng-model="$ctrl.nameBuffer">
             <button class="btn btn-link flex-last node-header-eidt-group">
               <span class="sr-only">Save</span>

--- a/app-frontend/src/app/pages/admin/organization/organization.module.js
+++ b/app-frontend/src/app/pages/admin/organization/organization.module.js
@@ -2,12 +2,13 @@ import angular from 'angular';
 
 class OrganizationController {
     constructor(
-      $stateParams, $q,
+      $stateParams, $q, $log,
       organizationService, authService, modalService) {
         'ngInject';
 
         this.$stateParams = $stateParams;
         this.$q = $q;
+        this.$log = $log;
         this.organizationService = organizationService;
         this.authService = authService;
         this.modalService = modalService;
@@ -68,6 +69,25 @@ class OrganizationController {
     // to differentiate logos since uri itself does not change
     // but the picture itself changes
         return uri.length ? `${uri}?${new Date().getTime()}` : '';
+    }
+
+    toggleOrgNameEdit() {
+        this.isEditOrgName = !this.isEditOrgName;
+        delete this.nameBuffer;
+    }
+
+    finishOrgNameEdit() {
+        if (this.nameBuffer && this.nameBuffer.length
+            && this.nameBuffer !== this.organization.name) {
+            let orgUpdated = Object.assign({}, this.organization, {name: this.nameBuffer});
+            this.organizationService.updateOrganization(
+              this.organization.platformId, this.organization.id, orgUpdated)
+            .then(resp => {
+                this.organization = resp;
+            });
+        }
+        delete this.nameBuffer;
+        delete this.isEditOrgName;
     }
 }
 

--- a/app-frontend/src/app/pages/admin/organization/organization.module.js
+++ b/app-frontend/src/app/pages/admin/organization/organization.module.js
@@ -2,12 +2,13 @@ import angular from 'angular';
 
 class OrganizationController {
     constructor(
-      $stateParams, $q,
+      $stateParams, $q, $window,
       organizationService, authService, modalService) {
         'ngInject';
 
         this.$stateParams = $stateParams;
         this.$q = $q;
+        this.$window = $window;
         this.organizationService = organizationService;
         this.authService = authService;
         this.modalService = modalService;
@@ -72,7 +73,6 @@ class OrganizationController {
 
     toggleOrgNameEdit() {
         this.isEditOrgName = !this.isEditOrgName;
-        delete this.nameBuffer;
     }
 
     finishOrgNameEdit() {
@@ -83,10 +83,17 @@ class OrganizationController {
               this.organization.platformId, this.organization.id, orgUpdated)
             .then(resp => {
                 this.organization = resp;
+                this.nameBuffer = this.organization.name;
+            }, () => {
+                this.$window.alert('Organization\'s name cannot be updated at the moment.');
+                delete this.nameBuffer;
+            }).finally(() => {
+                delete this.isEditOrgName;
             });
+        } else {
+            delete this.nameBuffer;
+            delete this.isEditOrgName;
         }
-        delete this.nameBuffer;
-        delete this.isEditOrgName;
     }
 }
 

--- a/app-frontend/src/app/pages/admin/organization/organization.module.js
+++ b/app-frontend/src/app/pages/admin/organization/organization.module.js
@@ -2,13 +2,12 @@ import angular from 'angular';
 
 class OrganizationController {
     constructor(
-      $stateParams, $q, $log,
+      $stateParams, $q,
       organizationService, authService, modalService) {
         'ngInject';
 
         this.$stateParams = $stateParams;
         this.$q = $q;
-        this.$log = $log;
         this.organizationService = organizationService;
         this.authService = authService;
         this.modalService = modalService;

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -18,11 +18,37 @@
     <tbody>
       <tr ng-repeat="team in $ctrl.teams track by team.id">
         <td class="name">
-          <a class="font-600"
-             title="View team details"
-             ui-sref="admin.team.users({teamId: team.id})">
-            {{team.name}}
-          </a>
+          <div ng-if="$ctrl.editTeamId !== team.id">
+            <a class="font-600"
+               title="View team details"
+               ui-sref="admin.team.users({teamId: team.id})">
+              {{team.name}}
+            </a>
+            <button class="btn btn-tiny btn-admin-name-edit-small"
+                    type="button"
+                    ng-click="$ctrl.toggleTeamNameEdit(team.id, true)"
+                    ng-disabled="$ctrl.isEditTeamName"
+                    ng-if="$ctrl.userTeamRole[team.id]">
+              <span class="icon-pencil"></span>
+            </button>
+          </div>
+          <div ng-if="$ctrl.editTeamId === team.id">
+            <form class="inline-form" ng-submit="$ctrl.finishTeamNameEdit(team)">
+              <div class="form-group all-in-one form-admin-name-edit">
+                <input id="name"
+                       type="text"
+                       class="form-control"
+                       ng-attr-placeholder="{{team.name}}"
+                       ng-model="$ctrl.nameBuffer">
+                <button class="btn btn-link flex-last node-header-eidt-group">
+                  <span class="icon-save node-label-name"></span>
+                </button>
+                <button type="button" class="btn btn-link node-header-eidt-group" ng-click="$ctrl.toggleTeamNameEdit(team.id, false)">
+                  <span class="icon-cancel node-label-name"></span>
+                </button>
+              </div>
+            </form>
+          </div>
         </td>
         <td class="users">
           <div class="user-group-avatars">

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -38,7 +38,7 @@
                 <input id="name"
                        type="text"
                        class="form-control"
-                       ng-attr-placeholder="{{team.name}}"
+                       ng-init="$ctrl.nameBuffer = $ctrl.getInitialNameBuffer(team.id)"
                        ng-model="$ctrl.nameBuffer">
                 <button class="btn btn-link flex-last node-header-eidt-group">
                   <span class="icon-save node-label-name"></span>

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -3,12 +3,13 @@ import _ from 'lodash';
 
 class OrganizationTeamsController {
     constructor(
-        $scope, $stateParams, $log,
+        $scope, $stateParams, $log, $window,
         modalService, organizationService, teamService, authService
     ) {
         this.$scope = $scope;
         this.$stateParams = $stateParams;
         this.$log = $log;
+        this.$window = $window;
         this.modalService = modalService;
         this.organizationService = organizationService;
         this.teamService = teamService;
@@ -217,11 +218,23 @@ class OrganizationTeamsController {
                 .updateTeam(this.platformId, this.organizationId, team.id, teamUpdated)
                 .then(resp => {
                     this.teams[this.teams.indexOf(team)] = resp;
+                }, () => {
+                    this.$window.alert('Team\'s name cannot be updated at the moment.');
+                }).finally(() => {
+                    delete this.editTeamId;
+                    delete this.isEditTeamName;
+                    this.nameBuffer = '';
                 });
+        } else {
+            delete this.editTeamId;
+            delete this.isEditTeamName;
+            this.nameBuffer = '';
         }
-        delete this.editTeamId;
-        delete this.isEditTeamName;
-        this.nameBuffer = '';
+    }
+
+    getInitialNameBuffer(teamId) {
+        let team = this.teams.filter(t => t.id === teamId)[0];
+        return team ? team.name : '';
     }
 }
 

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -233,7 +233,7 @@ class OrganizationTeamsController {
     }
 
     getInitialNameBuffer(teamId) {
-        let team = this.teams.filter(t => t.id === teamId)[0];
+        let team = this.teams.find(t => t.id === teamId);
         return team ? team.name : '';
     }
 }

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -216,7 +216,6 @@ class OrganizationTeamsController {
             this.teamService
                 .updateTeam(this.platformId, this.organizationId, team.id, teamUpdated)
                 .then(resp => {
-                    this.$log.log(resp);
                     this.teams[this.teams.indexOf(team)] = resp;
                 });
         }

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -38,11 +38,9 @@
                          ng-attr-placeholder="{{organization.name}}"
                          ng-model="$ctrl.nameBuffer">
                   <button class="btn btn-link flex-last node-header-eidt-group">
-                    <span class="sr-only">Save</span>
-                    <span class="icon-save node-label-name"</span>
+                    <span class="icon-save node-label-name"></span>
                   </button>
                   <button type="button" class="btn btn-link node-header-eidt-group" ng-click="$ctrl.toggleOrgNameEdit(organization.id, false)">
-                    <span class="sr-only">Cancel</span>
                     <span class="icon-cancel node-label-name"></span>
                   </button>
                 </div>

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -35,7 +35,7 @@
                   <input id="name"
                          type="text"
                          class="form-control"
-                         ng-attr-placeholder="{{organization.name}}"
+                         ng-init="$ctrl.nameBuffer = $ctrl.getInitialNameBuffer(organization.id)"
                          ng-model="$ctrl.nameBuffer">
                   <button class="btn btn-link flex-last node-header-eidt-group">
                     <span class="icon-save node-label-name"></span>

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -17,8 +17,36 @@
               <div ng-if="organization.logoUri">
                 <img class="avatar user-avatar" ng-src="{{organization.logoUri}}">
               </div>
-            <div >
-              <a class="font-600" ui-sref="admin.organization.users({organizationId: organization.id})">{{organization.name}}</a>
+            <div ng-if="$ctrl.editOrgId !== organization.id">
+              <a class="font-600"
+                 ui-sref="admin.organization.users({organizationId: organization.id})">
+                 {{organization.name}}</a>
+              <button class="btn btn-tiny btn-admin-name-edit-small"
+                      type="button"
+                      ng-click="$ctrl.toggleOrgNameEdit(organization.id, true)"
+                      ng-disabled="$ctrl.isEditOrgName"
+                      ng-if="$ctrl.userOrgRole[organization.id]">
+                <span class="icon-pencil"></span>
+              </button>
+            </div>
+            <div ng-if="$ctrl.editOrgId === organization.id">
+              <form class="inline-form" ng-submit="$ctrl.finishOrgNameEdit(organization)">
+                <div class="form-group all-in-one form-admin-name-edit">
+                  <input id="name"
+                         type="text"
+                         class="form-control"
+                         ng-attr-placeholder="{{organization.name}}"
+                         ng-model="$ctrl.nameBuffer">
+                  <button class="btn btn-link flex-last node-header-eidt-group">
+                    <span class="sr-only">Save</span>
+                    <span class="icon-save node-label-name"</span>
+                  </button>
+                  <button type="button" class="btn btn-link node-header-eidt-group" ng-click="$ctrl.toggleOrgNameEdit(organization.id, false)">
+                    <span class="sr-only">Cancel</span>
+                    <span class="icon-cancel node-label-name"></span>
+                  </button>
+                </div>
+              </form>
             </div>
           </td>
           <td class="users">

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -229,7 +229,7 @@ class PlatformOrganizationsController {
     }
 
     getInitialNameBuffer(orgId) {
-        let organization = this.organizations.filter(org => org.id === orgId)[0];
+        let organization = this.organizations.find(org => org.id === orgId);
         return organization ? organization.name : '';
     }
 }

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -3,13 +3,14 @@ import _ from 'lodash';
 
 class PlatformOrganizationsController {
     constructor(
-        $state, modalService, $stateParams, $scope, $log,
+        $state, modalService, $stateParams, $scope, $log, $window,
         platformService, organizationService
     ) {
         this.$state = $state;
         this.$scope = $scope;
         this.$stateParams = $stateParams;
         this.$log = $log;
+        this.$window = $window;
         this.modalService = modalService;
         this.platformService = platformService;
         this.organizationService = organizationService;
@@ -213,11 +214,23 @@ class PlatformOrganizationsController {
                 .updateOrganization(orgUpdated.platformId, orgUpdated.id, orgUpdated)
                 .then(resp => {
                     this.organizations[this.organizations.indexOf(org)] = resp;
+                }, () => {
+                    this.$window.alert('Organization\'s name cannot be updated at the moment.');
+                }).finally(() => {
+                    delete this.editOrgId;
+                    delete this.isEditOrgName;
+                    this.nameBuffer = '';
                 });
+        } else {
+            delete this.editOrgId;
+            delete this.isEditOrgName;
+            this.nameBuffer = '';
         }
-        delete this.editOrgId;
-        delete this.isEditOrgName;
-        this.nameBuffer = '';
+    }
+
+    getInitialNameBuffer(orgId) {
+        let organization = this.organizations.filter(org => org.id === orgId)[0];
+        return organization ? organization.name : '';
     }
 }
 

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -1,4 +1,3 @@
-/* globals document */
 import angular from 'angular';
 import _ from 'lodash';
 
@@ -213,7 +212,7 @@ class PlatformOrganizationsController {
     }
 
     finishOrgNameEdit(org) {
-        if (this.nameBuffer.length && org.name !== this.nameBuffer) {
+        if (this.nameBuffer && this.nameBuffer.length && org.name !== this.nameBuffer) {
             let orgUpdated = Object.assign({}, org, {name: this.nameBuffer});
             this.organizationService
                 .updateOrganization(orgUpdated.platformId, orgUpdated.id, orgUpdated)

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -202,13 +202,8 @@ class PlatformOrganizationsController {
 
     toggleOrgNameEdit(orgId, isEdit) {
         this.nameBuffer = '';
-        if (isEdit) {
-            this.editOrgId = orgId;
-            this.isEditOrgName = isEdit;
-        } else {
-            delete this.editOrgId;
-            delete this.isEditOrgName;
-        }
+        this.editOrgId = isEdit ? orgId : null;
+        this.isEditOrgName = isEdit;
     }
 
     finishOrgNameEdit(org) {

--- a/app-frontend/src/app/pages/admin/platform/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/platform/users/users.module.js
@@ -21,7 +21,6 @@ class PlatformUsersController {
             500,
             {leading: false, trailing: true}
         );
-
     }
 
     $onInit() {

--- a/app-frontend/src/app/pages/admin/team/team.html
+++ b/app-frontend/src/app/pages/admin/team/team.html
@@ -17,7 +17,7 @@
             <input id="name"
                    type="text"
                    class="form-control"
-                   ng-attr-placeholder="{{$ctrl.team.name}}"
+                   ng-init="$ctrl.nameBuffer = $ctrl.team.name"
                    ng-model="$ctrl.nameBuffer">
             <button class="btn btn-link flex-last node-header-eidt-group">
               <span class="icon-save node-label-name"</span>

--- a/app-frontend/src/app/pages/admin/team/team.html
+++ b/app-frontend/src/app/pages/admin/team/team.html
@@ -1,9 +1,33 @@
 <div class="container-admin-header">
   <div class="admin-header">
     <div class="admin-logo-text" ng-if="!$ctrl.fetching">
-      <h1 class="admin-logo-name h3">
+      <h1 class="admin-logo-name h3"
+          ng-if="!$ctrl.isEditTeamName">
         {{$ctrl.team.name}}
+        <button class="btn btn-tiny btn-admin-name-edit-small"
+                type="button"
+                ng-click="$ctrl.toggleTeamNameEdit()"
+                ng-if="$ctrl.isSuperOrAdmin">
+          <span class="icon-pencil"></span>
+        </button>
       </h1>
+      <div ng-if="$ctrl.isEditTeamName">
+        <form class="inline-form" ng-submit="$ctrl.finishTeamNameEdit()">
+          <div class="form-group all-in-one form-admin-name-edit-header">
+            <input id="name"
+                   type="text"
+                   class="form-control"
+                   ng-attr-placeholder="{{$ctrl.team.name}}"
+                   ng-model="$ctrl.nameBuffer">
+            <button class="btn btn-link flex-last node-header-eidt-group">
+              <span class="icon-save node-label-name"</span>
+            </button>
+            <button type="button" class="btn btn-link node-header-eidt-group" ng-click="$ctrl.toggleTeamNameEdit()">
+              <span class="icon-cancel node-label-name"></span>
+            </button>
+          </div>
+        </form>
+      </div>
       <div>
         Team Management
       </div>

--- a/app-frontend/src/app/pages/admin/team/team.js
+++ b/app-frontend/src/app/pages/admin/team/team.js
@@ -1,10 +1,11 @@
 import angular from 'angular';
 
 class TeamController {
-    constructor($q, $stateParams, teamService, organizationService, authService) {
+    constructor($q, $stateParams, $window, teamService, organizationService, authService) {
         'ngInject';
         this.$q = $q;
         this.$stateParams = $stateParams;
+        this.$window = $window;
         this.teamService = teamService;
         this.organizationService = organizationService;
         this.fetching = true;
@@ -45,7 +46,6 @@ class TeamController {
 
     toggleTeamNameEdit() {
         this.isEditTeamName = !this.isEditTeamName;
-        delete this.nameBuffer;
     }
 
     finishTeamNameEdit() {
@@ -59,10 +59,17 @@ class TeamController {
                 teamUpdated)
             .then(resp => {
                 this.team = resp;
+                this.nameBuffer = this.team.name;
+            }, () => {
+                this.$window.alert('Team\'s name cannot be updated at the moment.');
+                delete this.nameBuffer;
+            }).finally(() => {
+                delete this.isEditTeamName;
             });
+        } else {
+            delete this.nameBuffer;
+            delete this.isEditTeamName;
         }
-        delete this.nameBuffer;
-        delete this.isEditTeamName;
     }
 }
 

--- a/app-frontend/src/app/pages/admin/team/team.js
+++ b/app-frontend/src/app/pages/admin/team/team.js
@@ -1,13 +1,14 @@
 import angular from 'angular';
 
 class TeamController {
-    constructor($q, $stateParams, teamService, organizationService) {
+    constructor($q, $stateParams, teamService, organizationService, authService) {
         'ngInject';
         this.$q = $q;
         this.$stateParams = $stateParams;
         this.teamService = teamService;
         this.organizationService = organizationService;
         this.fetching = true;
+        this.authService = authService;
     }
 
     $onInit() {
@@ -26,6 +27,42 @@ class TeamController {
                         }, reject);
                 }, reject);
         });
+
+        this.isSuperOrAdmin = this.isUserSuperOrAdmin();
+    }
+
+    isUserSuperOrAdmin() {
+        return this.teamPromise.then(resp => {
+            this.platformId = resp.organization.platformId;
+            this.organizationId = resp.organization.id;
+            this.isSuperOrAdmin = this.authService.isSuperOrAdmin(
+                [this.platformId,
+                this.organizationId,
+                this.$stateParams.teamId]
+            );
+        });
+    }
+
+    toggleTeamNameEdit() {
+        this.isEditTeamName = !this.isEditTeamName;
+        delete this.nameBuffer;
+    }
+
+    finishTeamNameEdit() {
+        if (this.nameBuffer && this.nameBuffer.length
+            && this.nameBuffer !== this.team.name) {
+            let teamUpdated = Object.assign({}, this.team, {name: this.nameBuffer});
+            this.teamService.updateTeam(
+                this.platformId,
+                this.organizationId,
+                this.$stateParams.teamId,
+                teamUpdated)
+            .then(resp => {
+                this.team = resp;
+            });
+        }
+        delete this.nameBuffer;
+        delete this.isEditTeamName;
     }
 }
 

--- a/app-frontend/src/app/pages/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/projects/list/list.controller.js
@@ -11,7 +11,7 @@ class ProjectsListController {
         this.projectService = projectService;
         this.userService = userService;
         this.$scope = $scope;
-	this.authService = authService;
+        this.authService = authService;
     }
 
     $onInit() {
@@ -31,7 +31,7 @@ class ProjectsListController {
                 sort: 'createdAt,desc',
                 pageSize: 10,
                 page: page - 1,
-		owner: this.authService.getProfile().sub
+                owner: this.authService.getProfile().sub
             }
         ).then(
             (projectResult) => {

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -43,6 +43,13 @@ export default (app) => {
                             'organizations/:organizationId',
                         method: 'POST',
                         params: {platformId: '@platformId', organizationId: '@organizationId'}
+                    },
+                    updateOrganization: {
+                        url:
+                        `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
+                            'organizations/:organizationId',
+                        method: 'PUT',
+                        params: {platformId: '@platformId', organizationId: '@organizationId'}
                     }
                 }
             );
@@ -124,6 +131,11 @@ export default (app) => {
             return this.Organization
                 .addOrganizationLogo({organizationId}, logoBase64)
                 .$promise;
+        }
+
+        updateOrganization(platformId, organizationId, params) {
+            return this.PlatformOrganization
+                .updateOrganization({platformId, organizationId}, params).$promise;
         }
     }
 

--- a/app-frontend/src/app/services/auth/team.service.js
+++ b/app-frontend/src/app/services/auth/team.service.js
@@ -26,6 +26,17 @@ export default (app) => {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
                             'organizations/:organizationId/teams/',
                         method: 'POST'
+                    },
+                    update: {
+                        url:
+                        `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
+                            'organizations/:organizationId/teams/:teamId',
+                        method: 'PUT',
+                        params: {
+                            platformId: '@platformId',
+                            organizationId: '@organizationId',
+                            teamId: '@teamId'
+                        }
                     }
                 }
             );
@@ -96,6 +107,10 @@ export default (app) => {
 
         deactivateTeam(platformId, organizationId, teamId) {
             return this.PlatformTeam.delete({platformId, organizationId, teamId}).$promise;
+        }
+
+        updateTeam(platformId, organizationId, teamId, params) {
+            return this.PlatformTeam.update({platformId, organizationId, teamId}, params).$promise;
         }
     }
 

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -324,3 +324,18 @@
   padding-left: 3rem;
   padding-right: 3rem;
 }
+
+.btn-admin-name-edit-small {
+  padding: 0.2em;
+  border: 0px;
+}
+
+.form-admin-name-edit {
+  margin-bottom: 0;
+  input, button {
+    padding: 2px;
+    height: 2.5rem;
+  }
+
+  max-width: 140px;
+}

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -48,6 +48,7 @@
 
 .admin-logo-name {
   margin: 0;
+  display: flex;
 }
 
 .admin-tabs {
@@ -328,7 +329,7 @@
 .btn-admin-name-edit-small {
   padding: 0.2em;
   border: 0px;
-  margin-left: 0rem;
+  margin-left: 1rem;
 }
 
 .form-admin-name-edit {

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -328,6 +328,7 @@
 .btn-admin-name-edit-small {
   padding: 0.2em;
   border: 0px;
+  margin-left: 0rem;
 }
 
 .form-admin-name-edit {
@@ -338,4 +339,12 @@
   }
 
   max-width: 140px;
+}
+
+.form-admin-name-edit-header {
+  margin-bottom: 0;
+
+  input button {
+    height: 2rem;
+  }
 }


### PR DESCRIPTION
## Overview

This PR enables admins or super users to edit organization and team names on frontend.


### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions

 * Navigate to below pages to check if organization or team name editing is enabled and is possible considering your logged in user's group role:
     - a platform page that lists organizations
     - an organization's main page
     - an organization page that lists teams
     - a team main page

Closes #3506 
