### PR TITLE
Fix browse COG scene tile bug

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 class ProjectsSceneBrowserController {
     constructor( // eslint-disable-line max-params
         $log, $state, $location, $scope, $timeout,
-        modalService, mapService,
+        modalService, mapService, sceneService,
         projectService, sessionStorage, planetLabsService, authService, featureFlags,
         RasterFoundryRepository, PlanetRepository, CMRRepository
     ) {
@@ -22,6 +22,7 @@ class ProjectsSceneBrowserController {
         this.mapService = mapService;
         this.planetLabsService = planetLabsService;
         this.authService = authService;
+        this.sceneService = sceneService;
 
         this.helperText = null;
         this.zoomHelpText = 'Zoom in to search for scenes';


### PR DESCRIPTION
## Overview

This PR fixes browse COG scene tile bug due to the missing `sceneService`.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Make sure you have COG scenes before proceeding.
 * Go to a project and browse for COG scenes.
 * Check if COG tiles show up on map upon hovering or checking the checkbox.

Closes #3692 
