### PR TITLE
fixed avatar sizing and position issues, btn-square is now square

### DIFF
--- a/app-frontend/src/app/components/common/navBar/navBar.html
+++ b/app-frontend/src/app/components/common/navBar/navBar.html
@@ -100,7 +100,7 @@
       </div>
       <div ng-if="$ctrl.authService.isLoggedIn" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
         <a href uib-dropdown-toggle>
-          <img ng-if="$ctrl.authService.getProfile().picture" class="avatar" ng-src="{{$ctrl.authService.getProfile().picture}}">
+          <img ng-if="$ctrl.authService.getProfile().picture" class="avatar tiny" ng-src="{{$ctrl.authService.getProfile().picture}}">
           <div class="avatar image-placeholder" ng-if="$ctrl.authService.getProfile() && !$ctrl.authService.getProfile().picture"></div>
           <span class="username">{{$ctrl.authService.getProfile().nickname}}</span>
           <i class="icon-caret-down"></i>

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -1,8 +1,8 @@
 <div class="panel-body">
   <ng-container ng-if="!$ctrl.slim">
     <rf-status-tag ng-if="$ctrl.status && $ctrl.status != 'CURRENT' " entity-type="project" status="$ctrl.status" class="project-status"></rf-status-tag>
-    <a href ui-sref="projects.edit({projectid: $ctrl.project.id})" class="h4 font-600">
-      <img class="avatar user-avatar pull-left" ng-attr-src="{{ $ctrl.project.owner.profileImageUri }}" ng-if="$ctrl.project.owner.profileImageUri"/>
+    <a href ui-sref="projects.edit({projectid: $ctrl.project.id})" class="no-hover">
+      <img class="avatar tiny" ng-attr-src="{{ $ctrl.project.owner.profileImageUri }}" ng-if="$ctrl.project.owner.profileImageUri"/>
       <h4 class="project-title" data-title="{{$ctrl.project.name}}">{{$ctrl.project.name}}</h4>
     </a>
     <div class="project-actions" ng-if="!$ctrl.hideOptions">

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -94,7 +94,7 @@ export default class NewExportController {
         // Export defaults
         this.exportOptions = {
             resolution: 9,
-            stitch: true,
+            stitch: false,
             crop: false,
             raw: false
         };

--- a/app-frontend/src/app/pages/share/share.html
+++ b/app-frontend/src/app/pages/share/share.html
@@ -13,7 +13,7 @@
     <nav>
       <div ng-if="$ctrl.authService.isLoggedIn && !$ctrl.testNoAuth" uib-dropdown class="dropdown-my-account" on-toggle="toggled($ctrl.optionsOpen)">
         <a href uib-dropdown-toggle>
-          <img ng-if="$ctrl.authService.getProfile().picture" class="avatar" ng-src="{{$ctrl.authService.getProfile().picture}}">
+          <img ng-if="$ctrl.authService.getProfile().picture" class="avatar tiny" ng-src="{{$ctrl.authService.getProfile().picture}}">
           <div class="avatar image-placeholder" ng-if="$ctrl.authService.getProfile() && !$ctrl.authService.getProfile().picture"></div>
           <span class="username">{{$ctrl.authService.getProfile().nickname}}</span>
           <i class="icon-caret-down"></i>

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -219,7 +219,7 @@ export default (app) => {
         export(project, settings = {}, options = {}) {
             const defaultOptions = {
                 resolution: 9,
-                stitch: true,
+                stitch: false,
                 crop: false
             };
 

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -107,6 +107,10 @@
   }
 }
 
+.no-hover {
+  text-decoration: none !important;
+}
+
 .hide {
   display: none !important;
 }

--- a/app-frontend/src/assets/styles/sass/components/_avatar.scss
+++ b/app-frontend/src/assets/styles/sass/components/_avatar.scss
@@ -8,9 +8,28 @@
   height: 32px;
   width: 32px;
 
+  &.tiny {
+    width: 25px;
+    height: 25px;
+  }
+
+  /* 
+   * This is default sizing, but including a 
+   * class alternative in case of weird override issues
+   */
+  &.sm {
+    width: 32px;
+    height: 32px;
+  }
+
   &.md {
     width: 100px;
     height: 100px;
+  }
+
+  &.lg {
+    width: 250px;
+    height: 250px;
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -250,11 +250,9 @@
 }
 
 .btn-square {
-  padding: 0 1rem;
-}
-
-.btn.btn-square-small {
-  padding: 0.5rem;
+  width: 40px;
+  height: 40px;
+  padding: 0;
 }
 
 .btn-block {

--- a/app-frontend/src/assets/styles/sass/components/_permissions-modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_permissions-modal.scss
@@ -56,9 +56,17 @@ rf-permission-item {
         align-items: center;
         flex-shrink: 1;
         font-size: 1.5rem;
+        overflow: hidden;
         .labels {
             flex: 1;
+            flex-shrink: 1;
             margin-left: 0.5em;
+            overflow: hidden;
+            > * {
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
             .subtitle {
                 opacity: 0.8;
                 font-size: 1.3rem;

--- a/app-frontend/src/assets/styles/sass/components/_project-item.scss
+++ b/app-frontend/src/assets/styles/sass/components/_project-item.scss
@@ -6,9 +6,9 @@
   }
 
   .avatar {
-    position: relative;
+    position: absolute;
     z-index: 10;
-    top: -3px;
+    margin-top: -3px;
   }
 }
 
@@ -20,6 +20,7 @@
   overflow: hidden;
   max-width: 100%;
   text-overflow: ellipsis;
+  padding-left: 3.5rem;
   padding-right: 8.5rem;
 
   &:after {
@@ -35,7 +36,7 @@
     white-space: normal;
     background: $off-white;
     box-shadow: inset white 0 0 0 1px;
-    z-index: 1;
+    z-index: 2;
     visibility: hidden;
     opacity: 0;
   }
@@ -86,6 +87,8 @@
   margin: 1rem 0 0;
   border-radius: $border-radius-base;
   overflow: hidden;
+  position: relative;
+  z-index: 1;
 }
 
 .project-ownership {


### PR DESCRIPTION
## Overview
### Avatars and project-cards
Avatar default sizes were recently changed. This caused some issues to our project-card alignment. This PR adds some helper classes to avatars so we can have different sized avatars for different needs. I also adjusted the css for avatars in project-cards so sizing the avatar can't break the card any longer.

### Square buttons
A change was made to `.btn-square` recently which caused them to longer be square. This PR adds hard-defined widths and heights to this class.

### Checklist

- ~[ ] Styleguide updated, if necessary~
- ~[ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~[ ] Symlinks from new migrations present or corrected for any new migrations~
- [ ] PR has a name that won't get you publicly shamed for vagueness
- ~[ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~[ ] Any new SQL strings have tests~

## Testing Instructions

 * Look at project-cards to make sure they look as expected
 * View map control buttons to ensure they are square

Closes #3773
