### PR TITLE
Fix users/me endpoint

### DIFF
--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -128,23 +128,6 @@ object Auth0UserService extends Config with LazyLogging {
       }
   }
 
-  def getAuth0User(userId: String)(
-      implicit xa: Transactor[IO]): Future[UserWithOAuth] = {
-    val query: Future[Auth0User] = for {
-      bearerToken <- authBearerTokenCache.get(1)
-      auth0User <- requestAuth0User(userId, bearerToken)
-    } yield auth0User
-    query.flatMap { auth0User =>
-      UserDao.getUserById(userId).transact(xa).unsafeToFuture().map {
-        case Some(user: User) =>
-          UserWithOAuth(user, auth0User)
-        case _ =>
-          throw new Auth0Exception(StatusCodes.NotFound,
-                                   "Unable to find user in database.")
-      }
-    }
-  }
-
   def requestAuth0User(
       userId: String,
       bearerToken: ManagementBearerToken): Future[Auth0User] = {

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -44,7 +44,7 @@ trait UserRoutes
           get { getUserRoles }
         } ~
         pathEndOrSingleSlash {
-          get { getAuth0User } ~
+          get { getDbOwnUser } ~
             patch { updateAuth0User } ~
             put { updateOwnUser }
         }
@@ -80,10 +80,8 @@ trait UserRoutes
     }
   }
 
-  def getAuth0User: Route = authenticate { user =>
-    complete {
-      Auth0UserService.getAuth0User(user.id)
-    }
+  def getDbOwnUser: Route = authenticate { user =>
+    complete(UserDao.unsafeGetUserById(user.id).transact(xa).unsafeToFuture())
   }
 
   def updateAuth0User: Route = authenticate { user =>


### PR DESCRIPTION
## Overview

This PR updats the `users/me` endpoint so that it returns the user object from db based on the authenticated requesting user's id.

### Checklist

- ~Styleguide updated, if necessary~
- [X] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

~I will check off the spec item once a PR is made for it.~
**Updated spec in here:**
https://github.com/raster-foundry/raster-foundry-api-spec/pull/45


## Testing Instructions

 * Grab a token
 * `GET` to `/api/users/me` -- it should return an user object of the requesting user with all fields a user has

Closes #3910 
