### PR TITLE
Fix Match Error in Project Mosaics

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
@@ -77,11 +77,12 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
 
     val filters = List(
       polygonOption.map(polygon => fr"ST_Intersects(scenes.tile_footprint, ${polygon})"),
-      Some(fr"scenes_to_projects.project_id = ${projectId}")
+      Some(fr"scenes_to_projects.project_id = ${projectId}"),
+      Some(fr"scenes.ingest_status = 'INGESTED'")
     )
     val select = fr"""
     SELECT
-      scene_id, project_id,accepted, scene_order, mosaic_definition, scene_type, ingest_location
+      scene_id, project_id, accepted, scene_order, mosaic_definition, scene_type, ingest_location
     FROM
       scenes_to_projects
     LEFT JOIN

--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -287,10 +287,10 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
         }.toSet
 
         val tiles = mosaic.map {
-          case MosaicDefinition(sceneId, colorCorrectParams, sceneType, Some(ingestLocation)) => {
-            val tile = sceneType match {
-              case (Some(SceneType.COG)) => fetchCogTile(bbox, zoom, colorCorrect, sceneId, colorCorrectParams, ingestLocation)
-              case _ => {
+          case MosaicDefinition(sceneId, colorCorrectParams, sceneType, maybeIngestLocation) => {
+            val tile = (maybeIngestLocation, sceneType) match {
+              case (Some(ingestLocation), Some(SceneType.COG)) => fetchCogTile(bbox, zoom, colorCorrect, sceneId, colorCorrectParams, ingestLocation)
+              case (Some(ingestLocation), _) => {
                 MultiBandMosaic
                   .fetchRenderedExtent(sceneId, zoom, bbox)
                   .flatMap { tile =>
@@ -303,6 +303,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
                     }
                   }
               }
+              case _ => OptionT.none[Future, MultibandTile]
             }
             cacheKey match {
               case Some(key) =>


### PR DESCRIPTION
## Overview

This fixes an error we saw after the deploy yesterday where the tile server continued to experience match errors on mosaic definitions. The matching strategy was not exhaustive and in some cases scenes that had no ingest location would cause errors in the tile server.

This fixes the problem in two ways:
 - Adds an additional filter in `SceneToProjectDao` query to filter out scenes that have not been ingested
 - Makes the match more exhaustive and less error prone by allowing ingest location to be `null`/`None`

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~


## Testing Instructions

 * On `develop` make the following SQL query to update a scene currently listed as ingested in a project (`rasterfoundry=# update scenes set ingest_location = NULL where id = 'a9453bed-67ae-47c3-8320-25b6112c95df'`
 * Attempt to load the project with that scene (http://localhost:9091/projects/edit/3bc4ca13-d63e-4d62-ba22-363f28144ed2/scenes) - observe that there are errors
 * Restart the server with this branch and attempt to load the project again, notice no errors

Closes #3366 
