### PR TITLE
Add database query logging

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -129,7 +129,7 @@ object Dao extends LazyLogging {
         .zip(a.map(s => "'" + s + "'"))
         .flatMap({ case (t1, t2) => List(t1, t2) })
         .mkString("")
-      logger.info(s"""Successful Statement Execution:
+      logger.debug(s"""Successful Statement Execution:
         |
         |  ${logString}
         |


### PR DESCRIPTION
## Overview
Add logs for successful (debug) and unsuccessful (error) database queries

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
Query log for an intentional typo
![image](https://user-images.githubusercontent.com/4392704/45904919-894fa680-bdbc-11e8-9441-15fad094b3f5.png)

### Notes
Our logger seems to simply prepend the logging level, and whatever then outputs it to STDOUT adds its own log level (always info) on top of it. That's kinda stupid.
Also noticed that this only adds logging to the default dao functions... there's a lot more. Should I tackle those in this PR?

## Testing Instructions
 * Verify that logs work for errors, and are not output for normal statements unless you set log level to debug

Closes #3483
