### PR TITLE
Set uploadStatus to COMPLETE after a successful COG upload

### DIFF
--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -234,6 +234,7 @@ export default class SceneImportModalController {
 
     handleDone() {
         this.close();
+        this.$state.reload();
     }
 
     validateS3Config() {
@@ -355,7 +356,7 @@ export default class SceneImportModalController {
     }
 
     finishUpload() {
-        this.upload.uploadStatus = this.importType === 'COG' ?
+        this.upload.uploadStatus = this.isCog ?
             'COMPLETE' :
             'UPLOADED';
         this.uploadService.update(this.upload).then(() => {

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -130,7 +130,7 @@
       </div>
 
       <!-- Import config for S3 -->
-      <div ng-if="$ctrl.importType === 'S3'">
+      <div ng-if="$ctrl.importType === 'S3' && !$ctrl.isCog">
           <p>
             Enter the the S3 URI that points to where imagery is located.
             The import process will import any imagery found in that location into {{$ctrl.BUILDCONFIG.APP_NAME}}.
@@ -148,7 +148,7 @@
             </div>
           </form>
         </div>
-      <div ng-if="$ctrl.importType === 'COG'">
+      <div ng-if="$ctrl.importType === 'COG' && $ctrl.isCog">
         <p>
           Enter the the HTTP or S3 URI that points to where COG imagery is located.
         </p>
@@ -161,7 +161,7 @@
         </form>
       </div>
 
-      <div ng-if="$ctrl.importType === 'Planet'">
+      <div ng-if="$ctrl.importType === 'Planet' && !$ctrl.isCog">
         <p>
           Enter a list of comma-separated Planet Scene IDs into the text box for import.
           Note these should match the datasource selected in the previous screen.


### PR DESCRIPTION
## Overview

This PR
  - sets `uploadStatus` to `COMPLETE` after finish uploading COG scenes
  - triggers a page refresh after clicking `Done` to get a new list of imported rasters
  - shows correct input boxes for urls, ids, etc., based on cog or non-cog tab selections

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Import a COG scene and check if `uploadStatus` is set to `COMPLETE` in `PUT` request upon successful upload.
 * Import a non-COG scene and check if `uploadStatus` is set to `UPLOADED ` in `PUT` request upon successful upload.
 * Clicking on `Done` button after successful uploads should refresh the page and get you an up-to-date list of imported rasters
 * Selecting different tabs and items in the modal should show correct input boxes corresponding to what you select.

Closes #3892 
