### PR TITLE
Allow saving of bands without wavelength in UI

### DIFF
--- a/app-frontend/src/app/services/scenes/datasource.service.js
+++ b/app-frontend/src/app/services/scenes/datasource.service.js
@@ -35,11 +35,13 @@ export default (app) => {
                                 {}, payload, {
                                     bands: _.map(
                                         payload.bands,
-                                        (band) => {
-                                            let bookends = band.wavelength.trim().split(',');
-                                            band.wavelength = _.map(
-                                                bookends, (x) => Number.parseInt(x, 10)
-                                            );
+                                        band => {
+                                            if (band.wavelength) {
+                                                let bookends = band.wavelength.trim().split(',');
+                                                band.wavelength = _.map(
+                                                    bookends, (x) => Number.parseInt(x, 10)
+                                                );
+                                            }
                                             return band;
                                         }
                                     )


### PR DESCRIPTION
## Overview

Logic in the DatasourceService assumed the presence of wavelengths but we don't want it to be required. The PR fixes that.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

Trivial, going to merge once CI completes

Closes #3681 
