### PR TITLE
Auto accept team invitation if user is in same organization

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -178,7 +178,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       subjectId, GroupType.Organization, organizationId, groupRole
     )
 
-    createUserGroupRole(organizationId, actingUser, subjectId, userGroupRoleCreate, platformId)
+    createUserGroupRole(organizationId, actingUser, subjectId, userGroupRoleCreate, platformId, None)
   }
 
   def deactivateUserRoles(actingUser: User, subjectId: String, organizationId: UUID): ConnectionIO[List[UserGroupRole]] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -178,7 +178,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
       subjectId, GroupType.Organization, organizationId, groupRole
     )
 
-    createUserGroupRole(organizationId, actingUser, subjectId, userGroupRoleCreate, platformId, None)
+    createUserGroupRole(organizationId, actingUser, subjectId, userGroupRoleCreate, platformId, false.pure[ConnectionIO])
   }
 
   def deactivateUserRoles(actingUser: User, subjectId: String, organizationId: UUID): ConnectionIO[List[UserGroupRole]] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -215,13 +215,13 @@ object TeamDao extends Dao[Team] {
     val userGroupRoleCreate = UserGroupRole.Create(
       subjectId, GroupType.Team, teamId, groupRole
     )
-    val isSameOrganizationIO: ConnectionIO[Boolean] = for {
+    val isSameOrgIO: ConnectionIO[Boolean] = for {
       team <- unsafeGetTeamById(teamId)
       orgId = team.organizationId
       userToAdd <- UserDao.unsafeGetUserById(subjectId)
       userIsOrgMember <- OrganizationDao.userIsMember(userToAdd, orgId)
     } yield { userIsOrgMember }
-    createUserGroupRole(teamId, actingUser, subjectId, userGroupRoleCreate, platformId, Some(isSameOrganizationIO))
+    createUserGroupRole(teamId, actingUser, subjectId, userGroupRoleCreate, platformId, isSameOrgIO)
   }
 
   def deactivateUserRoles(actingUser: User, subjectId: String, teamId: UUID): ConnectionIO[List[UserGroupRole]] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UserGroupRoleDao.scala
@@ -82,62 +82,54 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
   @SuppressWarnings(Array("OptionGet"))
   def createWithGuard(adminCheckFunc: (User, UUID) => ConnectionIO[Boolean], groupType: GroupType)
                      (groupId: UUID, actingUser: User, subjectId: String, userGroupRoleCreate: UserGroupRole.Create,
-                      platformId: UUID, isSameOrganizationIOO: Option[ConnectionIO[Boolean]]):
-      ConnectionIO[UserGroupRole] =
-  {
-    val isSameOrgIO: ConnectionIO[Boolean] = isSameOrganizationIOO match {
-      case Some(isSameOrganizationIO) => isSameOrganizationIO
-      case _ => false.pure[ConnectionIO]
+                      platformId: UUID, isSameOrgIO: ConnectionIO[Boolean]): ConnectionIO[UserGroupRole] = for {
+    adminCheck <- adminCheckFunc(actingUser, groupId)
+    existingRoleO <- {
+      query
+        .filter(fr"user_id = ${subjectId}")
+        .filter(fr"group_id = ${groupId}")
+        .filter(fr"group_type = ${groupType.toString} :: group_type")
+        .filter(fr"is_active = true")
+        .selectOption
     }
-    for {
-      adminCheck <- adminCheckFunc(actingUser, groupId)
-      existingRoleO <- {
-        query
-          .filter(fr"user_id = ${subjectId}")
-          .filter(fr"group_id = ${groupId}")
-          .filter(fr"group_type = ${groupType.toString} :: group_type")
-          .filter(fr"is_active = true")
-          .selectOption
-      }
-      roleTargetEmail <- UserDao.unsafeGetUserById(subjectId) map { _.email }
-      roleCreatorEmail <- UserDao.unsafeGetUserById(actingUser.id) map { _.email }
-      existingMembershipStatus = existingRoleO map { _.membershipStatus }
-      rolesMatch = existingRoleO.map(
-        (ugr: UserGroupRole) => ugr.groupRole == userGroupRoleCreate.groupRole
-      ).getOrElse(false)
-      isSameOrg <- isSameOrgIO
-      createdOrReturned <- {
-        (existingMembershipStatus, adminCheck, rolesMatch) match {
-          // Only admins can change group roles, and only approved roles can have their group role changed
-          case (Some(MembershipStatus.Approved), true, false) =>
-            UserGroupRoleDao.deactivate(existingRoleO.map( _.id ).get, actingUser) *>
+    roleTargetEmail <- UserDao.unsafeGetUserById(subjectId) map { _.email }
+    roleCreatorEmail <- UserDao.unsafeGetUserById(actingUser.id) map { _.email }
+    existingMembershipStatus = existingRoleO map { _.membershipStatus }
+    rolesMatch = existingRoleO.map(
+      (ugr: UserGroupRole) => ugr.groupRole == userGroupRoleCreate.groupRole
+    ).getOrElse(false)
+    isSameOrg <- isSameOrgIO
+    createdOrReturned <- {
+      (existingMembershipStatus, adminCheck, rolesMatch) match {
+        // Only admins can change group roles, and only approved roles can have their group role changed
+        case (Some(MembershipStatus.Approved), true, false) =>
+          UserGroupRoleDao.deactivate(existingRoleO.map( _.id ).get, actingUser) *>
+          UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
+        // Accepting a role requires agreement about what the groupRole should be -- users can't cheat
+        // and become admins by accepting a MEMBER role by posting an ADMIN role
+        case (Some(MembershipStatus.Requested), true, true) | (Some(MembershipStatus.Invited), _, true) =>
+          UserGroupRoleDao.deactivate(existingRoleO.map( _.id).get, actingUser) *>
+          UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
+        // rolesMatch will always be false when existingRoleO is None, so don't bother checking it
+        case (None, true, _) =>
+          if (isSameOrg) {
             UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
-          // Accepting a role requires agreement about what the groupRole should be -- users can't cheat
-          // and become admins by accepting a MEMBER role by posting an ADMIN role
-          case (Some(MembershipStatus.Requested), true, true) | (Some(MembershipStatus.Invited), _, true) =>
-            UserGroupRoleDao.deactivate(existingRoleO.map( _.id).get, actingUser) *>
-            UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
-          // rolesMatch will always be false when existingRoleO is None, so don't bother checking it
-          case (None, true, _) =>
-            if (isSameOrg) {
-              UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Approved))
-            } else {
-              UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Invited)) <*
-                Notify.sendGroupNotification(
-                  platformId, groupId, groupType, actingUser.id, subjectId, MessageType.GroupInvitation
-                ).attempt
-            }
-          case (None, false, _) => {
-            UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Requested)) <*
+          } else {
+            UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Invited)) <*
               Notify.sendGroupNotification(
-                platformId, groupId, groupType, subjectId, subjectId, MessageType.GroupRequest
+                platformId, groupId, groupType, actingUser.id, subjectId, MessageType.GroupInvitation
               ).attempt
           }
-          case (Some(_), _, _) => existingRoleO.get.pure[ConnectionIO]
+        case (None, false, _) => {
+          UserGroupRoleDao.create(userGroupRoleCreate.toUserGroupRole(actingUser, MembershipStatus.Requested)) <*
+            Notify.sendGroupNotification(
+              platformId, groupId, groupType, subjectId, subjectId, MessageType.GroupRequest
+            ).attempt
         }
+        case (Some(_), _, _) => existingRoleO.get.pure[ConnectionIO]
       }
