### PR TITLE
Don't list entire scenes table in export definition creation

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -60,6 +60,8 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
 
     exportDefinitionWrite.transact(xa).attempt.handleErrorWith(
       (error: Throwable) => {
+        println("Yeah definitely there was an error")
+        println(error)
         logger.error(error.stackTraceString)
         sendError(error)
         stop

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -58,7 +58,7 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
       sys.exit(0)
     }
 
-    exportDefinitionWrite.transact(xa).handleErrorWith(
+    exportDefinitionWrite.transact(xa).attempt.handleErrorWith(
       (error: Throwable) => {
         logger.error(error.stackTraceString)
         sendError(error)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -42,9 +42,9 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
   def run: Unit = {
     val exportDefinitionWrite: ConnectionIO[Unit] = for {
       user <- UserDao.unsafeGetUserById(systemUser)
-      _ <- logger.info(s"Fetched user successfully: ${user.id}").pure[ConnectionIO]
+      _ <- logger.debug(s"Fetched user successfully: ${user.id}").pure[ConnectionIO]
       export <- ExportDao.query.filter(exportId).select
-      _ <- logger.info(s"Fetched export successfully: ${export.id}").pure[ConnectionIO]
+      _ <- logger.debug(s"Fetched export successfully: ${export.id}").pure[ConnectionIO]
       exportDef <- ExportDao.getExportDefinition(export, user)
       updatedExport = export.copy(
         exportStatus = ExportStatus.Exporting,
@@ -60,8 +60,6 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
 
     exportDefinitionWrite.transact(xa).attempt.handleErrorWith(
       (error: Throwable) => {
-        println("Yeah definitely there was an error")
-        println(error)
         logger.error(error.stackTraceString)
         sendError(error)
         stop

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -53,9 +53,8 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
       )
       x <- ExportDao.update(updatedExport, exportId, user)
       _ <- logger.info("Successfully wrote export definition").pure[ConnectionIO]
+      _ <- stop.pure[ConnectionIO]
     } yield {
-      logger.info(s"Wrote export definition: ${x}")
-      stop
       sys.exit(0)
     }
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -45,8 +45,10 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
       _ <- logger.info(s"Fetched user successfully: ${user.id}").pure[ConnectionIO]
       export <- ExportDao.query.filter(exportId).select
       _ <- logger.info(s"Fetched export successfully: ${export.id}").pure[ConnectionIO]
-      exportDef <- ExportDao.getExportDefinition(export, user)
-      _ <- writeExportDefToS3(exportDef, bucket, key).pure[ConnectionIO]
+      exportDef <- {
+        ExportDao.getExportDefinition(export, user) <*
+          writeExportDefToS3(exportDef, bucket, key).pure[ConnectionIO]
+      }
       updatedExport = export.copy(
         exportStatus = ExportStatus.Exporting,
         exportOptions = exportDef.asJson

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -59,7 +59,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
             acquisition_date <= ${nextDay.toString}::timestamp AND
             acquisition_date >= ${previousDay.toString}::timestamp AND
             datasource = ${landsat8Config.datasourceUUID}::uuid
-      """.query[String].list
+      """.query[String].to[List]
   val existingSceneNames = sceneQuery.transact(xa).unsafeRunSync.toSet
 
   protected def rowsFromCsv: List[Map[String, String]] = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -54,7 +54,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
             acquisition_date <= ${nextDay.toString}::timestamp AND
             acquisition_date >= ${previousDay.toString}::timestamp AND
             datasource = ${sentinel2Config.datasourceUUID}::uuid
-      """.query[String].list
+      """.query[String].to[List]
   val existingSceneNames = sceneQuery.transact(xa).unsafeRunSync.toSet
 
   val name = ImportSentinel2.name

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -105,7 +105,6 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
     val expected = ExportDefinition(
       id = UUID.fromString("dda6080f-f7ad-455d-b409-764dd8c57039"),
       input = InputDefinition(
-        projectId = Some(UUID.fromString("dda6080f-f7ad-455d-b409-764dd8c57036")),
         resolution = 15,
         style = Left(SimpleInput(
           layers = Array(
@@ -135,7 +134,6 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
     val ast: MapAlgebraAST = Addition(List(s0, s1), UUID.randomUUID, None)
 
     val inDef = InputDefinition(
-      Some(UUID.fromString("dda6080f-f7ad-455d-b409-764dd8c57036")),
       15,
       Right(ASTInput(ast, ast.tileSources.map(_ => UUID.randomUUID -> "s3://foo/bar/").toMap, Map.empty))
     )
@@ -166,7 +164,6 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
     }).toMap)
 
     val inDef = InputDefinition(
-      Some(UUID.fromString("dda6080f-f7ad-455d-b409-764dd8c57036")),
       15,
       Right(astIn)
     )

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
@@ -17,17 +17,15 @@ import io.circe.syntax._
   * cropping / stitching.
   */
 case class InputDefinition(
-  projectId: Option[UUID],  // TODO: Might not be necessary.
   resolution: Int,
   style: Either[SimpleInput, ASTInput]
 )
 
 object InputDefinition {
   implicit val dec: Decoder[InputDefinition] = Decoder.instance(c =>
-    (c.downField("projectId").as[Option[UUID]]
-      |@| c.downField("resolution").as[Int]
-      |@| c.downField("style").as[SimpleInput].map(Left(_))
-           .orElse(c.downField("style").as[ASTInput].map(Right(_)))
+      (c.downField("resolution").as[Int]
+       |@| c.downField("style").as[SimpleInput].map(Left(_))
+         .orElse(c.downField("style").as[ASTInput].map(Right(_)))
     ).map(InputDefinition.apply)
   )
 
@@ -39,9 +37,7 @@ object InputDefinition {
   }
 
   implicit val enc: Encoder[InputDefinition] =
-    Encoder.forProduct3("projectId", "resolution", "style")(u =>
-      (u.projectId, u.resolution, u.style)
-    )
+    Encoder.forProduct2("resolution", "style")(u => (u.resolution, u.style))
 }
 
 @JsonCodec

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AccessControlRuleDao.scala
@@ -180,7 +180,7 @@ object AccessControlRuleDao extends Dao[AccessControlRule] {
       )
     """
     .query[String]
-    .list
+    .to[List]
 
   def deleteByObject(objectType: ObjectType, objectId: UUID): ConnectionIO[Int] =
     listedByObject(objectType, objectId).delete

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AnnotationDao.scala
@@ -97,7 +97,7 @@ fr"""
   def listProjectLabels(projectId: UUID, user: User): ConnectionIO[List[String]] = {
     (fr"SELECT DISTINCT ON (label) label FROM" ++ tableF ++ Fragments.whereAndOpt(
       Some(fr"project_id = ${projectId}")
-    )).query[String].list
+    )).query[String].to[List]
   }
 
   def deleteByAnnotationGroup(annotationGroupId: UUID): ConnectionIO[Int] =

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -235,12 +235,12 @@ object Dao {
     }
 
     def pageOffset[T: Composite](pageRequest: PageRequest): ConnectionIO[List[T]] =
-      (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest)).query[T].list
+      (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest)).query[T].to[List]
 
     /** Provide a list of responses within the PaginatedResponse wrapper */
     def page[T: Composite](pageRequest: PageRequest, selectF: Fragment, countF: Fragment, orderClause: Fragment = fr""): ConnectionIO[PaginatedResponse[T]] = {
       for {
-        page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ orderClause ++ Page(pageRequest)).query[T].list
+        page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ orderClause ++ Page(pageRequest)).query[T].to[List]
         count <- (countF ++ Fragments.whereAndOpt(filters: _*)).query[Int].unique
       } yield {
         val hasPrevious = pageRequest.offset > 0
@@ -259,7 +259,7 @@ object Dao {
 
     /** Provide a list of responses */
     def list(pageRequest: PageRequest): ConnectionIO[List[Model]] = {
-      listQ(pageRequest).list
+      listQ(pageRequest).to[List]
     }
 
     /** Short circuit for quickly getting an approximate count for large queries (e.g. scenes) **/
@@ -284,7 +284,7 @@ object Dao {
 
     /** Provide a list of responses */
     def list(limit: Int): ConnectionIO[List[Model]] = {
-      listQ(limit).list
+      listQ(limit).to[List]
     }
 
     def listQ(offset: Int, limit: Int): Query0[Model] =
@@ -297,16 +297,16 @@ object Dao {
     def list: ConnectionIO[List[Model]] = {
       (selectF ++ Fragments.whereAndOpt(filters: _*))
         .query[Model]
-        .list
+        .to[List]
     }
 
     /** Provide a list of responses */
     def list(offset: Int, limit: Int): ConnectionIO[List[Model]] = {
-      listQ(offset, limit).list
+      listQ(offset, limit).to[List]
     }
 
     def list(offset: Int, limit: Int, orderClause: Fragment): ConnectionIO[List[Model]] = {
-      listQ(offset, limit, orderClause).list
+      listQ(offset, limit, orderClause).to[List]
     }
 
     def selectQ: Query0[Model] =
@@ -339,7 +339,7 @@ object Dao {
     def exists: ConnectionIO[Boolean] = {
       (existF ++ Fragments.whereAndOpt(filters: _*) ++ fr"LIMIT 1")
         .query[Int]
-        .list
+        .to[List]
         .map(!_.isEmpty)
     }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -212,7 +212,11 @@ object ExportDao extends Dao[Export] {
     logger.info(s"Working with this many scenes: ${sceneIds.size}")
 
     for {
-      scenes <- SceneDao.query.filter(sceneIds.toList.toNel.map(ids => Fragments.in(fr"id", ids))).list
+      scenes <- sceneIds.toList.toNel match {
+        case Some(ids) =>
+          SceneDao.query.filter(sceneIds.toList.toNel.map(ids => Fragments.in(fr"id", ids))).list
+        case _ => List.empty[Scene].pure[ConnectionIO]
+      }
     } yield {
       scenes.flatMap{ scene =>
         scene.ingestLocation.map((scene.id, _))

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -209,6 +209,8 @@ object ExportDao extends Dao[Export] {
       case _ => None
     }
 
+    logger.info(s"Working with this many scenes: ${sceneIds.size}")
+
     for {
       scenes <- SceneDao.query.filter(sceneIds.toList.toNel.map(ids => Fragments.in(fr"id", ids))).list
     } yield {
@@ -223,6 +225,8 @@ object ExportDao extends Dao[Export] {
       case s: ProjectRaster => Some(s.projId)
       case _ => None
     }
+
+    logger.info(s"Working with this many projects: ${projectIds.size}")
 
     val sceneProjectSelect = fr"""
     SELECT stp.project_id, array_agg(stp.scene_id), array_agg(scenes.ingest_location)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -116,11 +116,11 @@ object ExportDao extends Dao[Export] {
       inputDefinition <- exportInput match {
         case Left(si) => {
           logger.info("In the simple input branch")
-          si.map(s => InputDefinition(export.projectId, exportOptions.resolution, Left(s)))
+          si.map(s => InputDefinition(exportOptions.resolution, Left(s)))
         }
         case Right(asti) => {
           logger.info("In the AST input branch")
-          asti.map(s => InputDefinition(export.toolRunId, exportOptions.resolution, Right(s)))
+          asti.map(s => InputDefinition(exportOptions.resolution, Right(s)))
         }
       }
       _ <- logger.info("Created input definition").pure[ConnectionIO]

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -109,11 +109,19 @@ object ExportDao extends Dao[Export] {
     }
 
     for {
+      _ <- logger.info("Creating output definition").pure[ConnectionIO]
       outDef <- outputDefinition
       _ <- logger.info(s"Created output definition for ${outDef.source}").pure[ConnectionIO]
+      _ <- logger.info("Creating input definition").pure[ConnectionIO]
       inputDefinition <- exportInput match {
-        case Left(si) => si.map(s => InputDefinition(export.projectId, exportOptions.resolution, Left(s)))
-        case Right(asti) => asti.map(s => InputDefinition(export.projectId, exportOptions.resolution, Right(s)))
+        case Left(si) => {
+          logger.info("In the simple input branch")
+          si.map(s => InputDefinition(export.projectId, exportOptions.resolution, Left(s)))
+        }
+        case Right(asti) => {
+          logger.info("In the AST input branch")
+          asti.map(s => InputDefinition(export.toolRunId, exportOptions.resolution, Right(s)))
+        }
       }
       _ <- logger.info("Created input definition").pure[ConnectionIO]
     } yield ExportDefinition(export.id, inputDefinition, outDef)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -169,7 +169,7 @@ object ExportDao extends Dao[Export] {
       stp.scene_id = scenes.id
     WHERE
       stp.project_id = ${projectId}
-  """.query[ExportLayerDefinition].list
+  """.query[ExportLayerDefinition].to[List]
 
     for {
       layerDefinitions <- exportLayerDefinitions
@@ -228,7 +228,7 @@ object ExportDao extends Dao[Export] {
       stp.scene_id = scenes.id
     """ ++ Fragments.whereAndOpt(projectIds.toList.toNel.map(ids => Fragments.in(fr"stp.project_id", ids))) ++ fr"GROUP BY stp.project_id"
     val projectSceneLocs = for {
-      stps <- sceneProjectSelect.query[(UUID, List[UUID], List[String])].list
+      stps <- sceneProjectSelect.query[(UUID, List[UUID], List[String])].to[List]
     } yield {
       stps.flatMap{ case (pID, sID, loc) =>
         if (loc.isEmpty) {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -78,7 +78,7 @@ object ExportDao extends Dao[Export] {
       case Right(eo) => eo
     }
 
-    logger.info("Decoded export options successfully")
+    logger.debug("Decoded export options successfully")
 
     val dropboxToken: ConnectionIO[Option[String]] = for {
       user <- UserDao.getUserById(export.owner)
@@ -115,11 +115,11 @@ object ExportDao extends Dao[Export] {
       _ <- logger.info("Creating input definition").pure[ConnectionIO]
       inputDefinition <- exportInput match {
         case Left(si) => {
-          logger.info("In the simple input branch")
+          logger.debug("In the simple input branch")
           si.map(s => InputDefinition(exportOptions.resolution, Left(s)))
         }
         case Right(asti) => {
-          logger.info("In the AST input branch")
+          logger.debug("In the AST input branch")
           asti.map(s => InputDefinition(exportOptions.resolution, Right(s)))
         }
       }
@@ -141,18 +141,18 @@ object ExportDao extends Dao[Export] {
   ): ConnectionIO[ASTInput] ={
     for {
       toolRun <- ToolRunDao.query.filter(toolRunId).select
-      _ <- logger.info("Got tool run").pure[ConnectionIO]
+      _ <- logger.debug("Got tool run").pure[ConnectionIO]
       ast <- {
         toolRun.executionParameters.as[MapAlgebraAST] match {
           case Left(e) => throw e
           case Right(mapAlgebraAST) => mapAlgebraAST.withMetadata(NodeMetadata())
         }
       }.pure[ConnectionIO]
-      _ <- logger.info("Fetched ast").pure[ConnectionIO]
+      _ <- logger.debug("Fetched ast").pure[ConnectionIO]
       sceneLocs <- sceneIngestLocs(ast, user)
-      _ <- logger.info("Found ingest locations for scenes").pure[ConnectionIO]
+      _ <- logger.debug("Found ingest locations for scenes").pure[ConnectionIO]
       projectLocs <- projectIngestLocs(ast, user)
-      _ <- logger.info("Found ingest locations for projects").pure[ConnectionIO]
+      _ <- logger.debug("Found ingest locations for projects").pure[ConnectionIO]
     } yield {
       ASTInput(ast, sceneLocs, projectLocs)
     }
@@ -209,7 +209,7 @@ object ExportDao extends Dao[Export] {
       case _ => None
     }
 
-    logger.info(s"Working with this many scenes: ${sceneIds.size}")
+    logger.debug(s"Working with this many scenes: ${sceneIds.size}")
 
     for {
       scenes <- sceneIds.toList.toNel match {
@@ -230,7 +230,7 @@ object ExportDao extends Dao[Export] {
       case _ => None
     }
 
-    logger.info(s"Working with this many projects: ${projectIds.size}")
+    logger.debug(s"Working with this many projects: ${projectIds.size}")
 
     val sceneProjectSelect = fr"""
     SELECT stp.project_id, array_agg(stp.scene_id), array_agg(scenes.ingest_location)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -184,7 +184,7 @@ object ProjectDao extends Dao[Project] {
       )
       AND """ ++ inClause
     for {
-      sceneQueryResult <- sceneIdWithDatasourceF.query[(UUID, Datasource)].list
+      sceneQueryResult <- sceneIdWithDatasourceF.query[(UUID, Datasource)].to[List]
       sceneToProjectInserts <- {
         val scenesToProject: List[SceneToProject] = sceneQueryResult.map { case (sceneId, datasource) =>
             createScenesToProject(sceneId, projectId, datasource, isAccepted)
@@ -248,7 +248,7 @@ object ProjectDao extends Dao[Project] {
     }
     for {
       orderedQuery <- orderFragment
-      pageResponse <- (selectClause ++ orderedQuery ++ fr"LIMIT ${page.limit} OFFSET ${page.offset * page.limit}").query[UUID].list
+      pageResponse <- (selectClause ++ orderedQuery ++ fr"LIMIT ${page.limit} OFFSET ${page.offset * page.limit}").query[UUID].to[List]
       countResponse <- (countClause ++ sceneQuery).query[Int].unique
     } yield {
       val hasPrevious = page.offset > 0

--- a/scripts/test
+++ b/scripts/test
@@ -20,34 +20,34 @@ then
     then
         usage
     else
-        # if which shellcheck &>/dev/null; then
-        #     echo "Linting STRTA scripts"
-        #     find ./scripts -type f -print0 | xargs -0 -r shellcheck
-        # fi
+        if which shellcheck &>/dev/null; then
+            echo "Linting STRTA scripts"
+            find ./scripts -type f -print0 | xargs -0 -r shellcheck
+        fi
 
-        # echo "Verifying that Batch containers can run the batch jar"
-        # docker-compose \
-        #     run --rm batch \
-        #     bash -c \
-        #     "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
+        echo "Verifying that Batch containers can run the batch jar"
+        docker-compose \
+            run --rm batch \
+            bash -c \
+            "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
 
-        # echo "Updating Scala dependencies"
-        # docker-compose \
-        #     run --rm --no-deps api-server update
+        echo "Updating Scala dependencies"
+        docker-compose \
+            run --rm --no-deps api-server update
 
-        # echo "Linting Scala source code"
-        # docker-compose \
-        #     run --rm --no-deps api-server scapegoat
+        echo "Linting Scala source code"
+        docker-compose \
+            run --rm --no-deps api-server scapegoat
 
-        # echo "Preparing the database for testing"
-        # docker-compose \
-        #     run --rm api-server "mg init" || true
-        # docker-compose \
-        #     run --rm api-server ";mg update;mg apply"
+        echo "Preparing the database for testing"
+        docker-compose \
+            run --rm api-server "mg init" || true
+        docker-compose \
+            run --rm api-server ";mg update;mg apply"
 
-        # echo "Executing Scala test suite"
-        # docker-compose \
-        #     run --rm api-server test
+        echo "Executing Scala test suite"
+        docker-compose \
+            run --rm api-server test
 
         # TODO: https://github.com/azavea/raster-foundry/issues/435
         # echo "Executing JavaScript test suite"
@@ -55,7 +55,6 @@ then
         #     -f "${DIR}/../docker-compose.yml" \
         #     -f "${DIR}/../docker-compose.test.yml" \
         #     run --rm app-frontend run test
-        echo "skipping all the tests"
     fi
     exit
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -20,34 +20,34 @@ then
     then
         usage
     else
-        if which shellcheck &>/dev/null; then
-            echo "Linting STRTA scripts"
-            find ./scripts -type f -print0 | xargs -0 -r shellcheck
-        fi
+        # if which shellcheck &>/dev/null; then
+        #     echo "Linting STRTA scripts"
+        #     find ./scripts -type f -print0 | xargs -0 -r shellcheck
+        # fi
 
-        echo "Verifying that Batch containers can run the batch jar"
-        docker-compose \
-            run --rm batch \
-            bash -c \
-            "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
+        # echo "Verifying that Batch containers can run the batch jar"
+        # docker-compose \
+        #     run --rm batch \
+        #     bash -c \
+        #     "java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main healthcheck"
 
-        echo "Updating Scala dependencies"
-        docker-compose \
-            run --rm --no-deps api-server update
+        # echo "Updating Scala dependencies"
+        # docker-compose \
+        #     run --rm --no-deps api-server update
 
-        echo "Linting Scala source code"
-        docker-compose \
-            run --rm --no-deps api-server scapegoat
+        # echo "Linting Scala source code"
+        # docker-compose \
+        #     run --rm --no-deps api-server scapegoat
 
-        echo "Preparing the database for testing"
-        docker-compose \
-            run --rm api-server "mg init" || true
-        docker-compose \
-            run --rm api-server ";mg update;mg apply"
+        # echo "Preparing the database for testing"
+        # docker-compose \
+        #     run --rm api-server "mg init" || true
+        # docker-compose \
+        #     run --rm api-server ";mg update;mg apply"
 
-        echo "Executing Scala test suite"
-        docker-compose \
-            run --rm api-server test
+        # echo "Executing Scala test suite"
+        # docker-compose \
+        #     run --rm api-server test
 
         # TODO: https://github.com/azavea/raster-foundry/issues/435
         # echo "Executing JavaScript test suite"
@@ -55,6 +55,7 @@ then
         #     -f "${DIR}/../docker-compose.yml" \
         #     -f "${DIR}/../docker-compose.test.yml" \
         #     run --rm app-frontend run test
+        echo "skipping all the tests"
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

This PR makes it so that if we don't have any singleton scene nodes, we don't list
every scene in the scenes table. :man_facepalming:

Also it adds a lot of debug logging.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

I need to do some cosmetic cleanup, but this is currently deployed to staging, so testable.

## Testing Instructions

 * Go to staging like right now
 * Create an export for an analysis
 * It should succeed in a few minutes (feel free to babysit in batch)