### PR TITLE
Make upload notification quieter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Removed duplicate emails for repeated failures of the same upload [\#4130](https://github.com/raster-foundry/raster-foundry/pull/4130)
 - Use safer options for large tifs when processing uploads and ingests [\#4131](https://github.com/raster-foundry/raster-foundry/pull/4131)
 
 ### Security

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/UploadDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/UploadDao.scala
@@ -117,7 +117,7 @@ object UploadDao extends Dao[Upload] {
               nAffected.pure[ConnectionIO]
           }
           case _ => {
-            logger.info(
+            logger.debug(
               "No need to send notifications, status transition isn't something users care about")
             nAffected.pure[ConnectionIO]
           }

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -14,7 +14,7 @@ from ..utils.io import get_session
 
 logger = logging.getLogger(__name__)
 HOST = os.getenv('RF_HOST')
-
+JOB_ATTEMPT = int(os.getenv('AWS_BATCH_JOB_ATTEMPT', -1))
 
 @click.command(name='process-upload')
 @click.argument('upload_id')
@@ -87,5 +87,8 @@ def process_upload(upload_id):
     except:
         logger.error('Failed to process upload (%s) for user %s with files %s',
                      upload.id, upload.owner, upload.files)
-        upload.update_upload_status('FAILED')
+        if JOB_ATTEMPT >= 3:
+            upload.update_upload_status('FAILED')
+        else:
+            upload.update_upload_status('QUEUED')
         raise


### PR DESCRIPTION
## Overview

This PR checks for the third job attempt before deciding to update upload status and makes the
"not sending any email" logging message quieter than `info`.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * throw a random exception into upload processing
 * run with `AWS_BATCH_JOB_ATTEMPT` set to values below three and values >= 3
 * confirm you only see attempts to send emails from the api server if the variable is set to a value >= 3
