### PR TITLE
Fix copy button overflow in firefox

### DIFF
--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -382,7 +382,7 @@
 Copy button on project share modal
 */
 .btn-copy-modal {
-  width: 99.47px;
+  width: 100px;
   height: 38px;
 }
 

--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_button.scss
@@ -139,7 +139,7 @@ Copy button on project share modal
 */
 .btn-copy-modal,
 .btn-copy-modal-first {
-  width: 99.47px;
+  width: 100px;
   height: 39px;
 }
 


### PR DESCRIPTION
## Overview

Fixes fractions of a pixel causing copy button text in the lab share modal to overflow in the high contrast color them

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/44224478-7f50dd00-a158-11e8-8c61-6c6022693d48.png)




## Testing Instructions

 * Use the overrides webpack config file to change your theme to 'high-contrast' 
* Create an analysis and click the share button on a node once you've set the input nodes
* Verify that the copy buttons no longer overflow and cause the "y" to be on the next line **in Firefox**

Closes #3866 