### PR TITLE
Add some enhancements on admin and user frontend

### DIFF
--- a/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.html
+++ b/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.html
@@ -13,7 +13,7 @@
         </a>
       </li>
       <li class="sidebar-list-item"
-          ng-repeat="team in $ctrl.paginatedResponse.results  | limitTo: $ctrl.displayLimit">
+          ng-repeat="team in $ctrl.displayTeams">
         <div ng-if="$ctrl.showOrgLogo">
           <div class="avatar user-avatar image-placeholder"
                ng-if="!($ctrl.orgURIs[team.organizationId] && $ctrl.orgURIs[team.organizationId].length)"></div>

--- a/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.html
+++ b/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.html
@@ -13,8 +13,15 @@
         </a>
       </li>
       <li class="sidebar-list-item"
-          ng-repeat="team in $ctrl.paginatedResponse.results"
-      >
+          ng-repeat="team in $ctrl.paginatedResponse.results  | limitTo: $ctrl.displayLimit">
+        <div ng-if="$ctrl.showOrgLogo">
+          <div class="avatar user-avatar image-placeholder"
+               ng-if="!($ctrl.orgURIs[team.organizationId] && $ctrl.orgURIs[team.organizationId].length)"></div>
+          <div ng-if="$ctrl.orgURIs[team.organizationId] && $ctrl.orgURIs[team.organizationId].length">
+            <img class="avatar user-avatar"
+                 ng-src="{{$ctrl.cacheBustUri($ctrl.orgURIs[team.organizationId])}}">
+          </div>
+        </div>
         <a class="content"
            ui-sref="admin.team({teamId: team.id})"
         >{{team.name}}</a>

--- a/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.js
+++ b/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.js
@@ -5,30 +5,32 @@ const SidebarTeamListComponent = {
     bindings: {
         paginatedResponse: '<',
         showOrgLogo: '<?',
+        displayLimit: '<?',
         sref: '@'
     },
     templateUrl: tpl
 };
 
