### PR TITLE
[wip] Create nginx-backsplash service

### DIFF
--- a/app-backend/backsplash/Dockerfile
+++ b/app-backend/backsplash/Dockerfile
@@ -1,0 +1,21 @@
+FROM openjdk:8-jre-alpine
+
+ENV ASPECTJ_WEAVER_VERSION 1.8.10
+
+RUN \
+      addgroup -S rf \
+      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf \
+      && apk add --no-cache --virtual .build-deps \
+         ca-certificates \
+         tar \
+         wget \
+      && wget -qO /var/lib/rf/aspectjweaver.jar https://s3.amazonaws.com/rasterfoundry-global-artifacts-us-east-1/aspectjweaver/aspectjweaver-$ASPECTJ_WEAVER_VERSION.jar \
+      && apk del .build-deps
+
+COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
+
+USER rf
+WORKDIR /var/lib/rf
+
+ENTRYPOINT ["java"]
+CMD ["-jar", "backsplash-assembly.jar"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,6 +41,12 @@ services:
     build:
       context: ./app-backend/tile
       dockerfile: Dockerfile
+      
+  backsplash:
+    image: raster-foundry-backsplash:${GIT_COMMIT:-latest}
+    build:
+      context: ./app-backend/backsplash
+      dockerfile: Dockerfile
 
   app-migrations:
     image: raster-foundry-app-migrations:${GIT_COMMIT:-latest}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,23 @@ services:
       - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
       - ./nginx/etc/nginx/conf.d/api.conf:/etc/nginx/conf.d/default.conf
 
+  nginx-backsplash:
+    image: raster-foundry-nginx-backsplash
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile.backsplash
+    ports:
+      - "8080:443"
+    extra_hosts:
+      - "api-server:127.0.0.1"
+    links:
+      - backsplash
+    volumes:
+      - ./nginx/srv/dist/:/srv/dist/
+      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
+      - ./nginx/etc/nginx/conf.d/tiler.conf:/etc/nginx/conf.d/default.conf
+
   nginx-tiler:
     image: raster-foundry-nginx-tiler
     build:
@@ -148,8 +165,6 @@ services:
       - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
       - RF_LOG_LEVEL=INFO
       - SBT_OPTS="-Xmx2G -XX:MaxPermSize=2G"
-    ports:
-      - "8080:8080"
       - "9030:9020"
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/

--- a/nginx/Dockerfile.backsplash
+++ b/nginx/Dockerfile.backsplash
@@ -1,0 +1,7 @@
+FROM nginx:1.14
+
+RUN mkdir -p /etc/nginx/includes
+
+COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY etc/nginx/includes/*.conf /etc/nginx/includes/
+COPY etc/nginx/conf.d/tiler.conf /etc/nginx/conf.d/default.conf

--- a/nginx/etc/nginx/conf.d/backsplash.conf
+++ b/nginx/etc/nginx/conf.d/backsplash.conf
@@ -1,0 +1,31 @@
+server {
+	listen 80 default_server;
+	server_name backsplash.staging.rasterfoundry.com backsplash.rasterfoundry.com;
+	return 301 https://$host$request_uri;
+}
+
+upstream tile-server-upstream {
+	server backsplash:8080;
+}
+
+server {
+	listen 443 default_server;
+	server_name backsplash.staging.rasterfoundry.com backsplash.rasterfoundry.com localhost;
+
+	include /etc/nginx/includes/tiler-security-headers.conf;
+
+	# This route is deprecated; requests are rewritten for 
+	# backwards-compatibility.
+	location ~ /tiles/(.*) {
+		rewrite /tiles/(.*) /$1 last;
+	}
+
+	location / {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 20s;
+		proxy_redirect off;
+
+		proxy_pass http://tile-server-upstream;
+	}
+}


### PR DESCRIPTION
## Overview

This PR puts nginx in front of the backsplash service

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

`wip` until #3945 is merged

## Testing Instructions

 * Bring up your services
 * Confirm you can still get tiles from `localhost:8080`

Closes #3894 
