### PR TITLE
Filter out pending scenes from mosaic definitions

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneToProjectDao.scala
@@ -104,6 +104,7 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
       polygonOption.map(polygon =>
         fr"ST_Intersects(scenes.tile_footprint, ${polygon})"),
       Some(fr"scenes_to_projects.project_id = ${projectId}"),
+      Some(fr"scenes_to_projects.accepted = true"),
       Some(fr"scenes.ingest_status = 'INGESTED'")
     )
     val select = fr"""


### PR DESCRIPTION
## Overview

This PR adds a filter to remove pending scenes from mosaic definition construction.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * Open a project with some COG or ingested pending scenes, notice that they are not rendered

Closes #4084 
