### PR TITLE
Fix Indexing Duplicates

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -113,16 +113,14 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
     val keyPath: String = s"$tilePath/preview.jpg"
     val thumbnailUrl = s"${sentinel2Config.baseHttpPath}$keyPath"
 
-    if (!isUriExists(thumbnailUrl)) Nil
-    else
-      Thumbnail.Identified(
-        id = None,
-        thumbnailSize  = ThumbnailSize.Square,
-        widthPx        = 343,
-        heightPx       = 343,
-        sceneId        = sceneId,
-        url            = thumbnailUrl
-      ) :: Nil
+    Thumbnail.Identified(
+      id = None,
+      thumbnailSize  = ThumbnailSize.Square,
+      widthPx        = 343,
+      heightPx       = 343,
+      sceneId        = sceneId,
+      url            = thumbnailUrl
+    ) :: Nil
   }
 
   def getSentinel2Products(date: LocalDate): List[URI] = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -147,7 +147,6 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
     logger.info(s"Attempting to import ${scenePath}")
     val sceneId = UUID.randomUUID()
     val images = List(10f, 20f, 60f).map(createImages(sceneId, scenePath.some, _)).reduce(_ ++ _)
-    val thumbnails = createThumbnails(sceneId, scenePath)
     val sceneName = s"S2 ${scenePath}"
     logger.info(s"Starting scene creation: ${scenePath}- ${sceneName}")
     logger.info(s"Getting tile info for ${scenePath}")


### PR DESCRIPTION
## Overview

 - Checks the correct field when checking for duplicates
 - Switches to eager initial query to limit IO during indexing process

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

 * On `develop` run the following in the batch container (after assembling the batch jar):
`java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main import_landsat8 2018-07-21`
 * Run the SQL query and note the number: `SELECT count(*) from SCENES where acquisition_date = '2018-07-21`
 * Re-run the same import from `develop` and SQL query -- note the number increased
 * Switch to this branch, re-run the batch command and SQL query, note the number did not change

Closes #3749 
