### PR TITLE
Fix non-ASCII characters in health check cache key

### DIFF
--- a/app-backend/tile/src/main/scala/routes/HealthCheckRoute.scala
+++ b/app-backend/tile/src/main/scala/routes/HealthCheckRoute.scala
@@ -1,36 +1,32 @@
 package com.azavea.rf.tile.routes
 
-import com.azavea.rf.common.cache.kryo.KryoMemcachedClient
-import com.azavea.rf.database.{UserDao}
-import com.azavea.rf.database.util.RFTransactor
-
 import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server._
+import cats.effect.IO
+import com.azavea.rf.common.cache.kryo.KryoMemcachedClient
+import com.azavea.rf.database.UserDao
+import com.azavea.rf.database.util.RFTransactor
 import com.typesafe.scalalogging.LazyLogging
-import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import io.circe.syntax._
-import doobie._
+import doobie.hikari.HikariTransactor
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
+import io.circe.syntax._
 
-import scala.concurrent.{Future, Await}
+import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Try, Random, Success, Failure}
+import scala.util.{Failure, Random, Success, Try}
 
 object HealthCheckRoute extends LazyLogging {
-  lazy val memcachedClient = KryoMemcachedClient.DEFAULT
-  implicit val xa = RFTransactor.xa
+  lazy val memcachedClient: KryoMemcachedClient = KryoMemcachedClient.DEFAULT
+  implicit val xa: HikariTransactor[IO] = RFTransactor.xa
 
   def root: Route =
     complete {
       Seq(checkCacheReadHealth, checkCacheWriteHealth, checkDatabaseConn).flatten match {
-        case noMessage if noMessage.length == 0 =>
+        case noMessage if noMessage.isEmpty =>
           HttpResponse(
             200,
-            entity= Map(
+            entity = Map(
               "service" -> "tile",
               "status" -> "OK",
               "active threads" -> Thread.activeCount.toString,
@@ -39,7 +35,7 @@ object HealthCheckRoute extends LazyLogging {
             ).asJson.noSpaces
           )
         case messages =>
-          HttpResponse(503, entity=Map("failing" -> messages).asJson.noSpaces)
+          HttpResponse(503, entity = Map("failing" -> messages).asJson.noSpaces)
       }
     }
 
@@ -50,8 +46,10 @@ object HealthCheckRoute extends LazyLogging {
     * the Try will return a Failure
     */
   def checkCacheReadHealth: Option[String] = {
-    val cacheKey = "health-check-${Random.nextString(8)}"
-    Try { memcachedClient.get(cacheKey) } match {
+    val cacheKey = "health-check-${Random.alphanumeric.take(8).mkString}"
+    Try {
+      memcachedClient.get(cacheKey)
+    } match {
       case Success(_) => None
       case Failure(_) =>
         logger.error(
@@ -67,9 +65,11 @@ object HealthCheckRoute extends LazyLogging {
     * memcached sent back about the failure
     */
   def checkCacheWriteHealth: Option[String] = {
-    val cacheKey = "health-check-${Random.nextString(8)}"
+    val cacheKey = "health-check-${Random.alphanumeric.take(8).mkString}"
     val cacheValue = Random.nextInt(1000)
-    Try { memcachedClient.set(cacheKey, cacheValue, 5).getStatus } match {
+    Try {
+      memcachedClient.set(cacheKey, cacheValue, 5).getStatus
+    } match {
       case Success(x) if x.isSuccess => None
       case Success(x) =>
         val message = s"Failed writing to memcached client. Message: ${x.getMessage}"


### PR DESCRIPTION
## Overview

Remove non-ASCII characters from health check cache key. `nextString()` generates non-ASCII characters, but `alphanumeric()` does not.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

- Run the code in the Scastie project and compare the outputs: https://scastie.scala-lang.org/jslDiv0mTJGDrUKo8qMTeA
- Spin up the tile service (with `server`) and hit the health check endpoint

```bash
$ curl "http://localhost:9101/healthcheck/
```

Fixes https://papertrailapp.com/groups/4082183/events?focus=969459408197341255&q=program%3Aproduction%2Ftile-server&selected=969459408197341255