### PR TITLE
Add object ACR data model and meta

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
@@ -51,14 +51,14 @@ object AccessControlRule {
 @JsonCodec
 case class ObjectAccessControlRule(
   subjectType: SubjectType,
-  subjectIdO: Option[String],
+  subjectId: Option[String],
   actionType: ActionType
 ) {
-  def toObjAcrString: String = (subjectType, subjectIdO) match {
+  def toObjAcrString: String = (subjectType, subjectId) match {
     case (SubjectType.All, None) => s"ALL;;${actionType}"
-    case (SubjectType.All, Some(subjectId)) => throw new Exception(s"Invalid subjectId for subjectType All: ${subjectId}")
+    case (SubjectType.All, Some(subjectIdString)) => throw new Exception(s"Invalid subjectId for subjectType All: ${subjectIdString}")
     case (_, None) => throw new Exception(s"No subject Id provided for subject type: ${subjectType}")
-    case (_, Some(subjectId)) => s"${subjectType};${subjectId};${actionType}"
+    case (_, Some(subjectIdString)) => s"${subjectType};${subjectIdString};${actionType}"
   }
 }
 

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/AccessControlRule.scala
@@ -47,3 +47,36 @@ object AccessControlRule {
     }
   }
 }
+
+@JsonCodec
+case class ObjectAccessControlRule(
+  subjectType: SubjectType,
+  subjectIdO: Option[String],
+  actionType: ActionType
+) {
+  def toObjAcrString: String = (subjectType, subjectIdO) match {
+    case (SubjectType.All, None) => s"ALL;;${actionType}"
+    case (SubjectType.All, Some(subjectId)) => throw new Exception(s"Invalid subjectId for subjectType All: ${subjectId}")
+    case (_, None) => throw new Exception(s"No subject Id provided for subject type: ${subjectType}")
+    case (_, Some(subjectId)) => s"${subjectType};${subjectId};${actionType}"
+  }
+}
+
+object ObjectAccessControlRule {
+  def fromObjAcrString(objAcrString: String): Option[ObjectAccessControlRule] = objAcrString.split(";") match {
+    case Array(subjectType, subjectId, actionType) => (subjectType, subjectId.length) match {
+      case ("ALL", 0) => Some(ObjectAccessControlRule(SubjectType.All, None, ActionType.fromString(actionType)))
+      case ("ALL", _) => throw new Exception(s"Invalid subjectId for subjectType All: ${subjectId}")
+      case (_, 0) => throw new Exception(s"No subject Id provided for subject type: ${subjectType}")
+      case (_, _) => Some(ObjectAccessControlRule(
+        SubjectType.fromString(subjectType),
+        Some(subjectId),
+        ActionType.fromString(actionType)
+      ))
+    }
+    case _ => None
+  }
+
+  def unsafeFromObjAcrString(objAcrString: String): ObjectAccessControlRule =
+    fromObjAcrString(objAcrString).getOrElse(throw new Exception("Invalid format: " + objAcrString))
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/meta/PermissionsMeta.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/meta/PermissionsMeta.scala
@@ -1,16 +1,13 @@
 package com.azavea.rf.database.meta
 
 import com.azavea.rf.datamodel._
+import cats._
+import cats.effect.IO
+import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.util.invariant.InvalidObjectMapping
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.syntax.either._
 import io.circe._
+import io.circe.jawn._
 import io.circe.syntax._
 
 trait PermissionsMeta {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/meta/PermissionsMeta.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/meta/PermissionsMeta.scala
@@ -1,0 +1,19 @@
+package com.azavea.rf.database.meta
+
+import com.azavea.rf.datamodel._
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import doobie.util.invariant.InvalidObjectMapping
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.syntax.either._
+import io.circe._
+import io.circe.syntax._
+
+trait PermissionsMeta {
+  implicit val ObjectAccessControlRuleMeta: Meta[ObjectAccessControlRule] =
+    Meta[String].xmap(ObjectAccessControlRule.unsafeFromObjAcrString, _.toObjAcrString)
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/meta/package.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/meta/package.scala
@@ -7,4 +7,5 @@ package object meta {
       with SingleBandOptionsMeta
       with EnumMeta
       with BatchMeta
+      with PermissionsMeta
 }


### PR DESCRIPTION
## Overview

This PR adds data model and meta for object level acr field.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * `./scripts/console api-server ./sbt` -> `project db` -> `console`
 * Test that things like below should throw exceptions in your face:
    - `ObjectAccessControlRule(SubjectType.All, Some("id"), ActionType.View).toObjAcrString`
    - `ObjectAccessControlRule(SubjectType.User, None, ActionType.View).toObjAcrString`
    - `ObjectAccessControlRule.unsafeFromObjAcrString("ALL;id;VIEW")`
    - `ObjectAccessControlRule.unsafeFromObjAcrString("User;;VIEW")`
 * Test that things like below should behave:
    - `ObjectAccessControlRule(SubjectType.All, None, ActionType.View).toObjAcrString`
    - `ObjectAccessControlRule(SubjectType.User, Some("id"), ActionType.View).toObjAcrString`
    - `ObjectAccessControlRule.unsafeFromObjAcrString("ALL;;VIEW")`
     - `ObjectAccessControlRule.unsafeFromObjAcrString("User;id;VIEW")`
 * Try the code snippets in the comment of https://github.com/raster-foundry/raster-foundry/issues/3920 -- put them in`ProjectDao`: 
     - run migration (but without the first block in `150.scala` since we are not there yet, plus it should not take long in local dev even if we don't run that block)
     - substitute functions for getting project acrs and adding project acr in project routes
     - `curl` them (use something like`{"subjectType": "ORGANIZATION", "subjectIdO": <organization id>, "actionType": "VIEW"}` as body if you `POST`).

Closes #3919 
