### PR TITLE
Add tab completion to rf cli

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -32,4 +32,5 @@ RUN set -ex \
 COPY jars/ /opt/raster-foundry/jars/
 
 COPY rf/ /tmp/rf
-RUN (cd /tmp/rf && python setup.py install)
+COPY completion.bash /tmp/rf/completion.bash
+RUN (cat /tmp/rf/completion.bash | tee -a /root/.bashrc && cd /tmp/rf && python setup.py install)

--- a/app-tasks/completion.bash
+++ b/app-tasks/completion.bash
@@ -1,0 +1,3 @@
+
+# Completion for rf cli
+complete -W "export find-aoi-projects ingest-scene process-upload update-aoi-project" rf


### PR DESCRIPTION
## Overview

This PR adds tab completion to the rf cli in the batch container.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

Completed while waiting on processes working on fixing the COG resolution bug, it's the only part of
that work that accomplishes its goal, so separating and opening a PR for it.

## Testing Instructions

 * rebuild batch container
 * `rf i<TAB>`
 * `rf pro<TAB>`
 * etc

Closes #4003 
