### PR TITLE
Make routes consistent and add autoslash middleware

### DIFF
--- a/app-backend/backsplash/Dockerfile
+++ b/app-backend/backsplash/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8-jre-alpine
+
+ENV ASPECTJ_WEAVER_VERSION 1.8.10
+
+RUN \
+      addgroup -S rf \
+      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf \
+      && apk add --no-cache --virtual .build-deps \
+         ca-certificates \
+         tar \
+         wget \
+      && wget -qO /var/lib/rf/aspectjweaver.jar https://s3.amazonaws.com/rasterfoundry-global-artifacts-us-east-1/aspectjweaver/aspectjweaver-$ASPECTJ_WEAVER_VERSION.jar \
+      && apk del .build-deps
+
+COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
+
+USER rf
+WORKDIR /var/lib/rf
+
+ENTRYPOINT ["java"]
+CMD ["-jar", "backsplash-assembly.jar"]

--- a/app-backend/backsplash/src/main/scala/Server.scala
+++ b/app-backend/backsplash/src/main/scala/Server.scala
@@ -6,6 +6,7 @@ import com.azavea.rf.backsplash.services.{HealthCheckService, MultibandMosaicSer
 import cats.effect.{Effect, IO}
 import fs2.StreamApp
 import org.http4s.server.blaze.BlazeBuilder
+import org.http4s.server.middleware.AutoSlash
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -21,7 +22,7 @@ object ServerStream {
   def stream =
     BlazeBuilder[IO]
       .bindHttp(8080, "0.0.0.0")
-      .mountService(healthCheckService, "/")
-      .mountService(multibandMosaicService, "/mosaic")
+      .mountService(AutoSlash(multibandMosaicService), "/")
+      .mountService(AutoSlash(healthCheckService), "/healthcheck")
       .serve
 }

--- a/app-backend/backsplash/src/main/scala/services/HealthCheckService.scala
+++ b/app-backend/backsplash/src/main/scala/services/HealthCheckService.scala
@@ -9,7 +9,7 @@ import org.http4s.dsl.Http4sDsl
 class HealthCheckService[F[_]: Effect] extends Http4sDsl[F] {
   val service: HttpService[F] = {
     HttpService[F] {
-      case GET -> Root / "healthcheck" => {
+      case GET -> Root => {
         Ok(Json.obj("message" -> Json.fromString("Healthy"), "reason" -> Json.fromString("A-ok")))
       }
     }

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -410,7 +410,7 @@ export default (app) => {
             queryParams.tag = new Date().getTime();
             let formattedParams = L.Util.getParamString(queryParams);
 
-            return `http://localhost:8080/mosaic/${projectId}/{z}/{x}/{y}${formattedParams}`;
+            return `${this.tileServer}/${projectId}/{z}/{x}/{y}/${formattedParams}`;
         }
 
         getProjectShareLayerURL(project, token) {

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,6 +41,12 @@ services:
     build:
       context: ./app-backend/tile
       dockerfile: Dockerfile
+      
+  backsplash:
+    image: raster-foundry-backsplash:${GIT_COMMIT:-latest}
+    build:
+      context: ./app-backend/backsplash
+      dockerfile: Dockerfile
 
   app-migrations:
     image: raster-foundry-app-migrations:${GIT_COMMIT:-latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
     env_file: .env
     environment:
       - RF_HOST=http://rasterfoundry.com:9000
+      - TILE_SERVER_LOCATION=http://localhost:8080
       - LOCAL_INGEST_CORES=2
       - LOCAL_INGEST_MEM_GB=4
     command: rf


### PR DESCRIPTION
## Overview

This PR makes routes consistent with the existing tile server for mosaics and adds
a middleware that makes trailing slashes more ergonomic.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * bring up all of your backend services
 * note that the config variable TILE_SERVER_LOCATION is in the docker-compose file api-server environment section pointing to backsplash
 * try to render some tiles for an avro scene

Closes #3938 