### PR TITLE
Remove Scapegoat errors for authentication project

### DIFF
--- a/app-backend/authentication/src/main/scala/Authentication.scala
+++ b/app-backend/authentication/src/main/scala/Authentication.scala
@@ -1,31 +1,27 @@
 package com.azavea.rf.authentication
 
+import java.net.URL
+import java.util.UUID
+
 import akka.http.scaladsl.model.headers.HttpChallenge
 import akka.http.scaladsl.server.AuthenticationFailedRejection.CredentialsRejected
 import akka.http.scaladsl.server._
+import cats.effect.IO
+import cats.implicits._
+import com.azavea.rf.database._
 import com.azavea.rf.datamodel._
-import com.guizmaii.scalajwt.JwtToken
-import com.guizmaii.scalajwt.ConfigurableJwtValidator
+import com.guizmaii.scalajwt.{ConfigurableJwtValidator, JwtToken}
 import com.nimbusds.jose.jwk.source.{JWKSource, RemoteJWKSet}
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.proc.BadJWTException
 import com.typesafe.config.ConfigFactory
-
-import scala.concurrent.Future
-import java.net.URL
-import java.util.UUID
-
-import cats.effect.IO
-import cats.implicits._
-import com.azavea.rf.database._
-import doobie.util.transactor.Transactor
+import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
+import doobie.util.transactor.Transactor
 
-import com.typesafe.scalalogging.LazyLogging
+import scala.concurrent.Future
 
 trait Authentication extends Directives with LazyLogging {
 
@@ -38,7 +34,7 @@ trait Authentication extends Directives with LazyLogging {
   private val jwkSet: JWKSource[SecurityContext] = new RemoteJWKSet(new URL(jwksURL))
 
   // Default user returned when no credentials are provided
-  lazy val anonymousUser:Future[Option[User]] = UserDao.getUserById("default").transact(xa).unsafeToFuture
+  lazy val anonymousUser: Future[Option[User]] = UserDao.getUserById("default").transact(xa).unsafeToFuture
 
   // HTTP Challenge to use for Authentication failures
   lazy val challenge = HttpChallenge("Bearer", "https://rasterfoundry.com")
@@ -80,7 +76,7 @@ trait Authentication extends Directives with LazyLogging {
         val email = getStringClaimOrBlank(jwtClaims, "email")
         val name = getStringClaimOrBlank(jwtClaims, "name")
         val picture = getStringClaimOrBlank(jwtClaims, "picture")
-        case class MembershipAndUser(platform: Option[Platform], user: User)
+        final case class MembershipAndUser(platform: Option[Platform], user: User)
         // All users will have a platform role, either added by a migration or created with the user if they are new
         val query = for {
           userAndRoles <- UserDao.getUserAndActiveRolesById(userId).flatMap {
@@ -88,7 +84,7 @@ trait Authentication extends Directives with LazyLogging {
             case UserOptionAndRoles(None, _) => createUserWithRoles(userId, email, name, picture, jwtClaims)
           }
           (user, roles) = userAndRoles
-          platformRole = roles.filter(role => role.groupType == GroupType.Platform).headOption
+          platformRole = roles.find(role => role.groupType == GroupType.Platform)
           plat <- platformRole match {
             case Some(role) => PlatformDao.getPlatformById(role.groupId)
             case _ =>


### PR DESCRIPTION
## Overview

Remedy the warning messages emitted by Scapegoat. Also, clean up imports across all files touched.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

Execute the following command and confirm the Scapegoat output:

```bash
$ docker-compose run --rm --no-deps api-server authentication/scapegoat

...

[info] [scapegoat] Removing scapegoat class directory: /Users/hcastro/Projects/raster-foundry/app-backend/authentication/target/scala-2.11/scapegoat-classes
[info] [scapegoat] setting output dir to [/Users/hcastro/Projects/raster-foundry/app-backend/authentication/target/scala-2.11/scapegoat-report]
[info] [scapegoat] ignored file patterns: .*/datamodel/.*
[info] Compiling 1 Scala source to /Users/hcastro/Projects/raster-foundry/app-backend/datamodel/target/scala-2.11/classes ...
[info] Done compiling.
[info] Compiling 3 Scala sources to /Users/hcastro/Projects/raster-foundry/app-backend/db/target/scala-2.11/classes ...
[info] Done compiling.
[info] Compiling 2 Scala sources to /Users/hcastro/Projects/raster-foundry/app-backend/authentication/target/scala-2.11/scapegoat-classes ...
[info] [info] [scapegoat] 115 activated inspections
[info] [info] [scapegoat] List(.*/datamodel/.*) ignored file patterns
[info] [info] [scapegoat] Analysis complete: 2 files - 0 errors 0 warns 0 infos
[info] [info] [scapegoat] Written HTML report [/Users/hcastro/Projects/raster-foundry/app-backend/authentication/target/scala-2.11/scapegoat-report/scapegoat.html]
[info] [info] [scapegoat] Written XML report [/Users/hcastro/Projects/raster-foundry/app-backend/authentication/target/scala-2.11/scapegoat-report/scapegoat.xml]
[info] [info] [scapegoat] Written Scalastyle XML report [/Users/hcastro/Projects/raster-foundry/app-backend/authentication/target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml]
[info] Done compiling.

...
```

Connects https://github.com/raster-foundry/raster-foundry/issues/3758