### PR TITLE
Add sbt-sonatype plugin to support publishing to Maven Central

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -1,12 +1,13 @@
-name := "rf-backend"
-
 addCommandAlias("mg", "migrations/run")
 
-scalaVersion := Version.scala
+// Add the default sonatype repository setting
+publishTo := sonatypePublishTo.value
 
 lazy val commonSettings = Seq(
-  organization := "com.azavea",
-  version := Version.rasterFoundry,
+  organization := "com.rasterfoundry",
+  organizationName := "Raster Foundry",
+  organizationHomepage := Some(new URL("https://www.rasterfoundry.com")),
+  description := "A platform to find, combine and analyze earth imagery at any scale.",
   cancelable in Global := true,
   scapegoatVersion in ThisBuild := Version.scapegoat,
   scapegoatIgnoredFiles := Seq(".*/datamodel/.*"),

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -34,7 +34,6 @@ object Version {
   val maml               = "0.0.4-0fbf423"
   val nimbusJose         = "0.6.0"
   val postgres           = "42.1.1"
-  val rasterFoundry      = "0.1"
   val rollbar            = "1.0.1"
   val scaffeine          = "2.0.0"
   val scala              = "2.11.11"

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -1,3 +1,7 @@
+// For sbt 1.1.x, and 0.13.x
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")

--- a/app-backend/sonatype.sbt
+++ b/app-backend/sonatype.sbt
@@ -1,0 +1,16 @@
+import xerial.sbt.Sonatype._
+
+publishMavenStyle := true
+
+sonatypeProfileName := "com.rasterfoundry"
+sonatypeProjectHosting := Some(GitHubHosting(user="raster-foundry", repository="raster-foundry", email="info@rasterfoundry.com"))
+developers := List(
+  Developer(id = "azavea", name = "Azavea Inc.", email = "systems@azavea.com", url = url("https://www.azavea.com"))
+)
+licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+
+// For Travis CI - see http://www.cakesolutions.net/teamblogs/publishing-artefacts-to-oss-sonatype-nexus-using-sbt-and-travis-ci
+credentials ++= (for {
+  username <- Option(System.getenv().get("SONATYPE_USERNAME"))
+  password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
+} yield Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password)).toSeq

--- a/app-backend/version.sbt
+++ b/app-backend/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "1.8.0-SNAPSHOT"


### PR DESCRIPTION
## Overview

Add [sbt-sonatype](https://github.com/xerial/sbt-sonatype) plugin to support publishing to Maven Central. 

Resolves #3546 

## Notes

Next, we'll need to refactor artifact naming, add sbt-git, and create gpg signing keys for Raster Foundry. 

See: #3793

We should evaluate the scope of some of the sbt build variables. I think some use of `ThisBuild` and `Global` seems arbitrary.

#3788 provides an explanation as to why we're versioning the artifact as `1.8.0-SNAPSHOT`.

## Testing Instructions

```bash
vagrant@vagrant:/opt/raster-foundry$ docker-compose run --rm --no-deps api-server batch/clean && docker-compose run --rm --no-deps api-server batch/assembly
...
[info] SHA-1: 0362ccf705fcb81e415da038ee4d589373c9efa2
[info] Packaging /opt/raster-foundry/app-backend/batch/target/scala-2.11/rf-batch.jar ...
[info] Done packaging.
[success] Total time: 986 s, completed Aug 2, 2018 4:59:39 PM
vagrant@vagrant:/opt/raster-foundry$
```

