### PR TITLE
Distinct on ids when counting

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -95,7 +95,7 @@ object Dao {
 
   case class QueryBuilder[Model: Composite](selectF: Fragment, tableF: Fragment, filters: List[Option[Fragment]]) {
 
-    val countF = fr"SELECT count(*) FROM" ++ tableF
+    val countF = fr"SELECT count(distinct(id)) FROM" ++ tableF
     val deleteF = fr"DELETE FROM" ++ tableF
     val existF = fr"SELECT 1 FROM" ++ tableF
 


### PR DESCRIPTION
## Overview

This PR includes a distinct on id in the `countF` in the `Dao` base class so that we
don't double count.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

### Demo

![image](https://user-images.githubusercontent.com/5702984/41861043-31dd0732-786e-11e8-9b0f-ac89c7c87198.png)

### Notes

The `countF` is exercised anywhere `PaginatedResponse`s are returned, which happens in
some places in tests already, so we know it's valid sql.

I think larger changes are necessary to test that the count is correct, so I'm skipping that and we can
decide later whether we think it's necessary.

## Testing Instructions

 * list your projects and confirm the count matches
 * browse for scenes in a small area and confirm the count matches

Closes #3589 
