### PR TITLE
Add org search endpoint

### DIFF
--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -42,6 +42,10 @@ trait OrganizationRoutes extends Authentication
             post { addOrganizationLogo(orgId) }
           }
         }
+    } ~ pathPrefix("search") {
+      pathEndOrSingleSlash {
+        get { searchOrganizations() }
+      }
     }
   }
 
@@ -49,6 +53,14 @@ trait OrganizationRoutes extends Authentication
     rejectEmptyResponse {
       complete {
         OrganizationDao.query.filter(orgId).selectOption.transact(xa).unsafeToFuture()
+      }
+    }
+  }
+
+  def searchOrganizations(): Route = authenticate { user =>
+    searchParams { (searchParams)  =>
+      complete {
+        OrganizationDao.searchOrganizations(user, searchParams).transact(xa).unsafeToFuture
       }
     }
   }

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -92,7 +92,7 @@ trait PlatformRoutes extends Authentication
           ) {
             get {
               traceName("platforms-organizations-list") {
-                listOrganizations(platformId)
+                listPlatformOrganizations(platformId)
               }
             } ~
             post {
@@ -291,13 +291,13 @@ trait PlatformRoutes extends Authentication
     }
   }
 
-  def listOrganizations(platformId: UUID): Route = authenticate { user =>
+  def listPlatformOrganizations(platformId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
+      PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
     } {
       (withPagination & searchParams) { (page, search) =>
         complete {
-          OrganizationDao.listAuthorizedOrganizations(page, search, platformId, user)
+          OrganizationDao.listPlatformOrganizations(page, search, platformId, user)
             .transact(xa).unsafeToFuture
         }
       }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -306,7 +306,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       }, tableF, List.empty
     )
 
-  def listAuthorizedOrganizations(pageRequest: PageRequest, searchParams: SearchQueryParameters, platformId: UUID, user: User): ConnectionIO[PaginatedResponse[Organization]] =  {
+  def listPlatformOrganizations(pageRequest: PageRequest, searchParams: SearchQueryParameters, platformId: UUID, user: User): ConnectionIO[PaginatedResponse[Organization]] =  {
     val organizationSearchBuilder = {
       OrganizationDao.viewFilter(user)
         .filter(fr"platform_id=${platformId}")
@@ -322,5 +322,11 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
         count, hasPrevious, hasNext, pageRequest.offset, pageRequest.limit, organizations
       )
     }
+  }
+
+  def searchOrganizations(user: User, searchParams: SearchQueryParameters): ConnectionIO[List[Organization]] = {
+    OrganizationDao.viewFilter(user)
+      .filter(searchParams)
+      .list(0, 5, fr"order by name")
   }
 }


### PR DESCRIPTION
## Overview
Restrict the platform/organizations endpoint to platform admins
Add a new endpoint for searching up to 5 organizations ordered by name

### Checklist

- ~Styleguide updated, if necessary~
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Testing instructions

 *  Verify that the dev user no longer as permissions to access the platform orgs endpoint, and that the systems user still can.
* Verify that searching the `organizations/search?search={text}` endpoint only yields the public org for the dev user, but the systems user can use it to list any platform
* Verify that the search endpoint returns up to 5 results

Closes #3564 
Depends #3531 
