### PR TITLE
Remove option emptiness check for early stream exit

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
@@ -133,7 +133,6 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
             (p: (SceneToProjectwithSceneType, Option[Projected[MultiPolygon]])) =>
                !(coveredSoFar.map(mp => !geom(p).coveredBy(mp)).getOrElse(false))
           )
-          .zipWithNext
           .compile
           .toList
       }
@@ -149,9 +148,7 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
       countO map {
         (count: Int) => logger.debug(s"Using ${stpsWithFootprints.length} scenes in project out of $count")
       }
-      val stps = stpsWithFootprints map { _._1 } map { _._1 }
-      val nexts = stpsWithFootprints map { _._2 }
-      logger.debug(s"Stopped streaming results before the end of the stream? ${!nexts.last.isEmpty}")
+      val stps = stpsWithFootprints map { _._1 }
       val md = MosaicDefinition.fromScenesToProjects(stps)
       logger.debug(s"Mosaic Definition: ${md}")
       md


### PR DESCRIPTION
## Overview

This PR removes a misleading log statement. See [papertrail](https://papertrailapp.com/groups/4082193/events?q=program%3Astaging%2Ftile-server&focus=966068552857686026).

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Apparently we are exiting early from the stream, so that's going well, but the logging message was
incorrect all the time. :man_shrugging: It looked like it should have been correct to me, but it definitely
wasn't.

## Testing Instructions

 * look at papertrail above to confirm that this logging statement was a lie
