### PR TITLE
Change webpack merge strategy to override HtmlWebpackPlugin

### DIFF
--- a/app-frontend/webpack.config.js
+++ b/app-frontend/webpack.config.js
@@ -28,7 +28,13 @@ let load = function () {
     console.log('Current Environment: ', ENV);
 
     // load config file by environment
-    return configs && merge(
+    return configs && merge({
+        customizeArray: merge.unique(
+            'plugins',
+            ['HtmlWebpackPlugin'],
+            plugin => plugin.constructor && plugin.constructor.name
+        )}
+    )(
         configs.overrides ? configs.overrides(__dirname) : null,
         configs.global(__dirname),
         configs[ENV](__dirname)


### PR DESCRIPTION
## Overview
Use first defined HtmlWebpackPlugin definition, merging overrides, global, then env in order.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
After changing heapLoad in overrides.js to 'asdf':
![image](https://user-images.githubusercontent.com/4392704/46363157-3b4e6480-c640-11e8-810d-05c8df6297cc.png)


### Notes
 Didn't change order of global/env config merging because it may have unintended side effects and we don't override it there anyways.


## Testing Instructions

 * Create an overrides file which changes heapLoad to some nonsense string.
* in `tpl-index.html`, change the line to `if(... || true)` so heap tries to load in develop
* Start the frontend, load the page, and verify that it tries to load a file called `heap-{your nonsense string here}.js` instead of the develop / production heap load
