### PR TITLE
Make manual date range update work for scene browse filter

### DIFF
--- a/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.controller.js
+++ b/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.controller.js
@@ -1,7 +1,10 @@
-/* globals _ */
+/* globals _, document */
 export default class DateRangePickerModalController {
-    constructor(moment, dateRangePickerConf) {
+    constructor($log, $scope, $timeout, moment, dateRangePickerConf) {
         'ngInject';
+        this.$log = $log;
+        this.$scope = $scope;
+        this.$timeout = $timeout;
         this.Moment = moment;
         this.dateRangePickerConf = dateRangePickerConf;
     }
@@ -16,6 +19,21 @@ export default class DateRangePickerModalController {
         this.ranges = this.resolve.config.ranges || [];
         this.minDay = this.resolve.config.minDay;
         this.maxDay = this.resolve.config.maxDay;
+
+        this.$timeout(() => {
+            const ele = angular.element(document.getElementsByClassName('input-container'));
+            const startInput = angular.element(ele[0].lastChild);
+            const endInput = angular.element(ele[1].lastChild);
+            this.setStartEndValues(startInput, endInput);
+            // this.bindInputChangeEvents(startInput, endInput);
+        }, 100);
+    }
+
+    setStartEndValues(startInput, endInput) {
+        let startReformat = this.Moment(startInput.val(), 'MMM DD, YYYY').format('MM/DD/YYYY');
+        startInput.val(startReformat);
+        let endReformat = this.Moment(endInput.val(), 'MMM DD, YYYY').format('MM/DD/YYYY');
+        endInput.val(endReformat);
     }
 
     isActivePreset(range, index) {

--- a/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.html
+++ b/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.html
@@ -2,9 +2,7 @@
   <div class="content datepicker-row">
     <date-range-picker
         api="$ctrl.pickerApi"
-        range="$ctrl._range"
-        min-day="$ctrl._getMinDay()"
-        max-day="$ctrl._getMaxDay()">
+        range="$ctrl._range">
       </date-range-picker>
       <div class="datepicker-ranges">
         <h5 class="text-center preset-header">Date Filter Presets</h5>

--- a/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.html
+++ b/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.html
@@ -2,18 +2,27 @@
   <div class="content datepicker-row">
     <date-range-picker
         api="$ctrl.pickerApi"
-        range="$ctrl._range">
-      </date-range-picker>
-      <div class="datepicker-ranges">
-        <h5 class="text-center preset-header">Date Filter Presets</h5>
-        <button class="btn btn-range"
-            ng-repeat="range in $ctrl.ranges"
-            ng-class="{'btn-primary': $ctrl.isActivePreset(range, $index), 'disabled': range.disabled}"
-            ng-click="$ctrl.onPresetSelect(range, $index)"
-        >{{range.name}}
-        </button>
-      </div>
+        range="$ctrl._range"
+        ng-click="$ctrl.onCalendarClick()">
+    </date-range-picker>
+    <div class="datepicker-ranges">
+      <h5 class="text-center preset-header">Date Filter Presets</h5>
+      <button
+        class="btn btn-range"
+        ng-repeat="range in $ctrl.ranges"
+        ng-class="{'btn-primary': $ctrl.isActivePreset(range, $index), 'disabled': range.disabled}"
+        ng-click="$ctrl.onPresetSelect(range, $index)">
+        {{range.name}}
+      </button>
     </div>
+  </div>
+  <div class="content color-danger" ng-if="!$ctrl.isRangeValid()">
+    Range is invalid.
+  </div>
+  <div
+    class="content color-danger"
+    ng-if="$ctrl.isInvalidStartFormat || $ctrl.isInvalidEndFormat">
+    Date format is invalid. Please use format MM-DD-YYYY.
   </div>
 </div>
 <div class="modal-footer">
@@ -21,8 +30,11 @@
           ng-click="$ctrl.cancel()">
     Cancel
   </button>
-  <button type="button" class="btn btn-primary"
-          ng-click="$ctrl.apply()">
+  <button
+    type="button"
+    class="btn btn-primary"
+    ng-click="$ctrl.apply()"
+    ng-disabled="!$ctrl.isRangeValid() || $ctrl.isInvalidStartFormat || $ctrl.isInvalidEndFormat)">
     Apply
   </button>
 </div>

--- a/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.html
+++ b/app-frontend/src/app/components/common/dateRangePickerModal/dateRangePickerModal.html
@@ -16,7 +16,7 @@
       </button>
     </div>
   </div>
-  <div class="content color-danger" ng-if="!$ctrl.isRangeValid()">
+  <div class="content color-danger" ng-if="!$ctrl.isRangeValid">
     Range is invalid.
   </div>
   <div
@@ -34,7 +34,7 @@
     type="button"
     class="btn btn-primary"
     ng-click="$ctrl.apply()"
-    ng-disabled="!$ctrl.isRangeValid() || $ctrl.isInvalidStartFormat || $ctrl.isInvalidEndFormat)">
+    ng-disabled="!$ctrl.isRangeValid || $ctrl.isInvalidStartFormat || $ctrl.isInvalidEndFormat">
     Apply
   </button>
 </div>

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3236,3 +3236,9 @@ rf-navbar-search {
   border-color: $gray-lightest;
   height: 3.8rem;
 }
+
+// components/common/dateRangePickerModal
+.format-tip {
+  margin-left: 6.5rem;
+  font-size: 80%;
+}


### PR DESCRIPTION
## Overview

This PR enables manual update on date range picker and makes sure calendar selection and preset date range selection are not affected. It enables displaying and editing dates in `MM/DD/YYYY` format.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

![jul-23-2018 13-18-21](https://user-images.githubusercontent.com/16109558/43092341-eaaf0586-8e7a-11e8-99ff-984d283b5792.gif)


### Notes

This PR tries to use jQuery as minimal as possible since the two date input boxes are brought in by a third party library not very accessible to us.

## Testing Instructions

 * Go to a project and browse scenes
 * Open up date range picker modal and use it
 * Make sure: updating date range manually behaves as you expect (invalid format and invalid range warnings should show up when necessary), and calendar selection plus preset date range selection still work

Closes https://github.com/azavea/raster-foundry-platform/issues/398
