### PR TITLE
Fix scene item deletion frontend bug

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -120,6 +120,9 @@ class ProjectsEditController {
             ({count: sceneCount, scenes: allScenes}) => {
                 this.sceneCount = sceneCount;
                 if (!this.sceneCount) {
+                    this.orderedSceneIds = [];
+                    this.sceneList = [];
+                    this.sceneLayers = new Map();
                     return this.$q.resolve();
                 }
                 this.addUningestedScenesToMap(allScenes.filter(

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -123,6 +123,10 @@ class ProjectsEditController {
                     this.orderedSceneIds = [];
                     this.sceneList = [];
                     this.sceneLayers = new Map();
+                    this.getMap().then(m => {
+                        m.deleteLayers('Ingested Scenes');
+                        m.deleteLayers('Uningested Scenes');
+                    });
                     return this.$q.resolve();
                 }
                 this.addUningestedScenesToMap(allScenes.filter(


### PR DESCRIPTION
## Overview

This PR clears `sceneList`, `orderedSceneIds`, and `sceneLayers` when `sceneCount` becomes 0 in a project, which is the case when a user deletes all scenes from a project.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Spin up frontend
 * Add scenes to a project
 * Delete all of them one by one
 * Make sure frontend successfully reflects it by deleting them from map, sidebar, and project, without needing to refresh page

Closes #3981 