### PR TITLE
Add Lab Async Exports

### DIFF
--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -79,7 +79,7 @@ trait ExportRoutes extends Authentication
 
   def getExport(exportId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ExportDao.query.ownedBy(user, exportId).exists.transact(xa).unsafeToFuture
+      ExportDao.query.ownedByOrSuperUser(user, exportId).exists.transact(xa).unsafeToFuture
     } {
       rejectEmptyResponse {
         complete {
@@ -91,7 +91,7 @@ trait ExportRoutes extends Authentication
 
   def getExportDefinition(exportId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ExportDao.query.ownedBy(user, exportId).exists.transact(xa).unsafeToFuture
+      ExportDao.query.ownedByOrSuperUser(user, exportId).exists.transact(xa).unsafeToFuture
     } {
       rejectEmptyResponse {
         val exportDefinition = for {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/SparkJob.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/SparkJob.scala
@@ -16,5 +16,6 @@ trait SparkJob {
         .setAppName(s"Raster Foundry $jobName")
         .set("spark.serializer", classOf[org.apache.spark.serializer.KryoSerializer].getName)
         .set("spark.kryo.registrator", classOf[geotrellis.spark.io.kryo.KryoRegistrator].getName)
+        .set("spark.kryoserializer.buffer.max", "512m")
         .setIfMissing("spark.master", "local[*]")
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
@@ -98,7 +98,7 @@ case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60
   def notifyExportOwner(status: String): Unit = {
     logger.info(s"Preparing to notify export owners of status: ${status}")
     val export = ExportDao.query.filter(fr"id = ${exportId}").select.transact(xa).unsafeRunSync
-    logger.info(s"Retrieved export: ${export}")
+    logger.info(s"Retrieved export: ${export.id}")
     val platAndUserIO = for {
       ugr <- UserGroupRoleDao.query.filter(fr"user_id = ${export.owner}")
         .filter(fr"group_type = 'PLATFORM'").filter(fr"is_active = true").select
@@ -108,7 +108,7 @@ case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60
 
     logger.info(s"Retrieving Platform and User")
     val (platform, user) = platAndUserIO.transact(xa).unsafeRunSync
-    logger.info(s"Retrieved platform (${platform})and user (${user})")
+    logger.info(s"Retrieved platform (${platform.name}) and user (${user.id})")
 
     (export.projectId, export.toolRunId) match {
       case (Some(projectId), None) =>

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -74,7 +74,7 @@ object Export extends SparkJob with Config with LazyLogging {
 
           /* Create GeoTiffs and output them */
           val singles: RDD[(SpatialKey, SinglebandGeoTiff)] =
-            rdd.map({ case (key, tile) => (key, SinglebandGeoTiff(tile, mt(key), crs)) })
+            targetRDD.map({ case (key, tile) => (key, SinglebandGeoTiff(tile, mt(key), crs)) })
 
           writeGeoTiffs[Tile, SinglebandGeoTiff](singles, ed, conf)
         } else {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -263,7 +263,8 @@ object Export extends SparkJob with Config with LazyLogging {
       writeGeoTiffS3[T, G](tiff, path(ed))
     }
     case "file" => {
-      tiff.write(ed.output.source.getPath)
+      logger.info(s"Writing File Output: ${path(ed)}")
+      tiff.write(path(ed))
     }
     case _ => throw new Exception(s"Unknown schema for output location ${ed.output.source}")
   }
@@ -274,8 +275,9 @@ object Export extends SparkJob with Config with LazyLogging {
     ed: ExportDefinition,
     conf: HadoopConfiguration
   ): Unit = {
+
     def path(key: SpatialKey): ExportDefinition => String = { ed =>
-      s"${ed.output.getURLDecodedSource}/${ed.input.resolution}-${key.col}-${key.row}-${ed.id}.tiff"
+      s"${ed.output.source.getPath}/${ed.input.resolution}-${key.col}-${key.row}-${ed.id}.tiff"
     }
 
     rdd.foreachPartition({ iter =>
@@ -299,7 +301,10 @@ object Export extends SparkJob with Config with LazyLogging {
     val exportDef =
       decode[ExportDefinition](readString(params.jobDefinition)) match {
         case Right(r) => r
-        case _ => throw new Exception("Incorrect ExportDefinition JSON")
+        case Left(e) => {
+          logger.error(e.stackTraceString)
+          throw new Exception("Incorrect ExportDefinition JSON")
+        }
       }
 
     implicit val sc = new SparkContext(conf)

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
@@ -26,6 +26,7 @@ case class OutputDefinition(
   source: URI,
   dropboxCredential: Option[String]
 ) {
-  def getURLDecodedSource: String =
-    URLDecoder.decode(source.toString, "UTF-8").replace("dropbox:///", "/")
+  def getURLDecodedSource: String = URLDecoder.decode(source.toString, "UTF-8")
+    .replace("dropbox:///", "/")
+    .replace("file:///", "/")
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -15,6 +15,7 @@ import cats.data._
 import cats.effect.IO
 import cats.implicits._
 import io.circe._
+import io.circe.syntax._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 
 import scala.concurrent.Future
@@ -141,7 +142,7 @@ object ExportDao extends Dao[Export] {
       ast <- {
         toolRun.executionParameters.as[MapAlgebraAST] match {
           case Left(e) => throw e
-          case Right(mapAlgebraAST) => mapAlgebraAST
+          case Right(mapAlgebraAST) => mapAlgebraAST.withMetadata(NodeMetadata())
         }
       }.pure[ConnectionIO]
       sceneLocs <- sceneIngestLocs(ast, user)
@@ -198,7 +199,7 @@ object ExportDao extends Dao[Export] {
   ): ConnectionIO[Map[UUID, String]] = {
 
     val sceneIds: Set[UUID] = ast.tileSources.flatMap {
-      case s: SceneRaster => Some(s.id)
+      case s: SceneRaster => Some(s.sceneId)
       case _ => None
     }
 
@@ -213,7 +214,7 @@ object ExportDao extends Dao[Export] {
 
   private def projectIngestLocs(ast: MapAlgebraAST, user: User): ConnectionIO[Map[UUID, List[(UUID, String)]]] = {
     val projectIds: Set[UUID] = ast.tileSources.flatMap {
-      case s: ProjectRaster => Some(s.id)
+      case s: ProjectRaster => Some(s.projId)
       case _ => None
     }
 

--- a/app-frontend/src/app/components/map/labMap/labMap.module.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.module.js
@@ -432,7 +432,7 @@ class LabMapController {
             if (hasDropbox) {
                 this.exportTarget = target;
                 let appName = BUILDCONFIG.APP_NAME.toLowerCase().replace(' ', '-');
-                this.exportOptions.source = `dropbox:///Apps/${appName}/${this.analysisId}`;
+                this.exportOptions.source = `dropbox:///${appName}/analyses/${this.analysisId}`;
             } else {
                 this.displayDropboxModal();
             }

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -170,7 +170,7 @@ export default class NewExportController {
             this.exportOptions.source = this.exportTargetURI;
         } else if (this.getCurrentTarget().value === 'dropbox') {
             let appName = BUILDCONFIG.APP_NAME.toLowerCase().replace(' ', '-');
-            this.exportOptions.source = `dropbox:///Apps/${appName}/${this.project.id}`;
+            this.exportOptions.source = `dropbox:///${appName}/projects/${this.project.id}`;
         }
     }
 

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -11,3 +11,5 @@ dnspython==1.15.0
 planet==1.0
 retrying==1.3.3
 click==6.7
+dropbox==9.0.0
+rasterfoundry==0.6.0

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -102,9 +102,17 @@ def post_process_exports(export_definition, tiff_directory):
     logger.info('Retrieving Export: %s', export_definition['id'])
     export_obj = api.client.Imagery.get_exports_uuid(uuid=export_definition['id']).result()
     temp_geojson = os.path.join(tiff_directory, 'cut.json')
-    reproj_geojson = os.path.join(tiff_directory, 'reproj.json')
     with open(temp_geojson, 'wb') as fh:
-        geojson = {'type': 'FeatureCollection', 'features': [{"type":"Feature","properties":{},"geometry": export_obj.exportOptions.mask}]}
+        geojson = {
+            'type': 'FeatureCollection',
+            'features': [
+                {
+                    "type": "Feature",
+                    "properties": {},
+                    "geometry": export_obj.exportOptions.mask
+                }
+            ]
+        }
         json.dump(geojson, fh)
 
     tiff_files = [os.path.join(tiff_directory, f) for f in os.listdir(tiff_directory) if f.endswith('tiff')]
@@ -113,8 +121,6 @@ def post_process_exports(export_definition, tiff_directory):
     translated_tiff = os.path.join(tiff_directory, 'translated.tiff')
     export_tiff = os.path.join(tiff_directory, 'export.tiff')
     merge_command = ['gdal_merge.py', '-o', merged_tiff] + tiff_files
-    reproject_command = ['ogr2ogr', '-t_srs', 'epsg:3857', '-f', 'GeoJSON',
-                         reproj_geojson, temp_geojson]
     warp_command = ['gdalwarp', '-co', 'COMPRESS=LZW',
                     '-co', 'TILED=YES', '-crop_to_cutline',
                     '-cutline', temp_geojson, merged_tiff, export_tiff]

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -1,13 +1,17 @@
+from copy import deepcopy
+import json
 import logging
 import os
 import subprocess
-import time
+from urlparse import urlparse
 
+import boto3
 import click
+from rasterfoundry.api import API
 
+from rf.uploads.landsat8.io import get_tempdir
 from ..utils.exception_reporting import wrap_rollbar
-from ..utils.emr import get_cluster_id, wait_for_emr_success
-
+from ..utils.io import s3_upload_export, dropbox_upload_export, get_jwt
 logger = logging.getLogger(__name__)
 
 HOST = os.getenv('RF_HOST')
@@ -23,11 +27,24 @@ def export(export_id):
     Args:
         export_id (str): ID of export job to process
     """
+    logger.info('Creating Export Definition')
     export_uri = create_export_definition(export_id)
-    try:
-        status_uri = run_export(export_uri, export_id)
-    finally:
-        wait_for_status(export_id, status_uri)
+    logger.info('Retrieving Export Definition %s', export_uri)
+    export_definition = get_export_definition(export_uri)
+    with get_tempdir() as local_dir:
+        logger.info('Created Working Directory %s', local_dir)
+        logger.info('Rewriting Export Definition')
+        local_path = write_export_definition(export_definition, local_dir)
+        logger.info('Rewrote export definition to %s', local_path)
+        try:
+            logger.info('Preparing to Run Export')
+            status_uri = run_export('file://' + local_path, export_id)
+            logger.info('Post Processing Tiffs')
+            merged_tiff_path = post_process_exports(export_definition, local_dir)
+            logger.info('Uploading Processed Tiffs')
+            upload_processed_tif(merged_tiff_path, export_definition)
+        finally:
+            wait_for_status(export_id, status_uri)
 
 
 def create_export_definition(export_id):
@@ -50,6 +67,81 @@ def create_export_definition(export_id):
     return 's3://{}/{}'.format(bucket, key)
 
 
+def get_export_definition(export_uri):
+    """Reads export definition from S3, returns dict"""
+    s3 = boto3.resource('s3')
+
+    parsed_uri = urlparse(export_uri)
+    logger.info('Downloading export defintion %s', export_uri)
+    data = s3.Object(parsed_uri.netloc, parsed_uri.path[1:]).get()['Body']
+    return json.load(data)
+
+
+def write_export_definition(export_definition, local_dir):
+    """Returns local path where tiffs will be exported"""
+    local_ed_path = os.path.join(local_dir, 'export_definition.json')
+    copied = deepcopy(export_definition)
+    # Only two slashes in file:// because local_dir is an absolute unix path
+    # copied['output']['source'] = 's3://rasterfoundry-development-data-us-east-1/chris-test-local/'
+    copied['output']['source'] = 'file://{}'.format(local_dir)
+    # copied['output']['source'] = 'file:/{}.tif'.format(local_dir)
+    with open(local_ed_path, 'w') as outf:
+        outf.write(json.dumps(copied))
+    return local_ed_path
+
+
+def post_process_exports(export_definition, tiff_directory):
+    """Run GDAL commands to make exports sane
+
+    Returns: path to final tif file
+    """
+    jwt = get_jwt()
+    root_url = os.getenv('RF_HOST')
+    parsed_url = urlparse(root_url)
+    api = API(api_token=jwt, host=parsed_url.netloc, scheme=parsed_url.scheme)
+    logger.info('Retrieving Export: %s', export_definition['id'])
+    export_obj = api.client.Imagery.get_exports_uuid(uuid=export_definition['id']).result()
+    temp_geojson = os.path.join(tiff_directory, 'cut.json')
+    reproj_geojson = os.path.join(tiff_directory, 'reproj.json')
+    with open(temp_geojson, 'wb') as fh:
+        geojson = {'type': 'FeatureCollection', 'features': [{"type":"Feature","properties":{},"geometry": export_obj.exportOptions.mask}]}
+        json.dump(geojson, fh)
+
+    tiff_files = [os.path.join(tiff_directory, f) for f in os.listdir(tiff_directory) if f.endswith('tiff')]
+    logger.info('Found %s files to merge', len(tiff_files))
+    merged_tiff = os.path.join(tiff_directory, 'combined.tiff')
+    translated_tiff = os.path.join(tiff_directory, 'translated.tiff')
+    export_tiff = os.path.join(tiff_directory, 'export.tiff')
+    merge_command = ['gdal_merge.py', '-o', merged_tiff] + tiff_files
+    reproject_command = ['ogr2ogr', '-t_srs', 'epsg:3857', '-f', 'GeoJSON',
+                         reproj_geojson, temp_geojson]
+    warp_command = ['gdalwarp', '-co', 'COMPRESS=LZW',
+                    '-co', 'TILED=YES', '-crop_to_cutline',
+                    '-cutline', temp_geojson, merged_tiff, export_tiff]
+    translate_command = ['gdal_translate', '-co', 'COMPRESS=LZW', '-co', 'TILED=YES', '-stats',
+                         export_tiff, translated_tiff]
+    logger.info('Running Merge Command: %s', ' '.join(merge_command))
+    subprocess.check_call(merge_command)
+    logger.info('Running Warp Command: %s', ' '.join(warp_command))
+    subprocess.check_call(warp_command)
+    logger.info('Running Translate Command: %s', ' '.join(translate_command))
+    subprocess.check_call(translate_command)
+    logger.info('Finished post-processing export: %s', export_tiff)
+    return translated_tiff
+
+
+def upload_processed_tif(merged_tiff_path, export_definition):
+    """Uses original export definition location to upload to s3 or dropbox"""
+    dest = os.path.join(export_definition['output']['source'], 'export.tif')
+    logger.info('Preparing to upload processed export to: %s', dest)
+    export_type = 's3' if dest.startswith('s3') else 'dropbox'
+    dropbox_access_token = export_definition['output'].get('dropboxCredential')
+    if export_type == 's3':
+        s3_upload_export(merged_tiff_path, dest)
+    else:
+        dropbox_upload_export(dropbox_access_token, merged_tiff_path, dest.lstrip('dropbox://'))
+
+
 def run_export(export_s3_uri, export_id):
     """Run spark export
 
@@ -67,8 +159,7 @@ def run_export(export_s3_uri, export_id):
                '--driver-memory', '{}g'.format(export_memory),
                '--class', 'com.azavea.rf.batch.export.spark.Export',
                '/opt/raster-foundry/jars/rf-batch.jar',
-               '-j', export_s3_uri, '-b', status_uri
-    ]
+               '-j', export_s3_uri, '-b', status_uri]
     subprocess.check_call(command)
     logger.info('Finished exporting %s in spark local', export_s3_uri)
     return status_uri

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -145,7 +145,7 @@ def upload_processed_tif(merged_tiff_path, export_definition):
     if export_type == 's3':
         s3_upload_export(merged_tiff_path, dest)
     else:
-        dropbox_upload_export(dropbox_access_token, merged_tiff_path, dest.lstrip('dropbox://'))
+        dropbox_upload_export(dropbox_access_token, merged_tiff_path, dest.replace('dropbox:///', '/'))
 
 
 def run_export(export_s3_uri, export_id):

--- a/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
@@ -5,6 +5,7 @@ import subprocess
 import boto3
 
 import rf.uploads.geotiff.io as geotiff_io
+from rf.utils.io import s3_bucket_and_key_from_url
 from rf.models import Image
 from rf.uploads.landsat8.io import get_tempdir
 
@@ -29,7 +30,7 @@ def process_jp2000(scene_id, jp2_source):
     with get_tempdir() as temp_dir:
 
         s3client = boto3.client('s3')
-        in_bucket, in_key = geotiff_io.s3_bucket_and_key_from_url(jp2_source)
+        in_bucket, in_key = s3_bucket_and_key_from_url(jp2_source)
         in_bucket = in_bucket.replace(r'.s3.amazonaws.com', '')
         fname_part = os.path.split(in_key)[-1]
         out_bucket = os.getenv('DATA_BUCKET')

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -6,9 +6,8 @@ import boto3
 
 from .create_images import create_geotiff_image
 from .create_scenes import create_geotiff_scene
-from .io import s3_bucket_and_key_from_url
 from .utils import convert_to_cog
-from rf.utils.io import Visibility, IngestStatus, upload_tifs
+from rf.utils.io import Visibility, IngestStatus, upload_tifs, s3_bucket_and_key_from_url
 from rf.uploads.landsat8.io import get_tempdir
 
 import urllib

--- a/app-tasks/rf/src/rf/uploads/geotiff/io.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/io.py
@@ -1,6 +1,5 @@
 import os
 import rasterio
-import urlparse
 
 
 def get_geotiff_metadata(tif_path):
@@ -56,12 +55,6 @@ def get_geotiff_size_bytes(tif_path):
 
 def s3_url(bucket, key):
     return 's3://{bucket}/{key}'.format(bucket=bucket, key=key)
-
-
-def s3_bucket_and_key_from_url(s3_url):
-    parts = urlparse.urlparse(s3_url)
-    # parts.path[1:] drops the leading slash that urlparse includes
-    return (parts.netloc, parts.path[1:])
 
 
 def get_geotiff_dimensions(tif_path):

--- a/app-tasks/rf/src/rf/uploads/landsat8/io.py
+++ b/app-tasks/rf/src/rf/uploads/landsat8/io.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def get_tempdir():
+def get_tempdir(debug=False):
     """Returns a temporary directory that is cleaned up after usage
 
     Returns:
@@ -23,7 +23,8 @@ def get_tempdir():
     try:
         yield temp_dir
     finally:
-        shutil.rmtree(temp_dir)
+        if not debug:
+            shutil.rmtree(temp_dir)
 
 
 def get_rf_image(rf_image_id):

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -6,13 +6,20 @@ import urllib
 from urlparse import urlparse
 
 import boto3
+from dropbox.dropbox import Dropbox
+from dropbox.files import CommitInfo, UploadSessionCursor
 import requests
-
 
 logger = logging.getLogger(__name__)
 
 
 s3 = boto3.resource('s3', region_name='eu-central-1')
+
+
+def s3_bucket_and_key_from_url(s3_url):
+    parts = urlparse(s3_url)
+    # parts.path[1:] drops the leading slash that urlparse includes
+    return (parts.netloc, parts.path[1:])
 
 
 def delete_file(fname):
@@ -168,6 +175,32 @@ def upload_tifs(tifs, user_id, scene_id):
                 Key=key
             )
     return s3_uris
+
+
+def s3_upload_export(local_path, source):
+    s3_client = boto3.client('s3')
+    (bucket, key) = s3_bucket_and_key_from_url(urllib.unquote(source))
+    logger.info('Uploading %s => bucket: %s, key: %s', local_path, bucket, key)
+    with open(local_path, 'rb') as inf:
+        s3_client.put_object(Bucket=bucket, Body=inf, Key=key)
+    return key
+
+
+def dropbox_upload_export(access_token, local_path, remote_fname):
+    client = Dropbox(access_token)
+    with open(local_path, 'rb') as inf:
+        chunk_size = int(1.5e8 - 1)
+        next_bytes = inf.read(chunk_size)
+        upload_session_result = client.files_upload_session_start(next_bytes)
+        uploaded_so_far = len(next_bytes)
+        next_bytes = inf.read(chunk_size)
+        cursor = UploadSessionCursor(upload_session_result.session_id, uploaded_so_far)
+        while next_bytes:
+            client.files_upload_session_append_v2(next_bytes, cursor)
+            next_bytes = inf.read(chunk_size)
+            uploaded_so_far += chunk_size
+            cursor = UploadSessionCursor(upload_session_result.session_id, uploaded_so_far)
+        client.files_upload_session_finish('', cursor, CommitInfo(remote_fname))
 
 
 class JobStatus(object):


### PR DESCRIPTION
## Overview

Updates export code to support AST exports, shifts some IO to the python code for more flexibility.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

~This is kind of tough to test in the absence of https://github.com/raster-foundry/raster-foundry/pull/3782 so I would suggest merging that first.~

Mered #3782, so testing this should be more straightforward now

 * Create an export for an analysis, grab the ID
 * Run assembly on the batch jar: `./scripts/console api-server ./sbt` and then `project batch`, `assembly`
 * Run the export with the id: `docker-compose build batch && ./scripts/console batch "rf export <id>"`
 * Grab the export after it's finished and check it out in QGIS