### PR TITLE
Add user search endpoint

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -281,7 +281,7 @@ trait PlatformRoutes extends Authentication
 
   def listPlatformMembers(platformId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
+      PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
     } {
       (withPagination & searchParams) { (page, searchParams) =>
         complete {

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -18,9 +18,12 @@ import akka.http.scaladsl.marshalling.Marshal
 import cats.effect.IO
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.typesafe.scalalogging.LazyLogging
+
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.JsonCodec
+import io.circe.generic.semiauto._
+
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -55,6 +58,14 @@ case class UserWithOAuth(
   user: User,
   oauth: Auth0User
 )
+
+object UserWithOAuth {
+  implicit val encodeUser: Encoder[User] = Encoder.forProduct8(
+    "id", "name", "email", "profileImageUri", "emailNotifications", "visibility",
+    "dropboxCredential", "planetCredential"
+  )(u => (u.id, u.name, u.email,u.profileImageUri, u.emailNotifications, u.visibility, u.dropboxCredential, u.planetCredential))
+}
+
 
 @JsonCodec
 case class Auth0UserUpdate(

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 import io.circe._
 import io.circe.generic.JsonCodec
 import cats.syntax.either._
+import io.circe.generic.semiauto._
 
 sealed abstract class UserRole(val repr: String) extends Product with Serializable
 case object UserRoleRole extends UserRole("USER")
@@ -59,7 +60,6 @@ object Credential {
   }
 }
 
-@JsonCodec
 case class User(
   id: String,
   role: UserRole,
@@ -89,6 +89,12 @@ object User {
 
   def create = Create.apply _
 
+
+  implicit val decodeUser: Decoder[User] = deriveDecoder[User]
+
+  implicit val encodeUser: Encoder[User] = Encoder.forProduct4(
+    "id", "name", "email", "profileImageUri"
+  )(u => (u.id, u.name, u.email, u.profileImageUri))
 
   @JsonCodec
   case class WithGroupRole (

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserDao.scala
@@ -152,4 +152,60 @@ object UserDao extends Dao[User] {
 
   def isSuperUser(user: User): ConnectionIO[Boolean] =
     isSuperUserF(user).query[Boolean].option.map(_.getOrElse(false))
+
+  def viewFilter(user: User): Dao.QueryBuilder[User] =
+    Dao.QueryBuilder[User](
+      user.isSuperuser match {
+        case true => selectF
+        case _ =>
+          (selectF ++ fr"""
+        JOIN (
+          -- users in same platform and is admin
+          SELECT target_ugr1.user_id AS user_id
+          FROM user_group_roles requesting_ugr1
+          JOIN user_group_roles target_ugr1 ON requesting_ugr1.group_id = target_ugr1.group_id
+          WHERE
+          requesting_ugr1.group_type = 'PLATFORM' AND
+          requesting_ugr1.user_id = ${user.id} AND
+          requesting_ugr1.group_role = 'ADMIN'
+
+          UNION
+          -- users in same platform and public
+          SELECT target_ugr2.user_id AS user_id
+          FROM user_group_roles requesting_ugr2
+          JOIN user_group_roles target_ugr2 ON requesting_ugr2.group_id = target_ugr2.group_id
+          JOIN users platform_users ON target_ugr2.user_id = platform_users.id
+          WHERE
+          requesting_ugr2.group_type = 'PLATFORM' AND
+          requesting_ugr2.user_id = ${user.id} AND
+          platform_users.visibility = 'PUBLIC'
+
+          UNION
+          -- users in same orgs
+          SELECT target_ugr3.user_id AS user_id
+          FROM user_group_roles requesting_ugr3
+          JOIN user_group_roles target_ugr3 ON requesting_ugr3.group_id = target_ugr3.group_id
+          JOIN users organization_users ON target_ugr3.user_id = organization_users.id
+          WHERE
+          requesting_ugr3.group_type = 'ORGANIZATION' AND
+          requesting_ugr3.user_id = ${user.id}
+
+          UNION
+          -- users in same teams
+          SELECT target_ugr4.user_id AS user_id
+          FROM user_group_roles requesting_ugr4
+          JOIN user_group_roles target_ugr4 ON requesting_ugr4.group_id = target_ugr4.group_id
+          JOIN users team_users ON target_ugr4.user_id = team_users.id
+          WHERE
+          requesting_ugr4.group_type = 'TEAM' AND
+          requesting_ugr4.user_id = ${user.id}
+        ) AS search ON""" ++ Fragment.const(s"${tableName}.id") ++ fr"= search.user_id")
+      }, tableF, List.empty
+    )
+
+  def searchUsers(user: User, searchParams: SearchQueryParameters): ConnectionIO[List[User]] = {
+    UserDao.viewFilter(user)
+      .filter(searchParams)
+      .list(0, 5, fr"order by name")
+  }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
@@ -219,6 +219,10 @@ trait Filterables extends RFMeta with LazyLogging {
     Filters.searchQP(params, List("name"))
   }
 
+  implicit val userSearchQueryParamsFilter = Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
+    Filters.searchQP(params, List("name", "email"))
+  }
+
   implicit def projectedGeometryFilter = Filterable[Any, Projected[Geometry]] {
     geom => List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
   }


### PR DESCRIPTION
## Overview
Restrict platform user endpoint to platform users

### Checklist

- ~Styleguide updated, if necessary~
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Notes
Update endpoints still require a full user object.

## Testing Instructions

* Verify that the platform users endpoint is only accessible by platform admins
* Verify that the `users/search?search=searchtext` endpoint works as expected, and only returns users that the requester has permission to view when taking into account platform role, org, team, and user visibility on the platform
* Verify that endpoints that list users return a limited subset of fields

Closes #3565
Depends on #3569 