### PR TITLE
Only send email on third batch attempt or successful export

### DIFF
--- a/app-tasks/rf/src/rf/cli.py
+++ b/app-tasks/rf/src/rf/cli.py
@@ -3,7 +3,6 @@
 """Console script for Raster Foundry"""
 
 import logging
-import os
 
 import click
 
@@ -16,13 +15,6 @@ from .commands import (
 )
 
 logger = logging.getLogger('rf')
-
-
-# The max number of retries is currently hardcoded in commands/export.py
-# and batch.tf in the deployment repo. Please make sure that all 3 areas are
-# updated if this needs to be changed to a configurable variable
-if int(os.getenv('AWS_BATCH_JOB_ATTEMPT', '-1')) > 3:
-    raise Exception('Failing async task early after suspicious repeated failures')
 
 
 @click.group()

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -54,8 +54,8 @@ def export(export_id):
         final_status = 'FAILED'
         raise e
     finally:
-        # The max number of retries is currently hardcoded in ../cli.py and batch.tf
-        # in the deployment repo. Please make sure that all 3 areas are updated if
+        # The max number of retries is currently hardcoded in batch.tf
+        # in the deployment repo. Please make sure that both areas are updated if
         # this needs to be changed to a configurable variable
         if final_status == 'EXPORTED' or int(RETRY) >= 3:
             logger.info('Sending email notifications for export %s on try: %s', export_id, RETRY)


### PR DESCRIPTION
## Overview
Max retry attempts is hardcoded because it's silly to do a boto call to figure
it out when it's hardcoded in batch job definition anyways

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
Failing export doesn't send email
```
root@d5a280619e52:/# AWS_BATCH_JOB_ATTEMPT=2 rf export 057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
INFO:rf.commands.export:Creating Export Definition
INFO:rf.commands.export:Creating export definition for 057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
INFO:rf.commands.export:Running Command java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main create_export_def 057e7a7f-3cea-4f8f-87cb-f1a43dcf431c rasterfoundry-development-data-us-east-1 export-definitions/057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
[main] INFO  - Raster-Foundry-Hikari-Pool - Starting...
[main] INFO  - Raster-Foundry-Hikari-Pool - Start completed.
[main] INFO  - Creating output definition
[main] INFO  - Created output definition for s3://rasterfoundry-development-data-us-east-1/user-exports/auth0%7C59318a9d2fbbca3e16bcfc92/e3ad54f1-9c65-4b7d-957d-f903a3992679
[main] INFO  - Creating input definition
[main] INFO  - Created input definition
[main] INFO  - Uploading export definition 057e7a7f-3cea-4f8f-87cb-f1a43dcf431c to S3 at s3://rasterfoundry-development-data-us-east-1/export-definitions/057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
[main] INFO  - Wrote export definition: 1
[DEBUG] [09/19/2018 18:00:10.413] [main] [EventStream(akka://create_export_def-system)] logger log1-Logging$DefaultLogger started
[DEBUG] [09/19/2018 18:00:10.413] [main] [EventStream(akka://create_export_def-system)] Default Loggers started
[DEBUG] [09/19/2018 18:00:10.443] [create_export_def-system-shutdown-hook-1] [CoordinatedShutdown(akka://create_export_def-system)] Starting coordinated shutdown from JVM shutdown hook
[DEBUG] [09/19/2018 18:00:10.450] [create_export_def-system-shutdown-hook-1] [CoordinatedShutdown(akka://create_export_def-system)] Performing phase [before-service-unbind] with [0] tasks
[DEBUG] [09/19/2018 18:00:10.455] [create_export_def-system-akka.actor.default-dispatcher-5] [EventStream] shutting down: StandardOutLogger
INFO:rf.commands.export:Created export definition for 057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
INFO:rf.commands.export:Retrieving Export Definition s3://rasterfoundry-development-data-us-east-1/export-definitions/057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
INFO:rf.commands.export:Downloading export defintion s3://rasterfoundry-development-data-us-east-1/export-definitions/057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
INFO:rf.commands.export:Created Working Directory /tmp/tmpHem4tz
INFO:rf.commands.export:Rewriting Export Definition
INFO:rf.commands.export:Rewrote export definition to /tmp/tmpHem4tz/export_definition.json
INFO:rf.commands.export:Preparing to Run Export
INFO:rf.commands.export:Output from export command was:                         
2018-09-19 18:00:12,693 [main] WARN  org.apache.hadoop.util.NativeCodeLoader -  Unable to load native-hadoop library for your platform... using builtin-java classes where applicable

INFO:rf.commands.export:Finished exporting file:///tmp/tmpHem4tz/export_definition.json in spark local
INFO:rf.commands.export:Post Processing Tiffs
INFO:rf.commands.export:Retrieving Export: 057e7a7f-3cea-4f8f-87cb-f1a43dcf431c
INFO:rf.commands.export:Found 1 files to merge
INFO:rf.commands.export:Running Merge Command: gdal_merge.py -o /tmp/tmpHem4tz/combined.tiff /tmp/tmpHem4tz/9-17-12-057e7a7f-3cea-4f8f-87cb-f1a43dcf431c.tiff
Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.
0Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.
Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.
Warning 1: TIFFReadDirectory:Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples.
...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.commands.export:Running Warp Command: gdalwarp -co COMPRESS=LZW -co TILED=YES -crop_to_cutline -cutline /tmp/tmpHem4tz/cut.json /tmp/tmpHem4tz/combined.tiff /tmp/tmpHem4tz/export.tiff
ERROR 1: Cutline feature without a geometry.
ERROR:rf.commands.export:Output from failed command: None
INFO:rf.commands.export:Export failed, on try 2/3
Traceback (most recent call last):
  File "/usr/local/bin/rf", line 11, in <module>
    load_entry_point('rf==0.1.0', 'console_scripts', 'rf')()
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rf-0.1.0-py2.7.egg/rf/utils/exception_reporting.py", line 24, in func_wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/rf-0.1.0-py2.7.egg/rf/commands/export.py", line 51, in export
    raise e
subprocess.CalledProcessError: Command '['gdalwarp', '-co', 'COMPRESS=LZW', '-co', 'TILED=YES', '-crop_to_cutline', '-cutline', '/tmp/tmpHem4tz/cut.json', '/tmp/tmpHem4tz/combined.tiff', '/tmp/tmpHem4tz/export.tiff']' returned non-zero exit status 1
```


### Notes
Hardcoded the max retries to 3 for now, because we don't have it in an env var and it's hardcoded into the batch task definition

## Testing Instructions
* run `./sbt batch/assembly`
* Rebuild your batch container `docker-compose build batch`
* Create an export without a defined shape (these fail right now)
* run `AWS_BATCH_JOB_ATTEMPT=2 rf export <export id>` in your batch container and verify that it doesn't attempt to send an email
* run `AWS_BATCH_JOB_ATTEMPT=3 rf export <export id>` in your batch container and verify that it attempts to send an email
* Create an export with a shape (it should succeed)
* run `AWS_BATCH_JOB_ATTEMPT=2 rf export <2nd export id>` and verify that it tries to send an email

Closes #3964
