### PR TITLE
Allow removing users from an organization

### DIFF
--- a/app-frontend/src/app/pages/admin/organization/users/users.module.js
+++ b/app-frontend/src/app/pages/admin/organization/users/users.module.js
@@ -81,7 +81,17 @@ class OrganizationUsersController {
                         this.buildOptions();
                     });
                 }
-            });
+            }, {
+                label: 'Remove user',
+                callback: () => {
+                    this.organizationService.removeUser(
+                        this.platform.id, this.organization.id, user.id
+                    ).then(() => {
+                        return this.fetchPage();
+                    });
+                }
+            }
+            );
         }
         return options;
         /* eslint-enable */


### PR DESCRIPTION
## Overview
Add a "Remove User" button to users for admins

### Checklist

- ~Styleguide updated, if necessary~
- ~Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/46031158-1ac55e00-c0c6-11e8-8259-6e7c1057451b.png)

### Notes
Admins cannot be removed directly - Remove an admin's role in order to allow removing them from the organization. This is not enforced by the API, but I thought it would be sensible to do here.

## Testing Instructions

 * Log in as `systems@rasterfoundry.com`, go to the public org and remove `dev@rasterfoundry.com`
* Log in as `dev@rasterfoundry.com` and verify that things still work (projects, scenes, searching, lab if using old tile server etc)
* Log back in as `systems@rasterfoundry.com` and add `dev@rasterfoundry.com` back to the public org. Accept the invitation on `dev@rasterfoundry.com`
Closes #4070