### PR TITLE
Simplify and fix conditional logic in onRepositoryChange

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -160,24 +160,21 @@ class ProjectsSceneBrowserController {
 
         this.sceneList = [];
         this.getMap().then((mapWrapper) => {
-            if (this.bboxCoords || this.queryParams && this.queryParams.bbox &&
-                (mapWrapper.map.getZoom() >= 8 || repository.label !== 'Raster Foundry')) {
+            if (mapWrapper.map.getZoom() < 8 && repository.label === 'Raster Foundry') {
+                this.helperText = this.zoomHelpText;
+            } else if (this.bboxCoords || this.queryParams && this.queryParams.bbox) {
                 this.helperText = null;
                 this.fetchNextScenesForBbox = this.bboxFetchFactory(
                     this.bboxCoords || this.queryParams.bbox
                 );
                 this.fetchNextScenes();
             } else {
-                if (mapWrapper.map.getZoom() >= 8 || repository.label !== 'Raster Foundry') {
-                    this.helperText = null;
-                    this.onViewChange(
-                        mapWrapper.map.getBounds(),
-                        mapWrapper.map.getCenter(),
-                        mapWrapper.map.getZoom()
-                    );
-                } else {
-                    this.helperText = this.zoomHelpText;
-                }
+                this.helperText = null;
+                this.onViewChange(
+                    mapWrapper.map.getBounds(),
+                    mapWrapper.map.getCenter(),
+                    mapWrapper.map.getZoom()
+                );
             }
         });
     }


### PR DESCRIPTION
## Overview

This PR simplifies and fixes conditional logic in `onRepositoryChange`. Previously, changing filter
parameters caused a scene request to occur regardless of zoom level. With this change/with the
check for zoom pulled out to before the previous checks and then the previous checks proceeding
as before, that doesn't happen anymore and everything else is fine.

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Zoom out to under level 8
 * Change filter parameters
 * Observe that you don't get a new scene query
 * Switch repositories away from RF
 * Switch back
 * Confirm that I didn't introduce a regression there, though I was quite likely to
