### PR TITLE
Fix a couple missing double-quotes on email links

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/UploadSuccess.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/notification/templates/UploadSuccess.scala
@@ -42,7 +42,7 @@ case class UploadSuccess(
         val richBody = s"""
 <html>
   <p>
-    ${sceneAddedMsg} <a href="${projectUrl}>${project.name}</a> ${withImportIDMsg}. ${statusMsg} on the <a href="${importsUrl}>Imports Page</a>.
+    ${sceneAddedMsg} <a href="${projectUrl}">${project.name}</a> ${withImportIDMsg}. ${statusMsg} on the <a href="${importsUrl}">Imports Page</a>.
   </p>
   <p>
     ${signature}
@@ -59,7 +59,7 @@ case class UploadSuccess(
         val richBody = s"""
 <html>
   <p>
-    ${sceneAddedMsg} ${withImportIDMsg}. ${statusMsg} on the <a href="${importsUrl}>Imports Page</a>.
+    ${sceneAddedMsg} ${withImportIDMsg}. ${statusMsg} on the <a href="${importsUrl}">Imports Page</a>.
   </p>
   <p>
     ${signature}


### PR DESCRIPTION
## Overview

I missed a couple double-quotes in #3980, which caused some HTML to be gobbled up.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

Ultra trivial change that isn't worth the time to test before it hits staging, so I'm just going to merge it.