### PR TITLE
Add COG scene browse support for thumbnail and tiles

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -20,7 +20,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 import java.net._
 import java.util.UUID
-import org.apache.commons.codec.binary.{Base64 => ApacheBase64}
 
 import cats.effect.IO
 import com.azavea.rf.database._
@@ -345,7 +344,8 @@ trait SceneRoutes extends Authentication
                       CogUtils.thumbnail(
                         uri, thumbnailParams.width, thumbnailParams.height
                       ).map(
-                        (tile: MultibandTile) => HttpEntity(MediaTypes.`image/png`, tile.renderPng.bytes)).value
+                        (tile: MultibandTile) => HttpEntity(MediaTypes.`image/png`, tile.renderPng.bytes)
+                      ).value
                     }
                     case _ =>
                       Future.successful(None)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -20,6 +20,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success}
 import java.net._
 import java.util.UUID
+import org.apache.commons.codec.binary.{Base64 => ApacheBase64}
 
 import cats.effect.IO
 import com.azavea.rf.database._
@@ -344,7 +345,7 @@ trait SceneRoutes extends Authentication
                       CogUtils.thumbnail(
                         uri, thumbnailParams.width, thumbnailParams.height
                       ).map(
-                        (tile: MultibandTile) => HttpEntity(MediaTypes.`image/png`, tile.renderPng.bytes)
+                        (tile: MultibandTile) => ApacheBase64.encodeBase64String(tile.renderPng.bytes)
                       ).value
                     }
                     case _ =>

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -345,8 +345,7 @@ trait SceneRoutes extends Authentication
                       CogUtils.thumbnail(
                         uri, thumbnailParams.width, thumbnailParams.height
                       ).map(
-                        (tile: MultibandTile) => ApacheBase64.encodeBase64String(tile.renderPng.bytes)
-                      ).value
+                        (tile: MultibandTile) => HttpEntity(MediaTypes.`image/png`, tile.renderPng.bytes)).value
                     }
                     case _ =>
                       Future.successful(None)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -29,6 +29,7 @@ lazy val commonSettings = Seq(
   externalResolvers := Seq(
     "Geotoolkit Repo" at "http://maven.geotoolkit.org",
     "Open Source Geospatial Foundation Repo" at "http://download.osgeo.org/webdav/geotools/",
+    "boundless" at "https://repo.boundlessgeo.com/main/",
     "imageio-ext Repository" at "http://maven.geo-solutions.it",
     DefaultMavenRepository,
     Resolver.sonatypeRepo("snapshots"),

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -14,7 +14,6 @@ import com.lonelyplanet.akka.http.extensions.PageRequest
 import scala.concurrent.Future
 
 import com.azavea.rf.database.Implicits._
-import com.azavea.rf.datamodel._
 import com.azavea.rf.datamodel.color._
 import com.lonelyplanet.akka.http.extensions._
 import com.typesafe.scalalogging.LazyLogging

--- a/app-backend/tile/src/main/scala/Router.scala
+++ b/app-backend/tile/src/main/scala/Router.scala
@@ -65,6 +65,11 @@ class Router extends LazyLogging
             }
           }
         }
+      } ~
+      pathPrefix("scenes") {
+        pathPrefix(JavaUUID) { sceneId =>
+          MosaicRoutes.mosaicScene(sceneId)(xa)
+        }
       }
     }
   }

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -1,5 +1,4 @@
 import angular from 'angular';
