### PR TITLE
Staging frontend bug fix: scene date UTC filter; User profile; AOI datasource filter

### DIFF
--- a/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.html
+++ b/app-frontend/src/app/components/aoiFilterPane/aoiFilterPane.html
@@ -13,13 +13,11 @@
         <a href ng-click="$ctrl.resetAllFilters()" class="btn btn-toggle btn-small btn-block">Clear all filters</a>
       </div>
     </div>
-    <div class="filter-group">
-      <rf-search-select-filter
-        class="filter-group"
-        data-filter="$ctrl.datasourceFilter"
-        on-filter-change="$ctrl.onDatasourceFilterChange(filter, filterParams)">
-      </rf-search-select-filter>
-    </div>
+    <rf-search-select-filter
+      class="filter-group"
+      data-filter="$ctrl.datasourceFilter"
+      on-filter-change="$ctrl.onDatasourceFilterChange(filter, filterParams)">
+    </rf-search-select-filter>
     <div class="filter-group">
       <div class="filter">
         <label>Cloud cover</label>

--- a/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
+++ b/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
@@ -1,6 +1,6 @@
 <div class="filter">
   <label>{{$ctrl.filter.label}}</label>
-  <div class="flex-fill">
+  <div>
     <span ng-if="$ctrl.datefilterPreset">{{$ctrl.datefilterPreset}}</span>
     <span ng-if="!$ctrl.datefilterPreset">{{$ctrl.datefilter.start.calendar()}} to {{$ctrl.datefilter.end.calendar()}}</span>
   </div>
@@ -8,7 +8,7 @@
 <div class="filter">
   <label></label>
   <rf-toggle value="$ctrl.usingUTC" on-change="$ctrl.onSetUTC(value)">
-    &nbsp;<strong>Use UTC dates</strong>
+    <strong>&nbsp;&nbsp;Use UTC dates</strong>
     <span class="icon-help"
           tooltips
           tooltip-template="Scenes are filtered using the UTC definition of midnight 00:00 GMT. Uncheck this to use your local definition of midnight instead. This may result in you seeing scenes with different UTC dates depending on your timezone."
@@ -20,6 +20,6 @@
 </div>
 <div class="filter">
   <label></label>
-  <button class="btn btn-small btn-primary flex-fill"
+  <button class="btn btn-small btn-primary flex-fill btn-block"
           ng-click="$ctrl.openDateRangePickerModal()">{{$ctrl.hasDatetimeFilter ? 'Update ' : 'Set '}}Date</button>
 </div>

--- a/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
+++ b/app-frontend/src/app/components/filters/daterangeFilter/daterangeFilter.html
@@ -4,18 +4,19 @@
     <span ng-if="$ctrl.datefilterPreset">{{$ctrl.datefilterPreset}}</span>
     <span ng-if="!$ctrl.datefilterPreset">{{$ctrl.datefilter.start.calendar()}} to {{$ctrl.datefilter.end.calendar()}}</span>
   </div>
-  <span>
-    <rf-toggle value="$ctrl.usingUTC" on-change="$ctrl.onSetUTC(value)">
-      &nbsp;<strong>Use UTC dates</strong>
-      <span class="icon-help"
-            tooltips
-            tooltip-template="Scenes are filtered using the UTC definition of midnight 00:00 GMT. Uncheck this to use your local definition of midnight instead. This may result in you seeing scenes with different UTC dates depending on your timezone."
-            tooltop-size="small"
-            tooltip-class="rf-tooltip"
-            tooltip-side="left"
-      ></span>
-    </rf-toggle>
-  </span>
+</div>
+<div class="filter">
+  <label></label>
+  <rf-toggle value="$ctrl.usingUTC" on-change="$ctrl.onSetUTC(value)">
+    &nbsp;<strong>Use UTC dates</strong>
+    <span class="icon-help"
+          tooltips
+          tooltip-template="Scenes are filtered using the UTC definition of midnight 00:00 GMT. Uncheck this to use your local definition of midnight instead. This may result in you seeing scenes with different UTC dates depending on your timezone."
+          tooltop-size="small"
+          tooltip-class="rf-tooltip"
+          tooltip-side="bottom"
+    ></span>
+  </rf-toggle>
 </div>
 <div class="filter">
   <label></label>

--- a/app-frontend/src/app/pages/user/settings/profile/profile.html
+++ b/app-frontend/src/app/pages/user/settings/profile/profile.html
@@ -18,15 +18,6 @@
         </div>
       </div>
       <div class="form-group">
-        <label for="name">Name</label>
-        <input id="name"
-               type="text"
-               class="form-control"
-               placeholder="Name"
-               ng-attr-value="{{$ctrl.authService.user.name}}"
-               disabled>
-      </div>
-      <div class="form-group">
         <label for="username">Login email</label>
         <input id="username"
                type="text"

--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_filter.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_filter.scss
@@ -5,6 +5,10 @@
 .filter {
   flex-direction: column;
 
+  &:not(:last-child) {
+    margin-bottom: inherit;
+  }
+
   label {
     color: $shade-normal;
     width: auto;


### PR DESCRIPTION
## Overview

This PR:
 - fixes scene filter pane's date range UTC tooltip bug
 - deletes name field from user profile page
 - fixes AOI params' datasource display bug

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness

### Demo

**AOI filter pane**
<img width="387" alt="screen shot 2018-09-26 at 3 51 24 pm" src="https://user-images.githubusercontent.com/16109558/46106375-7f57ea00-c1a6-11e8-8fb9-c89c272e1b2d.png">

**User profile**
<img width="889" alt="screen shot 2018-09-26 at 4 08 18 pm" src="https://user-images.githubusercontent.com/16109558/46106342-6d764700-c1a6-11e8-8ee4-508665ba444d.png">

**Scene date range filter**
<img width="416" alt="screen shot 2018-09-26 at 4 04 39 pm" src="https://user-images.githubusercontent.com/16109558/46106301-59cae080-c1a6-11e8-9d51-8f99a08a69c2.png">


## Testing Instructions

 * Go to an AOI project and edit AOI parameters, open up the filter pane, notice that there should be no additional divider under datasource dropdown
 * Go to browse scenes, open up the filter pane, notice that date range filter contents should display on three separate lines and that the tooltip shows at the bottom of the cursor
 * Go to user profile page, notice that the previously not editable name field is gone.

Closes #4111 
Closes #4117 
Closes #4087 
