### PR TITLE
Allow user to search scenes using UTC or local time on frontend

### DIFF
--- a/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
+++ b/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
@@ -7,6 +7,13 @@
   <span>
     <rf-toggle value="$ctrl.usingUTC" on-change="$ctrl.onSetUTC(value)">
       &nbsp;<strong>Use UTC dates</strong>
+      <span class="icon-help"
+            tooltips
+            tooltip-template="Scenes are filtered using the UTC definition of midnight 00:00 GMT. Uncheck this to use your local definition of midnight instead. This may result in you seeing scenes with different UTC dates depending on your timezone."
+            tooltop-size="small"
+            tooltip-class="rf-tooltip"
+            tooltip-side="left"
+      ></span>
     </rf-toggle>
   </span>
 </div>

--- a/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
+++ b/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
@@ -4,6 +4,11 @@
     <span ng-if="$ctrl.datefilterPreset">{{$ctrl.datefilterPreset}}</span>
     <span ng-if="!$ctrl.datefilterPreset">{{$ctrl.datefilter.start.calendar()}} to {{$ctrl.datefilter.end.calendar()}}</span>
   </div>
+  <span>
+    <rf-toggle value="$ctrl.usingUTC" on-change="$ctrl.onSetUTC(value)">
+      &nbsp;<strong>Use UTC dates</strong>
+    </rf-toggle>
+  </span>
 </div>
 <div class="filter">
   <label></label>

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
@@ -44,12 +44,13 @@ class FilterPaneController {
     }
 
     $onInit() {
-        this.onDebouncedFilterChange = _.debounce(this.onFilterChange, 250);
+        this.debouncedOnRepositoryChange = _.debounce(this.onRepositoryChange, 250);
     }
 
     $onChanges(changes) {
         if (changes.onRepositoryChange && changes.onRepositoryChange.currentValue) {
             if (this.currentRepository) {
+                this.debouncedOnRepositoryChange = _.debounce(this.onRepositoryChange, 250);
                 this.onFilterChange();
             }
         }
@@ -123,7 +124,8 @@ class FilterPaneController {
                 this.$location.search(param, val);
             }
         });
-        this.onRepositoryChange({
+
+        this.debouncedOnRepositoryChange({
             fetchScenes: this.currentRepository.service.fetchScenes(this.filterParams),
             repository: this.currentRepository
         });
@@ -132,7 +134,7 @@ class FilterPaneController {
     createFilterComponent(filter) {
         const componentScope = this.$scope.$new(true, this.$scope);
         componentScope.filter = filter;
-        componentScope.onFilterChange = this.onDebouncedFilterChange.bind(this);
+        componentScope.onFilterChange = this.onFilterChange.bind(this);
         const template = `<rf-${filter.type}-filter
                            class="filter-group"
                            data-filter="filter"


### PR DESCRIPTION
## Overview
Add checkbox for using UTC date boundaries or local
Fix resulting inconsistencies 

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
UTC:
![image](https://user-images.githubusercontent.com/4392704/45388231-6536dd00-b5e6-11e8-8880-642739ccd7c5.png)
![image](https://user-images.githubusercontent.com/4392704/45388198-49cbd200-b5e6-11e8-8466-29b6e680758b.png)
Local (observe results for April 18th (UTC) in the results):
![image](https://user-images.githubusercontent.com/4392704/45388241-6d8f1800-b5e6-11e8-938e-daefd9645d13.png)
![image](https://user-images.githubusercontent.com/4392704/45388215-56e8c100-b5e6-11e8-9dbf-0ea5989ab30d.png)


### Notes
This component makes the assumption that date ranges are either a UTC date beginning/end or a local, and doesn't check to verify the latter. We don't allow users to set an exact time in the frontend, so this shouldn't be an issue. If the user specifies a datetime that doesn't line up with either, it will default to local and round to the nearest day.

## Testing Instructions
* Verify that the "Use UTC date" toggle works, and switches searches between a UTC date and the local date translated to UTC. All dates are sent in UTC, this just affects the date boundary used for the filter. (Eg: 2018-04-04T00:00:00.000Z is UTC, converted from local is 2018-04-04T04:00:00.000Z for a time zone 4 hours off UTC)
* Verify that the filter is consistent between reloads (checkbox and dates stay the same)
* Verify that the modal is consistent with the displayed date. UTC dates can screw it up, so all dates are handled in local and then translated to UTC for requests.
* Set dates with and without the checkbox checked and verify that the parameters used in requests make sense.

Closes https://github.com/raster-foundry/raster-foundry/issues/3636