### PR TITLE
Add and use color map modal

### DIFF
--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.html
@@ -9,12 +9,16 @@
   >
       <div class="gradient-bar gradient-bkg"
            title="{{ $ctrl.state.scheme.label }}"
-          ng-style="$ctrl.colorSchemeService.colorsToBackground(
+           ng-show="$ctrl.state.schemeType"
+           ng-style="$ctrl.colorSchemeService.colorsToBackground(
                       $ctrl.state.scheme.colors,
                       90,
                       $ctrl.state.blending.bins,
                       $ctrl.state.reversed)"
       ></div>
+      <div  ng-show="!$ctrl.state.schemeType">
+        Custom color map
+      </div>
       <i class="icon-caret-down"></i>
   </button>
   <div class="dropdown-menu dropdown-menu-light colorscheme-selector" uib-dropdown-menu role="menu">
@@ -24,7 +28,7 @@
           <a class="dropdown-header-link" ng-click="$ctrl.moveToView('BLENDING')">{{$ctrl.state.blending.label}}...</a>
         </div>
         <div class="dropdown-header-link-container">
-          <a class="dropdown-header-link" ng-click="$ctrl.moveToView('SCHEME')">{{$ctrl.state.schemeType.label}}...</a>
+          <a class="dropdown-header-link" ng-click="$ctrl.moveToView('SCHEME')">{{$ctrl.state.schemeType.label || 'Custom scheme'}}...</a>
         </div>
       </div>
       <ul class="dropdown-list">
@@ -69,7 +73,7 @@
             ng-class="$ctrl.getSchemeTypeClass(schemeType)"
             ng-click="$ctrl.setSchemeType(schemeType)"
         >
-          {{schemeType.label}} <span ng-if="$ctrl.isActiveSchemeType('CATEGORICAL')">(needs discrete bins)</span>
+          {{schemeType.label || 'Custom'}} <span ng-if="$ctrl.isActiveSchemeType('CATEGORICAL')">(needs discrete bins)</span>
         </li>
       </ul>
     </div>

--- a/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.module.js
+++ b/app-frontend/src/app/components/colorComposites/colorSchemeDropdown/colorSchemeDropdown.module.js
@@ -29,10 +29,11 @@ class ColorSchemeDropdownController {
         this.bins = [0, ...[ ...Array(1 + MAX_BINS - MIN_BINS).keys()].map(b => b + MIN_BINS)];
 
         this.filterToValidSchemes = (value) => {
-            return this.state &&
-                value.type === this.state.schemeType.value &&
-                (this.state.blending.bins === 0 ||
-                 Object.keys(value).length >= this.state.blending.bins);
+            const schemeValue = _.get(this, 'state.schemeType.value');
+            const bins = _.get(this, 'state.blending.bins', 0);
+            return value.type === schemeValue &&
+                (bins === 0 ||
+                 Object.keys(value).length >= bins);
         };
     }
 
