### PR TITLE
Fix scene double ingest bug

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneDao.scala
@@ -200,9 +200,9 @@ object SceneDao extends Dao[Scene] with LazyLogging {
     val idFilter = fr"id = ${id}".some
     val now = new Date()
 
-    val lastModifiedIO: ConnectionIO[Timestamp] =
-      (fr"select modified_at from scenes" ++ Fragments.whereAndOpt(idFilter))
-        .query[Timestamp]
+    val lastModifiedAndIngestIO: ConnectionIO[(Timestamp, IngestStatus)] =
+      (fr"select modified_at, ingest_status from scenes" ++ Fragments.whereAndOpt(idFilter))
+        .query[(Timestamp, IngestStatus)]
         .unique
     val updateIO: ConnectionIO[Int] = (sql"""
     UPDATE scenes
@@ -228,14 +228,14 @@ object SceneDao extends Dao[Scene] with LazyLogging {
       .update
       .run
 
-    lastModifiedIO flatMap {
-      case ts: Timestamp =>
+    lastModifiedAndIngestIO flatMap {
+      case (ts: Timestamp, prevIngestStatus: IngestStatus) =>
         updateIO map {
           case n =>
-            scene.statusFields.ingestStatus match {
-              case IngestStatus.ToBeIngested =>
+            (prevIngestStatus, scene.statusFields.ingestStatus) match {
+              case (IngestStatus.ToBeIngested, IngestStatus.ToBeIngested) =>
                 (n, true)
-              case IngestStatus.Ingesting =>
+              case (IngestStatus.Ingesting, IngestStatus.Ingesting) =>
                 (n, ts.getTime < now.getTime - (24 hours).toMillis)
               case _ =>
                 (n, false)


### PR DESCRIPTION
## Overview

This PR checks scene ingest status before and after a `PUT` request, then determines if to kick off ingest based on it (and how long it has been hanging at `INGESTING`, if this is the case). It updates the associated property test as well to reflect this process.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

### Notes

This still seems relevant/necessary after #3925 🌯 

## Testing Instructions

 * `batch/assembly`
 * `./scripts/server`
 * Add a scene to a project and grab the scene id
 * Watch the log and make sure an ingest job is submitted
 * `docker-compose build batch`
 * `./scripts/console batch bash`
 * `ingest-scene <scene ID> --local --ignore-previous`
 * Watch the log and make sure the ingest job is not submitted twice


Closes https://github.com/azavea/raster-foundry-platform/issues/391
