### PR TITLE
Add backsplash generated files to app-migrations .dockerignore

### DIFF
--- a/app-backend/.dockerignore
+++ b/app-backend/.dockerignore
@@ -10,4 +10,5 @@ project/target/*
 target/*
 tile/target/*
 tool/target/*
+backsplash/target/*
 .idea/*


### PR DESCRIPTION
## Overview

Add `backsplash/target` to app-migrations `.dockerignore` to reduce overall image size and prevent build failures that result from generated filenames being too long.

### Checklist

~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness

~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

* see http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/test%252Ftnation%252Ffix-dockerignore/1/console

* Build a `backsplash` assembly JAR, then build a `app-backend` image
```bash
$ docker-compose -f docker-compose.test.yml run --rm --no-deps build backsplash/assembly
$ docker-compose -f docker-compose.test.yml build app-migrations
```

Closes #4093 
