### PR TITLE
Make COG export work

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/RfmlRddResolver.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/RfmlRddResolver.scala
@@ -97,9 +97,9 @@ object RfmlRddResolver extends LazyLogging {
           }
         }
         case _ =>
-          IO(
-            throw new IllegalArgumentException("Only project sources can be resolved")
-          )
+          exp.children
+            .traverse(eval)
+            .map (_.toList.sequence.map(exp.withChildren(_)))
       }
     eval(fullExp)
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/RfmlRddResolver.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/RfmlRddResolver.scala
@@ -1,5 +1,9 @@
 package com.azavea.rf.batch.ast
 
+import com.azavea.rf.common.utils.CogUtils
+import com.azavea.rf.datamodel._
+import com.azavea.rf.database.SceneToProjectDao
+import com.azavea.rf.database.util.RFTransactor
 import com.azavea.rf.tool.ast._
 import com.azavea.rf.tool.maml._
 
@@ -11,25 +15,32 @@ import com.azavea.maml.util.NeighborhoodConversion
 import cats._
 import cats.data.Validated._
 import cats.data.{NonEmptyList => NEL, _}
+import cats.effect.IO
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
+import doobie.Transactor
+import doobie.implicits._
 import geotrellis.proj4.WebMercator
 import geotrellis.raster._
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.s3._
+import geotrellis.spark.io.s3.util._
 import geotrellis.spark.tiling._
 import geotrellis.vector.{Extent, MultiPolygon}
 import geotrellis.spark.io.postgres.PostgresAttributeStore
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
+import scala.concurrent.Future
 import scala.util.{Try, Failure, Success}
 import java.util.UUID
 
 
 /** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */
 object RfmlRddResolver extends LazyLogging {
+
+  implicit val xa = RFTransactor.xa
 
   val intNdTile = IntConstantTile(NODATA, 256, 256)
 
@@ -38,48 +49,86 @@ object RfmlRddResolver extends LazyLogging {
     zoom: Int,
     sceneLocs: Map[UUID,String],
     projLocs: Map[UUID, List[(UUID, String)]]
-  )(implicit sc: SparkContext): Interpreted[Expression] = {
+  )(implicit sc: SparkContext, xa: Transactor[IO]): IO[Interpreted[Expression]] = {
+    // TODO:
+    // - get mosaic definition for all the projects in projLocs -- those have scene types
+    // - that ends up UUID -> List[Source] (ish)
+    // - eval against this map
+    // - in each list of sources, map to discriminate over scene type
 
-    def eval(exp: Expression): Interpreted[Expression] =
+    val sourceFs: IO[List[(Option[CellType], Int) => Source]] = projLocs.keysIterator.toList.traverse(
+      (k: UUID) => SceneToProjectDao.getMosaicDefinition(k).transact(xa)
+    ).map(_.flatten).map( (mosaicDefinitions: List[MosaicDefinition]) =>
+      mosaicDefinitions map {
+        case MosaicDefinition(sceneId, _, Some(SceneType.COG), Some(s)) =>
+          (cellTypeO: Option[CellType], band: Int) => CogRaster(sceneId, Some(band), cellTypeO, s)
+        case MosaicDefinition(sceneId, _, Some(SceneType.Avro), Some(s)) =>
+          (cellTypeO: Option[CellType], band: Int) => SceneRaster(sceneId, Some(band), cellTypeO, s)
+      }
+    )
+
+    def eval(exp: Expression): IO[Interpreted[Expression]] =
       exp match {
         case pr@ProjectRaster(projId, None, celltype) =>
-          Invalid(NEL.of(NonEvaluableNode(exp, Some("no band given"))))
-        case pr@ProjectRaster(projId, Some(band), celltype) =>
-          getStores(projId, projLocs) match {
-            case None => Invalid(NEL.of(UnknownTileResolutionError(pr, None)))
-            case Some(stores) =>
-              val rdds: List[TileLayerRDD[SpatialKey]] =
-                stores.map({ case (sceneId, store) =>
-                  S3LayerReader(store)
-                    .read[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](LayerId(sceneId.toString, zoom))
-                    .withContext({rdd =>
-                      rdd.mapValues({ tile => tile.band(band).interpretAs(celltype.getOrElse(tile.cellType)) })
-                    })
-                })
-              Valid(RDDLiteral(rdds.reduce(_ merge _)))
-          }
-        case sr@SceneRaster(sceneId, None, celltype) =>
-          Invalid(NEL.of(NonEvaluableNode(exp, Some("no band given"))))
-        case sr@SceneRaster(sceneId, Some(band), celltype) =>
-          getStore(sceneId, sceneLocs) match {
-            case None =>
-              Invalid(NEL.of(NonEvaluableNode(sr, Some("attribute store error"))))
-            case Some(store) =>
-              val rdd = S3LayerReader(store)
-                .read[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](LayerId(sceneId.toString, zoom))
-                .withContext({ rdd =>
-                  rdd.mapValues({ tile => tile.band(band).interpretAs(celltype.getOrElse(tile.cellType)) })
-                })
+          IO.pure(Invalid(NEL.of(NonEvaluableNode(exp, Some("no band given")))))
+        case pr@ProjectRaster(projId, Some(band), celltypeO) => sourceFs map {
+          (funcs: List[(Option[CellType], Int) => Source]) => {
+            val sources = funcs map ( _(celltypeO, band) )
+            val rddsAndErrors = sources map {
+              case sr@SceneRaster(_, _, _, _) => {
+                avroSceneSourceAsRDD(sr, zoom)
+              }
+              case cr@CogRaster(_, _, _, _) => {
+                cogSceneSourceAsRDD(cr)
+              }
+            }
 
-            Valid(RDDLiteral(rdd))
+            val errors = rddsAndErrors flatMap {
+              case Left(nel) => Some(nel)
+              case _ => None
+            }
+
+            if (errors.length > 0) {
+              // ::: is the nonempty list combiner
+              Invalid(errors.reduce (_ ::: _))
+            } else {
+              Valid(RDDLiteral(rddsAndErrors.flatMap(_.toOption) reduce { _ merge _ }))
+            }
           }
+        }
         case _ =>
-          exp.children
-            .map({ child => eval(child) })
-            .toList.sequence
-            .map({ exp.withChildren(_) })
+          IO(
+            throw new IllegalArgumentException("Only project sources can be resolved")
+          )
       }
     eval(fullExp)
+  }
+
+    private def cogSceneSourceAsRDD(source: CogRaster)(implicit sc: SparkContext): Either[NEL[NonEvaluableNode], TileLayerRDD[SpatialKey]] = {
+      val tileRdd = CogUtils.fromUriAsRdd(source.location)
+        .withContext( { rdd =>
+          rdd.mapValues({ mbtile => mbtile.band(source.band.get).interpretAs(source.celltype.getOrElse(mbtile.cellType)) })
+      })
+      Right(tileRdd)
+    }
+
+  private def avroSceneSourceAsRDD(source: SceneRaster, zoom: Int)(implicit sc: SparkContext): Either[NEL[NonEvaluableNode], TileLayerRDD[SpatialKey]] = {
+    val storeO = S3InputFormat.S3UrlRx.findFirstMatchIn(source.location) map {
+      regexResult => {
+        S3AttributeStore(regexResult.group("bucket"), regexResult.group("prefix"))
+      }
+    }
+    storeO match {
+      case None =>
+        Left(NEL.of(NonEvaluableNode(source, Some("attribute store error"))))
+      case Some(store) =>
+        val rdd = S3LayerReader(store)
+          .read[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](LayerId(source.sceneId.toString, zoom))
+          .withContext({ rdd =>
+            rdd.mapValues({ tile => tile.band(source.band.get).interpretAs(source.celltype.getOrElse(tile.cellType)) })
+          })
+        Right(rdd)
+    }
   }
 
   /** Cleanly fetch an `AttributeStore`, given some the ID of a Scene (which

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/RfmlRddResolver.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/RfmlRddResolver.scala
@@ -115,6 +115,9 @@ object RfmlRddResolver extends LazyLogging {
     Right(tileRdd)
   }
 
+  // This method is private, so can't wander off to be called somewehre with a source
+  // that hasn't been constructed _always_ after ensuring that the band is a Some(b)
+  @SuppressWarnings(Array("OptionGet"))
   private def avroSceneSourceAsRDD(source: SceneRaster, zoom: Int)(implicit sc: SparkContext): Either[NEL[NonEvaluableNode], TileLayerRDD[SpatialKey]] = {
     val storeO = S3InputFormat.S3UrlRx.findFirstMatchIn(source.location) map {
       regexResult => {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ingest/spark/Ingest.scala
@@ -179,8 +179,6 @@ object Ingest extends SparkJob with RollbarNotifier with Config {
     val partitions: Array[Array[GridBounds]] = info.segmentLayout.partitionWindowsBySegments(
       windows, partitionBytes / math.max(info.cellType.bytes, 1))
 
-    val kryoInfo = KryoWrapper(info)
-
     sc.parallelize(partitions, partitions.length).flatMap { bounds =>
       // re-constructing here to avoid serialization pit-falls
       val info = readInfo

--- a/app-backend/batch/src/test/resources/export/localJob.json
+++ b/app-backend/batch/src/test/resources/export/localJob.json
@@ -47,7 +47,8 @@
             "autoBalance": {
               "enabled": false
             }
-          }
+          },
+          "sceneType": "AVRO"
         }
       ],
       "mask": {

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -111,7 +111,8 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
             ExportLayerDefinition(
               layerId = UUID.fromString("8436f7e9-b7f7-4d4f-bda8-76b32c356cff"),
               ingestLocation = new URI("s3://test/"),
-              colorCorrections = Some(cc)
+              colorCorrections = Some(cc),
+              sceneType = SceneType.Avro
             )),
           mask = Some(mask)
         ))

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -69,7 +69,7 @@ object CogUtils {
           bucket = s3uri.getBucket,
           key = s3uri.getKey,
           client = S3Client.DEFAULT),
-        decompress = false, streaming = true, withOverviews = true, None)
+        streaming = true, withOverviews = true, None)
     }
 
     val info = readInfo

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -25,9 +25,11 @@ import geotrellis.vector.Projected
 import org.apache.spark.{HashPartitioner, SparkContext}
 import org.apache.spark.rdd.RDD
 
-import scala.concurrent._
 import cats.data._
 import cats.implicits._
+
+import scala.concurrent._
+import java.net.URLDecoder
 
 object CogUtils {
   lazy val cacheConfig = CommonConfig.memcached
@@ -62,8 +64,9 @@ object CogUtils {
     val maxTileSize = 256
     val pixelBuffer = 16
     val partitionBytes = pixelBuffer * 1024 * 1024
+    println(uri)
     def readInfo = {
-      val s3uri = new AmazonS3URI(uri)
+      val s3uri = new AmazonS3URI(URLDecoder.decode(uri))
       GeoTiffReader.readGeoTiffInfo(
         S3RangeReader(
           bucket = s3uri.getBucket,

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -64,15 +64,13 @@ object CogUtils {
     val maxTileSize = 256
     val pixelBuffer = 16
     val partitionBytes = pixelBuffer * 1024 * 1024
-    println(uri)
     def readInfo = {
-      val s3uri = new AmazonS3URI(URLDecoder.decode(uri))
       GeoTiffReader.readGeoTiffInfo(
-        S3RangeReader(
-          bucket = s3uri.getBucket,
-          key = s3uri.getKey,
-          client = S3Client.DEFAULT),
-        streaming = true, withOverviews = true, None)
+        RangeReaderUtils.fromUri(uri).getOrElse(
+          throw new IllegalArgumentException(s"Unable to create range reader for uri $uri")
+        ),
+        streaming = true, withOverviews = true
+      )
     }
 
     val info = readInfo

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportLayerDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ExportLayerDefinition.scala
@@ -13,6 +13,7 @@ import java.util.UUID
 @JsonCodec
 case class ExportLayerDefinition(
   layerId: UUID,
+  sceneType: SceneType,
   ingestLocation: URI,
   colorCorrections: Option[ColorCorrect.Params]
 )

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MosaicDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/MosaicDefinition.scala
@@ -6,7 +6,12 @@ import io.circe._
 import io.circe.generic.JsonCodec
 
 @JsonCodec
-case class MosaicDefinition(sceneId: UUID, colorCorrections: ColorCorrect.Params, sceneType: Option[SceneType] = None, ingestLocation: Option[String])
+case class MosaicDefinition(
+  sceneId: UUID,
+  colorCorrections: ColorCorrect.Params,
+  sceneType: Option[SceneType] = None,
+  ingestLocation: Option[String]
+)
 
 object MosaicDefinition {
   def fromScenesToProjects(scenesToProjects: Seq[SceneToProjectwithSceneType]): Seq[MosaicDefinition] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ExportDao.scala
@@ -166,7 +166,7 @@ object ExportDao extends Dao[Export] {
   ): ConnectionIO[SimpleInput] = {
 
     val exportLayerDefinitions = fr"""
-    SELECT scenes.id, scenes.ingest_location, stp.mosaic_definition
+    SELECT scenes.id, scenes.scene_type, scenes.ingest_location, stp.mosaic_definition
     FROM
       scenes
     LEFT JOIN

--- a/app-backend/tile/src/main/scala/tool/TileResolver.scala
+++ b/app-backend/tile/src/main/scala/tool/TileResolver.scala
@@ -149,9 +149,9 @@ class TileResolver(xaa: Transactor[IO], ec: ExecutionContext) extends LazyLoggin
             }
           })
 
-        case sr@SceneRaster(sceneId, None, celltype) =>
+        case sr@SceneRaster(sceneId, None, celltype, _) =>
           Future.successful(Invalid(NEL.of(NonEvaluableNode(exp, Some("no band given")))))
-        case sr@SceneRaster(sceneId, Some(band), celltype) =>
+        case sr@SceneRaster(sceneId, Some(band), celltype, _) =>
           lazy val ndtile = celltype match {
             case Some(ct) => intNdTile.convert(ct)
             case None => intNdTile
@@ -223,9 +223,9 @@ class TileResolver(xaa: Transactor[IO], ec: ExecutionContext) extends LazyLoggin
 
   def resolveForExtent(fullExp: Expression, zoom: Int, extent: Extent): Future[Interpreted[Expression]] = {
     fullExp match {
-      case sr@SceneRaster(sceneId, None, celltype) =>
+      case sr@SceneRaster(sceneId, None, celltype, _) =>
         Future.successful(Invalid(NEL.of(NonEvaluableNode(fullExp, Some("no band given")))))
-      case sr@SceneRaster(sceneId, Some(band), celltype) =>
+      case sr@SceneRaster(sceneId, Some(band), celltype, _) =>
         Future.successful({
           Try {
             val layerId = LayerId(sceneId.toString, zoom)

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -439,6 +439,7 @@ object MapAlgebraAST {
     def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)
     def substitute(substitutions: Map[UUID, MapAlgebraAST]): Option[MapAlgebraAST] = Some(this)
     def withMetadata(newMd: NodeMetadata): MapAlgebraAST = copy(metadata = Some(newMd))
+
   }
 
   case class ToolReference(id: UUID, toolId: UUID) extends MapAlgebraLeaf {

--- a/app-backend/tool/src/main/scala/maml/MamlAdapter.scala
+++ b/app-backend/tool/src/main/scala/maml/MamlAdapter.scala
@@ -21,7 +21,7 @@ trait MamlAdapter {
       val args = ast.args.map(eval)
       ast match {
         case MapAlgebraAST.Source(id, _) => TileSource(id.toString)
-        case MapAlgebraAST.SceneRaster(_, sceneId, band, celltype, _) => SceneRaster(sceneId, band, celltype)
+        case MapAlgebraAST.SceneRaster(_, sceneId, band, celltype, _) => SceneRaster(sceneId, band, celltype, "")
         case MapAlgebraAST.ProjectRaster(_, projId, band, celltype, _) => ProjectRaster(projId, band, celltype)
         case MapAlgebraAST.CogRaster(_, sceneId, band, celltype, _, location) => CogRaster(sceneId, band, celltype, location)
         case MapAlgebraAST.Constant(_, const, _) => DoubleLiteral(const)

--- a/app-backend/tool/src/main/scala/maml/TileNodes.scala
+++ b/app-backend/tool/src/main/scala/maml/TileNodes.scala
@@ -10,7 +10,7 @@ case class CogRaster(sceneId: UUID, band: Option[Int], celltype: Option[CellType
   val kind = MamlKind.Tile
 }
 
-case class SceneRaster(sceneId: UUID, band: Option[Int], celltype: Option[CellType])
+case class SceneRaster(sceneId: UUID, band: Option[Int], celltype: Option[CellType], location: String)
     extends Source {
   val kind = MamlKind.Tile
 }

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -51,6 +51,7 @@ class BaseModel(object):
         except:
             logger.exception('Unable to create object via API: %s', response.text)
             logger.exception('Attempted to POST: \n%s\n', self.to_json())
+            logger.exception('Response was: %s', response.content)
             raise
         return self.from_dict(response.json())
 

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -102,7 +102,7 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
     logger.info('Creating image')
     ingest_location = 's3://{}/{}'.format(data_bucket, urllib.quote(s3_location))
     scene = Scene(
-        0, 'PRIVATE', [], datasource, {}, landsat_id, 'SUCCESS', 'SUCCESS',
+        'PRIVATE', [], datasource, {}, landsat_id, 'SUCCESS', 'SUCCESS',
         'INGESTED', [io.make_path_for_mtl(gcs_prefix, landsat_id)], ingestLocation=ingest_location,
         cloudCover=filter_metadata['cloud_cover'],
         acquisitionDate=filter_metadata['acquisition_date'],

--- a/app-tasks/rf/src/rf/uploads/modis/factories.py
+++ b/app-tasks/rf/src/rf/uploads/modis/factories.py
@@ -104,7 +104,7 @@ def create_scene(hdf_url, temp_directory, user_id, datasource):
     name = '.'.join(granule_parts[:-1])
     id = str(uuid.uuid4())
 
-    scene = Scene(0, Visibility.PRIVATE, [], datasource, {}, name,
+    scene = Scene(Visibility.PRIVATE, [], datasource, {}, name,
                   JobStatus.SUCCESS, JobStatus.SUCCESS, IngestStatus.INGESTED, [], owner=user_id, id=id,
                   acquisitionDate=acquisition_datetime.isoformat() + 'Z', cloudCover=0)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,7 @@ services:
       - statsd
     env_file: .env
     environment:
+      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
       - RF_LOG_LEVEL=INFO
     ports:
       - "9900:9900"


### PR DESCRIPTION
## Overview

This PR makes COGs export-able as project exports. It does not accomplish making them exportable
in ASTs. I'm not sure how to do the second part yet.

It also includes some ancillary fixes, like:

- telling the tile-server about the COURSIER_CACHE
- fixing ingest size bytes parameters that were never deleted for Landsat 4/5 import and MODIS import

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

~It's a little bit difficult to imagine currently how the AST export will look.~ Not anymore! ~In multiband export, it's fairly~
~easy -- the components of an export are scenes, and scenes have types, and scene types tell us how~
~to get an RDD for them. For AST exports, in the project branch, we rely on the ingested layer in S3~
~pretty heavily. I think we might need to reconsider what AST export definitions look like, but I'm not~
~sure about that.~

~Not going to close until a decision is reached about AST stuff~

COG + Avro AST exports are untested, because the lab UI doesn't work for them, but they
Should Work :TM:.

There's also one outstanding issue with remote (non-S3) COGs, e.g., ISERV. I'm not sure how
to handle them yet and will open a separate PR against this branch with the solution after I dig
in to the tile server a little more to see how it handles them.

## Testing Instructions

 * reassemble batch jar
 * create a project export for a project with COGs (file upload or Landsat 4/5 import or MODIS  import is the best way to get one -- don't point to a remote http link)
 * export it in your batch container
 * go to the lab with your COG project
 * do an operation to it, maybe several operations if you're feeling clever
 * create an export of an area of that COG
 * run that export
 * rejoice

Closes #3711
