### PR TITLE
Update scene authorization check to use updated logic

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -154,8 +154,9 @@ trait SceneRoutes extends Authentication
 
   def getScene(sceneId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      SceneWithRelatedDao.query
-        .authorized(user, ObjectType.Scene, sceneId, ActionType.View)
+      SceneDao.authViewQuery(user, ObjectType.Scene)
+        .filter(sceneId)
+        .exists
         .transact(xa)
         .unsafeToFuture
     } {
@@ -268,7 +269,9 @@ trait SceneRoutes extends Authentication
 
   def listUserSceneActions(sceneId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      SceneWithRelatedDao.query.authorized(user, ObjectType.Scene, sceneId, ActionType.View)
+      SceneDao.authViewQuery(user, ObjectType.Scene)
+        .filter(sceneId)
+        .exists
         .transact(xa).unsafeToFuture
     } { user.isSuperuser match {
       case true => complete(List("*"))
@@ -300,8 +303,9 @@ trait SceneRoutes extends Authentication
 
   def getSceneDatasource(sceneId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      SceneDao.query
-        .authorized(user, ObjectType.Scene, sceneId, ActionType.View)
+      SceneDao.authViewQuery(user, ObjectType.Scene)
+        .filter(sceneId)
+        .exists
         .transact(xa)
         .unsafeToFuture
     } {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -39,7 +39,7 @@ object SceneDao extends Dao[Scene] with LazyLogging {
     FROM
   """ ++ tableF
 
-  override def authQuery(user: User, objectType: ObjectType): Dao.QueryBuilder[Scene] = {
+  def authViewQuery(user: User, objectType: ObjectType): Dao.QueryBuilder[Scene] = {
     if (user.isSuperuser) {
       Dao.QueryBuilder[Scene](selectF, tableF, List.empty)
     } else {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -47,7 +47,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
     }
     sceneSearchBuilder = {
       SceneDao
-        .authQuery(user, ObjectType.Scene)
+        .authViewQuery(user, ObjectType.Scene)
         .filter(shapeO map { _.geometry })
         .filter(sceneParams)
     }


### PR DESCRIPTION
## Overview

In #3547 the logic for querying scenes was updated to improve
performance; however, this meant that the logic to check for scene
viewing permissions used when checking if a user is authorized to view
the scene's datasource or actions needed to be updated as well since
the rules for viewing public scenes was removed from the ACR table.
This meant if a user tried to use a scene with a public datasource in the lab
or in the color mode options they would see a 403.

This commit renames `authQuery` to be more explicit and also updates
other scene routes that check view permissions to use correct logic.

Closes #3561

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

![working](https://user-images.githubusercontent.com/898060/41602878-c3f61d94-73a9-11e8-8c52-40b15168bcdd.png)

## Testing Instructions

 * Start development server with the development database
 * Create an analysis with the "Change Detection" project
 * Observe you can see band information again
 * Go to color mode options for the "Change Detection" project
 * Observe you can see options