### PR TITLE
Add task to backfill COG histograms

### DIFF
--- a/app-backend/backsplash/Dockerfile
+++ b/app-backend/backsplash/Dockerfile
@@ -1,8 +1,16 @@
 FROM openjdk:8-jre-alpine
 
+ENV ASPECTJ_WEAVER_VERSION 1.8.10
+
 RUN \
       addgroup -S rf \
-      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf
+      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf \
+      && apk add --no-cache --virtual .build-deps \
+         ca-certificates \
+         tar \
+         wget \
+      && wget -qO /var/lib/rf/aspectjweaver.jar https://s3.amazonaws.com/rasterfoundry-global-artifacts-us-east-1/aspectjweaver/aspectjweaver-$ASPECTJ_WEAVER_VERSION.jar \
+      && apk del .build-deps
 
 COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
 

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -1,6 +1,7 @@
 package com.azavea.rf.batch
 
 import com.azavea.rf.batch.aoi.FindAOIProjects
+import com.azavea.rf.batch.cogMetadata.HistogramBackfill
 import com.azavea.rf.batch.export.spark.Export
 import com.azavea.rf.batch.export.{CreateExportDef, DropboxCopy, S3Copy, UpdateExportStatus}
 import com.azavea.rf.batch.healthcheck.HealthCheck
@@ -12,19 +13,20 @@ import com.azavea.rf.batch.notification.NotifyIngestStatus
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
-    Export.name             -> (Export.main(_)),
-    ImportLandsat8.name     -> (ImportLandsat8.main(_)),
-    ImportSentinel2.name    -> (ImportSentinel2.main(_)),
+    CheckExportStatus.name  -> (CheckExportStatus.main(_)),
     CreateExportDef.name    -> (CreateExportDef.main(_)),
-    FindAOIProjects.name    -> (FindAOIProjects.main(_)),
-    UpdateAOIProject.name   -> (UpdateAOIProject.main(_)),
-    S3Copy.name             -> (S3Copy.main(_)),
     DropboxCopy.name        -> (DropboxCopy.main(_)),
-    ImportLandsat8C1.name   -> (ImportLandsat8C1.main(_)),
+    Export.name             -> (Export.main(_)),
+    FindAOIProjects.name    -> (FindAOIProjects.main(_)),
     HealthCheck.name        -> (HealthCheck.main(_)),
-    ReadStacFeature.name    -> (ReadStacFeature.main(_)),
+    HistogramBackfill.name  -> (HistogramBackfill.main(_)),
+    ImportLandsat8.name     -> (ImportLandsat8.main(_)),
+    ImportLandsat8C1.name   -> (ImportLandsat8C1.main(_)),
+    ImportSentinel2.name    -> (ImportSentinel2.main(_)),
     NotifyIngestStatus.name -> (NotifyIngestStatus.main(_)),
-    UpdateExportStatus.name -> (UpdateExportStatus.main(_))
+    ReadStacFeature.name    -> (ReadStacFeature.main(_)),
+    S3Copy.name             -> (S3Copy.main(_)),
+    UpdateAOIProject.name   -> (UpdateAOIProject.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/Main.scala
@@ -13,7 +13,6 @@ import com.azavea.rf.batch.notification.NotifyIngestStatus
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
-    CheckExportStatus.name  -> (CheckExportStatus.main(_)),
     CreateExportDef.name    -> (CreateExportDef.main(_)),
     DropboxCopy.name        -> (DropboxCopy.main(_)),
     Export.name             -> (Export.main(_)),

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
@@ -119,6 +119,7 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
       logger.warn(
         s"Failed to create histograms for ${errors.length} scenes"
       )
+      sys.exit(0)
     }
 
   def main(args: Array[String]): Unit =

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
@@ -95,13 +95,14 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
         // If we don't have any ids, just get all the COG scenes without histograms
         case Nil => getScenesToBackfill
         // If we do have some ids, go get those scenes. Assume the user has picked scenes correctly
