### PR TITLE
Make planet uploads COGs

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -124,6 +124,7 @@ trait SceneRoutes extends Authentication
 
       val tileFootprint = (newScene.sceneType, newScene.ingestLocation, newScene.tileFootprint) match {
         case (Some(SceneType.COG), Some(ingestLocation), None) => {
+          logger.debug(s"Ingest location is: $ingestLocation")
           logger.info(s"Generating Footprint for Newly Added COG")
           CogUtils.getTiffExtent(ingestLocation)
         }

--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -33,6 +33,7 @@ def create_cog(image_locations, scene):
 def add_overviews(tif_path):
     logger.info('Adding overviews to %s', tif_path)
     overviews_command = ['gdaladdo',
+                         '-r', 'average',
                          '--config', 'COMPRESS_OVERVIEW', 'DEFLATE',
                          tif_path]
     subprocess.check_call(overviews_command)

--- a/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
+++ b/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
@@ -73,8 +73,10 @@ def create_geotiffs(modis_path, output_directory):
 
     # Generate overviews
     overview_command = [
-        'gdaladdo', '--config',
-        'COMPRESS_OVERVIEW', 'DEFLATE', warped_tif_path
+        'gdaladdo',
+        '-r', 'average',
+        '--config', 'COMPRESS_OVERVIEW', 'DEFLATE',
+        warped_tif_path
     ]
 
     # Create final tif with overviews

--- a/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
@@ -1,62 +1,16 @@
-import os
 import uuid
-import tempfile
 
-import boto3
-import requests
+from rf.models import Scene
+from rf.utils.io import Visibility, JobStatus
 
-from rf.models import Scene, Footprint, Thumbnail
-from rf.utils.io import Visibility, JobStatus, IngestStatus, delete_file
-
-from .create_footprints import bbox_from_planet_feature
 from ..geotiff.create_images import create_geotiff_image
 
 import logging
 logger = logging.getLogger(__name__)
 
 
-def get_planet_thumbnail(thumbnail_uri, planet_key, scene_id):
-    """Download planet thumbnail, push to S3, create RF thumbnail
-
-    Args:
-        thumbnail_uri (str): source thumbnail
-        planet_key (str): planet API key for authentication
-        scene_id (str): scene to attach thumbnail to
-
-    Returns:
-        Thumbnail
-
-    """
-    _, local_filepath = tempfile.mkstemp()
-    params = {'api_key': planet_key}
-
-    logger.info('Downloading thumbnail for Planet scene: %s', thumbnail_uri)
-    response = requests.get(thumbnail_uri, params=params, stream=True)
-
-    with open(local_filepath, 'wb') as filehandle:
-        for chunk in response.iter_content(1024):
-            filehandle.write(chunk)
-
-    thumbnail_key = '{}.png'.format(scene_id)
-    thumbnail_uri = '/thumbnails/{}.png'.format(scene_id)
-    logger.info('Uploading thumbnails to S3: %s', thumbnail_key)
-    s3_bucket_name = os.getenv('THUMBNAIL_BUCKET')
-    s3_bucket = boto3.resource('s3').Bucket(s3_bucket_name)
-    s3_bucket.upload_file(local_filepath, thumbnail_key, {'ContentType': 'image/png'})
-    delete_file(local_filepath)
-
-    return Thumbnail(
-        256,
-        256,
-        'SMALL',
-        thumbnail_uri,
-        sceneId=scene_id
-    )
-
-
 def create_planet_scene(planet_feature, datasource, planet_key,
-                        ingest_status=IngestStatus.TOBEINGESTED,
-                        visibility=Visibility.PRIVATE, tags=[], owner=None, sceneType="AVRO"):
+                        visibility=Visibility.PRIVATE, tags=[], owner=None):
     """Create a Raster Foundry scene from Planet scenes
 
     Args:
@@ -86,11 +40,8 @@ def create_planet_scene(planet_feature, datasource, planet_key,
         'acquisitionDate': acquisitionDate,
         'id': str(uuid.uuid4()),
         'thumbnails': None,
-        'tileFootprint': Footprint(
-            bbox_from_planet_feature(planet_feature)
-        ),
-        'dataFootprint': Footprint(
-            [planet_feature['geometry']['coordinates']]
+        'ingestLocation': planet_feature['added_props']['s3Location'].replace(
+            '|', '%7C'
         )
     }
 
@@ -110,15 +61,12 @@ def create_planet_scene(planet_feature, datasource, planet_key,
         name,
         JobStatus.QUEUED,
         JobStatus.QUEUED,
-        ingest_status,
+        'INGESTED',
         [],
         owner=owner,
         images=images,
-        sceneType=sceneType,
+        sceneType='COG',
         **scene_kwargs
     )
-
-    thumbnail_url = planet_feature['_links']['thumbnail']
-    scene.thumbnails = [get_planet_thumbnail(thumbnail_url, planet_key, scene.id)]
 
     return scene

--- a/app-tasks/rf/src/rf/uploads/planet/factories.py
+++ b/app-tasks/rf/src/rf/uploads/planet/factories.py
@@ -1,7 +1,6 @@
 # Factory to create Raster Foundry scenes from Planet Labs scenes
 import logging
 import os
-import tempfile
 import time
 from xml.dom import minidom
 
@@ -9,7 +8,9 @@ import boto3
 import requests
 from retrying import retry
 
-from rf.utils.io import IngestStatus, Visibility, delete_file
+from rf.uploads.geotiff.utils import convert_to_cog
+from rf.uploads.landsat8.io import get_tempdir
+from rf.utils.io import Visibility
 from .create_scenes import create_planet_scene
 
 logger = logging.getLogger(__name__)
@@ -43,22 +44,18 @@ class PlanetSceneFactory(object):
         # ingest status to TOBEINGESTED so that scene creation will kick off
         # an ingest. Otherwise, set the status to NOTINGESTED, so that the status
         # will be updated when the scene is added to this upload's project
-        if self.isProjectUpload:
-            ingest_status = IngestStatus.NOTINGESTED
-        else:
-            ingest_status = IngestStatus.TOBEINGESTED
         for planet_id in set(self.planet_ids):
             logger.info('Preparing to copy planet asset to s3: %s', planet_id)
-            planet_feature, temp_tif_file = self.copy_asset_to_s3(planet_id)
-            planet_key = self.client.auth.value
-            planet_scene = create_planet_scene(
-                planet_feature, self.datasource, planet_key,
-                ingest_status, self.visibility, self.tags, self.owner
-            )
-            delete_file(temp_tif_file)
-            yield planet_scene
+            with get_tempdir() as prefix:
+                planet_feature, temp_tif_file = self.copy_asset_to_s3(prefix, planet_id)
+                planet_key = self.client.auth.value
+                planet_scene = create_planet_scene(
+                    planet_feature, self.datasource, planet_key,
+                    self.visibility, self.tags, self.owner
+                )
+                yield planet_scene
 
-    def copy_asset_to_s3(self, planet_id):
+    def copy_asset_to_s3(self, prefix, planet_id):
         """Make the Planet tif available to Rater Foundry
 
         This function downloads the basic analytic tif from planet,
