### PR TITLE
Remove default argument from page with ordering method

### DIFF
--- a/app-backend/api/src/main/scala/categories/Routes.scala
+++ b/app-backend/api/src/main/scala/categories/Routes.scala
@@ -50,7 +50,7 @@ trait ToolCategoryRoutes
       complete {
         ToolCategoryDao.query
           .filter(combinedParams)
-          .page(page)
+          .page(page, fr"")
           .transact(xa)
           .unsafeToFuture
       }

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -80,7 +80,7 @@ trait DatasourceRoutes
               datasourceParams.groupQueryParameters.groupId
             )
             .filter(datasourceParams)
-            .page(page)
+            .page(page, fr"")
             .transact(xa)
             .unsafeToFuture
         }

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -72,7 +72,7 @@ trait ExportRoutes
           ExportDao.query
             .filter(queryParams)
             .filter(user)
-            .page(page)
+            .page(page, fr"")
             .transact(xa)
             .unsafeToFuture()
         }

--- a/app-backend/api/src/main/scala/license/LicenseRoutes.scala
+++ b/app-backend/api/src/main/scala/license/LicenseRoutes.scala
@@ -36,7 +36,8 @@ trait LicenseRoutes
 
   def listLicenses: Route = authenticate { user =>
     withPagination { pageRequest =>
-      complete(LicenseDao.query.page(pageRequest).transact(xa).unsafeToFuture)
+      complete(
+        LicenseDao.query.page(pageRequest, fr"").transact(xa).unsafeToFuture)
     }
   }
 

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -591,7 +591,7 @@ trait ProjectRoutes
             AnnotationDao.query
               .filter(fr"project_id=$projectId")
               .filter(queryParams)
-              .page(page)
+              .page(page, fr"")
               .transact(xa)
               .unsafeToFuture
               .map { p =>

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -161,7 +161,7 @@ trait ShapeRoutes
               queryParams.groupQueryParameters.groupId
             )
             .filter(queryParams)
-            .page(page)
+            .page(page, fr"")
             .transact(xa)
             .unsafeToFuture()
             .map { p =>

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -44,7 +44,11 @@ trait ToolTagRoutes
   def listToolTags: Route = authenticate { user =>
     (withPagination) { (page) =>
       complete {
-        ToolTagDao.query.filter(user).page(page).transact(xa).unsafeToFuture()
+        ToolTagDao.query
+          .filter(user)
+          .page(page, fr"")
+          .transact(xa)
+          .unsafeToFuture()
       }
     }
   }

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -82,7 +82,7 @@ trait ToolRunRoutes
                      runParams.groupQueryParameters.groupType,
                      runParams.groupQueryParameters.groupId)
           .filter(runParams)
-          .page(page)
+          .page(page, fr"")
           .transact(xa)
           .unsafeToFuture
       }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -150,7 +150,7 @@ trait ToolRoutes
               combinedToolQueryParameters.groupQueryParameters.groupId
             )
             .filter(combinedToolQueryParameters)
-            .page(page)
+            .page(page, fr"")
             .transact(xa)
             .unsafeToFuture
         }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -51,7 +51,7 @@ trait UploadRoutes
           UploadDao.query
             .filter(user)
             .filter(queryParams)
-            .page(page)
+            .page(page, fr"")
             .transact(xa)
             .unsafeToFuture
         }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/AoiDao.scala
