### PR TITLE
Add proxy for sentinel thumbnails to handle requester-pays

### DIFF
--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -25,7 +25,6 @@ package object S3 {
 
   def clientWithRegion(region: Regions): AmazonS3 =
     AmazonS3ClientBuilder.standard()
-      .withCredentials(new DefaultAWSCredentialsProviderChain())
       .withRegion(region)
       .build()
 

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -4,7 +4,7 @@ import jp.ne.opt.chronoscala.Imports._
 import org.apache.commons.io.IOUtils
 import com.amazonaws.auth._
 import com.amazonaws.regions._
-import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
 import com.amazonaws.services.s3.model.{ListObjectsRequest, ObjectListing, ObjectMetadata, S3Object}
 import com.amazonaws.HttpMethod
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest
@@ -23,6 +23,12 @@ package object S3 {
     .withRegion(Regions.US_EAST_1)
     .build()
 
+  def clientWithRegion(region: Regions): AmazonS3 =
+    AmazonS3ClientBuilder.standard()
+      .withCredentials(new DefaultAWSCredentialsProviderChain())
+      .withRegion(region)
+      .build()
+
   // we want to ignore here, because uri.getHost returns null instead of an Option[String] -- thanks Java
   @SuppressWarnings(Array("NullParameter"))
   def bucketAndPrefixFromURI(uri: URI): (String, String) = {
@@ -39,7 +45,7 @@ package object S3 {
       case _ => throw new IllegalStateException(s"Ambiguous bucket parse: $uri")
     }
 
-    (bucket, prefix)
+    (bucket.replace(".s3.amazonaws.com", ""), prefix.replaceAll("/\\z", ""))
   }
 
   def getObject(uri: URI): S3Object = {

--- a/app-frontend/src/app/services/common/thumbnail.service.js
+++ b/app-frontend/src/app/services/common/thumbnail.service.js
@@ -15,6 +15,10 @@ export default (app) => {
             }).url;
             if (url.startsWith('/')) {
                 url = `${BUILDCONFIG.API_HOST}/api${url}?token=${this.authService.token()}`;
+            } else if (url.startsWith('https://sentinel-s2')) {
+                url =
+                    `${BUILDCONFIG.API_HOST}/api/thumbnails/sentinel/` +
+                    `${encodeURIComponent(url)}?token=${this.authService.token()}`;
             }
             return url;
         }


### PR DESCRIPTION
## Overview

This PR adds a new endpoint `thumbnails/sentinel` that proxies a thumbnail request in order to 
handle the requester-pays change.

### Checklist

~- [ ] Styleguide updated, if necessary~
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
~ [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

![image](https://user-images.githubusercontent.com/2442245/43912585-a93d15d0-9bd0-11e8-82ab-cbf76b0836da.png)


### Notes

I had to modify the URI => Bucket, Key method in `common.S3`. But it's a rather innocuous change that allows us to handle one more URI style.


## Testing Instructions

 * Browse for some sentinel and see some thumbnails!
