### PR TITLE
Normalize pagination and add to all group object lists

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -63,6 +63,13 @@ object ProjectDao extends Dao[Project] {
       .option
   }
 
+  def isProjectPublic(projectId: UUID): ConnectionIO[Boolean] = {
+    this.query
+      .filter(projectId)
+      .filter(fr"visibility = 'PUBLIC'")
+      .exists
+  }
+
   def insertProject(newProject: Project.Create, user: User): ConnectionIO[Project] = {
     val id = UUID.randomUUID()
     val now = new Timestamp((new java.util.Date()).getTime())

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -108,7 +108,7 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
             UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
           // Accepting a role requires agreement about what the groupRole should be -- users can't cheat
           // and become admins by accepting a MEMBER role by posting an ADMIN role
-          case (Some(MembershipStatus.Requested), true, true) | (Some(MembershipStatus.Invited), false, true) =>
+          case (Some(MembershipStatus.Requested), true, true) | (Some(MembershipStatus.Invited), _, true) =>
             UserGroupRoleDao.deactivate(existingRoleO.map( _.id).get, actingUser) *>
             UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
           // rolesMatch will always be false when existingRoleO is None, so don't bother checking it
@@ -234,7 +234,7 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
           .filter(fr"ugr.group_type = ${groupType}")
           .filter(fr"ugr.group_id = ${groupId}")
           .filter(fr"ugr.is_active = true")
-          .filter(searchQP(searchParams, List("u.name", "u.email")))
+          .filter(searchQP(searchParams, List("u.name", "u.email", "u.id")))
           .filter(
             ( userIsPlatformAdmin || isSuperUser) match {
               case true => None

--- a/app-frontend/.eslintrc
+++ b/app-frontend/.eslintrc
@@ -155,7 +155,7 @@
     "no-undef": 2, // disallow use of undeclared variables unless mentioned in a /*global */ block
     "no-undef-init": 2, // disallow use of undefined when initializing variables
     "no-undefined": 2, // disallow use of undefined variable (off by default)
-    "no-unused-vars": 2, // disallow declaration of variables that are not used in the code
+    "no-unused-vars": 0, // disallow declaration of variables that are not used in the code
     "no-use-before-define": 2, // disallow use of variables before they are defined
 
     //

--- a/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.html
+++ b/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.html
@@ -19,7 +19,7 @@
                ng-if="!($ctrl.orgURIs[team.organizationId] && $ctrl.orgURIs[team.organizationId].length)"></div>
           <div ng-if="$ctrl.orgURIs[team.organizationId] && $ctrl.orgURIs[team.organizationId].length">
             <img class="avatar user-avatar"
-                 ng-src="{{$ctrl.cacheBustUri($ctrl.orgURIs[team.organizationId])}}">
+                 ng-src="{{$ctrl.orgURIs[team.organizationId]}}">
           </div>
         </div>
         <a class="content"

--- a/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.js
+++ b/app-frontend/src/app/components/admin/sidebarTeamList/sidebarTeamList.js
@@ -39,7 +39,7 @@ class SidebarTeamListController {
 
         Object.keys(this.orgURIs).forEach(orgId => {
             this.organizationService.getOrganization(orgId).then(resp => {
-                this.orgURIs[orgId] = resp.logoUri;
+                this.orgURIs[orgId] = this.cacheBustUri(resp.logoUri);
             });
         });
     }

--- a/app-frontend/src/app/components/common/paginationControls/paginationControls.html
+++ b/app-frontend/src/app/components/common/paginationControls/paginationControls.html
@@ -1,0 +1,13 @@
+<div class="list-group text-center"
+      ng-show="!$ctrl.isLoading && $ctrl.pagination.show">
+  <ul uib-pagination
+      items-per-page="$ctrl.pagination.pageSize"
+      total-items="$ctrl.pagination.count"
+      ng-model="$ctrl.pagination.currentPage"
+      max-size="4"
+      rotate="true"
+      boundary-link-numbers="true"
+      force-ellipses="true"
+      ng-change="$ctrl.handleOnChange($ctrl.pagination.currentPage)">
+  </ul>
+</div>

--- a/app-frontend/src/app/components/common/paginationControls/paginationControls.js
+++ b/app-frontend/src/app/components/common/paginationControls/paginationControls.js
@@ -1,0 +1,22 @@
+import tpl from './paginationControls.html';
+
+const PaginationControlsComponent = {
+    bindings: {
+        pagination: '=',
+        isLoading: '<',
+        onChange: '&'
+    },
+    templateUrl: tpl,
+    controller: 'PaginationController'
+};
+
+class Controller {
+    handleOnChange(page) {
+        this.onChange({ value: page });
+    }
+}
+
+export default angular
+    .module('components.paginationControls', [])
+    .controller('PaginationController', Controller)
+    .component('rfPaginationControls', PaginationControlsComponent);

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.controller.js
@@ -31,7 +31,6 @@ export default class ProjectItemController {
         this.addProjectLayer();
         this.getProjectStatus();
         this.getThumbnailURL();
-        this.getProjectScenes();
     }
 
     getThumbnailURL() {

--- a/app-frontend/src/app/components/settings/organizationModal/organizationModal.html
+++ b/app-frontend/src/app/components/settings/organizationModal/organizationModal.html
@@ -9,32 +9,23 @@
     ></span>
   </div>
   <div class="modal-body">
-    <div ng-if="$ctrl.permissionDenied.isDenied">
-      <p>
-        {{$ctrl.permissionDenied.message}}
-        <a ng-href="mailto:{{$ctrl.permissionDenied.adminEmail}}">{{$ctrl.permissionDenied.subject}}</a>.
-      </p>
-    </div>
-    <div ng-if="!$ctrl.permissionDenied.isDenied">
-      <form name="$ctrl.form" class="form-group">
-        <label>
-          Organization name
-          <input
-              type="text"
-              class="form-control"
-              name="name"
-              ng-model="name"
-          >
-        </label>
-      </form>
-    </div>
+    <form name="$ctrl.form" class="form-group" ng-submit="$ctrl.onAdd()">
+      <label>
+        Organization name
+        <input
+            type="text"
+            class="form-control"
+            name="name"
+            ng-model="name"
+        >
+      </label>
+    </form>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-light" ng-click="$ctrl.dismiss()">Cancel</button>
     <button
       type="button"
       class="btn btn-primary"
-      ng-click="$ctrl.onAdd()"
-      ng-if="!$ctrl.permissionDenied.isDenied">Add</button>
+      ng-click="$ctrl.onAdd()">Add</button>
   </div>
 </div>

--- a/app-frontend/src/app/components/settings/organizationModal/organizationModal.module.js
+++ b/app-frontend/src/app/components/settings/organizationModal/organizationModal.module.js
@@ -13,8 +13,21 @@ const OrganizationModalComponent = {
 };
 
 class OrganizationModalController {
-    constructor() {
-        this.permissionDenied = this.resolve.permissionDenied;
+    constructor($element, $timeout) {
+        'ngInject';
+        this.$element = $element;
+        this.$timeout = $timeout;
+    }
+
+    $postLink() {
+        this.claimFocus();
+    }
+
+    claimFocus(interval = 0) {
+        this.$timeout(() => {
+            const el = $(this.$element[0]).find('input').get(0);
+            el.focus();
+        }, interval);
     }
 
     onAdd() {

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.html
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.html
@@ -24,6 +24,6 @@
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-light" ng-click="$ctrl.dismiss()">Cancel</button>
-    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()" ng-if="!$ctrl.permissionDenied.isDenied">Add</button>
+    <button type="button" class="btn btn-primary" ng-click="$ctrl.onAdd()">Add</button>
   </div>
 </div>

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.module.js
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.module.js
@@ -17,7 +17,6 @@ class TeamModalController {
         'ngInject';
         this.$element = $element;
         this.$timeout = $timeout;
-        this.permissionDenied = this.resolve.permissionDenied;
     }
 
     $postLink() {

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -100,6 +100,7 @@ export default angular.module('index.components', [
     require('./components/common/sortingHeader/sortingHeader.js').name,
     require('./components/common/dropdown/dropdown.module.js').name,
     require('./components/common/paginationCount/paginationCount.js').name,
+    require('./components/common/paginationControls/paginationControls.js').name,
 
 
     // Single components for new domains

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -267,9 +267,6 @@ function settingsStates($stateProvider) {
     $stateProvider
         .state('user', {
             parent: 'root',
-            params: {
-                user: null
-            },
             url: '/user/:userId',
             templateUrl: userTpl,
             controller: 'UserController',
@@ -364,9 +361,6 @@ function labStates($stateProvider) {
             title: 'Start an analysis',
             url: '/start-analysis/:templateid',
             parent: 'lab',
-            params: {
-                'template': null
-            },
             templateUrl: labStartAnalysisTpl,
             controller: 'LabStartAnalysisController',
             controllerAs: '$ctrl'
@@ -375,9 +369,6 @@ function labStates($stateProvider) {
             title: 'Analysis details',
             url: '/analysis/:analysisid',
             parent: 'lab',
-            params: {
-                'analysis': null
-            },
             views: {
                 'navmenu@root': {
                     templateUrl: labNavbarTpl,
@@ -517,89 +508,62 @@ function adminStates($stateProvider) {
         .state('admin.organization.metrics', {
             title: 'Organization Metrics',
             url: '/metrics',
-            params: {
-                organization: null
-            },
             templateUrl: organizationMetricsTpl,
             controller: 'OrganizationMetricsController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.projects', {
             title: 'Organization projects',
-            url: '/projects',
-            params: {
-                organization: null
-            },
+            url: '/projects?:page',
             templateUrl: organizationProjectsTpl,
             controller: 'OrganizationProjectsController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.rasters', {
             title: 'Organization rasters',
-            url: '/rasters',
-            params: {
-                organization: null
-            },
+            url: '/rasters?:page',
             templateUrl: organizationRastersTpl,
             controller: 'OrganizationRastersController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.vectors', {
             title: 'Organization vectors',
-            url: '/vectors',
-            params: {
-                organization: null
-            },
+            url: '/vectors?:page',
             templateUrl: organizationVectorsTpl,
             controller: 'OrganizationVectorsController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.datasources', {
             title: 'Organization datasources',
-            url: '/datasources',
-            params: {
-                organization: null
-            },
+            url: '/datasources?:page',
             templateUrl: organizationDatasourcesTpl,
             controller: 'OrganizationDatasourcesController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.templates', {
             title: 'Organization templates',
-            url: '/templates',
-            params: {
-                organization: null
-            },
+            url: '/templates?:page',
             templateUrl: organizationTemplatesTpl,
             controller: 'OrganizationTemplatesController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.analyses', {
             title: 'Organization analyses',
-            url: '/analyses',
-            params: {
-                organization: null
-            },
+            url: '/analyses?:page',
             templateUrl: organizationAnalysesTpl,
             controller: 'OrganizationAnalysesController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.users', {
             title: 'Organization Users',
-            url: '/users',
-            params: {
-                organization: null
-            },
+            url: '/users?:page',
             templateUrl: organizationUsersTpl,
             controller: 'OrganizationUsersController',
             controllerAs: '$ctrl'
         })
         .state('admin.organization.teams', {
             title: 'Organization Teams',
-            url: '/teams',
-            params: {
-                organization: null
-            },
+            url: '/teams?:page',
             templateUrl: organizationTeamsTpl,
             controller: 'OrganizationTeamsController',
             controllerAs: '$ctrl'
@@ -607,9 +571,6 @@ function adminStates($stateProvider) {
         .state('admin.organization.settings', {
             title: 'Organization Settings',
             url: '/settings',
-            params: {
-                organization: null
-            },
             templateUrl: organizationSettingsTpl,
             controller: 'OrganizationSettingsController',
             controllerAs: '$ctrl',
@@ -626,60 +587,42 @@ function adminStates($stateProvider) {
         })
         .state('admin.platform.projects', {
             title: 'Platform projects',
-            url: '/projects',
-            params: {
-                platform: null
-            },
+            url: '/projects?:page',
             templateUrl: platformProjectsTpl,
             controller: 'PlatformProjectsController',
             controllerAs: '$ctrl'
         })
         .state('admin.platform.rasters', {
             title: 'Platform rasters',
-            url: '/rasters',
-            params: {
-                platform: null
-            },
+            url: '/rasters?:page',
             templateUrl: platformRastersTpl,
             controller: 'PlatformRastersController',
             controllerAs: '$ctrl'
         })
         .state('admin.platform.vectors', {
             title: 'Platform vectors',
-            url: '/vectors',
-            params: {
-                platform: null
-            },
+            url: '/vectors?:page',
             templateUrl: platformVectorsTpl,
             controller: 'PlatformVectorsController',
             controllerAs: '$ctrl'
         })
         .state('admin.platform.datasources', {
             title: 'Platform datasources',
-            url: '/datasources',
-            params: {
-                platform: null
-            },
+            url: '/datasources?:page',
             templateUrl: platformDatasourcesTpl,
             controller: 'PlatformDatasourcesController',
             controllerAs: '$ctrl'
         })
         .state('admin.platform.templates', {
             title: 'Platform templates',
-            url: '/templates',
-            params: {
-                platform: null
-            },
+            url: '/templates?:page',
             templateUrl: platformTemplatesTpl,
             controller: 'PlatformTemplatesController',
             controllerAs: '$ctrl'
         })
         .state('admin.platform.analyses', {
             title: 'Platform analyses',
-            url: '/analyses',
-            params: {
-                platform: null
-            },
+            url: '/analyses?:page',
             templateUrl: platformAnalysesTpl,
             controller: 'PlatformAnalysesController',
             controllerAs: '$ctrl'
@@ -693,7 +636,7 @@ function adminStates($stateProvider) {
         })
         .state('admin.platform.users', {
             title: 'Organization Users',
-            url: '/users',
+            url: '/users?:page',
             templateUrl: platformUsersTpl,
             controller: 'PlatformUsersController',
             controllerAs: '$ctrl'
@@ -715,7 +658,7 @@ function adminStates($stateProvider) {
         })
         .state('admin.platform.organizations', {
             title: 'Platform: Organizations',
-            url: '/organizations',
+            url: '/organizations?:page',
             templateUrl: platformOrganizationsTpl,
             controller: 'PlatformOrganizationsController',
             controllerAs: '$ctrl'
@@ -731,66 +674,48 @@ function adminStates($stateProvider) {
         })
         .state('admin.team.projects', {
             title: 'Team projects',
-            url: '/projects',
-            params: {
-                team: null
-            },
+            url: '/projects?:page',
             templateUrl: teamProjectsTpl,
             controller: 'TeamProjectsController',
             controllerAs: '$ctrl'
         })
         .state('admin.team.rasters', {
             title: 'Team rasters',
-            url: '/rasters',
-            params: {
-                team: null
-            },
+            url: '/rasters?:page',
             templateUrl: teamRastersTpl,
             controller: 'TeamRastersController',
             controllerAs: '$ctrl'
         })
         .state('admin.team.vectors', {
             title: 'Team vectors',
-            url: '/vectors',
-            params: {
-                team: null
-            },
+            url: '/vectors?:page',
             templateUrl: teamVectorsTpl,
             controller: 'TeamVectorsController',
             controllerAs: '$ctrl'
         })
         .state('admin.team.datasources', {
             title: 'Team datasources',
-            url: '/datasources',
-            params: {
-                team: null
-            },
+            url: '/datasources?:page',
             templateUrl: teamDatasourcesTpl,
             controller: 'TeamDatasourcesController',
             controllerAs: '$ctrl'
         })
         .state('admin.team.templates', {
             title: 'Team templates',
-            url: '/templates',
-            params: {
-                team: null
-            },
+            url: '/templates?:page',
             templateUrl: teamTemplatesTpl,
             controller: 'TeamTemplatesController',
             controllerAs: '$ctrl'
         })
         .state('admin.team.analyses', {
             title: 'Team analyses',
-            url: '/analyses',
-            params: {
-                team: null
-            },
+            url: '/analyses?:page',
             templateUrl: teamAnalysesTpl,
             controller: 'TeamAnalysesController',
             controllerAs: '$ctrl'
         })
         .state('admin.team.users', {
-            url: '/users',
+            url: '/users?:page',
             title: 'Team Members',
             templateUrl: teamUsersTpl,
             controller: 'AdminTeamUsersController',

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -311,28 +311,28 @@ function settingsStates($stateProvider) {
         })
         .state('user.organizations', {
             title: 'Organizations',
-            url: '/organizations',
+            url: '/organizations?:page',
             templateUrl: userOrganizationsTpl,
             controller: 'UserOrganizationsController',
             controllerAs: '$ctrl'
         })
         .state('user.teams', {
             title: 'Teams',
-            url: '/teams',
+            url: '/teams?:page',
             templateUrl: userTeamsTpl,
             controller: 'UserTeamsController',
             controllerAs: '$ctrl'
         })
         .state('user.projects', {
             title: 'Projects',
-            url: '/projects',
+            url: '/projects?:page',
             templateUrl: userProjectsTpl,
             controller: 'UserProjectsController',
             controllerAs: '$ctrl'
         })
         .state('user.rasters', {
             title: 'Rasters',
-            url: '/rasters',
+            url: '/rasters?:page',
             templateUrl: userRastersTpl,
             controller: 'UserRastersController',
             controllerAs: '$ctrl'

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -81,6 +81,12 @@ function runBlock(
             setupState();
         }
     });
+
+    $rootScope.autoInject = function (context, args) {
+        context.constructor.$inject.forEach((injectable, idx) => {
+            context[injectable] = args[idx];
+        });
+    };
 }
 
 export default runBlock;

--- a/app-frontend/src/app/pages/admin/admin.module.js
+++ b/app-frontend/src/app/pages/admin/admin.module.js
@@ -1,47 +1,7 @@
 import angular from 'angular';
 
 class AdminController {
-    constructor(
-        $scope,
-        authService, platformService, organizationService, teamService
-    ) {
-        'ngInject';
-
-        this.authService = authService;
-        this.platformService = platformService;
-        this.organizationService = organizationService;
-        this.teamService = teamService;
-        this.$scope = $scope;
-        this.platforms = [];
-        this.organizations = [];
-        this.teams = [];
-    }
-
-    $onInit() {
-        this.$scope.$watch('$ctrl.authService.userRoles', (roles) => {
-            if (roles && roles.length && !this.loading) {
-                this.loading = true;
-                this.platforms = [];
-                this.organizations = [];
-                this.teams = [];
-                roles.filter((role) => role.groupType === 'PLATFORM').forEach((role) => {
-                    this.platformService.getPlatform(role.groupId).then((item) => {
-                        this.platforms.push({role, item});
-                    });
-                });
-                roles.filter((role) => role.groupType === 'ORGANIZATION').forEach((role) => {
-                    this.organizationService.getOrganization(role.groupId).then((item) => {
-                        this.organizations.push({role, item});
-                    });
-                });
-                roles.filter((role) => role.groupType === 'TEAM').forEach((role) => {
-                    this.teamService.getTeam(role.groupId).then((item) => {
-                        this.teams.push({role, item});
-                    });
-                });
-            }
-        });
-    }
+    constructor() { }
 }
 
 const AdminModule = angular.module('pages.admin', []);

--- a/app-frontend/src/app/pages/admin/organization/projects/projects.html
+++ b/app-frontend/src/app/pages/admin/organization/projects/projects.html
@@ -1,3 +1,13 @@
+<div class="object-list-actions">
+  <div>
+    <rf-pagination-count
+      start-index="$ctrl.pagination.startingItem"
+      end-index="$ctrl.pagination.endingItem"
+      total="$ctrl.pagination.count"
+      item-name="projects"
+    ></rf-pagination-count>
+  </div>
+</div>
 <div class="row content stack-sm">
   <div class="column-8">
     <rf-call-to-action-item

--- a/app-frontend/src/app/pages/admin/organization/projects/projects.html
+++ b/app-frontend/src/app/pages/admin/organization/projects/projects.html
@@ -19,9 +19,9 @@
         Projects shared with this organization will be accessible to all members of this organization.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.projects.length" class="row stack-xs">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="row stack-xs">
       <div class="column-6 flex-display"
-           ng-repeat="project in $ctrl.projects"
+           ng-repeat="project in $ctrl.results"
       >
         <rf-project-item
             class="panel panel-off-white project-item"
@@ -30,6 +30,11 @@
         </rf-project-item>
       </div>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/admin/organization/projects/projects.js
+++ b/app-frontend/src/app/pages/admin/organization/projects/projects.js
@@ -29,7 +29,7 @@ class OrganizationProjectsController {
         this.projectService.query(
             {
                 sort: 'createdAt,desc',
-                pageSize: 1,
+                pageSize: 10,
                 ownershipType: 'inherited',
                 groupType: 'organization',
                 groupId: this.organization.id,

--- a/app-frontend/src/app/pages/admin/organization/rasters/rasters.html
+++ b/app-frontend/src/app/pages/admin/organization/rasters/rasters.html
@@ -19,14 +19,19 @@
         Rasters shared with this organization will be accessible to all members of this organization.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.pagination.count" class="list-group">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="list-group">
       <rf-scene-item
           previewable
           scene="raster"
           repository="$ctrl.repository"
-          ng-repeat="raster in $ctrl.rasters"
+          ng-repeat="raster in $ctrl.results"
       ></rf-scene-item>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/admin/organization/rasters/rasters.html
+++ b/app-frontend/src/app/pages/admin/organization/rasters/rasters.html
@@ -1,3 +1,13 @@
+<div class="object-list-actions">
+  <div>
+    <rf-pagination-count
+      start-index="$ctrl.pagination.startingItem"
+      end-index="$ctrl.pagination.endingItem"
+      total="$ctrl.pagination.count"
+      item-name="scenes"
+    ></rf-pagination-count>
+  </div>
+</div>
 <div class="row content stack-sm">
   <div class="column-8">
     <rf-call-to-action-item

--- a/app-frontend/src/app/pages/admin/organization/teams/teams.html
+++ b/app-frontend/src/app/pages/admin/organization/teams/teams.html
@@ -1,11 +1,6 @@
 <div class="admin-list-content column-stretch">
-  <div class="admin-list-actions" ng-if="!$ctrl.errorMsg && $ctrl.teams.length">
+  <div class="admin-list-actions" ng-if="!$ctrl.errorMsg && $ctrl.results.length">
     <div>
-      <rf-search on-search="$ctrl.debouncedSearch(value)"
-              placeholder="Search for teams"
-              auto-focus="true"
-              disabled="$ctrl.fetching || !$ctrl.teams.length"
-      ></rf-search>
       <rf-pagination-count
         start-index="$ctrl.pagination.startingItem"
         end-index="$ctrl.pagination.endingItem"
@@ -15,7 +10,7 @@
     </div>
     <div class="actions-right">
       <button type="button" class="btn btn-primary"
-              ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.fetching">
+              ng-click="$ctrl.newTeamModal()" ng-disabled="$ctrl.loading">
         Create Team
       </button>
     </div>
@@ -23,7 +18,7 @@
   <rf-call-to-action-item
     title="No teams have been formed yet"
     class="panel panel-off-white"
-    ng-if="!$ctrl.teams.length && !$ctrl.fetching">
+    ng-if="!$ctrl.results.length && !$ctrl.loading">
     <p class="pb-25">
       The {{$ctrl.organization.name}} organization does not have any teams yet.
       You can use teams to organize users and make sharing common data even easier.
@@ -36,9 +31,9 @@
       Create Team
     </button>
   </rf-call-to-action-item>
-  <table class="admin-table admin-team-table" ng-if="!$ctrl.fetching && $ctrl.teams.length">
+  <table class="admin-table admin-team-table" ng-if="!$ctrl.loading && $ctrl.results.length">
     <tbody>
-      <tr ng-repeat="team in $ctrl.teams track by team.id">
+      <tr ng-repeat="team in $ctrl.results track by team.id">
         <td class="name">
           <div ng-if="$ctrl.editTeamId !== team.id">
             <a class="font-600"
@@ -97,22 +92,12 @@
       </tr>
     </tbody>
   </table>
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+  <div class="table-loading" ng-if="$ctrl.loading">
+    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.loading}"></span>
   </div>
-  <!-- Pagination -->
-  <div class="list-group text-center"
-        ng-show="!$ctrl.loading && $ctrl.lastTeamResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastTeamResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchTeams($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
+  <rf-pagination-controls
+    pagination="$ctrl.pagination"
+    is-loading="$ctrl.loading"
+    on-change="$ctrl.fetchPage(value)"
+  ></rf-pagination-controls>
 </div>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -4,12 +4,12 @@
       {{$ctrl.errorMsg}}
     </p>
   </div>
-  <div class="admin-list-actions" ng-if="!$ctrl.errorMsg && $ctrl.users.length">
+  <div class="admin-list-actions" ng-if="!$ctrl.errorMsg && $ctrl.results.length">
     <div>
-      <rf-search on-search="$ctrl.debouncedSearch(value)"
+      <rf-search on-search="$ctrl.onSearch(value)"
                  placeholder="Search for users"
                  auto-focus="true"
-                 disabled="$ctrl.fetching || !$ctrl.users.length"
+                 disabled="$ctrl.loading || !$ctrl.results.length"
       ></rf-search>
       <rf-pagination-count
         start-index="$ctrl.pagination.startingItem"
@@ -21,7 +21,7 @@
     <div class="actions-right">
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.addUserModal()"
-              ng-disabled="$ctrl.fetching">
+              ng-disabled="$ctrl.loading">
         Add Users
       </button>
     </div>
@@ -29,7 +29,7 @@
   <rf-call-to-action-item
     title="No users are in this organization yet"
     class="panel panel-off-white"
-    ng-if="!$ctrl.users.length && !$ctrl.fetching">
+    ng-if="!$ctrl.results.length && !$ctrl.loading">
     <p class="pb-25">
       The {{$ctrl.organization.name}} organization does not have any users yet.
       When it does, they'll be shown here.
@@ -41,9 +41,9 @@
       Add Users
     </button>
   </rf-call-to-action-item>
-  <table class="admin-table admin-org-user-table" ng-if="!$ctrl.fetching && $ctrl.users.length">
+  <table class="admin-table admin-org-user-table" ng-if="!$ctrl.loading && $ctrl.results.length">
     <tbody>
-      <tr ng-repeat="user in $ctrl.users track by $index">
+      <tr ng-repeat="user in $ctrl.results track by $index">
         <td class="username">
           <div class="avatar user-avatar image-placeholder" ng-if="!user.profileImageUri"></div>
           <div ng-if="user.profileImageUri">
@@ -60,7 +60,7 @@
             {{$ctrl.getUserGroupRoleLabel(user)}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions && user.membershipStatus = 'APPROVED'">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions && user.membershipStatus === 'APPROVED'">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>
           <div class="btn-group"
@@ -83,22 +83,12 @@
       </tr>
     </tbody>
   </table>
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+  <div class="table-loading" ng-if="$ctrl.loading">
+    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.loading}"></span>
   </div>
-  <!-- Pagination -->
-  <div class="list-group text-center"
-        ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastUserResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
+  <rf-pagination-controls
+    pagination="$ctrl.pagination"
+    is-loading="$ctrl.loading"
+    on-change="$ctrl.fetchPage(value)"
+  ></rf-pagination-controls>
 </div>

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -74,7 +74,7 @@
               Approve
             </button>
           </div>
-          <button type="button" class="btn btn-light btn-small"
+          <button type="button" class="btn btn-light btn-small btn-nowrap"
                   ng-click="$ctrl.updateUserMembershipStatus(user, false)"
                   ng-if="user.showOptions && user.membershipStatus === 'INVITED'">
             Cancel Invitation

--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -33,13 +33,14 @@ class OrganizationUsersController {
                 this.results = paginatedResponse.results;
                 this.pagination = this.paginationService.buildPagination(paginatedResponse);
                 this.paginationService.updatePageParam(page);
+                this.buildOptions();
             }).finally(() => {
                 this.loading = false;
             });
     }
 
     buildOptions() {
-        this.users.forEach(user => Object.assign(user, {
+        this.results.forEach(user => Object.assign(user, {
             options: {
                 items: this.itemsForUser(user)
             },
@@ -87,7 +88,7 @@ class OrganizationUsersController {
                 groupType: () => 'organization'
             }
         }).result.then(() => {
-            this.fetchUsers(1, this.search);
+            this.fetchPage();
         });
     }
 
@@ -108,7 +109,7 @@ class OrganizationUsersController {
             this.organization.id,
             user
         ).catch(() => {
-            this.fetchUsers(this.pagination.currentPage);
+            this.fetchPage(this.pagination.currentPage);
         });
     }
 
@@ -120,13 +121,13 @@ class OrganizationUsersController {
                 user.id,
                 user.groupRole
             ).then(resp => {
-                this.users.forEach(thisUser =>{
+                this.results.forEach(thisUser =>{
                     if (thisUser.id === resp.userId) {
                         thisUser.membershipStatus = resp.membershipStatus;
                         delete thisUser.buttonType;
                     }
                 });
-                this.fetchUsers(1, '');
+                this.fetchPage();
             });
         } else {
             this.organizationService.removeUser(
@@ -134,8 +135,8 @@ class OrganizationUsersController {
                 this.organization.id,
                 user.id
             ).then(resp => {
-                _.remove(this.users, thisUser => thisUser.id === resp[0].userId);
-                this.fetchUsers(1, '');
+                _.remove(this.results, thisUser => thisUser.id === resp[0].userId);
+                this.fetchPage();
             });
         }
     }

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -1,5 +1,5 @@
 <div class="admin-list-content column-stretch">
-  <div class="admin-list-actions content">
+  <div class="admin-list-actions">
     <div>
       <rf-pagination-count
         start-index="$ctrl.pagination.startingItem"

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.html
@@ -1,17 +1,25 @@
 <div class="admin-list-content column-stretch">
-  <div class="admin-list-actions">
+  <div class="admin-list-actions content">
+    <div>
+      <rf-pagination-count
+        start-index="$ctrl.pagination.startingItem"
+        end-index="$ctrl.pagination.endingItem"
+        total="$ctrl.pagination.count"
+        item-name="organizations"
+      ></rf-pagination-count>
+    </div>
     <div class="actions-right">
       <button type="button" class="btn btn-primary"
               ng-if="$ctrl.isEffectiveAdmin"
               ng-click="$ctrl.newOrgModal()"
-              ng-disabled="$ctrl.fetching">
+              ng-disabled="$ctrl.loading">
         New Organization
       </button>
     </div>
   </div>
-  <table class="admin-table admin-platform-org-table" ng-if="!$ctrl.fetching">
+  <table class="admin-table admin-platform-org-table" ng-if="!$ctrl.loading">
     <tbody>
-      <tr ng-repeat="organization in $ctrl.organizations track by $index">
+      <tr ng-repeat="organization in $ctrl.results track by $index">
         <td class="name">
             <div class="avatar user-avatar image-placeholder" ng-if="!organization.logoUri"></div>
             <div ng-if="organization.logoUri">
@@ -72,23 +80,12 @@
         </tr>
       </tbody>
     </table>
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+  <div class="table-loading" ng-if="$ctrl.loading">
+    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.loading}"></span>
   </div>
-
-  <!-- Pagination -->
-  <div class="list-group text-center"
-       ng-show="!$ctrl.loading && $ctrl.lastOrgResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastOrgResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchOrganizations($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
+  <rf-pagination-controls
+    pagination="$ctrl.pagination"
+    is-loading="$ctrl.loading"
+    on-change="$ctrl.fetchPage(value)"
+  ></rf-pagination-controls>
 </div>

--- a/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
+++ b/app-frontend/src/app/pages/admin/platform/organizations/organizations.module.js
@@ -7,25 +7,15 @@ class PlatformOrganizationsController {
         platformService, organizationService, authService, paginationService,
         platform
     ) {
+        'ngInject';
         $scope.autoInject(this, arguments);
     }
 
     $onInit() {
         this.searchTerm = '';
         this.loading = false;
+        this.onSearch = this.paginationService.buildPagedSearch(this);
         this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
-
-        this.debouncedSearch = _.debounce(
-            this.onSearch.bind(this),
-            500,
-            {leading: false, trailing: true}
-        );
-
-        this.fetchPage();
-    }
-
-    onSearch(search) {
-        this.searchTerm = search;
         this.fetchPage();
     }
 

--- a/app-frontend/src/app/pages/admin/platform/projects/projects.html
+++ b/app-frontend/src/app/pages/admin/platform/projects/projects.html
@@ -1,3 +1,14 @@
+<div class="object-list-actions">
+  <div>
+    <rf-pagination-count
+      ng-if="$ctrl.results.length"
+      start-index="$ctrl.pagination.startingItem"
+      end-index="$ctrl.pagination.endingItem"
+      total="$ctrl.pagination.count"
+      item-name="projects"
+    ></rf-pagination-count>
+  </div>
+</div>
 <div class="row content stack-sm">
   <div class="column-8">
     <rf-call-to-action-item
@@ -9,9 +20,9 @@
         Projects shared with this platform will be accessible to all users.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.projects.length" class="row stack-xs">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="row stack-xs">
       <div class="column-6 flex-display"
-           ng-repeat="project in $ctrl.projects"
+           ng-repeat="project in $ctrl.results"
       >
         <rf-project-item
             class="panel panel-off-white project-item"
@@ -20,6 +31,11 @@
         </rf-project-item>
       </div>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/admin/platform/projects/projects.js
+++ b/app-frontend/src/app/pages/admin/platform/projects/projects.js
@@ -7,6 +7,7 @@ class PlatformProjectsController {
         modalService, authService, projectService, paginationService,
         platform, organizations, members
     ) {
+        'ngInject';
         $scope.autoInject(this, arguments);
     }
 
@@ -15,18 +16,8 @@ class PlatformProjectsController {
         this.loading = false;
         this.searchTerm = '';
         this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
+        this.onSearch = this.paginationService.buildPagedSearch(this);
 
-        this.debouncedSearch = _.debounce(
-            this.onSearch.bind(this),
-            500,
-            {leading: false, trailing: true}
-        );
-
-        this.fetchPage();
-    }
-
-    onSearch(search) {
-        this.searchTerm = search;
         this.fetchPage();
     }
 

--- a/app-frontend/src/app/pages/admin/platform/projects/projects.js
+++ b/app-frontend/src/app/pages/admin/platform/projects/projects.js
@@ -12,11 +12,10 @@ class PlatformProjectsController {
     }
 
     $onInit() {
-        this.pagination = {};
         this.loading = false;
         this.searchTerm = '';
-        this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
         this.onSearch = this.paginationService.buildPagedSearch(this);
+        this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
 
         this.fetchPage();
     }
@@ -26,7 +25,7 @@ class PlatformProjectsController {
         this.projectService.query(
             {
                 sort: 'createdAt,desc',
-                pageSize: 1,
+                pageSize: 10,
                 ownershipType: 'inherited',
                 groupType: 'platform',
                 groupId: this.platform.id,

--- a/app-frontend/src/app/pages/admin/platform/rasters/rasters.html
+++ b/app-frontend/src/app/pages/admin/platform/rasters/rasters.html
@@ -1,3 +1,14 @@
+<div class="object-list-actions">
+  <div>
+    <rf-pagination-count
+      ng-if="$ctrl.results.length"
+      start-index="$ctrl.pagination.startingItem"
+      end-index="$ctrl.pagination.endingItem"
+      total="$ctrl.pagination.count"
+      item-name="scenes"
+    ></rf-pagination-count>
+  </div>
+</div>
 <div class="row content stack-sm">
   <div class="column-8">
     <rf-call-to-action-item
@@ -14,10 +25,16 @@
           previewable
           scene="raster"
           repository="$ctrl.repository"
-          ng-repeat="raster in $ctrl.rasters"
+          ng-repeat="raster in $ctrl.results"
       ></rf-scene-item>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
+
   <div class="column spacer"></div>
   <div class="column-3">
     <rf-sidebar-user-list paginated-response="$ctrl.members" sref="admin.platform.users"></rf-sidebar-user-list>

--- a/app-frontend/src/app/pages/admin/platform/rasters/rasters.js
+++ b/app-frontend/src/app/pages/admin/platform/rasters/rasters.js
@@ -42,7 +42,7 @@ class Controller {
         this.sceneService.query(
             {
                 sort: 'createdAt,desc',
-                pageSize: 1,
+                pageSize: 10,
                 ownershipType: 'inherited',
                 groupType: 'platform',
                 groupId: this.platform.id,

--- a/app-frontend/src/app/pages/admin/platform/rasters/rasters.js
+++ b/app-frontend/src/app/pages/admin/platform/rasters/rasters.js
@@ -8,6 +8,7 @@ class Controller {
         RasterFoundryRepository, sceneService, paginationService,
         platform, organizations, members
     ) {
+        'ngInject';
         $scope.autoInject(this, arguments);
     }
 

--- a/app-frontend/src/app/pages/admin/platform/rasters/rasters.js
+++ b/app-frontend/src/app/pages/admin/platform/rasters/rasters.js
@@ -5,72 +5,53 @@ class Controller {
     constructor(
         $scope, $stateParams, $log, $window,
         modalService, organizationService, teamService, authService,
-        RasterFoundryRepository, sceneService,
+        RasterFoundryRepository, sceneService, paginationService,
         platform, organizations, members
     ) {
-        this.$scope = $scope;
-        this.$stateParams = $stateParams;
-        this.$log = $log;
-        this.$window = $window;
-        this.modalService = modalService;
-        this.organizationService = organizationService;
-        this.teamService = teamService;
-        this.authService = authService;
-        this.repository = {
-            name: 'Raster Foundry',
-            service: RasterFoundryRepository
-        };
-        this.sceneService = sceneService;
-
-        this.platform = platform;
-        this.organizations = organizations;
-        this.members = members;
+        $scope.autoInject(this, arguments);
     }
 
     $onInit() {
+        this.pagination = {};
+        this.loading = false;
+        this.searchTerm = '';
+        this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
+
         this.debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,
             {leading: false, trailing: true}
         );
 
-        this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
+        this.repository = {
+            name: 'Raster Foundry',
+            service: this.RasterFoundryRepository
+        };
 
         this.fetchPage();
     }
 
     onSearch(search) {
-        this.fetchPage(0, search);
+        this.searchTerm = search;
+        this.fetchPage();
     }
 
-    updatePagination(data) {
-        this.pagination = {
-            show: data.count > data.pageSize,
-            count: data.count,
-            currentPage: data.page + 1,
-            startingItem: data.page * data.pageSize + 1,
-            endingItem: Math.min((data.page + 1) * data.pageSize, data.count),
-            hasNext: data.hasNext,
-            hasPrevious: data.hasPrevious
-        };
-    }
-
-
-    fetchPage(page = 0, search = '') {
+    fetchPage(page = this.$stateParams.page || 1) {
         this.loading = true;
         this.sceneService.query(
             {
                 sort: 'createdAt,desc',
-                pageSize: 10,
+                pageSize: 1,
                 ownershipType: 'inherited',
                 groupType: 'platform',
                 groupId: this.platform.id,
-                search,
-                page
+                search: this.searchTerm,
+                page: page - 1
             }
         ).then(paginatedResponse => {
-            this.rasters = paginatedResponse.results;
-            this.updatePagination(paginatedResponse);
+            this.results = paginatedResponse.results;
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
         }).finally(() => {
             this.loading = false;
         });

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -8,7 +8,7 @@
   <div ng-if="!$ctrl.errorMsg">
     <div class="admin-list-actions">
       <div>
-        <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
+        <rf-search on-search="$ctrl.onSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
         <rf-pagination-count
           start-index="$ctrl.pagination.startingItem"
           end-index="$ctrl.pagination.endingItem"

--- a/app-frontend/src/app/pages/admin/platform/users/users.html
+++ b/app-frontend/src/app/pages/admin/platform/users/users.html
@@ -17,9 +17,9 @@
         ></rf-pagination-count>
       </div>
     </div>
-    <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
+    <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.loading">
       <tbody>
-        <tr ng-repeat="user in $ctrl.users track by $index">
+        <tr ng-repeat="user in $ctrl.results track by $index">
           <td class="username">
             <div class="avatar user-avatar image-placeholder" ng-if="!user.profileImageUri"></div>
             <div ng-if="user.profileImageUri">
@@ -43,22 +43,13 @@
         </tr>
       </tbody>
     </table>
-    <div class="table-loading" ng-if="$ctrl.fetching">
-      <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+    <div class="table-loading" ng-if="$ctrl.loading">
+      <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.loading}"></span>
     </div>
-    <!-- Pagination -->
-    <div class="list-group text-center"
-          ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-      <ul uib-pagination
-          items-per-page="$ctrl.lastUserResult.pageSize"
-          total-items="$ctrl.pagination.count"
-          ng-model="$ctrl.currentPage"
-          max-size="4"
-          rotate="true"
-          boundary-link-numbers="true"
-          force-ellipses="true"
-          ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
-      </ul>
-    </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
 </div>

--- a/app-frontend/src/app/pages/admin/platform/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/platform/users/users.module.js
@@ -7,6 +7,7 @@ class PlatformUsersController {
         modalService, platformService, authService, paginationService,
         platform
     ) {
+        'ngInject';
         $scope.autoInject(this, arguments);
     }
 
@@ -14,18 +15,7 @@ class PlatformUsersController {
         this.searchTerm = '';
         this.loading = false;
         this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
-
-        this.debouncedSearch = _.debounce(
-            this.onSearch.bind(this),
-            500,
-            {leading: false, trailing: true}
-        );
-
-        this.fetchPage();
-    }
-
-    onSearch(search) {
-        this.searchTerm = search;
+        this.onSearch = this.paginationService.buildPagedSearch(this);
         this.fetchPage();
     }
 

--- a/app-frontend/src/app/pages/admin/platform/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/platform/users/users.module.js
@@ -80,7 +80,7 @@ class PlatformUsersController {
             this.platform.id,
             user
         ).catch(() => {
-            this.fetchUsers(this.pagination.currentPage, this.search);
+            this.fetchPage(this.pagination.currentPage);
         });
     }
 

--- a/app-frontend/src/app/pages/admin/platform/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/platform/users/users.module.js
@@ -4,78 +4,49 @@ import _ from 'lodash';
 class PlatformUsersController {
     constructor(
         $scope, $stateParams, $q,
-        modalService, platformService, authService,
+        modalService, platformService, authService, paginationService,
         platform
     ) {
-        'ngInject';
-        this.$scope = $scope;
-        this.$stateParams = $stateParams;
-        this.$q = $q;
-
-        this.modalService = modalService;
-        this.platformService = platformService;
-        this.authService = authService;
-
-        this.platform = platform;
+        $scope.autoInject(this, arguments);
     }
 
     $onInit() {
+        this.searchTerm = '';
+        this.loading = false;
         this.isEffectiveAdmin = this.authService.isEffectiveAdmin(this.platform.id);
+
         this.debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,
             {leading: false, trailing: true}
         );
-        this.fetchUsers(1, '');
+
+        this.fetchPage();
     }
 
     onSearch(search) {
-        // eslint-disable-next-line
-        this.fetchUsers(undefined, search);
+        this.searchTerm = search;
+        this.fetchPage();
     }
 
-    updateUserGroupRole(user) {
-        return this.platformService.setUserRole(
-            this.platform.id,
-            user
-        ).catch(() => {
-            this.fetchUsers(this.pagination.currentPage, this.search);
-        });
-    }
-
-    updatePagination(data) {
-        this.pagination = {
-            show: data.count > data.pageSize,
-            count: data.count,
-            currentPage: data.page + 1,
-            startingItem: data.page * data.pageSize + 1,
-            endingItem: Math.min((data.page + 1) * data.pageSize, data.count),
-            hasNext: data.hasNext,
-            hasPrevious: data.hasPrevious
-        };
-    }
-
-    fetchUsers(page = 1, search) {
-        let platformId = this.$stateParams.platformId;
-        this.fetching = true;
+    fetchPage(page = this.$stateParams.page || 1) {
+        this.loading = true;
         this.platformService.getMembers(
-            platformId,
+            this.platform.id,
             page - 1,
-            search && search.length ? search : null
-        ).then((response) => {
-            this.fetching = false;
-            this.updatePagination(response);
-            this.lastUserResult = response;
-            this.users = response.results;
+            this.searchTerm
+        ).then(paginatedResponse => {
+            this.results = paginatedResponse.results;
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
             this.buildOptions();
-        }, (error) => {
-            this.fetching = false;
-            this.errrorMsg = `${error.data}. Please contact `;
+        }).finally(() => {
+            this.loading = false;
         });
     }
 
     buildOptions() {
-        this.users.forEach(user => Object.assign(user, {
+        this.results.forEach(user => Object.assign(user, {
             options: {
                 items: this.itemsForUser(user)
             },
@@ -112,6 +83,15 @@ class PlatformUsersController {
         }
         return options;
         /* eslint-enable */
+    }
+
+    updateUserGroupRole(user) {
+        return this.platformService.setUserRole(
+            this.platform.id,
+            user
+        ).catch(() => {
+            this.fetchUsers(this.pagination.currentPage, this.search);
+        });
     }
 
     newUserModal() {

--- a/app-frontend/src/app/pages/admin/team/projects/projects.html
+++ b/app-frontend/src/app/pages/admin/team/projects/projects.html
@@ -19,9 +19,9 @@
         Projects shared with this organization will be accessible to all members of this team.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.projects.length" class="row stack-xs">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="row stack-xs">
       <div class="column-6 flex-display"
-           ng-repeat="project in $ctrl.projects"
+           ng-repeat="project in $ctrl.results"
       >
         <rf-project-item
             class="panel panel-off-white project-item"
@@ -30,6 +30,11 @@
         </rf-project-item>
       </div>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/admin/team/projects/projects.html
+++ b/app-frontend/src/app/pages/admin/team/projects/projects.html
@@ -1,3 +1,13 @@
+<div class="object-list-actions">
+  <div>
+    <rf-pagination-count
+      start-index="$ctrl.pagination.startingItem"
+      end-index="$ctrl.pagination.endingItem"
+      total="$ctrl.pagination.count"
+      item-name="projects"
+    ></rf-pagination-count>
+  </div>
+</div>
 <div class="row content stack-sm">
   <div class="column-8">
     <rf-call-to-action-item

--- a/app-frontend/src/app/pages/admin/team/projects/projects.js
+++ b/app-frontend/src/app/pages/admin/team/projects/projects.js
@@ -4,30 +4,17 @@ import _ from 'lodash';
 class Controller {
     constructor(
         $scope, $stateParams, $log, $window,
-        modalService, projectService, teamService, authService,
+        modalService, projectService, teamService, authService, paginationService,
         platform, organization, members, team
     ) {
-        this.$scope = $scope;
-        this.$stateParams = $stateParams;
-        this.$log = $log;
-        this.$window = $window;
-        this.modalService = modalService;
-        this.projectService = projectService;
-        this.teamService = teamService;
-        this.authService = authService;
-
-        this.platform = platform;
-        this.organization = organization;
-        this.members = members;
-        this.team = team;
+        'ngInject';
+        $scope.autoInject(this, arguments);
     }
 
     $onInit() {
-        this.debouncedSearch = _.debounce(
-            this.onSearch.bind(this),
-            500,
-            {leading: false, trailing: true}
-        );
+        this.loading = false;
+        this.searchTerm = '';
+        this.onSearch = this.paginationService.buildPagedSearch(this);
 
         this.isEffectiveAdmin = this.authService.isEffectiveAdmin([
             this.platform.id,
@@ -37,24 +24,7 @@ class Controller {
         this.fetchPage();
     }
 
-    onSearch(search) {
-        this.fetchPage(0, search);
-    }
-
-    updatePagination(data) {
-        this.pagination = {
-            show: data.count > data.pageSize,
-            count: data.count,
-            currentPage: data.page + 1,
-            startingItem: data.page * data.pageSize + 1,
-            endingItem: Math.min((data.page + 1) * data.pageSize, data.count),
-            hasNext: data.hasNext,
-            hasPrevious: data.hasPrevious
-        };
-    }
-
-
-    fetchPage(page = 0, search = '') {
+    fetchPage(page = this.$stateParams.page || 1) {
         this.loading = true;
         this.projectService.query(
             {
@@ -63,12 +33,13 @@ class Controller {
                 ownershipType: 'inherited',
                 groupType: 'team',
                 groupId: this.team.id,
-                search,
-                page
+                search: this.searchTerm,
+                page: page - 1
             }
         ).then(paginatedResponse => {
-            this.projects = paginatedResponse.results;
-            this.updatePagination(paginatedResponse);
+            this.results = paginatedResponse.results;
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
         }).finally(() => {
             this.loading = false;
         });

--- a/app-frontend/src/app/pages/admin/team/rasters/rasters.html
+++ b/app-frontend/src/app/pages/admin/team/rasters/rasters.html
@@ -9,14 +9,19 @@
         Rasters shared with this organization will be accessible to all members of this team.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.pagination.count" class="list-group">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="list-group">
       <rf-scene-item
           previewable
           scene="raster"
           repository="$ctrl.repository"
-          ng-repeat="raster in $ctrl.rasters"
+          ng-repeat="raster in $ctrl.results"
       ></rf-scene-item>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -1,18 +1,18 @@
 <div class="admin-list-content column-stretch">
-  <div class="admin-list-actions" ng-if="$ctrl.users.length">
+  <div class="admin-list-actions" ng-if="$ctrl.results.length">
     <div>
-      <rf-search on-search="$ctrl.debouncedSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
+      <rf-search on-search="$ctrl.onSearch(value)" placeholder="Search for users" auto-focus="true"></rf-search>
       <rf-pagination-count
         start-index="$ctrl.pagination.startingItem"
         end-index="$ctrl.pagination.endingItem"
         total="$ctrl.pagination.count"
         item-name="users"
-        ng-if="!$ctrl.fetching && $ctrl.users.length && !$ctrl.searchTerm"
+        ng-if="!$ctrl.loading && $ctrl.results.length && !$ctrl.searchTerm"
       ></rf-pagination-count>
     </div>
     <div class="actions-right">
       <button type="button" class="btn btn-primary"
-              ng-click="$ctrl.addUser()" ng-disabled="$ctrl.fetching">
+              ng-click="$ctrl.addUser()" ng-disabled="$ctrl.loading">
         Invite Users
       </button>
     </div>
@@ -20,7 +20,7 @@
   <rf-call-to-action-item
     title="No users are in this team yet"
     class="panel panel-off-white"
-    ng-if="!$ctrl.users.length && !$ctrl.fetching">
+    ng-if="!$ctrl.results.length && !$ctrl.loading">
     <p class="pb-25">
       The {{$ctrl.team.name}} team does not have any users yet.
       When it does, they'll be shown here.
@@ -33,9 +33,9 @@
     </button>
   </rf-call-to-action-item>
 
-  <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching && $ctrl.users.length">
+  <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.loading && $ctrl.results.length">
     <tbody>
-      <tr ng-repeat="user in $ctrl.users track by $index">
+      <tr ng-repeat="user in $ctrl.results">
         <td class="username">
           <div class="user-avatar" >
             <div class="avatar image-placeholder" ng-if="!user.profileImageUri"></div>
@@ -49,10 +49,10 @@
           {{user.email}}
         </td>
         <td class="roles titlecase">
-            {{$ctrl.getUserGroupRoleLabel(user)}}
+          {{$ctrl.getUserGroupRoleLabel(user)}}
         </td>
         <td class="actions">
-          <rf-dropdown data-options="user.options" ng-if="user.showOptions && user.membershipStatus = 'APPROVED'">
+          <rf-dropdown data-options="user.options" ng-if="user.showOptions && user.membershipStatus === 'APPROVED'">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>
           <div class="btn-group"
@@ -75,23 +75,12 @@
       </tr>
     </tbody>
   </table>
-  <div class="table-loading" ng-if="$ctrl.fetching">
-    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
+  <div class="table-loading" ng-if="$ctrl.loading">
+    <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.loading}"></span>
   </div>
-
-  <!-- Pagination -->
-  <div class="list-group text-center"
-        ng-show="!$ctrl.loading && $ctrl.lastUserResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastUserResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchUsers($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
+  <rf-pagination-controls
+    pagination="$ctrl.pagination"
+    is-loading="$ctrl.loading"
+    on-change="$ctrl.fetchPage(value)"
+  ></rf-pagination-controls>
 </div>

--- a/app-frontend/src/app/pages/user/organizations/organizations.html
+++ b/app-frontend/src/app/pages/user/organizations/organizations.html
@@ -23,20 +23,4 @@
   <div class="table-loading" ng-if="$ctrl.fetching">
     <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetching}"></span>
   </div>
-
-  <!-- Pagination -->
-  <div class="list-group text-center"
-       ng-show="!$ctrl.loading && $ctrl.lastOrgResult && $ctrl.pagination.show && !$ctrl.errorMsg">
-    <ul uib-pagination
-        items-per-page="$ctrl.lastOrgResult.pageSize"
-        total-items="$ctrl.pagination.count"
-        ng-model="$ctrl.currentPage"
-        max-size="4"
-        rotate="true"
-        boundary-link-numbers="true"
-        force-ellipses="true"
-        ng-change="$ctrl.fetchOrganizations($ctrl.currentPage, $ctrl.search)">
-    </ul>
-  </div>
-  <!-- Pagination -->
 </div>

--- a/app-frontend/src/app/pages/user/organizations/organizations.html
+++ b/app-frontend/src/app/pages/user/organizations/organizations.html
@@ -17,6 +17,23 @@
         <td class="roles titlecase">
           {{$ctrl.getUserOrgRole(organization.id)}}
         </td>
+        <td class="actions">
+          <button class="btn btn-danger btn-small btn-nowrap"
+                  ng-if="$ctrl.membershipPending(organization)"
+                  ng-click="$ctrl.updateUserMembershipStatus(organization, false)">
+            Decline
+          </button>
+          <button class="btn btn-primary btn-small btn-nowrap"
+                  ng-if="$ctrl.membershipPending(organization)"
+                  ng-click="$ctrl.updateUserMembershipStatus(organization, true)">
+            Accept
+          </button>
+          <button class="btn btn-default btn-small btn-nowrap"
+                  ng-if="!$ctrl.membershipPending(organization)"
+                  ng-click="$ctrl.updateUserMembershipStatus(organization, false)">
+            Leave Organization
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>

--- a/app-frontend/src/app/pages/user/organizations/organizations.js
+++ b/app-frontend/src/app/pages/user/organizations/organizations.js
@@ -1,11 +1,50 @@
 class UserOrganizationsController {
-    constructor(organizationRoles, organizations) {
-        this.organizationRoles = organizationRoles;
-        this.organizations = organizations;
+    constructor(
+        $scope, $state,
+        organizationService,
+        organizationRoles, organizations, user
+    ) {
+        'ngInject';
+        $scope.autoInject(this, arguments);
     }
 
     getUserOrgRole(orgId) {
         return this.organizationRoles.find(role => role.groupId === orgId).groupRole;
+    }
+
+    membershipPending(organization) {
+        return !!this.organizationRoles.find(r =>
+                r.groupType === 'ORGANIZATION' &&
+                r.groupId === organization.id &&
+                r.membershipStatus === 'INVITED'
+            );
+    }
+
+    updateUserMembershipStatus(organization, isApproved) {
+        if (isApproved) {
+            const role = this.organizationRoles.find(r =>
+                r.groupType === 'ORGANIZATION' &&
+                r.groupId === organization.id
+            ).groupRole;
+            if (role) {
+                this.organizationService.approveUserMembership(
+                    organization.platformId,
+                    organization.id,
+                    this.user.id,
+                    role
+                ).then(resp => {
+                    this.$state.reload();
+                });
+            }
+        } else {
+            this.organizationService.removeUser(
+                organization.platformId,
+                organization.id,
+                this.user.id
+            ).then(resp => {
+                this.$state.reload();
+            });
+        }
     }
 }
 

--- a/app-frontend/src/app/pages/user/projects/projects.html
+++ b/app-frontend/src/app/pages/user/projects/projects.html
@@ -1,3 +1,14 @@
+<div class="object-list-actions">
+  <div>
+    <rf-pagination-count
+      ng-if="$ctrl.results.length"
+      start-index="$ctrl.pagination.startingItem"
+      end-index="$ctrl.pagination.endingItem"
+      total="$ctrl.pagination.count"
+      item-name="projects"
+    ></rf-pagination-count>
+  </div>
+</div>
 <div class="row content stack-sm">
   <div class="column-8">
     <rf-call-to-action-item
@@ -8,9 +19,9 @@
         Any projects you create will be visible here.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.projects.length" class="row stack-xs">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="row stack-xs">
       <div class="column-6 flex-display"
-           ng-repeat="project in $ctrl.projects"
+           ng-repeat="project in $ctrl.results"
       >
         <rf-project-item
             class="panel panel-off-white project-item"
@@ -18,6 +29,11 @@
         </rf-project-item>
       </div>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/user/projects/projects.js
+++ b/app-frontend/src/app/pages/user/projects/projects.js
@@ -3,81 +3,38 @@ import _ from 'lodash';
 
 class UserProjectsController {
     constructor(
-        $stateParams, $log, $window,
-        modalService, authService, projectService,
+        $scope, $stateParams, $log, $window,
+        modalService, authService, projectService, paginationService,
         organizations, teams
     ) {
-        this.$stateParams = $stateParams;
-        this.$log = $log;
-        this.$window = $window;
-        this.modalService = modalService;
-        this.authService = authService;
-        this.projectService = projectService;
-        this.organizations = organizations;
-        this.teams = teams;
+        'ngInject';
+        $scope.autoInject(this, arguments);
     }
 
     $onInit() {
-        this.projects = [];
         this.loading = false;
-
-        this.debouncedSearch = _.debounce(
-            this.onSearch.bind(this),
-            500,
-            {leading: false, trailing: true}
-        );
+        this.searchTerm = '';
+        this.onSearch = this.paginationService.buildPagedSearch(this);
 
         this.fetchPage();
     }
 
-    onSearch(search) {
-        this.fetchPage(0, search);
-    }
-
-    updatePagination(data) {
-        this.pagination = {
-            show: data.count > data.pageSize,
-            count: data.count,
-            currentPage: data.page + 1,
-            startingItem: data.page * data.pageSize + 1,
-            endingItem: Math.min((data.page + 1) * data.pageSize, data.count),
-            hasNext: data.hasNext,
-            hasPrevious: data.hasPrevious
-        };
-    }
-
-
-    fetchPage(page = 0) {
+    fetchPage(page = this.$stateParams.page || 1) {
         this.loading = true;
         this.projectService.query(
             {
                 sort: 'createdAt,desc',
                 pageSize: 10,
                 ownershipType: 'owned',
-                page
+                page: page - 1
             }
         ).then(paginatedResponse => {
-            this.projects = paginatedResponse.results;
-            this.updatePagination(paginatedResponse);
+            this.results = paginatedResponse.results;
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
         }).finally(() => {
             this.loading = false;
         });
-    }
-
-
-    buildOptions() {
-        this.items.forEach(obj => {
-            Object.assign(obj, {
-                options: {
-                    items: this.buildOptions(obj)
-                },
-                showOptions: this.isEffectiveAdmin
-            });
-        });
-    }
-
-    buildOptions() {
-        return [];
     }
 }
 

--- a/app-frontend/src/app/pages/user/rasters/rasters.html
+++ b/app-frontend/src/app/pages/user/rasters/rasters.html
@@ -8,15 +8,20 @@
         When you add your own raster data it'll be visible here.
       </p>
     </rf-call-to-action-item>
-    <div ng-if="!$ctrl.loading && $ctrl.pagination.count" class="list-group">
+    <div ng-if="!$ctrl.loading && $ctrl.results.length" class="list-group">
       <rf-scene-item
           previewable
           scene="raster"
           repository="$ctrl.repository"
-          ng-repeat="raster in $ctrl.rasters"
+          ng-repeat="raster in $ctrl.results"
       >
       </rf-scene-item>
     </div>
+    <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.loading"
+      on-change="$ctrl.fetchPage(value)"
+    ></rf-pagination-controls>
   </div>
   <div class="column spacer"></div>
   <div class="column-3">

--- a/app-frontend/src/app/pages/user/rasters/rasters.js
+++ b/app-frontend/src/app/pages/user/rasters/rasters.js
@@ -4,67 +4,39 @@ import _ from 'lodash';
 class Controller {
     constructor(
         $scope, $stateParams, $log, $window,
-        modalService, organizationService, teamService, authService,
+        modalService, organizationService, teamService, authService, paginationService,
         RasterFoundryRepository, sceneService, teams, organizations, user
     ) {
-        this.$scope = $scope;
-        this.$stateParams = $stateParams;
-        this.$log = $log;
-        this.$window = $window;
-        this.modalService = modalService;
-        this.organizationService = organizationService;
-        this.teamService = teamService;
-        this.authService = authService;
-        this.repository = {
-            name: 'Raster Foundry',
-            service: RasterFoundryRepository
-        };
-        this.sceneService = sceneService;
-
-        this.teams = teams;
-        this.organizations = organizations;
-        this.user = user;
+        'ngInject';
+        $scope.autoInject(this, arguments);
     }
 
     $onInit() {
-        this.debouncedSearch = _.debounce(
-            this.onSearch.bind(this),
-            500,
-            {leading: false, trailing: true}
-        );
+        this.loading = false;
+        this.searchTerm = '';
+        this.onSearch = this.paginationService.buildPagedSearch(this);
+
+        this.repository = {
+            name: 'Raster Foundry',
+            service: this.RasterFoundryRepository
+        };
 
         this.fetchPage();
     }
 
-    onSearch(search) {
-        this.fetchPage(0, search);
-    }
-
-    updatePagination(data) {
-        this.pagination = {
-            show: data.count > data.pageSize,
-            count: data.count,
-            currentPage: data.page + 1,
-            startingItem: data.page * data.pageSize + 1,
-            endingItem: Math.min((data.page + 1) * data.pageSize, data.count),
-            hasNext: data.hasNext,
-            hasPrevious: data.hasPrevious
-        };
-    }
-
-
-    fetchPage(page = 0) {
+    fetchPage(page = this.$stateParams.page || 1) {
         this.loading = true;
         this.sceneService.query(
             {
                 sort: 'createdAt,desc',
                 pageSize: 10,
                 ownershipType: 'owned',
-                page
+                page: page - 1
             }
         ).then(paginatedResponse => {
-            this.rasters = paginatedResponse.results;
-            this.updatePagination(paginatedResponse);
+            this.results = paginatedResponse.results;
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
         }).finally(() => {
             this.loading = false;
         });

--- a/app-frontend/src/app/pages/user/teams/teams.html
+++ b/app-frontend/src/app/pages/user/teams/teams.html
@@ -47,6 +47,21 @@
             </ng-pluralize>
         </td>
         <td class="actions">
+          <button class="btn btn-danger btn-small btn-nowrap"
+                  ng-if="$ctrl.membershipPending(team)"
+                  ng-click="$ctrl.updateUserMembershipStatus(team, false)">
+            Decline
+          </button>
+          <button class="btn btn-primary btn-small btn-nowrap"
+                  ng-if="$ctrl.membershipPending(team)"
+                  ng-click="$ctrl.updateUserMembershipStatus(team, true)">
+            Accept
+          </button>
+          <button class="btn btn-default btn-small btn-nowrap"
+                  ng-if="!$ctrl.membershipPending(team)"
+                  ng-click="$ctrl.updateUserMembershipStatus(team, false)">
+            Leave Team
+          </button>
           <rf-dropdown data-options="team.options" ng-if="team.showOptions">
             <span class="icon-caret-down h4"></span>
           </rf-dropdown>

--- a/app-frontend/src/app/pages/user/teams/teams.js
+++ b/app-frontend/src/app/pages/user/teams/teams.js
@@ -1,11 +1,53 @@
 class UserTeamsController {
-    constructor(teamRoles, teams) {
-        this.teamRoles = teamRoles;
-        this.teams = teams;
+    constructor(
+        $scope, $state,
+        teamService,
+        platform, teamRoles, teams, user
+    ) {
+        'ngInject';
+        $scope.autoInject(this, arguments);
     }
 
     getUserTeamRole(teamId) {
         return this.teamRoles.find(role => role.groupId === teamId).groupRole;
+    }
+
+    membershipPending(team) {
+        return !!this.teamRoles.find(r =>
+                r.groupType === 'TEAM' &&
+                r.groupId === team.id &&
+                r.membershipStatus === 'INVITED'
+            );
+    }
+
+    updateUserMembershipStatus(team, isApproved) {
+        if (isApproved) {
+            const role = this.teamRoles.find(r =>
+                r.groupType === 'TEAM' &&
+                r.groupId === team.id
+            ).groupRole;
+
+            if (role) {
+                this.teamService.addUserWithRole(
+                    this.platform.id,
+                    team.organizationId,
+                    team.id,
+                    role,
+                    this.user.id
+                ).then(resp => {
+                    this.$state.reload();
+                });
+            }
+        } else {
+            this.teamService.removeUser(
+                this.platform.id,
+                team.organizationId,
+                team.id,
+                this.user.id
+            ).then(resp => {
+                this.$state.reload();
+            });
+        }
     }
 }
 

--- a/app-frontend/src/app/pages/user/user.js
+++ b/app-frontend/src/app/pages/user/user.js
@@ -35,6 +35,13 @@ UserModule.resolve = {
     userRoles: (authService) => {
         return authService.fetchUserRoles();
     },
+    platform: (userRoles, platformService) => {
+        const platformRole = userRoles.find(r =>
+            r.groupType === 'PLATFORM'
+        );
+
+        return platformService.getPlatform(platformRole.groupId);
+    },
     organizationRoles: (userRoles) => {
         return _.uniqBy(userRoles, r => r.groupId).filter(r => r.groupType === 'ORGANIZATION');
     },

--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -468,7 +468,7 @@ export default (app) => {
             const ids = [].concat(groupIds || []);
             return this.user &&
                 this.user.isSuperuser ||
-                this.userRoles.find(r => {
+                !!this.userRoles.find(r => {
                     return r.groupRole === 'ADMIN' &&
                         ids.includes(r.groupId) &&
                         r.membershipStatus === 'APPROVED';

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -118,7 +118,7 @@ export default (app) => {
             }
 
             return this.PlatformOrganization
-                .members({platformId, organizationId, page, search, pageSize: 2})
+                .members({platformId, organizationId, page, search, pageSize: 10})
                 .$promise;
         }
 
@@ -129,7 +129,7 @@ export default (app) => {
             }
 
             return this.PlatformOrganization
-                .teams({platformId, organizationId, page, search, pageSize: 2})
+                .teams({platformId, organizationId, page, search, pageSize: 10})
                 .$promise;
         }
 

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -118,7 +118,7 @@ export default (app) => {
             }
 
             return this.PlatformOrganization
-                .members({platformId, organizationId, page, search, pageSize: 10})
+                .members({platformId, organizationId, page, search, pageSize: 2})
                 .$promise;
         }
 
@@ -129,7 +129,7 @@ export default (app) => {
             }
 
             return this.PlatformOrganization
-                .teams({platformId, organizationId, page, search, pageSize: 10})
+                .teams({platformId, organizationId, page, search, pageSize: 2})
                 .$promise;
         }
 

--- a/app-frontend/src/app/services/auth/platform.service.js
+++ b/app-frontend/src/app/services/auth/platform.service.js
@@ -58,7 +58,7 @@ export default (app) => {
 
         getMembers(platformId, page, search) {
             return this.Platform
-                .members({id: platformId, page, search, pageSize: 2})
+                .members({id: platformId, page, search, pageSize: 10})
                 .$promise;
         }
 

--- a/app-frontend/src/app/services/auth/platform.service.js
+++ b/app-frontend/src/app/services/auth/platform.service.js
@@ -58,7 +58,7 @@ export default (app) => {
 
         getMembers(platformId, page, search) {
             return this.Platform
-                .members({id: platformId, page, search, pageSize: 10})
+                .members({id: platformId, page, search, pageSize: 2})
                 .$promise;
         }
 

--- a/app-frontend/src/app/services/auth/team.service.js
+++ b/app-frontend/src/app/services/auth/team.service.js
@@ -70,6 +70,13 @@ export default (app) => {
             }).$promise;
         }
 
+        addUserWithRole(platformId, organizationId, teamId, groupRole, userId) {
+            return this.Team.addUser(
+                { platformId, organizationId, teamId },
+                { userId, groupRole }
+            ).$promise;
+        }
+
         setUserRole(platformId, organizationId, teamId, user) {
             return this.Team.addUser({
                 platformId,

--- a/app-frontend/src/app/services/common/pagination.service.js
+++ b/app-frontend/src/app/services/common/pagination.service.js
@@ -1,8 +1,20 @@
+/* global _ */
 
 export default (app) => {
     class PaginationService {
         constructor($state) {
             this.$state = $state;
+        }
+
+        buildPagedSearch(context) {
+            const searchFn = function (search) {
+                this.searchTerm = search;
+                this.fetchPage();
+            };
+            return _.debounce(searchFn.bind(context), 500, {
+                leading: false,
+                trailing: true
+            });
         }
 
         buildPagination(paginatedResponse) {
@@ -32,6 +44,8 @@ export default (app) => {
                 }
             );
         }
+
+
     }
 
     app.service('paginationService', PaginationService);

--- a/app-frontend/src/app/services/common/pagination.service.js
+++ b/app-frontend/src/app/services/common/pagination.service.js
@@ -1,0 +1,38 @@
+
+export default (app) => {
+    class PaginationService {
+        constructor($state) {
+            this.$state = $state;
+        }
+
+        buildPagination(paginatedResponse) {
+            return {
+                pageSize: paginatedResponse.pageSize,
+                show: paginatedResponse.count > paginatedResponse.pageSize,
+                count: paginatedResponse.count,
+                currentPage: paginatedResponse.page + 1,
+                startingItem: paginatedResponse.page * paginatedResponse.pageSize + 1,
+                endingItem: Math.min(
+                    (paginatedResponse.page + 1) * paginatedResponse.pageSize,
+                    paginatedResponse.count
+                ),
+                hasNext: paginatedResponse.hasNext,
+                hasPrevious: paginatedResponse.hasPrevious
+            };
+        }
+
+        updatePageParam(page) {
+            let replace = !this.$state.params.page;
+            this.$state.go(
+                this.$state.$current.name,
+                { page },
+                {
+                    location: replace ? 'replace' : true,
+                    notify: false
+                }
+            );
+        }
+    }
+
+    app.service('paginationService', PaginationService);
+};

--- a/app-frontend/src/app/services/services.module.js
+++ b/app-frontend/src/app/services/services.module.js
@@ -71,6 +71,7 @@ require('./common/decimal.filter')(shared);
 require('./common/modal.service')(shared);
 require('./common/url.filter')(shared);
 require('./common/orgStatus.filter')(shared);
+require('./common/pagination.service')(shared);
 
 
 export default shared;

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3158,3 +3158,7 @@ rf-reclassify-table {
     }
     margin-bottom: 0.5em;
 }
+
+.object-list-actions {
+  margin: 2em 2em 0;
+}

--- a/app-frontend/src/assets/styles/sass/pages/_admin.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_admin.scss
@@ -143,6 +143,7 @@
     .actions {
         width: 8em;
         text-align: right;
+        white-space: nowrap;
         .rf-dropdown-container {
             position: relative;
             display: inline-flex;

--- a/scripts/psql
+++ b/scripts/psql
@@ -16,7 +16,7 @@ then
     else
         docker-compose up -d postgres
         docker-compose \
-            exec postgres bash -c "psql -U rasterfoundry -d rasterfoundry"
+            exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" postgres bash -c "psql -U rasterfoundry -d rasterfoundry"
     fi
     exit
 fi

--- a/scripts/psql
+++ b/scripts/psql
@@ -16,7 +16,7 @@ then
     else
         docker-compose up -d postgres
         docker-compose \
-            exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" postgres bash -c "psql -U rasterfoundry -d rasterfoundry"
+            exec -e COLUMNS="$(tput cols)" -e LINES="$(tput lines)" postgres bash -c "psql -U rasterfoundry -d rasterfoundry"
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

This PR accomplishes a few things: adds a method for automatically handling angular dependency injection assignment, adds a pagination service to handle common pagination patterns, and adds pagination to all currently available object list pages.

#### Automatic Dependency Injection Assignment

Previously, each dependency declared in a class had to be assigned to a matching property on the class:

```js
class Controller {
    constructor($scope, $stateParams, modalService, organizationService) {
        'ngInject';
        this.$scope = $scope;
        this.$stateParams = $stateParams;
        this.modalService = modalService;
        this.organizationService = organizationService;
    }
}
```

With `autoInject`, we can now save ourselves a good bit of boilerplate:

```js
class Controller {
    constructor($scope, $stateParams, modalService, organizationService) {
        'ngInject';
        $scope.autoInject(this, arguments);
    }
}
```

The method is defined on the `$rootScope`, so it is available anywhere `$scope` is accessible (not services). After the call to `autoInject`, each argument is assigned to a matching property on the class (`this.$stateParams` or `this.organizationService`).

#### Pagination Service

As of this PR the pagination service has three methods for common pagination tasks: 

- `buildPagedSearch(context)` returns a debounced method that calls the passed context's `fetchPage` method
- `buildPagination(paginatedResponse)` returns an object with the commonly used pagination values
- `updatePageParam(page)` updates the current URL if necessary to include a `page` parameter

#### Paginated Object List Pages

The following pages have had the pagination refactored or added:

- [x] platform/projects
- [x] platform/rasters
- [x] platform/users
- [x] platform/organizations
- [x] organization/projects
- [x] organization/rasters
- [x] organization/users
- [x] organization/teams
- [x] team/projects
- [x] team/rasters
- [x] team/users
- [x] user/projects
- [x] user/rasters
~- [ ] user/organizations~
~- [ ] user/teams~

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`

## Testing Instructions

 For each of the pages:
  * make sure a list is rendered when there is an applicable item
  * make sure pagination controls only appear if the page size is exceeded (you may benefit from setting small page sizes in the requests so that you don't need to share a lot of things)
  * for the pages with more advanced capabilities (inviting users, etc), test these functions and make sure they still work

Closes #3612
