### PR TITLE
Fix raster data count for pagination

### DIFF
--- a/app-backend/api/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/QueryParameters.scala
@@ -35,7 +35,7 @@ trait SceneQueryParameterDirective extends QueryParametersCommon {
     )).as(SceneQueryParameters.apply _)
 
   val sceneSearchModeQueryParams = parameters(
-    ('isSceneBrowse.as[Boolean].?)
+    ('exactCount.as[Boolean].?)
   ).as(SceneSearchModeQueryParams.apply _)
 
   val sceneQueryParameters = (orgQueryParams &

--- a/app-backend/api/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/QueryParameters.scala
@@ -34,10 +34,15 @@ trait SceneQueryParameterDirective extends QueryParametersCommon {
       'shape.as[UUID].?
     )).as(SceneQueryParameters.apply _)
 
+  val sceneSearchModeQueryParams = parameters(
+    ('isSceneBrowse.as[Boolean].?)
+  ).as(SceneSearchModeQueryParams.apply _)
+
   val sceneQueryParameters = (orgQueryParams &
     userQueryParameters &
     timestampQueryParameters &
     sceneSpecificQueryParams &
     ownershipTypeQueryParameters &
-    groupQueryParameters).as(CombinedSceneQueryParams.apply _)
+    groupQueryParameters &
+    sceneSearchModeQueryParams).as(CombinedSceneQueryParams.apply _)
 }

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -87,6 +87,11 @@ final case class GridQueryParameters(
     ingestStatus: Iterable[String] = Seq.empty[String]
 )
 
+@JsonCodec
+final case class SceneSearchModeQueryParams(
+  isSceneBrowse: Option[Boolean] = None
+)
+
 /** Combined all query parameters */
 @JsonCodec
 final case class CombinedSceneQueryParams(
@@ -96,7 +101,8 @@ final case class CombinedSceneQueryParams(
     sceneParams: SceneQueryParameters = SceneQueryParameters(),
     ownershipTypeParams: OwnershipTypeQueryParameters =
       OwnershipTypeQueryParameters(),
-    groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
+    groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
+    sceneSearchModeParams: SceneSearchModeQueryParams = SceneSearchModeQueryParams()
 )
 
 /** Combined all query parameters for grids */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -89,7 +89,7 @@ final case class GridQueryParameters(
 
 @JsonCodec
 final case class SceneSearchModeQueryParams(
-    isSceneBrowse: Option[Boolean] = None
+    exactCount: Option[Boolean] = None
 )
 
 /** Combined all query parameters */

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/QueryParameters.scala
@@ -89,7 +89,7 @@ final case class GridQueryParameters(
 
 @JsonCodec
 final case class SceneSearchModeQueryParams(
-  isSceneBrowse: Option[Boolean] = None
+    isSceneBrowse: Option[Boolean] = None
 )
 
 /** Combined all query parameters */
@@ -102,7 +102,8 @@ final case class CombinedSceneQueryParams(
     ownershipTypeParams: OwnershipTypeQueryParameters =
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
-    sceneSearchModeParams: SceneSearchModeQueryParams = SceneSearchModeQueryParams()
+    sceneSearchModeParams: SceneSearchModeQueryParams =
+      SceneSearchModeQueryParams()
 )
 
 /** Combined all query parameters for grids */

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -250,14 +250,14 @@ object Dao extends LazyLogging {
 
     /** Short circuit for quickly getting an approximate count for large queries (e.g. scenes) **/
     def sceneCountIO(
-        isSceneBrowseOption: Option[Boolean]): ConnectionIO[Int] = {
+        exactCountOption: Option[Boolean]): ConnectionIO[Int] = {
       val countQuery = countF ++ Fragments.whereAndOpt(filters: _*)
       val over100IO: ConnectionIO[Boolean] =
         (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 100") ++ fr")")
           .query[Boolean]
           .unique
       over100IO.flatMap(over100 => {
-        (isSceneBrowseOption, over100) match {
+        (exactCountOption, over100) match {
           case (Some(false), _) =>
             countQuery.query[Int].unique
           case (_, true) =>

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -249,7 +249,8 @@ object Dao extends LazyLogging {
     }
 
     /** Short circuit for quickly getting an approximate count for large queries (e.g. scenes) **/
-    def sceneCountIO(isSceneBrowseOption: Option[Boolean]): ConnectionIO[Int] = {
+    def sceneCountIO(
+        isSceneBrowseOption: Option[Boolean]): ConnectionIO[Int] = {
       val countQuery = countF ++ Fragments.whereAndOpt(filters: _*)
       val over100IO: ConnectionIO[Boolean] =
         (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 100") ++ fr")")

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -249,8 +249,7 @@ object Dao extends LazyLogging {
     }
 
     /** Short circuit for quickly getting an approximate count for large queries (e.g. scenes) **/
-    def sceneCountIO(
-        exactCountOption: Option[Boolean]): ConnectionIO[Int] = {
+    def sceneCountIO(exactCountOption: Option[Boolean]): ConnectionIO[Int] = {
       val countQuery = countF ++ Fragments.whereAndOpt(filters: _*)
       val over100IO: ConnectionIO[Boolean] =
         (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 100") ++ fr")")

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -49,7 +49,7 @@ object SceneWithRelatedDao
       sceneBrowses <- scenesToSceneBrowse(scenes,
                                           sceneParams.sceneParams.project)
       count <- sceneSearchBuilder.sceneCountIO(
-        sceneParams.sceneSearchModeParams.isSceneBrowse)
+        sceneParams.sceneSearchModeParams.exactCount)
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -48,7 +48,7 @@ object SceneWithRelatedDao
       )
       sceneBrowses <- scenesToSceneBrowse(scenes,
                                           sceneParams.sceneParams.project)
-      count <- sceneSearchBuilder.sceneCountIO
+      count <- sceneSearchBuilder.sceneCountIO(sceneParams.sceneSearchModeParams.isSceneBrowse)
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/SceneWithRelatedDao.scala
@@ -48,7 +48,8 @@ object SceneWithRelatedDao
       )
       sceneBrowses <- scenesToSceneBrowse(scenes,
                                           sceneParams.sceneParams.project)
-      count <- sceneSearchBuilder.sceneCountIO(sceneParams.sceneSearchModeParams.isSceneBrowse)
+      count <- sceneSearchBuilder.sceneCountIO(
+        sceneParams.sceneSearchModeParams.isSceneBrowse)
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = ((pageRequest.offset + 1) * pageRequest.limit) < count

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -86,7 +86,7 @@ class ImportListController {
                 pageSize: pageSize,
                 page: page - 1,
                 ownershipType: this.ownershipType,
-                isSceneBrowse: false
+                exactCount: false
             }
         ).then((sceneResult) => {
             this.pagination = this.paginationService.buildPagination(sceneResult);

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -85,7 +85,8 @@ class ImportListController {
                 sort: 'createdAt,desc',
                 pageSize: pageSize,
                 page: page - 1,
-                ownershipType: this.ownershipType
+                ownershipType: this.ownershipType,
+                isSceneBrowse: false
             }
         ).then((sceneResult) => {
             this.pagination = this.paginationService.buildPagination(sceneResult);


### PR DESCRIPTION
## Overview

This PR adds a query parameter so that it, by default, short circuits count for large scene queries, but returns real count of scene for pagination when specified.

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness


## Testing Instructions

 * `GET` to `api/scenes?bbox=25.488281250000004,-24.96614015991296,52.9541015625,12.08229583736359&page=0&pageSize=20&sort=acquisitionDatetime,desc&isSceneBrowse=false` should give you the exact count of scenes (more than 100)
* `GET` to the above endpoint but use `&isSceneBrowse=true` or delete this query parameter -- it should give you 100 scenes
* Go to your raster data list. Check if such query parameter is used in requests.

Closes #4125 
