### PR TITLE
Fix preview changing when node histogram is opened

### DIFF
--- a/app-frontend/src/app/components/histogram/histogramBreakpoint/histogramBreakpoint.module.js
+++ b/app-frontend/src/app/components/histogram/histogramBreakpoint/histogramBreakpoint.module.js
@@ -138,9 +138,9 @@ class HistogramBreakpointController {
         ) {
             event.stopPropagation();
             // this is changing depending on the zoom width, so we need to find a way around it
-            let width = this.parent.width();
-            let position = event.offsetX;
-            let percent = position / width;
+            let leftBound = this.parent.offset().left;
+            let position = event.clientX;
+            let percent = (position - leftBound) / this.parent.width();
             let breakpoint = this.validateBreakpoint(
                 (this.range.max - this.range.min) * percent + this.range.min
             );

--- a/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.html
+++ b/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.html
@@ -22,6 +22,7 @@
   <button class="btn btn-default btn-square btn-small"
           type="button"
           title="Preview Node"
+          ng-disabled="$ctrl.preventSelecting"
           ng-click="$ctrl.onPreviewClick()"
           ng-class="{'btn-secondary': $ctrl.selectingNode === 'preview'}"
   >
@@ -31,6 +32,7 @@
           title="Compare Nodes"
           type="button"
           ng-click="$ctrl.onCompareClick()"
+          ng-disabled="$ctrl.preventSelecting"
           ng-class="{'btn-secondary': $ctrl.selectingNode === 'compare' || $ctrl.selectingNode === 'select'}"
   >
     <i class="icon-compare"></i>

--- a/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.module.js
+++ b/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.module.js
@@ -47,6 +47,7 @@ class DiagramContainerController {
             readonly: state.lab.readonly,
             selectingNode: state.lab.selectingNode,
             selectedNode: state.lab.selectedNode,
+            preventSelecting: state.lab.preventSelecting,
             reduxState: state
         };
     }

--- a/app-frontend/src/app/components/lab/labNode/labNode.html
+++ b/app-frontend/src/app/components/lab/labNode/labNode.html
@@ -7,6 +7,7 @@
   <div class="node-button-group" ng-if="!$ctrl.readonly">
     <button class="btn node-button" type="button"
             ng-if="$ctrl.model.get('cellType') !== 'const' && !$ctrl.analysisErrors.size"
+            ng-disabled="$ctrl.preventSelecting"
             ng-click="$ctrl.preview()">
       <span class="icon-map"></span>
     </button>

