### PR TITLE
Show imports in progress

### DIFF
--- a/app-backend/api/src/main/scala/uploads/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/uploads/QueryParameters.scala
@@ -10,6 +10,7 @@ import com.azavea.rf.api.utils.queryparams._
 trait UploadQueryParameterDirective extends QueryParametersCommon {
   val uploadQueryParams = parameters((
     'datasource.as[UUID].?,
-    'uploadStatus.as[String].?
+    'uploadStatus.as[String].?,
+    'projectId.as[UUID].?
   )).as(UploadQueryParameters.apply _)
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -260,7 +260,8 @@ case class CombinedMapTokenQueryParameters(
 @JsonCodec
 case class UploadQueryParameters(
   datasource: Option[UUID] = None,
-  uploadStatus: Option[String] = None
+  uploadStatus: Option[String] = None,
+  projectId: Option[UUID] = None
 )
 
 @JsonCodec

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
@@ -182,6 +182,7 @@ trait Filterables extends RFMeta with LazyLogging {
   implicit val uploadQueryParameters = Filterable[Any, UploadQueryParameters] {uploadParams: UploadQueryParameters =>
     List(
       uploadParams.datasource.map({ ds => fr"datasource = ${ds}"}),
+      uploadParams.projectId.map({ pid => fr"project_id = ${pid}"}),
       uploadParams.uploadStatus.map({ uploadStatus =>
         val statusF: List[Fragment] = uploadStatus.split(",")
           .map(_.trim)

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -24,10 +24,9 @@
         <div class="list-group-item" ng-repeat="datasource in $ctrl.datasources.results | filter: {name: $ctrl.searchString}">
           <div class="list-group-overflow">
             <strong class="color-dark">{{datasource.name}}</strong><br>
-            {{datasource.bands.length}}
             <ng-pluralize count="datasource.bands.length"
-                          when="{'one': 'band',
-                                'other': 'bands'
+                          when="{'one': '{} band',
+                                'other': '{} bands'
                                 }">
             </ng-pluralize>
           </div>

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -24,6 +24,12 @@
         <div class="list-group-item" ng-repeat="datasource in $ctrl.datasources.results | filter: {name: $ctrl.searchString}">
           <div class="list-group-overflow">
             <strong class="color-dark">{{datasource.name}}</strong><br>
+            {{datasource.bands.length}}
+            <ng-pluralize count="datasource.bands.length"
+                          when="{'one': 'band',
+                                'other': 'bands'
+                                }">
+            </ng-pluralize>
           </div>
           <div class="list-group-right">
             <button class="btn" ng-click="$ctrl.handleDatasourceSelect(datasource)">

--- a/app-frontend/src/app/pages/imports/raster/raster.html
+++ b/app-frontend/src/app/pages/imports/raster/raster.html
@@ -9,6 +9,16 @@
           Import scenes
         </a>
       </div>
+      <div class="alert alert-primary" ng-if="$ctrl.pendingImports">
+        <div class="alert-message">
+          {{$ctrl.pendingImports}}
+          <ng-pluralize count="$ctrl.pendingImports"
+                    when="{'one': 'import is',
+                          'other': 'imports are'
+                          }">
+          </ng-pluralize> being processed
+        </div>
+      </div>
       <!-- Dashboard Header -->
       <!-- Imports list -->
       <rf-import-list

--- a/app-frontend/src/app/pages/imports/raster/raster.html
+++ b/app-frontend/src/app/pages/imports/raster/raster.html
@@ -13,8 +13,8 @@
         <div class="alert-message">
           {{$ctrl.pendingImports}}
           <ng-pluralize count="$ctrl.pendingImports"
-                    when="{'one': 'import is',
-                          'other': 'imports are'
+                    when="{'one': '{} import is',
+                          'other': '{} imports are'
                           }">
           </ng-pluralize> being processed
         </div>

--- a/app-frontend/src/app/pages/imports/raster/raster.module.js
+++ b/app-frontend/src/app/pages/imports/raster/raster.module.js
@@ -1,15 +1,19 @@
 /* global BUILDCONFIG, HELPCONFIG */
 class RasterListController {
-    constructor(authService, $uibModal, platform) {
+    constructor(
+        $scope, $uibModal,
+        authService, uploadService,
+        platform
+    ) {
         'ngInject';
-        this.authService = authService;
-        this.$uibModal = $uibModal;
-        this.platform = platform;
+        $scope.autoInject(this, arguments);
     }
 
     $onInit() {
         this.BUILDCONFIG = BUILDCONFIG;
         this.HELPCONFIG = HELPCONFIG;
+        this.pendingImports = 0;
+        this.checkPendingImports();
     }
 
     $onDestroy() {
@@ -26,6 +30,14 @@ class RasterListController {
             resolve: {
                 origin: () => 'raster'
             }
+        });
+    }
+
+    checkPendingImports() {
+        this.uploadService.query({
+            uploadStatus: 'UPLOADED'
+        }).then(uploads => {
+            this.pendingImports = uploads.results.length;
         });
     }
 

--- a/app-frontend/src/app/pages/imports/raster/raster.module.js
+++ b/app-frontend/src/app/pages/imports/raster/raster.module.js
@@ -31,6 +31,10 @@ class RasterListController {
                 origin: () => 'raster'
             }
         });
+
+        this.activeModal.result.then(() => {
+            this.checkPendingImports();
+        });
     }
 
     checkPendingImports() {
@@ -48,10 +52,6 @@ class RasterListController {
 
         this.activeModal = this.$uibModal.open({
             component: 'rfDatasourceCreateModal'
-        });
-
-        this.activeModal.result.then(() => {
-
         });
 
         return this.activeModal;

--- a/app-frontend/src/app/pages/imports/raster/raster.module.js
+++ b/app-frontend/src/app/pages/imports/raster/raster.module.js
@@ -39,9 +39,10 @@ class RasterListController {
 
     checkPendingImports() {
         this.uploadService.query({
-            uploadStatus: 'UPLOADED'
+            uploadStatus: 'UPLOADED',
+            pageSize: 0
         }).then(uploads => {
-            this.pendingImports = uploads.results.length;
+            this.pendingImports = uploads.count;
         });
     }
 

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -20,7 +20,7 @@
   <div class="content">
     <div>
       <!-- Alert -->
-      <div class="alert alert-primary">
+      <div class="alert alert-primary" ng-if="$ctrl.pendingImports">
         <div class="alert-message">
           {{$ctrl.pendingImports}}
           <ng-pluralize count="$ctrl.pendingImports"
@@ -30,7 +30,7 @@
           </ng-pluralize> being processed
         </div>
       </div>
-      <div class="alert alert-secondary"  ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
+      <div class="alert alert-secondary" ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
         <div class="alert-message">{{$ctrl.$parent.pendingSceneCount}} scenes awaiting approval</div>
         <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
       </div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -18,9 +18,19 @@
     </h5>
   </div>
   <div class="content">
-    <div ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
+    <div>
       <!-- Alert -->
-      <div class="alert alert-secondary">
+      <div class="alert alert-primary">
+        <div class="alert-message">
+          {{$ctrl.pendingImports}}
+          <ng-pluralize count="$ctrl.pendingImports"
+                    when="{'one': 'import is',
+                          'other': 'imports are'
+                          }">
+          </ng-pluralize> being processed
+        </div>
+      </div>
+      <div class="alert alert-secondary"  ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
         <div class="alert-message">{{$ctrl.$parent.pendingSceneCount}} scenes awaiting approval</div>
         <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
       </div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -22,10 +22,9 @@
       <!-- Alert -->
       <div class="alert alert-primary" ng-if="$ctrl.pendingImports">
         <div class="alert-message">
-          {{$ctrl.pendingImports}}
           <ng-pluralize count="$ctrl.pendingImports"
-                    when="{'one': 'import is',
-                          'other': 'imports are'
+                    when="{'one': '{} import is',
+                          'other': '{} imports are'
                           }">
           </ng-pluralize> being processed
         </div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -76,13 +76,17 @@ class ProjectsScenesController {
     }
 
     openImportModal() {
-        this.modalService.open({
+        const activeModal = this.modalService.open({
             component: 'rfSceneImportModal',
             resolve: {
                 project: () => this.$parent.project,
                 origin: () => 'project'
             }
         });
+
+        activeModal.result.then(results => {
+            this.checkPendingImports();
+        })
     }
 
     updateSceneOrder(orderedSceneIds) {

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -111,9 +111,10 @@ class ProjectsScenesController {
     checkPendingImports() {
         this.uploadService.query({
             uploadStatus: 'UPLOADED',
-            projectId: this.projectId
+            projectId: this.projectId,
+            pageSize: 0
         }).then(uploads => {
-            this.pendingImports = uploads.results.length;
+            this.pendingImports = uploads.count;
         });
     }
 }

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -4,7 +4,7 @@ import angular from 'angular';
 class ProjectsScenesController {
     constructor( // eslint-disable-line max-params
         $log, $state, $scope, $timeout,
-        modalService, projectService, RasterFoundryRepository,
+        modalService, projectService, RasterFoundryRepository, uploadService,
         platform
     ) {
         'ngInject';
@@ -18,6 +18,8 @@ class ProjectsScenesController {
             name: 'Raster Foundry',
             service: this.RasterFoundryRepository
         };
+        this.pendingImports = 0;
+        this.checkPendingImports();
         // eslint-disable-next-line
         let thisItem = this;
         this.treeOptions = {
@@ -99,6 +101,16 @@ class ProjectsScenesController {
     sceneOrderTracker(scene) {
         Object.assign(scene, {'$$hashKey': scene.id});
         return scene.$$hashKey;
+
+    }
+
+    checkPendingImports() {
+        this.uploadService.query({
+            uploadStatus: 'UPLOADED',
+            projectId: this.projectId
+        }).then(uploads => {
+            this.pendingImports = uploads.results.length;
+        });
     }
 }
 

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -86,7 +86,7 @@ class ProjectsScenesController {
 
         activeModal.result.then(results => {
             this.checkPendingImports();
-        })
+        });
     }
 
     updateSceneOrder(orderedSceneIds) {

--- a/app-frontend/src/assets/styles/sass/components/_alert.scss
+++ b/app-frontend/src/assets/styles/sass/components/_alert.scss
@@ -1,33 +1,54 @@
 .alert {
-  padding: .5rem 1rem;
+  padding: .8rem 1rem;
   border-radius: $border-radius-base;
+  border: 1px solid;
   flex: 1;
-  text-align: center;
-  color: #fff;
-  background-color: $shade-normal;
   margin-bottom: 1rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.alert-action {
+  @extend .btn;
+  @extend .btn-ghost;
+  @extend .btn-small;
+  margin-top: .5rem;
+  background: transparent !important;
 }
 
 @mixin alert-state($color) {
-  background-color: $color;
+  background-color: rgba($color, .1);
+  border-color: rgba($color, .4);
+  color: desaturate(darken($color, 30%), 30%);
+
+  hr {
+    border-color: rgba($color, .4);
+  }
+
+  .alert-action {
+    border: 1px solid $color !important;
+    color: desaturate(darken($color, 30%), 30%) !important;
+  }
 }
 
 .alert-default {
-  @include alert-state($off-white);
-  color: $text-base;
-  border: 1px solid darken($off-white, 10%);
+  @include alert-state($shade-light);
+
 }
 
 .alert-primary {
   @include alert-state($brand-primary);
+
 }
 
 .alert-secondary {
   @include alert-state($brand-secondary);
+
 }
 
 .alert-warning {
   @include alert-state($warning);
+
 }
 
 .alert-danger {
@@ -36,10 +57,5 @@
 
 .alert-message {
   @extend .p;
-  margin-top: 0;
-}
-
-.alert-action {
-  @extend .btn;
-  @extend .btn-ghost-white
+  margin: 0;
 }


### PR DESCRIPTION
## Overview

This PR adds alerts to the imports page as well as the project scene list to inform the user of imports in progress. This should alleviate the sense of confusion that occurred after the import flow was completed without any indication that something happened.

### Checklist
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/44539777-11199680-a6d3-11e8-8520-3c001df68f0f.png)

![image](https://user-images.githubusercontent.com/2442245/44539850-2f7f9200-a6d3-11e8-9add-023ba8ee3fb1.png)

## Testing Instructions

 * Upload some scenes (not into a project) see that the message appears on the import page
 * Upload some scenes into a project and see that the message appears on the project scene list

Closes #1602
