### PR TITLE
Fix select in permission modal cutting off text

### DIFF
--- a/app-frontend/src/assets/styles/sass/components/_permissions-modal.scss
+++ b/app-frontend/src/assets/styles/sass/components/_permissions-modal.scss
@@ -82,7 +82,7 @@ rf-permission-item {
             margin-right: 0.5em;
             align-self: center;
             height: 3rem;
-            padding: 1rem 2rem;
+            padding: 3px 12px;
         }
         button {
             align-self: center;


### PR DESCRIPTION
## Overview
Adjust component padding

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/43657314-74b41842-9723-11e8-940d-e461236aef59.png)
![image](https://user-images.githubusercontent.com/4392704/43657652-7404028a-9724-11e8-9672-fadfb6a9c771.png)


## Testing Instructions

 * Verify that the permissions modal no longer as overflow / clipping issues on the select box in both themes

Closes #3778