### PR TITLE
Feature/lk/dont kick off cog ingest

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ProjectDao.scala
@@ -186,6 +186,7 @@ object ProjectDao extends Dao[Project] with AWSBatch {
                   (scenes.ingest_status = ${IngestStatus.Ingesting.toString} :: ingest_status AND
                    (now() - modified_at) > '1 day'::interval))
            AND sub.scene_id = scenes.id
+           AND scene_type = 'AVRO' :: scene_type
          """
     updateStatusQuery.update.run
   }


### PR DESCRIPTION
## Overview
Only change ingest status for AVRO scenes when adding to a project

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions
* Find a cog scene.
* Add the COG scene to a project
* Verify that its ingest status is unchanged
* Verify that there are no logs saying that it will be ingested
Closes #4023