### PR TITLE
Use COG image if available for scene download

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -237,7 +237,7 @@ trait SceneRoutes
                 val signedUrl = S3.maybeSignUri(ingestLocation, whitelist)
                 List(
                   Image.Downloadable(
-                    s"$sceneId-cog.tif",
+                    s"${sceneId}_COG.tif",
                     s"$ingestLocation",
                     signedUrl
                   )

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -227,21 +227,27 @@ trait SceneRoutes
         SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture) {
         scene =>
           complete {
-            scene.getOrElse {
+            val retrievedScene = scene.getOrElse {
               throw new Exception(
                 "Scene does not exist or is not accessible by this user")
-            }.images map { image =>
-              val downloadUri: String = {
-                image.sourceUri match {
-                  case uri if uri.startsWith(s"s3://$dataBucket") => {
-                    val s3Uri = new AmazonS3URI(
-                      URLDecoder.decode(image.sourceUri, "utf-8"))
-                    S3.getSignedUrl(s3Uri.getBucket, s3Uri.getKey).toString
-                  }
-                  case _ => image.sourceUri
+            }
+            val whitelist = List(s"s3://$dataBucket")
+            (retrievedScene.sceneType, retrievedScene.ingestLocation) match {
+              case (Some(SceneType.COG), Some(ingestLocation)) =>
+                val signedUrl = S3.maybeSignUri(ingestLocation, whitelist)
+                List(
+                  Image.Downloadable(
+                    s"$sceneId-cog.tif",
+                    s"$ingestLocation",
+                    signedUrl
+                  )
+                )
+              case _ =>
+                retrievedScene.images map { image =>
+                  val downloadUri: String =
+                    S3.maybeSignUri(image.sourceUri, whitelist)
+                  image.toDownloadable(downloadUri)
                 }
-              }
-              image.toDownloadable(downloadUri)
             }
           }
       }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -20,8 +20,10 @@ import java.util.Date
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
+import scala.util.Properties
 
 package object S3 {
+
   lazy val client = AmazonS3ClientBuilder
     .standard()
     .withCredentials(new DefaultAWSCredentialsProviderChain())
@@ -178,4 +180,14 @@ package object S3 {
 
   def doesObjectExist(bucket: String, key: String): Boolean =
     client.doesObjectExist(bucket, key)
+
+  def maybeSignUri(uriString: String,
+                   whitelist: List[String] = List()): String = {
+    val whitelisted =
+      whitelist.map(uriString.startsWith(_)).foldLeft(false)(_ || _)
+    if (whitelisted) {
+      val s3Uri = new AmazonS3URI(URLDecoder.decode(uriString, "utf-8"))
+      S3.getSignedUrl(s3Uri.getBucket, s3Uri.getKey).toString
+    } else uriString
+  }
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Image.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Image.scala
@@ -146,23 +146,10 @@ object Image {
       metadataFiles
     )
 
-    def toDownloadable(downloadUri: String): Image.WithRelatedDownladable =
-      Image.WithRelatedDownladable(
-        this.id,
-        this.createdAt,
-        this.modifiedAt,
-        this.createdBy,
-        this.modifiedBy,
-        this.owner,
-        this.rawDataBytes,
-        this.visibility,
+    def toDownloadable(downloadUri: String): Image.Downloadable =
+      Downloadable(
         this.filename,
         this.sourceUri,
-        this.scene,
-        this.imageMetadata,
-        this.resolutionMeters,
-        this.metadataFiles,
-        this.bands,
         downloadUri
       )
   }
@@ -185,20 +172,7 @@ object Image {
   }
 
   @JsonCodec
-  final case class WithRelatedDownladable(id: UUID,
-                                          createdAt: Timestamp,
-                                          modifiedAt: Timestamp,
-                                          createdBy: String,
-                                          modifiedBy: String,
-                                          owner: String,
-                                          rawDataBytes: Long,
-                                          visibility: Visibility,
-                                          filename: String,
-                                          sourceUri: String,
-                                          scene: UUID,
-                                          imageMetadata: Json,
-                                          resolutionMeters: Float,
-                                          metadataFiles: List[String],
-                                          bands: List[Band],
-                                          downloadUri: String)
+  final case class Downloadable(filename: String,
+                                sourceUri: String,
+                                downloadUri: String)
 }

--- a/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
@@ -8,7 +8,7 @@
     Download scenes
   </h4>
 </div>
-<div class="modal-body">
+<div class="modal-body" ng-if="!$ctrl.rejectionMessage">
   <div class="list-group" ng-show="$ctrl.isLoading">
     <span class="list-placeholder">
       <i class="icon-load animate-spin"></i>
@@ -27,8 +27,8 @@
         <strong class="color-dark">Images</strong>
         <ng-pluralize count="downloadSet.images.length"
                       when="{'0': 'No images',
-                            'one': 'One image',
-                            'other': '{} images'}">
+                            'one': 'One image ',
+                            'other': '{} images '}">
         </ng-pluralize>
         available
       </div>
@@ -94,8 +94,8 @@
         <strong class="color-dark">Metadata</strong>
         <ng-pluralize count="downloadSet.metadata.length"
                       when="{'0': 'No metadata files',
-                            'one': 'One metadata file',
-                            'other': '{} metadata files'}">
+                            'one': 'One metadata file ',
+                            'other': '{} metadata files '}">
         </ng-pluralize>
         available
       </div>
