### PR TITLE
Try Auto(x) instead of AutoHigherResolution for tile rendering and COG thumbnails

### DIFF
--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -123,7 +123,7 @@ object CogUtils {
           cols = 256, rows = 256
         )
         val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-        val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, AutoHigherResolution)
+        val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(1))
         cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
           raster.reproject(tmsTileRE, transform, inverseTransform).tile
         }
@@ -155,7 +155,7 @@ object CogUtils {
     rfCache.cachingOptionT(s"cog-thumbnail-${width}-${height}-${URIUtils.withNoParams(uri)}-${red}-${green}-${blue}-${floor}")(
       CogUtils.fromUri(uri).mapFilter { tiff =>
         val cellSize = CellSize(tiff.extent, width, height)
-        val overview = closestTiffOverview(tiff, cellSize, AutoHigherResolution)
+        val overview = closestTiffOverview(tiff, cellSize, Auto(0))
         val overviewRasterCellSize = overview.raster.cellSize
         val overviewExtentWidth = overview.extent.width
         val overviewExtentHeight = overview.extent.height
@@ -196,7 +196,7 @@ object CogUtils {
     val actualExtent = extent.getOrElse(tiff.extent.reproject(tiff.crs, WebMercator))
     val tmsTileRE = RasterExtent(extent = actualExtent, cellSize = TmsLevels(zoom).cellSize)
     val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-    val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, AutoHigherResolution)
+    val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(1))
 
     OptionT(Future(cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
       raster.reproject(tmsTileRE, transform, inverseTransform).tile


### PR DESCRIPTION
## Overview

This PR switches the overview strategy away from `AutoHigherResolution` to `Auto(0)` for
thumbnails and `Auto(1)` in places where we're producing tiles.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://user-images.githubusercontent.com/5702984/44734287-87454100-aab7-11e8-99c9-c0e7794790a1.png)

### Notes

I was exploding my java heap on `AutoHigherResolution` but was not doing so with `Auto(1)` (and tiles
are always slow locally for me), so I think this should be fine, but we'll see in a less resource constrained environment.

## Testing Instructions

 * Browse for some ingested scenes
 * Check out your thumbnails on the COG ones
 * Add some COGs to a project
 * Observe that you still get tiles

Closes #3961 
