### PR TITLE
Fix reversed scene order for projects

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -78,7 +78,7 @@ class ProjectsEditController {
     getAndReorderSceneList() {
         this.projectService.getSceneOrder(this.projectId).then(
             (res) => {
-                this.orderedSceneId = res.results;
+                this.orderedSceneIds = res.results;
             },
             () => {
                 this.$log.log('error getting ordered scene IDs');
@@ -116,9 +116,9 @@ class ProjectsEditController {
                 ));
                 return this.projectService.getSceneOrder(this.projectId).then(
                     (orderedIds) => {
-                        this.orderedSceneId = orderedIds;
+                        this.orderedSceneIds = orderedIds;
                         this.sceneList = _(
-                          this.orderedSceneId.map((id) => _.find(allScenes, {id}))
+                          this.orderedSceneIds.map((id) => _.find(allScenes, {id}))
                         ).uniqBy('id').compact().value();
 
                         this.fetchDatasources().then(datasources => {

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -500,7 +500,7 @@ export default (app) => {
                 .$promise.then((res) => {
                     const scenes = res.results;
                     const count = res.count;
-                    let promises = Array(Math.floor(count / pageSize) + 1).fill().map((x, page) => {
+                    let promises = Array(Math.ceil(count / pageSize) - 1).fill().map((x, page) => {
                         return this.Project.sceneOrder({
                             projectId,
                             pageSize,


### PR DESCRIPTION
## Overview
Make paging more consistent with other areas
Fix over-fetching of scene order pages on frontend


### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

This does not address any layer issues on the tile server, just the inconsistent ordering of scenes. My tile server is acting up and showing any projects which use z order (anything > 1) as completely transparent tiles...


## Testing Instructions

 * Create a project with two or more ingested scenes
* Verify that after swapping the position of several scenes, reloading the page shows that the scene ordering was preserved

Partially addresses #3668
