### PR TITLE
Correct scene geometry on insert

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -130,9 +130,9 @@ object SceneDao extends Dao[Scene] with LazyLogging {
          boundary_status, ingest_status, scene_type
       )""" ++ fr"""VALUES (
         ${scene.id}, ${scene.createdAt}, ${scene.createdBy}, ${scene.modifiedAt}, ${scene.modifiedBy}, ${scene.owner},
-        ${scene.visibility}, ${scene.tags},
-        ${scene.datasource}, ${scene.sceneMetadata}, ${scene.name}, ${scene.tileFootprint},
-        ${scene.dataFootprint}, ${scene.metadataFiles}, ${scene.ingestLocation}, ${scene.filterFields.cloudCover},
+        ${scene.visibility}, ${scene.tags}, ${scene.datasource}, ${scene.sceneMetadata}, ${scene.name},
+        ST_MakeValid(${scene.tileFootprint}), ST_MakeValid(${scene.dataFootprint}), ${scene.metadataFiles},
+        ${scene.ingestLocation}, ${scene.filterFields.cloudCover},
         ${scene.filterFields.acquisitionDate}, ${scene.filterFields.sunAzimuth}, ${scene.filterFields.sunElevation},
         ${scene.statusFields.thumbnailStatus}, ${scene.statusFields.boundaryStatus},
         ${scene.statusFields.ingestStatus}, ${scene.sceneType.getOrElse(SceneType.Avro)}


### PR DESCRIPTION
## Overview

This PR corrects scene geometries on insert. It's in response to a recent develop build failure in which
the geotrellis vector testkit helpfully pointed out another way we fail to handle invalid input data.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests

### Notes

I wasn't sure how to make this work with the other places where we insert geometries, but also
the other geometries have tended to be considerably less troublesome (shapes, annotations...)
so I think maybe it's fine. I attempted to edit the geometry meta in `GtWktMeta` but postgres
didn't like what I did.

## Testing Instructions

 * CI