### PR TITLE
Allow setting role when adding a user to an organization or team

### DIFF
--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.html
@@ -16,7 +16,7 @@
         <input type="text" class="form-control admin-search" placeholder="Search for users"
                ng-model="$ctrl.search" ng-disabled="$ctrl.fetching && !$ctrl.search.length">
         <p class="font-size-small"
-          ng-if="!$ctrl.searchString"
+          ng-if="!$ctrl.searchString && $ctrl.pagination"
         >
          Showing {{$ctrl.pagination.startingItem}} - {{$ctrl.pagination.endingItem}} of {{$ctrl.pagination.count}} users
         </p>
@@ -24,9 +24,10 @@
       <table class="admin-table admin-platform-user-table" ng-if="!$ctrl.fetching">
         <thead>
           <tr>
-            <td>Name</td>
-            <td>Email</td>
-            <td>Select</td>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Add as admin</th>
+            <th>Select</th>
           </tr>
         </thead>
         <tbody>
@@ -43,8 +44,12 @@
             <td class="emails" ng-class="{'color-light': !user.email}">
               {{user.email || 'None'}}
             </td>
+            <td>
+              <rf-toggle value="$ctrl.selected.has(user.id) && $ctrl.selected.get(user.id)"
+                         on-change="$ctrl.toggleUserSelect(user, true)"></rf-toggle>
+            </td>
             <td class="actions">
-              <rf-toggle value="$ctrl.selected.has(user.id)" on-change="$ctrl.toggleUserSelect(user)">
+              <rf-toggle value="$ctrl.selected.has(user.id)" on-change="$ctrl.toggleUserSelect(user, false)">
               </rf-toggle>
             </td>
           </tr>
@@ -71,7 +76,9 @@
     <div ng-if="!$ctrl.hasPermission">
       <p>
         {{$ctrl.permissionDeniedMsg}}
-        <a ng-href="mailto:{{$ctrl.adminEmail}}">{{$ctrl.subject}}</a>.
+        <a ng-href="mailto:{{$ctrl.adminEmail}}" ng-if="$ctrl.adminEmail">{{$ctrl.subject}}</a>
+        <span ng-if="!$ctrl.adminEmail">{{$ctrl.subject}}</span>
+        .
       </p>
     </div>
   </div>

--- a/app-frontend/src/app/services/auth/organization.service.js
+++ b/app-frontend/src/app/services/auth/organization.service.js
@@ -97,6 +97,13 @@ export default (app) => {
             }).$promise;
         }
 
+        addUserWithRole(platformId, organizationId, groupRole, userId) {
+            return this.PlatformOrganization.addUser(
+                { platformId, organizationId },
+                { userId, groupRole }
+            ).$promise;
+        }
+
         approveUserMembership(platformId, organizationId, userId, groupRole) {
             return this.PlatformOrganization.addUser({platformId, organizationId}, {
                 userId, groupRole


### PR DESCRIPTION
## Overview
Allow setting a role in the add user modals
Use search endpoint if the user is not a platform admin while adding users to an
organization
Remove example.com email since it isn't helpful

### Checklist

- ~Styleguide updated, if necessary
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/42970537-8ac0eb22-8b77-11e8-9188-c2e9c0dfddef.png)


### Notes


## Testing Instructions

* Log in as an organization admin
* Verify that you can search for users
* Verify that you can add users as admins

Closes https://github.com/raster-foundry/raster-foundry/issues/3737