### PR TITLE
Fix Planet Upload Processing

### DIFF
--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -41,15 +41,17 @@ def process_upload(upload_id):
             factory = GeoTiffS3SceneFactory(upload)
         elif upload.uploadType.lower() == 'planet':
             logger.info('Processing a planet upload. This might take a while...')
+            logger.info('Retrieving Planet API Client')
+            client = api.ClientV1(upload.metadata.get('planetKey'))
             factory = PlanetSceneFactory(
                 upload.files,
                 upload.datasource,
                 upload.id,
+                client,
                 upload.projectId,
                 upload.visibility,
                 [],
-                upload.owner,
-                api.ClientV1(upload.metadata.get('planetKey'))
+                upload.owner
             )
         elif upload.uploadType.lower() == 'modis_usgs':
             logger.info('Processing MODIS upload from USGS')

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -50,6 +50,7 @@ class BaseModel(object):
             response.raise_for_status()
         except:
             logger.exception('Unable to create object via API: %s', response.text)
+            logger.exception('Attempted to POST: \n%s\n', self.to_json())
             raise
         return self.from_dict(response.json())
 


### PR DESCRIPTION

## Overview

Remove unused argument for Planet scene factory, make `client`, a required argument, and also add additional logging at API boundaries. 

At some point the arguments to this function changed such that the default value of `None` was being passed to the Planet scene factory for the API client. The change in this PR moves the `client` to a required argument so that this mistake is harder to make in the future.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo
```
cbrown@trout:~/Projects/raster-foundry$ ./scripts/console batch "rf process-upload 4fcdf967-b49e-400d-a2bc-5cad00211c06"
Starting rasterfoundry_postgres_1 ... done
Processing upload
INFO:rf.commands.process_upload:Getting upload
INFO:rf.commands.process_upload:Updating upload status
INFO:rf.commands.process_upload:Processing upload (4fcdf967-b49e-400d-a2bc-5cad00211c06) for user auth0|59318a9d2fbbca3e16bcfc92 with files [u'PSScene4Band:20180429_180902_1011']
INFO:rf.commands.process_upload:Processing a planet upload. This might take a while...
INFO:rf.commands.process_upload:Retrieving Planet API Client
INFO:rf.commands.process_upload:Creating scene objects for upload 4fcdf967-b49e-400d-a2bc-5cad00211c06, preparing to POST to API
INFO:rf.uploads.planet.factories:Preparing to copy planet asset to s3: PSScene4Band:20180429_180902_1011
INFO:rf.uploads.planet.factories:Retrieving item type PSScene4Band with id 20180429_180902_1011
INFO:rf.uploads.planet.factories:Retrieved Item: <planet.api.models.JSON object at 0x7ffa55812750>
INFO:rf.uploads.planet.factories:Requesting asset from Planet: 20180429_180902_1011, PSScene4Band
INFO:rf.uploads.planet.factories:Determining Analytics Asset Type
INFO:rf.uploads.planet.factories:Found acceptable type: analytic
INFO:rf.uploads.planet.factories:Activating asset for 20180429_180902_1011
INFO:rf.uploads.planet.factories:Asset activated: 20180429_180902_1011
INFO:rf.uploads.planet.factories:Downloading asset: 20180429_180902_1011 to /tmp/tmpySZy4e
INFO:rf.uploads.planet.factories:Copying asset: 20180429_180902_1011 (/tmp/tmpySZy4e => s3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/4fcdf967-b49e-400d-a2bc-5cad00211c06/PSScene4Band-20180429_180902_1011-analytic.tif)
INFO:rf.uploads.planet.factories:Activating asset for 20180429_180902_1011
INFO:rf.uploads.planet.factories:Asset activated: 20180429_180902_1011
INFO:rf.uploads.planet.create_scenes:Downloading thumbnail for Planet scene: https://api.planet.com/data/v1/item-types/PSScene4Band/items/20180429_180902_1011/thumb
INFO:rf.uploads.planet.create_scenes:Uploading thumbnails to S3: 1bcba27e-1445-4b28-947d-b567d0b4b380.png
INFO:rf.commands.process_upload:Successfully created 1 scenes ([u'1bcba27e-1445-4b28-947d-b567d0b4b380'])
INFO:rf.commands.process_upload:Upload specified a project. Linking scenes to project 587743de-326b-432a-8785-bd23fed5c691
INFO:rf.commands.process_upload:Finished importing scenes for upload (4fcdf967-b49e-400d-a2bc-5cad00211c06) for user auth0|59318a9d2fbbca3e16bcfc92 with files [u'PSScene4Band:20180429_180902_1011']
```

Closes #3573 
