### PR TITLE
Fix lab export modal and dropbox check; Fix permission modal and tab

### DIFF
--- a/app-frontend/src/app/components/exports/exportAnalysisDownloadModal/exportAnalysisDownloadModal.module.js
+++ b/app-frontend/src/app/components/exports/exportAnalysisDownloadModal/exportAnalysisDownloadModal.module.js
@@ -14,14 +14,30 @@ const ExportAnalysisDownloadModalComponent = {
 };
 
 class ExportAnalysisDownloadModalController {
-    constructor($rootScope, $log, modalService) {
+    constructor($rootScope, $log, modalService, exportService) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
     }
 
     $postLink() {
         this.analysis = this.resolve.analysis;
-        this.exports = this.resolve.exports;
+        this.getExportsByAnalysisId();
+    }
+
+    getExportsByAnalysisId() {
+        // TODO: in a future card, implement paginated exports
+        this.exportService.query(
+            {
+                sort: 'createdAt,desc',
+                pageSize: '20',
+                page: 0,
+                analysis: this.analysis.id
+            }
+        ).then(firstPageExports => {
+            if (firstPageExports.results.find(r => r.toolRunId === this.analysis.id)) {
+                this.exports = firstPageExports.results;
+            }
+        });
     }
 
     isDownloadAllowed(thisExport) {

--- a/app-frontend/src/app/components/map/labMap/labMap.module.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.module.js
@@ -427,15 +427,15 @@ class LabMapController {
 
     updateTarget(target) {
         if (target.value === 'dropbox') {
-            let hasDropbox = this.authService.user.dropboxCredential &&
-                this.authService.user.dropboxCredential.length;
-            if (hasDropbox) {
-                this.exportTarget = target;
-                let appName = BUILDCONFIG.APP_NAME.toLowerCase().replace(' ', '-');
-                this.exportOptions.source = `dropbox:///${appName}/analyses/${this.analysisId}`;
-            } else {
-                this.displayDropboxModal();
-            }
+            this.authService.getCurrentUser().then(user => {
+                if (user.dropboxCredential && user.dropboxCredential.length) {
+                    this.exportTarget = target;
+                    let appName = BUILDCONFIG.APP_NAME.toLowerCase().replace(' ', '-');
+                    this.exportOptions.source = `dropbox:///${appName}/analyses/${this.analysisId}`;
+                } else {
+                    this.displayDropboxModal();
+                }
+            });
         } else {
             delete this.exportOptions.source;
         }

--- a/app-frontend/src/app/components/permissions/permissionModal/permissionModal.html
+++ b/app-frontend/src/app/components/permissions/permissionModal/permissionModal.html
@@ -11,7 +11,7 @@
         ng-click="$ctrl.dismiss()"
     ></span>
   </div>
-  <div class="modal-body">
+  <div class="modal-body" ng-if="$ctrl.objectOwnerId === $ctrl.userId">
     <form class="add-permission-form" ng-if="!$ctrl.loading">
       <label>Grant permissions to</label>
       <div class="permission-all-in-one">
@@ -149,7 +149,13 @@
       </rf-permission-item>
   </div>
 </div>
-<div class="modal-footer">
+<div class="modal-body add-permission-form color-danger" ng-if="$ctrl.objectOwnerId !== $ctrl.userId">
+  Only owner of this {{ $ctrl.resolve.objectType.toLowerCase() }} may grant permissions.
+</div>
+<div class="modal-footer" ng-if="$ctrl.objectOwnerId === $ctrl.userId">
   <button type="button" class="btn btn-light pull-left" ng-click="$ctrl.dismiss()">Cancel</button>
   <button type="button" class="btn btn-primary" ng-click="$ctrl.onSave()">Save Changes</button>
+</div>
+<div class="modal-footer" ng-if="$ctrl.objectOwnerId !== $ctrl.userId">
+  <button type="button" class="btn btn-light" ng-click="$ctrl.dismiss()">Cancel</button>
 </div>

--- a/app-frontend/src/app/components/permissions/permissionModal/permissionModal.js
+++ b/app-frontend/src/app/components/permissions/permissionModal/permissionModal.js
@@ -23,90 +23,95 @@ class PermissionModalController {
     }
 
     $onInit() {
-        this.loading = false;
-        this.rawPermissions = [];
-        this.actionsBuffer = {};
-        this.entityCache = {
-            organization: {},
-            team: {},
-            user: {}
-        };
+        this.objectOwnerId = this.resolve.object.owner.id || this.resolve.object.owner;
+        this.userId = this.authService.user.id;
 
-        this.actionTypes = [{
-            tag: 'view',
-            label: 'Can view',
-            applies: () => true,
-            actions: ['VIEW'],
-            default: true
-        }, {
-            tag: 'annotate',
-            label: 'Can annotate',
-            applies: (o) => o.toLowerCase() === 'project',
-            actions: ['VIEW', 'ANNOTATE'].sort()
-        }, {
-            tag: 'editNonProject',
-            label: 'Can edit',
-            applies: (o) => o.toLowerCase() !== 'project',
-            actions: ['VIEW', 'EDIT'].sort()
-        }, {
-            tag: 'editProject',
-            label: 'Can edit',
-            applies: (o) => o.toLowerCase() === 'project',
-            actions: ['VIEW', 'ANNOTATE', 'EDIT'].sort()
-        }, {
-            tag: 'deleteNonProject',
-            label: 'Can delete',
-            applies: (o) => o.toLowerCase() !== 'project',
-            actions: ['VIEW', 'EDIT', 'DELETE'].sort()
-        }, {
-            tag: 'deleteProject',
-            label: 'Can delete',
-            applies: (o) => o.toLowerCase() === 'project',
-            actions: ['VIEW', 'ANNOTATE', 'EDIT', 'DELETE'].sort()
-        }];
+        if (this.objectOwnerId === this.userId) {
+            this.loading = false;
+            this.rawPermissions = [];
+            this.actionsBuffer = {};
+            this.entityCache = {
+                organization: {},
+                team: {},
+                user: {}
+            };
 
-        this.subjectTypes = [
-            {
-                name: 'Everyone',
-                target: 'PLATFORM',
-                id: 0,
-                applies: () =>
-                    !this.actionsBuffer.PLATFORM ||
-                    !Object.keys(this.actionsBuffer.PLATFORM).length
+            this.actionTypes = [{
+                tag: 'view',
+                label: 'Can view',
+                applies: () => true,
+                actions: ['VIEW'],
+                default: true
             }, {
-                name: 'An organization',
-                singular: 'organization',
-                plural: 'organizations',
-                target: 'ORGANIZATION',
-                id: 1,
-                applies: () => true
+                tag: 'annotate',
+                label: 'Can annotate',
+                applies: (o) => o.toLowerCase() === 'project',
+                actions: ['VIEW', 'ANNOTATE'].sort()
             }, {
-                name: 'A team',
-                singular: 'team',
-                plural: 'teams',
-                target: 'TEAM',
-                id: 2,
-                applies: () => true
+                tag: 'editNonProject',
+                label: 'Can edit',
+                applies: (o) => o.toLowerCase() !== 'project',
+                actions: ['VIEW', 'EDIT'].sort()
             }, {
-                name: 'A user',
-                singular: 'user',
-                plural: 'users',
-                target: 'USER',
-                id: 3,
-                applies: () => true
-            }
-        ];
+                tag: 'editProject',
+                label: 'Can edit',
+                applies: (o) => o.toLowerCase() === 'project',
+                actions: ['VIEW', 'ANNOTATE', 'EDIT'].sort()
+            }, {
+                tag: 'deleteNonProject',
+                label: 'Can delete',
+                applies: (o) => o.toLowerCase() !== 'project',
+                actions: ['VIEW', 'EDIT', 'DELETE'].sort()
+            }, {
+                tag: 'deleteProject',
+                label: 'Can delete',
+                applies: (o) => o.toLowerCase() === 'project',
+                actions: ['VIEW', 'ANNOTATE', 'EDIT', 'DELETE'].sort()
+            }];
 
-        this.defaultAction = this.actionTypes.find(a => a.default);
+            this.subjectTypes = [
+                {
+                    name: 'Everyone',
+                    target: 'PLATFORM',
+                    id: 0,
+                    applies: () =>
+                        !this.actionsBuffer.PLATFORM ||
+                        !Object.keys(this.actionsBuffer.PLATFORM).length
+                }, {
+                    name: 'An organization',
+                    singular: 'organization',
+                    plural: 'organizations',
+                    target: 'ORGANIZATION',
+                    id: 1,
+                    applies: () => true
+                }, {
+                    name: 'A team',
+                    singular: 'team',
+                    plural: 'teams',
+                    target: 'TEAM',
+                    id: 2,
+                    applies: () => true
+                }, {
+                    name: 'A user',
+                    singular: 'user',
+                    plural: 'users',
+                    target: 'USER',
+                    id: 3,
+                    applies: () => true
+                }
+            ];
 
-        this.authTarget = {
-            permissionsBase: this.resolve.permissionsBase,
-            objectType: this.resolve.objectType,
-            objectId: this.resolve.object.id
-        };
+            this.defaultAction = this.actionTypes.find(a => a.default);
 
-        this.applicableActions = this.getApplicableActions(this.resolve.objectType);
-        this.fetchPermissions();
+            this.authTarget = {
+                permissionsBase: this.resolve.permissionsBase,
+                objectType: this.resolve.objectType,
+                objectId: this.resolve.object.id
+            };
+
+            this.applicableActions = this.getApplicableActions(this.resolve.objectType);
+            this.fetchPermissions();
+        }
     }
 
     fetchPermissions() {

--- a/app-frontend/src/app/pages/lab/browse/analyses/analyses.html
+++ b/app-frontend/src/app/pages/lab/browse/analyses/analyses.html
@@ -72,7 +72,7 @@
           <td>
             <a
               ng-click="$ctrl.onAnalysisExportModalClick(analysis)"
-              ng-if="$ctrl.analysesExports[analysis.id] && $ctrl.analysesExports[analysis.id].count">
+              ng-if="$ctrl.analysesExports[analysis.id] && $ctrl.analysesExports[analysis.id] > 0">
               Exports
             </a>
           </td>

--- a/app-frontend/src/app/pages/lab/browse/analyses/analyses.js
+++ b/app-frontend/src/app/pages/lab/browse/analyses/analyses.js
@@ -152,8 +152,7 @@ class LabBrowseAnalysesController {
         this.modalService.open({
             component: 'rfExportAnalysisDownloadModal',
             resolve: {
-                analysis: () => analysis,
-                exports: () => this.analysesExports[analysis.id].results
+                analysis: () => analysis
             }
         });
     }
@@ -174,7 +173,7 @@ class LabBrowseAnalysesController {
             }
         ).then(firstPageExports => {
             if (firstPageExports.results.find(r => r.toolRunId === analysisId)) {
-                this.analysesExports[analysisId] = firstPageExports;
+                this.analysesExports[analysisId] = firstPageExports.count;
             }
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/edit.html
+++ b/app-frontend/src/app/pages/projects/edit/edit.html
@@ -49,7 +49,8 @@
     </a>
     <a href
        ng-click="$ctrl.openShareModal()"
-       data-title="Share">
+       data-title="Share"
+       ng-if="$ctrl.projectOwnerId === $ctrl.actingUserId">
       <i class="icon-key"></i>
       <span>Permissions</span>
     </a>

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -64,6 +64,7 @@ class ProjectsEditController {
         this.resetAnnotations();
         if (this.projectId) {
             this.setProjectId(this.projectId);
+            this.setPermissionsTab();
         }
     }
 
@@ -73,6 +74,13 @@ class ProjectsEditController {
                 this.fitProjectExtent();
             }
         }
+    }
+
+    setPermissionsTab() {
+        this.projectService.fetchProject(this.projectId).then(thisProject => {
+            this.projectOwnerId = thisProject.owner.id || thisProject.owner;
+            this.actingUserId = this.authService.user.id;
+        });
     }
 
     getAndReorderSceneList() {


### PR DESCRIPTION
## Overview

This PR fixes frontend bugs so that:
  - lab export modal fetches a fresh list of exports every time you open it
  - lab map's export control gets fresh acting user's dropbox credential every time you use the control
  - permission modal's content depends on if the acting user is current object's owner
  - permission tab's appearance depends on if the acting user is current object's owner

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * For dropbox credential test:
     - Delete your dropbox credential from DB.
     - Head to lab, create an export, and choose to export to dropbox. Follow the modal and reconnect to dropbox. Head back to lab export. It should allow you to export to dropbox now.
     - Delete your dropbox credential from DB
     - Head to project, and perform similar tests as above
* For lab export modal:
     - Open up a lab export modal and check status
     - Change some export statuses of a lab export in DB
     - Close the lab export modal, don't refresh page, open up the modal again. It should show the updated export statuses.
* For permissions related:
     - Go to a project shared to you. There should be no `Permissions` tab on top
     - Make sure the permission modal always checks if you are the owner of the object you are about to grant permissions on.

Closes #3877 
Closes #3880 
Closes #3876 
