### PR TITLE
Tell users where to update profile photo

### DIFF
--- a/app-frontend/src/app/pages/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/settings/profile/profile.html
@@ -12,9 +12,13 @@
         </div>
         <div class="picture-description">
           <div class="panel panel-info">
-            <div class="panel-body">
+            <div class="panel-body" ng-if="!($ctrl.provider.provider === 'gravatar' || $ctrl.provider.provider === 'auth0')">
               To change your profile picture, upload a new one to your linked
-              <a ng-href="{{$ctrl.provider.link}}" target="_blank">{{$ctrl.provider.name}}</a> account
+              <a ng-href="{{$ctrl.provider.link}}" target="_blank">{{$ctrl.provider.name}}</a> account.
+            </div>
+            <div class="panel-body" ng-if="$ctrl.provider.provider === 'gravatar' || $ctrl.provider.provider === 'auth0'">
+              This profile picture is associated with your email in Gravatar. Please find out about how to change it
+              <a ng-href="{{$ctrl.provider.link}}" target="_blank">here</a>.
             </div>
           </div>
         </div>

--- a/app-frontend/src/app/pages/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/settings/profile/profile.html
@@ -12,13 +12,10 @@
         </div>
         <div class="picture-description">
           <div class="panel panel-info">
-            <div class="panel-body" ng-if="!($ctrl.provider.provider === 'gravatar' || $ctrl.provider.provider === 'auth0')">
-              To change your profile picture, upload a new one to your linked
-              <a ng-href="{{$ctrl.provider.link}}" target="_blank">{{$ctrl.provider.name}}</a> account.
-            </div>
-            <div class="panel-body" ng-if="$ctrl.provider.provider === 'gravatar' || $ctrl.provider.provider === 'auth0'">
-              This profile picture is associated with your email in Gravatar. Please find out about how to change it
-              <a ng-href="{{$ctrl.provider.link}}" target="_blank">here</a>.
+            <div class="panel-body">
+              Your profile picture is managed by
+              <span>{{$ctrl.provider.provider === 'gravatar' || $ctrl.provider.provider === 'auth0' ? 'Gravatar' : $ctrl.provider.name}}</span>.
+              <a ng-href="{{$ctrl.provider.link}}" target="_blank">Click here for instructions on how to change it</a>.
             </div>
           </div>
         </div>

--- a/app-frontend/src/app/pages/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/settings/profile/profile.html
@@ -72,7 +72,6 @@
           <p class="help-block">Contact support to change your username</p>
         </div>
         <button type="button"
-                ng-if="$ctrl.provider.provider === 'auth0'"
                 class="btn btn-primary btn-large"
                 ng-click="$ctrl.authService.changePassword()">
           Change Password

--- a/app-frontend/src/app/pages/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/settings/profile/profile.html
@@ -13,13 +13,14 @@
         <div class="picture-description">
           <div class="panel panel-info">
             <div class="panel-body">
-              To change your profile picture, upload a new one to your linked {{$ctrl.providerName}} account
+              To change your profile picture, upload a new one to your linked
+              <a ng-href="{{$ctrl.provider.link}}" target="_blank">{{$ctrl.provider.name}}</a> account
             </div>
           </div>
         </div>
       </div>
 
-      <div ng-if="$ctrl.provider === 'google-oauth2'">
+      <div ng-if="$ctrl.provider.provider === 'google-oauth2'">
         <div class="form-group">
           <label for="name">Name</label>
           <input id="name"
@@ -47,7 +48,7 @@
         </button>
       </div>
 
-      <div ng-if="$ctrl.provider === 'auth0'">
+      <div ng-if="$ctrl.provider.provider === 'auth0'">
         <div class="form-group">
           <label for="name">Name</label>
           <input id="name" type="text"
@@ -67,7 +68,7 @@
           <p class="help-block">Contact support to change your username</p>
         </div>
         <button type="button"
-                ng-if="$ctrl.provider === 'auth0'"
+                ng-if="$ctrl.provider.provider === 'auth0'"
                 class="btn btn-primary btn-large"
                 ng-click="$ctrl.authService.changePassword()">
           Change Password

--- a/app-frontend/src/app/pages/settings/profile/profile.module.js
+++ b/app-frontend/src/app/pages/settings/profile/profile.module.js
@@ -1,4 +1,41 @@
 /* globals process */
+
+/* eslint-disable */
+const providers = [
+    {
+        link: 'https://support.google.com/mail/answer/35529?hl=en&co=GENIE.Platform',
+        provider: 'google-oauth2',
+        name: 'Google'
+    },
+    {
+        link: 'https://help.twitter.com/en/managing-your-account/common-issues-when-uploading-profile-photo',
+        provider: 'twitter',
+        name: 'Twitter'
+    },
+    {
+        link: 'https://www.facebook.com/help/163248423739693?helpref=faq_content',
+        provider: 'facebook',
+        name: 'Facebook'
+    },
+    {
+        link: 'https://help.github.com/articles/setting-your-profile-picture/',
+        provider: 'github',
+        name: 'GitHub'
+    },
+    {
+        link: 'https://auth0.com/docs/user-profile/user-picture',
+        provider: 'auth0',
+        name: 'Auth0'
+    }
+];
+
+const defaultProvider = {
+    link: 'https://en.gravatar.com/',
+    provider: 'gravatar',
+    name: 'Gravatar'
+};
+/* eslint-enable */
+
 class ProfileController {
     constructor($log, localStorage, authService, $window, userService) {
         'ngInject';
@@ -13,6 +50,9 @@ class ProfileController {
 
     $onInit() {
         this.env = process.env.NODE_ENV;
+        this.providers = providers;
+        this.defaultProvider = defaultProvider;
+        this.getCurrentUser();
     }
 
     updateGoogleProfile() {
@@ -28,6 +68,14 @@ class ProfileController {
                 this.$log.debug('Error updating profile:', err);
                 this.profile = this.localStorage.get('profile');
             });
+    }
+
+    getCurrentUser() {
+        this.authService.getCurrentUser().then(resp => {
+            this.provider = this.providers.find(l => {
+                return resp.id.includes(l.provider);
+            }) || this.defaultProvider;
+        });
     }
 }
 

--- a/app-frontend/src/app/pages/settings/profile/profile.module.js
+++ b/app-frontend/src/app/pages/settings/profile/profile.module.js
@@ -23,14 +23,14 @@ const providers = [
         name: 'GitHub'
     },
     {
-        link: 'https://auth0.com/docs/user-profile/user-picture',
+        link: 'https://en.gravatar.com/support/activating-your-account/',
         provider: 'auth0',
         name: 'Auth0'
     }
 ];
 
 const defaultProvider = {
-    link: 'https://en.gravatar.com/',
+    link: 'https://en.gravatar.com/support/activating-your-account/',
     provider: 'gravatar',
     name: 'Gravatar'
 };

--- a/app-frontend/src/app/pages/settings/profile/profile.module.js
+++ b/app-frontend/src/app/pages/settings/profile/profile.module.js
@@ -72,8 +72,8 @@ class ProfileController {
 
     getCurrentUser() {
         this.authService.getCurrentUser().then(resp => {
-            this.provider = this.providers.find(l => {
-                return resp.id.includes(l.provider);
+            this.provider = this.providers.find(provider => {
+                return resp.id.includes(provider.provider);
             }) || this.defaultProvider;
         });
     }


### PR DESCRIPTION
## Overview

This PR updates profile info provider on the profile page under settings and directs users to the right place to change profile photo.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Log in with different provider accounts and check if the profile page under settings shows the corresponding contents.

Closes #3507 
