### PR TITLE
Fix broken links and buttons on home page and datasource create modal

### DIFF
--- a/app-frontend/src/app/components/datasources/datasourceCreateModal/datasourceCreateModal.html
+++ b/app-frontend/src/app/components/datasources/datasourceCreateModal/datasourceCreateModal.html
@@ -39,21 +39,9 @@
       <p>You have successfully created a new datasource. The next time you import imagery, you
       will be able to assign it to this datasource.
       </p>
-      <p>Now you can:</p>
-      <ul>
-        <li>
-          <a ui-sref="imports.datasources.detail.colorComposites({
-            datasourceid: $ctrl.datasource.id
-          })"
-            ng-click="$ctrl.dismiss()">Edit your datasource's color composites</a>
-        </li>
-        <li>
-          <a ui-sref="imports.datasources.detail({
-            datasourceid: $ctrl.datasource.id
-            })"
-            ng-click="$ctrl.dismiss()">Import imagery from this datasource</a>
-        </li>
-      </ul>
+      <p>Now you may <a ui-sref="imports.datasources.detail({
+        datasourceid: $ctrl.datasource.id
+      })">edit your datasource's bands and color composites</a>.</p>
     </div>
   </div>
   <!-- Footer -->

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -22,7 +22,7 @@ class HomeController {
         });
     }
 
-    openToolCreateModal() {
+    openTemplateCreateModal() {
         this.modalService.open({
             component: 'rfTemplateCreateModal'
         });

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -36,7 +36,7 @@
               <p class="pb-25">
                 Leverage {{$ctrl.BUILDCONFIG.APP_NAME}}'s powerful API to create your own imagery applications.
               </p>
-              <a class="btn btn-default" ui-sref="settings.tokens.api">Manage API Tokens</a>
+              <a class="btn btn-default" ui-sref="user.settings.api-tokens">Manage API Tokens</a>
               <div class="hide-sm"></div>
               <p>
                 <a ng-href="{{$ctrl.HELPCONFIG.DEVELOPER_RESOURCES}}" target="_blank">Developer Resources</a>

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.html
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.html
@@ -8,7 +8,18 @@
         <rf-toggle value="$ctrl.isPublic" on-change="$ctrl.changeVisibility()" ng-if="$ctrl.isOwner">
           <label>Share publicly</label>
         </rf-toggle>
-        <button class="btn btn-primary" ng-click="$ctrl.openImportModal()">Start an Import</button>
+        <button
+          class="btn btn-primary"
+          ng-click="$ctrl.openImportModal()"
+          ng-disabled="!$ctrl.hasBands">Start an Import</button>
+        <i
+          class="icon-info"
+          tooltips
+          tooltip-template="Band definitions are required before importing any scenes."
+          tooltip-size="small"
+          tooltip-class="rf-tooltip"
+          tooltip-side="right"
+          ng-if="!$ctrl.hasBands"></i>
       </div>
       <!-- Dashboard Header -->
       <div class="cta-row">

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
@@ -45,6 +45,7 @@ class DatasourceDetailController {
         this.datasourceService.get(this.datasourceId).then(
             datasourceResponse => {
                 this.datasource = datasourceResponse;
+                this.hasBands = !_.isEmpty(this.datasource.bands);
                 this.isPublic = this.isPublicDatasource();
                 let id = this.authService.getProfile().sub;
                 this.isOwner = id === this.datasource.owner;


### PR DESCRIPTION
## Overview

This PR fixes:
 - buttons on home page for creating templates and navigating to API token page
 - links in datasource creation modal to edit datasource bands and color composites
 - button on datasource detail page to check the existence of band definitions to avoid dead end scene import

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Home page -> click on `Create a new template` and `Manage API tokens` buttons, then check if they lead you to right places/modals
 * Datasource list page -> click on `New datasource`, then check if the link to datasource detail page at the end of modal process works
 * Datasource detail page -> scene import button should be disabled when there are no band definitions, in order to avoid dead end scene import

Closes #3697 
Closes #3731 
