### PR TITLE
Allow updating wavelength from datasource detail view

### DIFF
--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.html
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.html
@@ -83,6 +83,7 @@
                 <th>Name</th>
                 <th>Wavelength</th>
                 <th></th>
+                <th></th>
               </tr>
             </thead>
             <tbody>

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.html
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.html
@@ -81,6 +81,7 @@
                 <th>Index</th>
                 <th>Number</th>
                 <th>Name</th>
+                <th>Wavelength</th>
                 <th></th>
               </tr>
             </thead>
@@ -105,6 +106,14 @@
                          ng-change="$ctrl.updateBandBuffer($index, band)"
                          ng-disabled="!$ctrl.isOwner">
                 </td>
+                <td>
+                  <input type="text" class="form-control" placeholder="Wavelength"
+                         title="x,y min and max nanometers for band's wavelength"
+                         ng-model="band.wavelength"
+                         ng-model-options="{ debounce: 500 }"
+                         ng-change="$ctrl.updateBandBuffer($index, band)"
+                         ng-disabled="!$ctrl.isOwner">
+                </td>
                 <td class="text-right">
                   <div ng-show="$ctrl.isOwner">
                     <button class="btn btn-small" ng-click="$ctrl.removeBand($index)">
@@ -112,6 +121,13 @@
                       <i class="icon-trash"></i>
                     </button>
                   </div>
+                </td>
+                <td class="text-right">
+                  <span class="icon-warning color-warning"
+                        ng-if="band.invalidWavelength"
+                        tooltips
+                        tooltip-class="rf-tooltip" tooltip-side="top"
+                        tooltip-template="You have entered an invalid wavelength range. Wavelengths should be two integers separated by commas"></span>
                 </td>
               </tr>
             </tbody>
@@ -127,7 +143,12 @@
               <button class="btn" ng-click="$ctrl.resetBandsBuffer()">
                 Cancel
               </button>
-              <button class="btn btn-default" ng-click="$ctrl.saveBufferedBands()">
+              <button class="btn btn-default" ng-click="$ctrl.saveBufferedBands()"
+                      ng-if="$ctrl.anyInvalidWavelengths()" disabled>
+                Save Changes
+              </button>
+              <button class="btn btn-default" ng-click="$ctrl.saveBufferedBands()"
+                      ng-if="!$ctrl.anyInvalidWavelengths()">
                 Save Changes
               </button>
             </div>

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
@@ -24,6 +24,7 @@ class DatasourceDetailController {
         this.BUILDCONFIG = BUILDCONFIG;
         this.initLicenseSettings();
         this.loadDatasource();
+        this.bandsBuffer = [];
     }
 
     initLicenseSettings() {
@@ -215,7 +216,9 @@ class DatasourceDetailController {
             ...this.bandsBuffer,
             {
                 name: '',
-                number: ''
+                number: '',
+                wavelength: null,
+                invalidWavelength: true
             }
         ];
         this.changedBandsBuffer = true;
@@ -230,8 +233,28 @@ class DatasourceDetailController {
     }
 
     updateBandBuffer(index, band) {
+        if (band.wavelength === null || this.testWavelength(band.wavelength)) {
+            band.invalidWavelength = false;
+        } else {
+            band.invalidWavelength = true;
+        }
         this.bandsBuffer[index] = band;
         this.changedBandsBuffer = true;
+    }
+
+    testWavelength(wavelengthStr) {
+        let wavelengthRegex = /^ *\d+(,| )+( *)\d+ *$/;
+        return wavelengthRegex.test(wavelengthStr);
+    }
+
+    anyInvalidWavelengths() {
+        return this.bandsBuffer.length === 0 ?
+            false :
+            _.reduce(
+                this.bandsBuffer, (prior, band) => {
+                    return band.invalidWavelength || prior;
+                }, false
+            );
     }
 
     saveBufferedBands() {

--- a/app-frontend/src/app/services/scenes/datasource.service.js
+++ b/app-frontend/src/app/services/scenes/datasource.service.js
@@ -29,6 +29,23 @@ export default (app) => {
                         url: `${BUILDCONFIG.API_HOST}/api/datasources/:id`,
                         params: {
                             id: '@id'
+                        },
+                        transformRequest: (payload) => {
+                            let transformed = Object.assign(
+                                {}, payload, {
+                                    bands: _.map(
+                                        payload.bands,
+                                        (band) => {
+                                            let bookends = band.wavelength.trim().split(',');
+                                            band.wavelength = _.map(
+                                                bookends, (x) => Number.parseInt(x, 10)
+                                            );
+                                            return band;
+                                        }
+                                    )
+                                }
+                            );
+                            return angular.toJson(transformed);
                         }
                     }
                 }


### PR DESCRIPTION
## Overview

This PR makes it possible to add wavelengths to bands for a datasource.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/5702984/42350770-df0f6d1e-807f-11e8-92bb-df652e4d0f98.png)

### Notes

Also does some basic validation that it's a list of two ints

## Testing Instructions

 * Edit a datasource you own
 * Add wavelength
 * Make it something that isn't in the form `x, y` and observe validation results
 * Save changes once it's valid again
 * Refresh the page
 * Shouldn't be any errors

Closes #3370 
