### PR TITLE
Fix anti-meridian migration

### DIFF
--- a/app-backend/migrations/src_migrations/main/scala/128.scala
+++ b/app-backend/migrations/src_migrations/main/scala/128.scala
@@ -6,9 +6,9 @@ object M128 {
     sqlu"""
 UPDATE scenes
 SET data_footprint = (
-  SELECT st_collect(
-    ST_TRANSFORM(rightpoly.thegeom, 3857),
-    ST_TRANSFORM(ST_TRANSLATE(leftpoly.thegeom, -360, 0), 3857)
+  SELECT ST_UNION(
+    ST_COLLECT(ST_TRANSFORM(rightpoly.thegeom, 3857)),
+    ST_COLLECT(ST_TRANSFORM(ST_TRANSLATE(leftpoly.thegeom, -360, 0), 3857))
   ) FROM
   (SELECT foo2.thegeom thegeom FROM
     (SELECT (ST_DUMP(foo.geom)).geom AS thegeom FROM


### PR DESCRIPTION
## Overview
Migration did not handle multiple polygons on each side of the anti-meridian correctly.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

Ran it on staging:
![image](https://user-images.githubusercontent.com/4392704/41734423-dcee0af8-7554-11e8-88fd-2207679276ff.png)


## Testing Instructions

 * Verified on staging

Closes https://github.com/azavea/raster-foundry-platform/issues/366