-        case ids => ids traverse {
-          id => {
-            SceneDao.unsafeGetSceneById(id).transact(xa) map {
-              scene => (scene.id, scene.ingestLocation)
+        case ids =>
+          ids traverse { id =>
+            {
+              SceneDao.unsafeGetSceneById(id).transact(xa) map { scene =>
+                (scene.id, scene.ingestLocation)
+              }
             }
-          }
-        } map { _.grouped(8).toList }
+          } map { _.grouped(8).toList }
       }
       inserts <- (chunkedTuples parTraverse { sceneList =>
         sceneList traverse { scene =>

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
@@ -38,11 +38,12 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
     fr"""select
            id, ingest_location
          from
-           scenes
+           scenes left join layer_attributes on
+             cast(scenes.id as varchar(255)) = layer_attributes.layer_name
          where
            scene_type = 'COG' and
            ingest_location is not null and
-           cast(id as varchar(255)) not in (select layer_name from layer_attributes);
+           layer_attributes.layer_name is null;
        """.query[CogTuple].to[List].transact(xa) map { tuples =>
       {
         logger.info(s"Found ${tuples.length} scenes to create histograms for")

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
@@ -1,0 +1,112 @@
+package com.azavea.rf.batch.cogMetadata
+
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.common.utils.CogUtils
+import com.azavea.rf.datamodel.{LayerAttribute, Scene, SceneType}
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.database.Implicits._
+import com.azavea.rf.database.LayerAttributeDao
+
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster.io.json.HistogramJsonFormats
+
+import io.circe.parser._
+
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import java.util.UUID
+
+object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
+
+  implicit val xa = RFTransactor.xa
+
+  type CogTuple = (UUID, Option[String])
+
+  val name = "cog-histogram-backfill"
+
+  def getScenesToBackfill: IO[List[List[CogTuple]]] = {
+    logger.info("Finding COG scenes without histograms in layer_attributes")
+    fr"""select
+           id, ingest_location
+         from
+           scenes
+         where
+           scene_type = 'COG' and
+           ingest_location is not null and
+           cast(id as varchar(255)) not in (select layer_name from layer_attributes);
+       """.query[CogTuple].to[List].transact(xa) map {
+      tuples => {
+        logger.info(s"Found ${tuples.length} scenes to create histograms for")
+        tuples.grouped(8).toList
+      }
+    }
+  }
+
+  // presence of the ingest location is guaranteed by the filter in the sql string
+  @SuppressWarnings(Array("OptionGet"))
+  def insertHistogramLayerAttribute(cogTuple: CogTuple): OptionT[IO, LayerAttribute] = (
+    for {
+      histogram <- getSceneHistogram(cogTuple._2.get)
+      inserted  <- OptionT(
+        parse(histogram.toJson.toString).toOption traverse {
+          parsed => LayerAttributeDao.insertLayerAttribute(
+            LayerAttribute(
+              cogTuple._1.toString, 0, "histogram", parsed
+            )
+          ).transact(xa)
+        }
+      )
+    } yield inserted
+  )
+
+  def getSceneHistogram(ingestLocation: String): OptionT[IO, List[Histogram[Double]]] = {
+    logger.info(s"Fetching histogram for scene at $ingestLocation")
+    OptionT(
+      IO.fromFuture {
+        IO(
+          (CogUtils.fromUri(ingestLocation) map {
+             CogUtils.geoTiffDoubleHistogram(_).toList
+           }).value
+        )
+      }
+    )
+  }
+
+  def run: IO[Unit] = for {
+    chunkedTuples <- getScenesToBackfill
+    inserts       <- (chunkedTuples parTraverse { sceneList =>
+      sceneList traverse { scene => insertHistogramLayerAttribute(scene) }
+    }).value
+  } yield {
+    val allResults = inserts reduce { _ ++ _ }
+    val errors = allResults filter { _.isEmpty }
+    val successes = allResults filter { !_.isEmpty }
+    logger.info(
+      s"Created histograms for ${successes.length} scenes"
+    )
+    logger.warn(
+      s"Failed to create histograms for ${errors.length} scenes"
+    )
+  }
+
+  def main(args: Array[String]): Unit =
+    run.recoverWith(
+      {
+        case t: Throwable =>
+          IO {
+            sendError(t)
+            logger.error(t.getMessage, t)
+          }
+      }
+    ).unsafeRunSync
+}
+

--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
@@ -43,8 +43,8 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
            scene_type = 'COG' and
            ingest_location is not null and
            cast(id as varchar(255)) not in (select layer_name from layer_attributes);
-       """.query[CogTuple].to[List].transact(xa) map {
-      tuples => {
+       """.query[CogTuple].to[List].transact(xa) map { tuples =>
+      {
         logger.info(s"Found ${tuples.length} scenes to create histograms for")
         tuples.grouped(8).toList
       }
@@ -53,60 +53,71 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
 
   // presence of the ingest location is guaranteed by the filter in the sql string
   @SuppressWarnings(Array("OptionGet"))
-  def insertHistogramLayerAttribute(cogTuple: CogTuple): OptionT[IO, LayerAttribute] = (
+  def insertHistogramLayerAttribute(
+      cogTuple: CogTuple): OptionT[IO, LayerAttribute] = (
     for {
       histogram <- getSceneHistogram(cogTuple._2.get)
-      inserted  <- OptionT(
-        parse(histogram.toJson.toString).toOption traverse {
-          parsed => LayerAttributeDao.insertLayerAttribute(
-            LayerAttribute(
-              cogTuple._1.toString, 0, "histogram", parsed
+      inserted <- OptionT(
+        parse(histogram.toJson.toString).toOption traverse { parsed =>
+          LayerAttributeDao
+            .insertLayerAttribute(
+              LayerAttribute(
+                cogTuple._1.toString,
+                0,
+                "histogram",
+                parsed
+              )
             )
-          ).transact(xa)
+            .transact(xa)
         }
       )
     } yield inserted
   )
 
-  def getSceneHistogram(ingestLocation: String): OptionT[IO, List[Histogram[Double]]] = {
+  def getSceneHistogram(
+      ingestLocation: String): OptionT[IO, List[Histogram[Double]]] = {
     logger.info(s"Fetching histogram for scene at $ingestLocation")
     OptionT(
       IO.fromFuture {
         IO(
           (CogUtils.fromUri(ingestLocation) map {
-             CogUtils.geoTiffDoubleHistogram(_).toList
-           }).value
+            CogUtils.geoTiffDoubleHistogram(_).toList
+          }).value
         )
       }
     )
   }
 
-  def run: IO[Unit] = for {
-    chunkedTuples <- getScenesToBackfill
-    inserts       <- (chunkedTuples parTraverse { sceneList =>
-      sceneList traverse { scene => insertHistogramLayerAttribute(scene) }
-    }).value
-  } yield {
-    val allResults = inserts reduce { _ ++ _ }
-    val errors = allResults filter { _.isEmpty }
-    val successes = allResults filter { !_.isEmpty }
-    logger.info(
-      s"Created histograms for ${successes.length} scenes"
-    )
-    logger.warn(
-      s"Failed to create histograms for ${errors.length} scenes"
-    )
-  }
+  def run: IO[Unit] =
+    for {
+      chunkedTuples <- getScenesToBackfill
+      inserts <- (chunkedTuples parTraverse { sceneList =>
+        sceneList traverse { scene =>
+          insertHistogramLayerAttribute(scene)
+        }
+      }).value
+    } yield {
+      val allResults = inserts reduce { _ ++ _ }
+      val errors = allResults filter { _.isEmpty }
+      val successes = allResults filter { !_.isEmpty }
+      logger.info(
+        s"Created histograms for ${successes.length} scenes"
+      )
+      logger.warn(
+        s"Failed to create histograms for ${errors.length} scenes"
+      )
+    }
 
   def main(args: Array[String]): Unit =
-    run.recoverWith(
-      {
-        case t: Throwable =>
-          IO {
-            sendError(t)
-            logger.error(t.getMessage, t)
-          }
-      }
-    ).unsafeRunSync
+    run
+      .recoverWith(
+        {
+          case t: Throwable =>
+            IO {
+              sendError(t)
+              logger.error(t.getMessage, t)
+            }
+        }
+      )
+      .unsafeRunSync
 }
-

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -414,4 +414,3 @@ lazy val backsplash = Project("backsplash", file("backsplash"))
   })
   .settings(assemblyJarName in assembly := "backsplash-assembly.jar")
   .settings(test in assembly := {})
-

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
@@ -40,7 +40,7 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
     query.filter(fr"name = ${attributeName}").list
   }
 
-  def insertLayerAttribute(layerAttribute: LayerAttribute): ConnectionIO[Int] = {
+  def insertLayerAttribute(layerAttribute: LayerAttribute): ConnectionIO[LayerAttribute] = {
     // This insert includes conflict handling, because if we re-ingest a scene, its layerattributes should already
     // be in the db.
     val insertStatement = fr"INSERT into" ++ tableF ++

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/LayerAttributeDao.scala
@@ -50,7 +50,7 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
           (${layerAttribute.layerName}, ${layerAttribute.zoom}, ${layerAttribute.name}, ${layerAttribute.value})
       ON CONFLICT (layer_name, zoom, name) DO UPDATE set value = ${layerAttribute.value}
       """
-    insertStatement.update.run
+    insertStatement.update.withUniqueGeneratedKeys[LayerAttribute]("layer_name", "zoom", "name", "value")
   }
 
   def layerExists(layerId: LayerId): ConnectionIO[Boolean] = {

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -410,7 +410,7 @@ export default (app) => {
             queryParams.tag = new Date().getTime();
             let formattedParams = L.Util.getParamString(queryParams);
 
-            return `${this.tileServer}/${projectId}/{z}/{x}/{y}/${formattedParams}`;
+            return `http://localhost:8080/mosaic/${projectId}/{z}/{x}/{y}${formattedParams}`;
         }
 
         getProjectShareLayerURL(project, token) {

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -410,7 +410,7 @@ export default (app) => {
             queryParams.tag = new Date().getTime();
             let formattedParams = L.Util.getParamString(queryParams);
 
-            return `http://localhost:8080/mosaic/${projectId}/{z}/{x}/{y}${formattedParams}`;
+            return `${this.tileServer}/${projectId}/{z}/{x}/{y}/${formattedParams}`;
         }
 
         getProjectShareLayerURL(project, token) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,6 +117,7 @@ services:
     external_links:
       - postgres:database.service.rasterfoundry.internal
       - api-server:rasterfoundry.com
+      - memcached:tile-cache.service.rasterfoundry.internal
     env_file: .env
     environment:
       - RF_HOST=http://rasterfoundry.com:9000


### PR DESCRIPTION
## Overview

This PR adds a `batch` subproject job for backfilling histograms for COG scenes.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any new SQL strings have tests (these testing instructions are the test)

## Testing Instructions

 * find a cog scene id from your database
 * check whether it has a histogram in the `layer_attributes` table -- `select * from layer_attributes where layer_name = 'the_id' and name = 'histogram';` -- it shouldn't
 * reassemble your batch jar
 * `./scripts/console batch bash`
 * `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main cog-histogram-backfill <the scene id>` 
 * run the sql query again
 * also see if you have some other cog scenes without histograms
 * run the command without any parameters
 * you should get histograms in the `layer_attributes` table for everything that wasn't in there to begin with

Closes #3901
