### PR TITLE
Force re-fetching datasources after adding scenes to project

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -306,7 +306,9 @@ class ProjectsSceneBrowserController {
             this.projectSceneIds = this.projectSceneIds.concat(sceneIds);
             this.selectNoScenes();
         }).finally(() => {
-            this.$parent.getSceneList();
+            this.$parent.getSceneList().then(() => {
+                this.$parent.fetchDatasources(true);
+            });
         });
     }
 

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.controller.js
@@ -154,7 +154,9 @@ export default class ProjectsEditColormode {
 
     toggleProjectSingleBandMode(state) {
         this.initSingleBandDefaults();
-        if (typeof state !== 'undefined') {
+        if (!this.projectBuffer) {
+            return;
+        } else if (typeof state !== 'undefined') {
             this.projectBuffer.isSingleBand = state;
         } else {
             this.projectBuffer.isSingleBand = !this.projectBuffer.isSingleBand;
@@ -277,7 +279,7 @@ export default class ProjectsEditColormode {
     }
 
     isActiveColorMode(key) {
-        if (!this.isLoading) {
+        if (!this.isLoading && this.projectBuffer) {
             return (
                 !this.projectBuffer.isSingleBand &&
                 key === this.activeColorModeKey

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -2,7 +2,7 @@
   <div class="sidebar-header">
     <h5 class="sidebar-title">Color Mode</h5>
     <div class="header-controls">
-      <a ng-hide="$ctrl.projectBuffer.isSingleBand" ui-sref="projects.edit.advancedcolor"
+      <a ng-hide="($ctrl.projectBuffer && $ctrl.projectBuffer.isSingleBand) || !$ctrl.projectBuffer" ui-sref="projects.edit.advancedcolor"
         class="btn btn-primary">Corrections</a>
     </div>
   </div>
@@ -35,10 +35,10 @@
         </div>
     </div>
     <div class="list-group-item list-group-item-stacked"
-         ng-class="{'active': $ctrl.projectBuffer.isSingleBand}">
+         ng-class="{'active': $ctrl.projectBuffer && $ctrl.projectBuffer.isSingleBand}">
       <div class="list-group-item-row">
         <span class="font-600">Single band</span>
-        <div class="list-group-right" ng-if="$ctrl.$parent.bands.length">
+        <div class="list-group-right" ng-if="$ctrl.$parent.bands.length && $ctrl.projectBuffer">
           <rf-toggle radio="true" value="$ctrl.projectBuffer.isSingleBand" on-change="$ctrl.setActiveColorMode('singleband')">
           </rf-toggle>
         </div>

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -121,9 +121,6 @@ class ProjectsEditController {
                           this.orderedSceneId.map((id) => _.find(allScenes, {id}))
                         ).uniqBy('id').compact().value();
 
-                        this.fetchDatasources().then(datasources => {
-                            this.bands = this.datasourceService.getUnifiedBands(datasources);
-                        });
 
                         this.sceneLayers = this.sceneList.map(scene => ({
                             id: scene.id,
@@ -134,6 +131,7 @@ class ProjectsEditController {
 
                         this.layerFromProject();
                         this.initColorComposites();
+                        return this.fetchDatasources();
                     },
                     (err) => {
                         this.$log.error('Error while adding scenes to projects', err);
@@ -247,7 +245,10 @@ class ProjectsEditController {
         if (!this.datasourceRequest || force) {
             this.datasourceRequest = this.$q.all(
                 this.sceneList.map(s => this.sceneService.datasource(s))
-            );
+            ).then((datasources) => {
+                this.bands = this.datasourceService.getUnifiedBands(datasources);
+                return datasources;
+            });
         }
         return this.datasourceRequest;
     }


### PR DESCRIPTION
## Overview
Promise chaining was also set up in a way that promises were being executed out of order (branching vs chaining)

### Checklist

-~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions

 * Create a new project
* add scenes to it
* go to the color mode view directly, do not refresh the page, do not pass go
* Verify that single band and custom color mode options are available as they should be

Closes #3704
