### PR TITLE
Fix scene download permission bug

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -179,8 +179,8 @@ object Dao {
 
     // Filter to validate access to a specific object
     def authorize[M >: Model](user: User, objectType: ObjectType, objectId: UUID, actionType: ActionType)(implicit filterable: Filterable[M, Option[Fragment]]): QueryBuilder[Model] = {
-      val scenePublicF: Fragment = objectType match {
-        case ObjectType.Scene =>
+      val scenePublicF: Fragment = (objectType, actionType) match {
+        case (ObjectType.Scene, ActionType.View) | (ObjectType.Scene, ActionType.Download) =>
           fr"""
           -- Match if scene is Public
           visibility = 'PUBLIC' OR"""

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -179,8 +179,15 @@ object Dao {
 
     // Filter to validate access to a specific object
     def authorize[M >: Model](user: User, objectType: ObjectType, objectId: UUID, actionType: ActionType)(implicit filterable: Filterable[M, Option[Fragment]]): QueryBuilder[Model] = {
+      val scenePublicF: Fragment = objectType match {
+        case ObjectType.Scene =>
+          fr"""
+          -- Match if scene is Public
+          visibility = 'PUBLIC' OR"""
+        case _ => fr""
+      }
       this.copy(filters = filters ++ filterable.toFilters(Some(
-        fr"""(
+        fr"(" ++ scenePublicF ++ fr"""
           -- Match if the user owns the object
           owner = ${user.id} OR
           -- Match if the user is a super user

--- a/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
@@ -74,7 +74,7 @@
           <span class="badge"><i class="icon-download"></i></span>
         </a>
         <div class="list-group-overflow">
-          <a ng-attr-href="{{download}}" download>{{download}}</a>
+          <a ng-attr-href="{{download}}" download>{{download | shortenUrl}}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Overview

This PR
 - fixes the scene download permission bug so that `PUBLIC` scenes are download-able without further permissions
 - shortens the metadata download URL in scene download modal

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Download a public scene and see if it works
 * Make sure places other than scenes using `authorize` in `Dao` work as they used to

Closes #3650 
