### PR TITLE
Persist map bounds when entering browse mode

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -31,7 +31,7 @@
       <div class="column-6 nogutter btn-group">
         <button type="button"
                 class="btn btn-primary"
-                ui-sref="projects.edit.browse({sceneid: null})">
+                ng-click="$ctrl.gotoBrowse()">
           Browse
         </button>
         <button type="button"

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -91,7 +91,7 @@ class ProjectsScenesController {
         this.$parent.getMap().then(mapWrapper => {
             const bbox = mapWrapper.map.getBounds();
             this.$state.go('projects.edit.browse', {sceneid: null, bbox: bbox.toBBoxString()});
-        })
+        });
     }
 }
 

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -86,6 +86,13 @@ class ProjectsScenesController {
             this.$parent.layerFromProject();
         });
     }
+
+    gotoBrowse() {
+        this.$parent.getMap().then(mapWrapper => {
+            const bbox = mapWrapper.map.getBounds();
+            this.$state.go('projects.edit.browse', {sceneid: null, bbox: bbox.toBBoxString()});
+        })
+    }
 }
 
 const ProjectsScenesModule = angular.module('pages.projects.edit.scenes', ['ui.tree']);


### PR DESCRIPTION
## Overview

This PR passed the current map bounds to the browse mode so that the map view does not change when entering browse mode.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * go to a project
 * start browsing for scenes
 * notice that the map view does not change
