### PR TITLE
Fix misnamed function call in project list controller

### DIFF
--- a/app-frontend/src/app/pages/projects/list/list.controller.js
+++ b/app-frontend/src/app/pages/projects/list/list.controller.js
@@ -77,7 +77,7 @@ class ProjectsListController {
 
         modal.result.then((data) => {
             if (data && data.reloadProjectList) {
-                this.populateProjectList(1);
+                this.fetchPage(1);
             }
         });
     }


### PR DESCRIPTION
## Overview
Probably missed when moving to paginated scenes

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions
* Verify that there is no longer a JS error when reloading the scene list after creating a new project

