### PR TITLE
Fix Exports and S3 import

### DIFF
--- a/app-backend/api/src/main/scala/uploads/package.scala
+++ b/app-backend/api/src/main/scala/uploads/package.scala
@@ -8,7 +8,7 @@ package object uploads {
     implicit def stringAsJavaURI(uri: String): URI = new URI(uri)
 
     def listAllowedFilesInS3Source(source: String): List[String] = {
-        S3.getObjectPaths(source)
+        S3.getObjectPaths(source, false)
             .filter { p =>
                 val _p = p.toLowerCase
                 _p.endsWith(".tif") ||

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneType.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneType.scala
@@ -3,7 +3,7 @@ package com.azavea.rf.datamodel
 import io.circe._
 import cats.syntax.either._
 
-sealed abstract class SceneType(val repr: String) {
+sealed abstract class SceneType(val repr: String) extends Serializable {
   override def toString = repr
 }
 


### PR DESCRIPTION
## Overview

Fixes two issues:
 1. exports were failing for Avro tiles because SceneType could not be serialized in spark
 2. listing tifs during an s3 upload was failing

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

#### Testing Exports
 - Export a project with an avro scene through the UI (grab the ID from the server logs)
 - Run the export: `./scripts/console batch "rf export <export-id>"`
 - Export a project with a COG scene through the UI (grab the id from the server logs) and run the export
 - Export an analysis with an avro scene (grab the ID from the server logs)
 - Export an analysis with a COG scene (grab the ID from the server logs)
 - Rinse and repeat the above while configuring dropbox and verify that things get placed in dropbox properly

#### Testing S3 Imports
 - Create a new project in the UI, using S3 import with the following S3 URI: `s3://rasterfoundry-staging-data-us-east-1/s3-import-test/`
 - Note the ID from the API server logs, run a process upload: `./scripts/console batch "rf process-upload <upload-id>`


Closes #3886 
Closes https://github.com/azavea/raster-foundry-platform/issues/450
