### PR TITLE
Fix Export and Export Emails

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
@@ -98,7 +98,7 @@ case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60
     logger.info(s"Preparing to notify export owners of status: ${status}")
     val export = ExportDao.query.filter(fr"id = ${exportId}").select.transact(xa).unsafeRunSync
     logger.info(s"Retrieved export: ${export}")
-    if (export.owner == auth0Config.systemUser) {
+    if (export.owner === UUID.fromString(auth0Config.systemUser)) {
       logger.warn(s"Owner of export ${exportId} is a system user. Email is not sent.")
     } else {
       val platAndUserIO = for {

--- a/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
+++ b/app-backend/tile/src/main/scala/directives/TileAuthentication.scala
@@ -54,7 +54,7 @@ trait TileAuthentication extends Authentication
     onSuccess(
       ProjectDao.query
         .filter(id)
-        .filter(fr"visibility=${Visibility.Public.toString}::visibility")
+        .filter(fr"tile_visibility=${Visibility.Public.toString}::visibility")
         .selectOption.transact(xa).unsafeToFuture
     ).flatMap {
       case Some(_) => provide(true)

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -70,7 +70,7 @@ export default class NewExportController {
         // Export defaults
         this.exportOptions = {
             resolution: 9,
-            stitch: false,
+            stitch: true,
             crop: false,
             raw: false
         };

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -219,7 +219,7 @@ export default (app) => {
         export(project, settings = {}, options = {}) {
             const defaultOptions = {
                 resolution: 9,
-                stitch: false,
+                stitch: true,
                 crop: false
             };
 


### PR DESCRIPTION
## Overview

An `if` statement (still unclear why) was causing emails to not be sent when exports either succeeded or failed. This also caused the status update in the database to fail as well so that even successfully exported projects would not be downloadable because emails failed to send.

Two fixes are in this PR for that particular issue:
 - unecessary `if` statement is removed (system user never exports projects anyways)
 - export status is always updated prior to trying to send emails

One additional change in this PR is to update the frontend to always use "stitched" exports, this is more user-friendly and should be the default in most cases.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

 * Start server and attempt to export data
 * Build batch jar + container
 * Run export in batch container `rf export <export-id>`
 * Include any setup required, such as bundling scripts, restarting services, etc.
 * Include test case, and expected output

Supercedes https://github.com/raster-foundry/raster-foundry/pull/3721