@@ -80,15 +77,16 @@ class PlanetSceneFactory(object):
         asset_type = PlanetSceneFactory.get_asset_type(assets)
         updated_assets = self.activate_asset_and_wait(asset_type, assets, item_id, item_type)
 
-        temp_tif_file = self.download_planet_tif(asset_type, updated_assets, item_id)
-        bucket, s3_path = self.upload_planet_tif(asset_type, item_id, item_type, temp_tif_file)
+        temp_tif_file = self.download_planet_tif(prefix, asset_type, updated_assets, item_id)
+        cog_path = convert_to_cog(prefix, temp_tif_file)
+        bucket, s3_path = self.upload_planet_tif(asset_type, item_id, item_type, cog_path)
 
         analytic_xml = self.get_analytic_xml(assets, item_id, item_type)
         reflectance_coefficients = PlanetSceneFactory.get_reflectance_coefficients(analytic_xml)
         item['properties'].update(reflectance_coefficients)
 
         item['added_props'] = {}
-        item['added_props']['localPath'] = temp_tif_file
+        item['added_props']['localPath'] = cog_path
         item['added_props']['s3Location'] = 's3://{}/{}'.format(bucket, s3_path)
 
         # Return the json representation of the item
@@ -233,7 +231,7 @@ class PlanetSceneFactory(object):
         logger.info('Asset activated: %s', item_id)
         return assets
 
-    def download_planet_tif(self, asset_type, assets, item_id):
+    def download_planet_tif(self, prefix, asset_type, assets, item_id):
         """Downloads asset to local filesystem, returns path
 
         Args:
@@ -245,19 +243,20 @@ class PlanetSceneFactory(object):
             str
         """
 
-        _, temp_tif_file = tempfile.mkstemp()
-        logger.info('Downloading asset: %s to %s', item_id, temp_tif_file)
+        base_fname = '{}.tif'.format(item_id)
+        out_path = os.path.join(prefix, base_fname)
+        logger.info('Downloading asset: %s to %s', item_id, out_path)
 
         try:
             body = self.download_asset(asset_type, assets)
-        except:
+        except Exception:
             logger.exception('Failed to download asset %s with %s', asset_type, assets)
             raise
 
-        with open(temp_tif_file, 'wb') as outf:
+        with open(out_path, 'wb') as outf:
             body.write(file=outf)
 
-        return temp_tif_file
+        return base_fname
 
     def upload_planet_tif(self, asset_type, item_id, item_type, temp_tif_file):
         """Uploads planet tif to S3 -- returns bucket and path of tile


### PR DESCRIPTION
## Overview

This PR makes planet import processing produce COGs instead of scenes that need to be ingested.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

I attempted to solve the resolution issue at the same time as I was working on this, but I was unable to.
Work for that will continue under #3972 at some point.

## Testing Instructions

 * bring up your server and frontend
 * get a planet token and associate it with your user
 * find a planet scene you have access to (at least a month old, in california)
 * add it to a project
 * get the id for the most recently created upload
 * `docker-compose build batch`
 * `./scripts/console batch 'rf process-upload <upload id>'`

Closes #3658
