### PR TITLE
Create histograms for COG scenes when they're created

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import akka.http.scaladsl.model.{HttpEntity, MediaTypes, StatusCodes}
 import akka.http.scaladsl.server.Route
+import cats.data._
 import cats.effect.IO
 import cats.implicits._
 import com.amazonaws.services.s3.AmazonS3URI
@@ -20,20 +21,27 @@ import doobie.implicits._
 import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.raster.{IntArrayTile, MultibandTile}
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.io.json.HistogramJsonFormats
+import io.circe.parser._
 import kamon.akka.http.KamonTraceDirectives
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
 import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 
 trait SceneRoutes extends Authentication
-  with Config
-  with SceneQueryParameterDirective
-  with ThumbnailQueryParameterDirective
-  with PaginationDirectives
-  with CommonHandlers
-  with AWSBatch
-  with UserErrorHandler
-  with KamonTraceDirectives {
+    with Config
+    with SceneQueryParameterDirective
+    with ThumbnailQueryParameterDirective
+    with PaginationDirectives
+    with CommonHandlers
+    with AWSBatch
+    with UserErrorHandler
+    with HistogramJsonFormats
+    with KamonTraceDirectives {
 
   val xa: Transactor[IO]
 
@@ -121,7 +129,6 @@ trait SceneRoutes extends Authentication
 
   def createScene: Route = authenticate { user =>
     entity(as[Scene.Create]) { newScene =>
-
       val tileFootprint = (newScene.sceneType, newScene.ingestLocation, newScene.tileFootprint) match {
         case (Some(SceneType.COG), Some(ingestLocation), None) => {
           logger.info(s"Generating Footprint for Newly Added COG")
@@ -134,6 +141,14 @@ trait SceneRoutes extends Authentication
         case _ => None
       }
 
+      val histogram: OptionT[Future, Array[Histogram[Double]]] = (newScene.sceneType, newScene.ingestLocation) match {
+        case (Some(SceneType.COG), Some(ingestLocation)) =>
+          CogUtils.fromUri(ingestLocation) map { geoTiff =>
+            CogUtils.geoTiffDoubleHistogram(geoTiff)
+          }
+        case _ => OptionT.fromOption(None)
+      }
+
       val dataFootprint = (tileFootprint, newScene.dataFootprint) match {
         case (Some(tf), None) => tileFootprint
         case _ => newScene.dataFootprint
@@ -141,9 +156,26 @@ trait SceneRoutes extends Authentication
 
       val updatedScene = newScene.copy(dataFootprint = dataFootprint, tileFootprint = tileFootprint)
 
-      onSuccess(SceneDao.insert(updatedScene, user).transact(xa).unsafeToFuture) { scene =>
-        if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested) kickoffSceneIngest(scene.id)
-        complete((StatusCodes.Created, scene))
+      val histogramAndInsertFut = for {
+        hist <- histogram
+        insertedScene <- OptionT.liftF(SceneDao.insert(updatedScene, user).transact(xa).unsafeToFuture)
+        _ <- OptionT.liftF(
+          // We consider the geotrellis upstring json format to be infallible, and "guarantee" presence
+          // of the right projection
+          parse(hist.toJson.toString) traverse {
+            parsed => LayerAttributeDao.insertLayerAttribute(
+              LayerAttribute(insertedScene.id.toString, 0, "histogram", parsed)
+            ).transact(xa).unsafeToFuture
+          } map { _.toOption }
+        )
+      } yield insertedScene
+
+      onSuccess(histogramAndInsertFut.value) {
+        case Some(scene) => 
+          if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested) kickoffSceneIngest(scene.id)
+          complete((StatusCodes.Created, scene))
+        case None =>
+          complete(StatusCodes.BadRequest)
       }
     }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
@@ -29,7 +29,7 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
       FROM
     """ ++ tableF
 
-  def unsafeGetAttribute(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[LayerAttribute] = {
+  def unsafeGetAttribute(layerId: LayerId, attributeName: String): ConnectionIO[LayerAttribute] = {
     query
       .filter(fr"name = ${attributeName}")
       .filter(fr"zoom = ${layerId.zoom}")
@@ -37,7 +37,7 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
       .select
   }
 
-  def getAttribute(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[Option[LayerAttribute]] = {
+  def getAttribute(layerId: LayerId, attributeName: String): ConnectionIO[Option[LayerAttribute]] = {
     query
       .filter(fr"name = ${attributeName}")
       .filter(fr"zoom = ${layerId.zoom}")
@@ -45,11 +45,11 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
       .selectOption
   }
 
-  def listAllAttributes(attributeName: String)(implicit xa: Transactor[IO]): ConnectionIO[List[LayerAttribute]] = {
+  def listAllAttributes(attributeName: String): ConnectionIO[List[LayerAttribute]] = {
     query.filter(fr"name = ${attributeName}").list
   }
 
-  def insertLayerAttribute(layerAttribute: LayerAttribute)(implicit xa: Transactor[IO]): ConnectionIO[Int] = {
+  def insertLayerAttribute(layerAttribute: LayerAttribute): ConnectionIO[Int] = {
     // This insert includes conflict handling, because if we re-ingest a scene, its layerattributes should already
     // be in the db.
     val insertStatement = fr"INSERT into" ++ tableF ++
@@ -62,20 +62,20 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
     insertStatement.update.run
   }
 
-  def layerExists(layerId: LayerId)(implicit xa: Transactor[IO]): ConnectionIO[Boolean] = {
+  def layerExists(layerId: LayerId): ConnectionIO[Boolean] = {
     (fr"SELECT 1 FROM" ++ tableF ++ fr"""
       WHERE layer_name = ${layerId.name} LIMIT 1
     """).query[Int].to[List].map(!_.isEmpty)
   }
 
-  def delete(layerId: LayerId)(implicit xa: Transactor[IO]) = {
+  def delete(layerId: LayerId) = {
     query
       .filter(fr"layer_name = ${layerId.name}")
       .filter(fr"zoom = ${layerId.zoom}")
       .delete
   }
 
-  def delete(layerId: LayerId, attributeName: String)(implicit xa: Transactor[IO]) = {
+  def delete(layerId: LayerId, attributeName: String) = {
     query
       .filter(fr"layer_name = ${layerId.name}")
       .filter(fr"zoom = ${layerId.zoom}")
@@ -83,32 +83,32 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
       .delete
   }
 
-  def layerIds(implicit xa: Transactor[IO]): ConnectionIO[List[(String, Int)]] = {
+  def layerIds: ConnectionIO[List[(String, Int)]] = {
     (fr"SELECT layer_name, zoom FROM" ++ tableF)
       .query[(String, Int)].to[List]
   }
 
-  def layerIds(layerNames: Set[String])(implicit xa: Transactor[IO]): ConnectionIO[List[(String, Int)]] = {
+  def layerIds(layerNames: Set[String]): ConnectionIO[List[(String, Int)]] = {
     val f1 = layerNames.toList.toNel.map(lns => in(fr"layer_name", lns))
                                         (fr"SELECT layer_name, zoom FROM" ++ tableF ++ whereAndOpt(f1))
       .query[(String, Int)].to[List]
   }
 
-  def maxZoomsForLayers(layerNames: Set[String])(implicit xa: Transactor[IO]): ConnectionIO[List[(String, Int)]] = {
+  def maxZoomsForLayers(layerNames: Set[String]): ConnectionIO[List[(String, Int)]] = {
     val f1 = layerNames.toList.toNel.map(lns => in(fr"layer_name", lns))
     (fr"SELECT layer_name, COALESCE(MAX(zoom), 0) as zoom FROM" ++ tableF  ++ whereAndOpt(f1) ++ fr"GROUP BY layer_name")
       .query[(String, Int)]
       .to[List]
   }
 
-  def unsafeMaxZoomForLayer(layerName: String)(implicit xa: Transactor[IO]): ConnectionIO[(String, Int)] = {
+  def unsafeMaxZoomForLayer(layerName: String): ConnectionIO[(String, Int)] = {
     maxZoomsForLayers(Set(layerName)) map {
       case h :: Nil => h
       case _ => throw new Exception(s"Several or zero max zooms found for layer $layerName")
     }
   }
 
-  def availableAttributes(layerId: LayerId)(implicit xa: Transactor[IO]): ConnectionIO[List[String]] = {
+  def availableAttributes(layerId: LayerId): ConnectionIO[List[String]] = {
     val f1 = fr"layer_name = ${layerId.name}"
     val f2 = fr"zoom = ${layerId.zoom}"
     (fr"SELECT name FROM" ++ tableF ++ whereAnd(f1, f2)).query[String].to[List]


### PR DESCRIPTION
## Overview

This PR creates histograms in the `layer_attributes` table for COG scenes when they're created using
the pre-existing logic for histogram creation in `CogUtils.scala`. It also removes a bunch of worthless
`implicit xa: Transactor[IO]` parameters from the `LayerAttributeDao`.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * create a new cog scene -- this is easiest using a remote url, which i can give you one of
 * get the scene id from the most recently created scene in the database
 * `select name, value from layer_attributes where layer_name = 'the scene id' and zoom = 0;` should give you a name of histogram and a value of a double histogram

Closes #3899 