### PR TITLE
Enable requester pays for Sentinel-2 bucket access

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -131,7 +131,8 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
         s3bucket  = sentinel2Config.bucketName,
         s3prefix  = s"products/${date.getYear}/${date.getMonthValue}/${date.getDayOfMonth}/",
         ext       = "productInfo.json",
-        recursive = true
+        recursive = true,
+        requesterPays = true
       ).toList
   }
 
@@ -152,7 +153,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
     logger.info(s"Getting tile info for ${scenePath}")
     val tileinfo =
       s3Client
-        .getObject(sentinel2Config.bucketName, s"${scenePath}/tileInfo.json")
+        .getObject(sentinel2Config.bucketName, s"${scenePath}/tileInfo.json", true)
         .getObjectContent
         .toJson
         .getOrElse(Json.Null)
@@ -244,7 +245,7 @@ case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))
   }
 
   def getScenePaths(uri: URI): List[String] = {
-    val json: Option[Json] = s3Client.getObject(uri.getHost, uri.getPath.tail).getObjectContent.toJson
+    val json: Option[Json] = s3Client.getObject(uri.getHost, uri.getPath.tail, true).getObjectContent.toJson
     val tilesJson: Option[List[Json]] = json flatMap {
       _.hcursor.downField("tiles").as[List[Json]].toOption
     }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -46,8 +46,8 @@ case class S3(
     client.listObjects(listObjectsRequest)
 
   /** Get S3Object */
-  def getObject(s3bucket: String, s3prefix: String): S3Object =
-    client.getObject(s3bucket, s3prefix)
+  def getObject(s3bucket: String, s3prefix: String, requesterPays: Boolean = false): S3Object =
+    client.getObject(new GetObjectRequest(s3bucket, s3prefix, requesterPays))
 
   def getObject(uri: URI): S3Object = {
     val s3uri = new AmazonS3URI(uri)
@@ -79,11 +79,12 @@ case class S3(
   }
 
   /** List the keys to files found within a given bucket */
-  def listKeys(s3bucket: String, s3prefix: String, ext: String, recursive: Boolean = false): Array[URI] = {
+  def listKeys(s3bucket: String, s3prefix: String, ext: String, recursive: Boolean = false, requesterPays: Boolean = false): Array[URI] = {
     val objectRequest = (new ListObjectsRequest)
       .withBucketName(s3bucket)
       .withPrefix(s3prefix)
       .withMaxKeys(1000)
+      .withRequesterPays(requesterPays)
 
     // Avoid digging into a deeper directory
     if (!recursive) objectRequest.withDelimiter("/")

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.14.3
-boto3==1.4.4
+boto3==1.7.71
 pytest==2.9.2
 pytest-runner==2.9
 rasterio==1.0a8

--- a/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
+++ b/app-tasks/rf/src/rf/ingest/sentinel2_ingest.py
@@ -64,7 +64,7 @@ def process_jp2000(scene_id, jp2_source):
         logger.info('Downloading JPEG2000 file locally (%s/%s => %s)',
                     in_bucket, in_key, jp2_fname)
         with open(jp2_fname, 'wb') as src:
-            body = s3client.get_object(Bucket=in_bucket, Key=in_key)['Body']
+            body = s3client.get_object(Bucket=in_bucket, Key=in_key, RequestPayer='requester')['Body']
             src.write(body.read())
 
         logger.info('Running translate command to convert to TIF')


### PR DESCRIPTION
## Overview

This PR upgrades boto3 in app-tasks (we were _very_ behind) and sets requester pays on
requests from the java aws s3 sdk.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I tested Sentinel-2 import, testing ingest now

## Testing Instructions

 * run Sentinel-2 import -- from the `batch` subproject's console:

```scala
import com.azavea.rf.database.util.RFTransactor.xa
import com.azavea.rf.batch.sentinel2.ImportSentinel2
import java.time.LocalDate
ImportSentinel2(LocalDate.parse("2018-05-15")).run
```
 * You shouldn't get access denied almost immediately
 * Rebuild batch container
 * Re-assemble batch jar
 * run an ingest for a Sentinel-2 scene
 * You shouldn't get access denied
