### PR TITLE
Only mosaic scenes if they contribute to the visible layer

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
@@ -89,6 +89,7 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
     LEFT JOIN
       scenes
     ON scenes.id = scenes_to_projects.scene_id
+    ORDER BY scene_order ASC;
       """
     for {
       stpsWithFootprints <- {

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -13,6 +13,7 @@ class ProjectsScenesController {
 
     $onInit() {
         this.$parent = this.$scope.$parent.$ctrl;
+        this.projectId = this.$parent.projectId;
         this.repository = {
             name: 'Raster Foundry',
             service: this.RasterFoundryRepository


### PR DESCRIPTION
## Overview

This PR uses the doobie streaming API to filter out scenes and stop getting scenes from scenes_to_projects
when the scenes won't contribute to the visible layer.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

## Notes

There's a project called "Landsat only central america" or something that is a fairly deep set of stacks.
It's shared with everyone in staging.

## Testing Instructions

 * Go to staging and try to view some tiles for deep stacks
 * It might not work 100% first time, but future refreshes of the same layer should succeed, and also if you bump the number of tile servers slightly it should succeed (difficult to compare with prod for the tile servers reason)

Helps with #3766 
