### PR TITLE
Link to status page upon successful raster upload

### DIFF
--- a/app-frontend/src/app/components/projects/projectAddScenesModal/projectAddScenesModal.html
+++ b/app-frontend/src/app/components/projects/projectAddScenesModal/projectAddScenesModal.html
@@ -57,6 +57,11 @@
       <div class="repository-count">
         Added {{result.sceneCount}} scenes to project
       </div>
+    </div><br>
+    <div ng-if="$ctrl.addSceneMsg && $ctrl.addSceneMsg.length">
+      <strong>Import/Ingest Statuses:</strong><br>
+      {{$ctrl.addSceneMsg}}
+      <a ng-click="$ctrl.linkToStatus()">Click here to check their statuses.</a>
     </div>
   </div>
   <div class="modal-footer" ng-if="$ctrl.finished">

--- a/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
+++ b/app-frontend/src/app/components/projects/projectCreateModal/projectCreateModal.controller.js
@@ -106,7 +106,8 @@ export default class ProjectCreateModalController {
             backdrop: 'static',
             keyboard: false,
             resolve: {
-                project: () => this.project
+                project: () => this.project,
+                origin: () => 'projectCreate'
             }
         });
     }

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -92,7 +92,9 @@ class ImportListController {
     importModal() {
         this.modalService.open({
             component: 'rfSceneImportModal',
-            resolve: {}
+            resolve: {
+                origin: () => 'raster'
+            }
         });
     }
 
@@ -189,4 +191,3 @@ ImportListModule.component('rfImportList', ImportListComponent);
 ImportListModule.controller('ImportListController', ImportListController);
 
 export default ImportListModule;
-

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -15,26 +15,16 @@ const availableImportTypes = ['local', 'S3', 'Planet', 'COG'];
 
 export default class SceneImportModalController {
     constructor(
-        $scope, $state, $q,
+        $rootScope, $scope, $state, $q, $log,
         projectService, Upload, uploadService, authService,
         rollbarWrapperService, datasourceService, userService,
-        sceneService
+        sceneService, APP_CONFIG
     ) {
         'ngInject';
-        this.BUILDCONFIG = BUILDCONFIG;
-        this.$scope = $scope;
-        this.$state = $state;
-        this.$q = $q;
-        this.projectService = projectService;
-        this.Upload = Upload;
-        this.uploadService = uploadService;
-        this.authService = authService;
-        this.rollbarWrapperService = rollbarWrapperService;
-        this.datasourceService = datasourceService;
-        this.availableImportTypes = availableImportTypes;
-        this.userService = userService;
-        this.sceneService = sceneService;
+        $rootScope.autoInject(this, arguments);
 
+        this.BUILDCONFIG = BUILDCONFIG;
+        this.availableImportTypes = availableImportTypes;
         this.planetLogo = planetLogo;
         this.awsS3Logo = awsS3Logo;
         this.dropboxIcon = dropboxIcon;
@@ -656,6 +646,22 @@ export default class SceneImportModalController {
         if (this.locationChangeCanceller) {
             this.locationChangeCanceller();
             delete this.locationChangeCanceller;
+        }
+    }
+
+    linkToStatus() {
+        this.handleDone();
+        if (this.resolve.origin === 'project' || this.resolve.origin === 'raster') {
+            this.$state.reload();
+        }
+        if (this.resolve.origin === 'projectCreate') {
+            this.$state.go(
+                'projects.edit.scenes',
+                { projectid: this.resolve.project.id}
+            );
+        }
+        if (this.resolve.origin === 'datasource') {
+            this.$state.go('imports.rasters');
         }
     }
 }

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -396,7 +396,14 @@
       <p>
         Your scenes are importing into {{$ctrl.BUILDCONFIG.APP_NAME}} now.
         This may take some time and we will notify you when the process is complete.
-        In the meantime checkout your Notification Center for up to date information on all of your projects.
+        <span ng-if="$ctrl.resolve.origin">
+          <a ng-click="$ctrl.linkToStatus()">
+            Click here to check the status of your import.
+          </a>
+        </span>
+        <span ng-if="!$ctrl.resolve.origin">
+          You may check the status of your import later.
+        </span>
       </p>
     </div>
   </div>

--- a/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
+++ b/app-frontend/src/app/pages/imports/datasources/detail/detail.module.js
@@ -159,7 +159,8 @@ class DatasourceDetailController {
         this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
-                datasource: () => this.datasource
+                datasource: () => this.datasource,
+                origin: () => 'datasource'
             }
         });
     }

--- a/app-frontend/src/app/pages/imports/raster/raster.module.js
+++ b/app-frontend/src/app/pages/imports/raster/raster.module.js
@@ -23,7 +23,9 @@ class RasterListController {
 
         this.activeModal = this.$uibModal.open({
             component: 'rfSceneImportModal',
-            resolve: {}
+            resolve: {
+                origin: () => 'raster'
+            }
         });
     }
 

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -77,7 +77,8 @@ class ProjectsScenesController {
         this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
-                project: () => this.$parent.project
+                project: () => this.$parent.project,
+                origin: () => 'project'
             }
         });
     }


### PR DESCRIPTION
## Overview

This PR adds links directing to raster import status pages (should be either project scene list page or raster import list page) at the last step of scene import modal based on where the modal is initiated.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

This PR reflects the re-scoped requirements mentioned in the card it closes since the other parts are currently being handled in a WIP card: https://github.com/raster-foundry/raster-foundry/issues/1602 -- mutually agreed with @alkamin 

## Testing Instructions

 * Test scene import originated from the following places and make sure the link in the last step, i.e. scene upload success, takes you to the correct scene import status page.
   - Choose import your own scene in the second step of creating a new project and import
   - Import scene in an already existing project
   - Import scene on an empty raster data list page
   - Import scene on raster data list page (with rasters in there already)
   - Import scene on datasource detail page

Closes #3862 
