### PR TITLE
Allow defining band in lab if datasource has none

### DIFF
--- a/app-frontend/src/app/components/lab/inputNode/inputNode.html
+++ b/app-frontend/src/app/components/lab/inputNode/inputNode.html
@@ -21,10 +21,17 @@
     <div ng-if="!$ctrl.bands.length && $ctrl.fetchingDatasources">
       Loading band data
     </div>
-    <div ng-if="$ctrl.selectedProject && !$ctrl.bands.length && !$ctrl.fetchingDatasources">
-      <a class="btn btn-flat btn-block" ui-sref="imports.datasources.detail({
-        datasourceid: $ctrl.firstDatasourceWithoutBands().id
-      })">Requires defined bands</a>
+    <div ng-if="$ctrl.selectedProject && !$ctrl.bands.length && !$ctrl.fetchingDatasources"
+         class="form-group search-form">
+      <input class="form-control" type="number" min="0"
+             placeholder="Enter a 0 indexed band"
+             ng-model="$ctrl.manualBand"
+             ng-model-options="{updateOn: 'default', debounce: 500, allowInvalid: true}"
+             ng-change="$ctrl.onBandChange($ctrl.manualBand)">
+      <button disabled title="The datasources on this project do not have bands defined"
+              class="btn-link">
+        <i class="icon-help"></i>
+      </button>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
+++ b/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
@@ -153,10 +153,14 @@ class InputNodeController {
 
     onBandChange(index) {
         this.selectedBand = index;
+        if (!Number.isFinite(index) || index < 0) {
+            delete this.selectedBand;
+            this.manualBand = '';
+        }
         this.checkValidity();
         this.updateNode({
             payload: Object.assign({}, this.node, {
-                band: index
+                band: this.selectedBand
             }),
             hard: !this.analysisErrors.size
         });


### PR DESCRIPTION
## Overview
The generic datasource does not have any bands defined on it, and we want the user to still be able to specify bands without backing out and modifying the datasource.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/44109505-3de469ba-9fcb-11e8-8174-ff3081885b6a.png)


## Testing Instructions

 * Change the datasource for a scene / project to be generic (no bands defined)
* Verify that you can still set bands in the lab, and the previews work as expected
Closes #3844 
