### PR TITLE
Remove auth0 configuration that isn't used

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -106,7 +106,4 @@ dropbox {
 
 auth0 {
   systemUser = ${?AUTH0_SYSTEM_USER}
-  clientId = ${?AUTH0_MANAGEMENT_CLIENT_ID}
-  clientSecret = ${?AUTH0_MANAGEMENT_SECRET}
-  domain = ${?AUTH0_DOMAIN}
 }

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
@@ -102,12 +102,7 @@ trait Config {
   }
 
   @SuppressWarnings(Array("FinalModifierOnCaseClass"))
-  case class Auth0(
-    clientId: String,
-    clientSecret: String,
-    systemUser: String,
-    domain: String
-  )
+  case class Auth0(systemUser: String)
 
 
   private lazy val config = ConfigFactory.load()


### PR DESCRIPTION
## Overview

This PR removes a bunch of auth0 configuration that we never use in the batch project.
Since those values of the auth0 config were never used, I opted to remove them from the config,
rather than add the environment variables in deployment.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

This is probably a good time to revisit #3837, since we couldn't run some async tasks because they
were missing environment variables for configuration that they didn't use. That's a drag!

## Testing Instructions

 * `grep` for the removed values in `auth0Config.foo` to prove they're unneeded:

```
james@rf-dev-env ~/r/a/batch> rg "auth0Config."
src/main/scala/com/azavea/rf/batch/notification/NotifyIngestStatus.scala
29:    } yield projects.map(_.owner).distinct.filter(_ != auth0Config.systemUser).map(_.mkString)
182:    if (scene.owner == auth0Config.systemUser) {

src/main/scala/com/azavea/rf/batch/aoi/UpdateAOIProject.scala
82:      if (project.owner == auth0Config.systemUser) {

src/main/scala/com/azavea/rf/batch/util/conf/Config.scala
112:  protected lazy val auth0Config: Auth0 = config.as[Auth0]("auth0")
```

Closes azavea/raster-foundry-platform#465