### PR TITLE
Filter imports by ownership

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -246,7 +246,11 @@ trait ObjectPermissions[Model] {
           fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
       // shared to the requesting user due to group membership
       case Some(ownershipType) if ownershipType == "inherited" =>
-        Some(inheritedF ++ fr"&& acrs")
+        if (objectType == ObjectType.Shape) {
+          Some(inheritedF ++ fr"&& acrs")
+        } else {
+          Some(fr"visibility != 'PUBLIC' AND (" ++ inheritedF ++ fr"&& acrs)")
+        }
       // the default
       case _ =>
         Some(fr"(" ++ ownedF ++ fr"OR" ++ visibilityF ++ acrFilterF ++ fr")")

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -243,7 +243,7 @@ trait ObjectPermissions[Model] {
       // shared to the requesting user directly, across platform, or due to group membership
       case Some(ownershipType) if ownershipType == "shared" =>
         Some(
-          fr"(" ++ visibilityF ++ acrFilterF ++ fr") AND owner <> ${user.id}")
+          fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
       // shared to the requesting user due to group membership
       case Some(ownershipType) if ownershipType == "inherited" =>
         Some(inheritedF ++ fr"&& acrs")

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -242,8 +242,7 @@ trait ObjectPermissions[Model] {
         Some(ownedF)
       // shared to the requesting user directly, across platform, or due to group membership
       case Some(ownershipType) if ownershipType == "shared" =>
-        Some(
-          fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
+        Some(fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
       // shared to the requesting user due to group membership
       case Some(ownershipType) if ownershipType == "inherited" =>
         if (objectType == ObjectType.Shape) {

--- a/app-frontend/src/app/components/scenes/importList/importList.html
+++ b/app-frontend/src/app/components/scenes/importList/importList.html
@@ -1,3 +1,10 @@
+<rf-pagination-count
+    ng-if="$ctrl.pagination.count"
+    start-index="$ctrl.pagination.startingItem"
+    end-index="$ctrl.pagination.endingItem"
+    total="$ctrl.pagination.count"
+    item-name="rasters">
+</rf-pagination-count>
 <div class="text-center" ng-show="$ctrl.loading">
   <div>Loading Imports</div>
   <span class="list-placeholder h3">
@@ -24,23 +31,19 @@
     </div>
   </rf-scene-item>
 </div>
-<div class="list-group text-center"
-     ng-if="$ctrl.shouldShowImportList()">
-  <ul uib-pagination
-      items-per-page="$ctrl.lastSceneResult.pageSize"
-      total-items="$ctrl.lastSceneResult.count"
-      ng-model="$ctrl.currentPage"
-      max-size="4"
-      rotate="true"
-      boundary-link-numbers="true"
-      force-ellipses="true"
-      ng-change="$ctrl.populateImportList($ctrl.currentPage)">
-  </ul>
+<div class="list-group text-center">
+  <rf-pagination-controls
+    pagination="$ctrl.pagination"
+    is-loading="$ctrl.currentQuery"
+    on-change="$ctrl.populateImportList(value)"
+    ng-show="$ctrl.shouldShowImportList()"
+  ></rf-pagination-controls>
 </div>
 
 <!-- No imports placeholder -->
 <div ng-if="$ctrl.shouldShowImportBox()">
   <rf-call-to-action-item
+    ng-if="$ctrl.ownershipType == 'owned'"
     title="You haven't imported any scenes"
     class="panel panel-off-white">
     <p class="pb-25">
@@ -51,6 +54,14 @@
     <a class="btn btn-primary" ng-click="$ctrl.importModal()">Import scenes</a>
     <p>
       <a>Getting started with Imports</a>
+    </p>
+  </rf-call-to-action-item>
+  <rf-call-to-action-item
+    ng-if="$ctrl.ownershipType == 'shared'"
+    title="No raster data has been shared with you yet"
+    class="panel panel-off-white">
+    <p class="pb-25">
+      Once another user shares raster data with you or with organizations or teams you're a part of, you'll be able to see it here.
     </p>
   </rf-call-to-action-item>
 </div>

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -473,7 +473,7 @@ function importStates($stateProvider) {
         })
         .state('imports.rasters', {
             title: 'Rasters',
-            url: '/rasters?page',
+            url: '/rasters?page&ownership',
             templateUrl: rasterListTpl,
             controller: 'RasterListController',
             controllerAs: '$ctrl'

--- a/app-frontend/src/app/index.run.js
+++ b/app-frontend/src/app/index.run.js
@@ -22,7 +22,7 @@ function runBlock(
         $state.go('error');
     }
 
-    $rootScope.$on('$stateChangeStart', function (e, toState, params) {
+    $rootScope.$on('$stateChangeStart', function (e, toState, params, fromState) {
         function setupState(route) {
             let appName = BUILDCONFIG.APP_NAME;
             $window.document.title = toState.title ?
@@ -52,6 +52,13 @@ function runBlock(
                 }
             }
         }
+        if (
+            toState.name !== fromState.name &&
+            toState.redirectTo !== fromState.name &&
+            toState.resolve
+        ) {
+            $rootScope.isLoadingResolves = true;
+        }
         // TODO: I'm not sure exactly where this lies on the continuum between awful and the worst
         // thing ever, but it's pretty bad. We should either refactor our app initialization so this
         // is easier, or refactor FeatureFlags to deal in promises.
@@ -65,7 +72,8 @@ function runBlock(
         }
     });
 
-    $rootScope.$on('$stateChangeSuccess', () => {
+    $rootScope.$on('$stateChangeSuccess', (e, toState) => {
+        $rootScope.isLoadingResolves = false;
         modalService.closeActiveModal();
     });
 

--- a/app-frontend/src/app/pages/admin/platform/projects/projects.html
+++ b/app-frontend/src/app/pages/admin/platform/projects/projects.html
@@ -5,7 +5,7 @@
           start-index="$ctrl.pagination.startingItem"
           end-index="$ctrl.pagination.endingItem"
           total="$ctrl.pagination.count"
-          item-name="users"
+          item-name="projects"
           ng-if="!$ctrl.currentQuery"
       >
         <span ng-if="$ctrl.search">while searching for <strong>{{$ctrl.search}}</strong></span>
@@ -24,16 +24,11 @@
     <rf-call-to-action-item
         title="No projects have been shared with the {{$ctrl.platform.name}} platform"
         class="panel panel-off-white"
-        ng-if="!$ctrl.currentQuery && !$ctrl.pagination.count">
+        ng-if="!$ctrl.currentQuery && !$ctrl.fetchError && !$ctrl.search && $ctrl.pagination && !$ctrl.pagination.count">
       <p class="pb-25">
         When users share projects with this platform, they'll be visible here.
         Projects shared with this platform will be accessible to all users.
       </p>
-    </rf-call-to-action-item>
-    <rf-call-to-action-item
-        title="This platform has no projects in it yet"
-        ng-show="!$ctrl.currentQuery && !$ctrl.fetchError && !$ctrl.search && $ctrl.pagination && !$ctrl.pagination.count"
-        class="panel panel-off-white">
     </rf-call-to-action-item>
     <rf-call-to-action-item
         title="Your search didn't return any projects"

--- a/app-frontend/src/app/pages/imports/raster/raster.html
+++ b/app-frontend/src/app/pages/imports/raster/raster.html
@@ -2,14 +2,20 @@
   <div class="row content stack-sm">
     <div class="column-8">
       <!-- Dashboard Header -->
+      <h3>Imports</h3>
       <div class="dashboard-header">
-        <h1 class="h3">Imports</h1>
+        <select class="form-control"
+                ng-model="$ctrl.currentOwnershipFilter"
+        >
+          <option value="owned">Owned by me</option>
+          <option value="shared">Shared with me</option>
+        </select>
         <div class="flex-fill"></div>
         <a class="btn btn-primary" ng-click="$ctrl.importModal()">
           Import scenes
         </a>
       </div>
-      <div class="alert alert-primary" ng-if="$ctrl.pendingImports">
+      <div class="alert alert-primary" ng-if="$ctrl.pendingImports && $ctrl.currentOwnershipFilter == 'owned'">
         <div class="alert-message">
           <ng-pluralize count="$ctrl.pendingImports"
                     when="{'one': '{} import is',
@@ -22,6 +28,7 @@
       <!-- Imports list -->
       <rf-import-list
         platform="$ctrl.platform"
+        ownership-type="$ctrl.currentOwnershipFilter"
       ></rf-import-list>
       <!-- Imports list -->
     </div>

--- a/app-frontend/src/app/pages/imports/raster/raster.module.js
+++ b/app-frontend/src/app/pages/imports/raster/raster.module.js
@@ -1,7 +1,7 @@
 /* global BUILDCONFIG, HELPCONFIG */
 class RasterListController {
     constructor(
-        $scope, $uibModal,
+        $scope, $state, $uibModal,
         authService, uploadService,
         platform
     ) {
@@ -14,6 +14,7 @@ class RasterListController {
         this.HELPCONFIG = HELPCONFIG;
         this.pendingImports = 0;
         this.checkPendingImports();
+        this.currentOwnershipFilter = this.$state.params.ownership || 'owned';
     }
 
     $onDestroy() {

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.html
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.html
@@ -27,7 +27,7 @@
       <div class="alert-message">Any scenes added from this repository will also appear in your imports</div>
     </div>
   </div>
-  <div class="list-group-item" ng-if="$ctrl.sceneCount">
+  <div class="list-group-item" ng-if="$ctrl.sceneCount !== '0'">
     <strong class="color-dark">
       1 - {{$ctrl.sceneList.length}} of {{$ctrl.sceneCount}} scenes
     </strong>

--- a/app-frontend/src/app/services/common/pagination.service.js
+++ b/app-frontend/src/app/services/common/pagination.service.js
@@ -7,21 +7,19 @@ export default (app) => {
         }
 
         buildPagination(paginatedResponse) {
-            let startingItem = paginatedResponse.page * paginatedResponse.pageSize + 1;
-            let endingItem = Math.min(
-                (paginatedResponse.page + 1) * paginatedResponse.pageSize,
-                paginatedResponse.count
-            );
-            if (endingItem === 0) {
-                startingItem = 0;
-            }
             return {
                 pageSize: paginatedResponse.pageSize,
                 show: paginatedResponse.count > paginatedResponse.pageSize,
                 count: paginatedResponse.count,
                 currentPage: paginatedResponse.page + 1,
-                startingItem: startingItem,
-                endingItem: endingItem,
+                startingItem: Math.min(
+                    paginatedResponse.page * paginatedResponse.pageSize + 1,
+                    paginatedResponse.count
+                ),
+                endingItem: Math.min(
+                    (paginatedResponse.page + 1) * paginatedResponse.pageSize,
+                    paginatedResponse.count
+                ),
                 hasNext: paginatedResponse.hasNext,
                 hasPrevious: paginatedResponse.hasPrevious
             };

--- a/app-frontend/src/app/services/common/pagination.service.js
+++ b/app-frontend/src/app/services/common/pagination.service.js
@@ -7,16 +7,21 @@ export default (app) => {
         }
 
         buildPagination(paginatedResponse) {
+            let startingItem = paginatedResponse.page * paginatedResponse.pageSize + 1;
+            let endingItem = Math.min(
+                (paginatedResponse.page + 1) * paginatedResponse.pageSize,
+                paginatedResponse.count
+            );
+            if (endingItem === 0) {
+                startingItem = 0;
+            }
             return {
                 pageSize: paginatedResponse.pageSize,
                 show: paginatedResponse.count > paginatedResponse.pageSize,
                 count: paginatedResponse.count,
                 currentPage: paginatedResponse.page + 1,
-                startingItem: paginatedResponse.page * paginatedResponse.pageSize + 1,
-                endingItem: Math.min(
-                    (paginatedResponse.page + 1) * paginatedResponse.pageSize,
-                    paginatedResponse.count
-                ),
+                startingItem: startingItem,
+                endingItem: endingItem,
                 hasNext: paginatedResponse.hasNext,
                 hasPrevious: paginatedResponse.hasPrevious
             };

--- a/app-frontend/src/tpl-index.html
+++ b/app-frontend/src/tpl-index.html
@@ -39,11 +39,19 @@
         background: rgba(255, 255, 255, 0.50);
         opacity: 0;
         pointer-events: none;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 3147483647;
       }
 
       div.app-loading-indicator.is-visible {
         opacity: 1;
         pointer-events: all;
+      }
+
+      div.app-loading-indicator i.icon-load {
+        font-size: 36px;
       }
     </style>
     <!--[if lt IE 10]>
@@ -51,6 +59,9 @@
     <![endif]-->
     <div class="app-wrapper">
       <div ui-view></div>
+    </div>
+    <div class="app-loading-indicator" ng-class="{'is-visible': isLoadingResolves}">
+      <i class="icon-load animate-spin"></i>
     </div>
 
     {% for (var css in o.htmlWebpackPlugin.files.css) { %}


### PR DESCRIPTION
## Overview

This PR does two things:

  - adds a loading indicator that will be shown when transitioning to states with `resolves`. When a `resolves` async call took longer than expected there was no UI indication that anything was happening. With #4126, this can result in a seemingly unresponsive click for over four seconds.

 - adds ownership based filtering to the imports list. This behaves similar to the projects filtering. The default filter is `owned` and is not initially forced as a query parameter.

**Updated on Oct. 1st:**
It also fixes:
 - scene count on scene browse page
 - the display of lower bound value of pagination count component
 - the item type on platform projects page's pagination
 - `ownership=inherited` case so that `visibility = PUBLIC` is excluded in the filter (except `shape`, which does not have this field)

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

Loading indicator:
![image](https://user-images.githubusercontent.com/2442245/46235148-05ab3200-c347-11e8-9be8-252ac9f025c6.png)

Imports list:
![image](https://user-images.githubusercontent.com/2442245/46235190-37bc9400-c347-11e8-9811-14a316e0c750.png)

![image](https://user-images.githubusercontent.com/2442245/46235199-430fbf80-c347-11e8-8a35-47b2155a299a.png)


## Testing Instructions

 * Test the loading indicator by navigating to a platform, organization, or team page, which should take long enough to view the loading indicator. Ensure it goes away when expected.
 * Test the import list empty state first to make sure the wording makes sense -- go to the imports page and switch to shared scenes (assuming no scenes have been shared with your user)
 * Log in using a different account and share something to the dev account, or vice-versa and check that it appears as expected
* Check query parameters to make sure they match up with what is being displayed.

**Updated on Oct. 1st:**
* Go to a project and browse scenes. Adjust filter so that no scenes found. Notice that the should not show instead of showing something like `1-0 scenes of 0 scenes found`.
* On platform or organization or team object list page, search something to return no result, and notice the pagination count is something like `0-0 of 0 <item> found` -- this may not be ideal, but we could address it in another card

Closes #4124

**Updated on Oct. 1st:**
Closes #4126 
Closes #4128 
