### PR TITLE
Fix async exports for ingested scenes

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -271,6 +271,13 @@ lazy val batch = Project("batch", file("batch"))
       Dependencies.scalaCsv
     )
   })
+  .settings({
+    dependencyOverrides ++= Seq(
+      "com.fasterxml.jackson.core" % "jackson-core" % "2.9.2",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.2",
+      "com.fasterxml.jackson.module" % "jackson-module-scala_2.11" % "2.9.2"
+    )
+  })
   .settings(assemblyShadeRules in assembly := Seq(
       ShadeRule.rename("shapeless.**" -> "com.azavea.shaded.shapeless.@1").inAll,
       ShadeRule.rename(

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -116,12 +116,12 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
             UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Invited)) <*
               Notify.sendGroupNotification(
                 platformId, groupId, groupType, actingUser.id, subjectId, MessageType.GroupInvitation
-              )
+              ).attempt
           case (None, false, _) => {
             UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Requested)) <*
               Notify.sendGroupNotification(
                 platformId, groupId, groupType, subjectId, subjectId, MessageType.GroupRequest
-              )
+              ).attempt
           }
           case (Some(_), _, _) => existingRoleO.get.pure[ConnectionIO]
         }

--- a/docs/style/scala.md
+++ b/docs/style/scala.md
@@ -209,6 +209,20 @@ sometimes, the id won't be present in the database anyway. For this reason, a sa
 return a `ConnectionIO[Foo]`, you should name your method `unsafeGetFooById` to make it
 clear to users that it can fail in an unhandled way.
 
+### What should I do with purely side-effecting IO?
+
+This question is about the following scenario:
+
+- you want to do something in the database (add a user to a group, for example)
+- afterward, you want to do some kind of side-effect (logging, sending an email...) that can
+  fail
+- you don't care about whether the side-effect fails for whether the initial action should fail
+
+In that case, you should, supposing you have `addUserToGroupIO <* sendEmailIO`, you should
+`.attempt` the second IO -- `attempt(effect: M[A]): M[Either[Throwable, A]]`. Using `.attempt`
+will protect the first effect from failures in the second effect. `.attempt` is available on
+`ConnectionIO`s in `doobie` and on `IO`s in `cats.effect`.
+
 Migrations
 ---------
 


### PR DESCRIPTION
## Overview

This PR makes async exports work for ingested scenes. There were two problems:

- spark couldn't initialize due to a version conflict with a transitive dependency
- email failure caused the `ConnectionIO` to fail, which rolled back anything that happened previously in the transaction, which meant we never got the status update (even though the export succeeded)

### Checklist

- [x] Styleguide updated, if necessary
- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I'm adding a separate issue for COG exports, since they're more complicated than fits into the point on
this card.

#### Transactional proof

To prove the transactional nature of `ConnectionIO`s, you can:

- create a `Platform`
- create a `ConnectionIO` to add that platform (call it `platInsertIO`)
- `(platInsertIO flatMap { _ => sql"select * from users".query[Int].unique }).transact(xa).unsafeRunSync`
- verify that the platform wasn't inserted

#### `IO.attempt`

To get around failure of email notifications failing exports, I lifted the attempt to send notifications into
a `ConnectionIO` and `.attempt`-ed it. `.attempt` is `M[A] => M[Either[Throwable, A]]`, so it always
"succeeds" in a monadic sense and gives you an `Either` back instead of short-circuiting chains of
monadic operations.

I'm also throwing this into the group invitation emails, because we don't want those to fail if emails
fail either, I think.

## Testing Instructions

 * Create an export for a project with an ingested (non-COG) scene
 * reassemble batch jar
 * from the batch container: `rf export <most recent export id`
 * it should succeed

Closes #3652 
