### PR TITLE
Prevent container build failure when copying nginx/srv/dist before it exists

### DIFF
--- a/nginx/Dockerfile.api
+++ b/nginx/Dockerfile.api
@@ -2,8 +2,9 @@ FROM nginx:1.10
 
 RUN mkdir -p /etc/nginx/includes
 
-COPY srv/dist /srv/dist/
+COPY Dockerfile.api srv*/dist*/ /srv/dist/
 RUN chown nginx:nginx -R /srv/dist/
+RUN rm /srv/dist/Dockerfile.api
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY etc/nginx/includes/*.conf /etc/nginx/includes/

--- a/scripts/setup
+++ b/scripts/setup
@@ -21,6 +21,7 @@ then
     else
         # Ensure that a directory exists to house AWS profiles.
         mkdir -p "${HOME}/.aws"
+        mkdir -p "nginx/srv/dist/"
 
         vagrant up --provision
     fi


### PR DESCRIPTION
## Overview
Copy dockerfile over along with srv*/dist*/ wildcard so it always copies at
least one file

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/43653416-ff03be66-9715-11e8-853b-fd9679fd729c.png)

### Notes
the COPY command requires that at least one file is copied over - by copying a file that is known to exist and using a wildcard to fetch the rest, we avoid the error that occurs when trying to copy a non-existent directory.

## Testing Instructions

 * Delete your nginx/srv/dist folder
* On another branch, try building the container using `docker-compose build nginx-api`, verify that it fails
* switch to the PR branch, and try again. It should succeed
* Verify that Dockerfile.api does not appear in /srv/dist inside the container by running `docker-compose run nginx-api bash` `ls /srv/dist`
* nginx/srv/dist will now exist and an empty folder outside the docker container if it did not already exist.

Closes #2230 