-    } yield { createdOrReturned }
-  }
+    }
+  } yield { createdOrReturned }
 
   def getOption(id: UUID): ConnectionIO[Option[UserGroupRole]] = {
     query.filter(id).selectOption

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -171,11 +171,11 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
                      .copy(subjectType = SubjectType.Team, subjectId = Some(teamInsert.id.toString()))
             accessControlRule <- AccessControlRuleDao.create(acr)
             deactivateTeam <- TeamDao.deactivate(teamInsert.id)
-            deactivatedTeams <- TeamDao.query.filter(fr"is_active = false").list
+            deactivatedTeams <- TeamDao.query.filter(fr"is_active = false").filter(fr"modified_by=${userInsert.id}").list
             deactivatedACRs <- AccessControlRuleDao.query.filter(fr"is_active = false").list
             activatedTeams <- TeamDao.listOrgTeams(orgInsert.id, PageRequest(0, 30, Map.empty))
-          } yield (deactivatedTeams, deactivatedACRs, activatedTeams)
-          val (deactivatedTeams, deactivatedACRs, activatedTeams) = createTeamIO.transact(xa).unsafeRunSync
+          } yield (teamInsert, deactivateTeam, deactivatedTeams, deactivatedACRs, activatedTeams)
+          val (teamInsert, deactivateTeam, deactivatedTeams, deactivatedACRs, activatedTeams) = createTeamIO.transact(xa).unsafeRunSync
 
           assert(deactivatedTeams.size == 1, "Deactivated team should exist")
           assert(deactivatedACRs.size == 1, "Deactivated access control rules should exist")

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -174,8 +174,8 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
             deactivatedTeams <- TeamDao.query.filter(fr"is_active = false").filter(fr"modified_by=${userInsert.id}").list
             deactivatedACRs <- AccessControlRuleDao.query.filter(fr"is_active = false").list
             activatedTeams <- TeamDao.listOrgTeams(orgInsert.id, PageRequest(0, 30, Map.empty))
-          } yield (teamInsert, deactivateTeam, deactivatedTeams, deactivatedACRs, activatedTeams)
-          val (teamInsert, deactivateTeam, deactivatedTeams, deactivatedACRs, activatedTeams) = createTeamIO.transact(xa).unsafeRunSync
+          } yield (deactivatedTeams, deactivatedACRs, activatedTeams)
+          val (deactivatedTeams, deactivatedACRs, activatedTeams) = createTeamIO.transact(xa).unsafeRunSync
 
           assert(deactivatedTeams.size == 1, "Deactivated team should exist")
           assert(deactivatedACRs.size == 1, "Deactivated access control rules should exist")


### PR DESCRIPTION
## Overview

This PR enables auto-accepting team invitations if the user being added is in the same organization as this team. No emails will be sent in this case. 

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

We would not want to create a migration to deal with existing pending invitations, because, if done correctly, emails have already been sent to those pending users.


## Testing Instructions

 * CI since it tests this
 * Create a new team or use an existing one
 * Find some users in the same organization as the team and add them to this team. Make sure they have `APPROVED` in the `membership_status` field in UGR.
 * Find some users not in the same organization as the team and add them to this team. Make sure they have `INVITED` in the `membership_status` field in UGR.

Closes https://github.com/raster-foundry/raster-foundry/issues/3760
