### PR TITLE
Fix sentinel 2 ingest definition generation to fix missing band

### DIFF
--- a/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
@@ -136,7 +136,7 @@ def get_band_index(band_name):
     name, num = band_name.split(' - ')
     if num.lower() == '8a':
         return 9
-    elif num.lower() > '8a':
+    elif int(num) > 8:
         return int(num) + 1
     else:
         return int(num)


### PR DESCRIPTION
## Overview

Our ingest definition generation code had a tiny bug that caused bands above index 10 to be mis-indexed

## Testing Instructions

This really can only get tested on staging

Closes #3702 
