### PR TITLE
Fix dropbox dummy session store

### DIFF
--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -44,5 +44,5 @@ class DummySessionStore extends DbxSessionStore {
     }
   }
   def set(s: String): Unit = this.setToken(s)
-  def clear(): Unit = this.clear
+  def clear(): Unit = ()
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -19,7 +19,7 @@ object Version {
   val commonsIO = "2.5"
   val dnsJava = "2.1.8"
   val doobie = "0.5.3"
-  val dropbox = "2.1.1"
+  val dropbox = "3.0.9"
   val elasticacheClient = "1.1.1"
   val ficus = "1.4.0"
   val findbugAnnotations = "3.0.1u2"


### PR DESCRIPTION
## Overview

This PR fixes an infinitely recursive call that was ruining dropbox connection. It also updates the dropbox sdk. It turned out there isn't actually anything wrong with our using the old SDK for what we were using it for, but now we're current, so that's nice I guess.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Notes

The actual problem is that for some reason `DummySessionStore.clear()` was being called somewhere in the dropbox connection flow. That was bad because, e.g.:
 
```scala
@ object Foo {
    def bar(): Unit = this.bar
  }
defined object Foo

@ Foo.bar
```

It never terminates. I don't know why it worked before then suddenly stopped, but anyway it's fixed now.

## Testing Instructions

 * clear your dropbox credential from a user
 * unauthorize the raster foundry dev app from your dropbox account
 * connect your dropbox account again
 * it should succeed and you should have a `dropbox_credential` for that user in the db afterward

Closes #2199 

Closes #3914 