### PR TITLE
Add note about support for EPSG:4326 shapefiles only

### DIFF
--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -126,7 +126,7 @@ trait ShapeRoutes extends Authentication
                 complete(StatusCodes.Created, ShapeDao.insertShapes(Seq(shape), user).transact(xa).unsafeToFuture)
               }
               case _ => {
-                val reason = "No valid MultiPolygons found, please ensure coordinates are in EPSG:4326 before uploading"
+                val reason = "No valid MultiPolygons found, please ensure coordinates are in EPSG:4326 before uploading."
                 complete(StatusCodes.ClientError(400)("Bad Request", reason))
               }
             }

--- a/app-frontend/src/app/components/vectors/vectorImportModal/vectorImportModal.html
+++ b/app-frontend/src/app/components/vectors/vectorImportModal/vectorImportModal.html
@@ -21,7 +21,8 @@
     <div class="content">
       <h3 class="no-margin">Select a zipped shapefile</h3>
       <ng-container ng-if="!$ctrl.selectedFile">
-        <p>Select shape files from your computer. {{$ctrl.BUILDCONFIG.APP_NAME}} currently allows for uploading zipped shape files only.</p>
+        <p>Select shapefiles from your computer. {{$ctrl.BUILDCONFIG.APP_NAME}} currently allows for uploading zipped shapefiles
+          in projection EPSG:4326 only.</p>
         <br/>
         <br/>
 


### PR DESCRIPTION
## Overview

During backend processing, we emit a message that indicates shapefiles should be in EPSG:4326 in the event of a failure. This change set adds similar note to the shapefile upload control so that users have the ability know about the requirement prior to upload.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

<img width="940" alt="screen shot 2018-08-16 at 08 08 00" src="https://user-images.githubusercontent.com/43639/44207526-9200ed00-a12b-11e8-86c8-436b94b610f2.png">

## Testing Instructions

- After checking out this branch, use `server` to bring up the application
- Navigate to Data > Vector
- Click **Import Shape** and ensure the text matches what's in the PR

Fixes https://github.com/raster-foundry/raster-foundry/issues/3861