@@ -111,4 +111,8 @@
       </div>
     </div>
   </div>
+</div>
+
+<div class="modal-body" ng-if="$ctrl.rejectionMessage">
+    <p>{{ $ctrl.rejectionMessage }}</p>
 </div>

--- a/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
@@ -27,8 +27,8 @@
         <strong class="color-dark">Images</strong>
         <ng-pluralize count="downloadSet.images.length"
                       when="{'0': 'No images',
-                            'one': 'One image ',
-                            'other': '{} images '}">
+                            'one': 'One image&nbsp',
+                            'other': '{} images&nbsp'}">
         </ng-pluralize>
         available
       </div>
@@ -94,8 +94,8 @@
         <strong class="color-dark">Metadata</strong>
         <ng-pluralize count="downloadSet.metadata.length"
                       when="{'0': 'No metadata files',
-                            'one': 'One metadata file ',
-                            'other': '{} metadata files '}">
+                            'one': 'One metadata file&nbsp',
+                            'other': '{} metadata files&nbsp'}">
         </ng-pluralize>
         available
       </div>

--- a/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.module.js
@@ -22,7 +22,12 @@ class SceneDownloadModalController {
     $onInit() {
         this.downloads = [];
         this.isLoading = false;
-        if (this.resolve.scene) {
+        this.rejectionMessage = null;
+        // Sentinel-2 scenes can't be downloaded unless they've been added to a project --
+        // see https://github.com/raster-foundry/raster-foundry/issues/3989
+        let datasourceIngestCheck = this.resolve.scene.datasource.name !== 'Sentinel-2' ||
+            this.resolve.scene.sceneType === 'COG' && this.resolve.scene.ingestLocation;
+        if (this.resolve.scene && datasourceIngestCheck) {
             const scene = this.resolve.scene;
             this.isLoading = true;
             this.sceneService.getDownloadableImages(scene).then(images => {
@@ -41,6 +46,12 @@ class SceneDownloadModalController {
 
                 this.isLoading = false;
             });
+        } else if (this.resolve.scene.datasource.name === 'Sentinel-2') {
+            this.rejectionMessage =
+                'This scene can only be downloaded after it is transformed into a ' +
+                'Cloud-Optimized GeoTIFF (COG). ' +
+                'To transform this scene into a COG, add it to a project ' +
+                '(you can always remove it later).';
         }
     }
 


### PR DESCRIPTION
## Overview

This PR uses the COG image for scene downloads if it's available.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/5702984/45623409-80db3100-ba87-11e8-8f63-d9d444b992f6.png)

### Notes

I added to the copy in the issue a bit, since I think it was a little bit misleading about what needed
to happen for a Sentinel-2 scene to be downloadable

## Testing Instructions

 * have an ingested Sentinel-2 COG in your database (ingest one if you don't have it)
 * browse for scenes
 * try to download a non-Sentinel-2 scene (it should be fine)
 * try to download a Sentinel-2 scene that hasn't been turned into a COG yet (it should not be fine -- you should get a message about adding it to a project)
 * try to download a Sentinel-2 scene that has been turned into a COG (you should have one image available and it should be the COG)
 * try to download a non-Sentinel-2 COG (it should also be fine)

Closes #3989 
