### PR TITLE
Fix ingest notification bug

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
@@ -6,7 +6,6 @@ import java.util.UUID
 import cats.effect.IO
 
 import scala.concurrent.Future
-import scala.util._
 import com.azavea.rf.batch.Job
 import com.azavea.rf.common.notification.Email.NotificationEmail
 import com.azavea.rf.datamodel._

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -182,29 +182,20 @@ object PlatformDao extends Dao[Platform] {
     ).query[PlatformWithUsersSceneProjects].to[List]
   }
 
-  def getPlatAndUsersBySceneOwnerId(sceneOwnerIdO: Option[String]): ConnectionIO[Option[PlatformWithSceneOwner]] = {
-    sceneOwnerIdO match {
-      case Some(sceneOwnerId) => {
-        val ownerId = "'" ++ sceneOwnerId ++ "'"
-        Fragment.const(
-          s"""
-            SELECT DISTINCT
-              plat.id AS plat_id, plat.name AS plat_name, u.id AS u_id, u.name AS u_name,
-              plat.public_settings AS pub_settings, plat.private_settings AS pri_settings,
-              u.email AS email, u.email_notifications AS email_notifications
-            FROM users AS u
-              JOIN user_group_roles AS ugr
-              ON u.id = ugr.user_id
-              JOIN platforms AS plat
-              ON ugr.group_id = plat.id
-              JOIN projects AS prj
-              ON u.id = prj.owner
-              JOIN scenes_to_projects AS stp
-              ON prj.id = stp.project_id
-            WHERE u.id = ${ownerId}
-          """).query[PlatformWithSceneOwner].option
-      }
-      case _ => Option.empty.pure[ConnectionIO]
-    }
+  def getPlatAndUsersBySceneOwnerId(sceneOwnerId: String): ConnectionIO[PlatformWithSceneOwner] = {
+    val ownerId = "'" ++ sceneOwnerId ++ "'"
+    Fragment.const(
+      s"""
+        SELECT DISTINCT
+          plat.id AS plat_id, plat.name AS plat_name, u.id AS u_id, u.name AS u_name,
+          plat.public_settings AS pub_settings, plat.private_settings AS pri_settings,
+          u.email AS email, u.email_notifications AS email_notifications
+        FROM users AS u
+          JOIN user_group_roles AS ugr
+          ON u.id = ugr.user_id
+          JOIN platforms AS plat
+          ON ugr.group_id = plat.id
+        WHERE u.id = ${ownerId}
+      """).query[PlatformWithSceneOwner].unique
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -258,11 +258,10 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
             datasource <- unsafeGetRandomDatasource
             sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser, datasource, sceneCreate), dbUser)
             _ <- ProjectDao.addScenesToProject(List(sceneInsert.id), dbProject.id, dbUser)
-            pUO <- PlatformDao.getPlatAndUsersBySceneOwnerId(Some(sceneInsert.owner))
+            pUO <- PlatformDao.getPlatAndUsersBySceneOwnerId(sceneInsert.owner)
           } yield (dbUser, dbPlatform, dbProject, pUO)
 
-          val (dbUser, dbPlatform, dbProject, pUO) = puIO.transact(xa).unsafeRunSync
-          val pU = pUO.get
+          val (dbUser, dbPlatform, dbProject, pU) = puIO.transact(xa).unsafeRunSync
 
           assert(pU.platId == dbPlatform.id, "; platform ID don't match")
           assert(pU.platName == dbPlatform.name, "; platform name don't match")


### PR DESCRIPTION
## Overview

This PR fixes the ingest notification bug so that scene owners are notified even if they don't own any project. It also updates the associated property tests.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

## Testing Instructions

 * Refer to testing instructions https://github.com/raster-foundry/raster-foundry/pull/3525 to make sure if you own a scene but the scene is not in any project, you get the ingest status notification email. (Please make sure the scene is either `INGESTED` or `FAILED` since no notification will be sent in other cases by design)

Closes https://github.com/raster-foundry/raster-foundry/issues/3580
