### PR TITLE
Revert change to COPY in Dockerfile.api

### DIFF
--- a/nginx/Dockerfile.api
+++ b/nginx/Dockerfile.api
@@ -2,9 +2,8 @@ FROM nginx:1.14
 
 RUN mkdir -p /etc/nginx/includes
 
-COPY Dockerfile.api srv*/dist*/ /srv/dist/
+COPY /srv/dist/ /srv/dist/
 RUN chown nginx:nginx -R /srv/dist/
-RUN rm /srv/dist/Dockerfile.api
 
 COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY etc/nginx/includes/*.conf /etc/nginx/includes/


### PR DESCRIPTION
## Overview

A previous PR (https://github.com/raster-foundry/raster-foundry/pull/3800/) attempted to force creation of the /srv/dist by
copying over a single file into the directory. However, this causes
errors for actually built versions of the nginx container used in
staging/production. Two fixes for setting up an environment were
included in the previous PR so it seems safe to revert this one.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~