### PR TITLE
Use coveredBy geometry filter in scene to project stream

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
@@ -81,7 +81,7 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
     def maybeNotWorthless(coveredByGeomO: Option[MultiPolygon], targetCoverageO: Option[Polygon]): Boolean =
       (coveredByGeomO, targetCoverageO) match {
         case (Some(targetCoverage), Some(coveredSoFar)) => {
-          !targetCoverage.within(coveredSoFar)
+          !targetCoverage.coveredBy(coveredSoFar)
         }
         case _ => true
       }
@@ -131,7 +131,7 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
           )
           .filter(
             (p: (SceneToProjectwithSceneType, Option[Projected[MultiPolygon]])) =>
-               !(coveredSoFar.map(mp => !geom(p).within(mp)).getOrElse(false))
+               !(coveredSoFar.map(mp => !geom(p).coveredBy(mp)).getOrElse(false))
           )
           .zipWithNext
           .compile

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
@@ -151,7 +151,7 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
       }
       val stps = stpsWithFootprints map { _._1 } map { _._1 }
       val nexts = stpsWithFootprints map { _._2 }
-      logger.info(s"Stopped streaming results before the end of the stream? ${!nexts.last.isEmpty}")
+      logger.debug(s"Stopped streaming results before the end of the stream? ${!nexts.last.isEmpty}")
       val md = MosaicDefinition.fromScenesToProjects(stps)
       logger.debug(s"Mosaic Definition: ${md}")
       md


### PR DESCRIPTION
## Overview

This PR switches back to a coveredBy filter from a within filter and quiets logs.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I originally had a coveredBy filter that I thought was the cause of the holes in the resulting tile layers,
eventually figured out that the holes were caused by something else, and never changed the filter back.
Now, we're failing to exit the stream processing early ever (see papertrail -- search "stream?"), which
is likely caused by using the more restrictive within filter instead of the coveredBy filter (see [jts docs](https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/Geometry.html#within(org.locationtech.jts.geom.Geometry))).

## Testing Instructions

 * you can't unless you have a deep stack locally
 * on that note, I tried the staging db locally, and the dev environment hated it
 * so we just have to test on staging
 * and the change is small enough that I think we should just do that, but I could be talked out of it