### PR TITLE
Fix annotation shapefile export

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -80,6 +80,7 @@ lazy val apiSettings = commonSettings ++ Seq(
   assemblyMergeStrategy in assembly := {
     case "reference.conf" => MergeStrategy.concat
     case "application.conf" => MergeStrategy.concat
+    case n if n.startsWith("META-INF/services") => MergeStrategy.concat
     case n if n.endsWith(".SF") || n.endsWith(".RSA") || n.endsWith(".DSA") => MergeStrategy.discard
     case "META-INF/MANIFEST.MF" => MergeStrategy.discard
     case PathList("META-INF", "aop.xml") => aopMerge

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -347,8 +347,10 @@ object AnnotationShapefileService extends LazyLogging {
           featureStore.addFeatures(featureCollection)
           transaction.commit()
         } catch {
-          case default: Throwable =>
+          case default: Throwable => {
             transaction.rollback()
+            throw default
+          }
         } finally {
           transaction.close()
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,11 +73,16 @@ services:
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/
-    entrypoint: "java"
+    entrypoint: ./sbt
     command:
-      - "-Xmx768m"
-      - "-jar"
-      - "/opt/raster-foundry/app-backend/api/target/scala-2.11/rf-server.jar"
+      - "api/run"
+      - "-Dcom.sun.management.jmxremote.rmi.port=9010"
+      - "-Dcom.sun.management.jmxremote=true"
+      - "-Dcom.sun.management.jmxremote.port=9010"
+      - "-Dcom.sun.management.jmxremote.ssl=false"
+      - "-Dcom.sun.management.jmxremote.authenticate=false"
+      - "-Dcom.sun.management.jmxremote.local.only=false"
+      - "-Djava.rmi.server.hostname=localhost"
 
   batch:
     image: raster-foundry-batch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,16 +73,11 @@ services:
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/
-    entrypoint: ./sbt
+    entrypoint: "java"
     command:
-      - "api/run"
-      - "-Dcom.sun.management.jmxremote.rmi.port=9010"
-      - "-Dcom.sun.management.jmxremote=true"
-      - "-Dcom.sun.management.jmxremote.port=9010"
-      - "-Dcom.sun.management.jmxremote.ssl=false"
-      - "-Dcom.sun.management.jmxremote.authenticate=false"
-      - "-Dcom.sun.management.jmxremote.local.only=false"
-      - "-Djava.rmi.server.hostname=localhost"
+      - "-Xmx768m"
+      - "-jar"
+      - "/opt/raster-foundry/app-backend/api/target/scala-2.11/rf-server.jar"
 
   batch:
     image: raster-foundry-batch


### PR DESCRIPTION
## Overview

This PR changes our merge strategy for the API project so that it will keep necessary files
from `META-INF/services` from geotools.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * rebase out the "Stop pretending to be in prod" commit
 * `assembly` from the api subproject in your sbt shell
 * `./scripts/server --quiet`
 * create some annotations and try to export a shapefile

Closes #3666 
