### PR TITLE
Fix lab analysis export metadata

### DIFF
--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -111,7 +111,7 @@ package object S3 {
     val listObjectsRequest =
       new ListObjectsRequest()
         .withBucketName(bucket)
-        .withPrefix(prefix)
+        .withPrefix(s"${prefix}/")
         .withDelimiter("/")
 
     get(client.listObjects(listObjectsRequest), Nil)

--- a/app-frontend/src/app/pages/user/settings/connections/connections.html
+++ b/app-frontend/src/app/pages/user/settings/connections/connections.html
@@ -25,8 +25,6 @@
           >
             <span ng-show="!$ctrl.mouseOverDropbox">
               Connected
-              <span class="button-spacer"> </span>
-              <span class="icon-check"></span>
             </span>
             <span ng-show="$ctrl.mouseOverDropbox">
               Reconnect
@@ -41,8 +39,6 @@
                   ng-if="!$ctrl.dropboxConnected"
                   ng-disabled="!$ctrl.user">
             Connect
-            <span class="button-spacer"> </span>
-            <span class="icon-plus"></span>
           </button>
         </div>
       </div>

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -327,7 +327,8 @@ export default (app) => {
             return firstRequest.then((res) => {
                 const count = res.count;
                 const scenes = res.results;
-                const requests = Array(Math.floor(count / pageSize) - 1)
+                let arraySize = Math.max(Math.floor(count / pageSize) - 1, 0);
+                const requests = Array(arraySize)
                       .fill().map((x, page) => {
                           return this.getProjectScenes(Object.assign({}, params, {
                               pageSize,
@@ -499,7 +500,7 @@ export default (app) => {
                 .$promise.then((res) => {
                     const scenes = res.results;
                     const count = res.count;
-                    let promises = Array(Math.floor(count / pageSize) - 1).fill().map((x, page) => {
+                    let promises = Array(Math.floor(count / pageSize) + 1).fill().map((x, page) => {
                         return this.Project.sceneOrder({
                             projectId,
                             pageSize,


### PR DESCRIPTION
## Overview

This PR fixes lab analysis export metadata to use empty `NodeMetadata` instead.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Create an analysis with NDVI and export

Closes https://github.com/azavea/raster-foundry-platform/issues/438
