### PR TITLE
Add visibility check to shared ownership type

### DIFF
--- a/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/Dao.scala
@@ -257,12 +257,12 @@ object Dao extends LazyLogging {
           .unique
       over100IO.flatMap(over100 => {
         (exactCountOption, over100) match {
-          case (Some(false), _) =>
+          case (Some(true), _) =>
             countQuery.query[Int].unique
-          case (_, true) =>
-            100.pure[ConnectionIO]
           case (_, false) =>
             countQuery.query[Int].unique
+          case _ =>
+            100.pure[ConnectionIO]
         }
       })
     }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -245,7 +245,8 @@ trait ObjectPermissions[Model] {
         if (objectType == ObjectType.Shape) {
           Some(fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
         } else {
-          Some(fr"visibility != 'PUBLIC' AND (" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
+          Some(
+            fr"visibility != 'PUBLIC' AND (" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
         }
       // shared to the requesting user due to group membership
       case Some(ownershipType) if ownershipType == "inherited" =>

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -242,7 +242,11 @@ trait ObjectPermissions[Model] {
         Some(ownedF)
       // shared to the requesting user directly, across platform, or due to group membership
       case Some(ownershipType) if ownershipType == "shared" =>
-        Some(fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
+        if (objectType == ObjectType.Shape) {
+          Some(fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
+        } else {
+          Some(fr"visibility != 'PUBLIC' AND (" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
+        }
       // shared to the requesting user due to group membership
       case Some(ownershipType) if ownershipType == "inherited" =>
         if (objectType == ObjectType.Shape) {

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -86,7 +86,7 @@ class ImportListController {
                 pageSize: pageSize,
                 page: page - 1,
                 ownershipType: this.ownershipType,
-                exactCount: false
+                exactCount: true
             }
         ).then((sceneResult) => {
             this.pagination = this.paginationService.buildPagination(sceneResult);


### PR DESCRIPTION
## Overview

This PR adds `visibility != 'PUBLIC'` in the `where` statement when listing first class objects with `ownershipType=shared`. It also flips the cases for `exactCount` qp when listing scenes.

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness

## Testing Instructions

 * CI
 * Go to your imported rasters. Make sure ownership filter works correctly, with `exactCount=true` sent as query param
 * Go to a project and browse scenes. Make sure it returns not exact count of scenes when there are more than 100
