### PR TITLE
Improve error tolerance of histogram backfill

### DIFF
--- a/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/com/azavea/rf/batch/cogMetadata/HistogramBackfill.scala
@@ -60,12 +60,11 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
     for {
       histogram <- getSceneHistogram(cogTuple._2.get)
       inserted <- parse(histogram.toJson.toString).toOption match {
-        case Some(x) if x.toString == "null" | None =>
-          logger.info("Nah my dude none parsed")
+        case Some(x) if x.toString == "null" =>
+          None.pure[IO]
+        case None =>
           None.pure[IO]
         case Some(parsed) =>
-          logger.info("Yeah my dude some parsed")
-          logger.info(s"Parsed: $parsed")
           LayerAttributeDao
             .insertLayerAttribute(
               LayerAttribute(


### PR DESCRIPTION
## Overview

This PR makes it so a single failed insert in histogram backfill doesn't short-circuit the whole game.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * Give an ingested COG in your database an ingest location of `'bogus'` or something else that won't work
 * Assemble batch jar
 * From batch container -- `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main cog-histogram-backfill that-scene-id`
 * It should fail to insert the scene but not be mad at you and it shouldn't end up in `layer_attributes`
 * `java -cp /opt/raster-foundry/jars/rf-batch.jar com.azavea.rf.batch.Main cog-histogram-backfill`
 * everything should insert successfully except the scene you gave a status of `'bogus'` or whatever you picked to