### PR TITLE
Generate thumbnails from COG scenes

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -329,7 +329,6 @@ trait SceneRoutes extends Authentication
     {
       thumbnailQueryParameters {
         thumbnailParams => {
-          println(s"Params are: ${thumbnailParams}")
           authorizeAsync {
             SceneDao.authViewQuery(user, ObjectType.Scene)
               .filter(sceneId)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -337,7 +337,6 @@ trait SceneRoutes extends Authentication
               .unsafeToFuture
           } {
             complete {
-
               SceneDao.unsafeGetSceneById(sceneId).transact(xa).unsafeToFuture >>=
                 { (scene: Scene) =>
                   (scene.ingestLocation, scene.sceneType) match {

--- a/app-backend/api/src/main/scala/scene/ThumbnailQueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/ThumbnailQueryParameters.scala
@@ -1,0 +1,13 @@
+package com.azavea.rf.api.scene
+
+import com.azavea.rf.datamodel.SceneThumbnailQueryParameters
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
+
+trait ThumbnailQueryParameterDirective {
+  val thumbnailQueryParameters = parameters(
+    ('width.as[Int].?,
+     'height.as[Int].?,
+     'token.as[String])).as(SceneThumbnailQueryParameters.apply _)
+}

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -86,17 +86,7 @@ object CogUtils {
         val overviewRasterCellSize = overview.raster.cellSize
         val overviewExtentWidth = overview.extent.width
         val overviewExtentHeight = overview.extent.height
-        println(s"Cell data -- cell width ${overviewRasterCellSize.width}, cell height: ${overviewRasterCellSize.height}")
-        println(s"Extent data -- extent width: ${overviewExtentWidth}, extent height: ${overviewExtentHeight}")
-        val thumbnailExtent = ReprojectRasterExtent(
-          RasterExtent(overview.extent,
-                       (overviewExtentWidth / overviewRasterCellSize.width).toInt,
-                       (overviewExtentHeight / overviewRasterCellSize.height).toInt), transform
-        )
-        Some(
-          Raster(overview.tile, overview.extent)
-            .reproject(thumbnailExtent, transform, inverseTransform).tile
-        )
+        Some(Raster(overview.tile, overview.extent).tile)
       }
     )
   }

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -71,6 +71,10 @@ object CogUtils {
       OptionT[Future, MultibandTile] =
   {
     def trim: Int => Int = Math.min(_, 512)
+    // Check width and height parameters, defaulting to 256 if neither is provided, otherwise
+    // trimming to [0, 512]. Widths and heights are approximate anyway, with the actual size of
+    // the returned PNG determined by the size of the closest overview to the cell size implied by
+    // the requested width and height.
     val (width, height) = (widthO, heightO) match {
       case (Some(w), Some(h)) => (trim(w), trim(h))
       case (Some(w), None) => (trim(w), trim(w))

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -357,3 +357,10 @@ case class OrganizationQueryParameters(
   activationParams: ActivationQueryParameters = ActivationQueryParameters(),
   platformIdParams: PlatformIdQueryParameters = PlatformIdQueryParameters()
 )
+
+@JsonCodec
+case class SceneThumbnailQueryParameters(
+  width: Option[Int],
+  height: Option[Int],
+  token: String
+)


### PR DESCRIPTION
## Overview

This PR adds an endpoint to scenes for generation of thumbnails from COG overviews
on-the-fly for COG scenes.

### Checklist

- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated (raster-foundry/raster-foundry-api-spec#31)
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I'm reprojecting to make the png. Why am I reprojecting? I don't know why I'm reprojecting. :man_shrugging: 
Also I _think_ partly due to reprojecting the requested thumbnail sizes are approximate.
Not sure how important that is.

## Testing Instructions

 * Choose a COG scene (or just upload a scene and process it :sunglasses: )
 * Make some authenticated requests for thumbnails of different sizes
 * Make some of them more than once to confirm that the second time it's fast because cacheing

Closes #3364
