### PR TITLE
Upgrade Nginx to latest stable release

### DIFF
--- a/docker-compose.swagger.yml
+++ b/docker-compose.swagger.yml
@@ -6,7 +6,7 @@ services:
       - "8888:8080"
 
   swagger-ui:
-    image: nginx:1.10
+    image: nginx:1.14
     volumes:
       - ./docs/swagger/:/usr/share/nginx/html:ro
     ports:

--- a/nginx/Dockerfile.api
+++ b/nginx/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM nginx:1.10
+FROM nginx:1.14
 
 RUN mkdir -p /etc/nginx/includes
 

--- a/nginx/Dockerfile.tiler
+++ b/nginx/Dockerfile.tiler
@@ -1,4 +1,4 @@
-FROM nginx:1.10
+FROM nginx:1.14
 
 RUN mkdir -p /etc/nginx/includes
 

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -1,5 +1,3 @@
-limit_req_zone $binary_remote_addr zone=download:10m rate=1r/s;
-
 server {
     listen 80 default_server;
     server_name app.staging.rasterfoundry.com app.rasterfoundry.com;
@@ -37,7 +35,7 @@ server {
     }
 
     location ~* ^\/api\/exports\/.*\/files\/.* {
-        limit_req zone=download burst=5 nodelay;
+        limit_req zone=download_req;
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -1,5 +1,7 @@
 user nginx;
 worker_processes 1;
+
+error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;
 
 events {
@@ -18,8 +20,6 @@ http {
 
     access_log /var/log/nginx/access.log timed_combined;
 
-    sendfile on;
-
     keepalive_timeout 65;
 
     server_tokens off;
@@ -28,17 +28,16 @@ http {
     gzip_types application/javascript text/css application/json;
     gzip_disable "msie6";
 
-    set_real_ip_from 10.0.0.0/20;
-    set_real_ip_from 10.0.16.0/20;
-    set_real_ip_from 10.0.160.0/20;
-    set_real_ip_from 10.0.176.0/20;
-
+    set_real_ip_from 10.0.0.0/8;
     real_ip_header X-Forwarded-For;
 
     map $http_x_forwarded_proto $policy {
         default "";
         https   "default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https: wss://nexus-websocket-a.intercom.io wss://nexus-websocket-b.intercom.io";
     }
+
+    limit_req_zone $binary_remote_addr zone=download_req:10m rate=1r/s;
+    limit_req_status 429;
 
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
## Overview

In addition to upgrading Nginx:

- Add an explicit `error_log` directive
- Revert `sendfile` to its default (`off`)
- Simplify `set_real_ip_from` configuration
- Centralize `limit_req*` configuration
- Update rate limit status code to 429 (default is 503)

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

First, run `bootstrap` to ensure that the most up-to-date container images are built.

Then, use `server` to ensure that the development environment via Nginx is still operational. For the API that's http://localhost:9100/. The Nginx fronted tile service will be used automatically (just open an ingested project).