### PR TITLE
Remove worthless access control rule creation from importers

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -135,13 +135,6 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       ).toList
   }
 
-  protected def insertAcrForScene(swr: Scene.WithRelated, user: User): ConnectionIO[AccessControlRule] =
-    AccessControlRuleDao.create(
-      AccessControlRule.Create(
-        true, SubjectType.All, None, ActionType.View
-      ).toAccessControlRule(user, ObjectType.Scene, swr.id)
-    )
-
   /** Because it makes scenes -- get it? */
   def riot(scenePath: String, datasourceUUID: UUID, user: User): IO[Option[Scene.WithRelated]] = {
     logger.info(s"Attempting to import ${scenePath}")
@@ -213,13 +206,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
       sceneType = SceneType.Avro.some
     )
 
-    val sceneInsertIO = for {
-      sceneInsert <- SceneDao.insertMaybe(sceneCreate, user).transact(xa)
-      _ <- sceneInsert match {
-        case Some(swr) => insertAcrForScene(swr, user).transact(xa)
-        case _ => ().pure[IO]
-      }
-    } yield { sceneInsert }
+    val sceneInsertIO = SceneDao.insertMaybe(sceneCreate, user).transact(xa)
 
     IO.shift(SceneCreationIOContext) *> sceneInsertIO
   }


### PR DESCRIPTION
## Overview

This PR prevents creation of worthless (never checked) access control rules in Landsat 8 and
Sentinel-2 import.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * count the ACRs in your local db
 * run a landsat import
 * run a sentinel-2 import
 * confirm the count hasn't changed