### PR TITLE
Add property tests for acrs in ProjectDao

### DIFF
--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -845,5 +845,10 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbObjectAccessControlRule : Arbitrary[ObjectAccessControlRule] =
       Arbitrary { objectAccessControlRuleGen }
+
+    implicit def arbListObjectAccessControlRule: Arbitrary[List[ObjectAccessControlRule]] =
+      Arbitrary {
+        Gen.listOfN(10, arbitrary[ObjectAccessControlRule])
+      }
   }
 }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -696,6 +696,18 @@ object Generators extends ArbitraryInstances {
       searchName <- possiblyEmptyStringGen
     } yield { SearchQueryParameters(Some(searchName)) }
 
+  private def objectAccessControlRuleGen: Gen[ObjectAccessControlRule] = for {
+    subjectType <- subjectTypeGen
+    subjectId <- uuidGen
+    actionType <- actionTypeGen
+  } yield { ObjectAccessControlRule(
+    subjectType,
+    subjectType match {
+      case SubjectType.All => None
+      case _ => Some(subjectId.toString)
+    },
+    actionType) }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
       credentialGen
@@ -829,5 +841,9 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbSearchQueryParameters: Arbitrary[SearchQueryParameters] =
       Arbitrary { searchQueryParametersGen }
+
+
+    implicit def arbObjectAccessControlRule : Arbitrary[ObjectAccessControlRule] =
+      Arbitrary { objectAccessControlRuleGen }
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -274,4 +274,197 @@ class ProjectDaoSpec extends FunSuite with Matchers with Checkers with DBTestCon
       }
     }
   }
