### PR TITLE
Add Rollbar access token to environment for infra

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,11 @@ node {
         dir('raster-foundry-deployment') {
           wrap([$class: 'AnsiColorBuildWrapper']) {
             sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
-            sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+            withCredentials([[$class: 'StringBinding',
+                              credentialsId: 'ROLLBAR_ACCESS_TOKEN',
+                              variable: 'ROLLBAR_ACCESS_TOKEN']]) {
+              sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+            }
           }
         }
       }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -69,7 +69,11 @@ node{
             dir('raster-foundry-deployment') {
               wrap([$class: 'AnsiColorBuildWrapper']) {
                 sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
-                sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+                withCredentials([[$class: 'StringBinding',
+                                  credentialsId: 'ROLLBAR_ACCESS_TOKEN',
+                                  variable: 'ROLLBAR_ACCESS_TOKEN']]) {
+                    sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+                }
               }
             }
 


### PR DESCRIPTION
## Overview

When the `apply` subcommand of `infra` is applied, ensure that the Rollbar access token needed to alert the service of a new deployment is available.
### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

See: http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/PR-3858/3/console