### PR TITLE
Make planet credentials less persistent in service

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -1,23 +1,47 @@
 const availableResolutions = [
     {
-        label: '300m',
+        label: '~300m',
         value: 9
     },
     {
-        label: '75m',
+        label: '~150m',
+        value: 10
+    },
+    {
+        label: '~75m',
         value: 11
     },
     {
-        label: '20m',
+        label: '~38m',
+        value: 12
+    },
+    {
+        label: '~19m',
         value: 13
     },
     {
-        label: '5m',
+        label: '~10m',
+        value: 14
+    },
+    {
+        label: '~5m',
         value: 15
     },
     {
-        label: '1m',
+        label: '~2m',
+        value: 16
+    },
+    {
+        label: '~1m',
         value: 17
+    },
+    {
+        label: '~0.5m',
+        value: 18
+    },
+    {
+        label: '~0.3m',
+        value: 19
     }
 ];
 

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.html
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.html
@@ -61,17 +61,17 @@
     </div>
   </li>
   <li class="separator">
-    <span class="label">Approximate resolution</span>
+    <span class="label">Zoom Level</span>
     <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
       <a class="btn dropdown-label" >
-       {{$ctrl.getCurrentResolution().label}}
+       {{$ctrl.getCurrentResolution().value}} ({{$ctrl.getCurrentResolution().label}}<sup>2</sup>)
       </a>
       <button type="button" class="btn btn-default dropdown-toggle">
         <i class="icon-caret-down"></i>
       </button>
       <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
         <li ng-repeat="res in $ctrl.availableResolutions" role="menuitem">
-          <a ng-click="$ctrl.updateResolution(res.value)">{{res.label}}</a>
+          <a ng-click="$ctrl.updateResolution(res.value)">{{res.value}} ({{res.label}})</a>
         </li>
       </ul>
     </div>

--- a/app-frontend/src/app/services/scenes/planetRepository.service.js
+++ b/app-frontend/src/app/services/scenes/planetRepository.service.js
@@ -28,35 +28,31 @@ export default (app) => {
                     uuid: 'dd68e7eb-4055-4657-9cfb-bd82c0904f78',
                     name: 'RapidEye OrthoTiles'
                 }];
-                if (this.planetToken) {
-                    resolve();
-                } else {
-                    this.authService.getCurrentUser().then((user) => {
-                        if (user.planetCredential) {
-                            this.planetToken = user.planetCredential;
-                            resolve();
-                        } else {
-                            const modal = this.modalService.open({
-                                component: 'rfConfirmationModal',
-                                resolve: {
-                                    title: () => 'You don\'t have a Planet API token set',
-                                    content: () => 'Go to your API connections page and set one?',
-                                    confirmText: () => 'Add Planet API Token',
-                                    cancelText: () => 'Cancel'
-                                }
-                            });
+                this.authService.getCurrentUser().then((user) => {
+                    if (user.planetCredential) {
+                        this.planetToken = user.planetCredential;
+                        resolve();
+                    } else {
+                        const modal = this.modalService.open({
+                            component: 'rfConfirmationModal',
+                            resolve: {
+                                title: () => 'You don\'t have a Planet API token set',
+                                content: () => 'Go to your API connections page and set one?',
+                                confirmText: () => 'Add Planet API Token',
+                                cancelText: () => 'Cancel'
+                            }
+                        });
 
-                            modal.result.then(() => {
-                                reject();
-                                this.$state.go('settings.connections');
-                            }, () => {
-                                reject();
-                            });
-                        }
-                    }, () => {
-                        reject();
-                    });
-                }
+                        modal.result.then(() => {
+                            reject();
+                            this.$state.go('user.settings.connections');
+                        }, () => {
+                            reject();
+                        });
+                    }
+                }, () => {
+                    reject();
+                });
             });
         }
 

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -136,6 +136,7 @@ def get_session():
     session = requests.Session()
 
     session.headers.update({'Authorization': 'Bearer {}'.format(encoded_jwt)})
+    session.headers.update({'User-Agent': 'RF/App-Tasks Client'})
     return session
 
 


### PR DESCRIPTION
## Overview

Fixes two issues:
 - Setting the planet token would persist in the service even after updates to the planet token. Originally, I thought this was because we weren't checking for blank strings, but really it was because after updating the credential the old one was still being used
 - Fixes link in manage token modal when it isn't set

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Demo
![screenshot from 2018-07-26 09-38-53](https://user-images.githubusercontent.com/898060/43265782-c444060a-90b7-11e8-8059-e2208896be86.png)
![screenshot from 2018-07-26 09-35-27](https://user-images.githubusercontent.com/898060/43265784-c454ae9c-90b7-11e8-9762-144795e813cf.png)
![screenshot from 2018-07-26 09-57-44](https://user-images.githubusercontent.com/898060/43266990-b89a4ff0-90ba-11e8-8e7e-80fc16d87626.png)

## Testing Instructions

 * Open UI with a user that doesn't have a planet credential set
 * Go to browse scenes for planet, click on prompt to manage tokens and it should go to correct settings page
 * Enter in a random string
 * Go back to settings page and enter in empty string for planet credential
 * Go back to browse planet scenes again, should be re-prompted to enter in credential
 * Go to export, see that export options use zoom levels + approximate resolution
 * Create an export and ensure that zoom level is still passed as a parameter
 * Rebuild batch container (`docker-compose build batch`)
 * Open `ipython` inside the batch container (`./scripts/console batch ipython`) and do the following
```
In [4]: from rf.utils.io import get_session

In [5]: session = get_session()

In [7]: session.get('https://app.staging.rasterfoundry.com/api/test')
Out[7]: <Response [404]>
```
 * Look in logs and verify that correct user-agent is in the nginx logs

Closes https://github.com/raster-foundry/raster-foundry/issues/3754
Closes https://github.com/raster-foundry/raster-foundry/issues/3765
Closes https://github.com/raster-foundry/raster-foundry/issues/3337
