### PR TITLE
Only search for scenes if zoom level >= 8 when in RF repository

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.html
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.html
@@ -58,6 +58,11 @@
       Try again <i icon="icon-refresh"></i>
     </button>
   </div>
+  <div class="list-group-item" ng-if="$ctrl.helperText !== null">
+    <strong class="color-warning">
+      {{ $ctrl.helperText }}
+    </strong>
+  </div>
 </div>
 <div class="list-group" ng-if="$ctrl.fetchingScenes">
   <div class="list-group-item">
@@ -69,7 +74,7 @@
   </div>
 </div>
 <div class="list-group"
-     ng-if="$ctrl.sceneList && $ctrl.sceneList.length === 0 && !$ctrl.fetchingScenes && !$ctrl.fetchError">
+     ng-if="$ctrl.sceneList && $ctrl.sceneList.length === 0 && !$ctrl.fetchingScenes && !$ctrl.fetchError && $ctrl.helperText === null">
   <div class="list-group-item">
     <strong class="color-dark">
       No scenes match this filter

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 class ProjectsSceneBrowserController {
     constructor( // eslint-disable-line max-params
         $log, $state, $location, $scope, $timeout,
-        modalService, mapService, sceneService,
+        modalService, mapService,
         projectService, sessionStorage, planetLabsService, authService, featureFlags,
         RasterFoundryRepository, PlanetRepository, CMRRepository
     ) {
@@ -17,13 +17,14 @@ class ProjectsSceneBrowserController {
         this.$scope = $scope;
         this.$timeout = $timeout;
         this.modalService = modalService;
-        this.sceneService = sceneService;
         this.projectService = projectService;
         this.sessionStorage = sessionStorage;
         this.mapService = mapService;
         this.planetLabsService = planetLabsService;
         this.authService = authService;
 
+        this.helperText = null;
+        this.zoomHelpText = 'Zoom in to search for scenes';
         this.repositories = [
             {
                 label: 'Raster Foundry',
@@ -139,6 +140,10 @@ class ProjectsSceneBrowserController {
                     mapWrapper.map.getZoom()
                 );
             });
+            if (browseMap.zoom < 8) {
+                this.helperText = this.zoomHelpText;
+                this.sceneList = [];
+            }
         });
     }
 
@@ -154,20 +159,22 @@ class ProjectsSceneBrowserController {
         this.currentRepository = repository;
 
         this.sceneList = [];
-        if (this.bboxCoords || this.queryParams && this.queryParams.bbox) {
-            this.fetchNextScenesForBbox = this.bboxFetchFactory(
-                this.bboxCoords || this.queryParams.bbox
-            );
-            this.fetchNextScenes();
-        } else {
-            this.getMap().then((mapWrapper) => {
+        this.getMap().then((mapWrapper) => {
+            if (this.bboxCoords || this.queryParams && this.queryParams.bbox &&
+                (getZoom() >= 8 || repository.label !== 'Raster Foundry')) {
+                this.helperText = null;
+                this.fetchNextScenesForBbox = this.bboxFetchFactory(
+                    this.bboxCoords || this.queryParams.bbox
+                );
+                this.fetchNextScenes();
+            } else {
                 this.onViewChange(
                     mapWrapper.map.getBounds(),
                     mapWrapper.map.getCenter(),
                     mapWrapper.map.getZoom()
                 );
-            });
-        }
+            };
+        });
     }
 
     onViewChange(newBounds, newCenter, zoom) {
@@ -178,6 +185,13 @@ class ProjectsSceneBrowserController {
         this.$parent.center = newCenter;
 
         this.setBboxParam(this.bboxCoords);
+        if (this.currentRepository.label === 'Raster Foundry' && zoom < 8) {
+            this.sceneList = [];
+            this.sceneCount = 0;
+            this.helperText = this.zoomHelpText;
+            return;
+        }
+        this.helperText = null;
         this.onBboxChange();
     }
 

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -161,19 +161,24 @@ class ProjectsSceneBrowserController {
         this.sceneList = [];
         this.getMap().then((mapWrapper) => {
             if (this.bboxCoords || this.queryParams && this.queryParams.bbox &&
-                (getZoom() >= 8 || repository.label !== 'Raster Foundry')) {
+                (mapWrapper.map.getZoom() >= 8 || repository.label !== 'Raster Foundry')) {
                 this.helperText = null;
                 this.fetchNextScenesForBbox = this.bboxFetchFactory(
                     this.bboxCoords || this.queryParams.bbox
                 );
                 this.fetchNextScenes();
             } else {
-                this.onViewChange(
-                    mapWrapper.map.getBounds(),
-                    mapWrapper.map.getCenter(),
-                    mapWrapper.map.getZoom()
-                );
-            };
+                if (mapWrapper.map.getZoom() >= 8 || repository.label !== 'Raster Foundry') {
+                    this.helperText = null;
+                    this.onViewChange(
+                        mapWrapper.map.getBounds(),
+                        mapWrapper.map.getCenter(),
+                        mapWrapper.map.getZoom()
+                    );
+                } else {
+                    this.helperText = this.zoomHelpText;
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## Overview

This PR prevents searching for scenes in the Raster Foundry repository unless the zoom level
is higher than 8. It's supposed to help us not have so many timeouts in the scene query and
also to keep those really long queries out of the postgres queue.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`

### Notes

~Is it the `Raster Foundry` repo for Radiant also? It seems like maybe it should be, I'm not sure whether it is or not.~ Confirmed, it is.

~ I still need to make some kind of changes in `sceneFilterPane.module.js` because state and scene requests live everywhere but it's the end of the day and no one is reviewing this tonight anyway so :man_shrugging: I'll hit it first thing Monday. ~

## Testing Instructions

 * Load the app
 * Pan around, zoom in and out, and note that you don't fire any requests until zoom is at least 8

Closes #3557 