### PR TITLE
Polish local COG upload processing

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -365,7 +365,9 @@ export default class SceneImportModalController {
     }
 
     finishUpload() {
-        this.upload.uploadStatus = 'UPLOADED';
+        this.upload.uploadStatus = this.importType === 'COG' ?
+            'COMPLETE' :
+            'UPLOADED';
         this.uploadService.update(this.upload).then(() => {
             this.allowInterruptions();
         });
@@ -524,12 +526,10 @@ export default class SceneImportModalController {
                     this.handleNext();
                     return this.sceneService.createCogScene({
                         metadata: this.sceneData,
-                        location: f,
+                        location: encodeURI(f),
                         projectId: _.get(this, 'resolve.project.id') || false
                     }, this.datasource);
-                })).then(() => {
-                    this.handleNext();
-                });
+                }));
             } else {
                 this.handleNext();
             }

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -11,6 +11,8 @@ from .utils import convert_to_cog
 from rf.utils.io import Visibility, IngestStatus, upload_tifs
 from rf.uploads.landsat8.io import get_tempdir
 
+import urllib
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,7 +66,9 @@ class GeoTiffS3SceneFactory(object):
                 cog_path = convert_to_cog(tempdir, filename)
                 scene = self.create_geotiff_scene(tmp_fname, os.path.splitext(filename)[0])
                 scene.ingestLocation = upload_tifs([cog_path], self.owner, scene.id)[0]
-                images = [self.create_geotiff_image(tmp_fname, infile, scene, cog_path)]
+                images = [self.create_geotiff_image(
+                    tmp_fname, urllib.unquote(scene.ingestLocation), scene, cog_path
+                )]
 
             scene.thumbnails = []
             scene.images = images


### PR DESCRIPTION
## Overview

This PR escapes pipes when we upload COGs from local files and changes the
image file location for created scenes when we process COGs.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

We seemed not to be aware of how much work was already done for the two issues
this closes. We already created scenes directly without upload processing, so we
mainly needed to set the upload status correctly and escape the pipe.

However! In testing, I hypothesized that we should be able to round trip COGs
successfully: uploading a non-COG, processing it to a COG, downloading the scene
with the processed COG, and then local file uploading the downloaded scene
Should Work :tm:. It didn't, because in upload processing to create the COG, the
scene's image was set to the non-COG tif. So there's also a fix in this PR to make
upload/download/upload round trips(-ish, I guess) succeed.

## Testing Instructions

 * rebuild your batch jar
 * upload a non-COG
 * process the upload
 * download the scene
 * upload it as a COG
 * verify that nothing breaks or makes you sad

Closes #3420 

Closes #3522 