@@ -76,7 +76,7 @@ object AoiDao extends Dao[AOI] {
   // TODO embed shape into aoi
   def listAOIs(projectId: UUID,
                page: PageRequest): ConnectionIO[PaginatedResponse[AOI]] =
-    query.filter(fr"project_id = ${projectId}").page(page)
+    query.filter(fr"project_id = ${projectId}").page(page, fr"")
 
   def listAuthorizedAois(
       user: User,
@@ -94,7 +94,7 @@ object AoiDao extends Dao[AOI] {
         AoiDao.query
           .filter(aoiQueryParams)
           .filter(authFilterF)
-          .page(page)
+          .page(page, fr"")
       }
     } yield { aois }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -302,9 +302,8 @@ object Dao {
     }
 
     /** Provide a list of responses within the PaginatedResponse wrapper */
-    def page(
-        pageRequest: PageRequest,
-        orderClause: Fragment): ConnectionIO[PaginatedResponse[Model]] =
+    def page(pageRequest: PageRequest,
+             orderClause: Fragment): ConnectionIO[PaginatedResponse[Model]] =
       page(pageRequest, selectF, countF, orderClause)
 
     def listQ(pageRequest: PageRequest): Query0[Model] =

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -304,7 +304,7 @@ object Dao {
     /** Provide a list of responses within the PaginatedResponse wrapper */
     def page(
         pageRequest: PageRequest,
-        orderClause: Fragment = fr""): ConnectionIO[PaginatedResponse[Model]] =
+        orderClause: Fragment): ConnectionIO[PaginatedResponse[Model]] =
       page(pageRequest, selectF, countF, orderClause)
 
     def listQ(pageRequest: PageRequest): Query0[Model] =

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
@@ -32,7 +32,7 @@ object DatasourceDao extends Dao[Datasource] {
     : ConnectionIO[PaginatedResponse[Datasource]] = {
     DatasourceDao.query
       .filter(params)
-      .page(page)
+      .page(page, fr"")
   }
 
   def create(datasource: Datasource, user: User): ConnectionIO[Datasource] = {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/MapTokenDao.scala
@@ -104,7 +104,7 @@ object MapTokenDao extends Dao[MapToken] {
         MapTokenDao.query
           .filter(mapTokenParams)
           .filter(authFilterF)
-          .page(page)
+          .page(page, fr"")
       }
     } yield { mapTokens }
   }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/OrganizationDao.scala
@@ -336,7 +336,7 @@ object OrganizationDao extends Dao[Organization] with LazyLogging {
         .viewFilter(user)
         .filter(fr"platform_id=${platformId}")
         .filter(searchParams)
-        .page(pageRequest)
+        .page(pageRequest, fr"")
     }
 
     for {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/PlatformDao.scala
@@ -41,7 +41,7 @@ object PlatformDao extends Dao[Platform] {
 
   def listPlatforms(
       page: PageRequest): ConnectionIO[PaginatedResponse[Platform]] =
-    query.page(page)
+    query.page(page, fr"")
 
   def listMembers(
       platformId: UUID,

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -62,7 +62,7 @@ object ProjectDao extends Dao[Project] {
       params.groupQueryParameters.groupType,
       params.groupQueryParameters.groupId
     ).filter(params)
-      .page(page)
+      .page(page, fr"")
       .flatMap(projectsToProjectsWithRelated)
   }
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -92,7 +92,7 @@ object TeamDao extends Dao[Team] {
       .filter(fr"organization_id = ${organizationId}")
       .filter(fr"is_active = true")
       .filter(qp)
-      .page(page)
+      .page(page, fr"")
   }
 
   def listMembers(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -133,7 +133,7 @@ class ProjectDaoSpec extends FunSuite with Matchers with Checkers with DBTestCon
               ProjectDao
                 .authQuery(dbUser, ObjectType.Project)
                 .filter(dbUser)
-                .page(pageRequest)
+                .page(pageRequest, fr"")
                 .flatMap(ProjectDao.projectsToProjectsWithRelated)
             }
           } yield { listedProjects }


### PR DESCRIPTION
## Overview

This PR removes a default argument from one of the implementations of `page` in `Dao.QueryBuilder`,
since that for some mysterious reason causes `assembly` to throw the method straight into the
garbage.

### Checklist

- [x] Styleguide updated, if necessary -- I refuse to add "don't add default arguments to `page` implementations in `Dao.QueryBuilder` because it causes `assembly` to throw the method straight into the garbage" to the style guide. It's too absurd and shouldn't be our problem. Looking at you, `sbt`/`assembly`.
- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Output of decompiling the assembled api-server jar, searching for `page` in `Dao.java`:

```java
 *  com.azavea.rf.database.Dao$QueryBuilder$$anonfun$page
        public <T> Free<connection.ConnectionOp, List<T>> pageOffset(PageRequest pageRequest, composite.Composite<T> evidence$3) {
            fragment.Fragment qual$1 = this.selectF().$plus$plus(package$.MODULE$.Fragments().whereAndOpt(this.filters())).$plus$plus(Page$.MODULE$.apply(pageRequest, Page$.MODULE$.apply$default$2()));
        public <T> Free<connection.ConnectionOp, PaginatedResponse<T>> page(PageRequest pageRequest, fragment.Fragment selectF, fragment.Fragment countF, fragment.Fragment orderClause, composite.Composite<T> evidence$4) {
            fragment.Fragment qual$2 = selectF.$plus$plus(package$.MODULE$.Fragments().whereAndOpt(this.filters())).$plus$plus(orderClause).$plus$plus(Page$.MODULE$.apply(pageRequest, Page$.MODULE$.apply$default$2()));
            return qual$2.query(x$20, x$21).to(List$.MODULE$.canBuildFrom()).flatMap(new Serializable(this, pageRequest, countF){
                public final PageRequest pageRequest$1;
                public final Free<connection.ConnectionOp, PaginatedResponse<T>> apply(List<T> page2) {
                    return qual$3.query(x$22, x$23).unique().map(new Serializable(this, page2){
                        private final /* synthetic */ QueryBuilder$$anonfun$page$1 $outer;
                        private final List page$1;
                            boolean hasPrevious = this.$outer.pageRequest$1.offset() > 0;
                            boolean hasNext2 = this.$outer.pageRequest$1.offset() * this.$outer.pageRequest$1.limit() + 1 < count2;
                            return new PaginatedResponse<A>(count2, hasPrevious, hasNext2, this.$outer.pageRequest$1.offset(), this.$outer.pageRequest$1.limit(), this.page$1);
                            this.page$1 = page$1;
                    this.pageRequest$1 = pageRequest$1;
        public Free<connection.ConnectionOp, PaginatedResponse<Model>> page(PageRequest pageRequest, fragment.Fragment orderClause) {
            return this.page(pageRequest, this.selectF(), this.countF(), orderClause, this.evidence$2);
        public query.Query0<Model> listQ(PageRequest pageRequest) {
            fragment.Fragment qual$4 = this.selectF().$plus$plus(package$.MODULE$.Fragments().whereAndOpt(this.filters())).$plus$plus(Page$.MODULE$.apply(new Some<PageRequest>(pageRequest)));
        public Free<connection.ConnectionOp, List<Model>> list(PageRequest pageRequest) {
            return this.listQ(pageRequest).to(List$.MODULE$.canBuildFrom());
```

### Notes

We've run into this once before but I'm having trouble finding a reference to it. I'm going to cowboy this in once CI passes.

## Testing Instructions

 * `./scripts/console api-server bash`
 * Get a decompiler -- I used CFR
 * `./sbt api/assembly`
 * `java -jar cfr_0_132.jar --jarfilter 'com.azavea.rf.database.Dao' --outputdir uncompile /path/to/rf-server.jar`
 * find `Dao.java`, `cat Dao.java | grep page`, confirm that the methods are present
