### PR TITLE
Update top-level objects' listing filters

### DIFF
--- a/app-backend/api/src/main/scala/datasource/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/datasource/QueryParameters.scala
@@ -10,6 +10,7 @@ import com.azavea.rf.api.utils.queryparams._
 
 trait DatasourceQueryParameterDirective extends QueryParametersCommon {
   def datasourceQueryParams = (
+    userQueryParameters &
     searchParams &
     ownershipTypeQueryParameters &
     groupQueryParameters

--- a/app-backend/api/src/main/scala/datasource/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/datasource/QueryParameters.scala
@@ -10,6 +10,8 @@ import com.azavea.rf.api.utils.queryparams._
 
 trait DatasourceQueryParameterDirective extends QueryParametersCommon {
   def datasourceQueryParams = (
-    searchParams
+    searchParams &
+    ownershipTypeQueryParameters &
+    groupQueryParameters
   ).as(DatasourceQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -71,7 +71,12 @@ trait DatasourceRoutes extends Authentication
     (withPagination & datasourceQueryParams) { (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
       complete {
         DatasourceDao
-          .authQuery(user, ObjectType.Datasource)
+          .authQuery(
+            user,
+            ObjectType.Datasource,
+            datasourceParams.ownershipTypeParams.ownershipType,
+            datasourceParams.groupQueryParameters.groupType,
+            datasourceParams.groupQueryParameters.groupId)
           .filter(datasourceParams)
           .page(page)
           .transact(xa).unsafeToFuture

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -294,7 +294,12 @@ trait ProjectRoutes extends Authentication
     (withPagination & projectQueryParameters) { (page, projectQueryParameters) =>
       complete {
         ProjectDao
-          .authQuery(user, ObjectType.Project, projectQueryParameters.ownershipTypeParams.ownershipType)
+          .authQuery(
+            user, 
+            ObjectType.Project,
+            projectQueryParameters.ownershipTypeParams.ownershipType,
+            projectQueryParameters.groupQueryParameters.groupType,
+            projectQueryParameters.groupQueryParameters.groupId)
           .filter(projectQueryParameters)
           .page(page)
           .transact(xa).unsafeToFuture

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -294,7 +294,7 @@ trait ProjectRoutes extends Authentication
     (withPagination & projectQueryParameters) { (page, projectQueryParameters) =>
       complete {
         ProjectDao
-          .authQuery(user, ObjectType.Project)
+          .authQuery(user, ObjectType.Project, projectQueryParameters.ownershipTypeParams.ownershipType)
           .filter(projectQueryParameters)
           .page(page)
           .transact(xa).unsafeToFuture

--- a/app-backend/api/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/QueryParameters.scala
@@ -36,6 +36,8 @@ trait SceneQueryParameterDirective extends QueryParametersCommon {
   val sceneQueryParameters = (orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
-    sceneSpecificQueryParams
+    sceneSpecificQueryParams &
+    ownershipTypeQueryParameters &
+    groupQueryParameters
   ).as(CombinedSceneQueryParams.apply _)
 }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -140,7 +140,12 @@ trait ShapeRoutes extends Authentication
     (withPagination & shapeQueryParams) { (page: PageRequest, queryParams: ShapeQueryParameters) =>
       complete {
         ShapeDao
-          .authQuery(user, ObjectType.Shape)
+          .authQuery(
+            user,
+            ObjectType.Shape,
+            queryParams.ownershipTypeParams.ownershipType,
+            queryParams.groupQueryParameters.groupType,
+            queryParams.groupQueryParameters.groupId)
           .filter(queryParams)
           .page(page)
           .transact(xa).unsafeToFuture().map { p => {

--- a/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
@@ -16,6 +16,8 @@ trait ToolRunQueryParametersDirective extends QueryParametersCommon {
 
   val toolRunQueryParameters = (
     toolRunSpecificQueryParams &
-    timestampQueryParameters
+    timestampQueryParameters &
+    ownershipTypeQueryParameters &
+    groupQueryParameters
   ).as(CombinedToolRunQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
@@ -18,6 +18,7 @@ trait ToolRunQueryParametersDirective extends QueryParametersCommon {
     toolRunSpecificQueryParams &
     timestampQueryParameters &
     ownershipTypeQueryParameters &
-    groupQueryParameters
+    groupQueryParameters &
+    userQueryParameters
   ).as(CombinedToolRunQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -78,7 +78,12 @@ trait ToolRunRoutes extends Authentication
     (withPagination & toolRunQueryParameters) { (page, runParams) =>
       complete {
         ToolRunDao
-          .authQuery(user, ObjectType.Analysis)
+          .authQuery(
+            user,
+            ObjectType.Analysis,
+            runParams.ownershipTypeParams.ownershipType,
+            runParams.groupQueryParameters.groupType,
+            runParams.groupQueryParameters.groupId)
           .filter(runParams)
           .page(page)
           .transact(xa).unsafeToFuture

--- a/app-backend/api/src/main/scala/tools/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/tools/QueryParameters.scala
@@ -11,6 +11,8 @@ trait ToolQueryParameterDirective extends QueryParametersCommon {
     orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
-    searchParams
+    searchParams &
+    ownershipTypeQueryParameters &
+    groupQueryParameters
   ).as(CombinedToolQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -134,7 +134,12 @@ trait ToolRoutes extends Authentication
     (withPagination & combinedToolQueryParams) { (page, combinedToolQueryParameters) =>
       complete {
         ToolDao
-          .authQuery(user, ObjectType.Template)
+          .authQuery(
+            user,
+            ObjectType.Template,
+            combinedToolQueryParameters.ownershipTypeParams.ownershipType,
+            combinedToolQueryParameters.groupQueryParameters.groupType,
+            combinedToolQueryParameters.groupQueryParameters.groupId)
           .filter(combinedToolQueryParameters)
           .page(page)
           .transact(xa).unsafeToFuture

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -30,7 +30,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
     orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
-    searchParams
+    searchParams &
+    ownershipTypeQueryParameters
   ).as(ProjectQueryParameters.apply _)
 
   def aoiQueryParameters = (
@@ -44,6 +45,10 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
   def ownerQueryParameters = parameters(
     'owner.as[String].?
   ).as(OwnerQueryParameters.apply _)
+
+  def ownershipTypeQueryParameters = parameters(
+    'ownershipType.as[String].?
+  ).as(OwnershipTypeQueryParameters.apply _)
 
   def userAuditQueryParameters = parameters(
     (

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -95,7 +95,11 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
     ))).as(AnnotationQueryParameters.apply _)
 
   def shapeQueryParams = (
-    orgQueryParams & userQueryParameters & timestampQueryParameters
+    orgQueryParams &
+    userQueryParameters &
+    timestampQueryParameters &
+    ownershipTypeQueryParameters &
+    groupQueryParameters
   ).as(ShapeQueryParameters.apply _)
 
   def searchParams = parameters(

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -23,6 +23,9 @@ trait QueryParameterDeserializers {
     Timestamp.from(DatatypeConverter.parseDateTime(s).getTime().toInstant())
   }
 
+  implicit val deserializerGroupType: Unmarshaller[String, GroupType] = Unmarshaller.strict[String, GroupType] {s =>
+    GroupType.fromString(s)
+  }
 }
 
 trait QueryParametersCommon extends QueryParameterDeserializers {
@@ -31,7 +34,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
     userQueryParameters &
     timestampQueryParameters &
     searchParams &
-    ownershipTypeQueryParameters
+    ownershipTypeQueryParameters &
+    groupQueryParameters
   ).as(ProjectQueryParameters.apply _)
 
   def aoiQueryParameters = (
@@ -49,6 +53,13 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
   def ownershipTypeQueryParameters = parameters(
     'ownershipType.as[String].?
   ).as(OwnershipTypeQueryParameters.apply _)
+
+  def groupQueryParameters = parameters(
+    (
+    'groupType.as(deserializerGroupType).?,
+    'groupId.as(deserializerUUID).?
+    )
+  ).as(GroupQueryParameters.apply _)
 
   def userAuditQueryParameters = parameters(
     (

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -113,7 +113,9 @@ case class CombinedSceneQueryParams(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
-  sceneParams: SceneQueryParameters = SceneQueryParameters()
+  sceneParams: SceneQueryParameters = SceneQueryParameters(),
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
 /** Combined all query parameters for grids */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -150,7 +150,9 @@ case class CombinedToolQueryParameters(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
-  searchParams: SearchQueryParameters = SearchQueryParameters()
+  searchParams: SearchQueryParameters = SearchQueryParameters(),
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
 @JsonCodec
@@ -236,7 +238,9 @@ case class ToolRunQueryParameters(
 @JsonCodec
 case class CombinedToolRunQueryParameters(
   toolRunParams: ToolRunQueryParameters = ToolRunQueryParameters(),
-  timestampParams: TimestampQueryParameters = TimestampQueryParameters()
+  timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
 @JsonCodec
@@ -247,7 +251,9 @@ case class CombinedToolCategoryQueryParams(
 
 @JsonCodec
 case class DatasourceQueryParameters(
-  searchParams: SearchQueryParameters = SearchQueryParameters()
+  searchParams: SearchQueryParameters = SearchQueryParameters(),
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
 @JsonCodec
@@ -298,7 +304,9 @@ case class AnnotationQueryParameters(
 case class ShapeQueryParameters(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
-  timestampParams: TimestampQueryParameters = TimestampQueryParameters()
+  timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
 @JsonCodec

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -133,7 +133,8 @@ case class ProjectQueryParameters(
   userParams: UserQueryParameters = UserQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
   searchParams: SearchQueryParameters = SearchQueryParameters(),
-  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters()
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
 @JsonCodec
@@ -186,13 +187,21 @@ case class OwnerQueryParameters(
 )
 
 /** Query parameters to filter by ownership type:
-  - owned by me only: owned
-  - shared to be by group membership: inherited
-  - both the above: all, this is default
+  - owned by the requesting user only: owned
+  - shared to the requesting user due to group membership: inherited
+  - shared to the requesting user directly, across platform, or due to group membership: shared
+  - both the above: none, this is default
 */
 @JsonCodec
 case class OwnershipTypeQueryParameters(
   ownershipType: Option[String] = None
+)
+
+/** Query parameters to filter by group membership*/
+@JsonCodec
+case class GroupQueryParameters(
+  groupType: Option[GroupType] = None,
+  groupId: Option[UUID] = None
 )
 
 /** Query parameters to filter by users */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -132,7 +132,8 @@ case class ProjectQueryParameters(
   orgParams: OrgQueryParameters = OrgQueryParameters(),
   userParams: UserQueryParameters = UserQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
-  searchParams: SearchQueryParameters = SearchQueryParameters()
+  searchParams: SearchQueryParameters = SearchQueryParameters(),
+  ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters()
 )
 
 @JsonCodec
@@ -182,6 +183,16 @@ case class UserAuditQueryParameters(
 @JsonCodec
 case class OwnerQueryParameters(
   owner: Option[String] = None
+)
+
+/** Query parameters to filter by ownership type:
+  - owned by me only: owned
+  - shared to be by group membership: inherited
+  - both the above: all, this is default
+*/
+@JsonCodec
+case class OwnershipTypeQueryParameters(
+  ownershipType: Option[String] = None
 )
 
 /** Query parameters to filter by users */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -242,7 +242,8 @@ case class CombinedToolRunQueryParameters(
   toolRunParams: ToolRunQueryParameters = ToolRunQueryParameters(),
   timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
   ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
-  groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
+  groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
+  userParams: UserQueryParameters = UserQueryParameters()
 )
 
 @JsonCodec
@@ -253,6 +254,7 @@ case class CombinedToolCategoryQueryParams(
 
 @JsonCodec
 case class DatasourceQueryParameters(
+  userParams: UserQueryParameters = UserQueryParameters(),
   searchParams: SearchQueryParameters = SearchQueryParameters(),
   ownershipTypeParams: OwnershipTypeQueryParameters = OwnershipTypeQueryParameters(),
   groupQueryParameters: GroupQueryParameters = GroupQueryParameters()

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -64,12 +64,12 @@ abstract class Dao[Model: Composite] extends Filterables {
        AND acr.action_type = ${ActionType.View.toString}::action_type
     """
     val inheritedF: Fragment = (groupTypeO, groupIdO) match {
-     case (Some(groupType), Some(groupId)) => inheritedBaseF ++ fr"""
+      case (Some(groupType), Some(groupId)) => inheritedBaseF ++ fr"""
        AND ugr.group_type = ${groupType}
        AND ugr.group_id = ${groupId}
      """
      case _ => inheritedBaseF
-   }
+    }
     ownershipTypeO match {
       // owned by the requesting user only
       case Some(ownershipType) if ownershipType == "owned" =>

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -40,14 +40,21 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
     }
   }
 
-  def listAuthorizedScenes(pageRequest: PageRequest, sceneParams: CombinedSceneQueryParams, user: User): ConnectionIO[PaginatedResponse[Scene.WithRelated]] = for {
+  def listAuthorizedScenes(pageRequest: PageRequest, sceneParams: CombinedSceneQueryParams, user: User, ownershipTypeO: Option[String] = None,
+    groupTypeO: Option[GroupType] = None, groupIdO: Option[UUID] = None): ConnectionIO[PaginatedResponse[Scene.WithRelated]] = for {
     shapeO <- sceneParams.sceneParams.shape match {
       case Some(shpId) => ShapeDao.getShapeById(shpId)
       case _ => None.pure[ConnectionIO]
     }
     sceneSearchBuilder = {
       SceneDao
-        .authViewQuery(user, ObjectType.Scene)
+        .authViewQuery(
+          user,
+          ObjectType.Scene,
+          sceneParams.ownershipTypeParams.ownershipType,
+          sceneParams.groupQueryParameters.groupType,
+          sceneParams.groupQueryParameters.groupId
+        )
         .filter(shapeO map { _.geometry })
         .filter(sceneParams)
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
@@ -130,11 +130,13 @@ trait Filterables extends RFMeta with LazyLogging {
 
   implicit val combinedToolRunQueryParameters =
     Filterable[Any, CombinedToolRunQueryParameters] { combinedToolRunParams: CombinedToolRunQueryParameters =>
-      Filters.timestampQP(combinedToolRunParams.timestampParams) ++ List(
-        combinedToolRunParams.toolRunParams.createdBy.map({createdBy => fr"created_by = ${createdBy}"}),
-        combinedToolRunParams.toolRunParams.projectId.map({projectId => fr"project_id = ${projectId}"}),
-        combinedToolRunParams.toolRunParams.toolId.map({toolId => fr"tool_id = ${toolId}"})
-      )
+      Filters.userQP(combinedToolRunParams.userParams) ++
+        Filters.timestampQP(combinedToolRunParams.timestampParams) ++
+        List(
+          combinedToolRunParams.toolRunParams.createdBy.map({createdBy => fr"created_by = ${createdBy}"}),
+          combinedToolRunParams.toolRunParams.projectId.map({projectId => fr"project_id = ${projectId}"}),
+          combinedToolRunParams.toolRunParams.toolId.map({toolId => fr"tool_id = ${toolId}"})
+        )
     }
 
   implicit val fragmentFilter = Filterable[Any, Fragment] { fragment: Fragment => List(Some(fragment)) }
@@ -151,7 +153,8 @@ trait Filterables extends RFMeta with LazyLogging {
   }}
 
   implicit val datasourceQueryparamsFilter = Filterable[Any, DatasourceQueryParameters] { dsParams: DatasourceQueryParameters =>
-    Filters.searchQP(dsParams.searchParams, List("name"))
+    Filters.searchQP(dsParams.searchParams, List("name")) ++
+      Filters.userQP(dsParams.userParams)
   }
 
   implicit val uploadQueryParameters = Filterable[Any, UploadQueryParameters] {uploadParams: UploadQueryParameters =>


### PR DESCRIPTION
## Overview

This PR updates the below top-level objects' listing filters so that we may filter them just owned by ourselves, shared directly to us, shared to us due to group membership, etc.  It also enables us to filter these objects by a specific group type and id.
   - [X] Project
   - [x] Scene
   - [x] Datasource
   - [x] Shape
   - [x] Template
   - [x] Analysis

This is a backend PR supporting the new search UI frontend and the new admin frontend.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Make dev user admin of a platform/organization/team.
 * Grant view access of a certain top-level object owned by this dev user, say a project, to:
     - users in the same organization/team;
     - a specific user (in the same organization/team) of which you have login credentials.
 * Log in as this other user and test the below cases (take the list project endpoint as an example)
1. The default case:
     - GET `api/projects`: a list of projects owned by this user, shared to this user directly, shared to by `subject_type = ALL`, and shared to by group membership
2. For implementing ownership filter on main app page (i.e. not admin pages) on the frontend (#3523):
     - **Owned**: GET `api/projects?ownershipType=owned`: a list of projects owned by this user ONLY
     - **Not owned**: GET `api/projects?ownershipType=share`: a list of projects shared to the user due to group membership PLUS shared to the user directly or by `subject_type = ALL`
3. For implementing the first class object listing pages on the new admin frontend (#3484):
     - **List all projects shared in an organization/team under organization/team view**: GET `api/projects?ownershipType=inherited&groupType=<Group Type>&groupId=<Group ID>`
     - **List all projects on another user's profile**: GET `api/projects?ownershipType=shared&ownerId=<Owner ID>`
     - **List all projects owned by the viewing user themselves**: GET `api/projects?ownershipType=owned`

Backend support for #3484 
Closes #3523 
