### PR TITLE
Paginate and fix AOI scene approval

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.controller.js
@@ -1,21 +1,16 @@
 import _ from 'lodash';
+import {Set} from 'immutable';
 
 export default class AOIApproveController {
     constructor(
         $scope, $state, $q, $log, $window, $stateParams,
         projectService, projectEditService, mapService,
+        paginationService,
         RasterFoundryRepository
     ) {
         'ngInject';
+        $scope.autoInject(this, arguments);
         this.$parent = $scope.$parent.$ctrl;
-        this.$state = $state;
-        this.$q = $q;
-        this.$log = $log;
-        this.$window = $window;
-        this.$stateParams = $stateParams;
-        this.projectService = projectService;
-        this.projectEditService = projectEditService;
-        this.mapService = mapService;
         this.repository = {
             name: 'Raster Foundry',
             service: RasterFoundryRepository
@@ -24,66 +19,84 @@ export default class AOIApproveController {
     }
 
     $onInit() {
+        this.resetAllScenes();
+        this.resetStatusSets();
+    }
+
+    fetchPage(page = this.$state.params.page || 1) {
+        delete this.fetchError;
         this.pendingSceneList = [];
-        this.$parent.getPendingSceneList().then(pendingScenes => {
-            this.pendingSceneList = _(pendingScenes.scenes).uniqBy('id').compact().value();
-            this.resetAllScenes();
-            this.sceneStatusCounts = this.getSceneStatusCount();
+        const currentQuery = this.projectService.getProjectScenes(
+            this.$parent.projectId, {
+                pending: true,
+                pageSize: 30,
+                page: page - 1
+            }
+        ).then((paginatedResponse) => {
+            this.pendingSceneList = paginatedResponse.results;
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
+            if (this.currentQuery === currentQuery) {
+                delete this.fetchError;
+            }
+        }, (e) => {
+            if (this.currentQuery === currentQuery) {
+                this.fetchError = e;
+            }
+        }).finally(() => {
+            if (this.currentQuery === currentQuery) {
+                delete this.currentQuery;
+            }
         });
+        this.currentQuery = currentQuery;
+        return currentQuery;
+    }
+
+    resetStatusSets() {
+        this.approvedSet = new Set();
+        this.rejectedSet = new Set();
     }
 
     isSceneApproved(scene) {
-        return this.sceneStatuses[scene.id] === 'APPROVED';
+        return this.approvedSet.has(scene.id);
     }
 
     isSceneRejected(scene) {
-        return this.sceneStatuses[scene.id] === 'REJECTED';
+        return this.rejectedSet.has(scene.id);
     }
 
     resetScene(scene) {
-        this.sceneStatuses[scene.id] = null;
-        this.sceneStatusCounts = this.getSceneStatusCount();
+        this.approvedSet = this.approvedSet.delete(scene.id);
+        this.rejectedSet = this.rejectedSet.delete(scene.id);
     }
 
     toggleSceneApproval(scene) {
-        this.sceneStatuses[scene.id] = this.isSceneApproved(scene) ? null : 'APPROVED';
-        this.sceneStatusCounts = this.getSceneStatusCount();
+        this.rejectedSet = this.rejectedSet.delete(scene.id);
+        this.approvedSet = this.approvedSet.add(scene.id);
     }
 
     toggleSceneRejection(scene) {
-        this.sceneStatuses[scene.id] = this.isSceneRejected(scene) ? null : 'REJECTED';
-        this.sceneStatusCounts = this.getSceneStatusCount();
+        this.approvedSet = this.approvedSet.delete(scene.id);
+        this.rejectedSet = this.rejectedSet.add(scene.id);
     }
 
     resetAllScenes() {
-        this.sceneStatuses = this.pendingSceneList.reduce((statuses, scene) => {
-            statuses[scene.id] = null;
-            return statuses;
-        }, {});
-        this.sceneStatusCounts = this.getSceneStatusCount();
+        this.fetchPage(1);
+        this.resetStatusSets();
     }
 
-    approveAllScenes() {
-        this.sceneStatuses = this.pendingSceneList.reduce((statuses, scene) => {
-            statuses[scene.id] = 'APPROVED';
-            return statuses;
-        }, {});
-        this.sceneStatusCounts = this.getSceneStatusCount();
-    }
-
-    rejectAllScenes() {
-        this.sceneStatuses = this.pendingSceneList.reduce((statuses, scene) => {
-            statuses[scene.id] = 'REJECTED';
-            return statuses;
-        }, {});
-        this.sceneStatusCounts = this.getSceneStatusCount();
+    currentPageApproved() {
+        const currentSceneSet = new Set(this.pendingSceneList.map(s => s.id));
+        return currentSceneSet.size === this.approvedSet.intersect(currentSceneSet).size;
     }
 
     toggleAllSceneApproval() {
-        if (this.sceneStatusCounts.APPROVED === this.sceneStatusCounts.TOTAL) {
-            this.resetAllScenes();
+        const currentSceneSet = new Set(this.pendingSceneList.map(s => s.id));
+        if (currentSceneSet.size === this.approvedSet.intersect(currentSceneSet).size) {
+            this.approvedSet = this.approvedSet.subtract(currentSceneSet);
         } else {
-            this.approveAllScenes();
+            this.approvedSet = this.approvedSet.union(currentSceneSet);
+            this.rejectedSet = this.rejectedSet.subtract(currentSceneSet);
         }
     }
 
@@ -103,58 +116,26 @@ export default class AOIApproveController {
         });
     }
 
-    getSceneStatusCount() {
-        return Object.keys(this.sceneStatuses).reduce((counts, id) => {
-            const status = this.sceneStatuses[id];
-            if (status === 'APPROVED') {
-                counts.APPROVED += 1;
-            } else if (status === 'REJECTED') {
-                counts.REJECTED += 1;
-            }
-            counts.TOTAL += 1;
-            return counts;
-        }, {
-            APPROVED: 0,
-            REJECTED: 0,
-            TOTAL: 0
-        });
-    }
-
-    getScenesStatusIds() {
-        return Object.keys(this.sceneStatuses).reduce((statuses, id) => {
-            const status = this.sceneStatuses[id];
-            if (status === 'APPROVED') {
-                statuses.APPROVED.push(id);
-            } else if (status === 'REJECTED') {
-                statuses.REJECTED.push(id);
-            }
-            return statuses;
-        }, {
-            APPROVED: [],
-            REJECTED: []
-        });
-    }
-
     applySceneStatuses() {
-        const scenesToHandle = this.getScenesStatusIds();
         const requests = [];
 
-        if (scenesToHandle.REJECTED.length) {
-            requests.push(
-                this.projectService.removeScenesFromProject(
-                    this.$stateParams.projectid, scenesToHandle.REJECTED));
+        if (this.rejectedSet.size) {
+            requests.push(this.projectService.removeScenesFromProject(
+                this.$stateParams.projectid,
+                this.rejectedSet.toArray()
+            ));
         }
 
-        if (scenesToHandle.APPROVED.length) {
+        if (this.approvedSet.size) {
             requests.push(
               this.projectService.approveScenes(
-                  this.$stateParams.projectid, scenesToHandle.APPROVED));
+                  this.$stateParams.projectid, this.approvedSet.toArray()
+              ));
         }
 
         if (requests.length) {
             this.$q.all(requests).then(() => {
-                this.$state.go('projects.edit');
-                this.$window.location.reload();
+                this.$state.go('projects.edit', {page: 1});
             }, () => {
                 this.$log.error(
               'There was a problem applying the status to one or more scenes');

--- a/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.html
+++ b/app-frontend/src/app/pages/projects/edit/aoi-approve/aoi-approve.html
@@ -17,12 +17,13 @@
                 class="btn btn-primary"
                 style="width: 12rem;"
                 ng-click="$ctrl.applySceneStatuses()"
-                ng-disabled="!$ctrl.sceneStatusCounts.APPROVED && !$ctrl.sceneStatusCounts.REJECTED">
+                ng-disabled="!$ctrl.approvedSet.size && !$ctrl.rejectedSet.size">
           Apply
         </button>
         <button type="button"
                 class="btn dropdown-toggle"
-                ng-class="{'btn-secondary': $ctrl.sceneStatusCounts.APPROVED && $ctrl.sceneStatusCounts.APPROVED === $ctrl.sceneStatusCounts.TOTAL}"
+                ng-class="{'btn-secondary': $ctrl.currentPageApproved()}"
+                ng-title="Select scenes on this page"
                 ng-click="$ctrl.toggleAllSceneApproval()">
           <i class="icon-check"></i>
         </button>
@@ -32,18 +33,20 @@
 </div>
 <div class="list-group" ng-if="$ctrl.pendingSceneList">
   <div class="list-group-item">
-    <span class="no-margin" ng-if="!$ctrl.sceneStatusCounts.APPROVED && !$ctrl.sceneStatusCounts.REJECTED">No scenes selected to approve</span>
-    <span class="no-margin" ng-if="$ctrl.sceneStatusCounts.APPROVED">
-      <ng-pluralize count="$ctrl.sceneStatusCounts.APPROVED"
+    <span class="no-margin" ng-if="!$ctrl.approvedSet.size && !$ctrl.rejectedSet.size">
+      No scenes selected to approve
+    </span>
+    <span class="no-margin" ng-if="$ctrl.approvedSet.size">
+      <ng-pluralize count="$ctrl.approvedSet.size"
                     when="{'one': '1 scene',
                           'other': '{} scenes'
                           }">
       </ng-pluralize>
       <strong class="color-primary">approved</strong>
     </span>
-    <span class="no-margin" ng-if="$ctrl.sceneStatusCounts.APPROVED && $ctrl.sceneStatusCounts.REJECTED">&nbsp;and&nbsp;</span>
-    <span class="no-margin" ng-if="$ctrl.sceneStatusCounts.REJECTED">
-      <ng-pluralize count="$ctrl.sceneStatusCounts.REJECTED"
+    <span class="no-margin" ng-if="$ctrl.approvedSet.size && $ctrl.rejectedSet.size">&nbsp;and&nbsp;</span>
+    <span class="no-margin" ng-if="$ctrl.rejectedSet.size">
+      <ng-pluralize count="$ctrl.rejectedSet.size"
                     when="{'one': '1 scene',
                           'other': '{} scenes'
                           }">
@@ -70,13 +73,12 @@
       <i class="icon-cross"></i>
     </rf-toggle>
   </rf-scene-item>
-  <div class="sidebar-content">
-    <button class="btn btn-block btn-secondary"
-            ng-if="!$ctrl.loadingScenes && $ctrl.lastSceneResult && $ctrl.lastSceneResult.hasNext && !$ctrl.errorMsg"
-            ng-click="$ctrl.getMoreScenes()">
-      Load More Scenes
-    </button>
-  </div>
+  <rf-pagination-controls
+      pagination="$ctrl.pagination"
+      is-loading="$ctrl.currentQuery"
+      on-change="$ctrl.fetchPage(value)"
+      ng-show="!$ctrl.currentQuery && !$ctrl.fetchError"
+  ></rf-pagination-controls>
 </div>
 <div class="sidebar sidebar-extended sidebar-dark"
      ng-show="$ctrl.showFilterPane && !$ctrl.activeScene">

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -49,10 +49,6 @@ class ProjectsEditController {
                         this.fetchPage();
                         this.initColorComposites();
                         this.layerFromProject();
-
-                        if (this.project.isAOIProject) {
-                            this.getPendingSceneList();
-                        }
                     },
                     () => {
                         this.loadingProject = false;
@@ -61,8 +57,6 @@ class ProjectsEditController {
             } else {
                 this.$state.go('projects.list');
             }
-        } else if (this.project.isAOIProject) {
-            this.getPendingSceneList();
         }
         this.resetAnnotations();
         if (this.projectId) {
@@ -160,21 +154,6 @@ class ProjectsEditController {
                 });
             });
         });
-    }
-
-    getPendingSceneList() {
-        if (!this.pendingSceneRequest) {
-            this.pendingSceneRequest = this.projectService.getProjectScenes(this.projectId, {
-                pending: true,
-                pageSize: 30
-            });
-            this.pendingSceneRequest.then((paginatedResponse) => {
-                this.pendingSceneList = paginatedResponse.results;
-                this.pendingScenePagination =
-                    this.paginationService.buildPagination(paginatedResponse);
-            });
-        }
-        return this.pendingSceneRequest;
     }
 
     getIngestingSceneCount() {

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -37,9 +37,9 @@
     </div>
   </div>
   <div class="list-group-item no-border"
-       ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.$parent.pendingSceneCount">
+       ng-if="$ctrl.$parent.project.isAOIProject && $ctrl.pendingSceneCount">
     <div class="alert alert-secondary">
-      <div class="alert-message">{{$ctrl.$parent.pendingSceneCount}} scenes awaiting approval</div>
+      <div class="alert-message">{{$ctrl.pendingSceneCount}} scenes awaiting approval</div>
       <button class="alert-action" ui-sref="projects.edit.aoi-approve">Review Scenes</button>
     </div>
   </div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -5,7 +5,7 @@ class ProjectsScenesController {
     constructor( // eslint-disable-line max-params
         $log, $state, $scope, $timeout,
         modalService, projectService, RasterFoundryRepository, uploadService,
-        sceneService, authService,
+        sceneService, authService, paginationService,
         platform
     ) {
         'ngInject';
@@ -21,6 +21,10 @@ class ProjectsScenesController {
         };
         this.pendingImports = 0;
         this.checkPendingImports();
+        if (!this.$parent.currentRequest) {
+            this.$parent.fetchPage();
+        }
+        this.getPendingSceneCount();
         // eslint-disable-next-line
         let thisItem = this;
         this.treeOptions = {
@@ -31,6 +35,20 @@ class ProjectsScenesController {
                 thisItem.onSceneDropped(e.source.nodesScope.$modelValue);
             }
         };
+    }
+
+    getPendingSceneCount() {
+        if (!this.pendingSceneRequest) {
+            this.pendingSceneRequest = this.projectService.getProjectScenes(this.projectId, {
+                pending: true,
+                pageSize: 0
+            });
+            this.pendingSceneRequest.then((paginatedResponse) => {
+                this.pendingSceneCount =
+                    this.paginationService.buildPagination(paginatedResponse).count;
+            });
+        }
+        return this.pendingSceneRequest;
     }
 
     onSceneDragStart(e) {


### PR DESCRIPTION
## Overview
Fix AOI approval regression fallout from the scene pagination change
### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/45896628-bbeca580-bda2-11e8-8912-97ee908adf2a.png)
![image](https://user-images.githubusercontent.com/4392704/45896646-c4dd7700-bda2-11e8-8712-e34fa326bfc1.png)
![image](https://user-images.githubusercontent.com/4392704/45896738-053cf500-bda3-11e8-9096-ff8ea029a4c0.png)


### Notes
The checkmark button now selects / deselects scenes on the current page instead of all of them


## Testing Instructions

 * Create an AOI project, add some scenes, then use the database to make some of them unapproved
* Verify that the messages showing that some scenes await approval now shows
* Verify that approving and rejecting single scenes works, and the scene count on the scene list page updates appropriately
* Verify that you can move between pages and scenes stay selected. Add scenes on one page and approve from a different one and make sure it works as expected. This can be made easier by reducing the page size in the `aoi-approve.controller.js` `fetchPage()` function to use a smaller page size for testing.

Closes https://github.com/raster-foundry/raster-foundry/issues/4074