### PR TITLE
Add overridable initial map position

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -298,7 +298,9 @@ module.exports = function (_path) {
                     LOGOFILE: JSON.stringify('raster-foundry-logo.svg'),
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
-                    FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json')
+                    FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json'),
+                    MAP_CENTER: JSON.stringify([-6.7, 39.2]),
+                    MAP_ZOOM: 5
                 },
                 'HELPCONFIG': {
                     API_DOCS_URL: JSON.stringify('https://docs.rasterfoundry.com/'),

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -299,7 +299,7 @@ module.exports = function (_path) {
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
                     FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json'),
-                    MAP_CENTER: JSON.stringify([-6.7, 39.2]),
+                    MAP_CENTER: JSON.stringify([-6.8, 39.2]),
                     MAP_ZOOM: 5
                 },
                 'HELPCONFIG': {

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -62,7 +62,11 @@
 
   <!-- Main map area -->
   <div class="main">
-    <rf-map-container map-id="edit" ng-show="!$ctrl.showPreviewMap"></rf-map-container>
+    <rf-map-container map-id="edit"
+                      ng-show="!$ctrl.showPreviewMap"
+                      initial-center="$ctrl.initialCenter"
+                      initial-zoom="$ctrl.initialZoom"
+    ></rf-map-container>
     <rf-map-container map-id="preview"
                       ng-if="$ctrl.showPreviewMap"
                       initial-center="$ctrl.center"

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 import angular from 'angular';
 import {Map} from 'immutable';
 import ProjectActions from '_redux/actions/project-actions';
@@ -28,6 +29,8 @@ class ProjectsEditController {
         this.mosaicLayer = new Map();
         this.sceneLayers = new Map();
         this.projectId = this.$state.params.projectid;
+        this.initialCenter = BUILDCONFIG.MAP_CENTER || [0, 0];
+        this.initialZoom = BUILDCONFIG.MAP_ZOOM || 2;
 
         if (!this.project) {
             if (this.projectId) {


### PR DESCRIPTION
## Overview

This adds an overridable (via global.js or overrides.js by setting the `MAP_CENTER` and `MAP_ZOOM` values in the `BUILDCONFIG`) initial map position for the project editor. This also updates our global.js to center the map on Dar es Salaam.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

 * See that the initial map position for editing a project with no scene is Dar es Salaam
 * If you want, implement an overrides.js file and alter the `MAP_CENTER` or `MAP_ZOOM` parameters of the `BUILDCONFIG` to test the overridability of the values.
