### PR TITLE
Fix annotation shapefile export and import

### DIFF
--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.AmazonS3URI
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
+import scala.io.Source._
 import akka.http.scaladsl.model.{Uri, StatusCodes}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.FileInfo

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -949,8 +949,11 @@ trait ProjectRoutes extends Authentication
         case true => {
           val shapefilePath = matches.next.toString
           val features = ShapeFileReader.readSimpleFeatures(shapefilePath)
+          println("features")
+          println(features.toList)
+
           val featureAccumulationResult =
-            Shapefile.accumulateFeatures(Annotation.fromSimpleFeature)(List(), List(), features.toList)
+            Shapefile.accumulateFeatures(Annotation.getPropertiesNames)(List(), List(), features.toList)
           featureAccumulationResult match {
             case Left(errorIndices) =>
               complete(
@@ -959,15 +962,31 @@ trait ProjectRoutes extends Authentication
                   s"Several features could not be translated to annotations. Indices: ${errorIndices}"
                 )
               )
-            case Right(annotationCreates) => {
-              complete(
-                StatusCodes.Created,
-                (AnnotationDao.insertAnnotations(annotationCreates, projectId, user)
-                   map {(anns: List[Annotation]) => anns map { _.toGeoJSONFeature }}
-                ).transact(xa).unsafeToFuture
-              )
+            case Right(propertyNames) => {
+              complete(propertyNames)
             }
           }
+
+
+          // val featureAccumulationResult =
+          //   Shapefile.accumulateFeatures(Annotation.fromSimpleFeature)(List(), List(), features.toList)
+          // featureAccumulationResult match {
+          //   case Left(errorIndices) =>
+          //     complete(
+          //       StatusCodes.ClientError(400)(
+          //         "Bad Request",
+          //         s"Several features could not be translated to annotations. Indices: ${errorIndices}"
+          //       )
+          //     )
+          //   case Right(annotationCreates) => {
+          //     complete(
+          //       StatusCodes.Created,
+          //       (AnnotationDao.insertAnnotations(annotationCreates, projectId, user)
+          //          map {(anns: List[Annotation]) => anns map { _.toGeoJSONFeature }}
+          //       ).transact(xa).unsafeToFuture
+          //     )
+          //   }
+          // }
         }
       }
     }

