### PR TITLE
Fix datasource delete bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Removed duplicate emails for repeated failures of the same upload [\#4130](https://github.com/raster-foundry/raster-foundry/pull/4130)
 - Use safer options for large tifs when processing uploads and ingests [\#4131](https://github.com/raster-foundry/raster-foundry/pull/4131)
+- Re-enable datasource deletion and disable it if there is permission attached [\#4140](https://github.com/raster-foundry/raster-foundry/pull/4140), [\#4158](https://github.com/raster-foundry/raster-foundry/pull/4158)
 
 ### Security
 

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -139,7 +139,7 @@ trait DatasourceRoutes
   def deleteDatasource(datasourceId: UUID): Route = authenticate { user =>
     authorizeAsync {
       DatasourceDao
-        .isDeletable(datasourceId, user, ObjectType.Datasource)
+        .isDeletable(datasourceId, user)
         .transact(xa)
         .unsafeToFuture
     } {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
@@ -94,8 +94,7 @@ object DatasourceDao
     this.create(datasource, user)
   }
 
-  def isDeletable(datasourceId: UUID,
-                  user: User): ConnectionIO[Boolean] = {
+  def isDeletable(datasourceId: UUID, user: User): ConnectionIO[Boolean] = {
     val statusF: List[Fragment] =
       List("CREATED", "UPLOADING", "UPLOADED", "QUEUED", "PROCESSING")
         .map(status => fr"upload_status = ${status}::upload_status")
@@ -104,7 +103,7 @@ object DatasourceDao
       datasourceO <- DatasourceDao.getDatasourceById(datasourceId)
       isOwner = datasourceO match {
         case Some(datasource) if datasource.owner == user.id => true
-        case _ => false
+        case _                                               => false
       }
       isShared <- DatasourceDao.query
         .filter(datasourceId)

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
@@ -95,8 +95,7 @@ object DatasourceDao
   }
 
   def isDeletable(datasourceId: UUID,
-                  user: User,
-                  objectType: ObjectType): ConnectionIO[Boolean] = {
+                  user: User): ConnectionIO[Boolean] = {
     val statusF: List[Fragment] =
       List("CREATED", "UPLOADING", "UPLOADED", "QUEUED", "PROCESSING")
         .map(status => fr"upload_status = ${status}::upload_status")
@@ -105,11 +104,11 @@ object DatasourceDao
       datasourceO <- DatasourceDao.getDatasourceById(datasourceId)
       isOwner = datasourceO match {
         case Some(datasource) if datasource.owner == user.id => true
-        case _                                               => false
+        case _ => false
       }
       isShared <- DatasourceDao.query
         .filter(datasourceId)
-        .filter(fr"acrs <> '{}':text[]")
+        .filter(fr"array_length(acrs, 1) != 0")
         .exists
       hasUpload <- UploadDao.query
         .filter(fr"datasource = ${datasourceId}")

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/DatasourceDao.scala
@@ -108,7 +108,7 @@ object DatasourceDao
       }
       isShared <- DatasourceDao.query
         .filter(datasourceId)
-        .filter(fr"array_length(acrs, 1) != 0")
+        .filter(fr"array_length(acrs, 1) is not null")
         .exists
       hasUpload <- UploadDao.query
         .filter(fr"datasource = ${datasourceId}")


### PR DESCRIPTION
## Overview

This PR fixes the datasource delete bug and adds property tests for `isDeletable` function in `DatasourceDao`.

### Checklist

- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] PR has a name that won't get you publicly shamed for vagueness
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

## Testing Instructions

 * Create two datasources and define bands
 * Delete one of them to see if it works
 * Import a scene using this other datasource
 * Delete this other datasource and check if it works. Check if the scene is also deleted.

Closes #4138 
