### PR TITLE
Require first and last name for sharing, scrub email

### DIFF
--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/User.scala
@@ -129,6 +129,15 @@ final case class User(id: String,
       case (true, false)                => email
       case (false, false)               => ""
     }
+
+  def withScrubbedName: User = {
+    val scrubbedName =
+      s"${personalInfo.firstName} ${personalInfo.lastName}" match {
+        case " "      => "Anonymous"
+        case fullName => fullName
+      }
+    this.copy(name = scrubbedName)
+  }
 }
 
 object User {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -372,6 +372,7 @@ object ProjectDao extends Dao[Project] with AWSBatch {
                         "Somehow, a user id was lost to the aether")
                     )
                     .head
+                    .withScrubbedName
                 )
               }
             projectsPage.copy(results = withUsers)

--- a/app-frontend/src/app/components/permissions/permissionModal/permissionModal.html
+++ b/app-frontend/src/app/components/permissions/permissionModal/permissionModal.html
@@ -12,7 +12,19 @@
     ></span>
   </div>
   <div class="modal-body" ng-if="$ctrl.objectOwnerId === $ctrl.userId">
-    <form class="add-permission-form" ng-if="!$ctrl.loading">
+    <form class="add-permission-form" ng-if="!$ctrl.loading && (!$ctrl.authService.user.personalInfo.firstName || !$ctrl.authService.user.personalInfo.lastName)">
+      <div class="permission-message">
+        <div>
+            <p>
+              Sharing requires you to have entered your name so that we can let other users know who is sharing with them.
+            </p>
+            <p>
+              <a ui-sref="user.settings.profile({userId: 'me'})">Update your personal information</a>
+            </p>
+        </div>
+      </div>
+    </form>
+    <form class="add-permission-form" ng-if="!$ctrl.loading && $ctrl.authService.user.personalInfo.firstName && $ctrl.authService.user.personalInfo.lastName">
       <label>Grant permissions to</label>
       <div class="permission-all-in-one">
         <select class="form-control subject-select"
@@ -27,7 +39,7 @@
                ng-if="$ctrl.currentTargetSubject === 'PLATFORM'"
                placeholder="Grant VIEW permissions to everyone"
                disabled
-        ></input>
+        />
         <rf-search on-search="$ctrl.onOrganizationSearch(value)"
                    placeholder="Search for {{$ctrl.getCurrentSubject().plural}}"
                    auto-focus="true"


### PR DESCRIPTION
## Overview

This PR:
 
  - scrubs the email from the owner object of projects and instead defaults to the first and last name of the owner. If those are not defined, falls back to "Anonymous"
 - puts a requirement within the UI that the user have a first and last name defined to add permissions on their objects

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/45978988-b0f07a00-c01b-11e8-9cb6-adf654d0f9e8.png)

### Notes

@designmatty @jmorrison1847 Could use some attention/verification for styling and copy

## Testing Instructions

* List projects that are shared with you and notice that the owner object of the returned projects no longer has an email address under the name property
* Test that if you have a first and last name defined that you can share
* Test that if you don't have a first and last name defined that you can not share

Closes https://github.com/azavea/raster-foundry-platform/issues/489