### PR TITLE
Simplify output processing options for project export frontend

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -162,6 +162,7 @@ export default class NewExportController {
     }
 
     onOutputProcessingChange(option) {
+        this.exportProcessingOption = option;
         if (!option.default) {
             this.exportOptions = Object.assign(this.exportOptions, option.exportOptions);
         }

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.controller.js
@@ -14,7 +14,7 @@ export default class NewExportController {
 
         this.availableResolutions = this.exportService.getAvailableResolutions();
         this.availableTargets = this.exportService.getAvailableTargets();
-        this.availableProcessingOptions = this.projectService.availableProcessingOptions;
+        this.availableProcessingOptions = this.projectService.availableProcessingOptionsThin;
 
         this.getMap = () => mapService.getMap('edit');
     }
@@ -158,6 +158,12 @@ export default class NewExportController {
             if (option.templateId) {
                 this.loadTemplate(option.templateId);
             }
+        }
+    }
+
+    onOutputProcessingChange(option) {
+        if (!option.default) {
+            this.exportOptions = Object.assign(this.exportOptions, option.exportOptions);
         }
     }
 

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.html
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.html
@@ -22,7 +22,8 @@
     </button>
     <i class="icon-info"></i>
   </li>
-  <li class="separator">
+  <!-- Opens the output processing panel -->
+  <!-- <li class="separator">
     <div class="label">
       Output Processing
     </div>
@@ -33,6 +34,26 @@
       <button type="button" class="btn btn-default dropdown-toggle">
         <i class="icon-settings"></i>
       </button>
+    </div>
+    <i class="icon-info"></i>
+  </li> -->
+  <!-- Dropdown for output processing -->
+  <li class="separator">
+    <span class="label">Output Processing</span>
+    <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
+      <a class="btn dropdown-label">
+        {{$ctrl.getCurrentProcessingOption().label}}
+      </a>
+      <button type="button" class="btn btn-default dropdown-toggle">
+        <i class="icon-caret-down"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+        <li ng-repeat="option in $ctrl.availableProcessingOptions" role="menuitem">
+          <a ng-click="$ctrl.onOutputProcessingChange(option)">
+            {{option.label}}
+          </a>
+        </li>
+      </ul>
     </div>
     <i class="icon-info"></i>
   </li>
@@ -86,7 +107,9 @@
     Starting export...
   </button>
 </div>
-<div class="sidebar sidebar-extended sidebar-dark"
+
+<!-- Output processing panel -->
+<!-- <div class="sidebar sidebar-extended sidebar-dark"
      ng-show="$ctrl.showParameters">
   <div class="sidebar-header dark">
     <h5>Output Processing</h5>
@@ -130,4 +153,4 @@
       </li>
     </ul>
   </div>
-</div>
+</div> -->

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -49,6 +49,7 @@ export default (app) => {
             this.$location = $location;
             this.$q = $q;
             this.availableProcessingOptions = availableProcessingOptions;
+            this.availableProcessingOptionsThin = this.availableProcessingOptions.slice(0, 2);
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
 


### PR DESCRIPTION
## Overview
This PR updates project export frontend to:
* simplify output processing options to just raw and color corrected
* use dropdown instead of secondary select panel
* preserve the old panel just in case we want to bring it back in the future

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

<img width="400" alt="screen shot 2018-08-29 at 11 59 06 am" src="https://user-images.githubusercontent.com/16109558/44799859-f6d43280-ab82-11e8-91d2-6b39d5bfb9f9.png">


## Testing Instructions

 * Create a new project export. Don't change anything and export. Look at `exportOptions` -- `raw` field should be `false`, which is to indicate `Color corrected`.
 * Create a new export. Select options from `Output processing`. Export. Choosing `Color corrected` or `Raw` should result in `raw` being `false` or `true` in the `exportOptions`, respectively.

Closes #3962 
