### PR TITLE
Fix multiband COG creation for Sentinel-2 and Landsat

### DIFF
--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -123,7 +123,7 @@ object CogUtils {
           cols = 256, rows = 256
         )
         val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-        val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(1))
+        val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(0))
         cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
           raster.reproject(tmsTileRE, transform, inverseTransform).tile
         }
@@ -196,7 +196,7 @@ object CogUtils {
     val actualExtent = extent.getOrElse(tiff.extent.reproject(tiff.crs, WebMercator))
     val tmsTileRE = RasterExtent(extent = actualExtent, cellSize = TmsLevels(zoom).cellSize)
     val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-    val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(1))
+    val overview = closestTiffOverview(tiff, tiffTileRE.cellSize, Auto(0))
 
     OptionT(Future(cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
       raster.reproject(tmsTileRE, transform, inverseTransform).tile

--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -32,10 +32,10 @@ def create_cog(image_locations, scene):
 
 def add_overviews(tif_path):
     logger.info('Adding overviews to %s', tif_path)
-    overviews_command = ['gdaladdo',
-                         '-r', 'average',
-                         '--config', 'COMPRESS_OVERVIEW', 'DEFLATE',
-                         tif_path]
+    overviews_command = [
+        'gdaladdo', '-r', 'average', '--config', 'COMPRESS_OVERVIEW',
+        'DEFLATE', tif_path
+    ]
     subprocess.check_call(overviews_command)
 
 
@@ -43,16 +43,8 @@ def convert_to_cog(tif_with_overviews_path, local_dir):
     logger.info('Converting %s to a cog', tif_with_overviews_path)
     out_path = os.path.join(local_dir, 'cog.tif')
     cog_command = [
-        'gdal_translate',
-        tif_with_overviews_path,
-        '-co',
-        'TILED=YES',
-        '-co',
-        'COMPRESS=LZW',
-        '-co',
-        'COPY_SRC_OVERVIEWS=YES',
-        '-co',
-        'BIGTIFF=YES',
+        'gdal_translate', tif_with_overviews_path, '-co', 'TILED=YES', '-co',
+        'COMPRESS=LZW', '-co', 'COPY_SRC_OVERVIEWS=YES', '-co', 'BIGTIFF=YES',
         out_path
     ]
     subprocess.check_call(cog_command)
@@ -108,12 +100,8 @@ def merge_tifs(local_tif_paths, local_dir):
     logger.info('Merging {} tif paths'.format(len(local_tif_paths)))
     logger.debug('The files are:\n%s', '\n'.join(local_tif_paths))
     merged_path = os.path.join(local_dir, 'merged.tif')
-    merge_command = [
-        'gdal_merge.py',
-        '-o',
-        merged_path,
-        '-separate'
-    ] + local_tif_paths
+    merge_command = ['gdal_merge.py', '-o', merged_path, '-separate'
+                     ] + local_tif_paths
     subprocess.check_call(merge_command)
     return merged_path
 


### PR DESCRIPTION
## Overview

This PR resamples imagery before merging tifs based on the maximum resolution of all the
imagery that's going to get merged. Without setting this, the target pixel size ends up being the pixel
size of the first image in the list, which, for Sentinel-2 imagery, is 6x less resolute than the maximum,
which ruins tiles.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

I know there's a `-ps` option for `gdal_merge` that does what I'm doing here in one step, but when
I used that to go directly from JPEG2000 files to a merged tif with a target resolution in a single step,
file size blew up even worse than it's blowing up now.

## Testing Instructions

Testing is hard because it takes forever, but I can show you, but here's what I'm doing:

 * add a Sentinel-2 scene to a project
 * ingest it
 * add it to an analysis
 * measure the side length at a high zoom level -- it should only be off by one instead of off by... like 4
 * do the same with a Landsat 8 scene

Closes #3972 
