### PR TITLE
[WIP] Add cache value size to CacheClient debug log message

### DIFF
--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -45,7 +45,7 @@ memcached {
   dynamicClientMode = false
   dynamicClientMode = ${?MEMCACHED_DYNAMIC_CLIENT_MODE}
 
-  timeout = 3000
+  timeout = 5000
   timeout = ${?MEMCACHED_TIMEOUT}
 
   threads = 16
@@ -57,7 +57,7 @@ memcached {
   keySize = 250
   keySize = ${?MEMCACHED_KEY_SIZE}
 
-  localCache.enabled = true
+  localCache.enabled = false
   localCache.enabled = ${?MEMCACHED_LOCAL_CACHE_ENABLED}
 
   localCache.size = 20

--- a/app-backend/common/src/main/scala/cache/CacheClient.scala
+++ b/app-backend/common/src/main/scala/cache/CacheClient.scala
@@ -3,18 +3,17 @@ package com.azavea.rf.common.cache
 
 import com.azavea.rf.common.{Config, RfStackTrace, RollbarNotifier}
 import java.util.concurrent.Executors
-
 import net.spy.memcached._
 
 import scala.concurrent._
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+
 import cats.data._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.typesafe.scalalogging.LazyLogging
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
-import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator
 
 import scala.util.{Failure, Success}
 import scala.annotation.tailrec
@@ -64,10 +63,7 @@ class CacheClient(client: => MemcachedClient) extends LazyLogging with RollbarNo
 
   def setValue[T](key: String, value: T, ttlSeconds: Int = 0): Unit =
     withAbbreviatedKey(key) { key =>
-      if (logger.underlying.isDebugEnabled()) {
-        val size = ObjectSizeCalculator.getObjectSize(value)
-        logger.debug(s"Setting Key: ${key} of size ${size} with TTL ${ttlSeconds}")
-      }
+      logger.debug(s"Setting Key: ${key} with TTL ${ttlSeconds}")
       val f = Future {
         client.set(key, ttlSeconds, value)
       }

--- a/app-backend/common/src/main/scala/cache/CacheClient.scala
+++ b/app-backend/common/src/main/scala/cache/CacheClient.scala
@@ -3,17 +3,18 @@ package com.azavea.rf.common.cache
 
 import com.azavea.rf.common.{Config, RfStackTrace, RollbarNotifier}
 import java.util.concurrent.Executors
+
 import net.spy.memcached._
 
 import scala.concurrent._
 import scala.concurrent.duration._
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
-
 import cats.data._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.typesafe.scalalogging.LazyLogging
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
+import jdk.nashorn.internal.ir.debug.ObjectSizeCalculator
 
 import scala.util.{Failure, Success}
 import scala.annotation.tailrec
@@ -63,7 +64,10 @@ class CacheClient(client: => MemcachedClient) extends LazyLogging with RollbarNo
 
   def setValue[T](key: String, value: T, ttlSeconds: Int = 0): Unit =
     withAbbreviatedKey(key) { key =>
-      logger.debug(s"Setting Key: ${key} with TTL ${ttlSeconds}")
+      if (logger.underlying.isDebugEnabled()) {
+        val size = ObjectSizeCalculator.getObjectSize(value)
+        logger.debug(s"Setting Key: ${key} of size ${size} with TTL ${ttlSeconds}")
+      }
       val f = Future {
         client.set(key, ttlSeconds, value)
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,8 @@ services:
       postgres:
         condition: service_healthy
     env_file: .env
+    environment:
+      - RF_LOG_LEVEL=INFO
     ports:
       - "9000:9000"
       - "9010:9010"
@@ -113,6 +115,8 @@ services:
     external_links:
       - statsd
     env_file: .env
+    environment:
+      - RF_LOG_LEVEL=INFO
     ports:
       - "9900:9900"
       - "9020:9020"


### PR DESCRIPTION
## Overview

When writing keys to the cache with `CacheClient`, if the debug log level is set, add the object size to the log message.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~


### Notes

I don't actually think this will work because it claims to be HotSpot JVM specific. Haven't been able to test locally (but it compiles) because of https://github.com/raster-foundry/raster-foundry/pull/3725.

## Testing Instructions

TBD