### PR TITLE
Fix add user to team bug

### DIFF
--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -7,7 +7,7 @@
     <h4 class="modal-title">
       Add users
     </h4>
-    <p ng-if="!$ctrl.resolve.modalText">Select users to add to this {{$ctrl.resolve.adminView}}.</p>
+    <p ng-if="!$ctrl.resolve.modalText">Select users to add to this {{$ctrl.resolve.groupType}}.</p>
     <p ng-if="$ctrl.resolve.modalText">{{$ctrl.resolve.modalText}}</p>
   </div>
   <div class="modal-body">

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -56,7 +56,7 @@ class AddUserModalController {
 
     fetchUsers(page = 1, search) {
         this.fetching = true;
-        if (this.resolve.adminView === 'organization') {
+        if (this.resolve.groupType === 'organization') {
             this.platformService.getMembers(
                 this.platformId,
                 page - 1,
@@ -71,7 +71,7 @@ class AddUserModalController {
                 // platform admins or super users are allowed to list platform users
                 this.permissionDenied(error, 'platform admin', 'example@email.com');
             });
-        } else if (this.resolve.adminView === 'team') {
+        } else if (this.resolve.groupType === 'team') {
             this.organizationService.getMembers(
                 this.platformId,
                 this.organizationId,
@@ -100,14 +100,14 @@ class AddUserModalController {
     addUsers() {
         delete this.error;
         let promises = this.selected.toArray().map((userId) => {
-            if (this.resolve.adminView === 'team') {
+            if (this.resolve.groupType === 'team') {
                 return this.teamService.addUser(
                     this.resolve.platformId,
                     this.resolve.organizationId,
                     this.resolve.teamId,
                     userId
                 );
-            } else if (this.resolve.adminView === 'organization') {
+            } else if (this.resolve.groupType === 'organization') {
                 return this.organizationService.addUser(
                     this.resolve.platformId,
                     this.resolve.organizationId,

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.module.js
@@ -130,7 +130,7 @@ class OrganizationTeamsController {
                             platformId: () => this.organization.platformId,
                             organizationId: () => this.organization.id,
                             teamId: () => team.id,
-                            adminView: () => 'organization'
+                            groupType: () => 'team'
                         }
                     }).result.then(() => {
                         this.teamService

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -128,7 +128,7 @@ class OrganizationUsersController {
             resolve: {
                 platformId: () => this.organization.platformId,
                 organizationId: () => this.organization.id,
-                adminView: () => 'organization'
+                groupType: () => 'organization'
             }
         }).result.then(() => {
             this.fetchUsers(1, this.search);

--- a/app-frontend/src/app/pages/admin/team/users/users.js
+++ b/app-frontend/src/app/pages/admin/team/users/users.js
@@ -130,7 +130,7 @@ class TeamUsersController {
                 platformId: () => this.platformId,
                 organizationId: () => this.organization.id,
                 teamId: () => this.team.id,
-                adminView: () => 'team'
+                groupType: () => 'team'
             }
         }).result.then(() => {
             this.fetchUsers(1, this.search);


### PR DESCRIPTION
## Overview

This PR fixes the bug so that organization admins are able to add users/themselves to teams.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions

 * Navigate to the following pages and add users to a team, check if it behaves as expected considering the current logged in user's group role
     - organization page -> team tab -> add user modal through the pencil dropdown
     - team page -> add user button

Closes #3513 
Closes #3509 
