### PR TITLE
Fix scene item sidebar reorder bug on frontend

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -57,7 +57,7 @@
         repository="$ctrl.repository"
         ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
         ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
-        ng-repeat="scene in $ctrl.$parent.sceneList track by scene.id"
+        ng-repeat="scene in $ctrl.$parent.sceneList track by $ctrl.sceneTracker(scene)"
         ui-tree-node>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -57,7 +57,7 @@
         repository="$ctrl.repository"
         ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
         ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
-        ng-repeat="scene in $ctrl.$parent.sceneList track by $ctrl.sceneTracker(scene)"
+        ng-repeat="scene in $ctrl.$parent.sceneList track by $ctrl.sceneOrderTracker(scene)"
         ui-tree-node>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -94,6 +94,11 @@ class ProjectsScenesController {
             this.$state.go('projects.edit.browse', {sceneid: null, bbox: bbox.toBBoxString()});
         });
     }
+
+    sceneTracker(scene) {
+        Object.assign(scene, {'$$hashKey': scene.id});
+        return scene.$$hashKey;
+    }
 }
 
 const ProjectsScenesModule = angular.module('pages.projects.edit.scenes', ['ui.tree']);

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -95,7 +95,7 @@ class ProjectsScenesController {
         });
     }
 
-    sceneTracker(scene) {
+    sceneOrderTracker(scene) {
         Object.assign(scene, {'$$hashKey': scene.id});
         return scene.$$hashKey;
     }


### PR DESCRIPTION
## Overview

This PR fixes a bug so that reordering scene items on sidebar reflects the real order you intend them to have.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

![reorder](https://user-images.githubusercontent.com/16109558/44225862-88dc4400-a15c-11e8-9abd-022ebc1a2347.gif)


### Notes

This fix is actually a workaround due to a bug (that still has not been fixed it seems) in the library we use to help implement reordering.

## Testing Instructions

 * Go to a project with some scenes
 * Reordering them (especially moving items down one position) should respect the order you have specified.

Closes #3344 
