### PR TITLE
Fix band selection for singleband mosaics

### DIFF
--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -176,6 +176,40 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     )
   }
 
+  def layerSinglebandTileForExtent(layerId: UUID, zoom: Int, extent: Extent, band: Int):
+      OptionT[Future, Tile] = {
+    val cacheKey =
+      s"extent-tile-$layerId-$zoom-${extent.xmin}-${extent.ymin}-${extent.xmax}-${extent.ymax}-${band}"
+    OptionT(
+      timedFuture("layer-for-tile-extent-cache")(
+        rfCache.caching(cacheKey, doCache = cacheConfig.layerTile.enabled)(
+          timedFuture("layer-for-tile-extent-s3")(
+            Future {
+              Try {
+                S3CollectionLayerReader(store)
+                  .query[SpatialKey,
+                         MultibandTile,
+                         TileLayerMetadata[SpatialKey]](
+                    LayerId(layerId.toString, zoom))
+                  .where(Intersects(extent))
+                  .result
+                  .stitch
+                  .crop(extent)
+                  .tile
+                  .resample(256, 256)
+              } match {
+                case Success(tile) => Option(tile.band(band))
+                case Failure(e) =>
+                  logger.error(
+                    s"Query layer $layerId at zoom $zoom for $extent: ${e.getMessage}")
+                  None
+              }
+            }
+          ))
+      )
+    )
+  }
+
   val tileResolver =
     new TileResolver(implicitly[Transactor[IO]], implicitly[ExecutionContext])
 

--- a/app-backend/tile/src/main/scala/LayerCache.scala
+++ b/app-backend/tile/src/main/scala/LayerCache.scala
@@ -176,8 +176,10 @@ object LayerCache extends Config with LazyLogging with KamonTrace {
     )
   }
 
-  def layerSinglebandTileForExtent(layerId: UUID, zoom: Int, extent: Extent, band: Int):
-      OptionT[Future, Tile] = {
+  def layerSinglebandTileForExtent(layerId: UUID,
+                                   zoom: Int,
+                                   extent: Extent,
+                                   band: Int): OptionT[Future, Tile] = {
     val cacheKey =
       s"extent-tile-$layerId-$zoom-${extent.xmin}-${extent.ymin}-${extent.xmax}-${extent.ymax}-${band}"
     OptionT(

--- a/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
@@ -260,6 +260,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
       bandOverride: Int
   )(implicit xa: Transactor[IO]): OptionT[Future, MultibandTile] =
     traceName(s"SingleBandMosaic.render(${projectId}-band-$bandOverride)") {
+      logger.info("Yeah definitely invoked")
       val zoom: Int = zoomOption.getOrElse(8)
       val futureTiles
         : Future[Seq[(MultibandTile, Array[Histogram[Double]])]] = {

--- a/app-backend/tile/src/main/scala/tool/TileResolver.scala
+++ b/app-backend/tile/src/main/scala/tool/TileResolver.scala
@@ -444,7 +444,6 @@ class TileResolver(xaa: Transactor[IO], ec: ExecutionContext)
           .value
           .map({ maybeTile =>
             {
-              println("got a tile")
               maybeTile match {
                 case Some(tile) =>
                   val t =

--- a/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
+++ b/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
@@ -80,34 +80,13 @@ class InputNodeController {
     fetchDatasources(projectId) {
         if (this.selectedProject) {
             this.fetchingDatasources = true;
-            this.projectService.getAllProjectScenes(
-                {
-                    projectId: projectId,
-                    pending: false
-                }
-            ).then(({scenes})=> {
-                const datasourcesP = this.$q.all(
-                    _.map(
-                        _.uniqBy(scenes, scene => scene.datasource.id),
-                        scene => this.sceneService.datasource(scene)
-                    )
-                );
-                datasourcesP.then(datasources => {
-                    const previousBands = this.bands ? this.bands.slice(0) : false;
+            this.projectService.getProjectDatasources(projectId).then(
+                datasources => {
                     this.datasources = datasources;
                     this.bands = this.datasourceService.getUnifiedBands(this.datasources);
-                    if (
-                        previousBands &&
-                        !_.isEqual(
-                            angular.toJson(previousBands),
-                            angular.toJson(this.bands)
-                        )
-                    ) {
-                        this.removeBand();
-                    }
                     this.fetchingDatasources = false;
-                });
-            });
+                }
+            );
         }
     }
 

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -83,8 +83,7 @@ export default (app) => {
                         url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/scenes/`,
                         params: {
                             projectId: '@projectId'
-                        },
-                        isArray: true
+                        }
                     },
                     projectDatasources: {
                         method: 'GET',
@@ -335,39 +334,6 @@ export default (app) => {
         getProjectDatasources(projectId) {
             return this.Project.projectDatasources({projectId}).$promise;
         }
-
-
-        /** Return all scenes in a single collection, making multiple requests if necessary
-         *
-         * @param {object} params to pass as query params
-         * @return {Promise} promise that will resolve when all scenes are available
-         */
-        // getAllProjectScenes(params) {
-        //     let pageSize = 30;
-        //     let firstPageParams = Object.assign({}, params, {
-        //         pageSize: pageSize,
-        //         page: 0
-        //         // sort: 'createdAt,desc'
-        //     });
-        //     let firstRequest = this.getProjectScenes(firstPageParams);
-
-        //     return firstRequest.then((res) => {
-        //         const count = res.count;
-        //         const scenes = res.results;
-        //         let arraySize = Math.max(Math.floor(count / pageSize) - 1, 0);
-        //         const requests = Array(arraySize)
-        //               .fill().map((x, page) => {
-        //                   return this.getProjectScenes(Object.assign({}, params, {
-        //                       pageSize,
-        //                       page: page + 1,
-        //                       sort: 'createdAt,desc'
-        //                   })).then((pageResponse) => pageResponse.results);
-        //               });
-        //         return this.$q.all(requests).then((sceneChunks) => {
-        //             return {count, scenes: scenes.concat(_.flatten(sceneChunks))};
-        //         });
-        //     });
-        // }
 
         getProjectStatus(projectId) {
             return this.$q.all({


### PR DESCRIPTION
## Overview

This PR fixes band selection for single band mosaics. The original goal was to fix subtraction, but subtraction appeared to be the only broken op only because x - y = 0 always, so subtracting a band from itself always had worse results than adding or multiplying a band. Division should have had the same issue, but was unchecked.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/5702984/45888324-0f202180-bdbe-11e8-8352-fa8d9001e52d.png)

### Notes

There's still a "cannot cache object that's too big" error that happens, but you can ignore it. I'm not sure what's getting cached there but it doesn't hurt anything.

The demo image is histograms for a project with avro and cog scenes, up to you if you want to replicate that.

Look on my horrible colormap and despair!

## Testing Instructions

 * take a project to the lab (don't try to view it as a project first because there's a missing env variable right now and the tile server will die)
 * subtract two bands
 * the hist from the subtraction should have more than one value and the band histograms should be different if they're different bands

Closes #4057 