-const displayLimit = 3;
+const defaultDisplayLimit = 3;
 
 class SidebarTeamListController {
     constructor(organizationService) {
         'ngInject';
         this.organizationService = organizationService;
-        this.displayLimit = displayLimit;
+        this.displayLimit = this.displayLimit || defaultDisplayLimit;
     }
 
     $onInit() {
+        this.displayTeams = this.paginatedResponse.results.length <= this.displayLimit ?
+            this.paginatedResponse.results :
+            this.paginatedResponse.results.slice(this.displayLimit - 1);
         if (this.showOrgLogo) {
-            this.diplayTeams = this.paginatedResponse.results.length <= this.displayLimit ?
-                this.paginatedResponse.results : this.paginatedResponse.results.slice(2);
             this.getOrganizations();
         }
     }
 
     getOrganizations() {
-        this.orgURIs = this.diplayTeams.map(team => team.organizationId)
+        this.orgURIs = this.displayTeams.map(team => team.organizationId)
             .filter((val, idx, self) => self.indexOf(val) === idx)
             .reduce((obj, orgId) => {
                 obj[orgId] = '';

--- a/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.js
+++ b/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.js
@@ -1,13 +1,55 @@
 import tpl from './sidebarTeamList.html';
 
 const SidebarTeamListComponent = {
+    controller: 'SidebarTeamListController',
     bindings: {
         paginatedResponse: '<',
+        showOrgLogo: '<?',
         sref: '@'
     },
     templateUrl: tpl
 };
 
-export default angular
-    .module('components.sidebarTeamList', [])
-    .component('rfSidebarTeamList', SidebarTeamListComponent);
+const displayLimit = 3;
+
+class SidebarTeamListController {
+    constructor(organizationService) {
+        'ngInject';
+        this.organizationService = organizationService;
+        this.displayLimit = displayLimit;
+    }
+
+    $onInit() {
+        if (this.showOrgLogo) {
+            this.diplayTeams = this.paginatedResponse.results.length <= this.displayLimit ?
+                this.paginatedResponse.results : this.paginatedResponse.results.slice(2);
+            this.getOrganizations();
+        }
+    }
+
+    getOrganizations() {
+        this.orgURIs = this.diplayTeams.map(team => team.organizationId)
+            .filter((val, idx, self) => self.indexOf(val) === idx)
+            .reduce((obj, orgId) => {
+                obj[orgId] = '';
+                return obj;
+            }, {});
+
+        Object.keys(this.orgURIs).forEach(orgId => {
+            this.organizationService.getOrganization(orgId).then(resp => {
+                this.orgURIs[orgId] = resp.logoUri;
+            });
+        });
+    }
+
+    cacheBustUri(uri) {
+        return `${uri}?${new Date().getTime()}`;
+    }
+  }
+
+const SidebarTeamListModule = angular.module('components.sidebarTeamList', []);
+
+SidebarTeamListModule.component('rfSidebarTeamList', SidebarTeamListComponent);
+SidebarTeamListModule.controller('SidebarTeamListController', SidebarTeamListController);
+
+export default SidebarTeamListModule;

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -97,6 +97,7 @@ const App = angular.module(
         require('./pages/user/settings/map/map.module.js').name,
         require('./pages/user/settings/connections/connections.module.js').name,
         require('./pages/user/settings/privacy/privacy.module.js').name,
+        require('./pages/user/settings/notification/notification.module.js').name,
         require('./pages/user/organizations/organizations.js').name,
         require('./pages/user/teams/teams.js').name,
 

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -96,6 +96,7 @@ const App = angular.module(
         require('./pages/user/settings/api/api.module.js').name,
         require('./pages/user/settings/map/map.module.js').name,
         require('./pages/user/settings/connections/connections.module.js').name,
+        require('./pages/user/settings/privacy/privacy.module.js').name,
         require('./pages/user/organizations/organizations.js').name,
         require('./pages/user/teams/teams.js').name,
 

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -40,6 +40,7 @@ import userSettingsApiTokensTpl from './pages/user/settings/api/api.html';
 import userSettingsMapTokensTpl from './pages/user/settings/map/map.html';
 import userSettingsConnectionsTpl from './pages/user/settings/connections/connections.html';
 import userSettingsPrivacyTpl from './pages/user/settings/privacy/privacy.html';
+import userSettingsNotificationTpl from './pages/user/settings/notification/notification.html';
 import userOrganizationsTpl from './pages/user/organizations/organizations.html';
 import userTeamsTpl from './pages/user/teams/teams.html';
 import userProjectsTpl from './pages/user/projects/projects.html';
@@ -318,6 +319,13 @@ function settingsStates($stateProvider) {
             url: '/privacy',
             templateUrl: userSettingsPrivacyTpl,
             controller: 'PrivacyController',
+            controllerAs: '$ctrl'
+        })
+        .state('user.settings.notification', {
+            title: 'Settings: User Notification',
+            url: '/notification',
+            templateUrl: userSettingsNotificationTpl,
+            controller: 'NotificationController',
             controllerAs: '$ctrl'
         })
         .state('user.organizations', {

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -39,6 +39,7 @@ import userSettingsProfileTpl from './pages/user/settings/profile/profile.html';
 import userSettingsApiTokensTpl from './pages/user/settings/api/api.html';
 import userSettingsMapTokensTpl from './pages/user/settings/map/map.html';
 import userSettingsConnectionsTpl from './pages/user/settings/connections/connections.html';
+import userSettingsPrivacyTpl from './pages/user/settings/privacy/privacy.html';
 import userOrganizationsTpl from './pages/user/organizations/organizations.html';
 import userTeamsTpl from './pages/user/teams/teams.html';
 import userProjectsTpl from './pages/user/projects/projects.html';
@@ -310,6 +311,13 @@ function settingsStates($stateProvider) {
             url: '/connections',
             templateUrl: userSettingsConnectionsTpl,
             controller: 'ConnectionsController',
+            controllerAs: '$ctrl'
+        })
+        .state('user.settings.privacy', {
+            title: 'Settings: User Privacy',
+            url: '/privacy',
+            templateUrl: userSettingsPrivacyTpl,
+            controller: 'PrivacyController',
             controllerAs: '$ctrl'
         })
         .state('user.organizations', {

--- a/app-frontend/src/app/pages/admin/organization/settings/settings.html
+++ b/app-frontend/src/app/pages/admin/organization/settings/settings.html
@@ -1,7 +1,7 @@
 <div class="content">
   <h4>Organization Privacy</h4>
   <p class="column-8">
-    A <strong>public</strong> organization can be found by users though searching and will be shown on member's profiles.
+    A <strong>public</strong> organization can be found by users through searching and will be shown on member's profiles.
     A <strong>private</strong> organization is not discoverable and is only visible to those who have been invited or accepted membership.
     Both <strong>public</strong> and <strong>private</strong> organizations require users to recieve approval from organizational admins before joining.
   </p>

--- a/app-frontend/src/app/pages/user/projects/projects.html
+++ b/app-frontend/src/app/pages/user/projects/projects.html
@@ -21,8 +21,13 @@
   </div>
   <div class="column spacer"></div>
   <div class="column-3">
-    <rf-sidebar-organization-list paginated-response="{ 'count': $ctrl.organizations.length, 'results': $ctrl.organizations }" sref="user.organizations"></rf-sidebar-organization-list>
-    <rf-sidebar-team-list paginated-response="{ 'count': $ctrl.teams.length, 'results': $ctrl.teams }" sref="user.teams"></rf-sidebar-team-list>
+    <rf-sidebar-organization-list
+      paginated-response="{ 'count': $ctrl.organizations.length, 'results': $ctrl.organizations }"
+      sref="user.organizations"></rf-sidebar-organization-list>
+    <rf-sidebar-team-list
+      paginated-response="{ 'count': $ctrl.teams.length, 'results': $ctrl.teams }"
+      show-org-logo="true"
+      sref="user.teams"></rf-sidebar-team-list>
   </div>
   <div class="column-1"></div>
 </div>

--- a/app-frontend/src/app/pages/user/rasters/rasters.html
+++ b/app-frontend/src/app/pages/user/rasters/rasters.html
@@ -20,8 +20,13 @@
   </div>
   <div class="column spacer"></div>
   <div class="column-3">
-    <rf-sidebar-organization-list paginated-response="{ 'count': $ctrl.organizations.length, 'results': $ctrl.organizations }" sref="user.organizations"></rf-sidebar-organization-list>
-    <rf-sidebar-team-list paginated-response="{ 'count': $ctrl.teams.length, 'results': $ctrl.teams }" sref="user.teams"></rf-sidebar-team-list>
+    <rf-sidebar-organization-list
+      paginated-response="{ 'count': $ctrl.organizations.length, 'results': $ctrl.organizations }"
+      sref="user.organizations"></rf-sidebar-organization-list>
+    <rf-sidebar-team-list
+      paginated-response="{ 'count': $ctrl.teams.length, 'results': $ctrl.teams }"
+      show-org-logo="true"
+      sref="user.teams"></rf-sidebar-team-list>
   </div>
   <div class="column-1"></div>
 </div>

--- a/app-frontend/src/app/pages/user/settings/notification/notification.html
+++ b/app-frontend/src/app/pages/user/settings/notification/notification.html
@@ -1,0 +1,12 @@
+<div class="row content stack-sm">
+  <div class="column-8">
+    <p>
+      You may opt in to receive email notifications from your platform admin about {{$ctrl.subscriptionsString}}.
+    </p>
+    <rf-toggle value="$ctrl.user.emailNotifications === true"
+               on-change="$ctrl.updateUserEmailNotification()"
+               class="subscription-toggle">
+      <span>Send me email notifications</span>
+    </rf-toggle>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/user/settings/notification/notification.module.js
+++ b/app-frontend/src/app/pages/user/settings/notification/notification.module.js
@@ -1,0 +1,39 @@
+const SUBSCRIPTIONS = ['AOI project update', 'scene ingest status', 'scene export status'];
+
+class NotificationController {
+    constructor($window, authService, userService) {
+        'ngInject';
+        this.$window = $window;
+        this.authService = authService;
+        this.userService = userService;
+        this.subscriptions = SUBSCRIPTIONS;
+    }
+
+    $onInit() {
+        this.authService.getCurrentUser().then((user) => {
+            this.user = user;
+        });
+        this.subscriptionsString = this.subscriptions.join(', ');
+    }
+
+    updateUserEmailNotification() {
+        let emailNotifications = !this.user.emailNotifications;
+        this.userService.updateOwnUser(Object.assign(
+            {},
+            this.user,
+            {emailNotifications}
+        )).then(res => {
+            this.user = res;
+        }, () => {
+            this.$window.alert(
+                `Email notification preference cannot be changed at this time.
+                Please try again later.`);
+        });
+    }
+}
+
+const NotificationModule = angular.module('pages.settings.notification', []);
+
+NotificationModule.controller('NotificationController', NotificationController);
+
+export default NotificationModule;

--- a/app-frontend/src/app/pages/user/settings/privacy/privacy.html
+++ b/app-frontend/src/app/pages/user/settings/privacy/privacy.html
@@ -1,0 +1,17 @@
+<div class="row content stack-sm">
+  <div class="column-8">
+    <p>
+      A <strong>public</strong> user can be found by users through searching and will be shown on member's profiles.
+    </p>
+    <p>
+      A <strong>private</strong> user is not discoverable and is only visible to those who have permissions.
+    </p>
+    <rf-toggle radio="true" value="$ctrl.user.visibility === 'PUBLIC'" on-change="$ctrl.updateUserPrivacy('PUBLIC')">
+      <span><strong>Public</strong></span>
+    </rf-toggle>
+    <br/>
+    <rf-toggle radio="true" value="$ctrl.user.visibility === 'PRIVATE'" on-change="$ctrl.updateUserPrivacy('PRIVATE')">
+      <span><strong>Private</strong></span>
+    </rf-toggle>
+  </div>
+</div>

--- a/app-frontend/src/app/pages/user/settings/privacy/privacy.module.js
+++ b/app-frontend/src/app/pages/user/settings/privacy/privacy.module.js
@@ -1,0 +1,28 @@
+class PrivacyController {
+    constructor($window, authService, userService) {
+        'ngInject';
+        this.$window = $window;
+        this.authService = authService;
+        this.userService = userService;
+    }
+
+    $onInit() {
+        this.authService.getCurrentUser().then((user) => {
+            this.user = user;
+        });
+    }
+
+    updateUserPrivacy(visibility) {
+        this.userService.updateOwnUser(Object.assign({}, this.user, {visibility})).then(res => {
+            this.user = res;
+        }, () => {
+            this.$window.alert('Privacy cannot be set at this time. Please try again later.');
+        });
+    }
+}
+
+const PrivacyModule = angular.module('pages.settings.privacy', []);
+
+PrivacyModule.controller('PrivacyController', PrivacyController);
+
+export default PrivacyModule;

--- a/app-frontend/src/app/pages/user/settings/settings.html
+++ b/app-frontend/src/app/pages/user/settings/settings.html
@@ -15,6 +15,7 @@
         Map Tokens
       </a>
       <a ui-sref="user.settings.connections" ui-sref-active="active">Third Party Connections</a>
+      <a ui-sref="user.settings.privacy" ui-sref-active="active">Privacy</a>
     </nav>
   </div>
   <ui-view class="main"></ui-view>

--- a/app-frontend/src/app/pages/user/settings/settings.html
+++ b/app-frontend/src/app/pages/user/settings/settings.html
@@ -16,6 +16,7 @@
       </a>
       <a ui-sref="user.settings.connections" ui-sref-active="active">Third Party Connections</a>
       <a ui-sref="user.settings.privacy" ui-sref-active="active">Privacy</a>
+      <a ui-sref="user.settings.notification" ui-sref-active="active">Notifications</a>
     </nav>
   </div>
   <ui-view class="main"></ui-view>


### PR DESCRIPTION
## Overview

This PR:
 * adds visibility control on user profile settings page
 * adds notification control on user profile settings page
 * adds optional organization logo element on team list when on user pages

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

Visibility
<img width="1680" alt="screen shot 2018-07-03 at 12 09 11 pm" src="https://user-images.githubusercontent.com/16109558/42231718-49cd689e-7eba-11e8-9e34-a5add073e61f.png">

*Notification*
<img width="1680" alt="screen shot 2018-07-03 at 12 09 18 pm" src="https://user-images.githubusercontent.com/16109558/42231740-56cf9d46-7eba-11e8-83fa-15cf5b94bd45.png">

* Organizations logos under team list
<img width="1680" alt="screen shot 2018-07-03 at 12 09 25 pm" src="https://user-images.githubusercontent.com/16109558/42231757-646f06b2-7eba-11e8-98cd-818409ba77f1.png">


## Testing Instructions

 * Go to user profile settings page, check if visibility is editable
 * Go to user profile settings page, check if email visibility is editable
 * Add yourself to teams under different organizations. Go to your own pages for projects and rasters, and check if organization logos show up under team list. Go to organization pages for all first-class objects and make sure org logos don't show up under team list.

Closes #3610 
Closes #3611 
Closes #3629 
