### PR TITLE
Allow importing GeoJSON annotation with blank properties

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
@@ -39,7 +39,7 @@
       </div>
     </div>
   </div>
-  <div class="list-group" ng-if="$ctrl.dataProperties.length">
+  <div class="list-group" ng-if="$ctrl.uploadData">
     <div class="list-group-item">
       <div>
         <span title="Machine made"><strong>Machine made</strong></span>
@@ -77,7 +77,9 @@
       <span title="Default Label"><strong>Default Label</strong></span>
       <div class="list-group-right">
         <input type="text" class="form-control "
-               placeholder="No Default" ng-model="$ctrl.defaultKeys['label']">
+               placeholder="No Default"
+               ng-model="$ctrl.defaultKeys['label']"
+               ng-init="$ctrl.defaultKeys['label'] = 'Unlabeled'">
       </div>
     </div>
     <div class="list-group-item">
@@ -108,7 +110,9 @@
       <span title="Default Label"><strong>Default Description</strong></span>
       <div class="list-group-right">
         <input type="textarea" class="form-control "
-               placeholder="No Description" ng-model="$ctrl.defaultKeys['description']">
+               placeholder="No Description"
+               ng-model="$ctrl.defaultKeys['description']"
+               ng-init="$ctrl.defaultKeys['description'] = 'No Description'">
       </div>
     </div>
     <div class="list-group-item" ng-if="$ctrl.isMachineData">


### PR DESCRIPTION
## Overview

This PR allows importing GeoJSON annotation with blank properties.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

<img width="1341" alt="screen shot 2018-07-13 at 12 01 55 pm" src="https://user-images.githubusercontent.com/16109558/42701449-9a5669c8-8694-11e8-8d51-77e7f40d57d1.png">

## Testing Instructions

 * Go to project annotation page
 * Upload a GeoJSON file with empty properties
 * Make sure you see property selection fields afterwards
 * Select default values and make sure the import afterwards works

Closes #3588 
