### PR TITLE
Remove Tri-Decadal MSS from NASA CMR search options

### DIFF
--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -44,14 +44,6 @@ export default (app) => {
                 fileAdapter(scene) {
                     return [scene.name];
                 }
-            }, {
-                name: 'Landsat Tri-Decadal MSS',
-                uuid: '7b205ec9-6cce-444d-998a-f34d379258b2',
-                uploadType: 'LANDSAT_HISTORICAL',
-                id: 'MSS',
-                fileAdapter(scene) {
-                    return [scene.name];
-                }
             }];
         }
 


### PR DESCRIPTION
## Overview

This PR removes Tri-Decadal MSS from the search options in the NASA CMR repository. Since
the IDs that come back aren't mappable to Landsat IDs as GCS understands them, there isn't
a way to handle imports successfully for this datasource without a broader refactoring.
Fortunately, that refactoring should be pretty easy (see comment in #3555).

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Confirm that Tri-Decadal MSS isn't one of the options for scenes in the NASA CMR search
 * For extra credit, try to create and process uploads for L7 ETM+ and L4 or L5 TM scenes (or
   come by my area for proof)

Closes #3556 
