### PR TITLE
Route lab tile requests through single band mosaic

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -192,12 +192,16 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     rfCache.cachingOptionT(cacheKey, doCache = cacheConfig.tool.enabled) {
       for {
         toolRun <- LayerCache.toolRun(toolRunId, user, voidCache)
+        _ <- OptionT.liftF(logger.debug("Got tool run").pure[Future])
         (_, ast) <- LayerCache.toolEvalRequirements(toolRunId,
                                                     subNode,
                                                     user,
                                                     voidCache)
+        _ <- OptionT.liftF(logger.debug("Got ast").pure[Future])
         updatedAst <- OptionT(RelabelAst.cogScenes(ast))
+        _ <- OptionT.liftF(logger.debug("Updated ast").pure[Future])
         (extent, zoom) <- TileSources.fullDataWindow(updatedAst.tileSources)
+        _ <- OptionT.liftF(logger.debug("Got data extent").pure[Future])
         _ <- {
           OptionT.pure[Future](
             logger.debug(s"FOR EXTENT ZOOM: ${extent} ${zoom}"))
@@ -210,6 +214,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
               validatedAst.toOption
             })
         )
+        _ <- OptionT.liftF(logger.debug("Got literal AST").pure[Future])
         tile <- OptionT.fromOption[Future](
           NaiveInterpreter.DEFAULT(literalAst).andThen({ _.as[Tile] }) match {
             case Valid(tile) => Some(tile)
@@ -220,6 +225,7 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
               }
               None
           })
+        _ <- OptionT.liftF(logger.debug("Got tile").pure[Future])
       } yield {
         val hist = StreamingHistogram.fromTile(tile)
         hist

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -113,9 +113,9 @@ object GlobalSummary extends LazyLogging {
                                   Some(ingestLocation)) =>
               maybeSceneType match {
                 case Some(SceneType.COG) =>
-                  minAcceptableCogZoom(ingestLocation, 256).value
+                  minAcceptableCogZoom(ingestLocation, size).value
                 case _ =>
-                  Future { minAcceptableSceneZoom(sceneId, store, 256) }
+                  Future { minAcceptableSceneZoom(sceneId, store, size) }
               }
             case _ => Future { None }
           }


### PR DESCRIPTION
## Overview

This PR makes it so that if you have two scenes of the same datasource in a project and one's a
COG and the other was ingested as avro tiles, you can still use them together. Is it good? No.
Is it unusually fast? Also no. Does it solve the "object too large for cache error?" Absolutely not!

But backsplash is coming, so :man_shrugging:

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/5702984/45559755-a677f880-b843-11e8-827f-c10bddc64fd4.png)

### Notes

Much copypasta and an overall increase in complexity of where data flows in the existing tile server.
I'm banking on backsplash to bail us out.

## Testing Instructions

 * add a cog scene and an ingested scene with the same datasource to a project
 * go to the lab
 * you should (eventually) be able to get a histogram
 * you should be able to see tiles
 * change some things -- your tiles should change

Closes #3859 
