### PR TITLE
Separate Staging and production deployment pipelines

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,18 +23,10 @@ node {
 
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /(release|hotfix|test)\//) {
-      // When a release branch is used, override `env.RF_DOCS_BUCKET`
-      // and `env.RF_DEPLOYMENT_BRANCH`.
-      if (env.BRANCH_NAME =~ /(release|hotfix)\//) {
-        env.RF_DOCS_BUCKET = 'rasterfoundry-production-docs-site-us-east-1'
-        env.RF_DEPLOYMENT_BRANCH = 'master'
-        env.RF_DEPLOYMENT_ENVIRONMENT = "Production"
-      } else {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\//) {
         env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
         env.RF_DEPLOYMENT_BRANCH = 'develop'
         env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
-      }
 
       // Publish container images built and tested during `cibuild`
       // to the private Amazon Container Registry tagged with the
@@ -68,16 +60,6 @@ node {
                                      relativeTargetDir: 'raster-foundry-deployment']],
                        userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
                                             url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
-
-        // When a release branch is used, override `env.RF_SETTINGS_BUCKET`
-        // so that it uses the production infrastructure configuration
-        // settings.
-        if (env.BRANCH_NAME =~ /(release|hotfix)\//) {
-          env.RF_SETTINGS_BUCKET = 'rasterfoundry-production-config-us-east-1'
-
-          def slackMessage = ":rasterfoundry: production deployment in-progress... <${env.BUILD_URL}|View Build>"
-          slackSend color: 'warning', message: slackMessage
-        }
 
         dir('raster-foundry-deployment') {
           wrap([$class: 'AnsiColorBuildWrapper']) {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -1,0 +1,91 @@
+#!groovy
+
+def retagImage(String image_url, String source_tag, String dest_tag) {
+    // Pulls down image with source_tag and re-tags with dest_tag
+    // before pushing back to repository
+
+    sh "docker pull ${image_url}:${source_tag}"
+    sh "docker tag  ${image_url}:${source_tag} ${image_url}:${dest_tag}"
+    sh "docker push ${image_url}:${dest_tag}"
+}
+
+node{
+   properties(
+       [parameters(
+           [string(defaultValue: 'develop', description: 'First 7 characters of the SHA for the commit you wish to deploy.', name: 'GIT_COMMIT', trim: false),
+            string(defaultValue: '', description: 'Tag of the Current release.', name: 'RELEASE_TAG', trim: false),
+            string(defaultValue: 'rasterfoundry-production-docs-site-us-east-1', description: 'Location of swagger spec.', name: 'RF_DOCS_BUCKET', trim: false),
+            string(defaultValue: 'rasterfoundry-production-config-us-east-1', description: 'Location of terraform state & vars files.', name: 'RF_SETTINGS_BUCKET', trim: false),
+            string(defaultValue: 'Production', description: 'Environment name, used to target Batch Compute Environments.', name: 'RF_DEPLOYMENT_ENVIRONMENT', trim: false),
+            string(defaultValue: 'master', description: 'Branch of azavea/raster-foundry-deployment used for deployment.', name: 'RF_DEPLOYMENT_BRANCH', trim: false)]
+        )]
+    )
+    
+    try{
+        env.AWS_DEFAULT_REGION = "us-east-1"
+
+        stage('checkout') {
+          checkout([$class: 'GitSCM',
+                   branches: [[name: params.GIT_COMMIT ]],
+                   extensions: [[$class: 'PruneStaleBranch']],
+                   userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
+                                        url: 'https://github.com/raster-foundry/raster-foundry',
+                                        ]]
+                     ])
+        }
+
+        stage('re-tag images'){
+            sh 'eval $(aws ecr get-login --no-include-email)'
+            withCredentials([[$class: 'StringBinding',
+                              credentialsId: 'AWS_ECR_ENDPOINT',
+                              variable: 'AWS_ECR_ENDPOINT']]) {
+              wrap([$class: 'AnsiColorBuildWrapper']) {
+                // Retag images with release tag and push to ECR
+                [
+                    "raster-foundry-nginx-api",
+                    "raster-foundry-nginx-tiler",
+                    "raster-foundry-api-server",
+                    "raster-foundry-tile-server",
+                    "raster-foundry-batch",
+                    "raster-foundry-migrations"
+                ].each { image_url ->
+                    retagImage(env.AWS_ECR_ENDPOINT + "/${image_url}", params.GIT_COMMIT, params.RELEASE_TAG)
+                }
+              }
+            }
+        }
+
+        stage('deploy docs'){
+          sh './scripts/deploy-docs'
+        }
+
+        stage('infra') {
+
+            checkout scm: [$class: 'GitSCM',
+                           branches: [[name: params.RF_DEPLOYMENT_BRANCH]],
+                           extensions: [[$class: 'RelativeTargetDirectory',
+                                         relativeTargetDir: 'raster-foundry-deployment']],
+                           userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
+                                                url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
+
+            def slackMessage = ":rasterfoundry: production deployment in progress"
+            slackSend color: 'warning', message: slackMessage
+
+            dir('raster-foundry-deployment') {
+              wrap([$class: 'AnsiColorBuildWrapper']) {
+                sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+                sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+              }
+            }
+
+            slackMessage = ":rasterfoundry: production deployment is complete"
+            slackSend color: 'warning', message: slackMessage
+        }
+      } catch(err) {
+        def slackMessage = ":jenkins-angry: *Deployment #${env.BUILD_NUMBER} of release/hotfix ${params.RELEASE_TAG} has failed*"
+        slackMessage += "\n<${env.BUILD_URL}|View Build>"
+        slackSend color: 'danger', message: slackMessage
+
+        throw err
+      }
+}


### PR DESCRIPTION
## Overview

Moves `release/` and `hotfix/` builds into their own `Jenkinsfile` that skips `cibuild` and `cipublish` stages. Instead, existing images are re-tagged with the release tag and pushed to ECR, and the release tag is then threaded through to terraform before running `scripts/infra`. This should cut down build times substantially.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

N/A

### Notes

I played with the idea of keeping a single Jenkins job, adding a `--production` flag to `cipublish` to do the retagging, and using conditionals to determine if we should skip running `cibuild`. I opted against it, mainly because having a flag that completely changes the behavior of the script seems like it could be confusing when things break. Also, I disliked the idea of having 2 layers of decision making: Jenkins has to decide which flag to use for `cipublish`, and then `cipublish` has to decide what behavior to execute based on the flag. It seemed that the desired behavior was different enough that it was cleaner to just run completely separate builds.

## Testing Instructions
- I added a [Jenkins job](http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry%20Release%20Pipeline/) that runs commands based on `Jenkinsfile.releases`.
 
- I modified the release job parameters to re-tag `develop` with `tnation-test` and redeploy it to Staging. See [Jenkins build output](http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry%20Release%20Pipeline/32/consoleFull)

Closes azavea/raster-foundry-platform#334
