### PR TITLE
Support sending notifications to user contact email

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -74,13 +74,7 @@ case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) ex
   def sendAoiNotificationEmail(project: Project, platform: Platform, user: User, sceneCount: Int) = {
     val email = new NotificationEmail
 
-    val userEmailAddress: String = (user.emailNotifications, user.personalInfo.emailNotifications) match {
-      case (true, true) | (false, true) => user.personalInfo.email
-      case (true, false) => user.email
-      case (false, false) => ""
-    }
-
-    (userEmailAddress, platform.publicSettings.emailAoiNotification) match {
+    (user.getEmail, platform.publicSettings.emailAoiNotification) match {
       case ("", true) => logger.warn(email.userEmailNotificationDisabledWarning(user.id))
       case ("", false) => logger.warn(
         email.userEmailNotificationDisabledWarning(user.id) ++ " " ++ email.platformNotSubscribedWarning(platform.id.toString()))

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -97,22 +97,6 @@ case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) ex
         }
       case (_, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
     }
-    // (user.emailNotifications, platform.publicSettings.emailAoiNotification) match {
-    //   case (true, true) =>
-    //     val (pub, pri) = (platform.publicSettings, platform.privateSettings)
-    //     (pub.emailSmtpHost, pub.emailSmtpPort, pub.emailSmtpEncryption, pub.emailUser, pri.emailPassword, user.email) match {
-    //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-    //         email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
-    //         val (subject, html, plain) = aoiEmailContent(project, platform, user, sceneCount)
-    //         email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, subject, html, plain).map((configuredEmail: Email) => configuredEmail.send)
-    //         logger.info(s"Notified project owner ${user.id} about AOI updates")
-    //       case _ => logger.warn(email.insufficientSettingsWarning(platform.id.toString(), user.id))
-    //     }
-    //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(user.id))
-    //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
-    //   case (false, false) => logger.warn(
-    //     email.userEmailNotificationDisabledWarning(user.id) ++ " " ++ email.platformNotSubscribedWarning(platform.id.toString()))
-    // }
   }
 
   def notifyProjectOwner(projId: UUID, sceneCount: Int) = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -73,10 +73,21 @@ case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) ex
 
   def sendAoiNotificationEmail(project: Project, platform: Platform, user: User, sceneCount: Int) = {
     val email = new NotificationEmail
-    (user.emailNotifications, platform.publicSettings.emailAoiNotification) match {
-      case (true, true) =>
+
+    val userEmailAddress: String = (user.emailNotifications, user.personalInfo.emailNotifications) match {
+      case (true, true) | (false, true) => user.personalInfo.email
+      case (true, false) => user.email
+      case (false, false) => ""
+    }
+
+    (userEmailAddress, platform.publicSettings.emailAoiNotification) match {
+      case ("", true) => logger.warn(email.userEmailNotificationDisabledWarning(user.id))
+      case ("", false) => logger.warn(
+        email.userEmailNotificationDisabledWarning(user.id) ++ " " ++ email.platformNotSubscribedWarning(platform.id.toString()))
+      case (userEmailAddress, true) =>
+        // send emails
         val (pub, pri) = (platform.publicSettings, platform.privateSettings)
-        (pub.emailSmtpHost, pub.emailSmtpPort, pub.emailSmtpEncryption, pub.emailUser, pri.emailPassword, user.email) match {
+        (pub.emailSmtpHost, pub.emailSmtpPort, pub.emailSmtpEncryption, pub.emailUser, pri.emailPassword, userEmailAddress) match {
           case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
             email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
             val (subject, html, plain) = aoiEmailContent(project, platform, user, sceneCount)
@@ -84,11 +95,24 @@ case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) ex
             logger.info(s"Notified project owner ${user.id} about AOI updates")
           case _ => logger.warn(email.insufficientSettingsWarning(platform.id.toString(), user.id))
         }
-      case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(user.id))
-      case (true, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
-      case (false, false) => logger.warn(
-        email.userEmailNotificationDisabledWarning(user.id) ++ " " ++ email.platformNotSubscribedWarning(platform.id.toString()))
+      case (_, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
     }
+    // (user.emailNotifications, platform.publicSettings.emailAoiNotification) match {
+    //   case (true, true) =>
+    //     val (pub, pri) = (platform.publicSettings, platform.privateSettings)
+    //     (pub.emailSmtpHost, pub.emailSmtpPort, pub.emailSmtpEncryption, pub.emailUser, pri.emailPassword, user.email) match {
+    //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
+    //         email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
+    //         val (subject, html, plain) = aoiEmailContent(project, platform, user, sceneCount)
+    //         email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, subject, html, plain).map((configuredEmail: Email) => configuredEmail.send)
+    //         logger.info(s"Notified project owner ${user.id} about AOI updates")
+    //       case _ => logger.warn(email.insufficientSettingsWarning(platform.id.toString(), user.id))
+    //     }
+    //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(user.id))
+    //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
+    //   case (false, false) => logger.warn(
+    //     email.userEmailNotificationDisabledWarning(user.id) ++ " " ++ email.platformNotSubscribedWarning(platform.id.toString()))
+    // }
   }
 
   def notifyProjectOwner(projId: UUID, sceneCount: Int) = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
@@ -99,23 +99,6 @@ case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60
         }
       case (_, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
     }
-
-    // (user.emailNotifications, platform.publicSettings.emailExportNotification) match {
-    //   case (true, true) =>
-    //     val (pub, pri) = (platform.publicSettings, platform.privateSettings)
-    //     (pub.emailSmtpHost, pub.emailSmtpPort, pub.emailSmtpEncryption, pub.emailUser, pri.emailPassword, user.email) match {
-    //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-    //          email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
-    //          val (subject, html, plain) = exportEmailContent(status, user, platform, name, id, exportType)
-    //          email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, subject, html, plain).map((configuredEmail: Email) => configuredEmail.send)
-    //          logger.info(s"Notified owner ${user.id} about export ${exportId}.")
-    //       case _ => logger.warn(email.insufficientSettingsWarning(platform.id.toString(), user.id))
-    //     }
-    //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(user.id))
-    //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(platform.id.toString()))
-    //   case (false, false) => logger.warn(
-    //     email.userEmailNotificationDisabledWarning(user.id) ++ " " ++ email.platformNotSubscribedWarning(platform.id.toString()))
-    // }
   }
 
   def notifyExportOwner(status: String): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
