### PR TITLE
Fix organization setting button bug

### DIFF
--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -628,8 +628,7 @@ function adminStates($stateProvider) {
             },
             templateUrl: organizationSettingsTpl,
             controller: 'OrganizationSettingsController',
-            controllerAs: '$ctrl',
-            redirectTo: 'admin.organizations.settings.email'
+            controllerAs: '$ctrl'
         })
         .state('admin.platform', {
             title: 'Platform',

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -55,7 +55,7 @@
             <p>
               Hello, <strong>{{$ctrl.authService.getProfile().nickname}}</strong>
             </p>
-            <a class="btn btn-light" ui-sref="settings.profile">Manage account</a>
+            <a class="btn btn-light" ui-sref="user.settings.profile">Manage account</a>
           </section>
           <section ng-if="$ctrl.blogPosts && $ctrl.blogPosts.length">
             <h5>From our blog</h5>


### PR DESCRIPTION
## Overview

This PR:
- fixes org setting button bug.
- fixes manage account button bug on home page.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Go to home page and click on "Manage account" button, it should take you to your own account settings page
 * Login as an admin. Go to `admin/organization/<organization ID>/projects` and click on setting tab/icon/button, it should take you to organization privacy settings page.

Closes #3675 
Closes #3664 
