### PR TITLE
Make org de/activation work. Act on membership request/invitations.

### DIFF
--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -529,10 +529,10 @@ trait PlatformRoutes extends Authentication
     authorizeAsync {
       OrganizationDao.userIsAdmin(user, organizationId).transact(xa).unsafeToFuture
     } {
-      entity(as[ActiveStatus]) {
-        case ActiveStatus(true) =>
+      entity(as[String]) {
+        case status: String if status == OrgStatus.Active.toString =>
           activateOrganization(platformId, organizationId, user)
-        case ActiveStatus(false) =>
+        case status: String if status == OrgStatus.Inactive.toString =>
           deactivateOrganization(platformId, organizationId, user)
       }
     }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -111,7 +111,8 @@ object User {
     isSuperuser: Boolean,
     isActive: Boolean,
     visibility: UserVisibility,
-    groupRole: GroupRole
+    groupRole: GroupRole,
+    membershipStatus: MembershipStatus
   )
 
   @JsonCodec

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -227,9 +227,9 @@ object Dao {
       (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest)).query[T].list
 
     /** Provide a list of responses within the PaginatedResponse wrapper */
-    def page[T: Composite](pageRequest: PageRequest, selectF: Fragment, countF: Fragment): ConnectionIO[PaginatedResponse[T]] = {
+    def page[T: Composite](pageRequest: PageRequest, selectF: Fragment, countF: Fragment, orderClause: Fragment = fr""): ConnectionIO[PaginatedResponse[T]] = {
       for {
-        page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest)).query[T].list
+        page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ orderClause ++ Page(pageRequest)).query[T].list
         count <- (countF ++ Fragments.whereAndOpt(filters: _*)).query[Int].unique
       } yield {
         val hasPrevious = pageRequest.offset > 0

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -209,7 +209,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
          logo_uri = ${uri}
        WHERE id = ${orgID}
      """).update.withUniqueGeneratedKeys[Organization](
-       "id", "created_at", "modified_at", "name", "platform_id", "is_active",
+       "id", "created_at", "modified_at", "name", "platform_id", "status",
        "dropbox_credential", "planet_credential", "logo_uri", "visibility"
      )
   }
@@ -224,7 +224,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
 
   def activateOrganization(actingUser: User, organizationId: UUID) = {
     (fr"UPDATE" ++ tableF ++ fr"""SET
-       is_active = true,
+       status = 'ACTIVE'::org_status,
        modified_at = now()
        where id = ${organizationId}
       """).update.run
@@ -232,7 +232,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
 
   def deactivateOrganization(actingUser: User, organizationId: UUID) = {
     (fr"UPDATE" ++ tableF ++ fr"""SET
-       is_active = false,
+       status = 'INACTIVE'::org_status,
        modified_at = now()
        where id = ${organizationId}
       """).update.run

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -80,7 +80,8 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       case Some(org) => PlatformDao.organizationIsPublicOrg(organizationId, org.platformId)
       case None => false.pure[ConnectionIO]
     }
-    usersPage <- UserGroupRoleDao.listUsersByGroup(GroupType.Organization, organizationId, page, searchParams, actingUser)
+    usersPage <- UserGroupRoleDao.listUsersByGroup(GroupType.Organization, organizationId,
+      page, searchParams, actingUser, Some(fr"ORDER BY ugr.membership_status, ugr.group_role"))
     maybeSanitized = isDefaultOrg match {
       case true => usersPage.copy(
         results = usersPage.results map { _.copy(email = "") }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -79,7 +79,7 @@ object TeamDao extends Dao[Team] {
   }
 
   def listMembers(teamId: UUID, page: PageRequest, searchParams: SearchQueryParameters, actingUser: User): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
-    UserGroupRoleDao.listUsersByGroup(GroupType.Team, teamId, page, searchParams, actingUser)
+    UserGroupRoleDao.listUsersByGroup(GroupType.Team, teamId, page, searchParams, actingUser, Some(fr"ORDER BY ugr.membership_status, ugr.group_role"))
 
   def validatePath(platformId: UUID,
                    organizationId: UUID,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -171,7 +171,8 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
       .list
   }
 
-  def listUsersByGroup(groupType: GroupType, groupId: UUID, page: PageRequest, searchParams: SearchQueryParameters, actingUser: User): ConnectionIO[PaginatedResponse[User.WithGroupRole]] = {
+  def listUsersByGroup(groupType: GroupType, groupId: UUID, page: PageRequest,
+      searchParams: SearchQueryParameters, actingUser: User, orderClauseO: Option[Fragment] = None): ConnectionIO[PaginatedResponse[User.WithGroupRole]] = {
     // PUBLIC users can be seen by anyone within the same platform
     // PRIVATE users can be seen by anyone within the same organization
     // PRIVATE users can be seen by anyone within the same team (even if orgs are different)
@@ -240,7 +241,10 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
               case false => Some(ff)
             }
           )
-          .page[User.WithGroupRole](page, sf, cf)
+          .page[User.WithGroupRole](page, sf, cf, orderClauseO match {
+            case Some(orderClause) => orderClause
+            case None => fr""
+          })
       }
     } yield { result }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
@@ -90,7 +90,7 @@ class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTe
         (uc1: User.Create, uc2: User.Create,
          uc3: User.Create, pc1: Platform, pc2: Platform,
          org1: Organization.Create, org2: Organization.Create, org3: Organization.Create) => {
-          val defaultUser = uc1.toUser.copy(id="default")
+          val defaultUser = uc1.toUser.copy(id = "default")
           val orgsIO = for {
             p1 <- PlatformDao.create(pc1)
             p2 <- PlatformDao.create(pc2)

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -57,12 +57,29 @@
           {{user.email || 'No email available'}}
         </td>
         <td class="roles titlecase">
-            {{user.groupRole}}
+            {{$ctrl.getUserGroupRole(user)}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions && !user.buttonType">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>
+          <div class="btn-group">
+            <button type="button" class="btn btn-danger btn-small"
+                    ng-click="$ctrl.updateUserMembershipStatus(user, false)"
+                    ng-if="user.showOptions && user.buttonType === 'requested'">
+              Deny
+            </button>
+            <button type="button" class="btn btn-primary btn-small"
+                    ng-click="$ctrl.updateUserMembershipStatus(user, true)"
+                    ng-if="user.showOptions && user.buttonType === 'requested'">
+              Approve
+            </button>
+          </div>
+          <button type="button" class="btn btn-light btn-small"
+                  ng-click="$ctrl.updateUserMembershipStatus(user, false)"
+                  ng-if="user.showOptions && user.buttonType === 'invited'">
+            Cancel
+          </button>
         </td>
       </tr>
     </tbody>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -57,28 +57,27 @@
           {{user.email || 'No email available'}}
         </td>
         <td class="roles titlecase">
-            {{$ctrl.getUserGroupRole(user)}}
+            {{$ctrl.getUserGroupRoleLabel(user)}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions && !user.buttonType">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions && user.membershipStatus = 'APPROVED'">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>
-          <div class="btn-group">
+          <div class="btn-group"
+               ng-if="user.showOptions && user.membershipStatus === 'REQUESTED'">
             <button type="button" class="btn btn-danger btn-small"
-                    ng-click="$ctrl.updateUserMembershipStatus(user, false)"
-                    ng-if="user.showOptions && user.buttonType === 'requested'">
+                    ng-click="$ctrl.updateUserMembershipStatus(user, false)">
               Deny
             </button>
             <button type="button" class="btn btn-primary btn-small"
-                    ng-click="$ctrl.updateUserMembershipStatus(user, true)"
-                    ng-if="user.showOptions && user.buttonType === 'requested'">
+                    ng-click="$ctrl.updateUserMembershipStatus(user, true)">
               Approve
             </button>
           </div>
           <button type="button" class="btn btn-light btn-small"
                   ng-click="$ctrl.updateUserMembershipStatus(user, false)"
-                  ng-if="user.showOptions && user.buttonType === 'invited'">
-            Cancel
+                  ng-if="user.showOptions && user.membershipStatus === 'INVITED'">
+            Cancel Invitation
           </button>
         </td>
       </tr>

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -68,25 +68,23 @@ class OrganizationUsersController {
                 this.fetching = false;
                 this.updatePagination(response);
                 this.lastUserResult = response;
-                this.users = this.sortUserList(response.results);
+                this.users = response.results;
+                if (this.isEffectiveAdmin) {
+                    this.setUserActonButtons();
+                }
                 this.buildOptions();
             }, () => {
                 this.fetching = false;
             });
     }
 
-    sortUserList(userList) {
-        return _.sortBy(userList, (user) => {
-            if (user.membershipStatus === 'APPROVED' && user.groupRole === 'MEMBER') {
-                return 4;
-            } else if (user.membershipStatus === 'APPROVED' && user.groupRole === 'ADMIN') {
-                return 3;
-            } else if (user.membershipStatus === 'INVITED') {
+    setUserActonButtons() {
+        this.users.forEach(user => {
+            if (user.membershipStatus === 'INVITED') {
                 user.buttonType = 'invited';
-                return 2;
+            } else if (user.membershipStatus === 'REQUESTED') {
+                user.buttonType = 'requested';
             }
-            user.buttonType = 'requested';
-            return 1;
         });
     }
 
@@ -168,7 +166,7 @@ class OrganizationUsersController {
                         delete thisUser.buttonType;
                     }
                 });
-                this.users = this.sortUserList(this.users);
+                this.fetchUsers(1, '');
             });
         } else {
             this.organizationService.removeUser(
@@ -177,7 +175,7 @@ class OrganizationUsersController {
                 user.id
             ).then(resp => {
                 _.remove(this.users, thisUser => thisUser.id === resp[0].userId);
-                this.users = this.sortUserList(this.users);
+                this.fetchUsers(1, '');
             });
         }
     }

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -69,23 +69,10 @@ class OrganizationUsersController {
                 this.updatePagination(response);
                 this.lastUserResult = response;
                 this.users = response.results;
-                if (this.isEffectiveAdmin) {
-                    this.setUserActonButtons();
-                }
                 this.buildOptions();
             }, () => {
                 this.fetching = false;
             });
-    }
-
-    setUserActonButtons() {
-        this.users.forEach(user => {
-            if (user.membershipStatus === 'INVITED') {
-                user.buttonType = 'invited';
-            } else if (user.membershipStatus === 'REQUESTED') {
-                user.buttonType = 'requested';
-            }
-        });
     }
 
     buildOptions() {
@@ -141,7 +128,7 @@ class OrganizationUsersController {
         });
     }
 
-    getUserGroupRole(user) {
+    getUserGroupRoleLabel(user) {
         switch (user.membershipStatus) {
         case 'INVITED':
             return 'Pending invitation';
@@ -152,8 +139,8 @@ class OrganizationUsersController {
         }
     }
 
-    updateUserMembershipStatus(user, isApprove) {
-        if (isApprove) {
+    updateUserMembershipStatus(user, isApproved) {
+        if (isApproved) {
             this.organizationService.approveUserMembership(
                 this.organization.platformId,
                 this.organization.id,

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -77,7 +77,7 @@ class PlatformOrganizationsController {
     itemsForOrg(organization) {
         /* eslint-disable */
         let actions = [];
-        if (organization.isActive) {
+        if (organization.status === 'ACTIVE') {
             actions.push({
                 label: 'Deactivate',
                 callback: () => {

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -49,12 +49,29 @@
           {{user.email}}
         </td>
         <td class="roles titlecase">
-            <span>{{user.groupRole}}</span>
+            {{$ctrl.getUserGroupRole(user)}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions && !user.buttonType">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>
+          <div class="btn-group">
+            <button type="button" class="btn btn-danger btn-small"
+                    ng-click="$ctrl.updateUserMembershipStatus(user, false)"
+                    ng-if="user.showOptions && user.buttonType === 'requested'">
+              Deny
+            </button>
+            <button type="button" class="btn btn-primary btn-small"
+                    ng-click="$ctrl.updateUserMembershipStatus(user, true)"
+                    ng-if="user.showOptions && user.buttonType === 'requested'">
+              Approve
+            </button>
+          </div>
+          <button type="button" class="btn btn-light btn-small"
+                  ng-click="$ctrl.updateUserMembershipStatus(user, false)"
+                  ng-if="user.showOptions && user.buttonType === 'invited'">
+            Cancel
+          </button>
         </td>
       </tr>
     </tbody>

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -49,28 +49,27 @@
           {{user.email}}
         </td>
         <td class="roles titlecase">
-            {{$ctrl.getUserGroupRole(user)}}
+            {{$ctrl.getUserGroupRoleLabel(user)}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions && !user.buttonType">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions && user.membershipStatus = 'APPROVED'">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>
-          <div class="btn-group">
+          <div class="btn-group"
+               ng-if="user.showOptions && user.membershipStatus === 'REQUESTED'">
             <button type="button" class="btn btn-danger btn-small"
-                    ng-click="$ctrl.updateUserMembershipStatus(user, false)"
-                    ng-if="user.showOptions && user.buttonType === 'requested'">
+                    ng-click="$ctrl.updateUserMembershipStatus(user, false)">
               Deny
             </button>
             <button type="button" class="btn btn-primary btn-small"
-                    ng-click="$ctrl.updateUserMembershipStatus(user, true)"
-                    ng-if="user.showOptions && user.buttonType === 'requested'">
+                    ng-click="$ctrl.updateUserMembershipStatus(user, true)">
               Approve
             </button>
           </div>
-          <button type="button" class="btn btn-light btn-small"
+          <button type="button" class="btn btn-light btn-small btn-nowrap"
                   ng-click="$ctrl.updateUserMembershipStatus(user, false)"
-                  ng-if="user.showOptions && user.buttonType === 'invited'">
-            Cancel
+                  ng-if="user.showOptions && user.membershipStatus === 'INVITED'">
+            Cancel Invitation
           </button>
         </td>
       </tr>

--- a/app-frontend/src/app/pages/admin/team/users/users.js
+++ b/app-frontend/src/app/pages/admin/team/users/users.js
@@ -79,9 +79,6 @@ class TeamUsersController {
             this.updatePagination(response);
             this.lastUserResult = response;
             this.users = response.results;
-            if (this.isEffectiveAdmin) {
-                this.setUserActonButtons();
-            }
             this.buildOptions();
         });
     }
@@ -172,7 +169,7 @@ class TeamUsersController {
         });
     }
 
-    getUserGroupRole(user) {
+    getUserGroupRoleLabel(user) {
         switch (user.membershipStatus) {
         case 'INVITED':
             return 'Pending invitation';
@@ -183,8 +180,8 @@ class TeamUsersController {
         }
     }
 
-    updateUserMembershipStatus(user, isApprove) {
-        if (isApprove) {
+    updateUserMembershipStatus(user, isApproved) {
+        if (isApproved) {
             this.teamService.setUserRole(
                 this.organization.platformId,
                 this.organization.id,
@@ -194,7 +191,6 @@ class TeamUsersController {
                 this.users.forEach(thisUser =>{
                     if (thisUser.id === resp.userId) {
                         thisUser.membershipStatus = resp.membershipStatus;
-                        delete thisUser.buttonType;
                     }
                 });
                 this.fetchUsers(1, '');
@@ -210,16 +206,6 @@ class TeamUsersController {
                 this.fetchUsers(1, '');
             });
         }
-    }
-
-    setUserActonButtons() {
-        this.users.forEach(user => {
-            if (user.membershipStatus === 'INVITED') {
-                user.buttonType = 'invited';
-            } else if (user.membershipStatus === 'REQUESTED') {
-                user.buttonType = 'requested';
-            }
-        });
     }
 }
 

--- a/app-frontend/src/app/pages/user/organizations/organizations.html
+++ b/app-frontend/src/app/pages/user/organizations/organizations.html
@@ -14,6 +14,9 @@
             </a>
           </div>
         </td>
+        <td class="roles titlecase">
+          {{$ctrl.getUserOrgRole(organization.id)}}
+        </td>
       </tr>
     </tbody>
   </table>

--- a/app-frontend/src/app/pages/user/organizations/organizations.js
+++ b/app-frontend/src/app/pages/user/organizations/organizations.js
@@ -1,16 +1,11 @@
 class UserOrganizationsController {
-    constructor(organizations) {
-        this.userRoles = organizations.roles;
-        this.organizations = [];
-        organizations.orgs.forEach(orgPromise => {
-            orgPromise.then(org => {
-                this.organizations.push(org);
-            });
-        });
+    constructor(organizationRoles, organizations) {
+        this.organizationRoles = organizationRoles;
+        this.organizations = organizations;
     }
 
     getUserOrgRole(orgId) {
-        return this.userRoles.find(role => role.groupId === orgId).groupRole;
+        return this.organizationRoles.find(role => role.groupId === orgId).groupRole;
     }
 }
 

--- a/app-frontend/src/app/pages/user/organizations/organizations.js
+++ b/app-frontend/src/app/pages/user/organizations/organizations.js
@@ -1,6 +1,16 @@
 class UserOrganizationsController {
     constructor(organizations) {
-        this.organizations = organizations;
+        this.userRoles = organizations.roles;
+        this.organizations = [];
+        organizations.orgs.forEach(orgPromise => {
+            orgPromise.then(org => {
+                this.organizations.push(org);
+            });
+        });
+    }
+
+    getUserOrgRole(orgId) {
+        return this.userRoles.find(role => role.groupId === orgId).groupRole;
     }
 }
 

--- a/app-frontend/src/app/pages/user/teams/teams.html
+++ b/app-frontend/src/app/pages/user/teams/teams.html
@@ -19,6 +19,9 @@
             </a>
           </div>
         </td>
+        <td class="roles titlecase">
+          {{$ctrl.getUserTeamRole(team.id)}}
+        </td>
         <td class="users">
           <div class="user-group-avatars">
             <div class="avatar user-avatar image-placeholder"

--- a/app-frontend/src/app/pages/user/teams/teams.js
+++ b/app-frontend/src/app/pages/user/teams/teams.js
@@ -1,6 +1,18 @@
 class UserTeamsController {
     constructor(teams) {
-        this.teams = teams;
+        'ngInject';
+
+        this.userRoles = teams.roles;
+        this.teams = [];
+        teams.teams.forEach(teamPromises => {
+            teamPromises.then(team => {
+                this.teams.push(team);
+            });
+        });
+    }
+
+    getUserTeamRole(teamId) {
+        return this.userRoles.find(role => role.groupId === teamId).groupRole;
     }
 }
 

--- a/app-frontend/src/app/pages/user/teams/teams.js
+++ b/app-frontend/src/app/pages/user/teams/teams.js
@@ -1,18 +1,11 @@
 class UserTeamsController {
-    constructor(teams) {
-        'ngInject';
-
-        this.userRoles = teams.roles;
-        this.teams = [];
-        teams.teams.forEach(teamPromises => {
-            teamPromises.then(team => {
-                this.teams.push(team);
-            });
-        });
+    constructor(teamRoles, teams) {
+        this.teamRoles = teamRoles;
+        this.teams = teams;
     }
 
     getUserTeamRole(teamId) {
-        return this.userRoles.find(role => role.groupId === teamId).groupRole;
+        return this.teamRoles.find(role => role.groupId === teamId).groupRole;
     }
 }
 

--- a/app-frontend/src/app/pages/user/user.html
+++ b/app-frontend/src/app/pages/user/user.html
@@ -1,6 +1,7 @@
 <div class="admin-header">
     <rf-editable-logo
       uri="$ctrl.user.profileImageUri"
+      no-cache-bust="true"
     ></rf-editable-logo>
   <div class="admin-logo-text">
     <h4 class="admin-logo-name">

--- a/app-frontend/src/app/pages/user/user.js
+++ b/app-frontend/src/app/pages/user/user.js
@@ -36,20 +36,14 @@ UserModule.resolve = {
         return authService.fetchUserRoles();
     },
     organizations: ($q, userRoles, organizationService) => {
-        const promises =
-            _.uniqBy(userRoles, r => r.groupId)
-            .filter(r => r.groupType === 'ORGANIZATION')
-            .map(r => organizationService.getOrganization(r.groupId));
-
-        return $q.all(promises);
+        let roles = _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'ORGANIZATION');
+        let orgs = roles.map(r => organizationService.getOrganization(r.groupId));
+        return $q.all({roles, orgs});
     },
     teams: ($q, userRoles, teamService) => {
-        const promises =
-            _.uniqBy(userRoles, r => r.groupId)
-            .filter(r => r.groupType === 'TEAM')
-            .map(r => teamService.getTeam(r.groupId));
-
-        return $q.all(promises);
+        let roles = _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'TEAM');
+        let teams = roles.map(r => teamService.getTeam(r.groupId));
+        return $q.all({roles, teams});
     },
     projects: (user, projectService) => {
         return projectService.query(

--- a/app-frontend/src/app/pages/user/user.js
+++ b/app-frontend/src/app/pages/user/user.js
@@ -35,15 +35,17 @@ UserModule.resolve = {
     userRoles: (authService) => {
         return authService.fetchUserRoles();
     },
-    organizations: ($q, userRoles, organizationService) => {
-        let roles = _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'ORGANIZATION');
-        let orgs = roles.map(r => organizationService.getOrganization(r.groupId));
-        return $q.all({roles, orgs});
+    organizationRoles: (userRoles) => {
+        return _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'ORGANIZATION');
     },
-    teams: ($q, userRoles, teamService) => {
-        let roles = _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'TEAM');
-        let teams = roles.map(r => teamService.getTeam(r.groupId));
-        return $q.all({roles, teams});
+    organizations: ($q, organizationRoles, organizationService) => {
+        return $q.all(organizationRoles.map(r => organizationService.getOrganization(r.groupId)));
+    },
+    teamRoles: (userRoles) => {
+        return _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'TEAM');
+    },
+    teams: ($q, teamRoles, teamService) => {
+        return $q.all(teamRoles.map(r => teamService.getTeam(r.groupId)));
     },
     projects: (user, projectService) => {
         return projectService.query(

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -20,13 +20,16 @@ export default (app) => {
                     addUser: {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
                             'organizations/:organizationId/members',
-                        method: 'POST',
-                        isArray: true
+                        method: 'POST'
                     },
                     deactivateUser: {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
                             'organizations/:organizationId/members/:userId',
-                        method: 'DELETE'
+                        method: 'DELETE',
+                        params: {
+                            userId: '@userId'
+                        },
+                        isArray: true
                     },
                     teams: {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
@@ -88,6 +91,12 @@ export default (app) => {
             }).$promise;
         }
 
+        approveUserMembership(platformId, organizationId, userId, groupRole) {
+            return this.PlatformOrganization.addUser({platformId, organizationId}, {
+                userId, groupRole
+            }).$promise;
+        }
+
         setUserRole(platformId, organizationId, user) {
             return this.PlatformOrganization.addUser({
                 platformId,
@@ -143,6 +152,11 @@ export default (app) => {
         updateOrganization(platformId, organizationId, params) {
             return this.PlatformOrganization
                 .updateOrganization({platformId, organizationId}, params).$promise;
+        }
+
+        removeUser(platformId, organizationId, userId) {
+            return this.PlatformOrganization
+                .deactivateUser({platformId, organizationId, userId}).$promise;
         }
     }
 

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -42,7 +42,14 @@ export default (app) => {
                         `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
                             'organizations/:organizationId',
                         method: 'POST',
-                        params: {platformId: '@platformId', organizationId: '@organizationId'}
+                        params: {platformId: '@platformId', organizationId: '@organizationId'},
+                        /* eslint-disable */
+                        transformRequest: (data, headers) => {
+                            headers = angular.extend(
+                                {}, headers, {'Content-Type': 'application/json'});
+                            return angular.toJson(data);
+                        /* eslint-enable */
+                        }
                     },
                     updateOrganization: {
                         url:
@@ -119,12 +126,12 @@ export default (app) => {
 
         deactivate(platformId, organizationId) {
             return this.PlatformOrganization
-                .setOrganizationStatus({platformId, organizationId}, {status: 'INACTIVE'}).$promise;
+                .setOrganizationStatus({platformId, organizationId}, 'INACTIVE').$promise;
         }
 
         activate(platformId, organizationId) {
             return this.PlatformOrganization
-                .setOrganizationStatus({platformId, organizationId}, {status: 'ACTIVE'}).$promise;
+                .setOrganizationStatus({platformId, organizationId}, 'ACTIVE').$promise;
         }
 
         addOrganizationLogo(organizationId, logoBase64) {

--- a/app-frontend/src/app/services/auth/team.service.js
+++ b/app-frontend/src/app/services/auth/team.service.js
@@ -48,8 +48,7 @@ export default (app) => {
                     addUser: {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +
                             'organizations/:organizationId/teams/:teamId/members',
-                        method: 'POST',
-                        isArray: true
+                        method: 'POST'
                     },
                     removeUser: {
                         url: `${BUILDCONFIG.API_HOST}/api/platforms/:platformId/` +

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -396,3 +396,7 @@ Copy button on project share page
   width: 77.47px;
   height: 32px;
 }
+
+.btn-nowrap {
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Overview

This PR makes frontend and backend changes so that:
 * users will know their roles (i.e. ADMIN or MEMBER) when listing organizations and teams they belong to;
 * for admins, show invitation, request status on user list page on organization level and on team level, and enable these buttons' actions;
 * for admins, make organization de/activation work;
 * sort users in organization and team lists by membership status and by group role so that pending approval and pending invitation items show on top and that admin items show before members;
 * Fix user profile picture broken bug on profile pages.

~Marked as WIP since acting on membership invitation/request on team level has not been implemented yet.~

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

<img width="1680" alt="screen shot 2018-06-27 at 11 30 52 am" src="https://user-images.githubusercontent.com/16109558/41984021-969315d2-79fd-11e8-96bf-5a2aa4700c3b.png">


## Testing Instructions

 * Log in as an admin of a platform. Go to organization list page under platform management, check if organization activation/deactivation works
 * Check if user profile picture shows up on user profile pages
 * Log in as an admin of an organization. In DB, modify some organization users' membership status so that they are either `REQUESTED` or `INVITED`. Go to organization user list page, check if these pending statuses show up on top, then approved admins, and then approved members. Click on those approval/denial/cancelation buttons, and see if they work as you expect.
 * Log in as an admin of a team. Do similar tests as the previous case.
 * With any role, get to the user list page of the team/organization you belong to, make sure you see your role showing up in the list as well.

Closes #3593 
Closes #3594 
Closes #3595 
