### PR TITLE
Add support for configuring Hikari; setup connections with statement_timeout

### DIFF
--- a/app-backend/common/src/main/scala/utils/PGUtils.scala
+++ b/app-backend/common/src/main/scala/utils/PGUtils.scala
@@ -4,7 +4,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 
 
 /**

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/util/database.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/util/database.scala
@@ -1,31 +1,36 @@
 package com.azavea.rf.database.util
 
-import com.typesafe.config.ConfigFactory
-import doobie.hikari.HikariTransactor
 import cats.effect.IO
-import doobie.hikari.implicits._
-import scala.concurrent.duration._
+import doobie.hikari.HikariTransactor
+
 import scala.util.Properties
 
 trait Config {
-//  private val config = ConfigFactory.load()
-//  private val databaseConfig = config.getConfig("db")
-  val jdbcNoDBUrl =
+  var jdbcDriver: String = "org.postgresql.Driver"
+  val jdbcNoDBUrl: String =
     Properties.envOrElse("POSTGRES_URL", "jdbc:postgresql://database.service.rasterfoundry.internal/")
-  val jdbcDBName = Properties.envOrElse("POSTGRES_NAME", "rasterfoundry")
-  val jdbcUrl = jdbcNoDBUrl + jdbcDBName
-  val dbUser = Properties.envOrElse("POSTGRES_USER", "rasterfoundry")
-  val dbPassword = Properties.envOrElse("POSTGRES_PASSWORD", "rasterfoundry")
+  val jdbcDBName: String = Properties.envOrElse("POSTGRES_NAME", "rasterfoundry")
+  val jdbcUrl: String = jdbcNoDBUrl + jdbcDBName
+  val dbUser: String = Properties.envOrElse("POSTGRES_USER", "rasterfoundry")
+  val dbPassword: String = Properties.envOrElse("POSTGRES_PASSWORD", "rasterfoundry")
+  val dbStatementTimeout: String = Properties.envOrElse("POSTGRES_STATEMENT_TIMEOUT", "30000")
+  val dbMaximumPoolSize: Int = Properties.envOrElse("POSTGRES_DB_POOL_SIZE", "5").toInt
 }
 
 object RFTransactor extends Config {
-  implicit lazy val xa = HikariTransactor.newHikariTransactor[IO](
-    "org.postgresql.Driver",
-    jdbcUrl,
-    dbUser,
-    dbPassword
-  ).unsafeRunTimed(10 seconds) match {
-    case Some(x) => x
-    case _ => throw new Exception("ERRRR")
-  }
+
+  implicit lazy val xa: HikariTransactor[IO] = (for {
+    xa <- HikariTransactor.newHikariTransactor[IO](
+      driverClassName = jdbcDriver,
+      url = jdbcUrl,
+      user = dbUser,
+      pass = dbPassword
+    )
+    _ <- xa.configure(c => IO {
+      c.setPoolName("Raster-Foundry-Hikari-Pool")
+      c.setMaximumPoolSize(dbMaximumPoolSize)
+      c.setConnectionInitSql(s"SET statement_timeout = ${dbStatementTimeout};")
+    })
+  } yield xa).unsafeRunSync()
+
 }

--- a/app-backend/migrations/src/main/resources/application.conf
+++ b/app-backend/migrations/src/main/resources/application.conf
@@ -3,7 +3,7 @@ migrations {
   handled_location = "./migrations/src/main/scala/migrations"
   migration_object = "RFMigrations"
   slick {
-    driver = "slick.driver.PostgresDriver$"
+    driver = "slick.jdbc.PostgresProfile$"
     db {
       driver = org.postgresql.Driver
       url = "jdbc:postgresql://database.service.rasterfoundry.internal/"

--- a/app-backend/migrations/src_migrations/main/scala/1.scala
+++ b/app-backend/migrations/src_migrations/main/scala/1.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 /**

--- a/app-backend/migrations/src_migrations/main/scala/10.scala
+++ b/app-backend/migrations/src_migrations/main/scala/10.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M10 {

--- a/app-backend/migrations/src_migrations/main/scala/11.scala
+++ b/app-backend/migrations/src_migrations/main/scala/11.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M11 {

--- a/app-backend/migrations/src_migrations/main/scala/12.scala
+++ b/app-backend/migrations/src_migrations/main/scala/12.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M12 {

--- a/app-backend/migrations/src_migrations/main/scala/13.scala
+++ b/app-backend/migrations/src_migrations/main/scala/13.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M13 {

--- a/app-backend/migrations/src_migrations/main/scala/14.scala
+++ b/app-backend/migrations/src_migrations/main/scala/14.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M14 {

--- a/app-backend/migrations/src_migrations/main/scala/15.scala
+++ b/app-backend/migrations/src_migrations/main/scala/15.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M15 {

--- a/app-backend/migrations/src_migrations/main/scala/16.scala
+++ b/app-backend/migrations/src_migrations/main/scala/16.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M16 {

--- a/app-backend/migrations/src_migrations/main/scala/17.scala
+++ b/app-backend/migrations/src_migrations/main/scala/17.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M17 {

--- a/app-backend/migrations/src_migrations/main/scala/18.scala
+++ b/app-backend/migrations/src_migrations/main/scala/18.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M18 {

--- a/app-backend/migrations/src_migrations/main/scala/19.scala
+++ b/app-backend/migrations/src_migrations/main/scala/19.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M19 {

--- a/app-backend/migrations/src_migrations/main/scala/2.scala
+++ b/app-backend/migrations/src_migrations/main/scala/2.scala
@@ -1,7 +1,7 @@
 import com.liyaos.forklift.slick.{SqlMigration, DBIOMigration}
 import java.sql.Timestamp
 import java.util.{Calendar, Date, UUID}
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 
 /**
   * Data migration that adds a root organization

--- a/app-backend/migrations/src_migrations/main/scala/20.scala
+++ b/app-backend/migrations/src_migrations/main/scala/20.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M20 {

--- a/app-backend/migrations/src_migrations/main/scala/21.scala
+++ b/app-backend/migrations/src_migrations/main/scala/21.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M21 {

--- a/app-backend/migrations/src_migrations/main/scala/22.scala
+++ b/app-backend/migrations/src_migrations/main/scala/22.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M22 {

--- a/app-backend/migrations/src_migrations/main/scala/23.scala
+++ b/app-backend/migrations/src_migrations/main/scala/23.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M23 {

--- a/app-backend/migrations/src_migrations/main/scala/24.scala
+++ b/app-backend/migrations/src_migrations/main/scala/24.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M24 {

--- a/app-backend/migrations/src_migrations/main/scala/25.scala
+++ b/app-backend/migrations/src_migrations/main/scala/25.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M25 {

--- a/app-backend/migrations/src_migrations/main/scala/26.scala
+++ b/app-backend/migrations/src_migrations/main/scala/26.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M26 {

--- a/app-backend/migrations/src_migrations/main/scala/27.scala
+++ b/app-backend/migrations/src_migrations/main/scala/27.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M27 {

--- a/app-backend/migrations/src_migrations/main/scala/28.scala
+++ b/app-backend/migrations/src_migrations/main/scala/28.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M28 {

--- a/app-backend/migrations/src_migrations/main/scala/29.scala
+++ b/app-backend/migrations/src_migrations/main/scala/29.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M29 {

--- a/app-backend/migrations/src_migrations/main/scala/3.scala
+++ b/app-backend/migrations/src_migrations/main/scala/3.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 /**

--- a/app-backend/migrations/src_migrations/main/scala/30.scala
+++ b/app-backend/migrations/src_migrations/main/scala/30.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M30 {

--- a/app-backend/migrations/src_migrations/main/scala/31.scala
+++ b/app-backend/migrations/src_migrations/main/scala/31.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M31 {

--- a/app-backend/migrations/src_migrations/main/scala/32.scala
+++ b/app-backend/migrations/src_migrations/main/scala/32.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M32 {

--- a/app-backend/migrations/src_migrations/main/scala/33.scala
+++ b/app-backend/migrations/src_migrations/main/scala/33.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M33 {

--- a/app-backend/migrations/src_migrations/main/scala/34.scala
+++ b/app-backend/migrations/src_migrations/main/scala/34.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M34 {

--- a/app-backend/migrations/src_migrations/main/scala/35.scala
+++ b/app-backend/migrations/src_migrations/main/scala/35.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M35 {

--- a/app-backend/migrations/src_migrations/main/scala/36.scala
+++ b/app-backend/migrations/src_migrations/main/scala/36.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M36 {

--- a/app-backend/migrations/src_migrations/main/scala/37.scala
+++ b/app-backend/migrations/src_migrations/main/scala/37.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M37 {

--- a/app-backend/migrations/src_migrations/main/scala/38.scala
+++ b/app-backend/migrations/src_migrations/main/scala/38.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M38 {

--- a/app-backend/migrations/src_migrations/main/scala/39.scala
+++ b/app-backend/migrations/src_migrations/main/scala/39.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M39 {

--- a/app-backend/migrations/src_migrations/main/scala/4.scala
+++ b/app-backend/migrations/src_migrations/main/scala/4.scala
@@ -1,7 +1,7 @@
 import com.liyaos.forklift.slick.{SqlMigration, DBIOMigration}
 import java.sql.Timestamp
 import java.util.{Calendar, Date, UUID}
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 
 /**
   * Data migration that adds a root user, who is a member of

--- a/app-backend/migrations/src_migrations/main/scala/40.scala
+++ b/app-backend/migrations/src_migrations/main/scala/40.scala
@@ -1,5 +1,5 @@
 
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M40 {

--- a/app-backend/migrations/src_migrations/main/scala/41.scala
+++ b/app-backend/migrations/src_migrations/main/scala/41.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M41 {

--- a/app-backend/migrations/src_migrations/main/scala/42.scala
+++ b/app-backend/migrations/src_migrations/main/scala/42.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M42 {

--- a/app-backend/migrations/src_migrations/main/scala/43.scala
+++ b/app-backend/migrations/src_migrations/main/scala/43.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M43 {

--- a/app-backend/migrations/src_migrations/main/scala/44.scala
+++ b/app-backend/migrations/src_migrations/main/scala/44.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M44 {

--- a/app-backend/migrations/src_migrations/main/scala/45.scala
+++ b/app-backend/migrations/src_migrations/main/scala/45.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M45 {

--- a/app-backend/migrations/src_migrations/main/scala/46.scala
+++ b/app-backend/migrations/src_migrations/main/scala/46.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M46 {

--- a/app-backend/migrations/src_migrations/main/scala/47.scala
+++ b/app-backend/migrations/src_migrations/main/scala/47.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M47 {

--- a/app-backend/migrations/src_migrations/main/scala/48.scala
+++ b/app-backend/migrations/src_migrations/main/scala/48.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M48 {

--- a/app-backend/migrations/src_migrations/main/scala/49.scala
+++ b/app-backend/migrations/src_migrations/main/scala/49.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M49 {

--- a/app-backend/migrations/src_migrations/main/scala/5.scala
+++ b/app-backend/migrations/src_migrations/main/scala/5.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M5 {

--- a/app-backend/migrations/src_migrations/main/scala/50.scala
+++ b/app-backend/migrations/src_migrations/main/scala/50.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 /** We can't alter type inside a transaction block, and all migrations run inside

--- a/app-backend/migrations/src_migrations/main/scala/51.scala
+++ b/app-backend/migrations/src_migrations/main/scala/51.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M51 {

--- a/app-backend/migrations/src_migrations/main/scala/52.scala
+++ b/app-backend/migrations/src_migrations/main/scala/52.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M52 {

--- a/app-backend/migrations/src_migrations/main/scala/53.scala
+++ b/app-backend/migrations/src_migrations/main/scala/53.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M53 {

--- a/app-backend/migrations/src_migrations/main/scala/54.scala
+++ b/app-backend/migrations/src_migrations/main/scala/54.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M54 {

--- a/app-backend/migrations/src_migrations/main/scala/55.scala
+++ b/app-backend/migrations/src_migrations/main/scala/55.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M55 {

--- a/app-backend/migrations/src_migrations/main/scala/56.scala
+++ b/app-backend/migrations/src_migrations/main/scala/56.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M56 {

--- a/app-backend/migrations/src_migrations/main/scala/57.scala
+++ b/app-backend/migrations/src_migrations/main/scala/57.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M57 {

--- a/app-backend/migrations/src_migrations/main/scala/58.scala
+++ b/app-backend/migrations/src_migrations/main/scala/58.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M58 {

--- a/app-backend/migrations/src_migrations/main/scala/59.scala
+++ b/app-backend/migrations/src_migrations/main/scala/59.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M59 {

--- a/app-backend/migrations/src_migrations/main/scala/6.scala
+++ b/app-backend/migrations/src_migrations/main/scala/6.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.{SqlMigration, DBIOMigration}
 
 import java.util.{Calendar, Date, UUID}

--- a/app-backend/migrations/src_migrations/main/scala/60.scala
+++ b/app-backend/migrations/src_migrations/main/scala/60.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M60 {

--- a/app-backend/migrations/src_migrations/main/scala/61.scala
+++ b/app-backend/migrations/src_migrations/main/scala/61.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M61 {

--- a/app-backend/migrations/src_migrations/main/scala/62.scala
+++ b/app-backend/migrations/src_migrations/main/scala/62.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M62 {

--- a/app-backend/migrations/src_migrations/main/scala/63.scala
+++ b/app-backend/migrations/src_migrations/main/scala/63.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M63 {

--- a/app-backend/migrations/src_migrations/main/scala/64.scala
+++ b/app-backend/migrations/src_migrations/main/scala/64.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M64 {

--- a/app-backend/migrations/src_migrations/main/scala/65.scala
+++ b/app-backend/migrations/src_migrations/main/scala/65.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M65 {

--- a/app-backend/migrations/src_migrations/main/scala/66.scala
+++ b/app-backend/migrations/src_migrations/main/scala/66.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M66 {

--- a/app-backend/migrations/src_migrations/main/scala/67.scala
+++ b/app-backend/migrations/src_migrations/main/scala/67.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M67 {

--- a/app-backend/migrations/src_migrations/main/scala/68.scala
+++ b/app-backend/migrations/src_migrations/main/scala/68.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M68 {

--- a/app-backend/migrations/src_migrations/main/scala/69.scala
+++ b/app-backend/migrations/src_migrations/main/scala/69.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M69 {

--- a/app-backend/migrations/src_migrations/main/scala/7.scala
+++ b/app-backend/migrations/src_migrations/main/scala/7.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M7 {

--- a/app-backend/migrations/src_migrations/main/scala/70.scala
+++ b/app-backend/migrations/src_migrations/main/scala/70.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M70 {

--- a/app-backend/migrations/src_migrations/main/scala/71.scala
+++ b/app-backend/migrations/src_migrations/main/scala/71.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M71 {

--- a/app-backend/migrations/src_migrations/main/scala/72.scala
+++ b/app-backend/migrations/src_migrations/main/scala/72.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M72 {

--- a/app-backend/migrations/src_migrations/main/scala/73.scala
+++ b/app-backend/migrations/src_migrations/main/scala/73.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M73 {

--- a/app-backend/migrations/src_migrations/main/scala/74.scala
+++ b/app-backend/migrations/src_migrations/main/scala/74.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M74 {

--- a/app-backend/migrations/src_migrations/main/scala/75.scala
+++ b/app-backend/migrations/src_migrations/main/scala/75.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M75 {

--- a/app-backend/migrations/src_migrations/main/scala/76.scala
+++ b/app-backend/migrations/src_migrations/main/scala/76.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M76 {

--- a/app-backend/migrations/src_migrations/main/scala/77.scala
+++ b/app-backend/migrations/src_migrations/main/scala/77.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M77 {

--- a/app-backend/migrations/src_migrations/main/scala/78.scala
+++ b/app-backend/migrations/src_migrations/main/scala/78.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M78 {

--- a/app-backend/migrations/src_migrations/main/scala/79.scala
+++ b/app-backend/migrations/src_migrations/main/scala/79.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M79 {

--- a/app-backend/migrations/src_migrations/main/scala/8.scala
+++ b/app-backend/migrations/src_migrations/main/scala/8.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.{SqlMigration}
 
 import java.util.{Calendar, Date, UUID}

--- a/app-backend/migrations/src_migrations/main/scala/80.scala
+++ b/app-backend/migrations/src_migrations/main/scala/80.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M80 {

--- a/app-backend/migrations/src_migrations/main/scala/81.scala
+++ b/app-backend/migrations/src_migrations/main/scala/81.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M81 {

--- a/app-backend/migrations/src_migrations/main/scala/82.scala
+++ b/app-backend/migrations/src_migrations/main/scala/82.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M82 {

--- a/app-backend/migrations/src_migrations/main/scala/83.scala
+++ b/app-backend/migrations/src_migrations/main/scala/83.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M83 {

--- a/app-backend/migrations/src_migrations/main/scala/84.scala
+++ b/app-backend/migrations/src_migrations/main/scala/84.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M84 {

--- a/app-backend/migrations/src_migrations/main/scala/85.scala
+++ b/app-backend/migrations/src_migrations/main/scala/85.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M85 {

--- a/app-backend/migrations/src_migrations/main/scala/86.scala
+++ b/app-backend/migrations/src_migrations/main/scala/86.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M86 {

--- a/app-backend/migrations/src_migrations/main/scala/87.scala
+++ b/app-backend/migrations/src_migrations/main/scala/87.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M87 {

--- a/app-backend/migrations/src_migrations/main/scala/88.scala
+++ b/app-backend/migrations/src_migrations/main/scala/88.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M88 {

--- a/app-backend/migrations/src_migrations/main/scala/89.scala
+++ b/app-backend/migrations/src_migrations/main/scala/89.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M89 {

--- a/app-backend/migrations/src_migrations/main/scala/9.scala
+++ b/app-backend/migrations/src_migrations/main/scala/9.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M9 {

--- a/app-backend/migrations/src_migrations/main/scala/90.scala
+++ b/app-backend/migrations/src_migrations/main/scala/90.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M90 {

--- a/app-backend/migrations/src_migrations/main/scala/91.scala
+++ b/app-backend/migrations/src_migrations/main/scala/91.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M91 {

--- a/app-backend/migrations/src_migrations/main/scala/92.scala
+++ b/app-backend/migrations/src_migrations/main/scala/92.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M92 {

--- a/app-backend/migrations/src_migrations/main/scala/93.scala
+++ b/app-backend/migrations/src_migrations/main/scala/93.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M93 {

--- a/app-backend/migrations/src_migrations/main/scala/94.scala
+++ b/app-backend/migrations/src_migrations/main/scala/94.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M94 {

--- a/app-backend/migrations/src_migrations/main/scala/97.scala
+++ b/app-backend/migrations/src_migrations/main/scala/97.scala
@@ -1,4 +1,4 @@
-import slick.driver.PostgresDriver.api._
+import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M97 {


### PR DESCRIPTION
## Overview

Modifies the existing `HikariTransactor` setup so that it supports Hikari specific configuration (in this case, `PoolName`, `MaximumPoolSize`, and `ConnectionInitSql`). Then, use `ConnectionInitSql` to initialize connections by setting PostgreSQL `statement_timeout` to 30 seconds (default is 0, which equates to infinity).

Migrations setup database connectivity via Slick, so the per connection `statement_timeout` overrides should not apply.

Lastly, I noticed a variety of deprecation warnings from Slick around `slick.driver.PostgresDriver` during compile time. I updated all references to use `slick.jdbc.PostgresProfile`, which is the intended replacement.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Notes

See https://github.com/azavea/raster-foundry-platform/issues/429 for more discussion on rationale for `statement_timeout`.

## Testing Instructions

- Set `POSTGRES_STATEMENT_TIMEOUT` to `100` for API service
- Navigate to a project and browse scenes
- Ensure exceptions are raised in the logs due to triggering of `statement_timeout`

To test the deprecation warning fixes, ensure that you can run `update` without failures.

Fixes https://github.com/azavea/raster-foundry-platform/issues/430
Fixes https://github.com/azavea/raster-foundry-platform/issues/429