@@ -126,10 +126,20 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
   def sendIngestStatusEmailToConsumers(platformsWithConsumers: List[PlatformWithUsersSceneProjects], scene: Scene, ingestStatus: String) =
     platformsWithConsumers.map(pU => {
       val email = new NotificationEmail
-      (pU.emailNotifications, pU.pubSettings.emailIngestNotification) match {
-        case (true, true) =>
+
+      val userEmailAddress: String = (pU.emailNotifications, pU.personalInfo.emailNotifications) match {
+        case (true, true) | (false, true) => pU.personalInfo.email
+        case (true, false) => pU.email
+        case (false, false) => ""
+      }
+
+      (userEmailAddress, pU.pubSettings.emailIngestNotification) match {
+        case ("", true) => logger.warn(email.userEmailNotificationDisabledWarning(pU.uId))
+        case ("", false) => logger.warn(
+          email.userEmailNotificationDisabledWarning(pU.uId) ++ " " ++ email.platformNotSubscribedWarning(pU.platId.toString()))
+        case (userEmailAddress, true) =>
           (pU.pubSettings.emailSmtpHost, pU.pubSettings.emailSmtpPort, pU.pubSettings.emailSmtpEncryption,
-            pU.pubSettings.emailUser, pU.priSettings.emailPassword, pU.email) match {
+            pU.pubSettings.emailUser, pU.priSettings.emailPassword, userEmailAddress) match {
             case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
               email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
               val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForConsumers(pU, scene, ingestStatus)
@@ -137,19 +147,44 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
               logger.info(s"Notified project owner ${pU.uId}.")
             case _ => logger.warn(email.insufficientSettingsWarning(pU.platId.toString(), pU.uId))
           }
-        case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(pU.uId))
-        case (true, false) => logger.warn(email.platformNotSubscribedWarning(pU.platId.toString()))
-        case (false, false) => logger.warn(
-          email.userEmailNotificationDisabledWarning(pU.uId) ++ " " ++ email.platformNotSubscribedWarning(pU.platId.toString()))
+        case (_, false) => logger.warn(email.platformNotSubscribedWarning(pU.platId.toString()))
       }
+
+      // (pU.emailNotifications, pU.pubSettings.emailIngestNotification) match {
+      //   case (true, true) =>
+      //     (pU.pubSettings.emailSmtpHost, pU.pubSettings.emailSmtpPort, pU.pubSettings.emailSmtpEncryption,
+      //       pU.pubSettings.emailUser, pU.priSettings.emailPassword, pU.email) match {
+      //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
+      //         email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
+      //         val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForConsumers(pU, scene, ingestStatus)
+      //         email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, ingestEmailSubject, htmlBody, plainBody).map((configuredEmail: Email) => configuredEmail.send)
+      //         logger.info(s"Notified project owner ${pU.uId}.")
+      //       case _ => logger.warn(email.insufficientSettingsWarning(pU.platId.toString(), pU.uId))
+      //     }
+      //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(pU.uId))
+      //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(pU.platId.toString()))
+      //   case (false, false) => logger.warn(
+      //     email.userEmailNotificationDisabledWarning(pU.uId) ++ " " ++ email.platformNotSubscribedWarning(pU.platId.toString()))
+      // }
     })
 
   def sendIngestStatusEmailToOwner(pO: PlatformWithSceneOwner, scene: Scene, ingestStatus: String) = {
     val email = new NotificationEmail
-    (pO.emailNotifications, pO.pubSettings.emailIngestNotification) match {
-      case (true, true) =>
+
+    val userEmailAddress: String = (pO.emailNotifications, pO.personalInfo.emailNotifications) match {
+      case (true, true) | (false, true) => pO.personalInfo.email
+      case (true, false) => pO.email
+      case (false, false) => ""
+    }
+
+    (userEmailAddress, pO.pubSettings.emailIngestNotification) match {
+
+      case ("", true) => logger.warn(email.userEmailNotificationDisabledWarning(pO.uId))
+      case ("", false) => logger.warn(
+        email.userEmailNotificationDisabledWarning(pO.uId) ++ " " ++ email.platformNotSubscribedWarning(pO.platId.toString()))
+      case (userEmailAddress, true) =>
         (pO.pubSettings.emailSmtpHost, pO.pubSettings.emailSmtpPort, pO.pubSettings.emailSmtpEncryption,
-          pO.pubSettings.emailUser, pO.priSettings.emailPassword, pO.email) match {
+          pO.pubSettings.emailUser, pO.priSettings.emailPassword, userEmailAddress) match {
           case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
             email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
             val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForOwner(pO, scene, ingestStatus)
@@ -157,11 +192,24 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
             logger.info(s"Notified scene owner ${pO.uId}.")
           case _ => logger.warn(email.insufficientSettingsWarning(pO.platId.toString(), pO.uId))
         }
-      case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(pO.uId))
-      case (true, false) => logger.warn(email.platformNotSubscribedWarning(pO.platId.toString()))
-      case (false, false) => logger.warn(
-        email.userEmailNotificationDisabledWarning(pO.uId) ++ " " ++ email.platformNotSubscribedWarning(pO.platId.toString()))
+      case (_, false) => logger.warn(email.platformNotSubscribedWarning(pO.platId.toString()))
     }
+    // (pO.emailNotifications, pO.pubSettings.emailIngestNotification) match {
+    //   case (true, true) =>
+    //     (pO.pubSettings.emailSmtpHost, pO.pubSettings.emailSmtpPort, pO.pubSettings.emailSmtpEncryption,
+    //       pO.pubSettings.emailUser, pO.priSettings.emailPassword, pO.email) match {
+    //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
+    //         email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
+    //         val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForOwner(pO, scene, ingestStatus)
+    //         email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, ingestEmailSubject, htmlBody, plainBody).map((configuredEmail: Email) => configuredEmail.send)
+    //         logger.info(s"Notified scene owner ${pO.uId}.")
+    //       case _ => logger.warn(email.insufficientSettingsWarning(pO.platId.toString(), pO.uId))
+    //     }
+    //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(pO.uId))
+    //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(pO.platId.toString()))
+    //   case (false, false) => logger.warn(
+    //     email.userEmailNotificationDisabledWarning(pO.uId) ++ " " ++ email.platformNotSubscribedWarning(pO.platId.toString()))
+    // }
   }
   def notifyConsumers(scene: Scene, ingestStatus: String) = {
     logger.info("Notifying Consumers...")

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
@@ -127,13 +127,7 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
     platformsWithConsumers.map(pU => {
       val email = new NotificationEmail
 
-      val userEmailAddress: String = (pU.emailNotifications, pU.personalInfo.emailNotifications) match {
-        case (true, true) | (false, true) => pU.personalInfo.email
-        case (true, false) => pU.email
-        case (false, false) => ""
-      }
-
-      (userEmailAddress, pU.pubSettings.emailIngestNotification) match {
+      (pU.getUserEmail, pU.pubSettings.emailIngestNotification) match {
         case ("", true) => logger.warn(email.userEmailNotificationDisabledWarning(pU.uId))
         case ("", false) => logger.warn(
           email.userEmailNotificationDisabledWarning(pU.uId) ++ " " ++ email.platformNotSubscribedWarning(pU.platId.toString()))
@@ -154,14 +148,7 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
   def sendIngestStatusEmailToOwner(pO: PlatformWithSceneOwner, scene: Scene, ingestStatus: String) = {
     val email = new NotificationEmail
 
-    val userEmailAddress: String = (pO.emailNotifications, pO.personalInfo.emailNotifications) match {
-      case (true, true) | (false, true) => pO.personalInfo.email
-      case (true, false) => pO.email
-      case (false, false) => ""
-    }
-
-    (userEmailAddress, pO.pubSettings.emailIngestNotification) match {
-
+    (pO.getUserEmail, pO.pubSettings.emailIngestNotification) match {
       case ("", true) => logger.warn(email.userEmailNotificationDisabledWarning(pO.uId))
       case ("", false) => logger.warn(
         email.userEmailNotificationDisabledWarning(pO.uId) ++ " " ++ email.platformNotSubscribedWarning(pO.platId.toString()))

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
@@ -149,23 +149,6 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
           }
         case (_, false) => logger.warn(email.platformNotSubscribedWarning(pU.platId.toString()))
       }
-
-      // (pU.emailNotifications, pU.pubSettings.emailIngestNotification) match {
-      //   case (true, true) =>
-      //     (pU.pubSettings.emailSmtpHost, pU.pubSettings.emailSmtpPort, pU.pubSettings.emailSmtpEncryption,
-      //       pU.pubSettings.emailUser, pU.priSettings.emailPassword, pU.email) match {
-      //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-      //         email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
-      //         val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForConsumers(pU, scene, ingestStatus)
-      //         email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, ingestEmailSubject, htmlBody, plainBody).map((configuredEmail: Email) => configuredEmail.send)
-      //         logger.info(s"Notified project owner ${pU.uId}.")
-      //       case _ => logger.warn(email.insufficientSettingsWarning(pU.platId.toString(), pU.uId))
-      //     }
-      //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(pU.uId))
-      //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(pU.platId.toString()))
-      //   case (false, false) => logger.warn(
-      //     email.userEmailNotificationDisabledWarning(pU.uId) ++ " " ++ email.platformNotSubscribedWarning(pU.platId.toString()))
-      // }
     })
 
   def sendIngestStatusEmailToOwner(pO: PlatformWithSceneOwner, scene: Scene, ingestStatus: String) = {
@@ -194,22 +177,6 @@ case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) ex
         }
       case (_, false) => logger.warn(email.platformNotSubscribedWarning(pO.platId.toString()))
     }
-    // (pO.emailNotifications, pO.pubSettings.emailIngestNotification) match {
-    //   case (true, true) =>
-    //     (pO.pubSettings.emailSmtpHost, pO.pubSettings.emailSmtpPort, pO.pubSettings.emailSmtpEncryption,
-    //       pO.pubSettings.emailUser, pO.priSettings.emailPassword, pO.email) match {
-    //       case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-    //         email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
-    //         val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForOwner(pO, scene, ingestStatus)
-    //         email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, ingestEmailSubject, htmlBody, plainBody).map((configuredEmail: Email) => configuredEmail.send)
-    //         logger.info(s"Notified scene owner ${pO.uId}.")
-    //       case _ => logger.warn(email.insufficientSettingsWarning(pO.platId.toString(), pO.uId))
-    //     }
-    //   case (false, true) => logger.warn(email.userEmailNotificationDisabledWarning(pO.uId))
-    //   case (true, false) => logger.warn(email.platformNotSubscribedWarning(pO.platId.toString()))
-    //   case (false, false) => logger.warn(
-    //     email.userEmailNotificationDisabledWarning(pO.uId) ++ " " ++ email.platformNotSubscribedWarning(pO.platId.toString()))
-    // }
   }
   def notifyConsumers(scene: Scene, ingestStatus: String) = {
     logger.info("Notifying Consumers...")

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
@@ -58,7 +58,13 @@ case class PlatformWithUsersSceneProjects(
   projectId: UUID,
   projectName: String,
   personalInfo: User.PersonalInfo
-)
+) {
+  def getUserEmail: String = (emailNotifications, personalInfo.emailNotifications) match {
+    case (true, true) | (false, true) => personalInfo.email
+    case (true, false) => email
+    case (false, false) => ""
+  }
+}
 
 @JsonCodec
 case class PlatformWithSceneOwner(
@@ -71,4 +77,10 @@ case class PlatformWithSceneOwner(
   email: String,
   emailNotifications: Boolean,
   personalInfo: User.PersonalInfo
-)
+) {
+  def getUserEmail: String = (emailNotifications, personalInfo.emailNotifications) match {
+    case (true, true) | (false, true) => personalInfo.email
+    case (true, false) => email
+    case (false, false) => ""
+  }
+}

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Platform.scala
@@ -56,7 +56,8 @@ case class PlatformWithUsersSceneProjects(
   email: String,
   emailNotifications: Boolean,
   projectId: UUID,
-  projectName: String
+  projectName: String,
+  personalInfo: User.PersonalInfo
 )
 
 @JsonCodec
@@ -68,5 +69,6 @@ case class PlatformWithSceneOwner(
   pubSettings: Platform.PublicSettings,
   priSettings: Platform.PrivateSettings,
   email: String,
-  emailNotifications: Boolean
+  emailNotifications: Boolean,
+  personalInfo: User.PersonalInfo
 )

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -116,6 +116,12 @@ case class User(
 
   def getDefaultAnnotationShapefileSource(dataBucket: String): URI =
     new URI(s"s3://$dataBucket/user-exports/${URLEncoder.encode(id, "UTF-8")}/annotations/${UUID.randomUUID}/annotations.zip")
+
+  def getEmail: String = (emailNotifications, personalInfo.emailNotifications) match {
+    case (true, true) | (false, true) => personalInfo.email
+    case (true, false) => email
+    case (false, false) => ""
+  }
 }
 
 object User {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -197,7 +197,7 @@ object PlatformDao extends Dao[Platform] {
         SELECT plat.id AS plat_id, plat.name AS plat_name, u.id AS u_id, u.name AS u_name,
                plat.public_settings AS pub_settings, plat.private_settings AS pri_settings,
                u.email AS email, u.email_notifications AS email_notifications,
-               prj.id AS projectId, prj.name AS project_name
+               prj.id AS projectId, prj.name AS project_name, u.personal_info AS personal_info
         FROM users AS u
           JOIN user_group_roles AS ugr
           ON u.id = ugr.user_id
@@ -220,7 +220,8 @@ object PlatformDao extends Dao[Platform] {
         SELECT DISTINCT
           plat.id AS plat_id, plat.name AS plat_name, u.id AS u_id, u.name AS u_name,
           plat.public_settings AS pub_settings, plat.private_settings AS pri_settings,
-          u.email AS email, u.email_notifications AS email_notifications
+          u.email AS email, u.email_notifications AS email_notifications,
+          u.personal_info AS personal_info
         FROM users AS u
           JOIN user_group_roles AS ugr
           ON u.id = ugr.user_id

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/Notify.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/Notify.scala
@@ -63,7 +63,12 @@ object Notify extends RollbarNotifier {
         case MessageType.GroupInvitation =>
           UserDao.unsafeGetUserById(subjectId).map((usr: User) => List(usr))
       }
-      emails = users map { _.email }
+      emails = users map { user =>
+        (user.personalInfo.email, user.email) match {
+          case ("", loginEmail) => loginEmail
+          case (contactEmail, _) => contactEmail
+        }
+      }
       _ <- logger.debug(s"Sending emails to ${users.length} admins").pure[ConnectionIO]
       result <- emails.map(
         sendEmail(publicSettings, privateSettings, _,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -236,6 +236,8 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
             listOfPUSP(1).projectId == dbProject.id || listOfPUSP(1).projectId == dbProjectAnother.id, "; project ID don't match")
           assert((listOfPUSP(0).projectName == dbProject.name || listOfPUSP(0).projectName == dbProjectAnother.name) &&
             (listOfPUSP(1).projectName == dbProject.name || listOfPUSP(1).projectName == dbProjectAnother.name), "; project name don't match")
+          assert((listOfPUSP(0).personalInfo == dbUser.personalInfo || listOfPUSP(0).personalInfo == dbUserAnother.personalInfo) &&
+            (listOfPUSP(1).personalInfo == dbUser.personalInfo || listOfPUSP(1).personalInfo == dbUserAnother.personalInfo), "; user personal info don't match")
           true
         }
       }
@@ -271,6 +273,7 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
           assert(pU.priSettings == dbPlatform.privateSettings, "; platform private settings don't match")
           assert(pU.email == dbUser.email, "; user email don't match")
           assert(pU.emailNotifications == dbUser.emailNotifications, "; user email notification don't match")
+          assert(pU.personalInfo == dbUser.personalInfo, "; user personal info don't match")
           true
         }
       }

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -125,7 +125,7 @@ class AddUserModalController {
             const userId = select[0];
             const isAdmin = select[1];
             if (this.resolve.groupType === 'team') {
-                return this.teamService.addUserWithrole(
+                return this.teamService.addUserWithRole(
                     this.resolve.platformId,
                     this.resolve.organizationId,
                     this.resolve.teamId,


### PR DESCRIPTION
## Overview

This PR adds support for sending emails to user contact email address if users choose to receive notifications through it (instead of login email). It also fixes a bug in the modal for inviting team users.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (update existing tests to reflect SQL updates)

### Demo

Platform email settings and subscriptions:
<img width="1048" alt="screen shot 2018-07-23 at 6 11 27 pm" src="https://user-images.githubusercontent.com/16109558/43105729-e9def750-8ea3-11e8-87aa-31c545d9a98a.png">

Dev user has a contact email on file:
<img width="880" alt="screen shot 2018-07-23 at 6 10 43 pm" src="https://user-images.githubusercontent.com/16109558/43105745-fb45da04-8ea3-11e8-8c6d-0b237d7a2013.png">

Dev user chooses to receive emails through contact email:
<img width="897" alt="screen shot 2018-07-23 at 6 10 33 pm" src="https://user-images.githubusercontent.com/16109558/43105778-18e13cb6-8ea4-11e8-92a7-3d7c1552629c.png">

Emails sent to dev user's contact email:
<img width="1403" alt="screen shot 2018-07-23 at 6 10 52 pm" src="https://user-images.githubusercontent.com/16109558/43105793-2c123cfe-8ea4-11e8-973c-31a945ebc5d3.png">


## Testing Instructions

 * Configure platform email settings and subscriptions
 * Update your profile to include a contact email
 * Choose either your contact email or your login email as notification receiver
 * Make sure you receive corresponding emails to your designated email address specified in the last step after you test the following:
    - Invite yourself to an organization or a team using an admin account
    - Set an ingested scene's owner to yourself and add it to a project. `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main 'notify_ingest_status' '<scene id>'` (two emails in this case -- one sent to project owner, one sent to scene owner)
    - Export a scene from a project: `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main check_export_status <export_id> "s3://<data bucket>/export-statuses/<an existing export id>"`
    - Create an AOI project, set parameters, start monitoring. `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main find_aoi_projects`
 * CI for updated property tests on new SQL

Closes #3724 
