### PR TITLE
Choose AutoHigherResolution for OverviewStrategy

### DIFF
--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -123,7 +123,7 @@ object CogUtils {
           cols = 256, rows = 256
         )
         val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-        val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(0))
+        val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, AutoHigherResolution)
         cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
           raster.reproject(tmsTileRE, transform, inverseTransform).tile
         }
@@ -155,7 +155,7 @@ object CogUtils {
     rfCache.cachingOptionT(s"cog-thumbnail-${width}-${height}-${URIUtils.withNoParams(uri)}-${red}-${green}-${blue}-${floor}")(
       CogUtils.fromUri(uri).mapFilter { tiff =>
         val cellSize = CellSize(tiff.extent, width, height)
-        val overview = closestTiffOverview(tiff, cellSize, Auto(0))
+        val overview = closestTiffOverview(tiff, cellSize, AutoHigherResolution)
         val overviewRasterCellSize = overview.raster.cellSize
         val overviewExtentWidth = overview.extent.width
         val overviewExtentHeight = overview.extent.height
@@ -196,7 +196,7 @@ object CogUtils {
     val actualExtent = extent.getOrElse(tiff.extent.reproject(tiff.crs, WebMercator))
     val tmsTileRE = RasterExtent(extent = actualExtent, cellSize = TmsLevels(zoom).cellSize)
     val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-    val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(0))
+    val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, AutoHigherResolution)
 
     OptionT(Future(cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
       raster.reproject(tmsTileRE, transform, inverseTransform).tile


### PR DESCRIPTION
## Overview

Fixes a bug where the highest resolution was not being rendered
by the tile server

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Before:
![screenshot from 2018-08-27 10-32-47](https://user-images.githubusercontent.com/898060/44665798-cf476380-a9e4-11e8-9701-a6810847e77f.png)

After:
![screenshot from 2018-08-27 10-28-38](https://user-images.githubusercontent.com/898060/44665806-d2daea80-a9e4-11e8-8097-221e32762d55.png)


## Testing Instructions

 * View the same COG with a known resolution to staging + this branch
 * Compare highest zoom level