### PR TITLE
Make scenes with thin datasource postable

### DIFF
--- a/app-backend/common/src/main/scala/CommonHandlers.scala
+++ b/app-backend/common/src/main/scala/CommonHandlers.scala
@@ -38,6 +38,6 @@ trait CommonHandlers extends RouteDirectives {
   }
 
   def circeDecodingError = ExceptionHandler {
-    case df: DecodingFailure => complete { (StatusCodes.InternalServerError, DecodingFailure.showDecodingFailure.show(df)) }
+    case df: DecodingFailure => complete { (StatusCodes.BadRequest, DecodingFailure.showDecodingFailure.show(df)) }
   }
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -9,7 +9,6 @@ import geotrellis.slick.Projected
 
 import io.circe._
 import io.circe.generic.JsonCodec
-import io.circe._
 import io.circe.syntax._
 import io.circe.parser._
 


### PR DESCRIPTION
## Overview

This PR makes it so that the spec isn't lying about whether you can `POST` a scene
with a thin datasource.

It also does some housekeeping in separate commits.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

I can't actually test locally right now because I'm running into a weird initialization error
for the server, but I tested with `decode[Scene.Create]` in the console and know what occurs
in each branch for decoding successes/failures.

This may be broader than was intended -- the changes here make it so that if we _ever_ fail
to decode a UUID directly, we'll fall back to trying to get it from an `id` field in a json object. I
_think_ that's probably better / avoids accidental malicious compliance issues, but if not,
moving the alt UUID decoder into the companion object for `Scene.Create`s I think should scope
it to `Scene.Create`s only.

## Testing Instructions

 * `POST` the json from the linked issue
 * make the json bad by removing the `id` field from the `datasource` object
 * confirm the error message and status code from the server make sense after you try to post the bad json

Closes #3753 
