### PR TITLE
Remove Scapegoat errors for API project

### DIFF
--- a/app-backend/api/src/main/scala/config/Config.scala
+++ b/app-backend/api/src/main/scala/config/Config.scala
@@ -1,17 +1,13 @@
 package com.azavea.rf.api.config
 
-import cats.effect.IO
 import com.azavea.rf.api.utils.Config
 import com.azavea.rf.database.FeatureFlagDao
 import com.azavea.rf.datamodel.FeatureFlag
 import doobie.free.connection.ConnectionIO
-import doobie.util.transactor.Transactor
 import io.circe.generic.JsonCodec
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 @JsonCodec
-case class AngularConfig(
+final case class AngularConfig(
                           clientId: String,
                           clientEnvironment: String,
                           auth0Domain: String,

--- a/app-backend/api/src/main/scala/exports/package.scala
+++ b/app-backend/api/src/main/scala/exports/package.scala
@@ -1,24 +1,21 @@
 package com.azavea.rf.api
 
-import io.circe._
-import io.circe.syntax._
+import java.net.{URI, URL, URLDecoder}
+import java.nio.charset.StandardCharsets.UTF_8
+import java.sql.Timestamp
+import java.util.Date
 
+import com.amazonaws.services.s3.AmazonS3URI
+import com.azavea.rf.api.utils.Config
 import com.azavea.rf.common.S3
 import com.azavea.rf.datamodel.{Export, ExportOptions, User}
-import com.azavea.rf.api.utils.Config
-import com.amazonaws.services.s3.AmazonS3URI
-
-import java.time.Duration
-import java.util.Date
-import java.net.{URI, URL, URLDecoder}
-import java.sql.Timestamp
-import java.nio.charset.StandardCharsets.UTF_8
+import io.circe.syntax._
 
 package object exports extends Config {
   implicit def listUrlToListString(urls: List[URL]): List[String] = urls.map(_.toString)
 
   implicit class ExportOptionsMethods(exportOptions: ExportOptions) {
-    def getSignedUrls(duration: Duration = Duration.ofDays(1)): List[URL] = {
+    def getSignedUrls(): List[URL] = {
       (exportOptions.source.getScheme match {
         case "s3" | "s3a" | "s3n" => Some(S3.getSignedUrls(exportOptions.source))
         case _ => None
@@ -32,10 +29,10 @@ package object exports extends Config {
       }).getOrElse(Nil)
     }
 
-    def getSignedUrl(objectKey: String, duration: Duration = Duration.ofDays(1)): URL = {
+    def getSignedUrl(objectKey: String): URL = {
       val amazonURI = new AmazonS3URI(exportOptions.source + "/" + objectKey)
-      val bucket:String = amazonURI.getBucket
-      val key:String = URLDecoder.decode(amazonURI.getKey, UTF_8.toString())
+      val bucket: String = amazonURI.getBucket
+      val key: String = URLDecoder.decode(amazonURI.getKey, UTF_8.toString())
       (exportOptions.source.getScheme match {
         case "s3" | "s3a" | "s3n" => Some(S3.getSignedUrl(bucket, key))
         case _ => None
@@ -75,4 +72,5 @@ package object exports extends Config {
       export.copy(exportOptions = exportOptions.asJson)
     }
   }
+
 }

--- a/app-backend/api/src/main/scala/healthcheck/Healthcheck.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Healthcheck.scala
@@ -1,18 +1,11 @@
 package com.azavea.rf.api.healthcheck
 
-import cats.free.Free
 import com.azavea.rf.api.Codec._
-import io.circe.generic.JsonCodec
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.free.connection
-import doobie.postgres._
-import doobie.postgres.implicits._
 
+import io.circe.generic.JsonCodec
 
 /**
   * Available healthcheck values
@@ -35,7 +28,7 @@ object HealthCheckStatus extends Enumeration {
   *
   */
 @JsonCodec
-case class HealthCheck(status: HealthCheckStatus.Status, services: Seq[ServiceCheck])
+final case class HealthCheck(status: HealthCheckStatus.Status, services: Seq[ServiceCheck])
 
 /**
   * Individual service check for a component (database, cache, etc.)
@@ -44,14 +37,14 @@ case class HealthCheck(status: HealthCheckStatus.Status, services: Seq[ServiceCh
   * @param status  status of service (e.g. OK, UNHEALTHY)
   */
 @JsonCodec
-case class ServiceCheck(service: String, status: HealthCheckStatus.Status)
+final case class ServiceCheck(service: String, status: HealthCheckStatus.Status)
 
 /**
   * Exception for database errors
   *
   * @param description description of error
   */
-case class DatabaseException(description:String) extends Exception
+final case class DatabaseException(description: String) extends Exception
 
 object HealthCheckService {
 

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -2,40 +2,33 @@ package com.azavea.rf.api.shape
 
 import java.util.UUID
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
-import com.typesafe.scalalogging.LazyLogging
-import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe._
-import io.circe.generic.JsonCodec
-import io.circe.syntax._
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.directives.FileInfo
+import better.files.{File => ScalaFile}
+import cats.effect.IO
 import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 import com.azavea.rf.authentication.Authentication
 import com.azavea.rf.common._
-import com.azavea.rf.datamodel._
 import com.azavea.rf.database.Implicits._
-import com.azavea.rf.datamodel.GeoJsonCodec._
-import geotrellis.shapefile.ShapeFileReader
-import better.files.{File => ScalaFile, _}
-import akka.http.scaladsl.server.directives.FileInfo
-import cats.effect.IO
 import com.azavea.rf.database.{AccessControlRuleDao, ShapeDao}
-import geotrellis.proj4.{CRS, LatLng, WebMercator}
+import com.azavea.rf.datamodel.GeoJsonCodec._
+import com.azavea.rf.datamodel._
+import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
+import com.typesafe.scalalogging.LazyLogging
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import geotrellis.proj4.{LatLng, WebMercator}
+import geotrellis.shapefile.ShapeFileReader
 import geotrellis.vector.Projected
 import geotrellis.vector.reproject.Reproject
+import io.circe.generic.JsonCodec
 
-import doobie.util.transactor.Transactor
-import cats.implicits._
-import doobie._
-import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 @JsonCodec
-case class ShapeFeatureCollectionCreate (
+final case class ShapeFeatureCollectionCreate (
   features: Seq[Shape.GeoJSONFeatureCreate]
 )
 

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -1,41 +1,27 @@
 package com.azavea.rf.api.thumbnail
 
-import com.azavea.rf.authentication.Authentication
-import com.azavea.rf.common.{UserErrorHandler, S3, CommonHandlers}
-import com.azavea.rf.database.ThumbnailDao
-import com.azavea.rf.datamodel._
-import com.azavea.rf.api.utils.Config
+import java.net.{URI, URLDecoder}
 
-import io.circe._
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.model.{StatusCodes, ContentType, HttpEntity, HttpResponse, MediaType, MediaTypes}
-import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import kamon.akka.http.KamonTraceDirectives
-
-import java.util.UUID
-import java.net.{ URI, URLDecoder }
-
 import cats.effect.IO
-import doobie.util.transactor.Transactor
-import com.azavea.rf.database.filter.Filterables._
 import com.amazonaws.regions._
 import com.amazonaws.services.s3.model.GetObjectRequest
-import cats.implicits._
-import doobie._
-import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
+import com.azavea.rf.api.utils.Config
+import com.azavea.rf.authentication.Authentication
+import com.azavea.rf.common.{CommonHandlers, S3, UserErrorHandler}
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+import doobie.util.transactor.Transactor
+import kamon.akka.http.KamonTraceDirectives
 
 
 trait ThumbnailRoutes extends Authentication
-    with ThumbnailQueryParameterDirective
-    with PaginationDirectives
-    with CommonHandlers
-    with UserErrorHandler
-    with Config
-    with KamonTraceDirectives {
+  with ThumbnailQueryParameterDirective
+  with PaginationDirectives
+  with CommonHandlers
+  with UserErrorHandler
+  with Config
+  with KamonTraceDirectives {
 
   val xa: Transactor[IO]
 
@@ -56,6 +42,7 @@ trait ThumbnailRoutes extends Authentication
     }
   }
 
+  @SuppressWarnings(Array("AsInstanceOf"))
   def getThumbnailImage(thumbnailPath: String): Route = authenticateWithParameter { _ =>
     var uriString = s"http://s3.amazonaws.com/${thumbnailBucket}/${thumbnailPath}"
     val uri = new URI(uriString)
@@ -70,6 +57,7 @@ trait ThumbnailRoutes extends Authentication
     ))
   }
 
+  @SuppressWarnings(Array("AsInstanceOf"))
   def getProxiedThumbnailImage(thumbnailUri: String): Route = authenticateWithParameter { _ =>
     val bucketAndPrefix = S3.bucketAndPrefixFromURI(new URI(URLDecoder.decode(thumbnailUri)))
     val s3Object = sentinelS3client.getObject(new GetObjectRequest(bucketAndPrefix._1, bucketAndPrefix._2, true))

--- a/app-backend/api/src/main/scala/token/Token.scala
+++ b/app-backend/api/src/main/scala/token/Token.scala
@@ -3,31 +3,30 @@ package com.azavea.rf.api.token
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.Uri.{Path, Query}
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
-import scala.concurrent.Future
+import com.azavea.rf.api.utils.{Auth0Exception, Config, ManagementBearerToken}
 import com.azavea.rf.datamodel.User
-import com.azavea.rf.api.utils.Config
-import com.azavea.rf.api.utils.{Auth0Exception, ManagementBearerToken}
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import de.heikoseeberger.akkahttpcirce._
 import io.circe.generic.JsonCodec
 import io.circe.generic.auto._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
 // TODO: this sort of case class definition should live in datamodel
 @JsonCodec
-case class RefreshToken(refresh_token: String)
+final case class RefreshToken(refresh_token: String)
 @JsonCodec
-case class DeviceCredential(id: String, device_name: String)
+final case class DeviceCredential(id: String, device_name: String)
 @JsonCodec
-case class AuthorizedToken(id_token: String, access_token: String, expires_in: Int, token_type: String)
+final case class AuthorizedToken(id_token: String, access_token: String, expires_in: Int, token_type: String)
 @JsonCodec
-case class RefreshTokenRequest(grant_type: String, client_id: String, refresh_token: String)
+final case class RefreshTokenRequest(grant_type: String, client_id: String, refresh_token: String)
 
 object TokenService extends Config with ErrorAccumulatingCirceSupport {
 

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -3,27 +3,18 @@ package com.azavea.rf.api.uploads
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
-import com.azavea.rf.api.utils.Config
-import com.azavea.rf.datamodel.User
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.amazonaws.auth.{AWSCredentials, AWSSessionCredentials, AWSStaticCredentialsProvider}
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
 import com.amazonaws.services.securitytoken.model.AssumeRoleWithWebIdentityRequest
+import com.azavea.rf.api.utils.Config
+import com.azavea.rf.datamodel.User
 import com.typesafe.scalalogging.LazyLogging
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import io.circe.generic.JsonCodec
-import io.circe.optics.JsonPath._
-import io.circe.Json
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 
 @JsonCodec
-case class Credentials (
+final case class Credentials (
   AccessKeyId: String,
   Expiration: String,
   SecretAccessKey: String,
@@ -35,13 +26,12 @@ case class Credentials (
 }
 
 @JsonCodec
-case class CredentialsWithBucketPath (
+final case class CredentialsWithBucketPath (
   credentials: Credentials,
   bucketPath: String
 )
 
 object CredentialsService extends Config with LazyLogging {
-  import com.azavea.rf.api.AkkaSystem._
 
   def getCredentials(user: User, uploadId: UUID, jwt: String): CredentialsWithBucketPath = {
     val path = s"user-uploads/${user.id}/${uploadId.toString}"

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -1,29 +1,19 @@
 package com.azavea.rf.api.uploads
 
-import com.azavea.rf.authentication.Authentication
-import com.azavea.rf.common.{AWSBatch, CommonHandlers, S3, UserErrorHandler}
-import com.azavea.rf.datamodel._
-import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.model.StatusCodes
-import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
-import io.circe._
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import java.net.URI
 import java.util.UUID
 
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
 import cats.effect.IO
-
-import scala.util.{Success, Failure}
-import scala.concurrent.ExecutionContext.Implicits.global
-import doobie.util.transactor.Transactor
-import cats.implicits._
+import com.azavea.rf.authentication.Authentication
+import com.azavea.rf.common.{AWSBatch, CommonHandlers, UserErrorHandler}
 import com.azavea.rf.database.UploadDao
-import doobie._
-import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 import com.azavea.rf.database.filter.Filterables._
+import com.azavea.rf.datamodel._
+import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
 
 
 trait UploadRoutes extends Authentication
@@ -148,7 +138,7 @@ trait UploadRoutes extends Authentication
     } {
       extractTokenHeader { jwt =>
         onSuccess(UploadDao.query.filter(uploadId).selectOption.transact(xa).unsafeToFuture) {
-          case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt.toString))
+          case Some(_) => complete(CredentialsService.getCredentials(user, uploadId, jwt))
           case None => complete(StatusCodes.NotFound)
         }
       }

--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -1,14 +1,15 @@
 package com.azavea.rf.api.user
 
+import java.util.Base64
+
 import com.dropbox.core.DbxSessionStore
 import io.circe.generic.JsonCodec
 
 import scala.beans.BeanProperty
 import scala.util.Random
-import java.util.Base64
 
 @JsonCodec
-case class DropboxAuthRequest(
+final case class DropboxAuthRequest(
   authorizationCode: String,
   redirectURI: String
 )
@@ -43,5 +44,5 @@ class DummySessionStore extends DbxSessionStore {
     }
   }
   def set(s: String): Unit = this.setToken(s)
-  def clear: Unit = ()
+  def clear(): Unit = this.clear
 }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -2,37 +2,22 @@ package com.azavea.rf.api.user
 
 import java.net.URLDecoder
 
-import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
-import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
 import cats.effect.IO
-import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import com.dropbox.core.{DbxAppInfo, DbxRequestConfig, DbxWebAuth}
+import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 import com.azavea.rf.authentication.Authentication
 import com.azavea.rf.common.{CommonHandlers, UserErrorHandler}
 import com.azavea.rf.database._
-import com.azavea.rf.database.filter.Filterables._
 import com.azavea.rf.datamodel._
-import io.circe._
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import com.dropbox.core.{DbxAppInfo, DbxRequestConfig, DbxWebAuth}
+import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import com.typesafe.scalalogging.LazyLogging
-
-import doobie._
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
-import com.azavea.rf.common.{CommonHandlers, UserErrorHandler}
-import com.azavea.rf.authentication.Authentication
-import com.azavea.rf.database._
-import com.azavea.rf.database.filter.Filterables._
-import com.azavea.rf.datamodel._
-import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
+import scala.collection.JavaConverters._
 
 
 /**

--- a/app-backend/api/src/main/scala/utils/Auth0Exception.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0Exception.scala
@@ -5,15 +5,14 @@ import akka.http.scaladsl.model.StatusCode
 class Auth0Exception(code: StatusCode, message: String, cause: Throwable)
   extends RuntimeException(Auth0Exception.defaultMessage(message, cause), cause) {
 
-  def this(code: StatusCode, message: String) = {
-    this(code, message, null)
-  }
+  @SuppressWarnings(Array("NullParameter"))
+  def this(code: StatusCode, message: String) = this(code, message, null)
 
   def getClientMessage: String = s"Authentication service returned error $code"
 }
 
 object Auth0Exception {
-
+  @SuppressWarnings(Array("NullParameter"))
   def defaultMessage(message: String, cause: Throwable): String = {
     if (message != null) message
     else if (cause != null) cause.toString

--- a/app-backend/api/src/main/scala/utils/Auth0Util.scala
+++ b/app-backend/api/src/main/scala/utils/Auth0Util.scala
@@ -3,4 +3,4 @@ package com.azavea.rf.api.utils
 import io.circe.generic.JsonCodec
 
 @JsonCodec
-case class ManagementBearerToken(access_token: String, expires_in: Int, token_type: String, scope: String)
+final case class ManagementBearerToken(access_token: String, expires_in: Int, token_type: String, scope: String)


### PR DESCRIPTION
## Overview

Remedy the warning messages and use `SuppressWarnings` where a straightforward solution isn't obvious. Also, clean up imports across all files touched.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

<img width="1440" alt="screen shot 2018-08-21 at 00 18 27" src="https://user-images.githubusercontent.com/43639/44380161-be27bf80-a4d7-11e8-99e5-ce6c390a1147.png">

### Notes

There is still one **Match instead of partial function** that I was unable to make go away in `scene.Routes.scala:335`.


## Testing Instructions

Execute the following command and confirm the Scapegoat output:

```bash
$ docker-compose run --rm --no-deps api-server api/scapegoat

...

[info] [scapegoat] Removing scapegoat class directory: /opt/raster-foundry/app-backend/api/target/scala-2.11/scapegoat-classes
[info] [scapegoat] setting output dir to [/opt/raster-foundry/app-backend/api/target/scala-2.11/scapegoat-report]
[info] [scapegoat] ignored file patterns: .*/datamodel/.*
[info] Compiling 74 Scala sources to /opt/raster-foundry/app-backend/api/target/scala-2.11/scapegoat-classes ...
[info] [info] [scapegoat] 115 activated inspections
[info] [info] [scapegoat] List(.*/datamodel/.*) ignored file patterns
[info] scene.Routes.scala:335: Match instead of partial function
          A map match can be replaced with a partial function for greater readability: com.azavea.rf.common.utils.CogUtils.thumbnail(uri, thumbnailParams.width, thumbnailParams.height, thumbnailParams.red, thumbnailParams.green, thumbnailParams.blue, thumbnailParams.floor)(scala.concurrent.ExecutionContext.Implicits.global).map[akka.http.scaladsl.model.HttpEntity.Strict](((tile: geotrellis.raster.MultibandTile) => tile match {
  case (t @ _) if t.bands.length.>=(3) => akka.http.scaladsl.model.HttpEntity.apply(model.this.ContentType.apply(akka.http.scaladsl.model.MediaTypes.image/p

[info] /opt/raster-foundry/app-backend/api/src/main/scala/scene/Routes.scala:335:24: Match instead of partial function
[info]                   ).map(
[info]                        ^
[info] [info] [scapegoat] Analysis complete: 74 files - 0 errors 0 warns 1 infos
[info] [info] [scapegoat] Written HTML report [/opt/raster-foundry/app-backend/api/target/scala-2.11/scapegoat-report/scapegoat.html]
[info] [info] [scapegoat] Written XML report [/opt/raster-foundry/app-backend/api/target/scala-2.11/scapegoat-report/scapegoat.xml]
[info] [info] [scapegoat] Written Scalastyle XML report [/opt/raster-foundry/app-backend/api/target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml]

...
```

Connects https://github.com/raster-foundry/raster-foundry/issues/3758