### PR TITLE
Don't return scene images in scene list queries

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -98,6 +98,31 @@ case class Scene(
     this.statusFields,
     this.sceneType
   )
+
+  def withLessRelatedFromComponents(
+    thumbnails: List[Thumbnail],
+    datasource: Datasource
+  ): Scene.WithLessRelated = Scene.WithLessRelated(
+    this.id,
+    this.createdAt,
+    this.createdBy,
+    this.modifiedAt,
+    this.modifiedBy,
+    this.owner,
+    this.visibility,
+    this.tags,
+    datasource.toThin,
+    this.sceneMetadata,
+    this.name,
+    this.tileFootprint,
+    this.dataFootprint,
+    this.metadataFiles,
+    thumbnails.toList,
+    this.ingestLocation,
+    this.filterFields,
+    this.statusFields,
+    this.sceneType
+  )
 }
 
 
@@ -168,6 +193,51 @@ object Scene {
     dataFootprint: Option[Projected[MultiPolygon]],
     metadataFiles: List[String],
     images: List[Image.WithRelated],
+    thumbnails: List[Thumbnail],
+    ingestLocation: Option[String],
+    filterFields: SceneFilterFields = new SceneFilterFields(),
+    statusFields: SceneStatusFields,
+    sceneType: Option[SceneType] = None
+  ) {
+    def toScene: Scene =
+      Scene(
+        id,
+        createdAt,
+        createdBy,
+        modifiedAt,
+        modifiedBy,
+        owner,
+        visibility,
+        tags,
+        datasource.id,
+        sceneMetadata,
+        name,
+        tileFootprint,
+        dataFootprint,
+        metadataFiles,
+        ingestLocation,
+        filterFields,
+        statusFields,
+        sceneType
+      )
+  }
+
+  @JsonCodec
+  case class WithLessRelated(
+    id: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    modifiedBy: String,
+    owner: String,
+    visibility: Visibility,
+    tags: List[String],
+    datasource: Datasource.Thin,
+    sceneMetadata: Json,
+    name: String,
+    tileFootprint: Option[Projected[MultiPolygon]],
+    dataFootprint: Option[Projected[MultiPolygon]],
+    metadataFiles: List[String],
     thumbnails: List[Thumbnail],
     ingestLocation: Option[String],
     filterFields: SceneFilterFields = new SceneFilterFields(),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -81,7 +81,7 @@ class SceneWithRelatedDaoSpec extends FunSuite with Matchers with Checkers with 
 
           val (insertedScenes, listedScenes) = scenesIO.transact(xa).unsafeRunSync
           val insertedNamesSet = insertedScenes.toSet map { (scene: Scene.WithRelated) => scene.name }
-          val listedNamesSet = listedScenes.results.toSet map { (scene: Scene.WithRelated) => scene.name }
+          val listedNamesSet = listedScenes.results.toSet map { (scene: Scene.WithLessRelated) => scene.name }
           assert(listedNamesSet.intersect(insertedNamesSet) == listedNamesSet,
                  "listed scenes should be a strict subset of inserted scenes by user 1")
           true


### PR DESCRIPTION
## Overview

This PR makes it so that when listing scenes (not for a specific project) we don't query and return the images with each scene.

### Checklist

~- [ ] Styleguide updated, if necessary~
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

![image](https://user-images.githubusercontent.com/2442245/43915166-e54c95e4-9bd7-11e8-92cf-010b983bea4d.png)

## Testing Instructions

 * Browse for scenes in the Raster Foundry repository and check that no scenes are returned with images

Closes #3787 
