### PR TITLE
Fix navbar alignment on smaller screens

### DIFF
--- a/app-frontend/src/assets/styles/sass/layout/_navbar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_navbar.scss
@@ -1,5 +1,4 @@
 .navbar {
-  @extend %clearfix;
   background: $shade-normal;
   border-bottom: 1px solid $shade-dark;
   position: relative;
@@ -181,6 +180,7 @@
   justify-content: flex-start;
 
   &.secondary {
+    flex: none;
     align-items: center;
     justify-content: flex-end;
     text-align: right;


### PR DESCRIPTION
## Overview
Implements a fix to the navbar inner content alignment which would adjust incorrectly on smaller screens.

### Checklist

- [ ] PR has a name that won't get you publicly shamed for vagueness
~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo
**Before**
<img width="936" alt="screen shot 2018-10-01 at 3 15 17 pm" src="https://user-images.githubusercontent.com/1928955/46310392-3381b800-c58d-11e8-9ac0-74bcb1fd0ee0.png">

**After**
<img width="936" alt="screen shot 2018-10-01 at 3 15 22 pm" src="https://user-images.githubusercontent.com/1928955/46310401-38df0280-c58d-11e8-9dd1-e02928a3785d.png">

## Testing Instructions

 * Open a project with a relatively long name
 * Resize the browser
 * The nav layout should only get wonky when the user dropdown is nearest the project name.

Closes #3936 
