### PR TITLE
Fix pagination on project scenes

### DIFF
--- a/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
+++ b/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
@@ -85,7 +85,7 @@ class InputNodeController {
                     projectId: projectId,
                     pending: false
                 }
-            ).then(scenes => {
+            ).then(({scenes})=> {
                 const datasourcesP = this.$q.all(
                     _.map(
                         _.uniqBy(scenes, scene => scene.datasource.id),

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -140,7 +140,7 @@ export default class ProjectsAdvancedColorController {
             this.projectService.getAllProjectScenes({
                 projectId: this.project.id,
                 bbox: this.filterBboxList.map(r => r.toBBoxString()).join(';')
-            }).then((selectedScenes) => {
+            }).then(({scenes: selectedScenes}) => {
                 if (this.lastRequest === requestTime) {
                     this.selectNoScenes();
                     selectedScenes.map((scene) => this.setSelected(scene, true));

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -146,10 +146,11 @@ class ProjectsSceneBrowserController {
     }
 
     getProjectSceneIds() {
-        this.projectService.getAllProjectScenes({ projectId: this.project.id }).then((scenes) => {
-            this.projectSceneIds = scenes.map(s => s.id);
-            this.projectScenesReady = true;
-        });
+        this.projectService.getAllProjectScenes({ projectId: this.project.id })
+            .then(({scenes}) => {
+                this.projectSceneIds = scenes.map(s => s.id);
+                this.projectScenesReady = true;
+            });
     }
 
     onRepositoryChange(bboxFetchFactory, repository) {

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -109,13 +109,14 @@ class ProjectsEditController {
                 pending: false
             }
         ).then(
-            (allScenes) => {
+            ({count: sceneCount, scenes: allScenes}) => {
+                this.sceneCount = sceneCount;
                 this.addUningestedScenesToMap(allScenes.filter(
                     (scene) => scene.statusFields.ingestStatus !== 'INGESTED'
                 ));
                 return this.projectService.getSceneOrder(this.projectId).then(
-                    (res) => {
-                        this.orderedSceneId = res.results;
+                    (orderedIds) => {
+                        this.orderedSceneId = orderedIds;
                         this.sceneList = _(
                           this.orderedSceneId.map((id) => _.find(allScenes, {id}))
                         ).uniqBy('id').compact().value();
@@ -188,7 +189,8 @@ class ProjectsEditController {
                 projectId: this.projectId,
                 pending: true
             });
-            this.pendingSceneRequest.then(pendingScenes => {
+            this.pendingSceneRequest.then(({count, scenes: pendingScenes}) => {
+                this.pendingSceneCount = count;
                 this.pendingSceneList = _(pendingScenes).uniqBy('id').compact().value();
             });
         }

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -9,7 +9,7 @@
     </a>
     <h5 class="sidebar-title">
       Scenes
-      <ng-pluralize count="$ctrl.$parent.sceneList.length"
+      <ng-pluralize count="$ctrl.$parent.sceneCount"
                     when="{'0': '(0)',
                           'one': '(1)',
                           'other': '({})'
@@ -18,10 +18,10 @@
     </h5>
   </div>
   <div class="content">
-    <div ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneList.length">
+    <div ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
       <!-- Alert -->
       <div class="alert alert-secondary">
-        <div class="alert-message">{{$ctrl.$parent.pendingSceneList.length}} scenes awaiting approval</div>
+        <div class="alert-message">{{$ctrl.$parent.pendingSceneCount}} scenes awaiting approval</div>
         <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
       </div>
       <!-- Alert -->

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -47,7 +47,7 @@ class ProjectsScenesController {
     removeSceneFromProject(scene, $event) {
         $event.stopPropagation();
         $event.preventDefault();
-        this.projectService.removeScenesFromProject(this.projectId, [scene.id]).then(
+        this.projectService.removeScenesFromProject(this.$parent.projectId, [scene.id]).then(
             () => {
                 this.$parent.removeHoveredScene();
                 this.$parent.getSceneList();
@@ -82,7 +82,7 @@ class ProjectsScenesController {
     }
 
     updateSceneOrder(orderedSceneIds) {
-        this.projectService.updateSceneOrder(this.projectId, orderedSceneIds).then(() => {
+        this.projectService.updateSceneOrder(this.$parent.projectId, orderedSceneIds).then(() => {
             this.$parent.layerFromProject();
         });
     }


### PR DESCRIPTION
## Overview
Simplify and fix fetching scenes and scene ordering in the edit controller


### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/43612773-4b88e7fc-967b-11e8-8b0e-5a04f5171799.png)



## Testing Instructions

 * Verify that pagination on the project scene list endpoint now works correctly, instead of using limit/offset pagination
* Verify that the frontend correctly fetches multiple pages of scene ordering
* Verify that the project scene page correctly shows > 30 scenes in a project on the scene list panel
Closes https://github.com/raster-foundry/raster-foundry/issues/3792
