### PR TITLE
Only transform band wavelength if it's a string

### DIFF
--- a/app-frontend/src/app/services/scenes/datasource.service.js
+++ b/app-frontend/src/app/services/scenes/datasource.service.js
@@ -36,7 +36,7 @@ export default (app) => {
                                     bands: _.map(
                                         payload.bands,
                                         band => {
-                                            if (band.wavelength) {
+                                            if (_.isString(band.wavelength)) {
                                                 let bookends = band.wavelength.trim().split(',');
                                                 band.wavelength = _.map(
                                                     bookends, (x) => Number.parseInt(x, 10)


### PR DESCRIPTION
## Overview

This PR makes it so that saving new color composites works for datasources.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Edit a datasource
 * Add a color composite
 * Save it
 * :sunglasses:
 * Add a band
 * Save the datasource
 * :sunglasses:
 * Reload the page to prove to yourself that 204s are not a lie

Closes #3694 
