### PR TITLE
Add postgres implicit imports back to source

### DIFF
--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -17,6 +17,7 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe._
 

--- a/app-backend/api/src/main/scala/healthcheck/Routes.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Routes.scala
@@ -11,6 +11,7 @@ import doobie.util.transactor.Transactor
 import org.postgresql.util.PSQLException
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.Fragments.in
 import doobie.postgres._
 import doobie.postgres.implicits._

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -26,6 +26,7 @@ import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.shapefile.ShapeFileReader
 import io.circe.generic.JsonCodec

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -17,6 +17,7 @@ import com.azavea.rf.datamodel._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.raster.{IntArrayTile, MultibandTile}
 import kamon.akka.http.KamonTraceDirectives

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -18,6 +18,7 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.shapefile.ShapeFileReader

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -11,6 +11,7 @@ import com.azavea.rf.api.utils.Config
 import com.azavea.rf.authentication.Authentication
 import com.azavea.rf.common.{CommonHandlers, S3, UserErrorHandler}
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import kamon.akka.http.KamonTraceDirectives
 

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -13,6 +13,7 @@ import com.azavea.rf.datamodel._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -14,6 +14,7 @@ import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import io.circe._
 import io.circe.generic.JsonCodec
 import io.circe.syntax._

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -15,6 +15,7 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 import scala.collection.JavaConverters._

--- a/app-backend/authentication/src/main/scala/Authentication.scala
+++ b/app-backend/authentication/src/main/scala/Authentication.scala
@@ -19,6 +19,7 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 import scala.concurrent.Future

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
@@ -15,6 +15,7 @@ import com.azavea.rf.database.util.RFTransactor
 import com.azavea.rf.datamodel._
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.Decoder.Result
 import io.circe._

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CheckExportStatus.scala
@@ -15,6 +15,7 @@ import com.azavea.rf.database._
 import com.azavea.rf.datamodel._
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.parser.decode
 import org.apache.commons.mail.Email

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/export/CreateExportDef.scala
@@ -12,6 +12,7 @@ import com.azavea.rf.database.{ExportDao, UserDao}
 import com.azavea.rf.datamodel._
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/landsat8/ImportLandsat8C1.scala
@@ -16,6 +16,7 @@ import com.azavea.rf.datamodel._
 import com.github.tototoshi.csv._
 import doobie.free.connection.ConnectionIO
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.proj4.CRS
 import io.circe._

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
@@ -14,6 +14,7 @@ import com.azavea.rf.datamodel._
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import org.apache.commons.mail.Email
 


### PR DESCRIPTION
In an attempt to clean up imports in Raster Foundry, some imports for
postgres implicits were accidentally removed in the following commits:
 - 3d183b
 - bb05fd
 - a5e3d8

Apparently, at compile time there is no way for the compiler to
know if the implicits are being used so IntelliJ will remove it
when optimizing the imports. This reverts that specific change.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

There aren't really great testing instructions - there is a lot of surface area exposed unfortunately and likely bugs that we haven't encountered yet. There is _one_ which I have included here that is known to be fixed.

 * Re-assemble batch jar
 * Start server and front-end, create a new AOI project. Grab its ID from the URL in the browser.
 * Run `./scripts/console batch "rf update-aoi-project <ID>"` which should not error