@@ -259,8 +260,9 @@ class ColorSchemeDropdownController {
     }
 
     isActiveSchemeType(schemeType) {
-        if (this.state) {
-            return this.state.schemeType.value === schemeType.value;
+        const schemeValue = _.get(this, 'state.schemeType.value');
+        if (schemeValue) {
+            return schemeValue === schemeType.value;
         }
         return false;
     }

--- a/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
+++ b/app-frontend/src/app/components/histogram/nodeHistogram/nodeHistogram.html
@@ -27,7 +27,16 @@
       color-scheme-options="$ctrl.options.baseScheme"
       on-change="$ctrl.onColorSchemeChange(value)"
       data-disabled="$ctrl.isSource"
+      ng-show="!$ctrl.isSource"
   ></rf-color-scheme-dropdown>
+  <button class="btn btn-square btn-small btn-ghost"
+          ng-click="$ctrl.customColorModal()"
+          ng-disabled="!$ctrl.histogram"
+          ng-show="!$ctrl.isSource"
+          title="Customize color map"
+  >
+    <span class="icon-settings"></span>
+  </button>
 </div>
 
 <div class="graph-container"

--- a/app-frontend/src/app/components/lab/colormapModal/colormapModal.html
+++ b/app-frontend/src/app/components/lab/colormapModal/colormapModal.html
@@ -1,0 +1,155 @@
+<div class="modal-scrollable-body modal-sidebar-header">
+  <div class="modal-header">
+    <h4 class="modal-title">
+      Custom color map
+    </h4>
+    <p class="modal-subtitle">Upload, paste, or select a custom color mapping</p>
+  </div>
+  <div class="modal-body">
+    <div class="content">
+      <select class="form-control"
+              ng-model="$ctrl.selectMode"
+              ng-model-options="{ getterSetter: true }">
+        <option value="form" selected>Select colors and breakpoints</option>
+        <option value="file">Upload color map</option>
+        <option value="text">Paste color map</option>
+      </select>
+      <br>
+      <div ng-if="$ctrl.selectMode === 'form'">
+        <div class="cm-modal-section">
+          <table style="width: 100%">
+            <thead>
+              <tr>
+                <th class="float-width">Breakpoint</th>
+                <th>Color </th>
+                <th class="action-width">Action</th>
+              </tr>
+            </thead>
+            <tbody> <tr ng-repeat="breakpoint in $ctrl.breakpoints track by $index">
+                <td><input type="number" step="1" class="form-control float-width" ng-model="breakpoint.value"></td>
+                <td><input type="color" class="form-control" ng-model="breakpoint.color"></td>
+                <td>
+                  <button class="btn btn-tiny btn-ghost"
+                          title="Add breakpoint above"
+                          ng-click="$ctrl.addBreakpoint(breakpoint, $index)">
+                    <span class="icon-plus"></span>
+                  </button>
+                  <button class="btn btn-tiny btn-ghost"
+                          title="Delete breakpoint"
+                          ng-click="$ctrl.deleteBreakpoint($index)"
+                          ng-disabled="$ctrl.breakpoints.length <= 2">
+                    <span class="icon-trash"></span>
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div ng-if="$ctrl.selectMode === 'file'">
+        <div class="cm-modal-section">
+          <label class="btn btn-primary btn-block btn-upload-label"
+                 for="btn-upload"
+                 ng-click="$ctrl.onUploadClick()">
+            <input type="file"
+                   accept="application/json"
+                   id="btn-upload"
+                   class="btn-upload">
+            Upload
+          </label>
+        </div>
+        <div class="cm-modal-section bg-border">
+          Upload a JSON file which contains an array of hex color codes.
+          <br>
+          Eg: <code>["#fafafa", "#afafaf"]</code>
+        </div>
+        <div class="cm-modal-section bg-border error" ng-show="$ctrl.uploadError">
+          There was an error parsing the file you selected.
+          <br>
+          Please verify that it is valid JSON, and that the
+          colors are in the correct format.
+          <br>
+          {{$ctrl.uploadError}}
+        </div>
+      </div>
+      <div ng-if="$ctrl.selectMode === 'text'">
+        <div class="cm-modal-section">
+          <textarea class="form-control" placeholder="Paste colormap" ng-model="$ctrl.pastedColormap"></textarea>
+          <button class="btn btn-primary" ng-click="$ctrl.onPaste($ctrl.pastedColormap)">Apply</button>
+        </div>
+        <div class="cm-modal-section bg-border">
+          Paste an JSON array of hex color codes.
+          <br>
+          Eg: <code>["#fafafa", "#afafaf"]</code>
+          <br>
+          <a href="http://colorbrewer2.org" target="_blank">Colorbrewer can be used to generate such an array</a>
+        </div>
+        <div class="cm-modal-section bg-border error" ng-show="$ctrl.pasteError">
+          {{$ctrl.pasteError}}
+          <br><br>
+          There was an error parsing the colors you've pasted
+          <br>
+          Please verify that it is valid JSON, and that the
+          colors are in the correct format.
+        </div>
+      </div>
+    </div>
+    <div class="cm-modal-section horizontal">
+      <table class="cm-modal-value-table">
+        <tbody>
+          <tr>
+            <td>
+              Minimum pixel value detected: <br> {{$ctrl.histMin}}
+            </td>
+            <td>
+              <label>
+                Minimum pixel value:
+                <input class="form-control" type="number" ng-model="$ctrl.minPixelValue">
+              </label>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              Maximum pixel value detected: <br> {{$ctrl.histMax}}
+            </td>
+            <td>
+              <label>
+                Maximum pixel value:
+                <input class="form-control" type="number" ng-model="$ctrl.maxPixelValue">
+              </label>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <button class="btn btn-tertiary"
+            ng-click="$ctrl.redistributePixelValues()">
+      Distribute pixel values across defined range
+    </button>
+  </div>
+  <div class="modal-footer">
+    <div class="cm-modal-section horizontal">
+      <nvd3 id="chart-modal"
+            style="height: 51px; flex: 1;"
+            options="$ctrl.histOptions"
+            data="$ctrl.plot"
+            api="$ctrl.api"></nvd3>
+      <button class="btn"
+              ng-click="$ctrl.dismiss()"
+      >Cancel</button>
+      <button class="btn btn-primary"
+              ng-disabled="$ctrl.uploadError || $ctrl.pasteError || $ctrl.breakpointError"
+              ng-click="$ctrl.closeWithBreakpoints()"
+      >Use color scheme</button>
+    </div>
+  </div>
+</div>
+
+<style>
+ #chart-modal .nv-series-0 {
+     fill: url(#line-gradient-modal) !important;
+     fill-opacity: 1 !important;
+     stroke: url(#line-gradient-modal) !important;
+     stroke-opacity: 1 !important;
+ }
+</style>

--- a/app-frontend/src/app/components/lab/colormapModal/colormapModal.js
+++ b/app-frontend/src/app/components/lab/colormapModal/colormapModal.js
@@ -1,0 +1,218 @@
+/* globals FileReader d3 */
+import angular from 'angular';
+import _ from 'lodash';
+
+import colormapModalTpl from './colormapModal.html';
+
+const ColormapModalComponent = {
+    templateUrl: colormapModalTpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'ColormapModalController'
+};
+
+class ColormapModalController {
+    constructor($scope, colorSchemeService) {
+        this.$scope = $scope;
+        this.colorSchemeService = colorSchemeService;
+    }
+
+    $onInit() {
+        this.selectMode = 'form';
+        this.$scope.$watch('$ctrl.selectMode', (mode) => {
+            if (mode === 'file') {
+                delete this.uploadError;
+                this.$scope.$evalAsync(this.bindUploadEvent.bind(this));
+            }
+        });
+        this.histMin = _.get(this.resolve, 'histogram.data.minimum', 'unknown');
+        if (this.histMin === 'unknown') {
+            this.minPixelValue = 0;
+        } else {
+            this.minPixelValue = this.histMin;
+        }
+        this.histMax = _.get(this.resolve, 'histogram.data.maximum', 'unknown');
+        if (this.histmax === 'unknown') {
+            this.maxPixelValue = 255;
+        } else {
+            this.maxPixelValue = this.histMax;
+        }
+        this.breakpoints = _.clone(this.resolve.breakpoints) || [
+            {value: this.minPixelValue, color: '#ffffff'},
+            {value: this.maxPixelValue, color: '#000000'}
+        ];
+        this.histOptions = {
+            chart: {
+                type: 'lineChart', showLegend: false,
+                showXAxis: false,
+                showYAxis: false,
+                yScale: d3.scale.log(),
+                margin: {
+                    top: 0,
+                    right: 0,
+                    bottom: 0,
+                    left: 0
+                },
+                height: 50,
+                xAxis: {
+                    showLabel: false
+                },
+                yAxis: {
+                    showLabel: false
+                },
+                tooltip: {
+                    enabled: false
+                },
+                interpolate: 'step',
+                dispatch: {
+                    renderEnd: () => {
+                        this.updateHistogramColors();
+                    }
+                }
+            }
+        };
+        this.plot = this.resolve.plot;
+        this.$scope.$watch('$ctrl.breakpoints', (breakpoints) => {
+            if (breakpoints && this.api && this.api.refresh) {
+                this.api.refresh();
+            }
+        }, true);
+    }
+
+
+    bindUploadEvent() {
+        $('#btn-upload').change((e) => {
+            let upload = e.target.files[0];
+            if (upload) {
+                let reader = new FileReader();
+                reader.onload = (event) => {
+                    try {
+                        delete this.uploadError;
+                        const result = JSON.parse(event.target.result.replace(/'/g, '"'));
+                        this.breakpoints = this.colorsToBreakpoints(result);
+                        this.redistributePixelValues();
+                        this.selectMode = 'form';
+                        this.$scope.$evalAsync();
+                    } catch (err) {
+                        this.uploadError = err.message;
+                        this.$scope.$evalAsync();
+                    }
+                };
+                reader.readAsText(upload);
+            }
+        });
+    }
+
+    onPaste(text) {
+        try {
+            const result = JSON.parse(text.replace(/'/g, '"'));
+            this.breakpoints = this.colorsToBreakpoints(result);
+            this.selectMode = 'form';
+            this.redistributePixelValues();
+            this.$scope.$evalAsync();
+        } catch (e) {
+            this.pasteError = e.message;
+            this.$scope.$evalAsync();
+        }
+    }
+
+    colorsToBreakpoints(colors) {
+        let colorRegex = /^#([0-9a-f]{6})$/i;
+        if (colors.map) {
+            return colors.map((color, index) => {
+                if (colorRegex.test(color)) {
+                    return {value: index, color: color};
+                }
+                throw new Error(
+                    `${color} is not a valid hex color code. Colors must be in the form '#aaaaaa'.`
+                );
+            });
+        }
+        throw new Error(`Expected colors to be in an array. Found ${typeof colors}`);
+    }
+
+    addBreakpoint(breakpoint, index) {
+        if (breakpoint && typeof index === 'number') {
+            this.breakpoints.splice(index, 0, _.clone(breakpoint));
+        } else {
+            this.breakpoints.push(_.clone(_.last(this.breakpoints)));
+        }
+    }
+
+    deleteBreakpoint(index) {
+        this.breakpoints.splice(index, 1);
+    }
+
+    redistributePixelValues() {
+        this.breakpoints = this.breakpoints.map((breakpoint, index) => {
+            return Object.assign({}, breakpoint, {
+                value: (this.maxPixelValue - this.minPixelValue) *
+                    (index / (this.breakpoints.length - 1)) +
+                    this.minPixelValue
+            });
+        });
+    }
+
+    updateHistogramColors() {
+        if (!this.api.getElement) {
+            return;
+        }
+
+        let colors = this.calculateHistogramColors();
+
+        this.updateHistogramGradient(colors);
+    }
+
+    calculateHistogramColors() {
+        let range = this.histMax - this.histMin;
+        let data = this.breakpoints.map((bp) => {
+            let offset = (bp.value - this.histMin) / range * 100;
+            return {offset: offset, color: bp.color};
+        }).sort((a, b) => a.offset - b.offset).map((bp) => {
+            return {offset: `${bp.offset}%`, color: bp.color};
+        });
+
+        return data;
+    }
+
+    updateHistogramGradient(data) {
+        let svg = d3.select(this.api.getElement().children()[0]);
+        const selectedDef = svg.select('defs')[0];
+        let defs = selectedDef && selectedDef.length ?
+            svg.select('defs') : svg.append('defs');
+        const lg = defs.selectAll('linearGradient')[0];
+        let linearGradient = lg && lg.length ?
+            defs.selectAll('linearGradient') : defs.append('linearGradient');
+
+        linearGradient.attr('id', 'line-gradient-modal')
+            .attr('gradientUnits', 'userSpaceOnUse')
+            .attr('x1', '0%').attr('y1', 0)
+            .attr('x2', '100%').attr('y2', 0)
+            .selectAll('stop')
+            .data(data)
+            .enter().append('stop')
+            .attr('offset', (d) => d.offset)
+            .attr('stop-color', (d) => d.color)
+            .attr('stop-opacity', (d) => Number.isFinite(d.opacity) ? d.opacity : 1.0);
+        this.$scope.$evalAsync();
+    }
+
+    closeWithBreakpoints() {
+        const bpMap = {};
+        this.breakpoints.forEach(({value, color}) => {
+            bpMap[value] = color;
+        });
+        this.close({$value: bpMap});
+    }
+}
+
+const ColormapModalModule = angular.module('components.lab.colormapModal', []);
+
+ColormapModalModule.controller('ColormapModalController', ColormapModalController);
+ColormapModalModule.component('rfColormapModal', ColormapModalComponent);
+
+export default ColormapModalModule;

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -51,6 +51,7 @@ export default angular.module('index.components', [
     require('./components/lab/classifyNode/classifyNode.module.js').name,
     require('./components/lab/nodeStatistics/nodeStatistics.module.js').name,
     require('./components/lab/labNode/labNode.module.js').name,
+    require('./components/lab/colormapModal/colormapModal.js').name,
     require('./components/map/nodeSelector/nodeSelector.module.js').name,
 
     // map components

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3111,3 +3111,50 @@ rf-reclassify-table {
     }
   }
 }
+
+// color map modal
+.cm-modal-section {
+    &.bg-border {
+        border: 1px solid $gray-lightest;
+        background: lighten($gray-lightest, 10%);
+        border-radius: 2px;
+        padding: 1em;
+        color: $shade-dark;
+    }
+
+    &.error {
+        border: 1px solid $red;
+        background: lighten($red, 40%);
+    }
+
+    &.horizontal {
+        display: flex;
+        flex-direction: row;
+        .btn {
+            margin: 1em;
+        }
+    }
+    &.stationary {
+
+    }
+    .expand {
+        flex: 1;
+    }
+
+    .float-width {
+        width: 17em;
+    }
+    .action-width {
+        width: 5em;
+    }
+}
+
+.cm-modal-value-table {
+    width: 100%;
+    td {
+        border: 1px solid $shade-light;
+        border-collapse: collapse;
+        padding: 0.5em;
+    }
+    margin-bottom: 0.5em;
+}


### PR DESCRIPTION
## Overview

Add a color map modal that allows the user to define a custom color map manually, by uploading a json file that contains colors, or by pasting a json array of colors

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~PR has a name that won't get you publicly shamed for vagueness~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/41990821-8c459406-7a11-11e8-80e0-c0e50647b469.png)

### TODO
- [x] Add close / cancel button to modal
- [x] Hide histogram node color dropdown and modal on nodes where the histogram is disabled. Eg: input nodes

## Testing Instructions
* Verify that you can upload an array of color values
* Verify that you can paste an array of color values
* Verify that changing values and colors updates the visible histogram
* Verify that the way buttons add / remove breakpoints makes sense
* Verify that clicking "Use color scheme" applies the color scheme to the node
* Verify that the existing histogram and color scheme dropdown don't completely freak out when you use a custom color scheme.
* Verify that the tile server respects the color schemes set
* Verify that the value distribution algorithm works for ranges that contain negative numbers
* Verify that the color pickers work in every modern browser (Edge, Chrome, Firefox)

Closes https://github.com/raster-foundry/raster-foundry/issues/2838