### PR TITLE
Reset lab state when a new analysis is fetched

### DIFF
--- a/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.html
+++ b/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.html
@@ -19,26 +19,30 @@
   <!-- disabled> -->
   <!-- &#x3C;/&#x3E; -->
   <!-- </button> -->
+  <div tooltips tooltip-template="Select a node to preview"
+       tooltip-size="small"
+       tooltip-class="map-control-tooltip"
+       tooltip-side="right">
   <button class="map-control-btn"
           type="button"
-          title="Preview Node"
-          ng-disabled="$ctrl.preventSelecting"
           ng-click="$ctrl.onPreviewClick()"
-          ng-class="{'active': $ctrl.selectingNode === 'preview'}"
-          tooltips tooltip-template="Select a node to preview" tooltip-size="small" tooltip-class="map-control-tooltip"
-          tooltip-side="right">
+          ng-disabled="!$ctrl.canPreview()"
+          ng-class="{'active': $ctrl.canPreview() && $ctrl.selectingNode === 'preview'}">
     <i class="icon-map"></i>
   </button>
+  </div>
+  <div tooltips tooltip-template="Select 2 nodes to compare"
+       tooltip-size="small"
+       tooltip-class="map-control-tooltip"
+       tooltip-side="right">
   <button class="map-control-btn last-of-type"
-          title="Compare Nodes"
           type="button"
           ng-click="$ctrl.onCompareClick()"
-          ng-disabled="$ctrl.preventSelecting"
-          ng-class="{'active': $ctrl.selectingNode === 'compare' || $ctrl.selectingNode === 'select'}"
-          tooltips tooltip-template="Select 2 nodes to compare" tooltip-size="small" tooltip-class="map-control-tooltip"
-          tooltip-side="right">
+          ng-disabled="!$ctrl.canPreview()"
+          ng-class="{'active': $ctrl.canPreview() && ($ctrl.selectingNode === 'compare' || $ctrl.selectingNode === 'select')}">
     <i class="icon-compare"></i>
   </button>
+  </div>
   <!-- <button class="btn btn-default btn-square btn-small" -->
   <!-- type="button" -->
   <!-- title="Add Comment" -->

--- a/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.module.js
+++ b/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.module.js
@@ -48,6 +48,7 @@ class DiagramContainerController {
             selectingNode: state.lab.selectingNode,
             selectedNode: state.lab.selectedNode,
             preventSelecting: state.lab.preventSelecting,
+            analysisErrors: state.lab.analysisErrors,
             reduxState: state
         };
     }
@@ -82,6 +83,9 @@ class DiagramContainerController {
         }
     }
 
+    canPreview() {
+        return !this.preventSelecting && !(this.analysisErrors && this.analysisErrors.size);
+    }
 
     initDiagram() {
         let definition = this.analysis.executionParameters ?

--- a/app-frontend/src/app/components/map/labMap/labMap.module.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.module.js
@@ -67,8 +67,12 @@ class LabMapController {
     }
 
     $onDestroy() {
-        this.mapWrapper.deleteLayers('Measurement');
-        this.drawListener.forEach((listener) => this.map.off(listener));
+        if (this.mapWrapper) {
+            this.mapWrapper.deleteLayers('Measurement');
+        }
+        if (this.drawListener) {
+            this.drawListener.forEach((listener) => this.map.off(listener));
+        }
         this.disableDrawHandlers();
 
         this.mapService.deregisterMap(this.mapId);
@@ -240,8 +244,12 @@ class LabMapController {
     }
 
     disableDrawHandlers() {
-        this.drawPolygonHandler.disable();
-        this.drawPolylineHandler.disable();
+        if (this.drawPolygonHandler) {
+            this.drawPolygonHandler.disable();
+        }
+        if (this.drawPolylineHandler) {
+            this.drawPolylineHandler.disable();
+        }
     }
 
     addMeasureShapeToMap(layer, type) {

--- a/app-frontend/src/app/redux/reducers/node-reducer.js
+++ b/app-frontend/src/app/redux/reducers/node-reducer.js
@@ -69,7 +69,7 @@ export const nodeReducer = typeToReducer({
             });
         },
         ERROR: (state, action) => {
-            return Object.assign({
+            return Object.assign({}, state, {
                 preventSelecting: false,
                 selectingNode: null,
                 selectedNode: null,

--- a/app-frontend/src/assets/styles/sass/components/_map-controls.scss
+++ b/app-frontend/src/assets/styles/sass/components/_map-controls.scss
@@ -46,7 +46,7 @@
   color: $white;
 
   &:hover,
-  &.active {
+  &.active:not(.disabled,:disabled) {
     color: $brand-primary;
     background-color: $shade-normal;
   }
@@ -57,10 +57,10 @@
     z-index: 1;
   }
 
-  &.disabled {
+  &.disabled, &:disabled {
     cursor: not-allowed;
     background: none !important;
-    
+
     > i {
       color: $white;
       opacity: .5;
@@ -71,7 +71,7 @@
     border-radius: 0 0 $border-radius-base $border-radius-base;
     border-bottom: none;
   }
-  
+
   > i {
     font-size: 1.4rem;
   }


### PR DESCRIPTION
## Overview
Fix reducer which was clearing out lab state when it shouldn't be
Fix disabling of node preview buttons when there are analysis errors
Make sure that on lab state init, all values are set correctly (may need further
work)
Reset lab state when loading analysis

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


### Notes
The lab only works using the old tile server right now - to switch back to it, change `TILE_SERVER_LOCATION=http://localhost:8081` to `TILE_SEVER_LOCATION=http://localhost:9101` in `docker-compose.yml`

## Testing Instructions

 * Create a new analysis
* Verify that you cannot use the buttons in the upper left corner of the lab to preview / compare stuff before all the required inputs are filled in
* Fill in project sources
* Preview a node
* Leave the lab, and go back. Verify that the the preview pane is not opened when you enter the lab, and all state is reset to where it should be when you first open the lab.
* mess around with comparing nodes and try to break it. 
* Switch between analyses and verify that things don't break.

Closes #4056
