### PR TITLE
Paginate and streamline project scene views

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Scene.scala
@@ -81,10 +81,11 @@ final case class Scene(
       this.sceneType
     )
 
-  def withLessRelatedFromComponents(
+  def browseFromComponents(
       thumbnails: List[Thumbnail],
-      datasource: Datasource
-  ): Scene.WithLessRelated = Scene.WithLessRelated(
+      datasource: Datasource,
+      inProject: Option[Boolean]
+  ): Scene.Browse = Scene.Browse(
     this.id,
     this.createdAt,
     this.createdBy,
@@ -103,7 +104,35 @@ final case class Scene(
     this.ingestLocation,
     this.filterFields,
     this.statusFields,
-    this.sceneType
+    this.sceneType,
+    inProject
+  )
+
+  def projectSceneFromComponents(
+      thumbnails: List[Thumbnail],
+      datasource: Datasource,
+      sceneToProject: Option[SceneToProject]
+  ): Scene.ProjectScene = Scene.ProjectScene(
+    this.id,
+    this.createdAt,
+    this.createdBy,
+    this.modifiedAt,
+    this.modifiedBy,
+    this.owner,
+    this.visibility,
+    this.tags,
+    datasource.toThin,
+    this.sceneMetadata,
+    this.name,
+    this.tileFootprint,
+    this.dataFootprint,
+    this.metadataFiles,
+    thumbnails.toList,
+    this.ingestLocation,
+    this.filterFields,
+    this.statusFields,
+    this.sceneType,
+    sceneToProject.map(_.sceneOrder).flatten
   )
 }
 
@@ -203,7 +232,7 @@ object Scene {
   }
 
   @JsonCodec
-  final case class WithLessRelated(
+  final case class Browse(
       id: UUID,
       createdAt: Timestamp,
       createdBy: String,
@@ -222,7 +251,8 @@ object Scene {
       ingestLocation: Option[String],
       filterFields: SceneFilterFields = new SceneFilterFields(),
       statusFields: SceneStatusFields,
-      sceneType: Option[SceneType] = None
+      sceneType: Option[SceneType] = None,
+      inProject: Option[Boolean] = None
   ) {
     def toScene: Scene =
       Scene(
@@ -246,4 +276,28 @@ object Scene {
         sceneType
       )
   }
+
+  @JsonCodec
+  case class ProjectScene(
+      id: UUID,
+      createdAt: Timestamp,
+      createdBy: String,
+      modifiedAt: Timestamp,
+      modifiedBy: String,
+      owner: String,
+      visibility: Visibility,
+      tags: List[String],
+      datasource: Datasource.Thin,
+      sceneMetadata: Json,
+      name: String,
+      tileFootprint: Option[Projected[MultiPolygon]],
+      dataFootprint: Option[Projected[MultiPolygon]],
+      metadataFiles: List[String],
+      thumbnails: List[Thumbnail],
+      ingestLocation: Option[String],
+      filterFields: SceneFilterFields = new SceneFilterFields(),
+      statusFields: SceneStatusFields,
+      sceneType: Option[SceneType] = None,
+      sceneOrder: Option[Int]
+  )
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToProject.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/SceneToProject.scala
@@ -33,3 +33,7 @@ final case class SceneCorrectionParams(sceneId: UUID,
                                        params: ColorCorrect.Params)
 @JsonCodec
 final case class BatchParams(items: List[SceneCorrectionParams])
+@JsonCodec
+final case class ProjectColorModeParams(redBand: Int,
+                                        greenBand: Int,
+                                        blueBand: Int)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -281,7 +281,7 @@ object Dao {
         pageRequest: PageRequest,
         selectF: Fragment,
         countF: Fragment,
-        orderClause: Fragment = fr""): ConnectionIO[PaginatedResponse[T]] = {
+        orderClause: Fragment): ConnectionIO[PaginatedResponse[T]] = {
       for {
         page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ orderClause ++ Page(
           pageRequest)).query[T].to[List]
@@ -302,8 +302,10 @@ object Dao {
     }
 
     /** Provide a list of responses within the PaginatedResponse wrapper */
-    def page(pageRequest: PageRequest): ConnectionIO[PaginatedResponse[Model]] =
-      page(pageRequest, selectF, countF)
+    def page(
+        pageRequest: PageRequest,
+        orderClause: Fragment = fr""): ConnectionIO[PaginatedResponse[Model]] =
+      page(pageRequest, selectF, countF, orderClause)
 
     def listQ(pageRequest: PageRequest): Query0[Model] =
       (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(Some(pageRequest)))

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDatasourcesDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDatasourcesDao.scala
@@ -1,0 +1,37 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.database.util.Page
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.{
+  Scene,
+  SceneFilterFields,
+  SceneStatusFields,
+  User,
+  Visibility
+}
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
+import java.util.UUID
+
+object ProjectDatasourcesDao extends Dao[Datasource] {
+  val tableName = """scenes_to_projects sp
+                     INNER JOIN scenes s ON sp.scene_id = s.id
+                     INNER JOIN datasources d on s.datasource = d.id"""
+  val selectF = fr"""
+      SELECT
+        distinct(d.id), d.created_at, d.created_by, d.modified_at, d.modified_by, d.owner,
+        d.name, d.visibility, d.composites, d.extras, d.bands, d.license_name
+          FROM""" ++ tableF
+  def listProjectDatasources(
+      projectId: UUID): ConnectionIO[List[Datasource]] = {
+    query.filter(fr"sp.project_id=$projectId").list
+  }
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectScenesDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectScenesDao.scala
@@ -1,0 +1,113 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.database.util.Page
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.{
+  Scene,
+  SceneFilterFields,
+  SceneStatusFields,
+  User,
+  Visibility
+}
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
+import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+
+import java.util.UUID
+
+object ProjectScenesDao extends Dao[Scene] {
+  val tableName = "scenes_to_projects INNER JOIN scenes ON scene_id = id"
+  val selectF = fr"""
+      SELECT
+      id, created_at, created_by, modified_at, modified_by, owner,
+          visibility, tags,
+          datasource, scene_metadata, name, tile_footprint,
+          data_footprint, metadata_files, ingest_location, cloud_cover,
+          acquisition_date, sun_azimuth, sun_elevation, thumbnail_status,
+          boundary_status, ingest_status, scene_type FROM""" ++ tableF
+
+  def listProjectScenes(projectId: UUID,
+                        pageRequest: PageRequest,
+                        sceneParams: CombinedSceneQueryParams)
+    : ConnectionIO[PaginatedResponse[Scene.ProjectScene]] = {
+
+    val projectQuery = ProjectDao.query.filter(projectId).select
+    val andPendingF: Fragment = sceneParams.sceneParams.pending match {
+      case Some(true) => fr"accepted = false"
+      case _          => fr"accepted = true"
+    }
+
+    val manualOrderF = fr"ORDER BY scene_order ASC, id ASC"
+    val autoOrderF = fr"ORDER BY acquisition_date ASC, cloud_cover ASC"
+    val filterQ = query
+      .filter(fr"project_id = ${projectId}")
+      .filter(andPendingF)
+      .filter(sceneParams)
+
+    val paginatedScenes = for {
+      project <- projectQuery
+      page <- project.manualOrder match {
+        case true => filterQ.page(pageRequest, manualOrderF)
+        case _    => filterQ.page(pageRequest, autoOrderF)
+      }
+    } yield page
+    paginatedScenes.flatMap { (pr: PaginatedResponse[Scene]) =>
+      scenesToProjectScenes(pr.results.toList, projectId).map(
+        projectScenes =>
+          PaginatedResponse[Scene.ProjectScene](
+            pr.count,
+            pr.hasPrevious,
+            pr.hasNext,
+            pr.page,
+            pr.pageSize,
+            projectScenes
+        )
+      )
+    }
+  }
+
+  // We know the datasources list head exists because of the foreign key relationship
+  @SuppressWarnings(Array("TraversableHead"))
+  def scenesToProjectScenes(
+      scenes: List[Scene],
+      projectId: UUID): ConnectionIO[List[Scene.ProjectScene]] = {
+    // "The astute among you will note that we don’t actually need a monad to do this;
+    // an applicative functor is all we need here."
+    // let's roll, doobie
+    val componentsIO: ConnectionIO[
+      (List[Thumbnail], List[Datasource], List[SceneToProject])] = {
+      val thumbnails = SceneWithRelatedDao.getScenesThumbnails(scenes map {
+        _.id
+      })
+      val datasources = SceneWithRelatedDao.getScenesDatasources(scenes map {
+        _.datasource
+      })
+      val sceneToProjects = SceneWithRelatedDao.getSceneToProjects(scenes map {
+        _.id
+      }, projectId)
+      (thumbnails, datasources, sceneToProjects).tupled
+    }
+
+    componentsIO map {
+      case (thumbnails, datasources, sceneToProjects) => {
+        val groupedThumbs = thumbnails.groupBy(_.sceneId)
+        scenes map { scene: Scene =>
+          scene.projectSceneFromComponents(
+            groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail]),
+            datasources.filter(_.id == scene.datasource).head,
+            sceneToProjects.find(_.sceneId == scene.id)
+          )
+        }
+      }
+    }
+  }
+
+}

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/filters/Filterables.scala
@@ -184,7 +184,8 @@ trait Filterables extends RFMeta with LazyLogging {
               case _    => fr"ingest_status != 'INGESTED'"
             }),
             sceneParams.ingestStatus.toList.toNel.map({ statuses =>
-              Fragments.in(fr"ingest_status", statuses)
+              Fragments.in(fr"ingest_status",
+                           statuses.map(IngestStatus.fromString(_)))
             }),
             (sceneParams.bboxPolygon, sceneParams.shape) match {
               case (_, Some(shpId)) => None

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -215,8 +215,11 @@ class ProjectDaoSpec extends FunSuite with Matchers with Checkers with DBTestCon
 
           val listAddedSceneIDsIO = addScenesWithProjectAndUserAndScenesIO flatMap {
             case (dbProject: Project, dbUser: User, dbScenes: List[Scene.WithRelated]) => {
-              ProjectDao.listProjectSceneOrder(dbProject.id, pageRequest) map {
-                (resp: PaginatedResponse[UUID]) => (resp.results, dbScenes map { _.id })
+              // TODO test the normal list endpoint here
+              ProjectScenesDao.listProjectScenes(dbProject.id, pageRequest, CombinedSceneQueryParams()) map {
+                (resp: PaginatedResponse[Scene.ProjectScene]) => (
+                  resp.results map { _.id }, dbScenes map { _.id }
+                )
               }
             }
           }
@@ -263,8 +266,8 @@ class ProjectDaoSpec extends FunSuite with Matchers with Checkers with DBTestCon
 
           val listAddedSceneIDsIO = addAndDeleteScenesWithProjectAndUserIO flatMap {
             case (dbProject: Project, dbUser: User) => {
-              ProjectDao.listProjectSceneOrder(dbProject.id, pageRequest) map {
-                (resp: PaginatedResponse[UUID]) => resp.results
+              ProjectScenesDao.listProjectScenes(dbProject.id, pageRequest, CombinedSceneQueryParams()) map {
+                (resp: PaginatedResponse[Scene.ProjectScene]) => resp.results
               }
             }
           }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -1,0 +1,54 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
+import com.azavea.rf.database.Implicits._
+
+import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+
+import doobie._, doobie.implicits._
+import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import doobie.scalatest.imports._
+import org.scalacheck.Prop.{forAll, exists}
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import java.sql.Timestamp
+import java.time.LocalDate
+
+
+
+class ProjectDatasourcesDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+  test("list datasources for a project") {
+    check {
+      forAll {
+        (userCreate: User.Create, orgCreate: Organization.Create, project: Project.Create,
+         dsCreate1: Datasource.Create, dsCreate2: Datasource.Create, dsCreate3: Datasource.Create,
+         scenes1: List[Scene.Create], scenes2: List[Scene.Create]
+        ) => {
+          val createDsIO = for {
+            orgUserProjectInsert <- insertUserOrgProject(userCreate, orgCreate, project)
+            (dbOrg, dbUser, dbProject) = orgUserProjectInsert
+            dsInsert1 <- fixupDatasource(dsCreate1, dbUser)
+            dsInsert2 <- fixupDatasource(dsCreate2, dbUser)
+            dsInsert3 <- fixupDatasource(dsCreate3, dbUser)
+            scenesInsert1 <- (scenes1 map { fixupSceneCreate(dbUser, dsInsert1, _) }).traverse(
+              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+            )
+            scenesInsert2 <- (scenes2 map { fixupSceneCreate(dbUser, dsInsert2, _) }).traverse(
+              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+            )
+            _ <- ProjectDao.addScenesToProject(scenesInsert1 map {_.id}, dbProject.id)
+            _ <- ProjectDao.addScenesToProject(scenesInsert2 map {_.id}, dbProject.id)
+            projectDatasources <- ProjectDatasourcesDao.listProjectDatasources(dbProject.id)
+          } yield (projectDatasources)
+          val (pd) = createDsIO.transact(xa).unsafeRunSync
+          assert(pd.size == 2, "; Datasources are not duplicated in request")
+          true
+        }
+      }
+    }
+  }
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
@@ -1,0 +1,55 @@
+package com.azavea.rf.database
+
+import com.azavea.rf.datamodel._
+import com.azavea.rf.datamodel.Generators.Implicits._
+import com.azavea.rf.database.Implicits._
+
+import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+
+import doobie._, doobie.implicits._
+import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import org.scalacheck.Prop.{forAll, exists}
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import java.sql.Timestamp
+import java.time.LocalDate
+
+class ProjectScenesDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+  test("list scenes for a project") {
+    check {
+      forAll {
+        (user: User.Create, org: Organization.Create, project: Project.Create, scenes: List[Scene.Create],
+         dsCreate: Datasource.Create, page: PageRequest, csq: CombinedSceneQueryParams) => {
+          val scenesInsertWithUserProjectIO = for {
+            orgUserProject <- insertUserOrgProject(user, org, project)
+            (dbOrg, dbUser, dbProject) = orgUserProject
+            datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser), dbUser)
+            scenesInsert <- (scenes map { fixupSceneCreate(dbUser, datasource, _) }).traverse(
+              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+            )
+          } yield (scenesInsert, dbUser, dbProject)
+
+          val scenesListIO = scenesInsertWithUserProjectIO flatMap {
+            case (dbScenes: List[Scene.WithRelated], dbUser: User, dbProject: Project) => {
+              ProjectDao.addScenesToProject(dbScenes map { _.id }, dbProject.id) flatMap {
+                _ => {
+                  ProjectScenesDao.listProjectScenes(dbProject.id, page, csq) map {
+                    (paginatedResponse: PaginatedResponse[Scene.ProjectScene]) => (dbScenes, paginatedResponse.results)
+                  }
+                }
+              }
+            }
+          }
+
+          val (insertedScenes, listedScenes) = scenesListIO.transact(xa).unsafeRunSync
+          val insertedIds = insertedScenes.toSet map { (scene: Scene.WithRelated) => scene.id }
+          val listedIds = listedScenes.toSet map { (scene: Scene.ProjectScene) => scene.id }
+          insertedIds == listedIds
+        }
+      }
+    }
+  }
+}

--- a/app-frontend/src/app/components/common/paginationControls/paginationControls.html
+++ b/app-frontend/src/app/components/common/paginationControls/paginationControls.html
@@ -4,10 +4,11 @@
       items-per-page="$ctrl.pagination.pageSize"
       total-items="$ctrl.pagination.count"
       ng-model="$ctrl.pagination.currentPage"
-      max-size="4"
+      max-size="3"
       rotate="true"
       boundary-link-numbers="true"
       force-ellipses="true"
+      previous-text="&lsaquo;" next-text="&rsaquo;" first-text="&laquo;" last-text="&raquo;"
       ng-change="$ctrl.handleOnChange($ctrl.pagination.currentPage)">
   </ul>
 </div>

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
@@ -21,7 +21,7 @@ const SceneFilterPaneComponent = {
 
 class FilterPaneController {
     constructor(
-        $log, $q, $scope, $rootScope, $compile, $element, $timeout, $location
+        $log, $q, $scope, $rootScope, $compile, $element, $timeout, $location, $state
     ) {
         'ngInject';
         this.$log = $log;
@@ -35,6 +35,7 @@ class FilterPaneController {
         this.filterComponents = [];
         this.initializedFilters = new Set();
         this.firstReset = true;
+        this.$state = $state;
 
         this.$scope.$watch('$ctrl.opened', (opened) => {
             if (opened) {
@@ -126,7 +127,9 @@ class FilterPaneController {
         });
 
         this.debouncedOnRepositoryChange({
-            fetchScenes: this.currentRepository.service.fetchScenes(this.filterParams),
+            fetchScenes: this.currentRepository.service.fetchScenes(
+                this.filterParams, this.$state.params.projectid
+            ),
             repository: this.currentRepository
         });
     }

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -1,10 +1,33 @@
 <div class="list-group-item"
      ng-class="{'disabled': $ctrl.isDisabled,
                 'clickable': $ctrl.isClickable}">
-  <div title="Drag to reorder this scene"
-       ng-if="$ctrl.isDraggable"
-       ui-tree-handle>
-    <i class="icon-gripper"></i>
+  <div class="list-item-left-actions"
+       ng-if="$ctrl.isDraggable">
+    <div ng-attr-title="Drag to reorder this scene"
+         ui-tree-handle>
+      <i class="icon-gripper"></i>
+    </div>
+    <a title="Manually set position"
+       ng-click="$ctrl.onManualOrderToggle($event)"
+       ng-class="{'invert': $ctrl.orderingInProgress}"
+       ng-if="$ctrl.onMove"
+    >
+      <i class="icon-exchange"></i>
+    </a>
+    <div class="scene-item-ordering" ng-if="$ctrl.orderingInProgress">
+      <div class="form-group all-in-one" ng-click="$event.stopPropagation()">
+        <input type="number" class="form-control" min="1" ng-model="$ctrl.manualOrderValue" required />
+        <button type="button" class="btn btn-primary"
+                title="Move to the selected position"
+                ng-click="$ctrl.onManualOrderConfirm()"
+                ng-disabled="!$ctrl.positionIsValid($ctrl.manualOrderValue)"
+        >
+          <i class="icon-check" ></i></button>
+        <button type="button" class="btn btn-danger"
+                title="Revert changes" ng-click="$ctrl.onManualOrderCancel()">
+          <i class="icon-cross" ></i></button>
+      </div>
+    </div>
   </div>
   <div class="item-img-container"
        ng-class="{'previewable': $ctrl.isPreviewable}"

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -115,7 +115,7 @@ function projectEditStates($stateProvider) {
     $stateProvider
         .state('projects.edit', {
             title: 'Project: Edit',
-            url: '/edit/:projectid',
+            url: '/edit/:projectid?page',
             params: {project: null},
             views: {
                 'navmenu@root': {

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -168,7 +168,7 @@ export default class ProjectsAdvancedColorController {
         if (selected) {
             this.selectedScenes = this.selectedScenes.set(scene.id, scene);
             this.selectedLayers = this.selectedLayers.set(
-                scene.id, this.$parent.sceneLayers.get(scene.id)
+                scene.id, this.layerService.layerFromScene(scene, this.$parent.projectId)
             );
             this.getMap().then((map) => {
                 map.setGeojson(scene.id, this.sceneService.getStyledFootprint(scene));

--- a/app-frontend/src/app/pages/projects/edit/color/color.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/color/color.controller.js
@@ -1,6 +1,6 @@
 export default class ProjectsEditColorController {
     constructor( // eslint-disable-line max-params
-        $scope, projectService, projectEditService, colorCorrectService
+        $scope, projectService, projectEditService, colorCorrectService, $log
     ) {
         'ngInject';
         this.$scope = $scope;
@@ -8,27 +8,30 @@ export default class ProjectsEditColorController {
         this.projectService = projectService;
         this.projectEditService = projectEditService;
         this.colorCorrectService = colorCorrectService;
+        this.$log = $log;
     }
 
     $onInit() {
         this.currentBands = null;
         this.correction = {};
 
-        this.projectEditService.fetchCurrentProject().then(() => {
-            this.$parent.getSceneList().then(() => {
-                let layer = this.$parent.sceneLayers.values().next();
-                if (layer && layer.value) {
-                    layer.value.getColorCorrection().then((correction) => {
-                        this.currentBands = {
-                            redBand: correction.redBand,
-                            greenBand: correction.greenBand,
-                            blueBand: correction.blueBand
-                        };
-                        this.correction = correction;
-                    });
-                }
-            });
-        });
+        this.$log.error('color.controller has not been updated to use paginated scenes yet.' +
+                        'Update this controller before use.');
+        // this.projectEditService.fetchCurrentProject().then(() => {
+            // this.$parent.getSceneList().then(() => {
+            //     let layer = this.$parent.sceneLayers.values().next();
+            //     if (layer && layer.value) {
+            //         layer.value.getColorCorrection().then((correction) => {
+            //             this.currentBands = {
+            //                 redBand: correction.redBand,
+            //                 greenBand: correction.greenBand,
+            //                 blueBand: correction.blueBand
+            //             };
+            //             this.correction = correction;
+            //         });
+            //     }
+            // });
+        // });
     }
 
     isActiveAutoColorCorrection(correctionType) {

--- a/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
+++ b/app-frontend/src/app/pages/projects/edit/colormode/colormode.html
@@ -2,25 +2,35 @@
   <div class="sidebar-header">
     <h5 class="sidebar-title">Color Mode</h5>
     <div class="header-controls">
-      <a ng-hide="($ctrl.projectBuffer && $ctrl.projectBuffer.isSingleBand) || !$ctrl.projectBuffer" ui-sref="projects.edit.advancedcolor"
-        class="btn btn-primary">Corrections</a>
+      <button type="button" class="btn btn-primary"
+              ng-disabled="$ctrl.correctionsDisabled()"
+              ng-click="$ctrl.navToCorrections()">
+        Corrections
+        <span class="icon-info"
+              tooltips
+              tooltip-template="Projects with more than 30 scenes are not currently supported."
+              tooltip-size="small"
+              tooltip-class="rf-tooltip" tooltip-side="left"
+              ng-if="$ctrl.correctionsDisabled()"
+        ></span>
+      </button>
     </div>
   </div>
   <div class="content">
-    <div class="sidebar-actions-group" ng-if="$ctrl.$parent.sceneLayers.size">
+    <div class="sidebar-actions-group" ng-if="$ctrl.$parent.pagination.count">
       <label>Change the visual output</label>
     </div>
-    <div class="sidebar-actions-group" ng-if="!$ctrl.loading && $ctrl.$parent.sceneLayers && !$ctrl.$parent.sceneLayers.size">
+    <div class="sidebar-actions-group" ng-if="!$ctrl.$parent.currentRequest && $ctrl.$parent.pagination && !$ctrl.$parent.pagination.count">
       <label>You must add scenes to this project in order to set a color mapping</label>
     </div>
   </div>
 </div>
-<div class="sidebar-overlay" ng-show="(!$ctrl.corrections || $ctrl.isLoading) && ($ctrl.$parent.sceneLayers && !$ctrl.$parent.sceneLayers.size)">
+<div class="sidebar-overlay" ng-show="(!$ctrl.corrections || $ctrl.$parent.currentRequest) && ($ctrl.$parent.pagination && !$ctrl.$parent.pagination.count)">
   <div class="sidebar-loading">
     <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.isLoading}"></span>
   </div>
 </div>
-<div class="sidebar-scrollable" ng-show="$ctrl.$parent.sceneLayers && $ctrl.$parent.sceneLayers.size">
+<div class="sidebar-scrollable" ng-show="$ctrl.$parent.pagination && $ctrl.$parent.pagination.count">
   <div class="list-group" ng-if="!$ctrl.isLoading">
     <div class="list-group-item flex-column" ng-if="!$ctrl.$parent.bands.length">
         There are currently no bands defined for one or more datasources used in this project.

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -2,57 +2,62 @@
   <a ng-if="$ctrl.$parent.project.isAOIProject"
      class="aoi-tag"
      ui-sref="projects.edit.aoi-parameters">
-     <i class="icon-pencil"></i>
-     <span>Edit</span>
-     AOI Parameters
+    <i class="icon-pencil"></i>
+    <span>Edit</span>
+    AOI Parameters
   </a>
   <h5 class="sidebar-title">
     Scenes
-    <ng-pluralize count="$ctrl.$parent.sceneCount"
-                  when="{'0': '(0)',
-                        'one': '(1)',
-                        'other': '({})'
-                        }">
-    </ng-pluralize>
+    (
+    <span ng-show="$ctrl.$parent.pagination.count && $ctrl.$parent.ingesting.count">
+      <ng-pluralize count="$ctrl.$parent.pagination.count - $ctrl.$parent.ingesting.count"
+                    when="{'0': '0 /',
+                           'one': '1 /',
+                           'other': '{} /'
+                           }">
+      </ng-pluralize>
+    </span>
+    {{$ctrl.$parent.pagination.count}}
+    <span ng-if="$ctrl.$parent.ingesting.count && $ctrl.$parent.pagination.count">
+      ingested
+    </span>
+    )
   </h5>
 </div>
 <div class="list-group">
-  <div class="list-group-item no-border"
-       ng-if="$ctrl.pendingImports"
-  >
+  <div class="list-group-item no-border" ng-if="$ctrl.pendingImports ">
     <div class="alert alert-default">
       <div class="alert-message">
         <ng-pluralize count="$ctrl.pendingImports"
-                  when="{'one': '{} import is',
-                        'other': '{} imports are'
-                        }">
+                      when="{'one': '{} import is',
+                             'other': '{} imports are'
+                             }">
         </ng-pluralize> being processed
       </div>
     </div>
   </div>
   <div class="list-group-item no-border"
-       ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount"
-  >
+       ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
     <div class="alert alert-secondary">
       <div class="alert-message">{{$ctrl.$parent.pendingSceneCount}} scenes awaiting approval</div>
       <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
     </div>
   </div>
-  <div class="list-group-item sidebar-actions-group">
-      <label>Add scenes</label>
-      <div class="column-6 nogutter btn-group">
-        <button type="button"
-                class="btn btn-primary"
-                ng-click="$ctrl.gotoBrowse()">
-          Browse
-        </button>
-        <button type="button"
-                ng-click="$ctrl.openImportModal()"
-                class="btn btn-primary">
-          Import
-        </button>
-      </div>
-    </div>
+</div>
+<div class="list-group-item sidebar-actions-group">
+  <label>Add scenes</label>
+  <div class="column-6 nogutter btn-group">
+    <button type="button"
+            class="btn btn-primary"
+            ng-click="$ctrl.gotoBrowse()">
+      Browse
+    </button>
+    <button type="button"
+            ng-click="$ctrl.openImportModal()"
+            class="btn btn-primary">
+      Import
+    </button>
+  </div>
 </div>
 <div class="sidebar-scrollable"
      ui-tree="$ctrl.treeOptions"
@@ -63,16 +68,38 @@
     ui-tree-nodes>
     <rf-scene-item
         previewable
+        scene="scene"
+        repository="$ctrl.repository"
+        ng-mouseover="$ctrl.setHoveredScene(scene)"
+        ng-mouseleave="$ctrl.removeHoveredScene()"
+        ng-repeat="scene in $ctrl.$parent.sceneList track by $ctrl.sceneOrderTracker(scene)"
+        on-move="$ctrl.onMove(scene, position)"
+        ng-if="$ctrl.$parent.pagination.count > 30"
+        ui-tree-node>
+      <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
+        <i class="icon-trash"></i>
+      </button>
+    </rf-scene-item>
+    <rf-scene-item
+        previewable
         draggable
         scene="scene"
         repository="$ctrl.repository"
-        ng-mouseover="$ctrl.$parent.setHoveredScene(scene)"
-        ng-mouseleave="$ctrl.$parent.removeHoveredScene()"
+        ng-mouseover="$ctrl.setHoveredScene(scene)"
+        ng-mouseleave="$ctrl.removeHoveredScene()"
         ng-repeat="scene in $ctrl.$parent.sceneList track by $ctrl.sceneOrderTracker(scene)"
+        on-move="$ctrl.onMove(scene, position)"
+        ng-if="$ctrl.$parent.pagination.count <= 30"
         ui-tree-node>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>
       </button>
     </rf-scene-item>
   </div>
+  <rf-pagination-controls
+      pagination="$ctrl.$parent.pagination"
+      is-loading="$ctrl.$parent.currentQuery"
+      on-change="$ctrl.$parent.fetchPage(value)"
+      ng-show="!$ctrl.$parent.currentQuery && !$ctrl.$parent.fetchError"
+  ></rf-pagination-controls>
 </div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -5,6 +5,7 @@ class ProjectsScenesController {
     constructor( // eslint-disable-line max-params
         $log, $state, $scope, $timeout,
         modalService, projectService, RasterFoundryRepository, uploadService,
+        sceneService, authService,
         platform
     ) {
         'ngInject';
@@ -43,8 +44,40 @@ class ProjectsScenesController {
     }
 
     onSceneDropped(orderedScenes) {
+        // get order using paginator
+        const pagination = this.$parent.pagination;
+        this.$parent.sceneList = this.$parent.sceneList.map(
+            (scene, index) => Object.assign(scene, {sceneOrder: index})
+        );
         let orderedSceneIds = orderedScenes.map(s => s.id);
         this.updateSceneOrder(orderedSceneIds);
+    }
+
+    onMove(scene, position) {
+        function arrayMove(arr, oldIndex, newIndex) {
+            if (newIndex >= arr.length) {
+                let k = newIndex - arr.length + 1;
+                // eslint-disable-next-line
+                while (k--) {
+                    // eslint-disable-next-line
+                    arr.push(undefined);
+                }
+            }
+            arr.splice(newIndex, 0, arr.splice(oldIndex, 1)[0]);
+        }
+        let p = position;
+        if (p < 0) {
+            p = 0;
+        } else if (p > this.$parent.pagination.count - 1) {
+            p = this.$parent.pagination.count - 1;
+        }
+
+        arrayMove(
+            this.$parent.sceneList,
+            this.$parent.sceneList.findIndex((s) => s.id === scene.id),
+            p
+        );
+        this.onSceneDropped(this.$parent.sceneList);
     }
 
     removeSceneFromProject(scene, $event) {
@@ -53,7 +86,8 @@ class ProjectsScenesController {
         this.projectService.removeScenesFromProject(this.$parent.projectId, [scene.id]).then(
             () => {
                 this.$parent.removeHoveredScene();
-                this.$parent.getSceneList();
+                this.$parent.fetchPage();
+                this.$parent.layerFromProject();
             },
             () => {
                 this.$log.log('error removing scene from project');
@@ -114,6 +148,31 @@ class ProjectsScenesController {
             pageSize: 0
         }).then(uploads => {
             this.pendingImports = uploads.count;
+        });
+    }
+
+    setHoveredScene(scene) {
+        if (scene !== this.hoveredScene) {
+            this.hoveredScene = scene;
+            this.$parent.getMap().then((map) => {
+                if (scene.sceneType !== 'COG' && scene.statusFields.ingestStatus === 'INGESTED') {
+                    this.$parent.setHoveredScene(scene);
+                } else {
+                    map.setThumbnail(scene, this.repository);
+                }
+            });
+        }
+    }
+
+    removeHoveredScene() {
+        this.$parent.getMap().then((map) => {
+            if (this.hoveredScene.sceneType !== 'COG' &&
+                this.hoveredScene.statusFields.ingestStatus === 'INGESTED') {
+                this.$parent.removeHoveredScene();
+            } else {
+                map.deleteThumbnail();
+            }
+            delete this.hoveredScene;
         });
     }
 }

--- a/app-frontend/src/app/services/projects/colorCorrect.service.js
+++ b/app-frontend/src/app/services/projects/colorCorrect.service.js
@@ -165,7 +165,6 @@ export default (app) => {
                 { items: bulkData }
             ).$promise;
         }
-
     }
 
     app.service('colorCorrectService', ColorCorrectService);

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -137,7 +137,7 @@ export default (app) => {
           Function chain:
           (filters) => (bbox) => () => Future(next page of scenes)
         */
-        fetchScenes(filters) {
+        fetchScenes(filters, projectId) {
             if (filters.shape && typeof filters.shape === 'object') {
                 filters.shape = filters.shape.id;
             }
@@ -159,7 +159,8 @@ export default (app) => {
                                 pageSize: '20',
                                 page,
                                 bbox,
-                                maxCreateDatetime: requestTime
+                                maxCreateDatetime: requestTime,
+                                project: projectId
                             }, params)
                         ).then((response) => {
                             // We aren't supporting concurrent scene paged requests

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3152,3 +3152,22 @@ rf-navbar-search {
 .annotation-upload-error {
   margin-top: 1em;
 }
+
+.list-item-left-actions {
+    a {
+        color: $brand-primary;
+    }
+    a.invert {
+        background-color: $brand-primary;
+        color: $white;
+    }
+}
+
+.scene-item-ordering {position: absolute;
+    .form-control {
+        width: 5em;
+    }
+    .btn {
+        padding: 0.5em;
+    }
+}


### PR DESCRIPTION
## Overview
* Modify views to paginate project scenes instead of fetching all of them upfront
* Add ability to manually set the layer position of a scene using an additional component
* Order `api/projects/{projectid}/scenes` according to the expected layering order
  * Remove the endpoint for fetching order by id - it won't be useful for a paginated view
* Consolidate API calls where possible
  * Create a `/projects/{}/datasources` endpoint
  * Create a `/projects/{}/project-color-mode` endpoint for setting the color mode of every scene in a project without knowing the ids
* fix the ingest_status filter and use it to display project ingest status on the project list page
* Make project param on scene list endpoint determine the value of an inProject property on the scene. Use this for determining the which scenes are in a project when browsing. 
* Switch back to displaying uningested scene thumbnails on hover in the project scenes view - we can't display all uningested scenes, and only showing the currently listed scenes on the map seems unhelpful. 

#### Disable functionality which requires more work in order to fully support pagination on large projects. Projects with < 30 scenes will still work as before
* Disable advanced color correction on large projects
* Disable scene re-ordering on large projects

### Checklist

- ~Styleguide updated, if necessary~
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Demo
![image](https://user-images.githubusercontent.com/4392704/45177809-fcb0c000-b1e1-11e8-8045-fa74219839b7.png)
![image](https://user-images.githubusercontent.com/4392704/45177823-05a19180-b1e2-11e8-9067-b67a424ccce7.png)


### Notes
TODO:
- [x] write testing instructions
- [x] make issues for disabled functionality
- [x] Fix color mode pane for projects with no scenes (currently hangs)
- [ ] Update spec - might want to wait until all required api changes for this stuff are finished though?
- [x] write tests

## Testing Instructions
### Misc stuff
- [x] Verify that the project list page uses scene counts with and without the ingesting filter to determine the overall ingest status of each project correctly

### Test projects with low scene counts 
- [x] Create a new project
  - [x] verify that with no scenes, the scene list view shows the correct count
  - [x] Add an uningested scene, and verify that the count at the top of the sidepanel is correct
  - [x] Verify that RF scenes which are added in browse still show when they are already in the project
  - [x] Add a COG and ingested scene
  - [x] Verify that the cog and ingested scene show up on the map as expected
  - [x] Verify that the uningested scene shows up when you mouse over it
  - [x] Verify that you can set the position by using the drag handle or manually setting the position. mess with it and see if you can break it. Refresh the page every so often and make sure things are consistent
  - [x] Add a modis scene and verify that the pending ingests message appears when 
you go back to the scene list page
  - [x] Verify that color mode selection works, and only makes a single datasource request instead of one for each scene

- [x] Create a new project and add some ingested scenes with the same datasource to it
  - [x] Verify that each type of mode for color mode selection works (single band, multiband, etc)
  - [x] Verify that advanced color selection still works as well as it has in the past
 
### Test projects with high scene counts
- [x] Create a new project
  - [x] Add > 30 scenes to it
  - [x] Verify that scene dragging / manual positioning are no longer visible.
  - [x] Verify that pagination works in the scene list
  - [x] verify that color mode selection still works, but advanced color correction is disabled
  - [x] Verify that when adding scenes again, scenes which are already in the project are correctly indicated. Check again after reloading the page to reset any local state.

Closes #3950 
Closes #3202 