--- a/app-backend/common/src/main/scala/utils/Shapefile.scala
+++ b/app-backend/common/src/main/scala/utils/Shapefile.scala
@@ -1,8 +1,8 @@
 package com.azavea.rf.common.utils
 
 object Shapefile {
-  def accumulateFeatures[T1, T2](f: T1 => Option[T2])
-                        (accum: List[T2], errorIndices: List[Int], accumulateFrom: List[T1], fieldsO: Option[Map[String, String]] = None):
+  def accumulateFeatures[T1, T2, T3, T4](f: (T1, T3, T4) => Option[T2])
+                        (accum: List[T2], errorIndices: List[Int], accumulateFrom: List[T1], props: T3, user: T4):
       Either[List[Int], List[T2]] =
     accumulateFrom match {
       case Nil => {
@@ -12,12 +12,12 @@ object Shapefile {
         }
       }
       case h +: t => {
-        f(h, fieldsO) match {
+        f(h, props, user) match {
           case Some(t2) => accumulateFeatures(f)(
-            accum :+ t2, errorIndices, t
+            accum :+ t2, errorIndices, t, props, user
           )
           case None => accumulateFeatures(f)(
-            accum, errorIndices :+ (accum.length + errorIndices.length + 1), t
+            accum, errorIndices :+ (accum.length + errorIndices.length + 1), t, props, user
           )
         }
       }

--- a/app-backend/common/src/main/scala/utils/Shapefile.scala
+++ b/app-backend/common/src/main/scala/utils/Shapefile.scala
@@ -2,7 +2,7 @@ package com.azavea.rf.common.utils
 
 object Shapefile {
   def accumulateFeatures[T1, T2](f: T1 => Option[T2])
-                        (accum: List[T2], errorIndices: List[Int], accumulateFrom: List[T1]):
+                        (accum: List[T2], errorIndices: List[Int], accumulateFrom: List[T1], fieldsO: Option[Map[String, String]] = None):
       Either[List[Int], List[T2]] =
     accumulateFrom match {
       case Nil => {
@@ -12,7 +12,7 @@ object Shapefile {
         }
       }
       case h +: t => {
-        f(h) match {
+        f(h, fieldsO) match {
           case Some(t2) => accumulateFeatures(f)(
             accum :+ t2, errorIndices, t
           )

--- a/app-backend/common/src/main/scala/utils/Shapefile.scala
+++ b/app-backend/common/src/main/scala/utils/Shapefile.scala
@@ -1,8 +1,10 @@
 package com.azavea.rf.common.utils
 
 object Shapefile {
-  def accumulateFeatures[T1, T2, T3, T4](f: (T1, T3, T4) => Option[T2])
-                        (accum: List[T2], errorIndices: List[Int], accumulateFrom: List[T1], props: T3, user: T4):
+
+  def accumulateFeatures[T1, T2](f: (T1, Map[String, String], String, String) => Option[T2])
+                        (accum: List[T2], errorIndices: List[Int], accumulateFrom: List[T1],
+                         props: Map[String, String], userId: String, prj: String):
       Either[List[Int], List[T2]] =
     accumulateFrom match {
       case Nil => {
@@ -12,12 +14,12 @@ object Shapefile {
         }
       }
       case h +: t => {
-        f(h, props, user) match {
+        f(h, props, userId, prj) match {
           case Some(t2) => accumulateFeatures(f)(
-            accum :+ t2, errorIndices, t, props, user
+            accum :+ t2, errorIndices, t, props, userId, prj
           )
           case None => accumulateFeatures(f)(
-            accum, errorIndices :+ (accum.length + errorIndices.length + 1), t, props, user
+            accum, errorIndices :+ (accum.length + errorIndices.length + 1), t, props, userId, prj
           )
         }
       }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -133,7 +133,6 @@ object Annotation extends LazyLogging {
       case null => "Unlabeled"
       case _ => sf.getProperty(labelPropName).getValue.toString
     }
-    println(label)
     val description = desPropName match {
       case null => Some("No Description")
       case _ => Some(sf.getProperty(desPropName).getValue.toString)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -114,27 +114,6 @@ object Annotation {
   def tupled = (Annotation.apply _).tupled
   def create = Create.apply _
 
-  def getPropertiesNames(sf: SimpleFeature): List[String] = {
-    println("fromSimpleFeature")
-    val geom = WKT.read(sf.getDefaultGeometry.toString)
-    println("geom")
-    println(geom)
-    val projected = Projected(Reproject(geom, LatLng, WebMercator), 3857)
-    println("projected")
-    println(projected)
-    println("projected.isValid")
-    println(projected.isValid)
-    println("sf.getProperties()")
-    println(sf.getProperties())
-    sf.getProperties()
-      .toArray
-      .toList(0)
-      .toString
-      .split("SimpleFeatureImpl.Attribute: ")
-      .filter(s => s != "")
-      .map(s => s.split("<")(0))
-      .toList
-  }
 
   def fromSimpleFeature(sf: SimpleFeature): Option[Create] = {
     println("fromSimpleFeature")

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -114,45 +114,117 @@ object Annotation {
   def tupled = (Annotation.apply _).tupled
   def create = Create.apply _
 
-  def fromSimpleFeature(sf: SimpleFeature): Option[Create] = {
+  def getPropertiesNames(sf: SimpleFeature): List[String] = {
+    println("fromSimpleFeature")
     val geom = WKT.read(sf.getDefaultGeometry.toString)
+    println("geom")
+    println(geom)
     val projected = Projected(Reproject(geom, LatLng, WebMercator), 3857)
-    if (projected.isValid) {
-      val owner = Option(sf.getAttribute("owner")) map { (o: Object) => o.toString }
-      val label = sf.getProperty("label").getValue.toString
-      val description = Option(sf.getAttribute("descriptio")) map { (o: Object) => o.toString }
-      val machineGenerated = Option(sf.getProperty("machineGen")) flatMap {
-        (p: Property) => p.getValue.toString match {
-          // Apparently ogr2ogr stores bools as ints /shrug
-          case "1" => Some(true)
-          case "0" => Some(false)
-          case _ => None
-        }
+    println("projected")
+    println(projected)
+    println("projected.isValid")
+    println(projected.isValid)
+    println("sf.getProperties()")
+    println(sf.getProperties())
+    sf.getProperties()
+      .toArray
+      .toList(0)
+      .toString
+      .split("SimpleFeatureImpl.Attribute: ")
+      .filter(s => s != "")
+      .map(s => s.split("<")(0))
+      .toList
+  }
+
+  def fromSimpleFeature(sf: SimpleFeature): Option[Create] = {
+    println("fromSimpleFeature")
+    val geom = WKT.read(sf.getDefaultGeometry.toString)
+    println("geom")
+    println(geom)
+    val projected = Projected(Reproject(geom, LatLng, WebMercator), 3857)
+    println("projected")
+    println(projected)
+    println("projected.isValid")
+    println(projected.isValid)
+    println("sf.getProperties()")
+    println(sf.getProperties())
+
+    val owner = Option(sf.getAttribute("owner")) map { (o: Object) => o.toString }
+    val label = sf.getProperty("label").getValue.toString
+    val description = Option(sf.getAttribute("descriptio")) map { (o: Object) => o.toString }
+    val machineGenerated = Option(sf.getProperty("machineGen")) flatMap {
+      (p: Property) => p.getValue.toString match {
+        // Apparently ogr2ogr stores bools as ints /shrug
+        case "1" => Some(true)
+        case "0" => Some(false)
+        case _ => None
       }
-      val confidence = Option(sf.getProperty("confidence")) flatMap {
-        (p: Property) =>  decode[Float](p.getValue.toString).toOption
-      }
-      val quality = Option(sf.getProperty("quality")) flatMap {
-        (p: Property) => decode[AnnotationQuality](p.getValue.toString).toOption
-      }
-      val annotationGroup = Option(sf.getProperty("group")) flatMap {
-        (p: Property) => decode[UUID](p.getValue.toString).toOption
-      }
-      Some(
-        Create(
-          Some("auth0|59318a9d2fbbca3e16bcfc92"),
-          label,
-          description,
-          machineGenerated,
-          confidence,
-          quality,
-          Some(projected),
-          annotationGroup
-        )
-      )
-    } else {
-      None
     }
+    val confidence = Option(sf.getProperty("confidence")) flatMap {
+      (p: Property) =>  decode[Float](p.getValue.toString).toOption
+    }
+    val quality = Option(sf.getProperty("quality")) flatMap {
+      (p: Property) => decode[AnnotationQuality](p.getValue.toString).toOption
+    }
+    // TODO: this is not correct
+    // this function is only used when uploading shapefile to a project
+    // so if a project has annotations, it should use the same group id
+    // if not, create one
+    val annotationGroup = Option(sf.getProperty("group")) flatMap {
+      (p: Property) => decode[UUID](p.getValue.toString).toOption
+    }
+    Some(
+      Create(
+        Some("auth0|59318a9d2fbbca3e16bcfc92"),
+        label,
+        description,
+        machineGenerated,
+        confidence,
+        quality,
+        Some(projected),
+        annotationGroup
+      )
+    )
+    // if (projected.isValid) {
+    //   val owner = Option(sf.getAttribute("owner")) map { (o: Object) => o.toString }
+    //   val label = sf.getProperty("label").getValue.toString
+    //   val description = Option(sf.getAttribute("descriptio")) map { (o: Object) => o.toString }
+    //   val machineGenerated = Option(sf.getProperty("machineGen")) flatMap {
+    //     (p: Property) => p.getValue.toString match {
+    //       // Apparently ogr2ogr stores bools as ints /shrug
+    //       case "1" => Some(true)
+    //       case "0" => Some(false)
+    //       case _ => None
+    //     }
+    //   }
+    //   val confidence = Option(sf.getProperty("confidence")) flatMap {
+    //     (p: Property) =>  decode[Float](p.getValue.toString).toOption
+    //   }
+    //   val quality = Option(sf.getProperty("quality")) flatMap {
+    //     (p: Property) => decode[AnnotationQuality](p.getValue.toString).toOption
+    //   }
+    //   // TODO: this is not correct
+    //   // this function is only used when uploading shapefile to a project
+    //   // so if a project has annotations, it should use the same group id
+    //   // if not, create one
+    //   val annotationGroup = Option(sf.getProperty("group")) flatMap {
+    //     (p: Property) => decode[UUID](p.getValue.toString).toOption
+    //   }
+    //   Some(
+    //     Create(
+    //       Some("auth0|59318a9d2fbbca3e16bcfc92"),
+    //       label,
+    //       description,
+    //       machineGenerated,
+    //       confidence,
+    //       quality,
+    //       Some(projected),
+    //       annotationGroup
+    //     )
+    //   )
+    // } else {
+    //   None
+    // }
   }
 
   @ConfiguredJsonCodec

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -115,7 +115,7 @@ object Annotation {
   def create = Create.apply _
 
 
-  def fromSimpleFeature(sf: SimpleFeature): Option[Create] = {
+  def fromSimpleFeature(sf: SimpleFeature, fields: Option[Map[String, String]] = None): Option[Create] = {
     println("fromSimpleFeature")
     val geom = WKT.read(sf.getDefaultGeometry.toString)
     println("geom")

--- a/app-frontend/src/app/api/annotations.js
+++ b/app-frontend/src/app/api/annotations.js
@@ -54,13 +54,30 @@ export function clearProjectAnnotationsRequest(state) {
     }, state);
 }
 
-export function postShapefile(state, shapefileBuf) {
+export function uploadShapefileOnly(state, shapefileBuf) {
     let data = new FormData();
     data.append('name', shapefileBuf);
     return authedRequest({
         method: 'post',
         url: `${state.api.apiUrl}` +
             `/api/projects/${state.projects.projectId}/annotations/shapefile`,
+        data: data,
+        headers: {'Content-Type': 'multipart/form-data;boundary="=="'}
+    }, state);
+}
+
+export function uploadShapefileWithProps(state, shapefileBuf, matchedKeys) {
+    let data = new FormData();
+    data.append('shapefile', shapefileBuf);
+    data.append('label', matchedKeys.label);
+    data.append('description', matchedKeys.description);
+    data.append('isMachine', matchedKeys.isMachine);
+    data.append('confidence', matchedKeys.confidence);
+    data.append('quality', matchedKeys.quality);
+    return authedRequest({
+        method: 'post',
+        url: `${state.api.apiUrl}` +
+            `/api/projects/${state.projects.projectId}/annotations/shapefile/import`,
         data: data,
         headers: {'Content-Type': 'multipart/form-data;boundary="=="'}
     }, state);

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.html
@@ -3,7 +3,7 @@
   <div class="sidebar-item annotation-item">
     <div class="inner">
       <i class="icon-polygon"
-         ng-if="$ctrl.annotation.geometry.type === 'Polygon'"></i>
+         ng-if="$ctrl.annotation.geometry.type === 'Polygon' || $ctrl.annotation.geometry.type === 'MultiPolygon'"></i>
       <i class="icon-map-pin"
          ng-if="$ctrl.annotation.geometry.type === 'Point'"></i>
       <p class="annotation-confidence" ng-if="$ctrl.annotation.properties.machineGenerated">

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -52,6 +52,7 @@ class AnnotateController {
         }
         let persistedLabels = state.projects.labels;
         let labels = [{name: 'All'}].concat(persistedLabels.map(label => ({name: label})));
+        let annotationShapefileProps = state.projects.annotationShapefileProps;
         return {
             user: state.api.user,
             annotations,
@@ -61,7 +62,8 @@ class AnnotateController {
             fetchingAnnotations: state.projects.fetchingAnnotations,
             fetchingAnnotationsError: state.projects.fetchingAnnotationsError,
             editingAnnotation: state.projects.editingAnnotation,
-            annotationTemplate: state.projects.annotationTemplate
+            annotationTemplate: state.projects.annotationTemplate,
+            annotationShapefileProps
         };
     }
 

--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
@@ -39,7 +39,7 @@
       </div>
     </div>
   </div>
-  <div class="list-group" ng-if="$ctrl.uploadData">
+  <div class="list-group" ng-if="$ctrl.uploadData || $ctrl.hasShapefileProps">
     <div class="list-group-item">
       <div>
         <span title="Machine made"><strong>Machine made</strong></span>
@@ -113,6 +113,30 @@
                placeholder="No Description"
                ng-model="$ctrl.defaultKeys['description']"
                ng-init="$ctrl.defaultKeys['description'] = 'No Description'">
+      </div>
+    </div>
+    <div class="list-group-item" ng-if="$ctrl.isMachineData && $ctrl.hasShapefileProps">
+      <span title="Confidence"><strong>Machine Made</strong></span>
+      <div class="list-group-right">
+        <div class="dropdown btn-group fixedwidth upload" uib-dropdown uib-dropdown-toggle>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.isMachine !== null">
+            {{$ctrl.matchKeys.isMachine || 'Choose a column'}}
+          </a>
+          <a class="btn dropdown-label" ng-show="$ctrl.matchKeys.isMachine === null">
+            No indication
+          </a>
+          <button type="button" class="btn btn-primary dropdown-toggle">
+            <i class="icon-caret-down"></i>
+          </button>
+          <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('isMachine', null)">No indication</a>
+            </li>
+            <li ng-repeat="p in $ctrl.dataProperties" role="menuitem">
+              <a ng-click="$ctrl.updateKeySelection('isMachine', p)">{{p}}</a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
     <div class="list-group-item" ng-if="$ctrl.isMachineData">

--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
@@ -8,6 +8,9 @@
       <h5 class="sidebar-title">Import Annotations</h5>
     </div>
     <div class="list-group" ng-show="!$ctrl.uploadData">
+      <div class="color-danger font-700 text-center annotation-upload-error" ng-if="$ctrl.uploadAnnotationsError">
+        {{$ctrl.uploadAnnotationsError}}
+      </div>
       <div class="list-group-item">
         <label class="btn btn-primary btn-block btn-upload-label"
                for="geojson-btn-upload"

--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.html
@@ -2,7 +2,7 @@
 <div class="sidebar-project">
   <div class="sidebar-static">
     <div class="sidebar-header">
-      <a class="btn sidebar-header-nav-btn" ui-sref="projects.edit.annotate">
+      <a class="btn sidebar-header-nav-btn" ng-click="$ctrl.onGoToParent()">
         <i class="icon-arrow-left"></i>
       </a>
       <h5 class="sidebar-title">Import Annotations</h5>
@@ -19,6 +19,8 @@
                  class="btn-upload"/>
           Upload GeoJSON
         </label>
+      </div>
+      <div class="list-group-item">
         <label class="btn btn-primary btn-block btn-upload-label"
                for="shapefile-btn-upload"
                ng-click="$ctrl.onUploadClick()">

--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.module.js
@@ -85,7 +85,6 @@ class AnnotateImportController {
     setShapefileUploadData(shapefileData) {
         this.shapefileData = shapefileData;
         this.$parent.uploadShapefile(shapefileData);
-        // this.$state.go('projects.edit.annotate');
     }
 
     updateKeySelection(appKey, dataKey) {
@@ -146,6 +145,13 @@ class AnnotateImportController {
             this.hasShapefileProps = false;
         }
 
+        this.$state.go('projects.edit.annotate');
+    }
+
+    onGoToParent() {
+        this.hasShapefileProps = false;
+        this.dataProperties = [];
+        this.$parent.deleteShapeFileUpload();
         this.$state.go('projects.edit.annotate');
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/annotate/import/import.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/import/import.module.js
@@ -5,7 +5,7 @@ require('./import.scss');
 
 class AnnotateImportController {
     constructor( // eslint-disable-line max-params
-        $log, $state, $scope, $timeout
+        $log, $state, $scope, $timeout, $ngRedux
     ) {
         'ngInject';
         this.$log = $log;
@@ -13,6 +13,11 @@ class AnnotateImportController {
         this.$scope = $scope;
         this.$timeout = $timeout;
         this.$parent = $scope.$parent.$ctrl;
+
+        $ngRedux.subscribe(() => {
+            this.state = $ngRedux.getState();
+            this.uploadAnnotationsError = this.state.projects.uploadAnnotationsError;
+        });
     }
 
     $onInit() {

--- a/app-frontend/src/app/redux/actions/annotation-actions.js
+++ b/app-frontend/src/app/redux/actions/annotation-actions.js
@@ -1,7 +1,7 @@
 import {
     getProjectAnnotationsRequest, createProjectAnnotationsRequest, updateProjectAnnotationRequest,
     getProjectLabelsRequest, clearProjectAnnotationsRequest, deleteProjectAnnotationRequest,
-    postShapefile
+    uploadShapefileOnly, uploadShapefileWithProps
 } from '_api/annotations';
 
 // IF YOU ADD CONSTANTS:
@@ -21,6 +21,7 @@ export const ANNOTATIONS_EDIT = 'ANNOTATIONS_EDIT';
 export const ANNOTATIONS_BULK_CREATE = 'ANNOTATIONS_BULK_CREATE';
 export const ANNOTATIONS_SIDEBAR = 'ANNOTATIONS_SIDEBAR';
 export const ANNOTATIONS_TRANSFORM_DRAWLAYER = 'ANNOTATIONS_TRANSFORM_DRAWLAYER';
+export const ANNOTATIONS_UPLOAD_SHAPEFILE = 'ANNOTATIONS_UPLOAD_SHAPEFILE';
 export const ANNOTATIONS_IMPORT_SHAPEFILE = 'ANNOTATIONS_IMPORT_SHAPEFILE';
 
 export const ANNOTATIONS_ACTION_PREFIX = 'ANNOTATIONS';
@@ -81,11 +82,20 @@ export function createAnnotations(annotations, edit) {
     };
 }
 
-export function importShapefile(shapefile) {
+export function uploadShapefile(shapefile) {
+    return (dispatch, getState) => {
+        dispatch({
+            type: ANNOTATIONS_UPLOAD_SHAPEFILE,
+            payload: uploadShapefileOnly(getState(), shapefile)
+        });
+    };
+}
+
+export function importShapefileWithProps(shapefile, matchedKeys) {
     return (dispatch, getState) => {
         dispatch({
             type: ANNOTATIONS_IMPORT_SHAPEFILE,
-            payload: postShapefile(getState(), shapefile)
+            payload: uploadShapefileWithProps(getState(), shapefile, matchedKeys)
         });
     };
 }
@@ -191,5 +201,5 @@ export default {
     createAnnotations, updateAnnotation, filterAnnotations,
     clearAnnotations, editAnnotation, finishEditingAnnotation,
     deleteAnnotation, bulkCreateAnnotations, finishBulkCreate,
-    transformDrawlayer, importShapefile
+    transformDrawlayer, uploadShapefile, importShapefileWithProps
 };

--- a/app-frontend/src/app/redux/actions/annotation-actions.js
+++ b/app-frontend/src/app/redux/actions/annotation-actions.js
@@ -23,6 +23,7 @@ export const ANNOTATIONS_SIDEBAR = 'ANNOTATIONS_SIDEBAR';
 export const ANNOTATIONS_TRANSFORM_DRAWLAYER = 'ANNOTATIONS_TRANSFORM_DRAWLAYER';
 export const ANNOTATIONS_UPLOAD_SHAPEFILE = 'ANNOTATIONS_UPLOAD_SHAPEFILE';
 export const ANNOTATIONS_IMPORT_SHAPEFILE = 'ANNOTATIONS_IMPORT_SHAPEFILE';
+export const ANNOTATIONS_UPLOAD_SHAPEFILE_DELETE = 'ANNOTATIONS_UPLOAD_SHAPEFILE_DELETE';
 
 export const ANNOTATIONS_ACTION_PREFIX = 'ANNOTATIONS';
 
@@ -87,6 +88,14 @@ export function uploadShapefile(shapefile) {
         dispatch({
             type: ANNOTATIONS_UPLOAD_SHAPEFILE,
             payload: uploadShapefileOnly(getState(), shapefile)
+        });
+    };
+}
+
+export function deleteShapeFileUpload() {
+    return (dispatch, getState) => {
+        dispatch({
+            type: ANNOTATIONS_UPLOAD_SHAPEFILE_DELETE
         });
     };
 }
@@ -201,5 +210,6 @@ export default {
     createAnnotations, updateAnnotation, filterAnnotations,
     clearAnnotations, editAnnotation, finishEditingAnnotation,
     deleteAnnotation, bulkCreateAnnotations, finishBulkCreate,
-    transformDrawlayer, uploadShapefile, importShapefileWithProps
+    transformDrawlayer, uploadShapefile, importShapefileWithProps,
+    deleteShapeFileUpload
 };

--- a/app-frontend/src/app/redux/reducers/annotation-reducer.js
+++ b/app-frontend/src/app/redux/reducers/annotation-reducer.js
@@ -9,6 +9,7 @@ import {
     ANNOTATIONS_CLEAR, ANNOTATIONS_EDIT, ANNOTATIONS_DELETE,
     ANNOTATIONS_BULK_CREATE,
     ANNOTATIONS_TRANSFORM_DRAWLAYER,
+    ANNOTATIONS_UPLOAD_SHAPEFILE,
     ANNOTATIONS_IMPORT_SHAPEFILE,
 
     fetchAnnotations, updateAnnotation, fetchLabels
@@ -45,6 +46,24 @@ export const annotationReducer = typeToReducer({
     // action.payload should contain the returned annotations (in the fulfilled case)
     // not clear what comes back in pending
     // error body in rejected.action.payload
+    [ANNOTATIONS_UPLOAD_SHAPEFILE]: {
+        PENDING: (state) => {
+            return Object.assign({}, state, {fetchingAnnotations: true});
+        },
+        REJECTED: (state, action) => {
+            return Object.assign(
+                {}, state, {fetchingAnnotationsError: action.payload}
+            );
+        },
+        FULFILLED: (state, action) => {
+            let annotationShapefileProps = action.payload.data;
+            console.log(state, action);
+            return Object.assign({}, state, {
+                annotationShapefileProps,
+                fetchingAnnotations: false
+            });
+        }
+    },
     [ANNOTATIONS_IMPORT_SHAPEFILE]: {
         PENDING: (state) => {
             return Object.assign({}, state, {fetchingAnnotations: true});
@@ -60,7 +79,10 @@ export const annotationReducer = typeToReducer({
             newAnnotations.forEach(annotation => {
                 annotations = annotations.set(annotation.id, annotation);
             });
-            return Object.assign({}, state, { annotations, fetchingAnnotations: false });
+            return Object.assign({}, state, {
+                annotations,
+                fetchingAnnotations: false
+            });
         }
     },
     [ANNOTATIONS_FETCH]: {

--- a/app-frontend/src/app/redux/reducers/annotation-reducer.js
+++ b/app-frontend/src/app/redux/reducers/annotation-reducer.js
@@ -11,6 +11,7 @@ import {
     ANNOTATIONS_TRANSFORM_DRAWLAYER,
     ANNOTATIONS_UPLOAD_SHAPEFILE,
     ANNOTATIONS_IMPORT_SHAPEFILE,
+    ANNOTATIONS_UPLOAD_SHAPEFILE_DELETE,
 
     fetchAnnotations, updateAnnotation, fetchLabels
 } from '_redux/actions/annotation-actions';
@@ -57,7 +58,6 @@ export const annotationReducer = typeToReducer({
         },
         FULFILLED: (state, action) => {
             let annotationShapefileProps = action.payload.data;
-            console.log(state, action);
             return Object.assign({}, state, {
                 annotationShapefileProps,
                 fetchingAnnotations: false
@@ -81,9 +81,13 @@ export const annotationReducer = typeToReducer({
             });
             return Object.assign({}, state, {
                 annotations,
-                fetchingAnnotations: false
+                fetchingAnnotations: false,
+                annotationShapefileProps: []
             });
         }
+    },
+    [ANNOTATIONS_UPLOAD_SHAPEFILE_DELETE]: (state) => {
+        return Object.assign({}, state, {annotationShapefileProps: []});
     },
     [ANNOTATIONS_FETCH]: {
         PENDING: (state) => {

--- a/app-frontend/src/app/redux/reducers/annotation-reducer.js
+++ b/app-frontend/src/app/redux/reducers/annotation-reducer.js
@@ -49,28 +49,35 @@ export const annotationReducer = typeToReducer({
     // error body in rejected.action.payload
     [ANNOTATIONS_UPLOAD_SHAPEFILE]: {
         PENDING: (state) => {
-            return Object.assign({}, state, {fetchingAnnotations: true});
+            return Object.assign({}, state, {
+                fetchingAnnotations: true,
+                uploadAnnotationsError: null
+            });
         },
         REJECTED: (state, action) => {
             return Object.assign(
-                {}, state, {fetchingAnnotationsError: action.payload}
+                {}, state, {uploadAnnotationsError: action.payload.response.data}
             );
         },
         FULFILLED: (state, action) => {
             let annotationShapefileProps = action.payload.data;
             return Object.assign({}, state, {
                 annotationShapefileProps,
-                fetchingAnnotations: false
+                fetchingAnnotations: false,
+                uploadAnnotationsError: null
             });
         }
     },
     [ANNOTATIONS_IMPORT_SHAPEFILE]: {
         PENDING: (state) => {
-            return Object.assign({}, state, {fetchingAnnotations: true});
+            return Object.assign({}, state, {
+                fetchingAnnotations: true,
+                uploadAnnotationsError: null
+            });
         },
         REJECTED: (state, action) => {
             return Object.assign(
-                {}, state, {fetchingAnnotationsError: action.payload}
+                {}, state, {uploadAnnotationsError: action.payload.response.data}
             );
         },
         FULFILLED: (state, action) => {
@@ -82,7 +89,8 @@ export const annotationReducer = typeToReducer({
             return Object.assign({}, state, {
                 annotations,
                 fetchingAnnotations: false,
-                annotationShapefileProps: []
+                annotationShapefileProps: [],
+                uploadAnnotationsError: null
             });
         }
     },

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3269,7 +3269,13 @@ rf-navbar-search {
     text-align: center;
 }
 
+
 // components/exports/exportAnalysisDownloadModal/exportAnalysisDownloadModal.html
 .export-modal-download-btn {
   width: 155px;
+}
+
+// pages/projects/edit/annotate/import/import.html
+.annotation-upload-error {
+  margin-top: 1em;
 }


### PR DESCRIPTION
## Overview

This PR fixes annotation shapefile frontend and backend for:
 - import:
    * read and parse projection from `.prj` and re-project to web mercator before storing in db
    * use user specified field names to read and parse properties before storing in db
 - export:
    * re-project from web mercator to wgs84 and set so in the schema

### Checklist

- ~Styleguide updated, if necessary~
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

Annotation export as shapefile projected to `WGS84`
![video-play-close](https://raw.githubusercontent.com/aaronxsu/MyData/master/gifs/rf-pr-gifs/export.gif)

Annotation import as shapefile with field selection and `.prj` reading under the hood
![video-play-close](https://raw.githubusercontent.com/aaronxsu/MyData/master/gifs/rf-pr-gifs/import.gif)


### Notes

Swagger spec ~and frontend messages upon failures~ will be updated on ~Monday~ Wednesday.

## Testing Instructions

 * Draw some annotations on the frontend and export as shapefile
 * Re-upload these annotations to the same project or a different one. Specify field names and import. Check if it succeeds.
 * Export annotations as geojson or shapefile. Re-project them to another CRS as you like. Re-upload these annotations as zipped shapefile. Check if it works.
 * Upload zipped annotation shapefile without `.shp` or `.prj`. It should fail with alerts notifying users ~(I will add frontend messages/alerts on Monday)~

Closes #3672
