### PR TITLE
Add default sort to platform member list

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -41,7 +41,8 @@ object PlatformDao extends Dao[Platform] {
     query.page(page)
 
   def listMembers(platformId: UUID, page: PageRequest, searchParams: SearchQueryParameters, actingUser: User): ConnectionIO[PaginatedResponse[User.WithGroupRole]] =
-    UserGroupRoleDao.listUsersByGroup(GroupType.Platform, platformId, page, searchParams, actingUser) map {
+    UserGroupRoleDao.listUsersByGroup(GroupType.Platform, platformId, page, searchParams, actingUser,
+                                      Some(fr"ORDER BY ugr.membership_status, ugr.group_role")) map {
       (usersPage: PaginatedResponse[User.WithGroupRole]) => {
          usersPage.copy(results = usersPage.results map { _.copy(email = "" ) })
       }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -61,7 +61,7 @@ object SceneWithRelatedDao extends Dao[Scene.WithRelated] {
     scenes <- sceneSearchBuilder.list(
       (pageRequest.offset * pageRequest.limit),
       pageRequest.limit,
-      fr"ORDER BY coalesce (acquisition_date, created_at) DESC, id"
+      fr"ORDER BY coalesce (acquisition_date, created_at) DESC, id DESC"
     )
     withRelateds <- scenesToScenesWithRelated(scenes)
     count <- sceneSearchBuilder.countIO


### PR DESCRIPTION
## Overview

This PR default sorts the users returned on the platforms members endpoint. Users on
team members and organization members were already sorted by the same columns used
here.

It also adds explicit ordering to the `id` default sort on scenes, since in the past inconsistent
ordering directions resulted in the index not getting used.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests (exercised in existing tests)

### Notes

@alkamin claims that the order didn't have anything to do with index use in scene query
performance testing because they were using the index before, and also that there were
indices present in prod and staging that make it so inconsistent ordering should be fine.
I didn't find those indices. The scene ordering is sort of a shot in the dark.

It's not obvious that this was the _preferred_ default ordering aside from its use elsewhere,
but the issue was _very_ light on details.

## Testing Instructions

 * Make your dev user a platform admin
 * List users
 * Confirm that users are grouped by membership status starting with approved users,
   then that users are ordered by group role

Closes #3485
