### PR TITLE
[wip] Log more export info to find the error

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -42,8 +42,11 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
   def run: Unit = {
     val exportDefinitionWrite = for {
       user <- UserDao.unsafeGetUserById(systemUser)
+      _ <- logger.info(s"Obtained user ${user.id}")
       export <- ExportDao.query.filter(exportId).select
+      _ <- logger.info(s"Obtained export ${export.id}")
       exportDef <- ExportDao.getExportDefinition(export, user)
+      _ <- logger.info(s"Obtained export definition for ${export.id}")
       x <- {
         writeExportDefToS3(exportDef, bucket, key)
         val updatedExport = export.copy(

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -42,11 +42,8 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
   def run: Unit = {
     val exportDefinitionWrite = for {
       user <- UserDao.unsafeGetUserById(systemUser)
-      _ <- logger.info(s"Obtained user ${user.id}")
       export <- ExportDao.query.filter(exportId).select
-      _ <- logger.info(s"Obtained export ${export.id}")
       exportDef <- ExportDao.getExportDefinition(export, user)
-      _ <- logger.info(s"Obtained export definition for ${export.id}")
       x <- {
         writeExportDefToS3(exportDef, bucket, key)
         val updatedExport = export.copy(

--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -223,9 +223,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
 
     OptionT(
       mergeTiles(
-        colorCorrectTiles(
-          renderForBbox(md, polygonBbox, zoom, None)
-        )
+        renderForBbox(md, polygonBbox, zoom, None)
       )
     )
   }
@@ -248,10 +246,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
     val md: Future[Seq[MosaicDefinition]] = mosaicDefinition(projectId, Option(polygonBbox))
     OptionT(
       mergeTiles(
-        // This seems to cause issues -- disabled
-        // colorCorrectTiles(
-          renderForBbox(md, Some(polygonBbox), zoom, Some(s"${zoom}-${col}-${row}"))
-        // )
+        renderForBbox(md, Some(polygonBbox), zoom, Some(s"${zoom}-${col}-${row}"))
       )
     )
   }
@@ -342,10 +337,6 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
       }
     )
 
-  }
-
-  def colorCorrectTiles(tiles: Future[Seq[MultibandTile]]): Future[Seq[MultibandTile]] = {
-    tiles.map(ts => WhiteBalance(ts.toList))
   }
 
   def mergeTiles(tiles: Future[Seq[MultibandTile]]): Future[Option[MultibandTile]] = {


### PR DESCRIPTION
## Overview

This PR holds extra logging for exports to find the difference between running locally and
in staging.

Locally, exports work fine. In staging, they instantly fail with

```
ERROR c.a.rf.batch.export.CreateExportDef - doobie.util.invariant$UnexpectedEnd$: ResultSet exhausted; more rows expected.```
```

It also contains a one-line fix for the checkerboard pattern in COG tiles because I was passing through.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

See azavea/raster-foundry-platform#406 for debugging help

## Testing Instructions

 * tbd
