### PR TITLE
Add download button to scene list

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -76,6 +76,9 @@
         on-move="$ctrl.onMove(scene, position)"
         ng-if="$ctrl.$parent.pagination.count > 30"
         ui-tree-node>
+      <button class="btn btn-tiny" ng-click="$ctrl.downloadSceneModal(scene)" title="Download scene data">
+        <i class="icon-download"></i>
+      </button>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>
       </button>
@@ -91,6 +94,9 @@
         on-move="$ctrl.onMove(scene, position)"
         ng-if="$ctrl.$parent.pagination.count <= 30"
         ui-tree-node>
+      <button class="btn btn-tiny" ng-click="$ctrl.downloadSceneModal(scene)" title="Download scene data">
+        <i class="icon-download"></i>
+      </button>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
         <i class="icon-trash"></i>
       </button>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -175,6 +175,15 @@ class ProjectsScenesController {
             delete this.hoveredScene;
         });
     }
+
+    downloadSceneModal(scene) {
+        this.modalService.open({
+            component: 'rfSceneDownloadModal',
+            resolve: {
+                scene: () => scene
+            }
+        });
+    }
 }
 
 const ProjectsScenesModule = angular.module('pages.projects.edit.scenes', ['ui.tree']);


### PR DESCRIPTION
## Overview

Add download button to scenes in the scene list view


### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/45505870-be744d00-b75b-11e8-96e4-097370a32ae4.png)


## Testing Instructions

 * Verify the download button works as expected

Closes #2835 
Depends on https://github.com/raster-foundry/raster-foundry/pull/4014 (rebase when it's merged)