+  // addPermission and getPermissions
+  test("add a permission to a project and get it back") {
+    check {
+      forAll {
+        ( userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+          acr: ObjectAccessControlRule,
+          project: Project.Create,
+          grantedUser: User.Create
+        ) => {
+          val projectPermissionIO = for {
+            projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
+            (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
+            dbGrantedUser <- UserDao.create(grantedUser)
+            dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(_1 = dbGrantedUser)
+            acrInsert = fixUpObjectAcr(acr, dbUserGrantedTeamOrgPlat)
+            perms <- ProjectDao.addPermission(projectInsert.id, acrInsert)
+            permissions <- ProjectDao.getPermissions(projectInsert.id)
+          } yield { (permissions, acrInsert) }
+
+          val (permissions, acrInsert) = projectPermissionIO.transact(xa).unsafeRunSync
+
+          assert(permissions.flatten.headOption == Some(acrInsert),
+            "Inserting a permission to a project and get it back should return the granted permission")
+          true
+        }
+      }
+    }
+  }
+
+  // addPermissionsMany
+  test("add multiple permissions to a project and get it back") {
+    check {
+      forAll {
+        ( userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+          acr1: ObjectAccessControlRule,
+          acr2: ObjectAccessControlRule,
+          acr3: ObjectAccessControlRule,
+          project: Project.Create,
+          grantedUser: User.Create
+        ) => {
+          val projectPermissionsIO = for {
+            projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
+            (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
+            dbGrantedUser <- UserDao.create(grantedUser)
+            dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(_1 = dbGrantedUser)
+            acrInsert1 = fixUpObjectAcr(acr1, dbUserGrantedTeamOrgPlat)
+            acrInsert2 = fixUpObjectAcr(acr2, dbUserGrantedTeamOrgPlat)
+            acrInsert3 = fixUpObjectAcr(acr3, dbUserGrantedTeamOrgPlat)
+            permissions <- ProjectDao.addPermissionsMany(projectInsert.id, List(
+              acrInsert1,
+              acrInsert2,
+              acrInsert3
+            ))
+          } yield { (permissions, List(acrInsert1, acrInsert2, acrInsert3).map(Some(_))) }
+
+          val (permissions, acrOptionList) = projectPermissionsIO.transact(xa).unsafeRunSync
+
+          assert(permissions.diff(acrOptionList).length == 0,
+            "Inserting a list of permissions to a project should get back the same list of them")
+          true
+        }
+      }
+    }
+  }
+
+  // addPermission and replacePermissions
+  test("add a permission to a project and replace it with many others") {
+    check {
+      forAll {
+        ( userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+          acr1: ObjectAccessControlRule,
+          acr2: ObjectAccessControlRule,
+          acr3: ObjectAccessControlRule,
+          project: Project.Create,
+          grantedUser: User.Create
+        ) => {
+          val projectReplacePermissionsIO = for {
+            projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
+            (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
+            dbGrantedUser <- UserDao.create(grantedUser)
+            dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(_1 = dbGrantedUser)
+            acrInsert1 = fixUpObjectAcr(acr1, dbUserGrantedTeamOrgPlat)
+            permAdded <- ProjectDao.addPermission(projectInsert.id, acrInsert1)
+            acrInsert2 = fixUpObjectAcr(acr2, dbUserGrantedTeamOrgPlat)
+            acrInsert3 = fixUpObjectAcr(acr3, dbUserGrantedTeamOrgPlat)
+            permReplaced <- ProjectDao.replacePermissions(projectInsert.id, List(
+              acrInsert2,
+              acrInsert3
+            ))
+          } yield { (
+            permAdded,
+            List(Some(acrInsert1)),
+            permReplaced,
+            List(acrInsert2, acrInsert3).map(Some(_))
+          ) }
+
+          val (permAdded, acrAdded, permReplaced, acrReplaced) =
+            projectReplacePermissionsIO.transact(xa).unsafeRunSync
+
+          assert(permAdded.diff(acrAdded).length == 0,
+            "Inserting a permission to a project should get the permission back")
+          assert(permReplaced.diff(acrReplaced).length == 0,
+            "Replacing project permissions should get the replaced permissions back")
+          true
+        }
+      }
+    }
+  }
+
+  // deletePermissions
+  test("add permissions to a project and delete them") {
+    check {
+      forAll {
+        ( userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+          acr1: ObjectAccessControlRule,
+          acr2: ObjectAccessControlRule,
+          project: Project.Create,
+          grantedUser: User.Create
+        ) => {
+          val projectDeletePermissionsIO = for {
+            projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
+            (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
+            dbGrantedUser <- UserDao.create(grantedUser)
+            dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(_1 = dbGrantedUser)
+            acrInsert1 = fixUpObjectAcr(acr1, dbUserGrantedTeamOrgPlat)
+            acrInsert2 = fixUpObjectAcr(acr2, dbUserGrantedTeamOrgPlat)
+            permsAdded <- ProjectDao.addPermissionsMany(projectInsert.id, List(
+              acrInsert1,
+              acrInsert2
+            ))
+            permsDeleted <- ProjectDao.deletePermissions(projectInsert.id)
+          } yield { (permsAdded, List(acrInsert1, acrInsert2).map(Some(_)), permsDeleted) }
+
+          val (permsAdded, acrsAdded, permsDeleted) = projectDeletePermissionsIO.transact(xa).unsafeRunSync
+
+          assert(permsAdded.diff(acrsAdded).length == 0,
+            "Inserting permissions to a project should get them back")
+          assert(permsDeleted.length == 0,
+            "Deleting project permissions should get an empty list back")
+          true
+        }
+      }
+    }
+  }
+
+  // listUserActions
+  test("add permissions to a project and list user actions") {
+    check {
+      forAll {
+        ( userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+          acr1: ObjectAccessControlRule,
+          acr2: ObjectAccessControlRule,
+          acr3: ObjectAccessControlRule,
+          project: Project.Create,
+          grantedUser: User.Create
+        ) => {
+          val userActionsIO = for {
+            projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
+            (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
+            (dbUser, dbTeam, dbOrg, dbPlatform) = dbUserTeamOrgPlat
+            dbGrantedUser <- UserDao.create(grantedUser)
+            dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(_1 = dbGrantedUser)
+            _ <- {
+              UserGroupRoleDao.create(UserGroupRole.Create(dbGrantedUser.id, GroupType.Platform, dbPlatform.id, GroupRole.Member)
+                .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+              UserGroupRoleDao.create(UserGroupRole.Create(dbGrantedUser.id, GroupType.Organization, dbOrg.id, GroupRole.Member)
+                .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+              UserGroupRoleDao.create(UserGroupRole.Create(dbGrantedUser.id, GroupType.Team, dbTeam.id, GroupRole.Member)
+                .toUserGroupRole(dbUser, MembershipStatus.Approved))
+            }
+            acrInsert1 = fixUpObjectAcr(acr1, dbUserGrantedTeamOrgPlat)
+            acrInsert2 = fixUpObjectAcr(acr2, dbUserGrantedTeamOrgPlat)
+            acrInsert3 = fixUpObjectAcr(acr3, dbUserGrantedTeamOrgPlat)
+            permissions <- ProjectDao.addPermissionsMany(projectInsert.id, List(
+              acrInsert1,
+              acrInsert2,
+              acrInsert3
+            ))
+            actions <- ProjectDao.listUserActions(dbGrantedUser, projectInsert.id)
+          } yield { (actions, List(acrInsert1, acrInsert2, acrInsert3)) }
+
+          val (userActions, acrsList) = userActionsIO.transact(xa).unsafeRunSync
+
+          val acrActionsDistinct = acrsList.map(_.actionType.toString).distinct
+
+          assert(
+            acrActionsDistinct.diff(userActions).length == 0,
+            "Listing actions granted to a user on a project should return all action string")
+          true
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds property tests for `ProjectDao` that extends the `ObjectPermissions` trait, which enables the former to use `acrs` for interacting with permissions.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

## Testing Instructions

 * CI

Closes https://github.com/raster-foundry/raster-foundry/issues/3921
