### PR TITLE
Add cron task to clean up Coursier cache

### DIFF
--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -9,10 +9,6 @@
   notify:
     - Restart Jenkins
   with_items:
-    - { regexp: '(.*<useSecurity>).*(</useSecurity>.*)',
-        line: '\1false\2',
-        state: present,
-        backrefs: yes }
     - { regexp: '(.*<numExecutors>)\d+(</numExecutors>.*)',
         line: '\g<1>2\g<2>',
         state: present,

--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -85,3 +85,12 @@
     job: find /var/lib/jenkins/workspace/ -path "*/.ivy/*" -delete
     state: "present"
   changed_when: False
+
+- name: Setup weekly Coursier cleanup cron task
+  cron:
+    name: "coursier-cleanup"
+    user: "root"
+    special_time: "weekly"
+    job: find /var/lib/jenkins/workspace/ -path "*/.coursier-cache/*" -delete
+    state: "present"
+  changed_when: False


### PR DESCRIPTION
## Overview

Add an additional cron task that cleans up the Jenkins workspace Coursier cache weekly.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~

- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Notes

I also removed the `useSecurity` resetting via `config.xml` because Jenkins appears to reset it back to `true` after every restart.

## Testing Instructions

- Install dependent Ansible roles
- Execute `ansible-playbook` against the current Jenkins instance

```bash
$ ansible-playbook -i deployment/ansible/inventory/jenkins deployment/ansible/raster-foundry-jenkins.yml
```

- Ensure `Setup weekly Coursier cleanup cron task` task is marked as OK
- SSH into the Jenkins machine and ensure that the `root` cron tab was updated

```bash
ubuntu@ip-172-31-52-80:~$ sudo crontab -l | grep coursier
#Ansible: coursier-cleanup
@weekly find /var/lib/jenkins/workspace/ -path "*/.coursier-cache/*" -delete
```

Fixes #4031 