### PR TITLE
Add support for sbt-git and PGP signed build artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,19 @@ node {
         // Jenkins. In includes the Amazon ECR registry endpoint.
         withCredentials([[$class: 'StringBinding',
                           credentialsId: 'AWS_ECR_ENDPOINT',
-                          variable: 'AWS_ECR_ENDPOINT']]) {
+                          variable: 'AWS_ECR_ENDPOINT'], 
+                          [$class: 'StringBinding',
+                          credentialsId: 'SONATYPE_USERNAME',
+                          variable: 'SONATYPE_USERNAME'],
+                          [$class: 'StringBinding',
+                          credentialsId: 'SONATYPE_PASSWORD',
+                          variable: 'SONATYPE_PASSWORD'],
+                          [$class: 'StringBinding',
+                          credentialsId: 'PGP_HEX_KEY',
+                          variable: 'PGP_HEX_KEY'],
+                          [$class: 'StringBinding',
+                          credentialsId: 'PGP_PASSPHRASE',
+                          variable: 'PGP_PASSPHRASE']]) {
           wrap([$class: 'AnsiColorBuildWrapper']) {
             sh './scripts/cipublish'
           }

--- a/app-backend/Dockerfile.build
+++ b/app-backend/Dockerfile.build
@@ -1,0 +1,10 @@
+FROM openjdk:8-jre
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		git \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+ENV GIT_DISCOVERY_ACROSS_FILESYSTEM 1

--- a/app-backend/Dockerfile.build
+++ b/app-backend/Dockerfile.build
@@ -1,10 +1,10 @@
 FROM openjdk:8-jre
 
-RUN set -ex; \
-	apt-get update; \
+RUN set -ex && \
+	apt-get update && \
 	apt-get install -y --no-install-recommends \
 		git \
-	; \
+	&& \
 	rm -rf /var/lib/apt/lists/*
 
 ENV GIT_DISCOVERY_ACROSS_FILESYSTEM 1

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -1,5 +1,14 @@
 addCommandAlias("mg", "migrations/run")
 
+enablePlugins(GitVersioning)
+
+git.gitTagToVersionNumber in ThisBuild := { tag: String =>
+  if(tag matches "[0-9]+\\..*") Some(tag)
+  else None
+}
+
+git.useGitDescribe := true
+
 lazy val commonSettings = Seq(
   // Add the default sonatype repository setting
   publishTo := sonatypePublishTo.value,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -1,9 +1,9 @@
 addCommandAlias("mg", "migrations/run")
 
-// Add the default sonatype repository setting
-publishTo := sonatypePublishTo.value
-
 lazy val commonSettings = Seq(
+  // Add the default sonatype repository setting
+  publishTo := sonatypePublishTo.value,
+
   organization := "com.rasterfoundry",
   organizationName := "Raster Foundry",
   organizationHomepage := Some(new URL("https://www.rasterfoundry.com")),

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -1,13 +1,11 @@
 addCommandAlias("mg", "migrations/run")
 
-enablePlugins(GitVersioning)
+addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVersion.value.get + \"-SNAPSHOT\"")
 
 git.gitTagToVersionNumber in ThisBuild := { tag: String =>
   if(tag matches "[0-9]+\\..*") Some(tag)
   else None
 }
-
-git.useGitDescribe := true
 
 lazy val commonSettings = Seq(
   // Add the default sonatype repository setting

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("io.gatling" % "gatling-sbt" % "2.2.2")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 // addSbtPlugin("io.kamon" % "sbt-aspectj-runner" % "1.0.1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")

--- a/app-backend/sonatype.sbt
+++ b/app-backend/sonatype.sbt
@@ -4,7 +4,7 @@ publishMavenStyle := true
 
 pgpPassphrase := Some(System.getenv().getOrDefault("PGP_PASSPHRASE", "").toCharArray())
 pgpSecretRing := file("/root/.gnupg/secring.gpg")
-usePgpKeyHex(System.getenv().getOrDefault("PGP_KEY_HEX", "0"))
+usePgpKeyHex(System.getenv().getOrDefault("PGP_HEX_KEY", "0"))
 
 sonatypeProfileName := "com.rasterfoundry"
 sonatypeProjectHosting := Some(GitHubHosting(user="raster-foundry", repository="raster-foundry", email="info@rasterfoundry.com"))

--- a/app-backend/sonatype.sbt
+++ b/app-backend/sonatype.sbt
@@ -2,6 +2,10 @@ import xerial.sbt.Sonatype._
 
 publishMavenStyle := true
 
+pgpPassphrase := Some(System.getenv().getOrDefault("PGP_PASSPHRASE", "").toCharArray())
+pgpSecretRing := file("/root/.gnupg/secring.gpg")
+usePgpKeyHex(System.getenv().getOrDefault("PGP_KEY_HEX", "0"))
+
 sonatypeProfileName := "com.rasterfoundry"
 sonatypeProjectHosting := Some(GitHubHosting(user="raster-foundry", repository="raster-foundry", email="info@rasterfoundry.com"))
 developers := List(

--- a/app-backend/version.sbt
+++ b/app-backend/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.8.0-SNAPSHOT"
+version in ThisBuild := "1.10.0-SNAPSHOT"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -61,7 +61,6 @@ services:
     build:
       context: ./app-backend
       dockerfile: Dockerfile.build
-    env_file: .env
     environment:
       - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
     volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -55,3 +55,22 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
+
+  build:
+    image: raster-foundry-build:${GIT_COMMIT:-latest}
+    build:
+      context: ./app-backend
+      dockerfile: Dockerfile.build
+    env_file: .env
+    environment:
+       - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+    volumes:
+      - ./app-backend/:/opt/raster-foundry/app-backend/
+      - ./scratch/:/opt/raster-foundry/scratch/
+      - ./.sbt:/root/.sbt
+      - ./.git:/opt/raster-foundry/.git
+      - ./.bintray:/root/.bintray
+      - $HOME/.aws:/root/.aws:ro
+      - $HOME/.gnupg:/root/.gnupg
+    working_dir: /opt/raster-foundry/app-backend/
+    entrypoint: ./sbt

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -63,7 +63,7 @@ services:
       dockerfile: Dockerfile.build
     env_file: .env
     environment:
-       - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./scratch/:/opt/raster-foundry/scratch/

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -42,9 +42,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         echo "Building batch JAR"
         docker-compose \
-            run --rm --no-deps api-server batch/clean
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm --no-deps \
+            build batch/clean
+
         docker-compose \
-            run --rm --no-deps api-server batch/assembly
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm --no-deps \
+            build batch/assembly
 
         cp "${DIR}/../app-backend/batch/target/scala-2.11/rf-batch.jar" \
            "${DIR}/../app-tasks/jars/rf-batch.jar"

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -64,7 +64,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 #                     docker-compose \
 #                        -f "${DIR}/../docker-compose.test.yml" \
 #                        run --rm --no-deps \
-#                        build "${project}/publishSigned"
+#                        -e SONATYPE_USERNAME="${SONATYPE_USERNAME}" \
+#                        -e SONATYPE_PASSWORD="${SONATYPE_PASSWORD}" \
+#                        -e PGP_HEX_KEY="${PGP_HEX_KEY}" \
+#                        -e PGP_PASSPHRASE="${PGP_PASSPHRASE}" \
+#                        build gitSnapshots "${project}/publishSigned"
                 done
             fi
 

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -35,11 +35,38 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
             echo "Building application JAR"
             docker-compose \
-                run --rm --no-deps api-server api/assembly
+                -f "${DIR}/../docker-compose.test.yml" \
+                run --rm --no-deps \
+                build api/assembly
 
             echo "Building tile server JAR"
             docker-compose \
-                run --rm --no-deps tile-server tile/assembly
+                -f "${DIR}/../docker-compose.test.yml" \
+                run --rm --no-deps \
+                build tile/assembly
+
+            # Build these projects as SNAPSHOT artifacts and publish to
+            # Sonatype OSSRH (Snapshot Repository). 
+            if [ "$(whoami)" == "jenkins" ]; then
+                projects=( \
+                    "api" \
+                    "authentication" \
+                    "batch" \
+                    "datamodel" \
+                    "db" \
+                    "tile" \
+                )
+
+                for project in "${projects[@]}"
+                do
+                    echo "Publishing ${project} artifact"
+
+#                     docker-compose \
+#                        -f "${DIR}/../docker-compose.test.yml" \
+#                        run --rm --no-deps \
+#                        build "${project}/publishSigned"
+                done
+            fi
 
             echo "Building container images"
             GIT_COMMIT="${GIT_COMMIT}" docker-compose \


### PR DESCRIPTION
## Overview

Add support for [sbt-git](https://github.com/sbt/sbt-git) and PGP signed build artifacts. This PR is in support of publishing build artifacts to Maven Central.

Connects #3793 
Resolves #3788 

## Notes

After this is merged, we need to complete https://github.com/azavea/raster-foundry-platform/issues/447.

## Testing Instructions

First, test the `assembly` stage:

```bash
vagrant@vagrant:/opt/raster-foundry$ docker-compose -f docker-compose.test.yml run --rm build api/assembly
```

Next, define a `.env` file so we can test publishing to the OSSRH:

```bash
PGP_PASSPHRASE=...
PGP_KEY_HEX=...

SONATYPE_USERNAME=...
SONATYPE_PASSWORD=...
```

And finally, publish:

```bash
vagrant@vagrant:/opt/raster-foundry$ docker-compose -f docker-compose.test.yml run --rm build gitSnapshots api/publishSigned
```

See: https://oss.sonatype.org/content/repositories/snapshots/com/rasterfoundry/ (these will be wiped after we do more refactoring)