### PR TITLE
cleaned up project card frontend and project title hover bug

### DIFF
--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -1,9 +1,9 @@
 <div class="panel-body">
   <ng-container ng-if="!$ctrl.slim">
     <rf-status-tag ng-if="$ctrl.status && $ctrl.status != 'CURRENT' " entity-type="project" status="$ctrl.status" class="project-status"></rf-status-tag>
-    <a href ui-sref="projects.edit({projectid: $ctrl.project.id})" class="h4 font-600 project-title" data-title="{{$ctrl.project.name}}">
+    <a href ui-sref="projects.edit({projectid: $ctrl.project.id})" class="h4 font-600">
       <img class="avatar user-avatar pull-left" ng-attr-src="{{ $ctrl.project.owner.profileImageUri }}" ng-if="$ctrl.project.owner.profileImageUri"/>
-      <span>{{$ctrl.project.name}}</span>
+      <h4 class="project-title" data-title="{{$ctrl.project.name}}">{{$ctrl.project.name}}</h4>
     </a>
     <div class="project-actions" ng-if="!$ctrl.hideOptions">
       <a href ng-click="$ctrl.publishModal()">
@@ -20,24 +20,20 @@
       </a>
     </div>
     <div class="project-preview">
-      <!-- IF project has no scenes -->
       <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+        <!-- IF project has no scenes -->
         <div class="project-preview-container placeholder"
              ng-if="$ctrl.status === 'NOSCENES'"
              style="background-image: url({{$ctrl.projectPlaceholder}})">
         </div>
-      </a>
-
-       <!-- IF not all scenes ingested: -->
-      <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+        
+        <!-- IF not all scenes ingested: -->
         <div class="project-preview-container placeholder"
              ng-if="$ctrl.status !== 'CURRENT' && $ctrl.status !== 'NOSCENES'"
              style="background-image: url({{$ctrl.projectPlaceholder}})">
         </div>
-      </a>
-
-      <!-- IF using a project's thumbnail: -->
-      <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+        
+        <!-- IF using a project's thumbnail: -->
         <div class="project-preview-container placeholder"
              ng-if="$ctrl.thumbnailUrl && $ctrl.status === 'CURRENT'"
              style="background-image: url({{$ctrl.projectPlaceholder}})">

--- a/app-frontend/src/assets/styles/sass/components/_project-item.scss
+++ b/app-frontend/src/assets/styles/sass/components/_project-item.scss
@@ -4,12 +4,16 @@
   .panel-body {
     padding: 1rem;
   }
+
+  .avatar {
+    position: relative;
+    z-index: 10;
+    top: -3px;
+  }
 }
 
 .project-title {
   @extend .font-base;
-  display: flex;
-  align-items: center;
   font-size: 1.6rem;
   margin: 0;
   white-space: nowrap;
@@ -17,32 +21,31 @@
   max-width: 100%;
   text-overflow: ellipsis;
   padding-right: 8.5rem;
-  color: inherit;
-  transition: .5s ease opacity;
-  transition-delay: .25s;
 
-  // &:after {
-  //   content: attr(data-title);
-  //   position: absolute;
-  //   top: 0;
-  //   left: 0;
-  //   padding: 1rem;
-  //   max-width: 100%;
-  //   white-space: normal;
-  //   background: $off-white;
-  //   z-index: 1;
-  //   visibility: hidden;
-  //   opacity: 0;
-  // }
+  &:after {
+    content: attr(data-title);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 90px;
+    border-radius: 5px;
+    padding: 1rem;
+    padding-left: 4.5rem;
+    max-width: 100%;
+    white-space: normal;
+    background: $off-white;
+    box-shadow: inset white 0 0 0 1px;
+    z-index: 1;
+    visibility: hidden;
+    opacity: 0;
+  }
 
-  // &:hover {
-  //   visibility: hidden;
-  // }
-
-  // &:hover:after {
-  //   visibility: visible;
-  //   opacity: 1;
-  // }
+  &:hover:after {
+    visibility: visible;
+    opacity: 1;
+    transition: .5s ease opacity;
+    transition-delay: .5s;
+  }
 }
 
 .project-status {

--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_project-item.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_project-item.scss
@@ -1,3 +1,7 @@
+.project-title {
+  font-size: 1.5rem;
+}
+
 .project-title:after {
   background: $white;
 }


### PR DESCRIPTION
## Overview
- Removes duplicate a tags within project card preview window
- Re-adds the project-title overflow hover effect

### Demo

**Default theme**
<img width="389" alt="screen shot 2018-06-27 at 4 22 21 pm" src="https://user-images.githubusercontent.com/1928955/41997746-e3206084-7a26-11e8-992b-10254e7f380a.png">
<img width="384" alt="screen shot 2018-06-27 at 4 22 24 pm" src="https://user-images.githubusercontent.com/1928955/41997747-e32dd7a0-7a26-11e8-9d72-813703eda74a.png">

**High-contrast theme**
<img width="384" alt="screen shot 2018-06-27 at 4 23 30 pm" src="https://user-images.githubusercontent.com/1928955/41997748-e33a35e0-7a26-11e8-8bc8-82246860397b.png">
<img width="383" alt="screen shot 2018-06-27 at 4 23 34 pm" src="https://user-images.githubusercontent.com/1928955/41997749-e3484e96-7a26-11e8-9931-e78ce15050a8.png">


## Testing Instructions

- rename a project with a long string
- navigate to project card and hover over the title
- the user image and project action buttons should still be visible
