### PR TITLE
Allow public project share page to be viewed by non-logged in users

### DIFF
--- a/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.module.js
+++ b/app-frontend/src/app/components/projects/projectPublishModal/projectPublishModal.module.js
@@ -118,7 +118,12 @@ class ProjectPublishModalController {
         policy.active = true;
 
         this.project.tileVisibility = policy.enum;
+        this.project.visibility = policy.enum;
+
         if (shouldUpdate) {
+            if (this.project.owner.id) {
+                this.project.owner = this.project.owner.id;
+            }
             this.projectService.updateProject(this.project).then((res) => {
                 this.$log.debug(res);
             }, (err) => {

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -428,7 +428,8 @@ function shareStates($stateProvider) {
             url: '/share/:projectid',
             templateUrl: shareTpl,
             controller: 'ShareController',
-            controllerAs: '$ctrl'
+            controllerAs: '$ctrl',
+            bypassAuth: true
         });
 }
 
@@ -439,7 +440,8 @@ function loginStates($stateProvider) {
             url: '/login',
             templateUrl: loginTpl,
             controller: 'LoginController',
-            controllerAs: '$ctrl'
+            controllerAs: '$ctrl',
+            bypassAuth: true
         });
 }
 

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -30,12 +30,14 @@ function runBlock(
             if (APP_CONFIG.error && toState.name !== 'error') {
                 e.preventDefault();
                 $state.go('error');
-            } else if (toState.name !== 'login' && !authService.verifyAuthCache()) {
+            } else if (toState.bypassAuth && !authService.verifyAuthCache()) {
+                rollbarWrapperService.init();
+            } else if (!toState.bypassAuth && !authService.verifyAuthCache()) {
                 e.preventDefault();
                 rollbarWrapperService.init();
                 intercomService.shutdown();
                 $state.go('login');
-            } else if (toState.name !== 'login' && toState.name !== 'callback') {
+            } else if (!toState.bypassAuth && toState.name !== 'callback') {
                 rollbarWrapperService.init(authService.getProfile());
                 intercomService.bootWithUser(authService.getProfile());
                 if (toState.redirectTo) {

--- a/app-frontend/src/app/pages/projects/edit/sharing/sharing.module.js
+++ b/app-frontend/src/app/pages/projects/edit/sharing/sharing.module.js
@@ -139,6 +139,7 @@ class SharingController {
             this.activePolicy = policy;
             this.activePolicy.active = true;
             this.project.tileVisibility = this.activePolicy.enum;
+            this.project.visibility = this.activePolicy.enum;
 
             if (shouldUpdate) {
                 this.projectService.updateProject(this.project).then((res) => {

--- a/app-frontend/src/app/pages/share/share.html
+++ b/app-frontend/src/app/pages/share/share.html
@@ -11,11 +11,6 @@
 
   <div class="navbar-section secondary">
     <nav>
-      <div ng-if="!$ctrl.authService.isLoggedIn || $ctrl.testNoAuth">
-        <button class="btn btn-primary">
-          Sign Up or Sign In
-        </button>
-      </div>
       <div ng-if="$ctrl.authService.isLoggedIn && !$ctrl.testNoAuth" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
         <a href uib-dropdown-toggle>
           <img ng-if="$ctrl.authService.getProfile().picture" class="avatar" ng-src="{{$ctrl.authService.getProfile().picture}}">


### PR DESCRIPTION
## Overview

This PR does a few things to enable viewing of the share page of a public project by non-authenticated users:

- adds a `bypassAuth` option to front-end routes that skips authentication
- adds a check for a visibility value of `PUBLIC` on the project GET endpoint that bypasses the authentication and authorization checks when the project is set as public
- sets both `tileVisibility` and `visibility` from the front-end when toggling public/private

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

 * Choose a project and set it to public
 * Open an incognito window of some sort and try navigating to the project share page, it should all load
 * Set the same project to private
 * Check that navigating to the share page kicks the user over to the login page

Closes #1518
