### PR TITLE
Replace deprecated (a |@| b) with (a, b).mapN

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/InputDefinition.scala
@@ -22,11 +22,15 @@ case class InputDefinition(
 )
 
 object InputDefinition {
-  implicit val dec: Decoder[InputDefinition] = Decoder.instance(c =>
-    (c.downField("resolution").as[Int]
-      |@| c.downField("style").as[SimpleInput].map(Left(_))
-      .orElse(c.downField("style").as[ASTInput].map(Right(_)))
-      ).map(InputDefinition.apply)
+  implicit val dec: Decoder[InputDefinition] = Decoder.instance(
+    c =>
+      (
+        c.downField("resolution").as[Int],
+        c.downField("style")
+          .as[SimpleInput]
+          .map(Left(_))
+          .orElse(c.downField("style").as[ASTInput].map(Right(_)))
+      ).mapN(InputDefinition.apply)
   )
 
   implicit val eitherEnc: Encoder[Either[SimpleInput, ASTInput]] = new Encoder[Either[SimpleInput, ASTInput]] {


### PR DESCRIPTION
## Overview

The compiler reports that `|@|` in class `SemigroupalOps` is deprecated. Replace with `mapN`.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

Execute the following command and confirm the Scapegoat output:

```bash
$ docker-compose run --rm --no-deps api-server datamodel/scapegoat

...

[info] [info] [scapegoat] 117 activated inspections
[info] [info] [scapegoat] List(.*/datamodel/.*) ignored file patterns
[info] [info] [scapegoat] Analysis complete: 80 files - 0 errors 0 warns 0 infos
[info] [info] [scapegoat] Written HTML report [/opt/raster-foundry/app-backend/datamodel/target/scala-2.11/scapegoat-report/scapegoat.html]
[info] [info] [scapegoat] Written XML report [/opt/raster-foundry/app-backend/datamodel/target/scala-2.11/scapegoat-report/scapegoat.xml]
[info] [info] [scapegoat] Written Scalastyle XML report [/opt/raster-foundry/app-backend/datamodel/target/scala-2.11/scapegoat-report/scapegoat-scalastyle.xml]
[info] Done compiling.
[success] Total time: 104 s, completed Aug 26, 2018 2:34:37 PM

...
```

(Compiler warnings are usually under the Scapegoat output.)

Connects https://github.com/raster-foundry/raster-foundry/issues/3758