### PR TITLE
Fix TILE_SERVER_LOCATION environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,7 @@ services:
     environment:
       - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
       - RF_LOG_LEVEL=INFO
+      - TILE_SERVER_LOCATION=http://localhost:8080
     ports:
       - "9000:9000"
       - "9010:9010"
@@ -102,7 +103,6 @@ services:
     env_file: .env
     environment:
       - RF_HOST=http://rasterfoundry.com:9000
-      - TILE_SERVER_LOCATION=http://localhost:8080
       - LOCAL_INGEST_CORES=2
       - LOCAL_INGEST_MEM_GB=4
     command: rf


### PR DESCRIPTION
## Overview

TILE_SERVER_LOCATION was being specified in the `batch` container, when it should have been in `api-server`.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Bring up the backend and frontend
 * Verify that tile request are routing to port 8080
