### PR TITLE
Differentiate rendered tiles from raw tiles for caching

### DIFF
--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -303,7 +303,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
             }
             cacheKey match {
               case Some(key) =>
-                rfCache.cachingOptionT(s"tile-${sceneId}-${key}")(tile)
+                rfCache.cachingOptionT(s"tile-rendered-${sceneId}-${key}")(tile)
               case _ =>
             }
             tile


### PR DESCRIPTION
## Overview

This PR fixes an issue where we were storing rendered and raw tiles with the same cache key. This would cause problems when a scene had been loaded in a project and rendered in RGB (or false-color) thereby reducing the tile to 3 bands but then later used in an analysis with more than 3 bands used. This would throw an error like:

```Band N does exist```

I verified this by requesting the same tile for a scene in both a project and analysis, clearing the cache, and varying the load order. If I loaded the project tile first and the analysis tile second, the later one would fail to render.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

Closes #3098
