### PR TITLE
Remove Scapegoat errors for batch project

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Job.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Job.scala
@@ -1,18 +1,18 @@
 package com.azavea.rf.batch
 
-import com.azavea.rf.common.RollbarNotifier
-import com.azavea.rf.batch.util.conf.Config
-
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
+import com.azavea.rf.batch.util.conf.Config
+import com.azavea.rf.common.RollbarNotifier
 
-@SuppressWarnings(Array("ParamaterlessMethodReturnsUnit"))
+import scala.concurrent.ExecutionContextExecutor
+
 trait Job extends Config with RollbarNotifier {
   val name: String
 
-  implicit lazy val system           = ActorSystem(s"$name-system")
-  implicit lazy val materializer     = ActorMaterializer()
-  implicit lazy val executionContext = materializer.executionContext
+  implicit lazy val system: ActorSystem = ActorSystem(s"$name-system")
+  implicit lazy val materializer: ActorMaterializer = ActorMaterializer()
+  implicit lazy val executionContext: ExecutionContextExecutor = materializer.executionContext
 
   /** ActorSystem needs to be closed manually. */
   def stop(): Unit = system.terminate()

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Job.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Job.scala
@@ -15,8 +15,8 @@ trait Job extends Config with RollbarNotifier {
   implicit lazy val executionContext = materializer.executionContext
 
   /** ActorSystem needs to be closed manually. */
-  def stop: Unit = system.terminate()
+  def stop(): Unit = system.terminate()
 
   /** Run function should be defined for all Jobs */
-  def run: Unit
+  def run(): Unit
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -1,28 +1,24 @@
 package com.azavea.rf.batch.aoi
 
-import com.azavea.rf.batch.Job
-import java.sql.Timestamp
-import java.time.ZonedDateTime
+import java.util.UUID
 
 import cats.effect.IO
 import cats.syntax.option._
-import doobie.{ConnectionIO, Fragment, Fragments}
+import com.azavea.rf.batch.Job
+import com.azavea.rf.common.AWSBatch
+import com.azavea.rf.database.util.RFTransactor
+import com.typesafe.scalalogging.LazyLogging
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
-import com.azavea.rf.database.Implicits._
-import com.azavea.rf.database.util.RFTransactor
-import java.util.UUID
-import com.typesafe.scalalogging.LazyLogging
-
-import com.azavea.rf.common.AWSBatch
+import doobie.{ConnectionIO, Fragment, Fragments}
 
 final case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job with AWSBatch {
   val name = FindAOIProjects.name
 
   def run(): Unit = {
     def timeToEpoch(timeFunc: String): Fragment = Fragment.const(s"extract(epoch from ${timeFunc})")
+
     val aoiProjectsToUpdate: ConnectionIO[List[UUID]] = {
 
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/FindAOIProjects.scala
@@ -14,13 +14,14 @@ import doobie.util.transactor.Transactor
 import com.azavea.rf.database.Implicits._
 import com.azavea.rf.database.util.RFTransactor
 import java.util.UUID
+import com.typesafe.scalalogging.LazyLogging
 
 import com.azavea.rf.common.AWSBatch
 
-case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job with AWSBatch {
+final case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job with AWSBatch {
   val name = FindAOIProjects.name
 
-  def run: Unit = {
+  def run(): Unit = {
     def timeToEpoch(timeFunc: String): Fragment = Fragment.const(s"extract(epoch from ${timeFunc})")
     val aoiProjectsToUpdate: ConnectionIO[List[UUID]] = {
 
@@ -56,10 +57,13 @@ case class FindAOIProjects(implicit val xa: Transactor[IO]) extends Job with AWS
   }
 }
 
-object FindAOIProjects {
+object FindAOIProjects extends LazyLogging {
   val name = "find_aoi_projects"
 
   def main(args: Array[String]): Unit = {
+    if (args.length > 0) {
+      logger.warn(s"Ignoring arguments to FindAOIProjects: ${args}")
+    }
     implicit val xa = RFTransactor.xa
     val job = FindAOIProjects()
     job.run

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -6,7 +6,6 @@ import com.auth0.client.auth._
 import com.auth0.json.auth.TokenHolder
 import com.azavea.rf.batch.Job
 import com.azavea.rf.datamodel._
-import java.sql.Timestamp
 import java.time.ZonedDateTime
 import java.util.UUID
 
@@ -39,7 +38,7 @@ import com.azavea.rf.database.util.RFTransactor
 import java.sql.Timestamp
 import java.time.Instant
 
-case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) extends Job with AWSBatch {
+final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) extends Job with AWSBatch {
   val name = FindAOIProjects.name
 
   type LastChecked = Timestamp
@@ -113,7 +112,7 @@ case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) ex
     }
   }
 
-  def run: Unit = {
+  def run(): Unit = {
     logger.info(s"Updating project ${projectId}")
     /** Fetch the project, AOI area, last checked time, start time, and AOI scene query parameters */
     def fetchBaseData: ConnectionIO[

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -1,42 +1,25 @@
 package com.azavea.rf.batch.aoi
 
-import com.auth0.client.mgmt._
-import com.auth0.client.mgmt.filter.UserFilter
-import com.auth0.client.auth._
-import com.auth0.json.auth.TokenHolder
-import com.azavea.rf.batch.Job
-import com.azavea.rf.datamodel._
-import java.time.ZonedDateTime
-import java.util.UUID
-
-import cats._
-import cats.data._
-import cats.implicits._
-import cats.syntax._
-import cats.effect.IO
-import doobie._
-import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.util.transactor.Transactor
-import io.circe._
-import io.circe.Decoder.Result
-import io.circe.syntax._
-
-import scala.concurrent.Future
-import scala.util.{Failure, Success}
-
-import geotrellis.vector._
-
-import com.azavea.rf.common.AWSBatch
-import com.azavea.rf.common.notification.Email.NotificationEmail
-import com.azavea.rf.database._
-import com.azavea.rf.database.Implicits._
-import org.apache.commons.mail.Email
-import com.azavea.rf.database.util.RFTransactor
-
 import java.sql.Timestamp
 import java.time.Instant
+import java.util.UUID
+
+import cats.effect.IO
+import cats.implicits._
+import com.azavea.rf.batch.Job
+import com.azavea.rf.common.AWSBatch
+import com.azavea.rf.common.notification.Email.NotificationEmail
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.database._
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.datamodel._
+import doobie._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import io.circe.Decoder.Result
+import io.circe._
+import geotrellis.vector._
+import org.apache.commons.mail.Email
 
 final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[IO]) extends Job with AWSBatch {
   val name = FindAOIProjects.name
@@ -81,7 +64,7 @@ final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[I
         val (pub, pri) = (platform.publicSettings, platform.privateSettings)
         (pub.emailSmtpHost, pub.emailSmtpPort, pub.emailSmtpEncryption, pub.emailUser, pri.emailPassword, userEmailAddress) match {
           case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-            email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
+          email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
             val (subject, html, plain) = aoiEmailContent(project, platform, user, sceneCount)
             email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, subject, html, plain).map((configuredEmail: Email) => configuredEmail.send)
             logger.info(s"Notified project owner ${user.id} about AOI updates")
@@ -114,6 +97,7 @@ final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[I
 
   def run(): Unit = {
     logger.info(s"Updating project ${projectId}")
+
     /** Fetch the project, AOI area, last checked time, start time, and AOI scene query parameters */
     def fetchBaseData: ConnectionIO[
       (String, Projected[MultiPolygon], StartTime, LastChecked, Result[CombinedSceneQueryParams])] = {
@@ -134,7 +118,7 @@ final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[I
         .query[(String, Projected[MultiPolygon], StartTime, LastChecked, Json)]
         .unique
         .map(
-          { case (projOwner: String, g: Projected[MultiPolygon], startTime: StartTime, lastChecked: LastChecked, f:Json) => (projOwner, g, startTime, lastChecked, f.as[CombinedSceneQueryParams])
+          { case (projOwner: String, g: Projected[MultiPolygon], startTime: StartTime, lastChecked: LastChecked, f: Json) => (projOwner, g, startTime, lastChecked, f.as[CombinedSceneQueryParams])
           }
         )
     }
@@ -146,11 +130,11 @@ final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[I
       val baseParams = queryParams.getOrElse(CombinedSceneQueryParams())
       val augmentedQueryParams =
         baseParams.copy(
-          sceneParams=baseParams.sceneParams.copy(
-            minAcquisitionDatetime=Some(startTime)
+          sceneParams = baseParams.sceneParams.copy(
+            minAcquisitionDatetime = Some(startTime)
           ),
-          timestampParams=baseParams.timestampParams.copy(
-            minCreateDatetime=Some(lastChecked)
+          timestampParams = baseParams.timestampParams.copy(
+            minCreateDatetime = Some(lastChecked)
           )
         )
       SceneDao
@@ -175,7 +159,7 @@ final case class UpdateAOIProject(projectId: UUID)(implicit val xa: Transactor[I
 
     def updateProjectIO(user: User, projectId: UUID): ConnectionIO[Int] = for {
       proj <- ProjectDao.unsafeGetProjectById(projectId)
-      newProject = proj.copy(aoisLastChecked=Timestamp.from(Instant.now))
+      newProject = proj.copy(aoisLastChecked = Timestamp.from(Instant.now))
       affectedRows <- ProjectDao.updateProject(newProject, proj.id, user)
     } yield affectedRows
 
@@ -201,11 +185,11 @@ object UpdateAOIProject {
   def main(args: Array[String]): Unit = {
 
     val job = args.toList match {
-     case List(projectId) => UpdateAOIProject(UUID.fromString(projectId))
-     case _ =>
-       throw new IllegalArgumentException("Argument could not be parsed to UUID")
-   }
+      case List(projectId) => UpdateAOIProject(UUID.fromString(projectId))
+      case _ =>
+        throw new IllegalArgumentException("Argument could not be parsed to UUID")
+    }
 
-   job.run
+    job.run
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/ast/package.scala
@@ -1,30 +1,16 @@
 package com.azavea.rf.batch
 
-import com.azavea.rf.tool.ast._
-import com.azavea.rf.tool.eval._
-import com.azavea.rf.tool.maml.{ProjectRaster => PrRaster, SceneRaster => ScRaster, _}
-import com.azavea.rf.tool.ast.MapAlgebraAST._
+import java.util.UUID
 
-import com.azavea.maml.spark.eval._
-import com.azavea.maml.eval._
-import cats.data.NonEmptyList
-import cats.data.Validated._
 import cats.effect.IO
-import cats.implicits._
+import com.azavea.maml.eval._
+import com.azavea.maml.spark.eval._
+import com.azavea.rf.tool.ast._
+import com.azavea.rf.tool.maml._
 import doobie.Transactor
 import geotrellis.raster._
-import geotrellis.raster.mapalgebra.local.{Pow => GTPow, Xor => GTXor, Or => GTOr, And => GTAnd}
-import geotrellis.raster.mapalgebra.local.{Less => GTLess, LessOrEqual => GTLessOrEqual}
-import geotrellis.raster.mapalgebra.local.{Equal => GTEqual, Unequal => GTUnequal}
-import geotrellis.raster.mapalgebra.local.{Greater => GTGreater, GreaterOrEqual => GTGreaterOrEqual}
 import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.s3._
-import geotrellis.spark.render._
 import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
-
-import java.util.UUID
 
 
 package object ast {
@@ -35,12 +21,11 @@ package object ast {
   def interpretRDD(
     ast: MapAlgebraAST,
     zoom: Int,
-    sceneLocs: Map[UUID, String],
     projLocs: Map[UUID, List[(UUID, String)]]
   )(implicit sc: SparkContext, xa: Transactor[IO]): IO[Interpreted[TileLayerRDD[SpatialKey]]] = {
 
     /* Guarantee correctness before performing Map Algebra */
-    RfmlRddResolver.resolveRdd(ast.asMaml._1, zoom, sceneLocs, projLocs) map {
+    RfmlRddResolver.resolveRdd(ast.asMaml._1, zoom, projLocs) map {
       _.andThen(RDDInterpreter.DEFAULT(_))
         .andThen(_.as[ContextRDD[SpatialKey, Tile, TileLayerMetadata[SpatialKey]]])
     }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/dropbox/Implicits.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/dropbox/Implicits.scala
@@ -1,20 +1,20 @@
 package com.azavea.rf.batch.dropbox
 
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataOutputStream, InputStream}
+
 import geotrellis.raster.CellGrid
 import geotrellis.raster.io.geotiff.GeoTiff
 import geotrellis.raster.io.geotiff.writer.GeoTiffWriter
-import geotrellis.spark.io.hadoop._
 import geotrellis.util.MethodExtensions
-
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
 import org.apache.spark.SparkContext
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, DataOutputStream, InputStream}
-
 trait Implicits {
+
   trait HadoopRasterMethods[T] extends MethodExtensions[T] {
     def write(path: Path)(implicit sc: SparkContext): Unit = write(path, sc.hadoopConfiguration)
+
     def write(path: Path, conf: Configuration): Unit
   }
 
@@ -35,4 +35,5 @@ trait Implicits {
       }
     }
   }
+
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/dropbox/Implicits.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/dropbox/Implicits.scala
@@ -18,6 +18,7 @@ trait Implicits {
     def write(path: Path, conf: Configuration): Unit
   }
 
+  @SuppressWarnings(Array("ClassNames"))
   implicit class withGeoTiffWriteMethods[T <: CellGrid](val self: GeoTiff[T]) {
     def dropboxWrite(save: InputStream => String): String = {
       val bos = new ByteArrayOutputStream()

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 import scala.io.Source
 import scala.util._
 
-case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60.minutes, region: Option[String] = None)(implicit val xa: Transactor[IO]) extends Job {
+final case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60.minutes, region: Option[String] = None)(implicit val xa: Transactor[IO]) extends Job {
   val name = CreateExportDef.name
 
   /** Get S3 client per each call */
@@ -121,7 +121,8 @@ case class CheckExportStatus(exportId: UUID, statusURI: URI, time: Duration = 60
     }
   }
 
-  def run: Unit = {
+  @SuppressWarnings(Array("CatchThrowable")) // need to catch everything and ensure actor system stops
+  def run(): Unit = {
     logger.info(s"Checking export ${exportId} process...")
     val json =
       try {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
@@ -5,6 +5,7 @@ import java.net.URI
 import scala.util._
 
 object CommandLine {
+
   final case class Params(
     jobDefinition: URI = new URI(""),
     statusURI: URI = new URI("")
@@ -20,13 +21,13 @@ object CommandLine {
 
     head("raster-foundry-export", "0.1")
 
-    opt[URI]('j',"jobDefinition")
+    opt[URI]('j', "jobDefinition")
       .action((jd, conf) => conf.copy(jobDefinition = jd))
       .text("The location of the json which defines an ingest job")
       .required
 
-    opt[URI]('b',"statusURI")
-      .action( (s, conf) => conf.copy(statusURI = s) )
+    opt[URI]('b', "statusURI")
+      .action((s, conf) => conf.copy(statusURI = s))
       .text("S3 URI to write status jsons to")
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CommandLine.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import scala.util._
 
 object CommandLine {
-  case class Params(
+  final case class Params(
     jobDefinition: URI = new URI(""),
     statusURI: URI = new URI("")
   )

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -2,7 +2,6 @@ package com.azavea.rf.batch.export
 
 import java.util.UUID
 
-import cats.data._
 import cats.effect.IO
 import cats.implicits._
 import com.azavea.rf.batch._
@@ -11,21 +10,18 @@ import com.azavea.rf.database.Implicits._
 import com.azavea.rf.database.util.RFTransactor
 import com.azavea.rf.database.{ExportDao, UserDao}
 import com.azavea.rf.datamodel._
-import doobie.util.transactor.Transactor
-import io.circe.syntax._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
+import doobie.util.transactor.Transactor
+import io.circe.syntax._
 
-import scala.util._
-
-case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit val xa: Transactor[IO]) extends Job {
+final case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit val xa: Transactor[IO]) extends Job {
   val name = CreateExportDef.name
 
   /** Get S3 client per each call */
   def s3Client = S3(region = None)
 
+  @SuppressWarnings(Array("CatchThrowable"))
   protected def writeExportDefToS3(exportDef: ExportDefinition, bucket: String, key: String): Unit = {
     logger.info(s"Uploading export definition ${exportDef.id.toString} to S3 at s3://${bucket}/${key}")
 
@@ -39,7 +35,7 @@ case class CreateExportDef(exportId: UUID, bucket: String, key: String)(implicit
     }
   }
 
-  def run: Unit = {
+  def run(): Unit = {
     val exportDefinitionWrite: ConnectionIO[Unit] = for {
       user <- UserDao.unsafeGetUserById(systemUser)
       _ <- logger.debug(s"Fetched user successfully: ${user.id}").pure[ConnectionIO]

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/DropboxCopy.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/DropboxCopy.scala
@@ -27,20 +27,22 @@ final case class DropboxCopy(source: URI, target: URI, accessToken: String, regi
           .asScala
           .toList
           .filterNot(_.getKey.endsWith("/"))
-          .map { os => Future {
-            val (bucket, key) = os.getBucketName -> os.getKey
-            logger.info(s"Uploading: $key")
-            val obj = s3Client.client.getObject(bucket, key)
-            is(obj.getObjectContent, key)
-          } } ::: accumulator
+          .map { os =>
+            Future {
+              val (bucket, key) = os.getBucketName -> os.getKey
+              logger.info(s"Uploading: $key")
+              val obj = s3Client.client.getObject(bucket, key)
+              is(obj.getObjectContent, key)
+            }
+          } ::: accumulator
 
-      if(!listing.isTruncated) getObjects
+      if (!listing.isTruncated) getObjects
       else copy(s3Client.client.listNextBatchOfObjects(listing), getObjects)
     }
 
     val prefix = {
       val p = source.getPath.tail
-      if(!p.endsWith("/")) s"$p/" else p
+      if (!p.endsWith("/")) s"$p/" else p
     }
 
     val listObjectsRequest =

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/DropboxCopy.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/DropboxCopy.scala
@@ -13,12 +13,12 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.util._
 
-case class DropboxCopy(source: URI, target: URI, accessToken: String, region: Option[String] = None) extends Job {
+final case class DropboxCopy(source: URI, target: URI, accessToken: String, region: Option[String] = None) extends Job {
   val name: String = DropboxCopy.name
 
   lazy val s3Client = S3(region = region)
 
-  final def copyListing(is: (InputStream, String) => String): List[Future[String]] = {
+  def copyListing(is: (InputStream, String) => String): List[Future[String]] = {
     @tailrec
     def copy(listing: ObjectListing, accumulator: List[Future[String]]): List[Future[String]] = {
       def getObjects: List[Future[String]] =
@@ -52,7 +52,7 @@ case class DropboxCopy(source: URI, target: URI, accessToken: String, region: Op
     copy(s3Client.client.listObjects(listObjectsRequest), Nil)
   }
 
-  def run: Unit = {
+  def run(): Unit = {
     logger.info(s"Dropbox copy from $source to $target Started...")
     val client = dropboxConfig.client(accessToken)
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/S3Copy.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/S3Copy.scala
@@ -5,12 +5,13 @@ import java.net.URI
 import com.azavea.rf.batch.Job
 import com.azavea.rf.batch.util.S3
 
-case class S3Copy(source: URI, target: URI, region: Option[String] = None) extends Job {
+final case class S3Copy(source: URI, target: URI, region: Option[String] = None) extends Job {
   val name = S3Copy.name
 
   lazy val client = S3(region = region)
 
-  def run: Unit = try {
+  @SuppressWarnings(Array("CatchThrowable")) // need to ensure actor system stops and exit status set
+  def run(): Unit = try {
     logger.info(s"S3 copy from $source to $target started...")
     client.copyListing(
       source.getHost,

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/json/S3ExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/json/S3ExportStatus.scala
@@ -1,9 +1,9 @@
 package com.azavea.rf.batch.export.json
 
+import java.util.UUID
+
 import com.azavea.rf.datamodel._
 import io.circe.generic.JsonCodec
-
-import java.util.UUID
 
 @JsonCodec
 final case class S3ExportStatus(exportId: UUID, exportStatus: ExportStatus)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/json/S3ExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/json/S3ExportStatus.scala
@@ -6,4 +6,4 @@ import io.circe.generic.JsonCodec
 import java.util.UUID
 
 @JsonCodec
-case class S3ExportStatus(exportId: UUID, exportStatus: ExportStatus)
+final case class S3ExportStatus(exportId: UUID, exportStatus: ExportStatus)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -1,55 +1,46 @@
 package com.azavea.rf.batch.export.spark
 
 import java.io.ByteArrayInputStream
+import java.util.UUID
 
-import com.azavea.rf.batch.export.json.S3ExportStatus
+import cats.data.Validated._
+import cats.effect.IO
+import cats.implicits._
+import com.amazonaws.services.s3.AmazonS3URI
+import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
+import com.azavea.maml.eval._
 import com.azavea.rf.batch._
 import com.azavea.rf.batch.ast._
 import com.azavea.rf.batch.dropbox._
 import com.azavea.rf.batch.export._
+import com.azavea.rf.batch.export.json.S3ExportStatus
 import com.azavea.rf.batch.util._
 import com.azavea.rf.batch.util.conf._
 import com.azavea.rf.common.utils.CogUtils
 import com.azavea.rf.database.util.RFTransactor
 import com.azavea.rf.datamodel._
 import com.azavea.rf.tool.ast.MapAlgebraAST
-import com.azavea.maml.eval._
-
-import com.amazonaws.services.s3.AmazonS3URI
-import com.amazonaws.services.s3.model.{ObjectMetadata, PutObjectRequest}
-import cats.data.Validated._
-import cats.effect.IO
-import cats.implicits._
 import com.dropbox.core.v2.DbxClientV2
 import com.dropbox.core.v2.files.{CreateFolderErrorException, WriteMode}
 import com.typesafe.scalalogging.LazyLogging
 import doobie.Transactor
+import geotrellis.proj4.{CRS, LatLng}
 import io.circe.parser._
 import io.circe.syntax._
-import geotrellis.proj4.{CRS, LatLng}
 import geotrellis.raster._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.io._
 import geotrellis.raster.io.geotiff.{GeoTiff, MultibandGeoTiff, SinglebandGeoTiff}
-import geotrellis.raster.io.geotiff.reader.GeoTiffReader
-import geotrellis.raster.resample.Bilinear
 import geotrellis.spark._
 import geotrellis.spark.io._
 import geotrellis.spark.io.file._
-import geotrellis.spark.io.hadoop._
 import geotrellis.spark.io.s3._
-import geotrellis.spark.io.s3.util.S3RangeReader
-import geotrellis.spark.regrid._
 import geotrellis.spark.resample.ZoomResample
 import geotrellis.spark.tiling._
-import geotrellis.spark.util._
 import geotrellis.vector._
-import org.apache.hadoop.fs.Path
-import spray.json.DefaultJsonProtocol._
-import org.apache.spark.rdd.RDD
 import org.apache.spark._
-
-import java.util.UUID
+import org.apache.spark.rdd.RDD
+import spray.json.DefaultJsonProtocol._
 
 
 object Export extends SparkJob with Config with LazyLogging {
@@ -61,18 +52,16 @@ object Export extends SparkJob with Config with LazyLogging {
   def s3Client = S3()
 
   def astExport(
-    ed: ExportDefinition,
-    ast: MapAlgebraAST,
-    sceneLocs: Map[UUID, String],
-    projLocs: Map[UUID, List[(UUID, String)]],
-    conf: HadoopConfiguration
-  )(implicit sc: SparkContext, xa: Transactor[IO]): IO[Unit] = {
-    interpretRDD(ast, ed.input.resolution, sceneLocs, projLocs) map {
+                 ed: ExportDefinition,
+                 ast: MapAlgebraAST,
+                 projLocs: Map[UUID, List[(UUID, String)]]
+               )(implicit sc: SparkContext, xa: Transactor[IO]): IO[Unit] = {
+    interpretRDD(ast, ed.input.resolution, projLocs) map {
       case Invalid(errs) => throw InterpreterException(errs)
       case Valid(rdd) => {
         val crs: CRS = rdd.metadata.crs
 
-        if(!ed.output.stitch) {
+        if (!ed.output.stitch) {
           val targetRDD: TileLayerRDD[SpatialKey] =
             ed.output.rasterSize match {
               case Some(size) => rdd.regrid(size)
@@ -85,7 +74,7 @@ object Export extends SparkJob with Config with LazyLogging {
           val singles: RDD[(SpatialKey, SinglebandGeoTiff)] =
             targetRDD.map({ case (key, tile) => (key, SinglebandGeoTiff(tile, mt(key), crs)) })
 
-          writeGeoTiffs[Tile, SinglebandGeoTiff](singles, ed, conf)
+          writeGeoTiffs[Tile, SinglebandGeoTiff](singles, ed)
         } else {
           /* Stitch the Layer into a single GeoTiff and output it */
           val single: SinglebandGeoTiff = GeoTiff(rdd.stitch, crs)
@@ -98,7 +87,7 @@ object Export extends SparkJob with Config with LazyLogging {
 
   /** Get a LayerReader and an attribute store for the catalog located at the provided URI
     *
-    *  @param ed export job's layer definition
+    * @param ed export job's layer definition
     */
   def getRfLayerManagement(
     ed: ExportLayerDefinition
@@ -142,24 +131,27 @@ object Export extends SparkJob with Config with LazyLogging {
         .map { _ => store.read[Array[Histogram[Double]]](requestedLayerId.copy(zoom = 0), "histogram") }
 
     val queryLayer = (q: BoundLayerQuery[SpatialKey, TileLayerMetadata[SpatialKey], RDD[(SpatialKey, MultibandTile)] with Metadata[TileLayerMetadata[SpatialKey]]]) =>
-    mask
-      .fold(q)(mp => q.where(Intersects(mp)))
-      .result
-      .withContext(
-        {
-          rdd => rdd.mapValues(
-            {
-              tile =>
-              val ctile = (eld.colorCorrections |@| hist) map { _.colorCorrect(tile, _) } getOrElse tile
+      mask
+        .fold(q)(mp => q.where(Intersects(mp)))
+        .result
+        .withContext(
+          {
+            rdd =>
+              rdd.mapValues(
+                {
+                  tile =>
+                    val ctile = (eld.colorCorrections, hist) mapN {
+                      _.colorCorrect(tile, _)
+                    } getOrElse tile
 
-              ed.output.render.flatMap(_.bands.map(_.toSeq)) match {
-                case Some(seq) if seq.nonEmpty => ctile.subsetBands(seq)
-                case _ => ctile
-              }
-            }
-          )
-        }
-      )
+                    ed.output.render.flatMap(_.bands.map(_.toSeq)) match {
+                      case Some(seq) if seq.nonEmpty => ctile.subsetBands(seq)
+                      case _ => ctile
+                    }
+                }
+              )
+          }
+        )
 
     val query: MultibandTileLayerRDD[SpatialKey] =
       if (requestedLayerId.zoom <= maxAvailableZoom)
@@ -187,15 +179,14 @@ object Export extends SparkJob with Config with LazyLogging {
   def multibandExport(
     ed: ExportDefinition,
     layers: Array[ExportLayerDefinition],
-    mask: Option[MultiPolygon],
-    conf: HadoopConfiguration
+    mask: Option[MultiPolygon]
   )(implicit @transient sc: SparkContext): Unit = {
     val rdds = layers.map { ld =>
       if (ld.sceneType == SceneType.Avro) getAvroLayerRdd(ed, ld, mask) else getCOGLayerRdd(ld)
     }
 
     /** Tile merge with respect to layer initial ordering */
-    if(!ed.output.stitch) {
+    if (!ed.output.stitch) {
       val result: RDD[(SpatialKey, MultibandGeoTiff)] =
         rdds
           .zipWithIndex
@@ -213,19 +204,27 @@ object Export extends SparkJob with Config with LazyLogging {
           }
           .flatMapValues(v => v)
 
-      writeGeoTiffs[MultibandTile, MultibandGeoTiff](result, ed, conf)
+      writeGeoTiffs[MultibandTile, MultibandGeoTiff](result, ed)
     } else {
       val md = rdds.map(_.metadata).reduce(_ combine _)
       val raster: Raster[MultibandTile] =
         rdds
           .zipWithIndex
           .map { case (rdd, i) => rdd.mapValues { value => i -> value } }
-          .foldLeft(ContextRDD(sc.emptyRDD[(SpatialKey, (Int, MultibandTile))], md))((acc, r) => acc.withContext { _.union(r) })
-          .withContext { _.combineByKey(createTiles[(Int, MultibandTile)], mergeTiles1[(Int, MultibandTile)], mergeTiles2[(Int, MultibandTile)]) }
-          .withContext { _.mapValues { _.sortBy(_._1).map(_._2).reduce(_ merge _) } }
+          .foldLeft(ContextRDD(sc.emptyRDD[(SpatialKey, (Int, MultibandTile))], md))((acc, r) => acc.withContext {
+            _.union(r)
+          })
+          .withContext {
+            _.combineByKey(createTiles[(Int, MultibandTile)], mergeTiles1[(Int, MultibandTile)], mergeTiles2[(Int, MultibandTile)])
+          }
+          .withContext {
+            _.mapValues {
+              _.sortBy(_._1).map(_._2).reduce(_ merge _)
+            }
+          }
           .stitch
       val craster =
-        if(ed.output.crop) mask.fold(raster)(mp => raster.crop(mp.envelope.reproject(LatLng, md.crs)))
+        if (ed.output.crop) mask.fold(raster)(mp => raster.crop(mp.envelope.reproject(LatLng, md.crs)))
         else raster
 
       writeGeoTiff[MultibandTile, MultibandGeoTiff](GeoTiff(craster, md.crs), ed, singlePath)
@@ -295,8 +294,7 @@ object Export extends SparkJob with Config with LazyLogging {
   /** Write a layer of GeoTiffs. */
   private def writeGeoTiffs[T <: CellGrid, G <: GeoTiff[T]](
     rdd: RDD[(SpatialKey, G)],
-    ed: ExportDefinition,
-    conf: HadoopConfiguration
+    ed: ExportDefinition
   ): Unit = {
 
     def path(key: SpatialKey): ExportDefinition => String = { ed =>
@@ -309,7 +307,7 @@ object Export extends SparkJob with Config with LazyLogging {
   }
 
   /**
-    *  Sample ingest definitions can be found in the accompanying test/resources
+    * Sample ingest definitions can be found in the accompanying test/resources
     *
     * @param args Arguments to be parsed by the tooling defined in [[CommandLine]]
     */
@@ -340,13 +338,11 @@ object Export extends SparkJob with Config with LazyLogging {
       S3ExportStatus(exportDef.id, status).asJson.noSpaces
 
     try {
-      val conf: HadoopConfiguration = HadoopConfiguration(S3.setCredentials(sc.hadoopConfiguration))
-
       exportDef.input.style match {
         case Left(SimpleInput(layers, mask)) =>
-          multibandExport(exportDef, layers, mask, conf)
-        case Right(ASTInput(ast, sceneLocs, projLocs)) =>
-          astExport(exportDef, ast, sceneLocs, projLocs, conf).unsafeRunSync
+          multibandExport(exportDef, layers, mask)
+        case Right(ASTInput(ast, _, projLocs)) =>
+          astExport(exportDef, ast, projLocs).unsafeRunSync
       }
 
       logger.info(s"Writing status into the ${params.statusURI}")

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/spark/Export.scala
@@ -313,6 +313,7 @@ object Export extends SparkJob with Config with LazyLogging {
     *
     * @param args Arguments to be parsed by the tooling defined in [[CommandLine]]
     */
+  @SuppressWarnings(Array("CatchThrowable")) // need to ensure that status is written for errors
   def main(args: Array[String]): Unit = {
     implicit val xa = RFTransactor.xa
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/healthcheck/HealthCheck.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/healthcheck/HealthCheck.scala
@@ -5,11 +5,14 @@ import com.typesafe.scalalogging.LazyLogging
 object HealthCheck extends LazyLogging {
   val name = "healthcheck"
 
-  def run: Unit = {
+  def run(): Unit = {
     logger.info("Batch containers and the batch jar are friends")
   }
 
   def main(args: Array[String]): Unit = {
+    if (args.length > 0) {
+      logger.warn(s"Ignoring arguments provided to healthcheck: ${args}")
+    }
     this.run
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
@@ -1,25 +1,17 @@
 package com.azavea.rf.batch.landsat8
 
-import com.azavea.rf.batch.Job
-import com.azavea.rf.batch.util._
-import com.azavea.rf.database.util.RFTransactor
-import com.azavea.rf.datamodel._
-import io.circe._
-import io.circe.syntax._
-import geotrellis.proj4.CRS
-import geotrellis.vector._
-import jp.ne.opt.chronoscala.Imports._
-import org.postgresql.util.PSQLException
 import java.time.{LocalDate, ZoneOffset}
 import java.util.UUID
 
 import cats.effect.IO
+import com.azavea.rf.batch.Job
+import com.azavea.rf.batch.util._
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.datamodel._
 import doobie.util.transactor.Transactor
+import jp.ne.opt.chronoscala.Imports._
 
-import scala.collection.mutable.ListBuffer
-import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
-import scala.util.control.Breaks._
 
 @deprecated(message = "Use com.azavea.rf.batch.landsat8.airflow.ImportLandsat8C1 instead, as USGS changes LC8 storage rules: https://landsat.usgs.gov/landsat-collections", since = "https://github.com/azavea/raster-foundry/pull/1821")
 final case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), threshold: Int = 10)(implicit val xa: Transactor[IO]) extends Job {
@@ -27,38 +19,6 @@ final case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.
 
   /** Get S3 client per each call */
   def s3Client = S3(region = landsat8Config.awsRegion)
-//
-//  protected def scenesFromCsv(user: User, srcProj: CRS = CRS.fromName("EPSG:4326"), targetProj: CRS = CRS.fromName("EPSG:3857")): Future[ListBuffer[Option[Scene]]] = {
-//    val reader = CSV.parse(landsat8Config.usgsLandsatUrl)
-//    val iterator = reader.iterator()
-//
-//    val endDate = startDate + 1.day
-//    val buffer = ListBuffer[Future[Option[Scene]]]()
-//    val (_, indexToId) = CSV.getBiFunctions(iterator.next())
-//
-//    var counter = 0
-//    breakable {
-//      while(iterator.hasNext) {
-//        val line = reader.readNext()
-//
-//        val row =
-//          line
-//            .zipWithIndex
-//            .map { case (v, i) => indexToId(i) -> v }
-//            .toMap
-//
-//        row.get("acquisitionDate") foreach { dateStr =>
-//          val date = LocalDate.parse(dateStr)
-//          if (startDate <= date && endDate > date) buffer += csvRowToScene(row, user, srcProj, targetProj)
-//          else if (date < startDate) counter += 1
-//        }
-//
-//        if (counter > threshold) break
-//      }
-//    }
-//
-//    Future.sequence(buffer)
-//  }
 
   protected def getLandsatPath(productId: String): String = {
     val (wPath, wRow) = productId.substring(3, 6) -> productId.substring(6, 9)
@@ -109,175 +69,7 @@ final case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.
     ) :: Nil
   }
 
-
-//  @SuppressWarnings(Array("TraversableHead"))
-//  protected def csvRowToScene(row: Map[String, String], user: User, srcProj: CRS = CRS.fromName("EPSG:4326"), targetProj: CRS = CRS.fromName("EPSG:3857")): Future[Option[Scene]] = Future {
-//    val sceneId = UUID.randomUUID()
-//    val productId = row("sceneID")
-//    val landsatPath = getLandsatPath(productId)
-//    val sceneName = s"L8 $landsatPath"
-//
-//    Scenes.sceneNameExistsForUser(sceneName, user).flatMap { exists =>
-//      if (exists) Future(None)
-//      else {
-//        val ll = row("lowerLeftCornerLongitude").toDouble -> row("lowerLeftCornerLatitude").toDouble
-//        val lr = row("lowerRightCornerLongitude").toDouble -> row("lowerRightCornerLatitude").toDouble
-//        val ul = row("upperLeftCornerLongitude").toDouble -> row("upperLeftCornerLatitude").toDouble
-//        val ur = row("upperRightCornerLongitude").toDouble -> row("upperRightCornerLatitude").toDouble
-//
-//        val srcCoords  = ll :: ul :: ur :: lr :: Nil
-//        val srcPolygon = Polygon(Line(srcCoords :+ srcCoords.head))
-//
-//        val sortedByX = srcCoords.sortBy(_.x)
-//        val sortedByY = srcCoords.sortBy(_.y)
-//
-//        val extent = Extent(
-//          xmin = sortedByX.head.x,
-//          ymin = sortedByY.head.y,
-//          xmax = sortedByX.last.x,
-//          ymax = sortedByY.last.y
-//        )
-//
-//        val (transformedCoords, transformedExtent) = {
-//          if (srcProj.equals(targetProj)) srcPolygon -> extent
-//          else srcPolygon.reproject(srcProj, targetProj) -> extent.reproject(srcProj, targetProj)
-//        }
-//
-//        val s3Url = s"${landsat8Config.awsLandsatBase}${landsatPath}/index.html"
-//
-//        if (!isUriExists(s3Url)) {
-//          logger.warn(
-//            "AWS and USGS are not always in sync. Try again in several hours.\n" +
-//              s"If you believe this message is in error, check $s3Url manually."
-//          )
-//          Future(None)
-//        } else {
-//          val acquisitionDate =
-//            row.get("acquisitionDate").map { dt =>
-//              new java.sql.Timestamp(
-//                LocalDate
-//                  .parse(dt)
-//                  .atStartOfDay(ZoneOffset.UTC)
-//                  .toInstant
-//                  .getEpochSecond * 1000l
-//              )
-//            }
-//
-//          val cloudCover = row.get("cloudCoverFull").map(_.toFloat)
-//          val sunElevation = row.get("sunElevation").map(_.toFloat)
-//          val sunAzimuth = row.get("sunAzimuth").map(_.toFloat)
-//          val bands15m = landsat8Config.bandLookup.`15m`
-//          val bands30m = landsat8Config.bandLookup.`30m`
-//          val tags = List("Landsat 8", "GeoTIFF")
-//          val sceneMetadata = row.filter { case (_, v) => v.nonEmpty }
-//
-//          val images = (
-//            bands15m.map { band =>
-//              val b = band.name.split(" - ").last
-//              (15f, s"${productId}_B${b}.TIF", band)
-//            } ++ bands30m.map { band =>
-//              val b = band.name.split(" - ").last
-//              (30f, s"${productId}_B${b}.TIF", band)
-//            }
-//            ).map {
-//            case (resolution, tiffPath, band) =>
-//              Image.Banded(
-//                organizationId = landsat8Config.organizationUUID,
-//                rawDataBytes = sizeFromPath(tiffPath, productId),
-//                visibility = Visibility.Public,
-//                filename = tiffPath,
-//                sourceUri = s"${getLandsatUrl(productId)}/${tiffPath}",
-//                owner = Some(systemUser),
-//                scene = sceneId,
-//                imageMetadata = Json.Null,
-//                resolutionMeters = resolution,
-//                metadataFiles = List(),
-//                bands = List(band)
-//              )
-//          }
-//
-//          val scene = Scene.Create(
-//            id = Some(sceneId),
-//            organizationId = landsat8Config.organizationUUID,
-//            visibility = Visibility.Public,
-//            tags = tags,
-//            datasource = landsat8Config.datasourceUUID,
-//            sceneMetadata = sceneMetadata.asJson,
-//            name = sceneName,
-//            owner = Some(systemUser),
-//            tileFootprint = targetProj.epsgCode.map(Projected(MultiPolygon(transformedExtent.toPolygon()), _)),
-//            dataFootprint = targetProj.epsgCode.map(Projected(MultiPolygon(transformedCoords), _)),
-//            metadataFiles = List(s"${landsat8Config.awsLandsatBase}${landsatPath}/${productId}_MTL.txt"),
-//            images = images,
-//            thumbnails = createThumbnails(sceneId, productId),
-//            ingestLocation = None,
-//            filterFields = SceneFilterFields(
-//              cloudCover = cloudCover,
-//              sunAzimuth = sunAzimuth,
-//              sunElevation = sunElevation,
-//              acquisitionDate = acquisitionDate
-//            ),
-//            statusFields = SceneStatusFields(
-//              thumbnailStatus = JobStatus.Success,
-//              boundaryStatus = JobStatus.Success,
-//              ingestStatus = IngestStatus.NotIngested
-//            )
-//          )
-//
-//          val future =
-//            Scenes.insertScene(scene, user).map(_.toScene).recover {
-//              case e: PSQLException => {
-//                logger.error(s"An error occurred during scene ${scene.id} import. Skipping...")
-//                logger.error(e.stackTraceString)
-//                sendError(e)
-//                scene.toScene(user)
-//              }
-//            }
-//
-//          future onComplete {
-//            case Success(s) => logger.info(s"Finished importing scene ${s.id}.")
-//            case Failure(e) => {
-//              logger.error(s"An error occurred during scene ${scene.id} import.")
-//              logger.error(e.stackTraceString)
-//              sendError(e)
-//            }
-//          }
-//          future.map(Some(_))
-//        }
-//      }
-//    }
-//  }.flatMap(identity)
-
   def run(): Unit = ???
-//    logger.info("Importing scenes...")
-//    Users.getUserById(systemUser).flatMap { (userOpt) =>
-//      scenesFromCsv(
-//        userOpt.getOrElse {
-//          val e = new Exception(s"User $systemUser doesn't exist.")
-//          sendError(e)
-//          throw e
-//        })
-//    } onComplete {
-//      case Success(scenes) => {
-//        val unskippedScenes = scenes.flatten
-//        if(unskippedScenes.nonEmpty) logger.info(s"Successfully imported scenes: ${unskippedScenes.map(_.id.toString).mkString(", ")}.")
-//        else if (scenes.nonEmpty) logger.info("All scenes were already imported")
-//        else {
-//          val e = new Exception(s"No scenes available for the ${startDate}")
-//          logger.error(e.stackTraceString)
-//          sendError(e)
-//          stop
-//          sys.exit(1)
-//        }
-//        stop
-//      }
-//      case Failure(e) => {
-//        logger.error(e.stackTraceString)
-//        sendError(e)
-//        stop
-//        sys.exit(1)
-//      }
-//    }
 }
 
 object ImportLandsat8 {
@@ -287,21 +79,21 @@ object ImportLandsat8 {
 
   def main(args: Array[String]): Unit = {
 
-   /** Since 30/04/2017 old LC8 collection is not updated */
-   val job = args.toList match {
-     case List(date, threshold) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date), threshold.toInt)
-     case List(date) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date))
-     case List(date, threshold) => throw new NotImplementedError(
-       "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
-     )
-     case List(date) => throw new NotImplementedError(
-       "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
-     )
-     case _ =>  throw new NotImplementedError(
-       "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
-     )
-   }
+    /** Since 30/04/2017 old LC8 collection is not updated */
+    val job = args.toList match {
+      case List(date, threshold) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date), threshold.toInt)
+      case List(date) if LocalDate.parse(date) > LocalDate.of(2017, 4, 30) => ImportLandsat8C1(LocalDate.parse(date))
+      case List(date, threshold) => throw new NotImplementedError(
+        "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
+      )
+      case List(date) => throw new NotImplementedError(
+        "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
+      )
+      case _ => throw new NotImplementedError(
+        "Landsat 8 import for dates prior to May 1, 2017 is not implemented"
+      )
+    }
 
-   job.run
+    job.run
   }
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success, Try}
 import scala.util.control.Breaks._
 
 @deprecated(message = "Use com.azavea.rf.batch.landsat8.airflow.ImportLandsat8C1 instead, as USGS changes LC8 storage rules: https://landsat.usgs.gov/landsat-collections", since = "https://github.com/azavea/raster-foundry/pull/1821")
-case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), threshold: Int = 10)(implicit val xa: Transactor[IO]) extends Job {
+final case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), threshold: Int = 10)(implicit val xa: Transactor[IO]) extends Job {
   val name = ImportLandsat8.name
 
   /** Get S3 client per each call */
@@ -248,7 +248,7 @@ case class ImportLandsat8(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), 
 //    }
 //  }.flatMap(identity)
 
-  def run: Unit = ???
+  def run(): Unit = ???
 //    logger.info("Importing scenes...")
 //    Users.getUserById(systemUser).flatMap { (userOpt) =>
 //      scenesFromCsv(

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -1,48 +1,34 @@
 package com.azavea.rf.batch.landsat8
 
-import com.azavea.rf.batch.Job
-import com.azavea.rf.batch.util.{isUriExists, S3}
-import com.azavea.rf.database._
-import com.azavea.rf.database.filter.Filterables._
-import com.azavea.rf.datamodel._
-import com.azavea.rf.common.utils.AntimeridianUtils
-import com.github.tototoshi.csv._
-import io.circe._
-import io.circe.syntax._
-import geotrellis.proj4.CRS
-import geotrellis.vector._
-import jp.ne.opt.chronoscala.Imports._
-import org.postgresql.util.PSQLException
-
-import cats.implicits._
-import cats.effect.IO
-import com.azavea.rf.database.util.RFTransactor
-import doobie.free.connection.ConnectionIO
-import doobie.util.transactor.Transactor
-import doobie._
-import doobie.Fragments._
-import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import cats.free.Free
-import doobie.free.connection
-
-import scala.collection.mutable.ListBuffer
-import scala.collection.parallel.ForkJoinTaskSupport
-import scala.collection.parallel.immutable.ParSeq
-import scala.concurrent.Future
-import scala.concurrent.forkjoin.ForkJoinPool
-import scala.util.{Failure, Success, Try}
-import scala.util.control.Breaks._
-
-import java.io.{File, FileInputStream}
+import java.io.File
 import java.time.{LocalDate, ZoneOffset}
 import java.util.UUID
 
-import sys.process._
+import cats.effect.IO
+import cats.implicits._
+import com.azavea.rf.batch.Job
+import com.azavea.rf.batch.util.{S3, isUriExists}
+import com.azavea.rf.common.utils.AntimeridianUtils
+import com.azavea.rf.database._
+import com.azavea.rf.database.filter.Filterables._
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.datamodel._
+import com.github.tototoshi.csv._
+import doobie.free.connection.ConnectionIO
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+import geotrellis.proj4.CRS
+import io.circe._
+import io.circe.syntax._
+import geotrellis.vector._
+
+import scala.collection.parallel.ForkJoinTaskSupport
+import scala.collection.parallel.immutable.ParSeq
+import scala.concurrent.forkjoin.ForkJoinPool
+import scala.sys.process._
 
 
-case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), threshold: Int = 10)(implicit val xa: Transactor[IO]) extends Job {
+final case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC), threshold: Int = 10)(implicit val xa: Transactor[IO]) extends Job {
   val name = ImportLandsat8C1.name
 
   /** Get S3 client per each call */
@@ -146,7 +132,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
             None.pure[ConnectionIO]
           }
           case _ => {
-            createSceneFromRow(row, user, srcProj, targetProj, sceneId, productId, landsatPath) match {
+            createSceneFromRow(row, srcProj, targetProj, sceneId, productId, landsatPath) match {
               case Some(scene) => SceneDao.insertMaybe(scene, user)
               case _ => None.pure[ConnectionIO]
             }
@@ -161,7 +147,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
 
   // All of the heads here are from a locally constructed list that we know has members
   @SuppressWarnings(Array("TraversableHead"))
-  private def createSceneFromRow(row: Map[String, String], user: User, srcProj: CRS, targetProj: CRS, sceneId: UUID, productId: String, landsatPath: String) = {
+  private def createSceneFromRow(row: Map[String, String], srcProj: CRS, targetProj: CRS, sceneId: UUID, productId: String, landsatPath: String) = {
 
     val (tileFootprint, dataFootprint) = getRowFootprints(row, srcProj, targetProj)
 
@@ -186,80 +172,81 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
         }
 
       val cloudCover = row.get("cloudCoverFull").map(_.toFloat)
+
       /** Some Landsat 8 scenes have negative cloud cover, indicating that they're bad
         * or non-imagery data in some way. We don't know what they are. But we dislike them
         * and never want to see them again
         */
-      if (cloudCover.map( _ < 0 ).getOrElse(false) ) {
+      if (cloudCover.map(_ < 0).getOrElse(false)) {
         logger.info(s"Skipping import for ${landsatPath} since cloud_cover was ${cloudCover}")
         None
       } else {
-      val sunElevation = row.get("sunElevation").map(_.toFloat)
-      val sunAzimuth = row.get("sunAzimuth").map(_.toFloat)
-      val bands15m = landsat8Config.bandLookup.`15m`
-      val bands30m = landsat8Config.bandLookup.`30m`
-      val tags = List("Landsat 8", "GeoTIFF")
-      val sceneMetadata = row.filter { case (_, v) => v.nonEmpty }
+        val sunElevation = row.get("sunElevation").map(_.toFloat)
+        val sunAzimuth = row.get("sunAzimuth").map(_.toFloat)
+        val bands15m = landsat8Config.bandLookup.`15m`
+        val bands30m = landsat8Config.bandLookup.`30m`
+        val tags = List("Landsat 8", "GeoTIFF")
+        val sceneMetadata = row.filter { case (_, v) => v.nonEmpty }
 
-      val images = (
-        bands15m.map { band =>
-          val b = band.name.split(" - ").last
-          (15f, s"${productId}_B${b}.TIF", band)
-        } ++ bands30m.map { band =>
-          val b = band.name.split(" - ").last
-          (30f, s"${productId}_B${b}.TIF", band)
+        val images = (
+          bands15m.map { band =>
+            val b = band.name.split(" - ").last
+            (15f, s"${productId}_B${b}.TIF", band)
+          } ++ bands30m.map { band =>
+            val b = band.name.split(" - ").last
+            (30f, s"${productId}_B${b}.TIF", band)
+          }
+          ).map {
+          case (resolution, tiffPath, band) =>
+            Image.Banded(
+              rawDataBytes = 0,
+              visibility = Visibility.Public,
+              filename = tiffPath,
+              sourceUri = s"${getLandsatUrl(productId)}/${tiffPath}",
+              owner = Some(systemUser),
+              scene = sceneId,
+              imageMetadata = Json.Null,
+              resolutionMeters = resolution,
+              metadataFiles = List(),
+              bands = List(band)
+            )
         }
-        ).map {
-        case (resolution, tiffPath, band) =>
-          Image.Banded(
-            rawDataBytes = 0,
-            visibility = Visibility.Public,
-            filename = tiffPath,
-            sourceUri = s"${getLandsatUrl(productId)}/${tiffPath}",
-            owner = Some(systemUser),
-            scene = sceneId,
-            imageMetadata = Json.Null,
-            resolutionMeters = resolution,
-            metadataFiles = List(),
-            bands = List(band)
-          )
-      }
 
-      val scene = Scene.Create(
-        id = Some(sceneId),
-        visibility = Visibility.Public,
-        tags = tags,
-        datasource = landsat8Config.datasourceUUID,
-        sceneMetadata = sceneMetadata.asJson,
-        name = landsatPath,
-        owner = Some(systemUser),
-        tileFootprint = tileFootprint,
-        dataFootprint = dataFootprint,
-        metadataFiles = List(s"${landsat8Config.awsLandsatBaseC1}${landsatPath}/${productId}_MTL.txt"),
-        images = images,
-        thumbnails = createThumbnails(sceneId, productId),
-        ingestLocation = None,
-        filterFields = SceneFilterFields(
-          cloudCover = cloudCover,
-          sunAzimuth = sunAzimuth,
-          sunElevation = sunElevation,
-          acquisitionDate = acquisitionDate
-        ),
-        statusFields = SceneStatusFields(
-          thumbnailStatus = JobStatus.Success,
-          boundaryStatus = JobStatus.Success,
-          ingestStatus = IngestStatus.NotIngested
-        ),
-        sceneType = Some(SceneType.Avro)
-      )
-      Some(scene)
+        val scene = Scene.Create(
+          id = Some(sceneId),
+          visibility = Visibility.Public,
+          tags = tags,
+          datasource = landsat8Config.datasourceUUID,
+          sceneMetadata = sceneMetadata.asJson,
+          name = landsatPath,
+          owner = Some(systemUser),
+          tileFootprint = tileFootprint,
+          dataFootprint = dataFootprint,
+          metadataFiles = List(s"${landsat8Config.awsLandsatBaseC1}${landsatPath}/${productId}_MTL.txt"),
+          images = images,
+          thumbnails = createThumbnails(sceneId, productId),
+          ingestLocation = None,
+          filterFields = SceneFilterFields(
+            cloudCover = cloudCover,
+            sunAzimuth = sunAzimuth,
+            sunElevation = sunElevation,
+            acquisitionDate = acquisitionDate
+          ),
+          statusFields = SceneStatusFields(
+            thumbnailStatus = JobStatus.Success,
+            boundaryStatus = JobStatus.Success,
+            ingestStatus = IngestStatus.NotIngested
+          ),
+          sceneType = Some(SceneType.Avro)
+        )
+        Some(scene)
       }
     }
   }
 
-  @SuppressWarnings(Array("TraversableHead"))
+  @SuppressWarnings(Array("ListAppend", "TraversableHead", "TraversableLast"))
   def getRowFootprints(row: Map[String, String], srcProj: CRS, targetProj: CRS):
-      (Option[Projected[MultiPolygon]], Option[Projected[MultiPolygon]]) = {
+  (Option[Projected[MultiPolygon]], Option[Projected[MultiPolygon]]) = {
     val ll = row("lowerLeftCornerLongitude").toDouble -> row("lowerLeftCornerLatitude").toDouble
     val lr = row("lowerRightCornerLongitude").toDouble -> row("lowerRightCornerLatitude").toDouble
     val ul = row("upperLeftCornerLongitude").toDouble -> row("upperLeftCornerLatitude").toDouble
@@ -294,7 +281,7 @@ case class ImportLandsat8C1(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC)
     (correctedTileFootprint, correctedDataFootprint)
   }
 
-  def run: Unit = {
+  def run(): Unit = {
     logger.info("Importing scenes...")
 
     val user = UserDao.unsafeGetUserById(systemUser).transact(xa).unsafeRunSync

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
@@ -1,26 +1,21 @@
 package com.azavea.rf.batch.notification
 
-import com.typesafe.scalalogging.LazyLogging
 import java.util.UUID
 
 import cats.effect.IO
 import cats.implicits._
-
-import scala.concurrent.Future
 import com.azavea.rf.batch.Job
+import com.azavea.rf.common.RollbarNotifier
 import com.azavea.rf.common.notification.Email.NotificationEmail
-import com.azavea.rf.datamodel._
 import com.azavea.rf.database.filter.Filterables._
-import com.azavea.rf.common.{RollbarNotifier, S3}
-import com.azavea.rf.database.{ProjectDao, SceneDao, PlatformDao}
-import doobie.util.transactor.Transactor
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.database.{PlatformDao, ProjectDao, SceneDao}
+import com.azavea.rf.datamodel._
+import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import Fragments._
+import doobie.util.transactor.Transactor
 import org.apache.commons.mail.Email
-import com.azavea.rf.database.util.RFTransactor
 
 final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[IO]) extends Job
   with RollbarNotifier {
@@ -30,7 +25,7 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
   def getSceneConsumers(sceneId: UUID): ConnectionIO[List[String]] = {
     for {
       projects <- ProjectDao.query.filter(fr"id IN (SELECT project_id FROM scenes_to_projects WHERE scene_id = ${sceneId})").list
-    } yield projects.map(_.owner).distinct.filter(_ != auth0Config.systemUser).map(_.toString)
+    } yield projects.map(_.owner).distinct.filter(_ != auth0Config.systemUser).map(_.mkString)
   }
 
   def createIngestEmailContentForConsumers(pU: PlatformWithUsersSceneProjects, scene: Scene, ingestStatus: String): (String, String, String) = {
@@ -50,12 +45,12 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
           </html>
           """,
           s"""
-          | ${pU.uName}: The scene "${scene.name}" has been successfully ingested into your project: ${pU.projectName}!
-          | You can access this project at here: https://${platformHost}/projects/edit/${pU.projectId}/scenes or
-          | any past projects you've created at any time here: https://${platformHost}/projects/ . If you have
-          | questions, support is available via in-app chat at ${platformHost} or less quickly via email to
-          | ${pU.pubSettings.emailUser}.
-          | - The ${pU.platName} Team
+             | ${pU.uName}: The scene "${scene.name}" has been successfully ingested into your project: ${pU.projectName}!
+             | You can access this project at here: https://${platformHost}/projects/edit/${pU.projectId}/scenes or
+             | any past projects you've created at any time here: https://${platformHost}/projects/ . If you have
+             | questions, support is available via in-app chat at ${platformHost} or less quickly via email to
+             | ${pU.pubSettings.emailUser}.
+             | - The ${pU.platName} Team
           """.trim.stripMargin
         )
       case status: String if status == "FAILED" =>
@@ -72,11 +67,11 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
           </html>
           """,
           s"""
-          | ${pU.uName}: The scene "${scene.name}" in your project: ${pU.projectName} has failed to ingest. But you can
-          | access this project at here: https://${platformHost}/projects/edit/${pU.projectId}/scenes or
-          | any past projects you've created at any time here: https://${platformHost}/projects/ . If you have
-          | questions, support is available via in-app chat at ${platformHost} or less quickly via email to ${pU.pubSettings.emailUser}.
-          | - The ${pU.platName} Team
+             | ${pU.uName}: The scene "${scene.name}" in your project: ${pU.projectName} has failed to ingest. But you can
+             | access this project at here: https://${platformHost}/projects/edit/${pU.projectId}/scenes or
+             | any past projects you've created at any time here: https://${platformHost}/projects/ . If you have
+             | questions, support is available via in-app chat at ${platformHost} or less quickly via email to ${pU.pubSettings.emailUser}.
+             | - The ${pU.platName} Team
           """.trim.stripMargin
         )
     }
@@ -97,9 +92,9 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
           </html>
           """,
           s"""
-          | ${pO.uName}: The scene "${scene.name}" has been successfully ingested!
-          | If you have questions, support is available via in-app chat at ${platformHost} or less quickly via email to ${pO.pubSettings.emailUser}.
-          | - The ${pO.platName} Team
+             | ${pO.uName}: The scene "${scene.name}" has been successfully ingested!
+             | If you have questions, support is available via in-app chat at ${platformHost} or less quickly via email to ${pO.pubSettings.emailUser}.
+             | - The ${pO.platName} Team
           """.trim.stripMargin
         )
       case status: String if status == "FAILED" =>
@@ -114,10 +109,10 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
           </html>
           """,
           s"""
-          | ${pO.uName}: The scene "${scene.name}" has failed to ingest.
-          | If you have questions,
-          | support is available via in-app chat at ${platformHost} or less quickly via email to ${pO.pubSettings.emailUser}.
-          | - The ${pO.platName} Team
+             | ${pO.uName}: The scene "${scene.name}" has failed to ingest.
+             | If you have questions,
+             | support is available via in-app chat at ${platformHost} or less quickly via email to ${pO.pubSettings.emailUser}.
+             | - The ${pO.platName} Team
           """.trim.stripMargin
         )
     }
@@ -135,7 +130,7 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
           (pU.pubSettings.emailSmtpHost, pU.pubSettings.emailSmtpPort, pU.pubSettings.emailSmtpEncryption,
             pU.pubSettings.emailUser, pU.priSettings.emailPassword, userEmailAddress) match {
             case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-              email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
+            email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
               val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForConsumers(pU, scene, ingestStatus)
               email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, ingestEmailSubject, htmlBody, plainBody).map((configuredEmail: Email) => configuredEmail.send)
               logger.info(s"Notified project owner ${pU.uId}.")
@@ -156,7 +151,7 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
         (pO.pubSettings.emailSmtpHost, pO.pubSettings.emailSmtpPort, pO.pubSettings.emailSmtpEncryption,
           pO.pubSettings.emailUser, pO.priSettings.emailPassword, userEmailAddress) match {
           case (host: String, port: Int, encryption: String, platUserEmail: String, pw: String, userEmail: String) if
-            email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
+          email.isValidEmailSettings(host, port, encryption, platUserEmail, pw, userEmail) =>
             val (ingestEmailSubject, htmlBody, plainBody) = createIngestEmailContentForOwner(pO, scene, ingestStatus)
             email.setEmail(host, port, encryption, platUserEmail, pw, userEmail, ingestEmailSubject, htmlBody, plainBody).map((configuredEmail: Email) => configuredEmail.send)
             logger.info(s"Notified scene owner ${pO.uId}.")
@@ -165,6 +160,7 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
       case (_, false) => logger.warn(email.platformNotSubscribedWarning(pO.platId.toString()))
     }
   }
+
   def notifyConsumers(scene: Scene, ingestStatus: String): Unit = {
     logger.info("Notifying Consumers...")
 
@@ -191,7 +187,7 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
     }
   }
 
-  def run: Unit = {
+  def run(): Unit = {
 
     logger.info(s"Notifying owner and consumer about ingest status for scene ${sceneId}...")
 
@@ -205,8 +201,8 @@ final case class NotifyIngestStatus(sceneId: UUID)(implicit val xa: Transactor[I
       case Some(scene) =>
         scene.statusFields.ingestStatus.toString match {
           case ingestStatus: String if ingestStatus == "INGESTED" || ingestStatus == "FAILED" =>
-              notifyOwners(scene, ingestStatus)
-              notifyConsumers(scene, ingestStatus)
+            notifyOwners(scene, ingestStatus)
+            notifyConsumers(scene, ingestStatus)
           case _ => logger.warn(s"Won't send an email unless the scene ${sceneId} is ingested or failed.")
         }
       case _ => logger.warn(s"No matched scene of id: ${sceneId}")
@@ -222,7 +218,7 @@ object NotifyIngestStatus extends LazyLogging {
     implicit val xa = RFTransactor.xa
 
     val job = args.toList match {
-      case List(id:String) => NotifyIngestStatus(UUID.fromString(id))
+      case List(id: String) => NotifyIngestStatus(UUID.fromString(id))
     }
 
     job.run

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/package.scala
@@ -1,36 +1,36 @@
 package com.azavea.rf
 
-import geotrellis.raster.split._
-import geotrellis.raster.{CellSize, MultibandTile}
-import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.LayerAttributes
-import geotrellis.spark.tiling._
-import geotrellis.util.Component
-import geotrellis.vector._
-import geotrellis.spark.io.index.KeyIndex
-
-import org.apache.avro.Schema
 import cats._
 import cats.data._
 import cats.implicits._
-import com.github.blemale.scaffeine.{Cache, Scaffeine}
-import spray.json._
+import com.github.blemale.scaffeine.Cache
+import geotrellis.raster.split._
+import geotrellis.raster.{CellSize, MultibandTile}
+import geotrellis.spark._
+import geotrellis.spark.io.{LayerAttributes, _}
+import geotrellis.spark.io.index.KeyIndex
+import geotrellis.spark.tiling._
+import geotrellis.util.Component
+import geotrellis.vector._
+import org.apache.avro.Schema
 import spray.json.DefaultJsonProtocol._
+import spray.json._
 
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 import scala.util.Either
 
 package object batch {
-  implicit class HasCellSize[A <: { def rows: Int; def cols: Int; def extent: Extent }](obj: A) {
+
+  implicit class HasCellSize[A <: {def rows : Int; def cols : Int; def extent : Extent}](obj: A) {
     def cellSize: CellSize = CellSize(obj.extent.width / obj.cols, obj.extent.height / obj.rows)
   }
 
   @SuppressWarnings(Array("ClassNames"))
   implicit class withRasterFoundryTilerKeyMethods(val self: (ProjectedExtent, Int))
-      extends TilerKeyMethods[(ProjectedExtent, Int), (SpatialKey, Int)] {
+    extends TilerKeyMethods[(ProjectedExtent, Int), (SpatialKey, Int)] {
     def extent = self._1.extent
+
     def translate(spatialKey: SpatialKey) = (spatialKey, self._2)
   }
 
@@ -46,8 +46,8 @@ package object batch {
   /**
     * Custom cache implemented to allow safe multithreading.
     * Can be removed after GeoTrellis 1.2 release.
-    * */
-  @SuppressWarnings(Array("ClassNames"))
+    **/
+  @SuppressWarnings(Array("ClassNames", "asInstanceOf"))
   implicit class withAttributeStoreMethods(that: AttributeStore) {
     def cacheReadSafe[T: JsonFormat](layerId: LayerId, attributeName: String)(implicit cache: Cache[(LayerId, String), Any]): T =
       cache.get(layerId -> attributeName, _ => that.read[T](layerId, attributeName)).asInstanceOf[T]

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/package.scala
@@ -27,6 +27,7 @@ package object batch {
     def cellSize: CellSize = CellSize(obj.extent.width / obj.cols, obj.extent.height / obj.rows)
   }
 
+  @SuppressWarnings(Array("ClassNames"))
   implicit class withRasterFoundryTilerKeyMethods(val self: (ProjectedExtent, Int))
       extends TilerKeyMethods[(ProjectedExtent, Int), (SpatialKey, Int)] {
     def extent = self._1.extent
@@ -39,12 +40,14 @@ package object batch {
   implicit val rfProjectedExtentIntComponent =
     Component[(ProjectedExtent, Int), ProjectedExtent](from => from._1, (from, to) => (to, from._2))
 
+  @SuppressWarnings(Array("ClassNames"))
   implicit class withMultibandTileSplitMethods(val self: MultibandTile) extends MultibandTileSplitMethods
 
   /**
     * Custom cache implemented to allow safe multithreading.
     * Can be removed after GeoTrellis 1.2 release.
     * */
+  @SuppressWarnings(Array("ClassNames"))
   implicit class withAttributeStoreMethods(that: AttributeStore) {
     def cacheReadSafe[T: JsonFormat](layerId: LayerId, attributeName: String)(implicit cache: Cache[(LayerId, String), Any]): T =
       cache.get(layerId -> attributeName, _ => that.read[T](layerId, attributeName)).asInstanceOf[T]

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -23,7 +23,6 @@ import java.util.UUID
 import java.util.concurrent.Executors
 
 import cats.effect.{IO, Fiber}
-import cats.implicits._
 import com.azavea.rf.common.RollbarNotifier
 import doobie.{ConnectionIO, Fragment, Fragments}
 import doobie.implicits._
@@ -35,7 +34,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.forkjoin.ForkJoinPool
 import scala.util.{Failure, Success, Try}
 
-case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))(implicit val xa: Transactor[IO]) extends Job {
+final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))(implicit val xa: Transactor[IO]) extends Job {
 
   // To resolve an ambiguous implicit
   import doobie.free.connection.AsyncConnectionIO

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/sentinel2/ImportSentinel2.scala
@@ -1,44 +1,39 @@
 package com.azavea.rf.batch.sentinel2
 
 import java.net.URI
-
-import com.azavea.rf.batch.Job
-import com.azavea.rf.database.Implicits._
-import com.azavea.rf.database._
-import com.azavea.rf.database.util.RFTransactor
-import com.azavea.rf.datamodel._
-import com.azavea.rf.batch.util._
-import com.azavea.rf.common.utils.AntimeridianUtils
-import io.circe._
-import io.circe.syntax._
-import cats.implicits._
-import geotrellis.proj4._
-import geotrellis.vector._
-import geotrellis.vector.io._
-import com.vividsolutions.jts.geom.LineString
-import org.postgresql.util.PSQLException
 import java.security.InvalidParameterException
 import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 import java.util.concurrent.Executors
 
-import cats.effect.{IO, Fiber}
+import cats.effect.IO
+import cats.implicits._
+import com.azavea.rf.batch.Job
+import com.azavea.rf.batch.util._
 import com.azavea.rf.common.RollbarNotifier
-import doobie.{ConnectionIO, Fragment, Fragments}
+import com.azavea.rf.common.utils.AntimeridianUtils
+import com.azavea.rf.database._
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.datamodel._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import io.circe._
+import io.circe.syntax._
+import geotrellis.proj4._
+import geotrellis.vector._
+import geotrellis.vector.io._
 
 import scala.collection.parallel.ForkJoinTaskSupport
 import scala.collection.parallel.immutable.ParSeq
 import scala.concurrent.ExecutionContext
 import scala.concurrent.forkjoin.ForkJoinPool
-import scala.util.{Failure, Success, Try}
 
 final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset.UTC))(implicit val xa: Transactor[IO]) extends Job {
 
   // To resolve an ambiguous implicit
-  import doobie.free.connection.AsyncConnectionIO
   import ImportSentinel2._
+
   val cachedThreadPool = Executors.newFixedThreadPool(5)
   val SceneCreationIOContext = ExecutionContext.fromExecutor(cachedThreadPool)
 
@@ -95,16 +90,16 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
       val filename = obj.split("/").last
       val imageBand = filename.split("\\.").head
       Image.Banded(
-        rawDataBytes     = 0,
-        visibility       = Visibility.Public,
-        filename         = filename,
-        sourceUri        = s"${sentinel2Config.baseHttpPath}${obj}",
-        owner            = systemUser.some,
-        scene            = sceneId,
-        imageMetadata    = Json.Null,
+        rawDataBytes = 0,
+        visibility = Visibility.Public,
+        filename = filename,
+        sourceUri = s"${sentinel2Config.baseHttpPath}${obj}",
+        owner = systemUser.some,
+        scene = sceneId,
+        imageMetadata = Json.Null,
         resolutionMeters = resolution,
-        metadataFiles    = List(),
-        bands            = Seq(sentinel2Config.bandByName(imageBand)).flatten
+        metadataFiles = List(),
+        bands = Seq(sentinel2Config.bandByName(imageBand)).flatten
       )
     }
   }
@@ -115,20 +110,20 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
 
     Thumbnail.Identified(
       id = None,
-      thumbnailSize  = ThumbnailSize.Square,
-      widthPx        = 343,
-      heightPx       = 343,
-      sceneId        = sceneId,
-      url            = thumbnailUrl
+      thumbnailSize = ThumbnailSize.Square,
+      widthPx = 343,
+      heightPx = 343,
+      sceneId = sceneId,
+      url = thumbnailUrl
     ) :: Nil
   }
 
   def getSentinel2Products(date: LocalDate): List[URI] = {
     s3Client
       .listKeys(
-        s3bucket  = sentinel2Config.bucketName,
-        s3prefix  = s"products/${date.getYear}/${date.getMonthValue}/${date.getDayOfMonth}/",
-        ext       = "productInfo.json",
+        s3bucket = sentinel2Config.bucketName,
+        s3prefix = s"products/${date.getYear}/${date.getMonthValue}/${date.getDayOfMonth}/",
+        ext = "productInfo.json",
         recursive = true,
         requesterPays = true
       ).toList
@@ -154,7 +149,7 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
     logger.info(s"${datasourcePrefix} - Extracting polygons for ${scenePath}")
     val tileFootprint = multiPolygonFromJson(tileinfo, "tileGeometry", sentinel2Config.targetProjCRS)
     val dataFootprint = multiPolygonFromJson(tileinfo, "tileDataGeometry", sentinel2Config.targetProjCRS)
-    val intersects = dataFootprint.map(AntimeridianUtils.crossesAntimeridian).getOrElse(false)
+    val intersects = dataFootprint.exists(AntimeridianUtils.crossesAntimeridian)
     val correctedDataFootprint = AntimeridianUtils.correctDataFootprint(
       intersects, dataFootprint, sentinel2Config.targetProjCRS
     )
@@ -185,7 +180,7 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
       sceneMetadata = sceneMetadata.asJson,
       name = sceneName,
       owner = systemUser.some,
-      tileFootprint = (sentinel2Config.targetProjCRS.epsgCode |@| tileFootprint).map {
+      tileFootprint = (sentinel2Config.targetProjCRS.epsgCode, tileFootprint).mapN {
         case (code, mp) => Projected(mp, code)
       },
       dataFootprint = correctedDataFootprint,
@@ -245,7 +240,7 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
     paths
   }
 
-  def run: Unit = {
+  def run(): Unit = {
     logger.info(s"Importing Sentinel 2 scenes for ${startDate}")
     val keys = getSentinel2Products(startDate).par
     keys.tasksupport = new ForkJoinTaskSupport(new ForkJoinPool(16))
@@ -255,12 +250,13 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
     val insertedScenes: ParSeq[Option[Scene.WithRelated]] = keys flatMap {
       (key: URI) => {
         insertSceneFromURI(key, sentinel2Config.datasourceUUID, user) map {
-          (sceneIO: IO[Option[Scene.WithRelated]]) => sceneIO.handleErrorWith(
-            (error: Throwable) => {
-              sendError(error)
-              IO.pure(None)
-            }
-          ).unsafeRunSync
+          (sceneIO: IO[Option[Scene.WithRelated]]) =>
+            sceneIO.handleErrorWith(
+              (error: Throwable) => {
+                sendError(error)
+                IO.pure(None)
+              }
+            ).unsafeRunSync
         }
       }
     }
@@ -273,12 +269,13 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(ZoneOffset
 object ImportSentinel2 extends RollbarNotifier {
   val name = "import_sentinel2"
 
+  @SuppressWarnings(Array("CatchThrowable"))
   def multiPolygonFromJson(tileinfo: Json, key: String, targetCrs: CRS = CRS.fromName("EPSG:3857")): Option[MultiPolygon] = {
     val geom = tileinfo.hcursor.downField(key)
     val polygon = try {
       geom.focus.map(_.noSpaces.parseGeoJson[Polygon])
     } catch {
-      case (e: Throwable) => {
+      case e: Throwable => {
         sendError(e)
         logger.warn(s"Error parsing geometry for Sentinel Scene: ${key}")
         None
@@ -293,7 +290,7 @@ object ImportSentinel2 extends RollbarNotifier {
         .flatMap(_.as[String].toOption)
         .map { crs => CRS.fromName(s"EPSG:${crs.split(":").last}") }
 
-    (srcProj |@| polygon).map { case (sourceProjCRS, poly) =>
+    (srcProj, polygon).mapN { case (sourceProjCRS, poly) =>
       MultiPolygon(poly.reproject(sourceProjCRS, targetCrs))
     }
   }
@@ -301,6 +298,7 @@ object ImportSentinel2 extends RollbarNotifier {
   def getSceneMetadata(tileinfo: Json): Map[String, String] = {
     /** Required for sceneMetadata collection, to unbox Options */
     implicit def optionToString(opt: Option[String]): String = opt.getOrElse("")
+
     implicit def optionTToString[T](opt: Option[T]): String = opt.map(_.toString)
 
     Map(

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -39,7 +39,7 @@ import com.azavea.rf.batch.util.conf.Config
 case class MetadataWithStartStop(start: Timestamp, end: Timestamp)
 
 object CommandLine {
-  case class Params(
+  final case class Params(
     path: String = "",
     testRun: Boolean = false,
     // Default will never be used because parameter is required

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/stac/ReadStacFeature.scala
@@ -147,14 +147,12 @@ object ReadStacFeature extends Config with LazyLogging {
 
   protected def writeSceneToDb(scene: Scene.Create)(implicit xa: Transactor[IO]): Scene.WithRelated = {
     val sceneInsertIO: ConnectionIO[Scene.WithRelated] =
-      UserDao.getUserById(systemUser) flatMap { (mbUser: Option[User]) =>
-        mbUser match {
-          case Some(user) =>
-            logger.info(s"\nuser: ${user.id}\ninserting scene: \n${scene.name}")
-            SceneDao.insert(scene, user)
-          case _ =>
-            throw new RuntimeException("System user not found. Make sure migrations have been run, and that batch config is correct")
-        }
+      UserDao.getUserById(systemUser) flatMap {
+        case Some(user) =>
+          logger.info(s"\nuser: ${user.id}\ninserting scene: \n${scene.name}")
+          SceneDao.insert(scene, user)
+        case _ =>
+          throw new RuntimeException("System user not found. Make sure migrations have been run, and that batch config is correct")
       }
     sceneInsertIO.transact(xa).unsafeRunSync
   }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/HadoopConfiguration.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/HadoopConfiguration.scala
@@ -1,15 +1,15 @@
 package com.azavea.rf.batch.util
 
-import org.apache.hadoop.conf.Configuration
-
 import java.io.{ObjectInputStream, ObjectOutputStream}
+
+import org.apache.hadoop.conf.Configuration
 
 /**
   * Serializable [[Configuration]] wrapper
   * @param conf Hadoop Configuration
   */
 
-case class HadoopConfiguration(var conf: Configuration) extends Serializable {
+final case class HadoopConfiguration(var conf: Configuration) extends Serializable {
   def get: Configuration = conf
 
   private def writeObject(out: ObjectOutputStream): Unit =

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -1,19 +1,17 @@
 package com.azavea.rf.batch.util
 
-import geotrellis.spark.io.s3.S3InputFormat
-
-import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
-import com.amazonaws.services.s3.model._
-import com.amazonaws.regions.Regions
-import org.apache.hadoop.conf.Configuration
-import org.apache.commons.io.IOUtils
-
 import java.net.URI
 
-import scala.collection.mutable
-import scala.collection.JavaConverters._
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.services.s3.model._
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
+import geotrellis.spark.io.s3.S3InputFormat
+import org.apache.commons.io.IOUtils
+import org.apache.hadoop.conf.Configuration
+
 import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 
 final case class S3(
   credentialsProviderChain: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain,
@@ -85,7 +83,7 @@ final case class S3(
       .withPrefix(s3prefix)
       .withMaxKeys(1000)
       .withRequesterPays(requesterPays)
-    
+
     // Avoid digging into a deeper directory
     if (!recursive) objectRequest.withDelimiter("/")
 
@@ -94,7 +92,7 @@ final case class S3(
   }
 
   /** List the keys to files found within a given bucket.
-    *  (copied from GeoTrellis codebase)
+    * (copied from GeoTrellis codebase)
     */
   @SuppressWarnings(Array("NullAssignment")) // copied from GeoTrellis so ignoring null assignment
   def listKeys(listObjectsRequest: ListObjectsRequest): Seq[String] = {
@@ -125,8 +123,8 @@ object S3 {
       * Identify whether function is called on EMR
       * fs.AbstractFileSystem.s3a.impl is a specific key which should be set on EMR
       *
-      * */
-    if(conf.isKeyUnset("fs.AbstractFileSystem.s3a.impl")) {
+      **/
+    if (conf.isKeyUnset("fs.AbstractFileSystem.s3a.impl")) {
       conf.set("fs.s3.impl", classOf[org.apache.hadoop.fs.s3native.NativeS3FileSystem].getName)
       conf.set("fs.s3.awsAccessKeyId", credentialsProviderChain.getCredentials.getAWSAccessKeyId)
       conf.set("fs.s3.awsSecretAccessKey", credentialsProviderChain.getCredentials.getAWSSecretKey)

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/S3.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
 import scala.collection.JavaConverters._
 import scala.annotation.tailrec
 
-case class S3(
+final case class S3(
   credentialsProviderChain: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain,
   region: Option[String] = None
 ) extends Serializable {
@@ -31,7 +31,7 @@ case class S3(
 
   /** Copy buckets */
   @tailrec
-  final def copyListing(bucket: String, destBucket: String, sourcePrefix: String, destPrefix: String, listing: ObjectListing): Unit = {
+  def copyListing(bucket: String, destBucket: String, sourcePrefix: String, destPrefix: String, listing: ObjectListing): Unit = {
     listing.getObjectSummaries.asScala.foreach { os =>
       val key = os.getKey
       client.copyObject(bucket, key, destBucket, key.replace(sourcePrefix, destPrefix))
@@ -96,6 +96,7 @@ case class S3(
   /** List the keys to files found within a given bucket.
     *  (copied from GeoTrellis codebase)
     */
+  @SuppressWarnings(Array("NullAssignment")) // copied from GeoTrellis so ignoring null assignment
   def listKeys(listObjectsRequest: ListObjectsRequest): Seq[String] = {
     var listing: ObjectListing = null
     val result = mutable.ListBuffer[String]()

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -16,12 +16,14 @@ trait Config {
   import ArbitraryTypeReader._
   import Ficus._
 
-  protected final case class Landsat8Bands(
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  protected case class Landsat8Bands(
     `15m`: List[Band.Create],
     `30m`: List[Band.Create]
   )
 
-  protected final case class Landsat8(
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  protected case class Landsat8(
     organization: String,
     bandLookup: Landsat8Bands,
     datasourceId: String,
@@ -37,7 +39,8 @@ trait Config {
     def datasourceUUID: UUID = UUID.fromString(datasourceId)
   }
 
-  protected final case class ExportDef(
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  protected case class ExportDef(
     awsRegion: Option[String],
     bucketName: String,
     awsDataproc: String,
@@ -47,7 +50,8 @@ trait Config {
     sparkMemory: String
   )
 
-  protected final case class Sentinel2Bands(
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  protected case class Sentinel2Bands(
     // 10m
     B02: Band.Create,
     B03: Band.Create,
@@ -66,7 +70,8 @@ trait Config {
     B10: Band.Create
   )
 
-  protected final case class Sentinel2(
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  protected case class Sentinel2(
     organization: String,
     bandLookup: Sentinel2Bands,
     datasourceId: String,
@@ -88,14 +93,16 @@ trait Config {
       }.headOption.flatten
   }
 
-  final case class Dropbox(appKey: String, appSecret: String) {
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  case class Dropbox(appKey: String, appSecret: String) {
     lazy val appInfo = new DbxAppInfo(appKey, appSecret)
     lazy val config = new DbxRequestConfig("azavea/rf-dropbox-test")
 
     def client(accessToken: String) = new DbxClientV2(config, accessToken)
   }
 
-  final case class Auth0(
+  @SuppressWarnings(Array("FinalModifierOnCaseClass"))
+  case class Auth0(
     clientId: String,
     clientSecret: String,
     systemUser: String,

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -16,12 +16,12 @@ trait Config {
   import Ficus._
   import ArbitraryTypeReader._
 
-  protected case class Landsat8Bands(
+  protected final case class Landsat8Bands(
     `15m`: List[Band.Create],
     `30m`: List[Band.Create]
   )
 
-  protected case class Landsat8(
+  protected final case class Landsat8(
     organization: String,
     bandLookup: Landsat8Bands,
     datasourceId: String,
@@ -36,7 +36,7 @@ trait Config {
     def datasourceUUID = UUID.fromString(datasourceId)
   }
 
-  protected case class ExportDef(
+  protected final case class ExportDef(
     awsRegion: Option[String],
     bucketName: String,
     awsDataproc: String,
@@ -46,7 +46,7 @@ trait Config {
     sparkMemory: String
   )
 
-  protected case class Sentinel2Bands(
+  protected final case class Sentinel2Bands(
     // 10m
     B02: Band.Create,
     B03: Band.Create,
@@ -65,7 +65,7 @@ trait Config {
     B10: Band.Create
   )
 
-  protected case class Sentinel2(
+  protected final case class Sentinel2(
     organization: String,
     bandLookup: Sentinel2Bands,
     datasourceId: String,
@@ -84,14 +84,14 @@ trait Config {
       }.headOption.flatten
   }
 
-  case class Dropbox(appKey: String, appSecret: String) {
+  final case class Dropbox(appKey: String, appSecret: String) {
     lazy val appInfo = new DbxAppInfo(appKey, appSecret)
     lazy val config  = new DbxRequestConfig("azavea/rf-dropbox-test")
 
     def client(accessToken: String) = new DbxClientV2(config, accessToken)
   }
 
-  case class Auth0(
+  final case class Auth0(
     clientId: String,
     clientSecret: String,
     systemUser: String,

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -1,20 +1,20 @@
 package com.azavea.rf.batch.util.conf
 
-import com.azavea.rf.datamodel.Band
-
-import geotrellis.proj4.CRS
-import shapeless.syntax.typeable._
-import com.typesafe.config.ConfigFactory
-import net.ceedubs.ficus.Ficus
-import net.ceedubs.ficus.readers.ArbitraryTypeReader
-import com.dropbox.core.v2.DbxClientV2
-import com.dropbox.core.{DbxAppInfo, DbxRequestConfig}
-
 import java.util.UUID
 
+import com.azavea.rf.datamodel.Band
+import com.dropbox.core.v2.DbxClientV2
+import com.dropbox.core.{DbxAppInfo, DbxRequestConfig}
+import com.typesafe.config.ConfigFactory
+import geotrellis.proj4.CRS
+import net.ceedubs.ficus.Ficus
+import net.ceedubs.ficus.readers.ArbitraryTypeReader
+import shapeless.syntax.typeable._
+
 trait Config {
-  import Ficus._
+
   import ArbitraryTypeReader._
+  import Ficus._
 
   protected final case class Landsat8Bands(
     `15m`: List[Band.Create],
@@ -32,8 +32,9 @@ trait Config {
     awsLandsatBaseC1: String,
     bucketName: String
   ) {
-    def organizationUUID = UUID.fromString(organization)
-    def datasourceUUID = UUID.fromString(datasourceId)
+    def organizationUUID: UUID = UUID.fromString(organization)
+
+    def datasourceUUID: UUID = UUID.fromString(datasourceId)
   }
 
   protected final case class ExportDef(
@@ -74,9 +75,12 @@ trait Config {
     bucketName: String,
     targetProj: String
   ) {
-    def organizationUUID = UUID.fromString(organization)
-    def datasourceUUID = UUID.fromString(datasourceId)
-    def targetProjCRS = CRS.fromName(targetProj)
+    def organizationUUID: UUID = UUID.fromString(organization)
+
+    def datasourceUUID: UUID = UUID.fromString(datasourceId)
+
+    def targetProjCRS: CRS = CRS.fromName(targetProj)
+
     def bandByName(key: String): Option[Band.Create] =
       bandLookup.getClass.getDeclaredFields.toList.filter(_.getName == key).map { field =>
         field.setAccessible(true)
@@ -86,7 +90,7 @@ trait Config {
 
   final case class Dropbox(appKey: String, appSecret: String) {
     lazy val appInfo = new DbxAppInfo(appKey, appSecret)
-    lazy val config  = new DbxRequestConfig("azavea/rf-dropbox-test")
+    lazy val config = new DbxRequestConfig("azavea/rf-dropbox-test")
 
     def client(accessToken: String) = new DbxClientV2(config, accessToken)
   }
@@ -100,11 +104,11 @@ trait Config {
 
 
   private lazy val config = ConfigFactory.load()
-  protected lazy val landsat8Config = config.as[Landsat8]("landsat8")
-  protected lazy val sentinel2Config = config.as[Sentinel2]("sentinel2")
-  protected lazy val systemUser = config.as[String]("auth0.systemUser")
-  protected lazy val auth0Config = config.as[Auth0]("auth0")
-  protected lazy val exportDefConfig = config.as[ExportDef]("export-def")
-  protected lazy val dropboxConfig = config.as[Dropbox]("dropbox")
+  protected lazy val landsat8Config: Landsat8 = config.as[Landsat8]("landsat8")
+  protected lazy val sentinel2Config: Sentinel2 = config.as[Sentinel2]("sentinel2")
+  protected lazy val systemUser: String = config.as[String]("auth0.systemUser")
+  protected lazy val auth0Config: Auth0 = config.as[Auth0]("auth0")
+  protected lazy val exportDefConfig: ExportDef = config.as[ExportDef]("export-def")
+  protected lazy val dropboxConfig: Dropbox = config.as[Dropbox]("dropbox")
   val jarPath = "s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar"
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
@@ -1,24 +1,23 @@
 package com.azavea.rf.batch
 
-import io.circe.parser.parse
-import cats.implicits._
-import com.typesafe.scalalogging.LazyLogging
+import java.io._
+import java.net._
+import java.util.Scanner
 
+import cats.implicits._
+import com.amazonaws.auth._
+import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3Client => AWSAmazonS3Client}
+import com.typesafe.scalalogging.LazyLogging
 import geotrellis.raster.io.geotiff.reader.TiffTagsReader
 import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.spark.io.s3.AmazonS3Client
 import geotrellis.spark.io.s3.util.S3RangeReader
-
-import com.amazonaws.auth._
-import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3Client => AWSAmazonS3Client}
+import io.circe.parser.parse
 import org.apache.commons.io.IOUtils
 import org.apache.hadoop.conf.Configuration
 
-import java.util.Scanner
-import java.io._
-import java.net._
-
 package object util extends LazyLogging {
+
   implicit class ConfigurationMethods(conf: Configuration) {
     @SuppressWarnings(Array("NullParameter"))
     def isKeyUnset(key: String): Boolean = conf.get(key) == null
@@ -78,7 +77,7 @@ package object util extends LazyLogging {
     targetName.getScheme match {
       case "file" | "http" | "https" | "s3" => targetName
       case _ => if (prefix.toString.endsWith("/")) new URI(prefix.toString + targetName.toString)
-                else new URI(prefix.toString + "/" + targetName.toString)
+      else new URI(prefix.toString + "/" + targetName.toString)
     }
   }
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/package.scala
@@ -20,6 +20,7 @@ import java.net._
 
 package object util extends LazyLogging {
   implicit class ConfigurationMethods(conf: Configuration) {
+    @SuppressWarnings(Array("NullParameter"))
     def isKeyUnset(key: String): Boolean = conf.get(key) == null
   }
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -11,7 +11,6 @@ lazy val commonSettings = Seq(
   cancelable in Global := true,
   scapegoatVersion in ThisBuild := Version.scapegoat,
   scapegoatIgnoredFiles := Seq(".*/datamodel/.*"),
-  scapegoatDisabledInspections := Seq("PartialFunctionInsteadOfMatch"),
   scalaVersion in ThisBuild := Version.scala,
   scalacOptions := Seq(
     "-deprecation",

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -11,6 +11,7 @@ lazy val commonSettings = Seq(
   cancelable in Global := true,
   scapegoatVersion in ThisBuild := Version.scapegoat,
   scapegoatIgnoredFiles := Seq(".*/datamodel/.*"),
+  scapegoatDisabledInspections := Seq("PartialFunctionInsteadOfMatch"),
   scalaVersion in ThisBuild := Version.scala,
   scalacOptions := Seq(
     "-deprecation",

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
@@ -23,10 +23,10 @@ case class InputDefinition(
 
 object InputDefinition {
   implicit val dec: Decoder[InputDefinition] = Decoder.instance(c =>
-      (c.downField("resolution").as[Int]
-       |@| c.downField("style").as[SimpleInput].map(Left(_))
-         .orElse(c.downField("style").as[ASTInput].map(Right(_)))
-    ).map(InputDefinition.apply)
+    (c.downField("resolution").as[Int]
+      |@| c.downField("style").as[SimpleInput].map(Left(_))
+      .orElse(c.downField("style").as[ASTInput].map(Right(_)))
+      ).map(InputDefinition.apply)
   )
 
   implicit val eitherEnc: Encoder[Either[SimpleInput, ASTInput]] = new Encoder[Either[SimpleInput, ASTInput]] {

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/OutputDefinition.scala
@@ -17,7 +17,7 @@ import java.net.{URI, URLDecoder}
   * @param dropboxCredential dropbox token
   */
 @JsonCodec
-case class OutputDefinition(
+final case class OutputDefinition(
   crs: Option[CRS],
   rasterSize: Option[Int],
   render: Option[Render],

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/EmailData.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/EmailData.scala
@@ -1,6 +1,6 @@
 package com.azavea.rf.database.notification.templates
 
-case class EmailData(
+final case class EmailData(
   subject: String,
   plainBody: String,
   richBody: String

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupInvitation.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupInvitation.scala
@@ -7,7 +7,7 @@ import doobie.ConnectionIO
 
 import java.util.UUID
 
-case class PlainGroupInvitation(
+final case class PlainGroupInvitation(
   groupId: UUID,
   groupType: GroupType,
   subjectId: String,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupInvitation.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupInvitation.scala
@@ -1,11 +1,10 @@
 package com.azavea.rf.database.notification.templates
 
+import java.util.UUID
+
 import com.azavea.rf.database._
 import com.azavea.rf.datamodel._
-
 import doobie.ConnectionIO
-
-import java.util.UUID
 
 final case class PlainGroupInvitation(
   groupId: UUID,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupRequest.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupRequest.scala
@@ -7,7 +7,7 @@ import doobie.ConnectionIO
 
 import java.util.UUID
 
-case class PlainGroupRequest(
+final case class PlainGroupRequest(
   groupId: UUID,
   groupType: GroupType,
   subjectId: String,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupRequest.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/PlainGroupRequest.scala
@@ -1,11 +1,10 @@
 package com.azavea.rf.database.notification.templates
 
+import java.util.UUID
+
 import com.azavea.rf.database._
 import com.azavea.rf.datamodel._
-
 import doobie.ConnectionIO
-
-import java.util.UUID
 
 final case class PlainGroupRequest(
   groupId: UUID,

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -44,7 +44,7 @@ object Version {
   val scalaTest          = "3.0.1"
   val scalajHttp         = "2.3.0"
   val scalaz             = "7.2.8"
-  val scapegoat          = "1.3.3"
+  val scapegoat          = "1.3.7"
   val scopt              = "3.5.0"
   val shapeless          = "2.3.2"
   val slf4j              = "1.6.4"


### PR DESCRIPTION
## Overview

Remedy the warning messages and use `SuppressWarnings` where a straightforward solution isn't obvious. Also, clean up imports across all files touched.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

Execute the following command and confirm the Scapegoat output:

```bash
$ docker-compose run --rm --no-deps api-server batch/scapegoat

...

[info] [info] [scapegoat] 116 activated inspections
[info] [info] [scapegoat] List(.*/datamodel/.*) ignored file patterns
[info] [info] [scapegoat] Analysis complete: 40 files - 0 errors 0 warns 0 infos
[info] [info] [scapegoat] Written HTML report [/opt/raster-foundry/app-backend/batch/target/scala-2.11/scapegoat-report/scapegoat.html]
[info] [info] [scapegoat] Written XML report [/opt/raster-foundry/app-backend/batch/target/scala-2.11/scapegoat-report/scapegoat.xml]
[info] [info] [scapegoat] Written Scalastyle XML report [/opt/raster-foundry/app-backend/batch/target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml]

...
```

Connects https://github.com/raster-foundry/raster-foundry/issues/3758