### PR TITLE
Add team search backend support

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -478,6 +478,9 @@ object Generators extends ArbitraryInstances {
       userCreate <- userCreateGen
     } yield { (userCreate, orgCreate, platform) }
 
+  private def searchQueryParametersGen: Gen[SearchQueryParameters] = for {
+    searchName <- possiblyEmptyStringGen
+  } yield { SearchQueryParameters(Some(searchName)) }
 
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary { credentialGen }
@@ -561,5 +564,7 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbUserVisibility : Arbitrary[UserVisibility] = Arbitrary { userVisibilityGen }
+
+    implicit def arbSearchQueryParameters : Arbitrary[SearchQueryParameters] = Arbitrary { searchQueryParametersGen }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -54,13 +54,21 @@ object PlatformDao extends Dao[Platform] {
       id IN (
         SELECT group_id
         FROM user_group_roles
-        WHERE group_type = 'TEAM' AND user_id = ${user.id})
+        WHERE
+          group_type = 'TEAM' AND
+          user_id = ${user.id} AND
+          is_active = true
+        )
     """
     val organizationsF: Fragment = fr"""
       organization_id IN (
         SELECT group_id
         FROM user_group_roles
-        WHERE group_type = 'ORGANIZATION' AND user_id = ${user.id})
+        WHERE
+          group_type = 'ORGANIZATION' AND
+          user_id = ${user.id} AND
+          is_active = true
+        )
     """
     TeamDao.query
       .filter(teamsF ++ fr"OR" ++ organizationsF)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.database
 
-import com.azavea.rf.datamodel.{Organization, Platform, User, GroupRole, GroupType, Scene, Project, UserGroupRole}
+import com.azavea.rf.datamodel._
 import com.azavea.rf.datamodel.Generators.Implicits._
 import com.azavea.rf.database.Implicits._
 import doobie._
@@ -272,6 +272,72 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
           assert(pU.email == dbUser.email, "; user email don't match")
           assert(pU.emailNotifications == dbUser.emailNotifications, "; user email notification don't match")
           true
+        }
+      }
+    }
+  }
+
+  test("list teams a platform user belongs to or can see due to organization memberships") {
+    check {
+      forAll{
+        (
+          orgCreate1: Organization.Create,
+          orgCreate2: Organization.Create,
+          orgCreate3: Organization.Create,
+          teamCreate1: Team.Create,
+          teamCreate2: Team.Create,
+          teamCreate3: Team.Create,
+          userCreate: User.Create,
+          teamNamePartial: SearchQueryParameters
+        ) => {
+          val creatTeamsIO =  for {
+            // Team# is in Org#
+            // User belongs to Org1 and Team1
+            orgUserInserted1 <- insertUserAndOrg(userCreate, orgCreate1, true)
+            (org1, user) = orgUserInserted1
+            teamInsert1 <- TeamDao.create(fixupTeam(
+              fixTeamName(teamCreate1, teamNamePartial), org1, user))
+            _ <- UserGroupRoleDao.create(
+              UserGroupRole.Create(
+                user.id,
+                GroupType.Team,
+                teamInsert1.id,
+                GroupRole.Member
+              ).toUserGroupRole(user, MembershipStatus.Approved))
+
+            // User belongs to Org2 but not Team2
+            org2 <- OrganizationDao.createOrganization(orgCreate2)
+            _ <- UserGroupRoleDao.create(
+              UserGroupRole.Create(
+                user.id,
+                GroupType.Organization,
+                org2.id,
+                GroupRole.Member
+              ).toUserGroupRole(user, MembershipStatus.Approved))
+            teamInsert2 <- TeamDao.create(fixupTeam(
+              fixTeamName(teamCreate2, teamNamePartial), org2, user))
+
+            // User belongs to Team3 but not Org3
+            org3 <- OrganizationDao.createOrganization(orgCreate3)
+            teamInsert3 <- TeamDao.create(fixupTeam(
+              fixTeamName(teamCreate3, teamNamePartial), org3, user))
+            _ <- UserGroupRoleDao.create(
+              UserGroupRole.Create(
+                user.id,
+                GroupType.Team,
+                teamInsert3.id,
+                GroupRole.Member
+              ).toUserGroupRole(user, MembershipStatus.Approved))
+
+          } yield (teamInsert1, teamInsert2, teamInsert3, user)
+
+          val filterTeamIO = creatTeamsIO flatMap {
+            case (teamInsert1: Team, teamInsert2: Team, teamInsert3: Team, user: User) =>
+              PlatformDao.listPlatformUserTeams(user, teamNamePartial)
+          }
+          val teams = filterTeamIO.transact(xa).unsafeRunSync
+
+          teams.length == 3
         }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -319,8 +319,7 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
 
             // User belongs to Team3 but not Org3
             org3 <- OrganizationDao.createOrganization(orgCreate3)
-            teamInsert3 <- TeamDao.create(fixupTeam(
-              fixTeamName(teamCreate3, teamNamePartial), org3, user))
+            teamInsert3 <- TeamDao.create(fixupTeam(teamCreate3, org3, user))
             _ <- UserGroupRoleDao.create(
               UserGroupRole.Create(
                 user.id,
@@ -337,7 +336,10 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
           }
           val teams = filterTeamIO.transact(xa).unsafeRunSync
 
-          teams.length == 3
+          teamNamePartial.search match {
+            case Some(teamName) if teamName.length != 0 => teams.length == 2
+            case _ => teams.length == 3
+          }
         }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -152,4 +152,9 @@ trait PropTestHelpers {
       case GroupType.Team => ugrCreate.copy(groupId = team.id, userId = user.id)
     }
   }
+
+  def fixTeamName(teamCreate: Team.Create, searchParams: SearchQueryParameters): Team.Create = searchParams.search match {
+    case Some(teamName) if teamName.length != 0 => teamCreate.copy(name = teamName)
+    case _ => teamCreate
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds backend support to search for teams a user directly belongs to and has access to due to organization memberships

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

### Notes

The frontend is in scope of the modal issue, mutually agreed with @alkamin 

## Testing Instructions

 * Create some teams in different organizations you are in
 * Add yourself to some of these created teams as members/admins
 * `GET api/platforms/<platform ID>/teams/search` should list at most 5 teams you have membership of and have access to due to organization memberships, ordered by team names in an ascending manner
 * `GET api/platforms/<platform ID>/teams/search?search=<team name>` should do something similar to above but filter by the team name parameter
 * CI

Closes #3510 