--- a/app-frontend/src/app/components/lab/labNode/labNode.module.js
+++ b/app-frontend/src/app/components/lab/labNode/labNode.module.js
@@ -51,6 +51,7 @@ class LabNodeController {
     mapStateToThis(state) {
         return {
             readonly: state.lab.readonly,
+            preventSelecting: state.lab.preventSelecting,
             analysis: state.lab.analysis,
             selectingNode: state.lab.selectingNode,
             selectedNode: state.lab.selectedNode,
@@ -152,7 +153,7 @@ class LabNodeController {
     }
 
     onNodeClick(event) {
-        if (this.selectingNode && this.selectedNode !== this.nodeId) {
+        if (this.selectingNode && this.selectedNode !== this.nodeId && !this.preventSelecting) {
             event.stopPropagation();
             this.selectNode(this.nodeId);
         }

--- a/app-frontend/src/app/components/lab/labNode/labNode.module.js
+++ b/app-frontend/src/app/components/lab/labNode/labNode.module.js
@@ -30,16 +30,16 @@ class LabNodeController {
         });
         $scope.$watch('$ctrl.selectingNode', (selectingNode) => {
             if (selectingNode) {
-                this.$element.addClass('selectable');
+                this.$element.addClass('selectable-node');
             } else {
-                this.$element.removeClass('selectable');
+                this.$element.removeClass('selectable-node');
             }
         });
         $scope.$watch('$ctrl.selectedNode', (selectedNode) => {
             if (selectedNode === this.nodeId) {
-                this.$element.addClass('selected');
+                this.$element.addClass('selected-node');
             } else {
-                this.$element.removeClass('selected');
+                this.$element.removeClass('selected-node');
             }
         });
     }

--- a/app-frontend/src/app/redux/actions/histogram-actions.js
+++ b/app-frontend/src/app/redux/actions/histogram-actions.js
@@ -1,38 +1,12 @@
 import {authedRequest} from '_api/authentication';
-import {colorStopsToRange} from '_redux/histogram-utils';
+import {colorStopsToRange, createRenderDefinition} from '_redux/histogram-utils';
 import {getNodeDefinition, astFromNodes} from '_redux/node-utils';
 import {NODE_UPDATE_HARD} from './node-actions';
-
-const { colorSchemes: colorSchemes } = require('../../services/projects/colorScheme.defaults.json');
 
 export const HISTOGRAM_FETCH = 'HISTOGRAM_FETCH';
 export const HISTOGRAM_UPDATE = 'HISTOGRAM_UPDATE';
 
 export const HISTOGRAM_ACTION_PREFIX = 'HISTOGRAM';
-
-function createRenderDefinition(histogram) {
-    let min = histogram.minimum;
-    let max = histogram.maximum;
-
-    let defaultColorScheme = colorSchemes.find(
-        s => s.label === 'Viridis'
-    );
-    let breakpoints = colorStopsToRange(defaultColorScheme.colors, min, max);
-    let renderDefinition = {clip: 'none', scale: 'SEQUENTIAL', breakpoints};
-    let histogramOptions = {range: {min, max}, baseScheme: {
-        colorScheme: Object.entries(defaultColorScheme.colors)
-            .map(([key, val]) => ({break: key, color: val}))
-            .sort((a, b) => a.break - b.break)
-            .map((c) => c.color),
-        dataType: 'SEQUENTIAL',
-        colorBins: 0
-    }};
-
-    return {
-        renderDefinition,
-        histogramOptions
-    };
-}
 
 // Histogram ActionCreators
 export function fetchHistogram(nodeId) {
@@ -75,7 +49,7 @@ export function fetchHistogram(nodeId) {
                                 })
                             }
                         );
-                        let updatedAnalysis = astFromNodes(callbackState.lab, newNodeDefinition);
+                        let updatedAnalysis = astFromNodes(callbackState.lab, [newNodeDefinition]);
                         let promise = authedRequest({
                             method: 'put',
                             url: `${callbackState.api.apiUrl}` +
@@ -119,7 +93,7 @@ export function updateRenderDefinition({nodeId, renderDefinition, histogramOptio
             })
         });
 
-        const updatedAnalysis = astFromNodes(state.lab, newNodeDefinition);
+        const updatedAnalysis = astFromNodes(state.lab, [newNodeDefinition]);
         dispatch({
             type: NODE_UPDATE_HARD,
             payload: authedRequest({

--- a/app-frontend/src/app/redux/actions/node-actions.js
+++ b/app-frontend/src/app/redux/actions/node-actions.js
@@ -101,7 +101,6 @@ export function compareNodes(nodeIds) {
             Promise.all(
                 renderDefPromises
             ).then((nodesToUpdate) => {
-                // update nodes
                 const updatedNodes = nodesToUpdate;
                 const updatedAnalysis = astFromNodes(labState, updatedNodes);
                 const nodeUpdateRequest = authedRequest({

--- a/app-frontend/src/app/redux/actions/node-actions.js
+++ b/app-frontend/src/app/redux/actions/node-actions.js
@@ -1,4 +1,6 @@
 import {authedRequest} from '_api/authentication';
+import {Promise} from 'es6-promise';
+import _ from 'lodash';
 
 export const NODE_PREVIEWS = 'NODE_PREVIEWS';
 export const NODE_SET_ERROR = 'NODE_SET_ERROR';
@@ -10,7 +12,7 @@ export const NODE_UPDATE_HARD = 'NODE_UPDATE_HARD';
 
 export const NODE_ACTION_PREFIX = 'NODE';
 
-import { astFromNodes } from '../node-utils';
+import { astFromNodes, createNodeMetadata } from '../node-utils';
 
 // Node ActionCreators
 
@@ -27,16 +29,114 @@ export function startNodeCompare() {
 }
 
 export function selectNode(nodeId) {
-    return {
-        type: `${NODE_PREVIEWS}_SELECT_NODE`,
-        nodeId
+    return (dispatch, getState) => {
+        const state = getState();
+        const labState = state.lab;
+        const nodes = labState.nodes;
+        const selectedNode = nodes.get(nodeId);
+        const renderDef = selectedNode.metadata.renderDefinition;
+        if (!renderDef) {
+            dispatch({
+                type: `${NODE_PREVIEWS}_PAUSE_SELECT`
+            });
+            createNodeMetadata(state, {node: selectedNode})
+                .then((metadata) => {
+                    return _.merge({}, selectedNode, {metadata});
+                })
+                .then((updatedNode) => {
+                    const updatedAnalysis = astFromNodes(labState, [updatedNode]);
+                    const nodeUpdateRequest = authedRequest({
+                        method: 'put',
+                        url: `${state.api.apiUrl}/api/tool-runs/${labState.analysis.id}`,
+                        data: updatedAnalysis
+                    }, state);
+                    dispatch({
+                        type: NODE_UPDATE_HARD,
+                        meta: {
+                            node: updatedNode,
+                            analysis: updatedAnalysis
+                        },
+                        payload: nodeUpdateRequest
+                    });
+                    return nodeUpdateRequest.then(() => updatedNode);
+                }).then((updatedNode) => {
+                    dispatch({
+                        type: `${NODE_PREVIEWS}_SELECT_NODE`,
+                        nodeId: updatedNode.id
+                    });
+                }).catch((error) => {
+                    // eslint-disable-next-line
+                    console.log('Error while updating nodes before preview', error);
+                    dispatch({
+                        type: `${NODE_PREVIEWS}_ERROR`,
+                        error: error
+                    });
+                });
+        } else {
+            dispatch({
+                type: `${NODE_PREVIEWS}_SELECT_NODE`,
+                nodeId
+            });
+        }
     };
 }
 
-export function compareNodes(nodes) {
-    return {
-        type: `${NODE_PREVIEWS}_COMPARE_NODES`,
-        nodes
+export function compareNodes(nodeIds) {
+    return (dispatch, getState) => {
+        const state = getState();
+        const labState = state.lab;
+        const nodes = labState.nodes;
+        const selectedNodes = nodeIds.map((id) => nodes.get(id));
+        const missingRenderDefs = selectedNodes.filter((node) => !node.metadata.renderDefinition);
+        if (missingRenderDefs.length) {
+            dispatch({
+                type: `${NODE_PREVIEWS}_PAUSE_SELECT`
+            });
+            const renderDefPromises = missingRenderDefs.map((node) => {
+                return createNodeMetadata(state, {node})
+                    .then((metadata) => {
+                        return _.merge({}, node, {metadata});
+                    });
+            });
+            Promise.all(
+                renderDefPromises
+            ).then((nodesToUpdate) => {
+                // update nodes
+                const updatedNodes = nodesToUpdate;
+                const updatedAnalysis = astFromNodes(labState, updatedNodes);
+                const nodeUpdateRequest = authedRequest({
+                    method: 'put',
+                    url: `${state.api.apiUrl}/api/tool-runs/${labState.analysis.id}`,
+                    data: updatedAnalysis
+                }, state);
+                dispatch({
+                    type: NODE_UPDATE_HARD,
+                    meta: {
+                        nodes: updatedNodes,
+                        analysis: updatedAnalysis
+                    },
+                    payload: nodeUpdateRequest
+                });
+                return nodeUpdateRequest.then(() => nodesToUpdate);
+            }).then((updatedNodes) => {
+                dispatch({
+                    type: `${NODE_PREVIEWS}_COMPARE_NODES`,
+                    nodes: updatedNodes
+                });
+            }).catch((error) => {
+                // eslint-disable-next-line
+                console.log('Error while updating nodes before preview', error);
+                dispatch({
+                    type: `${NODE_PREVIEWS}_ERROR`,
+                    error: error
+                });
+            });
+        } else {
+            dispatch({
+                type: `${NODE_PREVIEWS}_COMPARE_NODES`,
+                nodes: nodeIds
+            });
+        }
     };
 }
 
@@ -65,7 +165,7 @@ export function updateNode({payload, hard = false}) {
         let labState = getState().lab;
         let promise;
         let updatedNode = payload;
-        let updatedAnalysis = astFromNodes(labState, updatedNode);
+        let updatedAnalysis = astFromNodes(labState, [updatedNode]);
         promise = authedRequest({
             method: 'put',
             url: `${state.api.apiUrl}/api/tool-runs/${labState.analysis.id}`,

--- a/app-frontend/src/app/redux/histogram-utils.js
+++ b/app-frontend/src/app/redux/histogram-utils.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+
+const { colorSchemes: colorSchemes } = require('../services/projects/colorScheme.defaults.json');
 // return an ordered array of breakpoints
 export function breakpointsFromRenderDefinition(renderDefinition, idGenerator) {
     if (renderDefinition.breakpoints) {
@@ -83,4 +85,28 @@ export function colorStopsToRange(colors, min, max) {
         });
     }
     return rangedColors;
+}
+
+export function createRenderDefinition(histogram) {
+    let min = histogram.minimum;
+    let max = histogram.maximum;
+
+    let defaultColorScheme = colorSchemes.find(
+        s => s.label === 'Viridis'
+    );
+    let breakpoints = colorStopsToRange(defaultColorScheme.colors, min, max);
+    let renderDefinition = {clip: 'none', scale: 'SEQUENTIAL', breakpoints};
+    let histogramOptions = {range: {min, max}, baseScheme: {
+        colorScheme: Object.entries(defaultColorScheme.colors)
+            .map(([key, val]) => ({break: key, color: val}))
+            .sort((a, b) => a.break - b.break)
+            .map((c) => c.color),
+        dataType: 'SEQUENTIAL',
+        colorBins: 0
+    }};
+
+    return {
+        renderDefinition,
+        histogramOptions
+    };
 }

--- a/app-frontend/src/app/redux/node-utils.js
+++ b/app-frontend/src/app/redux/node-utils.js
@@ -5,7 +5,6 @@ import {authedRequest} from '../api/authentication';
 import {colorStopsToRange} from '_redux/histogram-utils';
 import {createRenderDefinition} from '_redux/histogram-utils';
 
-// make this work for multiple nodes
 export function astFromNodes(labState, updatedNodes) {
     const analysis = labState.analysis;
     const nodes = labState.nodes;

--- a/app-frontend/src/app/redux/node-utils.js
+++ b/app-frontend/src/app/redux/node-utils.js
@@ -1,14 +1,21 @@
 import _ from 'lodash';
 import {Map} from 'immutable';
+import {Promise} from 'es6-promise';
+import {authedRequest} from '../api/authentication';
+import {colorStopsToRange} from '_redux/histogram-utils';
+import {createRenderDefinition} from '_redux/histogram-utils';
 
-export function astFromNodes(labState, updatedNode) {
-    let analysis = labState.analysis;
-    let nodes = labState.nodes;
+// make this work for multiple nodes
+export function astFromNodes(labState, updatedNodes) {
+    const analysis = labState.analysis;
+    const nodes = labState.nodes;
     let root = Object.assign({}, _.first(nodes.filter((node) => !node.parent).toArray()));
     let stack = [root];
+    const updatedNodeMap = updatedNodes.reduce((m, node) => m.set(node.id, node), new Map());
     while (stack.length) {
         let currentNode = stack.pop();
-        if (currentNode.id === updatedNode.id) {
+        if (updatedNodeMap.has(currentNode.id)) {
+            let updatedNode = updatedNodeMap.get(currentNode.id);
             let parent = currentNode.parent;
             currentNode = Object.assign({}, updatedNode);
             if (root.id === currentNode.id) {
@@ -79,4 +86,15 @@ export function getNodeHistogram(state, context) {
         return state.lab.histograms.get(context.nodeId);
     }
     return false;
+}
+
+export function createNodeMetadata(state, context) {
+    return authedRequest({
+        method: 'get',
+        url: `${state.api.tileUrl}/tools/${state.lab.analysis.id}/histogram` +
+            `?node=${context.node.id}&voidCache=true&token=${state.api.apiToken}`
+    }, state).then((response) => {
+        const histogram = response.data;
+        return createRenderDefinition(histogram);
+    });
 }

--- a/app-frontend/src/app/redux/reducers.js
+++ b/app-frontend/src/app/redux/reducers.js
@@ -29,6 +29,7 @@ const INITIAL_LAB_STATE = {
 
     // node state
     nodes: new Map(), previewNodes: [], selectingNode: null, selectedNode: null,
+    preventSelecting: false,
 
     // histogram & statistics state
     histograms: new Map(), statistics: new Map()

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -2985,7 +2985,7 @@ rf-reclassify-table {
     margin-bottom: 0;
 }
 
-.selectable {
+.selectable-node {
     pointer-events: auto;
     cursor: pointer;
     * {
@@ -2995,6 +2995,15 @@ rf-reclassify-table {
         /* outline: 2px solid $brand-secondary; */
         /* outline-radius: 5px; */
         box-shadow: 0 0 3pt 2pt $brand-secondary;
+    }
+}
+.selected-node {
+    pointer-events: auto;
+    cursor: not-allowed;
+    box-shadow: 0 0 3pt 2pt $brand-secondary;
+
+    * {
+        pointer-events: none;
     }
 }
 


### PR DESCRIPTION
## Overview

Initialize render definitions before previewing.
Fix highlight for selected nodes (someone removed the style?)
Move createRenderDefinition to histogram-utils
Fix histogram breakpoints when zoomed in or out

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions
* Create a new analysis
* Set the sources
* View / compare nodes before opening the histogram
* While preview is open, open histogram and verify that things don't change
* Verify that histogram breakpoints no longer break when zoomed in or out
Closes #3606
Closes #3258 