-import _ from 'lodash';
 import sceneTpl from './sceneItem.html';
 
 const SceneItemComponent = {
@@ -63,10 +62,7 @@ class SceneItemController {
                     this.scene.id,
                     this.authService.token()
                 ).then(res => {
-                    let base64String = Object.values(res)
-                        .filter(chr => _.isString(chr))
-                        .join('');
-                    this.thumbnail = `data:image/png;base64,${base64String}`;
+                    this.thumbnail = `data:image/png;base64,${res}`;
                 });
             } else {
                 this.repository.service.getThumbnail(this.scene).then((thumbnail) => {

--- a/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-parameters/aoi-parameters.controller.js
@@ -40,7 +40,7 @@ const addMethods = [
 ];
 */
 
-const startTimeTooltip = 'Start time may not be changed once a monitoring has started.'
+const startTimeTooltip = 'Start time may not be changed once a monitoring has started.';
 
 export default class AOIParametersController {
     constructor(

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -223,15 +223,31 @@ class ProjectsSceneBrowserController {
         if (scene !== this.hoveredScene) {
             this.hoveredScene = scene;
             this.getMap().then((map) => {
-                map.setThumbnail(scene, this.currentRepository);
+                if (scene.sceneType !== 'COG') {
+                    map.setThumbnail(scene, this.currentRepository);
+                } else {
+                    map.setLayer(
+                      'Hovered Scene',
+                      L.tileLayer(
+                        this.sceneService.getSceneLayerURL(
+                            scene,
+                            {token: this.authService.token()}
+                        ),
+                        {maxZoom: 30})
+                    );
+                }
             });
         }
     }
 
     removeHoveredScene() {
         this.getMap().then((map) => {
+            if (this.hoveredScene.sceneType === 'COG') {
+                map.deleteLayers('Hovered Scene');
+            } else {
+                map.deleteThumbnail();
+            }
             delete this.hoveredScene;
-            map.deleteThumbnail();
         });
     }
 

--- a/app-frontend/src/app/services/map/map.service.js
+++ b/app-frontend/src/app/services/map/map.service.js
@@ -527,9 +527,11 @@ class MapWrapper {
                 }
             }
         );
-        if (scene.tileFootprint && scene.thumbnails && scene.thumbnails.length) {
-            // get smallest thumbnail - it's a small map
 
+        let displayThumbnail = scene.tileFootprint &&
+            (scene.thumbnails && scene.thumbnails.length || scene.sceneType === 'COG');
+
+        if (displayThumbnail) {
             let boundsGeoJson = L.geoJSON();
             boundsGeoJson.addData(scene.tileFootprint);
             let imageBounds = boundsGeoJson.getBounds();

--- a/app-frontend/src/app/services/map/map.service.js
+++ b/app-frontend/src/app/services/map/map.service.js
@@ -528,10 +528,7 @@ class MapWrapper {
             }
         );
 
-        let displayThumbnail = scene.tileFootprint &&
-            (scene.thumbnails && scene.thumbnails.length || scene.sceneType === 'COG');
-
-        if (displayThumbnail) {
+        if (scene.tileFootprint && scene.thumbnails && scene.thumbnails.length) {
             let boundsGeoJson = L.geoJSON();
             boundsGeoJson.addData(scene.tileFootprint);
             let imageBounds = boundsGeoJson.getBounds();

--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+// import _ from 'lodash';
 import axios from 'axios';
 
 export default (app) => {
@@ -88,14 +88,6 @@ export default (app) => {
                 const thumbnails = this.getThumbnails(scene);
                 if (thumbnails.length) {
                     resolve(thumbnails[0].href);
-                } else if (scene.sceneType === 'COG') {
-                    this.sceneService.cogThumbnail(scene.id, this.authService.token(), 300, 300)
-                        .then(resp => {
-                            let base64String = Object.values(resp)
-                                .filter(chr => _.isString(chr))
-                                .join('');
-                            resolve(`data:image/png;base64,${base64String}`);
-                        });
                 } else {
                     reject();
                 }

--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -3,12 +3,11 @@ import axios from 'axios';
 
 export default (app) => {
     class CMRRepository {
-        constructor($q, authService, uploadService, sceneService) {
+        constructor($q, authService, uploadService) {
             this.$q = $q;
             this.previewOnMap = false;
             this.authService = authService;
             this.uploadService = uploadService;
-            this.sceneService = sceneService;
         }
 
         initDatasources() {

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -196,24 +196,6 @@ export default (app) => {
             return this.$q((resolve, reject) => {
                 if (scene.thumbnails.length) {
                     resolve(this.thumbnailService.getBestFitUrl(scene.thumbnails, 1000));
-                } else if (scene.sceneType === 'COG') {
-                    let matchedCt = this.cogThumbnailCache.length &&
-                        this.cogThumbnailCache.find(ct => ct.id === scene.id);
-                    if (matchedCt) {
-                        resolve(`data:image/png;base64,${matchedCt.thumbnail}`);
-                    } else {
-                        this.sceneService.cogThumbnail(
-                            scene.id, this.authService.token(), 512, 512)
-                            .then(resp => {
-                                this.cogThumbnailCache.push({
-                                    id: scene.id,
-                                    thumbnail: resp
-                                });
-                                resolve(`data:image/png;base64,${resp}`);
-                            }, () => {
-                                reject();
-                            });
-                    }
                 } else {
                     reject();
                 }

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -195,6 +195,14 @@ export default (app) => {
             return this.$q((resolve, reject) => {
                 if (scene.thumbnails.length) {
                     resolve(this.thumbnailService.getBestFitUrl(scene.thumbnails, 1000));
+                } else if (scene.sceneType === 'COG') {
+                    this.sceneService.cogThumbnail(scene.id, this.authService.token(), 300, 300)
+                        .then(resp => {
+                            let base64String = Object.values(resp)
+                                .filter(chr => _.isString(chr))
+                                .join('');
+                            resolve(`data:image/png;base64,${base64String}`);
+                        });
                 } else {
                     reject();
                 }

--- a/app-frontend/src/app/services/scenes/scene.service.js
+++ b/app-frontend/src/app/services/scenes/scene.service.js
@@ -44,6 +44,18 @@ export default (app) => {
                         params: {
                             id: '@id'
                         }
+                    },
+                    cogThumbnail: {
+                        method: 'GET',
+                        url: `${BUILDCONFIG.API_HOST}/api/scenes/:sceneId/thumbnail?` +
+                            'token=:token&width=:width&height=:height',
+                        cache: true,
+                        params: {
+                            sceneId: '@sceneId',
+                            token: '@token',
+                            width: '@width',
+                            height: '@width'
+                        }
                     }
                 }
             );
@@ -151,6 +163,10 @@ export default (app) => {
 
         datasource({id}) {
             return this.Scene.datasource({id: id}).$promise;
+        }
+
+        cogThumbnail(sceneId, token, width = 128, height = 128) {
+            return this.Scene.cogThumbnail({sceneId, token, width, height}).$promise;
         }
     }
 

--- a/app-frontend/src/app/services/scenes/scene.service.js
+++ b/app-frontend/src/app/services/scenes/scene.service.js
@@ -2,12 +2,15 @@
 
 export default (app) => {
     class SceneService {
-        constructor($resource, $http, authService, projectService, uuid4) {
+        constructor($resource, $http, APP_CONFIG,
+            authService, projectService, uuid4) {
             'ngInject';
             this.$http = $http;
             this.authService = authService;
             this.projectService = projectService;
             this.uuid4 = uuid4;
+
+            this.tileServer = `${APP_CONFIG.tileServerLocation}`;
 
             this.Scene = $resource(
                 `${BUILDCONFIG.API_HOST}/api/scenes/:id/`, {
@@ -183,6 +186,13 @@ export default (app) => {
                 result.push(String.fromCharCode.apply(null, u8a.subarray(i, i + CHUNK_SZ)));
             }
             return result.join('');
+        }
+
+        getSceneLayerURL(scene, params) {
+            let sceneId = typeof scene === 'object' ? scene.id : scene;
+            let queryParams = params || {};
+            let formattedParams = L.Util.getParamString(queryParams);
+            return `${this.tileServer}/scenes/${sceneId}/{z}/{x}/{y}/${formattedParams}`;
         }
     }
 


### PR DESCRIPTION
## Overview

~This PR reflects the re-scoped requirements in the original card to add frontend support for displaying COG scene thumbnail and put thumbnail on the map before we have tile server support for it.~

This PR supports COG scene browse so that COG scene thumbnails show up on sidebar and COG scene tiles show up on map when a user is browsing before adding any scenes in a project.

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~



### Notes

 * `boundless` is added as an external resolver for `geotool` since it did not stop giving me dependency errors until I added this in yesterday when I was trying to rebuild containers (they were unhealthy and I 🔥them down)
* ~For COG thumbnail backend, `MediaTypes.image/png` is modified to be `base64` string since this can be incorporated to frontend html more directly afaik.~ This is no longer true per the latest commit.


## Testing Instructions

 * Go to browse some COG scenes and see if thumbnails show up on sidebar and on map upon hovering.

Closes #3365 
