### PR TITLE
Add Backsplash Lab Integration

### DIFF
--- a/app-backend/backsplash/src/main/scala/Color.scala
+++ b/app-backend/backsplash/src/main/scala/Color.scala
@@ -1,46 +1,14 @@
 package com.rf.azavea.backsplash
-import java.util.UUID
 
-import cats.data.{OptionT, NonEmptyList => NEL}
-import cats.effect.{IO, Timer}
-import cats.implicits._
-import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
+import cats.data.{NonEmptyList => NEL}
 import com.azavea.rf.common.RollbarNotifier
-import com.azavea.rf.database._
-import com.azavea.rf.datamodel.{
-  ColorRampMosaic,
-  MosaicDefinition,
-  SceneType,
-  SingleBandOptions
-}
-import doobie.implicits._
-import geotrellis.proj4.{CRS, Proj4Transform, WebMercator}
+import com.azavea.rf.datamodel.{ColorRampMosaic, SingleBandOptions}
 import geotrellis.raster.histogram._
-import geotrellis.raster.io.geotiff.{Auto, AutoHigherResolution}
-import geotrellis.raster.io.json.HistogramJsonFormats
-import geotrellis.raster.reproject.ReprojectRasterExtent
-import geotrellis.raster.{CellSize, Raster, io => _, _}
-import geotrellis.server.core.cog.CogUtils
-import geotrellis.server.core.cog.CogUtils.{
-  closestTiffOverview,
-  cropGeoTiff,
-  tmsLevels
-}
-import geotrellis.server.core.maml.metadata._
-import geotrellis.server.core.maml.reification._
-import geotrellis.spark.io._
-import geotrellis.spark.io.postgres.PostgresAttributeStore
-import geotrellis.spark.io.s3.S3ValueReader
-import geotrellis.spark.tiling.{LayoutDefinition, ZoomedLayoutScheme}
-import geotrellis.spark.{io => _, _}
-import geotrellis.vector.{Extent, Projected}
-import io.circe.generic.semiauto._
-import spray.json.DefaultJsonProtocol._
-import spray.json._
+import geotrellis.raster.{Raster, io => _, _}
+import geotrellis.spark.{io => _}
+import geotrellis.vector.Extent
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
-object color extends RollbarNotifier {
+object Color extends RollbarNotifier {
   def colorSingleBandTile(
       tile: Tile,
       extent: Extent,

--- a/app-backend/backsplash/src/main/scala/MamlAdapter.scala
+++ b/app-backend/backsplash/src/main/scala/MamlAdapter.scala
@@ -1,0 +1,118 @@
+package com.azavea.rf.backsplash.maml
+
+import com.azavea.rf.tool.ast._
+import com.azavea.maml.ast._
+import com.azavea.maml.util.{NeighborhoodConversion, ClassMap => MamlClassMap}
+import geotrellis.vector.io._
+import cats._
+import cats.data._
+import cats.implicits._
+import java.security.InvalidParameterException
+
+import com.azavea.rf.backsplash.nodes.ProjectNode
+import com.azavea.rf.datamodel.{BandDataType, SingleBandOptions}
+import io.circe.Json
+
+trait BacksplashMamlAdapter {
+
+
+  def rfmlAst: MapAlgebraAST
+
+  def asMaml: (Expression, Option[NodeMetadata], Map[String, ProjectNode]) = {
+
+    def evalParams(ast: MapAlgebraAST): Map[String, ProjectNode] = {
+      val args = ast.args.map(evalParams)
+
+      ast match {
+        case MapAlgebraAST.ProjectRaster(_, projId, band, celltype, _) => {
+          val bandActual = band.getOrElse(throw new IllegalArgumentException("Band must be provided to evaluate AST"))
+          // This is silly - mostly making up single band options here when all we really need is the band number
+          val singleBandOptions = SingleBandOptions.Params(bandActual, BandDataType.Diverging, 0, Json.Null, "Up")
+          Map[String, ProjectNode](s"${projId.toString}_${bandActual}" -> ProjectNode(projId, None, None, None, true, Some(singleBandOptions)))
+        }
+        case _ => args.foldLeft(Map.empty[String, ProjectNode])( (a, b) => a ++ b)
+      }
+    }
+
+    def eval(ast: MapAlgebraAST): Expression = {
+
+      val args = ast.args.map(eval)
+      ast match {
+        case MapAlgebraAST.Source(id, _) => RasterVar(id.toString)
+        case MapAlgebraAST.ProjectRaster(_, projId, band, celltype, _) => {
+          val bandActual = band.getOrElse(1)
+          RasterVar(s"${projId.toString}_${bandActual}")
+        }
+        case MapAlgebraAST.Constant(_, const, _) => DblLit(const)
+        case MapAlgebraAST.LiteralTile(_, lt, _) =>
+          throw new InvalidParameterException(
+            "No literal tiles should appear on pre-MAML RFML tools")
+        case MapAlgebraAST.ToolReference(_, _) =>
+          throw new InvalidParameterException(
+            "Tool references not yet supported via MAML")
+        /* --- LOCAL OPERATIONS --- */
+        case MapAlgebraAST.Addition(_, _, _)       => Addition(args)
+        case MapAlgebraAST.Subtraction(_, _, _)    => Subtraction(args)
+        case MapAlgebraAST.Multiplication(_, _, _) => Multiplication(args)
+        case MapAlgebraAST.Division(_, _, _)       => Division(args)
+        case MapAlgebraAST.Max(_, _, _)            => Max(args)
+        case MapAlgebraAST.Min(_, _, _)            => Min(args)
+        case MapAlgebraAST.Classification(_, _, _, classmap) =>
+          Classification(args, MamlClassMap(classmap.classifications))
+//        case MapAlgebraAST.Masking(_, _, _, mask) =>
+//          Masking(args :+ GeomJson(mask.toGeoJson))
+        case MapAlgebraAST.Equality(_, _, _)       => Equal(args)
+        case MapAlgebraAST.Inequality(_, _, _)     => Unequal(args)
+        case MapAlgebraAST.Greater(_, _, _)        => Greater(args)
+        case MapAlgebraAST.GreaterOrEqual(_, _, _) => GreaterOrEqual(args)
+        case MapAlgebraAST.Less(_, _, _)           => Lesser(args)
+        case MapAlgebraAST.LessOrEqual(_, _, _)    => LesserOrEqual(args)
+        case MapAlgebraAST.And(_, _, _)            => And(args)
+        case MapAlgebraAST.Or(_, _, _)             => Or(args)
+        case MapAlgebraAST.Xor(_, _, _)            => Xor(args)
+        case MapAlgebraAST.Pow(_, _, _)            => Pow(args)
+        case MapAlgebraAST.Atan2(_, _, _)          => Atan2(args)
+
+        /* --- Unary Operations --- */
+        case MapAlgebraAST.IsDefined(_, _, _)       => Defined(args)
+        case MapAlgebraAST.IsUndefined(_, _, _)     => Undefined(args)
+        case MapAlgebraAST.SquareRoot(_, _, _)      => SquareRoot(args)
+        case MapAlgebraAST.Log(_, _, _)             => LogE(args)
+        case MapAlgebraAST.Log10(_, _, _)           => Log10(args)
+        case MapAlgebraAST.Round(_, _, _)           => Round(args)
+        case MapAlgebraAST.Floor(_, _, _)           => Floor(args)
+        case MapAlgebraAST.Ceil(_, _, _)            => Ceil(args)
+        case MapAlgebraAST.NumericNegation(_, _, _) => NumericNegation(args)
+        case MapAlgebraAST.LogicalNegation(_, _, _) => LogicalNegation(args)
+        case MapAlgebraAST.Abs(_, _, _)             => Abs(args)
+        case MapAlgebraAST.Sin(_, _, _)             => Sin(args)
+        case MapAlgebraAST.Cos(_, _, _)             => Cos(args)
+        case MapAlgebraAST.Tan(_, _, _)             => Tan(args)
+        case MapAlgebraAST.Sinh(_, _, _)            => Sinh(args)
+        case MapAlgebraAST.Cosh(_, _, _)            => Cosh(args)
+        case MapAlgebraAST.Tanh(_, _, _)            => Tanh(args)
+        case MapAlgebraAST.Asin(_, _, _)            => Asin(args)
+        case MapAlgebraAST.Acos(_, _, _)            => Acos(args)
+        case MapAlgebraAST.Atan(_, _, _)            => Atan(args)
+
+        /* --- FOCAL OPERATIONS --- */
+        case MapAlgebraAST.FocalMax(_, _, _, n) =>
+          FocalMax(args, NeighborhoodConversion(n))
+        case MapAlgebraAST.FocalMin(_, _, _, n) =>
+          FocalMin(args, NeighborhoodConversion(n))
+        case MapAlgebraAST.FocalMean(_, _, _, n) =>
+          FocalMean(args, NeighborhoodConversion(n))
+        case MapAlgebraAST.FocalMedian(_, _, _, n) =>
+          FocalMedian(args, NeighborhoodConversion(n))
+        case MapAlgebraAST.FocalMode(_, _, _, n) =>
+          FocalMode(args, NeighborhoodConversion(n))
+        case MapAlgebraAST.FocalSum(_, _, _, n) =>
+          FocalSum(args, NeighborhoodConversion(n))
+        case MapAlgebraAST.FocalStdDev(_, _, _, n) =>
+          FocalStdDev(args, NeighborhoodConversion(n))
+      }
+    }
+
+    (eval(rfmlAst), rfmlAst.metadata, evalParams(rfmlAst))
+  }
+}

--- a/app-backend/backsplash/src/main/scala/Server.scala
+++ b/app-backend/backsplash/src/main/scala/Server.scala
@@ -2,8 +2,9 @@ package com.azavea.rf.backsplash
 
 import com.azavea.rf.backsplash.nodes._
 import com.azavea.rf.backsplash.services.{HealthCheckService, MosaicService}
-
 import cats.effect.{Effect, IO}
+import com.azavea.rf.backsplash.analysis.AnalysisService
+import doobie.util.analysis.Analysis
 import fs2.StreamApp
 import org.http4s.server.blaze.BlazeBuilder
 import org.http4s.server.middleware.AutoSlash
@@ -19,11 +20,13 @@ object BacksplashServer extends StreamApp[IO] {
 object ServerStream {
   def healthCheckService = new HealthCheckService[IO].service
   def mosaicService = new MosaicService().service
+  def analysisService = new AnalysisService().service
 
   def stream =
     BlazeBuilder[IO]
       .bindHttp(8080, "0.0.0.0")
       .mountService(AutoSlash(mosaicService), "/")
       .mountService(AutoSlash(healthCheckService), "/healthcheck")
+      .mountService(AutoSlash(analysisService), "/tools")
       .serve
 }

--- a/app-backend/backsplash/src/main/scala/color.scala
+++ b/app-backend/backsplash/src/main/scala/color.scala
@@ -7,7 +7,12 @@ import cats.implicits._
 import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
 import com.azavea.rf.common.RollbarNotifier
 import com.azavea.rf.database._
-import com.azavea.rf.datamodel.{ColorRampMosaic, MosaicDefinition, SceneType, SingleBandOptions}
+import com.azavea.rf.datamodel.{
+  ColorRampMosaic,
+  MosaicDefinition,
+  SceneType,
+  SingleBandOptions
+}
 import doobie.implicits._
 import geotrellis.proj4.{CRS, Proj4Transform, WebMercator}
 import geotrellis.raster.histogram._
@@ -16,7 +21,11 @@ import geotrellis.raster.io.json.HistogramJsonFormats
 import geotrellis.raster.reproject.ReprojectRasterExtent
 import geotrellis.raster.{CellSize, Raster, io => _, _}
 import geotrellis.server.core.cog.CogUtils
-import geotrellis.server.core.cog.CogUtils.{closestTiffOverview, cropGeoTiff, tmsLevels}
+import geotrellis.server.core.cog.CogUtils.{
+  closestTiffOverview,
+  cropGeoTiff,
+  tmsLevels
+}
 import geotrellis.server.core.maml.metadata._
 import geotrellis.server.core.maml.reification._
 import geotrellis.spark.io._
@@ -33,24 +42,24 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object color extends RollbarNotifier {
   def colorSingleBandTile(
-                           tile: Tile,
-                           extent: Extent,
-                           histogram: Histogram[Double],
-                           singleBandOptions: SingleBandOptions.Params): Raster[Tile] = {
+      tile: Tile,
+      extent: Extent,
+      histogram: Histogram[Double],
+      singleBandOptions: SingleBandOptions.Params): Raster[Tile] = {
     logger.debug(s"Applying Colorings")
     val colorScheme = singleBandOptions.colorScheme
     val colorMap = (colorScheme.asArray,
-      colorScheme.asObject,
-      singleBandOptions.extraNoData) match {
+                    colorScheme.asObject,
+                    singleBandOptions.extraNoData) match {
       case (Some(a), None, _) =>
         ColorRampMosaic.colorMapFromVector(a.map(_.noSpaces),
-          singleBandOptions,
-          histogram)
+                                           singleBandOptions,
+                                           histogram)
       case (None, Some(o), Nil) =>
         ColorRampMosaic.colorMapFromMap(o.toMap map {
           case (k, v) => (k, v.noSpaces)
         })
-      case (None, Some(o), masked@(h +: t)) =>
+      case (None, Some(o), masked @ (h +: t)) =>
         ColorRampMosaic.colorMapFromMap(o.toMap map {
           case (k, v) =>
             (k, if (masked.contains(k.toInt)) "#00000000" else v.noSpaces)
@@ -64,6 +73,5 @@ object color extends RollbarNotifier {
     }
     Raster(tile.color(colorMap), extent)
   }
-
 
 }

--- a/app-backend/backsplash/src/main/scala/color.scala
+++ b/app-backend/backsplash/src/main/scala/color.scala
@@ -1,0 +1,69 @@
+package com.rf.azavea.backsplash
+import java.util.UUID
+
+import cats.data.{OptionT, NonEmptyList => NEL}
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.database._
+import com.azavea.rf.datamodel.{ColorRampMosaic, MosaicDefinition, SceneType, SingleBandOptions}
+import doobie.implicits._
+import geotrellis.proj4.{CRS, Proj4Transform, WebMercator}
+import geotrellis.raster.histogram._
+import geotrellis.raster.io.geotiff.{Auto, AutoHigherResolution}
+import geotrellis.raster.io.json.HistogramJsonFormats
+import geotrellis.raster.reproject.ReprojectRasterExtent
+import geotrellis.raster.{CellSize, Raster, io => _, _}
+import geotrellis.server.core.cog.CogUtils
+import geotrellis.server.core.cog.CogUtils.{closestTiffOverview, cropGeoTiff, tmsLevels}
+import geotrellis.server.core.maml.metadata._
+import geotrellis.server.core.maml.reification._
+import geotrellis.spark.io._
+import geotrellis.spark.io.postgres.PostgresAttributeStore
+import geotrellis.spark.io.s3.S3ValueReader
+import geotrellis.spark.tiling.{LayoutDefinition, ZoomedLayoutScheme}
+import geotrellis.spark.{io => _, _}
+import geotrellis.vector.{Extent, Projected}
+import io.circe.generic.semiauto._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object color extends RollbarNotifier {
+  def colorSingleBandTile(
+                           tile: Tile,
+                           extent: Extent,
+                           histogram: Histogram[Double],
+                           singleBandOptions: SingleBandOptions.Params): Raster[Tile] = {
+    logger.debug(s"Applying Colorings")
+    val colorScheme = singleBandOptions.colorScheme
+    val colorMap = (colorScheme.asArray,
+      colorScheme.asObject,
+      singleBandOptions.extraNoData) match {
+      case (Some(a), None, _) =>
+        ColorRampMosaic.colorMapFromVector(a.map(_.noSpaces),
+          singleBandOptions,
+          histogram)
+      case (None, Some(o), Nil) =>
+        ColorRampMosaic.colorMapFromMap(o.toMap map {
+          case (k, v) => (k, v.noSpaces)
+        })
+      case (None, Some(o), masked@(h +: t)) =>
+        ColorRampMosaic.colorMapFromMap(o.toMap map {
+          case (k, v) =>
+            (k, if (masked.contains(k.toInt)) "#00000000" else v.noSpaces)
+        })
+      case _ => {
+        val message =
+          "Invalid color scheme format. Color schemes must be defined as an array of hex colors or a mapping of raster values to hex colors."
+        logger.error(message)
+        throw new IllegalArgumentException(message)
+      }
+    }
+    Raster(tile.color(colorMap), extent)
+  }
+
+
+}

--- a/app-backend/backsplash/src/main/scala/io/Avro.scala
+++ b/app-backend/backsplash/src/main/scala/io/Avro.scala
@@ -1,0 +1,187 @@
+package com.azavea.rf.backsplash.io
+
+import java.util.UUID
+
+import cats.data.{OptionT, NonEmptyList => NEL}
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.database.LayerAttributeDao
+import com.azavea.rf.datamodel.{MosaicDefinition, SingleBandOptions}
+import com.rf.azavea.backsplash.color
+import doobie.implicits._
+import geotrellis.raster.histogram._
+import geotrellis.raster.io.json.HistogramJsonFormats
+import geotrellis.raster.{Raster, io => _, _}
+import geotrellis.spark.io._
+import geotrellis.spark.io.postgres.PostgresAttributeStore
+import geotrellis.spark.io.s3.{S3CollectionLayerReader, S3ValueReader}
+import geotrellis.spark.tiling.LayoutLevel
+import geotrellis.spark.{SpatialKey, TileLayerMetadata, io => _, _}
+import geotrellis.vector.Extent
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+import scala.util._
+
+object avro extends RollbarNotifier with HistogramJsonFormats {
+
+  import com.azavea.rf.database.util.RFTransactor.xa
+
+  val store = PostgresAttributeStore()
+
+  // TODO: this essentially inlines a bunch of logic from LayerCache, which isn't super cool
+  // it would be nice to get that logic somewhere more appropriate, especially since a lot of
+  // it is grid <-> geometry math, but I'm not certain where it should go.
+  def fetchMultiBandAvroTile(
+      md: MosaicDefinition,
+      zoom: Int,
+      col: Int,
+      row: Int,
+      extent: Extent)(implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
+    OptionT(
+      for {
+        _ <- IO.pure(
+          logger.debug(
+            s"Fetching multi-band avro tile for scene id ${md.sceneId}"))
+        metadata <- IO.shift(t) *> tileLayerMetadata(md.sceneId, zoom)
+        (sourceZoom, tlm) = metadata
+        zoomDiff = zoom - sourceZoom
+        resolutionDiff = 1 << zoomDiff
+        sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
+        histograms <- IO.shift(t) *> layerHistogram(md.sceneId)
+        mbTileE <- {
+          if (tlm.bounds.includes(sourceKey))
+            avroLayerTile(md.sceneId, sourceZoom, sourceKey).attempt
+          else
+            IO(
+              Left(
+                new Exception(
+                  s"Source key outside of tile layer bounds for scene ${md.sceneId}, key ${sourceKey}")
+              )
+            )
+        }
+      } yield {
+        (mbTileE map {
+          (mbTile: MultibandTile) =>
+            {
+              val innerCol = col % resolutionDiff
+              val innerRow = row % resolutionDiff
+              val cols = mbTile.cols / resolutionDiff
+              val rows = mbTile.rows / resolutionDiff
+              val corrected =
+                md.colorCorrections.colorCorrect(mbTile, histograms.toSeq)
+              Raster(corrected.color, extent).resample(256, 256)
+            }
+        }).toOption
+      }
+    )
+  }
+
+  def fetchMultiBandAvroTile(md: MosaicDefinition,
+                             layoutLevel: LayoutLevel,
+                             extent: Extent)(
+      implicit t: Timer[IO]): OptionT[IO, Raster[MultibandTile]] = {
+    val layerId = LayerId(md.sceneId.toString, layoutLevel.zoom)
+    val tileIO = IO(Try {
+      S3CollectionLayerReader(store)
+        .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](
+          layerId)
+        .where(Intersects(extent))
+        .result
+        .stitch
+        .crop(extent)
+        .tile
+        .resample(256, 256)
+    } match {
+      case Success(tile) => Option(Raster(tile, extent))
+      case Failure(e) =>
+        logger.error(
+          s"Query layer ${layerId} at zoom ${layoutLevel.zoom}for $extent: ${e.getMessage}")
+        None
+    })
+    OptionT(tileIO)
+  }
+
+  def fetchSingleBandAvroTile(md: MosaicDefinition,
+                              zoom: Int,
+                              col: Int,
+                              row: Int,
+                              extent: Extent,
+                              singleBandOptions: SingleBandOptions.Params,
+                              rawSingleBandValues: Boolean)(
+      implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
+    OptionT(
+      for {
+        _ <- IO.pure(
+          logger.debug(
+            s"Fetching single-band avro tile for scene id ${md.sceneId}"))
+        metadata <- IO.shift(t) *> tileLayerMetadata(md.sceneId, zoom)
+        (sourceZoom, tlm) = metadata
+        zoomDiff = zoom - sourceZoom
+        resolutionDiff = 1 << zoomDiff
+        sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
+        histograms <- IO.shift(t) *> layerHistogram(md.sceneId)
+        mbTileE <- {
+          if (tlm.bounds.includes(sourceKey))
+            avroLayerTile(md.sceneId, sourceZoom, sourceKey).attempt
+          else
+            IO(
+              Left(
+                new Exception(
+                  s"Source key outside of tile layer bounds for scene ${md.sceneId}, key ${sourceKey}")
+              )
+            )
+        }
+      } yield {
+        (mbTileE map {
+          (mbTile: MultibandTile) =>
+            {
+              val tile = mbTile.bands.lift(singleBandOptions.band) getOrElse {
+                throw new Exception("No band found in single-band options")
+              }
+              val histogram = histograms
+                .lift(singleBandOptions.band) getOrElse {
+                throw new Exception("No histogram found for band")
+              }
+              rawSingleBandValues match {
+                case false =>
+                  color.colorSingleBandTile(tile,
+                                            extent,
+                                            histogram,
+                                            singleBandOptions)
+                case _ => Raster(tile, extent)
+              }
+            }
+        }).toOption
+      }
+    )
+  }
+
+  def tileLayerMetadata(id: UUID,
+                        zoom: Int): IO[(Int, TileLayerMetadata[SpatialKey])] = {
+    val layerName = id.toString
+    LayerAttributeDao.unsafeMaxZoomForLayer(layerName).transact(xa) map {
+      case (_, maxZoom) =>
+        val z = if (zoom > maxZoom) maxZoom else zoom
+        z -> store.readMetadata[TileLayerMetadata[SpatialKey]](
+          LayerId(layerName, z))
+    }
+  }
+
+  def layerHistogram(id: UUID): IO[Array[Histogram[Double]]] = {
+    val layerId = LayerId(name = id.toString, zoom = 0)
+    LayerAttributeDao
+      .unsafeGetAttribute(layerId, "histogram")
+      .transact(xa) map { attribute =>
+      attribute.value.noSpaces.parseJson.convertTo[Array[Histogram[Double]]]
+    }
+  }
+
+  def avroLayerTile(id: UUID, zoom: Int, key: SpatialKey): IO[MultibandTile] = {
+    val reader = new S3ValueReader(store)
+      .reader[SpatialKey, MultibandTile](LayerId(id.toString, zoom))
+    IO(reader.read(key))
+  }
+
+}

--- a/app-backend/backsplash/src/main/scala/io/Avro.scala
+++ b/app-backend/backsplash/src/main/scala/io/Avro.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import com.azavea.rf.common.RollbarNotifier
 import com.azavea.rf.database.LayerAttributeDao
 import com.azavea.rf.datamodel.{MosaicDefinition, SingleBandOptions}
-import com.rf.azavea.backsplash.color
+import com.rf.azavea.backsplash.Color
 import doobie.implicits._
 import geotrellis.raster.histogram._
 import geotrellis.raster.io.json.HistogramJsonFormats
@@ -24,7 +24,7 @@ import spray.json._
 
 import scala.util._
 
-object avro extends RollbarNotifier with HistogramJsonFormats {
+object Avro extends RollbarNotifier with HistogramJsonFormats {
 
   import com.azavea.rf.database.util.RFTransactor.xa
 
@@ -146,7 +146,7 @@ object avro extends RollbarNotifier with HistogramJsonFormats {
               }
               rawSingleBandValues match {
                 case false =>
-                  color.colorSingleBandTile(tile,
+                  Color.colorSingleBandTile(tile,
                                             extent,
                                             histogram,
                                             singleBandOptions)

--- a/app-backend/backsplash/src/main/scala/io/Cog.scala
+++ b/app-backend/backsplash/src/main/scala/io/Cog.scala
@@ -1,0 +1,91 @@
+package com.azavea.rf.backsplash.io
+
+import cats.data.OptionT
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.datamodel.{MosaicDefinition, SingleBandOptions}
+import com.rf.azavea.backsplash.color
+import geotrellis.raster.{Raster, io => _, _}
+import geotrellis.server.core.cog.CogUtils
+import geotrellis.spark.{io => _}
+import geotrellis.vector.Extent
+
+object cog extends RollbarNotifier {
+
+  def fetchSingleBandCogTile(md: MosaicDefinition,
+                             zoom: Int,
+                             col: Int,
+                             row: Int,
+                             extent: Extent,
+                             singleBandOptions: SingleBandOptions.Params,
+                             rawSingleBandValues: Boolean
+                            )(
+                              implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
+    val tileIO = for {
+      _ <- IO.pure(
+        logger.debug(
+          s"Fetching single-band COG tile for scene ID ${md.sceneId}"))
+      raster <- IO.shift(t) *> CogUtils.fetch(
+        md.ingestLocation.getOrElse(
+          throw new IllegalArgumentException("Cannot fetch scene with no ingest location")
+        ),
+        zoom,
+        col,
+        row)
+      histograms <- IO.shift(t) *> avro.layerHistogram(md.sceneId)
+    } yield {
+      logger.debug(s"Retrieved Tile: ${raster.tile.dimensions}")
+      val tile = raster.tile.bands.lift(singleBandOptions.band) getOrElse {
+        throw new Exception("No band found in single-band options")
+      }
+      val histogram = histograms
+        .lift(singleBandOptions.band) getOrElse {
+        throw new Exception("No histogram found for band")
+      }
+
+      rawSingleBandValues match {
+        case false => color.colorSingleBandTile(tile, extent, histogram, singleBandOptions)
+        case _ => Raster(tile, extent)
+      }
+    }
+    OptionT(tileIO.attempt.map(_.toOption))
+  }
+
+  def fetchMultiBandCogTile(
+                             md: MosaicDefinition,
+                             zoom: Int,
+                             col: Int,
+                             row: Int,
+                             extent: Extent)(implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
+    val tileIO = for {
+      _ <- IO.pure(logger.debug(s"Fetching multi-band COG tile for scene ID ${md.sceneId}"))
+      raster <- IO.shift(t) *> CogUtils.fetch(md.ingestLocation.getOrElse("Cannot fetch scene with no ingest location"),
+        zoom,
+        col,
+        row)
+      histograms <- IO.shift(t) *> avro.layerHistogram(md.sceneId)
+    } yield {
+      val bandOrder = List(
+        md.colorCorrections.redBand,
+        md.colorCorrections.greenBand,
+        md.colorCorrections.blueBand
+      )
+      val subsetBands = raster.tile.subsetBands(bandOrder)
+      val subsetHistograms = bandOrder map histograms
+      val normalized =
+        subsetBands.mapBands { (i: Int, tile: Tile) => {
+          (subsetHistograms(i).minValue, subsetHistograms(i).maxValue) match {
+            case (Some(min), Some(max)) => tile.normalize(min, max, 0, 255)
+            case _ =>
+              throw new Exception(
+                "Histogram bands don't match up with tile bands")
+          }
+        }
+        }
+
+      Raster(normalized.color, extent).resample(256, 256)
+    }
+    OptionT(tileIO.attempt.map(_.toOption))
+  }
+}

--- a/app-backend/backsplash/src/main/scala/io/Mosaic.scala
+++ b/app-backend/backsplash/src/main/scala/io/Mosaic.scala
@@ -1,0 +1,79 @@
+package com.azavea.rf.backsplash.io
+
+import cats.effect.{IO, Timer}
+import cats.implicits._
+import com.azavea.rf.backsplash.nodes.ProjectNode
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.database.SceneToProjectDao
+import com.azavea.rf.datamodel.{MosaicDefinition, SceneType, SingleBandOptions}
+import doobie.implicits._
+import geotrellis.raster.{Raster, io => _, _}
+import geotrellis.spark.tiling.LayoutLevel
+import geotrellis.spark.{io => _}
+import geotrellis.vector.{Extent, Projected}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+object mosaic extends RollbarNotifier {
+
+  import com.azavea.rf.database.util.RFTransactor.xa
+
+  def getMosaicDefinitions(self: ProjectNode, extent: Extent): IO[Seq[MosaicDefinition]] = {
+    self.getBandOverrides match {
+      case Some((red, green, blue)) =>
+        SceneToProjectDao
+          .getMosaicDefinition(
+            self.projectId,
+            Some(Projected(extent, 3857)),
+            Some(red),
+            Some(green),
+            Some(blue)
+          )
+          .transact(xa)
+      case None =>
+        SceneToProjectDao
+          .getMosaicDefinition(
+            self.projectId,
+            Some(Projected(extent, 3857))
+          )
+          .transact(xa)
+    }
+  }
+
+  def getMultiBandTileFromMosaic(z: Int, x: Int, y: Int, extent: Extent)(md: MosaicDefinition): IO[Option[Raster[Tile]]] =
+    md.sceneType match {
+      case Some(SceneType.COG) =>
+        cog.fetchMultiBandCogTile(md, z, x, y, extent).value
+      case Some(SceneType.Avro) =>
+        avro.fetchMultiBandAvroTile(md, z, x, y, extent).value
+      case None =>
+        throw new Exception("Unable to fetch tiles with unknown scene type")
+    }
+
+  def getMosaicDefinitionTiles(self: ProjectNode, z: Int, x: Int, y: Int, extent: Extent, mds: Seq[MosaicDefinition]) = {
+    mds.toList.parTraverse(self.isSingleBand match {
+      case false =>
+        getMultiBandTileFromMosaic(z, x, y, extent)
+      case true => {
+        logger.info(s"Getting Single Band Tile From Mosaic: ${z} ${x} ${y} ${self.projectId}")
+        getSingleBandTileFromMosaic(z, x, y, extent, self.singleBandOptions getOrElse {
+          throw new Exception(
+              "No single-band options found for single-band visualization")
+          }, self.rawSingleBandValues)
+      }
+    })
+  }
+
+  def getSingleBandTileFromMosaic(z: Int, x: Int, y: Int, extent: Extent, singleBandOptions: SingleBandOptions.Params, rawSingleBandValues: Boolean)(
+    md: MosaicDefinition)(implicit t: Timer[IO]): IO[Option[Raster[Tile]]] =
+    md.sceneType match {
+      case Some(SceneType.COG) =>
+        cog.fetchSingleBandCogTile(md, z, x, y, extent, singleBandOptions, rawSingleBandValues).value
+      case Some(SceneType.Avro) =>
+        avro.fetchSingleBandAvroTile(md, z, x, y, extent, singleBandOptions, rawSingleBandValues).value
+      case None =>
+        throw new Exception("Unable to fetch tiles with unknown scene type")
+    }
+}
+

--- a/app-backend/backsplash/src/main/scala/nodes/ProjectNode.scala
+++ b/app-backend/backsplash/src/main/scala/nodes/ProjectNode.scala
@@ -6,7 +6,7 @@ import cats.data.{NonEmptyList => NEL}
 import cats.effect.{IO, Timer}
 import cats.implicits._
 import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
-import com.azavea.rf.backsplash.io.mosaic
+import com.azavea.rf.backsplash.io.Mosaic
 import com.azavea.rf.common.RollbarNotifier
 import com.azavea.rf.datamodel.SingleBandOptions
 import geotrellis.raster.io.json.HistogramJsonFormats
@@ -55,10 +55,10 @@ object ProjectNode extends RollbarNotifier with HistogramJsonFormats {
           implicit t: Timer[IO]): (Int, Int, Int) => IO[Literal] =
         (z: Int, x: Int, y: Int) => {
           val extent = CogUtils.tmsLevels(z).mapTransform.keyToExtent(x, y)
-          val mdIO = mosaic.getMosaicDefinitions(self, extent)
+          val mdIO = Mosaic.getMosaicDefinitions(self, extent)
           for {
             mds <- mdIO
-            mbTiles <- mosaic.getMosaicDefinitionTiles(self,
+            mbTiles <- Mosaic.getMosaicDefinitionTiles(self,
                                                        z,
                                                        x,
                                                        y,

--- a/app-backend/backsplash/src/main/scala/nodes/ProjectNode.scala
+++ b/app-backend/backsplash/src/main/scala/nodes/ProjectNode.scala
@@ -1,46 +1,22 @@
 package com.azavea.rf.backsplash.nodes
 
-import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
-import com.azavea.rf.common.RollbarNotifier
-import com.azavea.rf.database._
-import com.azavea.rf.datamodel.{
-  ColorRampMosaic,
-  HistogramAttribute,
-  LayerAttribute,
-  MosaicDefinition,
-  SceneType,
-  SingleBandOptions
-}
+import java.util.UUID
 
-import cats.data.{OptionT, EitherT}
+import cats.data.{NonEmptyList => NEL}
 import cats.effect.{IO, Timer}
 import cats.implicits._
-import doobie.implicits._
-import geotrellis.raster.{CellSize, CellType, Raster, GridBounds}
-import geotrellis.raster.render.{ColorMap, ColorRamps}
-import geotrellis.server.core.cog.CogUtils
-import geotrellis.server.core.maml.CogNode
-import geotrellis.server.core.maml.persistence._
-import geotrellis.server.core.maml.metadata._
-import geotrellis.server.core.maml.reification._
-import geotrellis.raster.{io => _, _}
+import com.azavea.maml.ast.{Literal, MamlKind, RasterLit}
+import com.azavea.rf.backsplash.io.mosaic
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.datamodel.SingleBandOptions
 import geotrellis.raster.io.json.HistogramJsonFormats
-import geotrellis.raster.histogram._
+import geotrellis.raster.{Raster, io => _, _}
+import geotrellis.server.core.cog.CogUtils
+import geotrellis.server.core.maml.reification._
 import geotrellis.spark.io.postgres.PostgresAttributeStore
-import geotrellis.spark.{io => _, _}
-import geotrellis.spark.io._
-import geotrellis.spark.io.s3.S3ValueReader
-import geotrellis.vector.{Extent, Projected}
-
-import io.circe._
-import io.circe.parser._
+import geotrellis.spark.tiling.LayoutDefinition
+import geotrellis.spark.{io => _}
 import io.circe.generic.semiauto._
-
-import spray.json._
-import DefaultJsonProtocol._
-
-import java.net.URI
-import java.util.UUID
 
 case class ProjectNode(
     projectId: UUID,
@@ -48,7 +24,8 @@ case class ProjectNode(
     greenBandOverride: Option[Int] = None,
     blueBandOverride: Option[Int] = None,
     isSingleBand: Boolean = false,
-    singleBandOptions: Option[SingleBandOptions.Params] = None
+    singleBandOptions: Option[SingleBandOptions.Params] = None,
+    rawSingleBandValues: Boolean = true
 ) {
   def getBandOverrides: Option[(Int, Int, Int)] =
     (redBandOverride, greenBandOverride, blueBandOverride).tupled
@@ -64,6 +41,12 @@ object ProjectNode extends RollbarNotifier with HistogramJsonFormats {
   implicit val projectNodeDecoder = deriveDecoder[ProjectNode]
   implicit val projectNodeEncoder = deriveEncoder[ProjectNode]
 
+  def getClosest(cellWidth: Double, listNums: List[LayoutDefinition]) =
+    listNums match {
+      case Nil  => Double.MaxValue
+      case list => list.minBy(ld => math.abs(ld.cellSize.width - cellWidth))
+    }
+
   implicit val projectNodeTmsReification: MamlTmsReification[ProjectNode] =
     new MamlTmsReification[ProjectNode] {
       def kind(self: ProjectNode): MamlKind = MamlKind.Tile
@@ -72,344 +55,29 @@ object ProjectNode extends RollbarNotifier with HistogramJsonFormats {
           implicit t: Timer[IO]): (Int, Int, Int) => IO[Literal] =
         (z: Int, x: Int, y: Int) => {
           val extent = CogUtils.tmsLevels(z).mapTransform.keyToExtent(x, y)
-          val mdIO = self.getBandOverrides match {
-            case Some((red, green, blue)) =>
-              SceneToProjectDao
-                .getMosaicDefinition(
-                  self.projectId,
-                  Some(Projected(extent, 3857)),
-                  Some(red),
-                  Some(green),
-                  Some(blue)
-                )
-                .transact(xa)
-            case None =>
-              SceneToProjectDao
-                .getMosaicDefinition(
-                  self.projectId,
-                  Some(Projected(extent, 3857))
-                )
-                .transact(xa)
-          }
+          val mdIO = mosaic.getMosaicDefinitions(self, extent)
           for {
             mds <- mdIO
-            mbTiles <- mds.toList.parTraverse(self.isSingleBand match {
-              case false =>
-                getMultiBandTileFromMosaic(z, x, y, extent)
-              case true =>
-                getSingleBandTileFromMosaic(
-                  z,
-                  x,
-                  y,
-                  extent,
-                  self.singleBandOptions getOrElse {
-                    throw new Exception(
-                      "No single-band options found for single-band visualization")
-                  })
-            })
+            mbTiles <- mosaic.getMosaicDefinitionTiles(self,
+                                                       z,
+                                                       x,
+                                                       y,
+                                                       extent,
+                                                       mds)
           } yield {
             RasterLit(
               mbTiles.flatten match {
-                case Nil              => Raster(IntArrayTile.fill(NODATA, 256, 256), extent)
-                case tiles @ (h :: _) => tiles reduce { _ merge _ }
+                case Nil => {
+                  logger.info(s"NO DATA")
+                  Raster(IntArrayTile.fill(NODATA, 256, 256), extent)
+                }
+                case tiles @ (h :: _) =>
+                  tiles reduce {
+                    _ merge _
+                  }
               }
             )
           }
         }
     }
-
-  def getSingleBandTileFromMosaic(z: Int,
-                                  x: Int,
-                                  y: Int,
-                                  extent: Extent,
-                                  singleBandOptions: SingleBandOptions.Params)(
-      md: MosaicDefinition)(implicit t: Timer[IO]): IO[Option[Raster[Tile]]] =
-    md.sceneType match {
-      case Some(SceneType.COG) =>
-        IO.shift(t) *> fetchSingleBandCogTile(md,
-                                              z,
-                                              x,
-                                              y,
-                                              extent,
-                                              singleBandOptions).value
-      case Some(SceneType.Avro) =>
-        IO.shift(t) *> fetchSingleBandAvroTile(md,
-                                               z,
-                                               x,
-                                               y,
-                                               extent,
-                                               singleBandOptions).value
-      case None =>
-        throw new Exception("Unable to fetch tiles with unknown scene type")
-    }
-
-  def getMultiBandTileFromMosaic(z: Int, x: Int, y: Int, extent: Extent)(
-      md: MosaicDefinition)(implicit t: Timer[IO]): IO[Option[Raster[Tile]]] =
-    md.sceneType match {
-      case Some(SceneType.COG) =>
-        IO.shift(t) *> fetchMultiBandCogTile(md, z, x, y, extent).value
-      case Some(SceneType.Avro) =>
-        IO.shift(t) *> fetchMultiBandAvroTile(md, z, x, y, extent).value
-      case None =>
-        throw new Exception("Unable to fetch tiles with unknown scene type")
-    }
-
-  def tileLayerMetadata(id: UUID,
-                        zoom: Int): IO[(Int, TileLayerMetadata[SpatialKey])] = {
-    val layerName = id.toString
-    LayerAttributeDao.unsafeMaxZoomForLayer(layerName).transact(xa) map {
-      case (_, maxZoom) =>
-        val z = if (zoom > maxZoom) maxZoom else zoom
-        z -> store.readMetadata[TileLayerMetadata[SpatialKey]](
-          LayerId(layerName, z))
-    }
-  }
-
-  def layerHistogram(id: UUID): IO[Array[Histogram[Double]]] = {
-    val layerId = LayerId(name = id.toString, zoom = 0)
-    LayerAttributeDao
-      .unsafeGetAttribute(layerId, "histogram")
-      .transact(xa) map { attribute =>
-      attribute.value.noSpaces.parseJson.convertTo[Array[Histogram[Double]]]
-    }
-  }
-
-  def avroLayerTile(id: UUID, zoom: Int, key: SpatialKey): IO[MultibandTile] = {
-    val reader = new S3ValueReader(store)
-      .reader[SpatialKey, MultibandTile](LayerId(id.toString, zoom))
-    IO(reader.read(key))
-  }
-
-  def colorSingleBandTile(
-      tile: Tile,
-      extent: Extent,
-      histogram: Histogram[Double],
-      singleBandOptions: SingleBandOptions.Params): Raster[Tile] = {
-    val colorScheme = singleBandOptions.colorScheme
-    val colorMap = (colorScheme.asArray,
-                    colorScheme.asObject,
-                    singleBandOptions.extraNoData) match {
-      case (Some(a), None, _) =>
-        ColorRampMosaic.colorMapFromVector(a.map(_.noSpaces),
-                                           singleBandOptions,
-                                           histogram)
-      case (None, Some(o), Nil) =>
-        ColorRampMosaic.colorMapFromMap(o.toMap map {
-          case (k, v) => (k, v.noSpaces)
-        })
-      case (None, Some(o), masked @ (h +: t)) =>
-        ColorRampMosaic.colorMapFromMap(o.toMap map {
-          case (k, v) =>
-            (k, if (masked.contains(k.toInt)) "#00000000" else v.noSpaces)
-        })
-      case _ =>
-        val message =
-          "Invalid color scheme format. Color schemes must be defined as an array of hex colors or a mapping of raster values to hex colors."
-        throw new IllegalArgumentException(message)
-    }
-    Raster(tile.color(colorMap), extent)
-  }
-
-  def getCroppedGridBounds(tile: MultibandTile,
-                           zoom: Int,
-                           col: Int,
-                           row: Int,
-                           sourceZoom: Int): GridBounds = {
-    val resolutionDiff = 1 << (zoom - sourceZoom)
-    val innerCol = col % resolutionDiff
-    val innerRow = row % resolutionDiff
-    val cols = tile.cols / resolutionDiff
-    val rows = tile.rows / resolutionDiff
-    GridBounds(
-      colMin = innerCol * cols,
-      rowMin = innerRow * rows,
-      colMax = (innerCol + 1) * cols - 1,
-      rowMax = (innerRow + 1) * rows - 1
-    )
-  }
-
-  // TODO: this essentially inlines a bunch of logic from LayerCache, which isn't super cool
-  // it would be nice to get that logic somewhere more appropriate, especially since a lot of
-  // it is grid <-> geometry math, but I'm not certain where it should go.
-  def fetchMultiBandAvroTile(
-      md: MosaicDefinition,
-      zoom: Int,
-      col: Int,
-      row: Int,
-      extent: Extent)(implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
-    OptionT(
-      for {
-        _ <- IO.pure(
-          logger.debug(
-            s"Fetching multi-band avro tile for scene id ${md.sceneId}"))
-        metadata <- IO.shift(t) *> tileLayerMetadata(md.sceneId, zoom)
-        (sourceZoom, tlm) = metadata
-        zoomDiff = zoom - sourceZoom
-        resolutionDiff = 1 << zoomDiff
-        sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
-        histograms <- IO.shift(t) *> layerHistogram(md.sceneId)
-        mbTileE <- {
-          if (tlm.bounds.includes(sourceKey))
-            avroLayerTile(md.sceneId, sourceZoom, sourceKey).attempt
-          else
-            IO(
-              Left(
-                new Exception(
-                  s"Source key outside of tile layer bounds for scene ${md.sceneId}, key ${sourceKey}")
-              )
-            )
-        }
-      } yield {
-        (mbTileE map {
-          (mbTile: MultibandTile) =>
-            {
-              val corrected = if (zoom > sourceZoom) {
-                md.colorCorrections.colorCorrect(
-                  mbTile.crop(
-                    getCroppedGridBounds(mbTile, zoom, col, row, sourceZoom)
-                  ),
-                  histograms.toSeq)
-              } else {
-                md.colorCorrections.colorCorrect(mbTile, histograms.toSeq)
-              }
-              Raster(corrected.color, extent).resample(256, 256)
-            }
-        }).toOption
-      }
-    )
-  }
-
-  def fetchMultiBandCogTile(
-      md: MosaicDefinition,
-      zoom: Int,
-      col: Int,
-      row: Int,
-      extent: Extent)(implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
-    val tileIO = for {
-      _ <- IO.pure(
-        logger.debug(
-          s"Fetching multi-band COG tile for scene ID ${md.sceneId}"))
-      raster <- IO.shift(t) *> CogUtils.fetch(
-        md.ingestLocation.getOrElse(
-          "Cannot fetch scene with no ingest location"),
-        zoom,
-        col,
-        row)
-      histograms <- IO.shift(t) *> layerHistogram(md.sceneId)
-    } yield {
-      val bandOrder = List(
-        md.colorCorrections.redBand,
-        md.colorCorrections.greenBand,
-        md.colorCorrections.blueBand
-      )
-      val subsetBands = raster.tile.subsetBands(bandOrder)
-      val subsetHistograms = bandOrder map histograms
-      val normalized = (
-        subsetBands.mapBands { (i: Int, tile: Tile) =>
-          {
-            (subsetHistograms(i).minValue, subsetHistograms(i).maxValue) match {
-              case (Some(min), Some(max)) => tile.normalize(min, max, 0, 255)
-              case _ =>
-                throw new Exception(
-                  "Histogram bands don't match up with tile bands")
-            }
-          }
-        }
-      ).color
-
-      Raster(normalized, extent).resample(256, 256)
-    }
-    OptionT(tileIO.attempt.map(_.toOption))
-  }
-
-  def fetchSingleBandAvroTile(md: MosaicDefinition,
-                              zoom: Int,
-                              col: Int,
-                              row: Int,
-                              extent: Extent,
-                              singleBandOptions: SingleBandOptions.Params)(
-      implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
-    OptionT(
-      for {
-        _ <- IO.pure(
-          logger.debug(
-            s"Fetching single-band avro tile for scene id ${md.sceneId}"))
-        metadata <- IO.shift(t) *> tileLayerMetadata(md.sceneId, zoom)
-        (sourceZoom, tlm) = metadata
-        zoomDiff = zoom - sourceZoom
-        resolutionDiff = 1 << zoomDiff
-        sourceKey = SpatialKey(col / resolutionDiff, row / resolutionDiff)
-        histograms <- IO.shift(t) *> layerHistogram(md.sceneId)
-        mbTileE <- {
-          if (tlm.bounds.includes(sourceKey))
-            avroLayerTile(md.sceneId, sourceZoom, sourceKey).attempt
-          else
-            IO(
-              Left(
-                new Exception(
-                  s"Source key outside of tile layer bounds for scene ${md.sceneId}, key ${sourceKey}")
-              )
-            )
-        }
-      } yield {
-        (mbTileE map {
-          (mbTile: MultibandTile) =>
-            {
-              val tile = mbTile.bands.lift(singleBandOptions.band) getOrElse {
-                throw new Exception("No band found in single-band options")
-              }
-              val histogram = histograms
-                .lift(singleBandOptions.band) getOrElse {
-                throw new Exception("No histogram found for band")
-              }
-
-              if (zoom > sourceZoom) {
-                colorSingleBandTile(
-                  tile.crop(
-                    getCroppedGridBounds(mbTile, zoom, col, row, sourceZoom)
-                  ),
-                  extent,
-                  histogram,
-                  singleBandOptions
-                )
-              } else {
-                colorSingleBandTile(tile, extent, histogram, singleBandOptions)
-              }
-
-            }
-        }).toOption
-      }
-    )
-  }
-
-  def fetchSingleBandCogTile(md: MosaicDefinition,
-                             zoom: Int,
-                             col: Int,
-                             row: Int,
-                             extent: Extent,
-                             singleBandOptions: SingleBandOptions.Params)(
-      implicit t: Timer[IO]): OptionT[IO, Raster[Tile]] = {
-    val tileIO = for {
-      _ <- IO.pure(
-        logger.debug(
-          s"Fetching single-band COG tile for scene ID ${md.sceneId}"))
-      raster <- IO.shift(t) *> CogUtils.fetch(
-        md.ingestLocation.getOrElse(
-          "Cannot fetch scene with no ingest location"),
-        zoom,
-        col,
-        row)
-      histograms <- IO.shift(t) *> layerHistogram(md.sceneId)
-    } yield {
-      val tile = raster.tile.bands.lift(singleBandOptions.band) getOrElse {
-        throw new Exception("No band found in single-band options")
-      }
-      val histogram = histograms
-        .lift(singleBandOptions.band) getOrElse {
-        throw new Exception("No histogram found for band")
-      }
-      colorSingleBandTile(tile, extent, histogram, singleBandOptions)
-    }
-    OptionT(tileIO.attempt.map(_.toOption))
-  }
 }

--- a/app-backend/backsplash/src/main/scala/package.scala
+++ b/app-backend/backsplash/src/main/scala/package.scala
@@ -16,8 +16,8 @@ import java.util.Arrays.binarySearch
 
 package object backsplash {
 
-  implicit class MapAlgebraAstConversion(val rfmlAst: MapAlgebraAST) extends BacksplashMamlAdapter
-
+  implicit class MapAlgebraAstConversion(val rfmlAst: MapAlgebraAST)
+      extends BacksplashMamlAdapter
 
   implicit class renderTileWithDefinition(tile: Tile) {
 
@@ -27,7 +27,7 @@ package object backsplash {
     private def buildFn(definition: RenderDefinition): Double => RGBA =
       definition.scale match {
         case Continuous | Sequential | Diverging => continuous(definition)
-        case Qualitative(fallback) => qual(definition, fallback)
+        case Qualitative(fallback)               => qual(definition, fallback)
       }
 
     /** RGB color interpolation logic */
@@ -36,7 +36,7 @@ package object backsplash {
       val g = (color1.green + (color2.green - color1.green) * proportion).toInt
       val b = (color1.blue + (color2.blue - color1.blue) * proportion).toInt
       val a
-      : Double = (color1.alpha + (color2.alpha - color1.alpha) * proportion).toDouble / 2.55
+        : Double = (color1.alpha + (color2.alpha - color1.alpha) * proportion).toDouble / 2.55
       RGBA(r, g, b, a)
     }
 
@@ -52,12 +52,12 @@ package object backsplash {
           // MIN VALUE
           definition.clip match {
             case ClipNone | ClipRight => colors(0)
-            case ClipLeft | ClipBoth => 0x00000000
+            case ClipLeft | ClipBoth  => 0x00000000
           }
         } else if (abs(insertionPoint) - 1 == breaks.size) {
           // MAX VALUE
           definition.clip match {
-            case ClipNone | ClipLeft => colors.last
+            case ClipNone | ClipLeft  => colors.last
             case ClipRight | ClipBoth => 0x00000000
           }
         } else if (insertionPoint < 0) {
@@ -87,12 +87,12 @@ package object backsplash {
         // MIN VALUE
         definition.clip match {
           case ClipNone | ClipRight => fallback
-          case ClipLeft | ClipBoth => 0x00000000
+          case ClipLeft | ClipBoth  => 0x00000000
         }
       } else if (abs(insertionPoint) - 1 == breaks.size) {
         // MAX VALUE
         definition.clip match {
-          case ClipNone | ClipLeft => fallback
+          case ClipNone | ClipLeft  => fallback
           case ClipRight | ClipBoth => 0x00000000
         }
       } else if (insertionPoint < 0) {
@@ -123,4 +123,3 @@ package object backsplash {
     }
   }
 }
-

--- a/app-backend/backsplash/src/main/scala/package.scala
+++ b/app-backend/backsplash/src/main/scala/package.scala
@@ -1,0 +1,126 @@
+package com.azavea.rf
+
+import com.azavea.rf.backsplash.maml.BacksplashMamlAdapter
+import com.azavea.rf.tool.ast._
+
+import com.azavea.rf.tool._
+
+import geotrellis.raster.Tile
+import geotrellis.raster._
+import geotrellis.raster.render._
+import geotrellis.raster.render.png._
+import geotrellis.raster.histogram.Histogram
+
+import scala.math.abs
+import java.util.Arrays.binarySearch
+
+package object backsplash {
+
+  implicit class MapAlgebraAstConversion(val rfmlAst: MapAlgebraAST) extends BacksplashMamlAdapter
+
+
+  implicit class renderTileWithDefinition(tile: Tile) {
+
+    /** This function produces a function from cell value to color appropriate to the color
+      * space defined by the provided [[RenderDefinition]]
+      */
+    private def buildFn(definition: RenderDefinition): Double => RGBA =
+      definition.scale match {
+        case Continuous | Sequential | Diverging => continuous(definition)
+        case Qualitative(fallback) => qual(definition, fallback)
+      }
+
+    /** RGB color interpolation logic */
+    private def RgbLerp(color1: RGBA, color2: RGBA, proportion: Double): Int = {
+      val r = (color1.red + (color2.red - color1.red) * proportion).toInt
+      val g = (color1.green + (color2.green - color1.green) * proportion).toInt
+      val b = (color1.blue + (color2.blue - color1.blue) * proportion).toInt
+      val a
+      : Double = (color1.alpha + (color2.alpha - color1.alpha) * proportion).toDouble / 2.55
+      RGBA(r, g, b, a)
+    }
+
+    /** For production of colors along a continuum */
+    private def continuous(definition: RenderDefinition): Double => RGBA = {
+      dbl: Double =>
+        val decomposed = definition.breakpoints.toArray.sortBy(_._1).unzip
+        val breaks: Array[Double] = decomposed._1
+        val colors: Array[RGBA] = decomposed._2
+
+        val insertionPoint: Int = binarySearch(breaks, dbl)
+        if (insertionPoint == -1) {
+          // MIN VALUE
+          definition.clip match {
+            case ClipNone | ClipRight => colors(0)
+            case ClipLeft | ClipBoth => 0x00000000
+          }
+        } else if (abs(insertionPoint) - 1 == breaks.size) {
+          // MAX VALUE
+          definition.clip match {
+            case ClipNone | ClipLeft => colors.last
+            case ClipRight | ClipBoth => 0x00000000
+          }
+        } else if (insertionPoint < 0) {
+          // MUST INTERPOLATE
+          val lowerIdx = abs(insertionPoint) - 2
+          val higherIdx = abs(insertionPoint) - 1
+          val lower = breaks(lowerIdx)
+          val higher = breaks(higherIdx)
+          val proportion = (dbl - lower) / (higher - lower)
+
+          RgbLerp(colors(lowerIdx), colors(higherIdx), proportion)
+        } else {
+          // Direct hit
+          colors(insertionPoint)
+        }
+    }
+
+    /** For production of colors according to discrete breaks */
+    private def qual(definition: RenderDefinition,
+                     fallback: RGBA): Double => RGBA = { dbl: Double =>
+      val decomposed = definition.breakpoints.toArray.sortBy(_._1).unzip
+      val breaks: Array[Double] = decomposed._1
+      val colors: Array[RGBA] = decomposed._2
+
+      val insertionPoint: Int = binarySearch(breaks, dbl)
+      if (insertionPoint == -1) {
+        // MIN VALUE
+        definition.clip match {
+          case ClipNone | ClipRight => fallback
+          case ClipLeft | ClipBoth => 0x00000000
+        }
+      } else if (abs(insertionPoint) - 1 == breaks.size) {
+        // MAX VALUE
+        definition.clip match {
+          case ClipNone | ClipLeft => fallback
+          case ClipRight | ClipBoth => 0x00000000
+        }
+      } else if (insertionPoint < 0) {
+        // GRAB LOWER VALUE
+        colors(abs(insertionPoint) - 2)
+      } else {
+        // Direct hit
+        if (insertionPoint == colors.size - 1) colors(insertionPoint - 1)
+        else colors(insertionPoint)
+      }
+    }
+
+    /** This method extension provides sugar to match GeoTrellis' renderPng method */
+    def renderPng(definition: RenderDefinition): Png = {
+      val toWrite =
+        if (tile.cellType.isFloatingPoint) {
+          tile.mapDouble({ cellValue: Double =>
+            buildFn(definition)(cellValue).int
+          })
+        } else {
+          tile.map({ cellValue: Int =>
+            buildFn(definition)(cellValue).int
+          })
+        }
+
+      new PngEncoder(Settings(RgbaPngEncoding, PaethFilter))
+        .writeByteArray(toWrite)
+    }
+  }
+}
+

--- a/app-backend/backsplash/src/main/scala/services/AnalysisService.scala
+++ b/app-backend/backsplash/src/main/scala/services/AnalysisService.scala
@@ -1,0 +1,108 @@
+package com.azavea.rf.backsplash.analysis
+
+import java.security.InvalidParameterException
+import java.util.UUID
+
+import cats.data.Validated._
+import cats.effect.{IO, Timer}
+import com.azavea.maml.eval.BufferingInterpreter
+import com.azavea.rf.authentication.Authentication
+import com.azavea.rf.backsplash._
+import com.azavea.rf.backsplash.maml.BacksplashMamlAdapter
+import com.azavea.rf.backsplash.parameters.PathParameters._
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.database.ToolRunDao
+import com.azavea.rf.database.filter.Filterables._
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.tool.ast.{MapAlgebraAST, _}
+import doobie.implicits._
+import geotrellis.raster._
+import geotrellis.raster.render._
+import geotrellis.server.core.maml._
+import org.http4s.{MediaType, _}
+import org.http4s.dsl._
+import org.http4s.headers._
+
+import scala.util._
+
+class AnalysisService(
+                       interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
+                     )(implicit t: Timer[IO])
+  extends Http4sDsl[IO]
+  with RollbarNotifier
+  with Authentication {
+
+  implicit val xa = RFTransactor.xa
+
+  // TODO: DRY OUT
+  object TokenQueryParamMatcher
+    extends QueryParamDecoderMatcher[String]("token")
+
+  object NodeQueryParamMatcher
+    extends OptionalQueryParamDecoderMatcher[String]("node")
+
+  object VoidCacheQueryParamMatcher
+    extends QueryParamDecoderMatcher[Boolean]("voidCache")
+
+  implicit class MapAlgebraAstConversion(val rfmlAst: MapAlgebraAST)
+    extends BacksplashMamlAdapter
+
+  val service: HttpService[IO] =
+    HttpService {
+      case GET -> Root / UUIDWrapper(analysisId) / histogram
+        :? TokenQueryParamMatcher(token)
+        :? NodeQueryParamMatcher(node)
+        :? VoidCacheQueryParamMatcher(void) => {
+
+        ???
+      }
+
+
+      case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(y)
+        :? NodeQueryParamMatcher(node) => {
+
+        logger.info(s"Requesting Analysis: ${analysisId}")
+        val tr = ToolRunDao.query.filter(analysisId).select.transact(xa)
+
+        val mapAlgebraAST = tr.flatMap{ toolRun =>
+          logger.info(s"Getting AST")
+          val astOption = toolRun.executionParameters.as[MapAlgebraAST].right.toOption
+          (astOption, node) match {
+            case (Some(ast), Some(id)) => IO.pure(ast.find(UUID.fromString(id)).getOrElse(
+              throw new InvalidParameterException(s"Node ${id} missing from in AST ${analysisId}")))
+            case (Some(ast), _) => IO.pure(ast)
+          }
+        }
+
+        logger.debug(s"AST: ${mapAlgebraAST}")
+        mapAlgebraAST.flatMap { ast =>
+          val (exp, mdOption, params) = ast.asMaml
+          val mamlEval = MamlTms.apply(IO.pure(exp), IO.pure(params), interpreter)
+          val tileIO = mamlEval(z, x, y)
+          tileIO.attempt flatMap {
+            case Left(error) => ???
+            case Right(Valid(tile)) => {
+              val colorMap  = for {
+                md <- mdOption
+                renderDef <- md.renderDef
+              } yield renderDef
+
+              colorMap match {
+                case Some(rd) => {
+                  logger.debug(s"Using Render Definition: ${rd}")
+                  Ok(tile.renderPng(rd).bytes, `Content-Type`(MediaType.`image/png`))
+                }
+                case _ => {
+                  logger.debug(s"Using Default Color Ramp: Viridis")
+                  Ok(tile.renderPng(ColorRamps.Viridis).bytes, `Content-Type`(MediaType.`image/png`))
+                }
+              }
+            }
+            case Right(Invalid(e)) => {
+              BadRequest(e.toString)
+            }
+          }
+        }
+      }
+    }
+}

--- a/app-backend/backsplash/src/main/scala/services/MosaicService.scala
+++ b/app-backend/backsplash/src/main/scala/services/MosaicService.scala
@@ -1,39 +1,23 @@
 package com.azavea.rf.backsplash.services
 
-import com.azavea.rf.authentication.Authentication
-import com.azavea.rf.backsplash.parameters.PathParameters._
-import com.azavea.rf.backsplash.nodes.ProjectNode
-import com.azavea.rf.common.RollbarNotifier
-import com.azavea.rf.database.{ProjectDao, SceneToProjectDao, UserDao}
-import com.azavea.rf.database.util.RFTransactor
-import com.azavea.rf.datamodel._
-import com.azavea.maml.error.Interpreted
-import com.azavea.maml.eval.BufferingInterpreter
-
-import cats._
-import cats.data._
 import cats.data.Validated._
+import cats.data._
 import cats.effect.{IO, Timer}
 import cats.implicits._
-import cats.syntax._
+import com.azavea.maml.error.Interpreted
+import com.azavea.maml.eval.BufferingInterpreter
+import com.azavea.rf.authentication.Authentication
+import com.azavea.rf.backsplash.nodes.ProjectNode
+import com.azavea.rf.backsplash.parameters.PathParameters._
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.database.{ProjectDao, UserDao}
+import com.azavea.rf.datamodel._
 import doobie.implicits._
-import geotrellis.proj4.WebMercator
-import geotrellis.raster.{IntArrayTile, MultibandTile, Raster, Tile}
-import geotrellis.raster.render.ColorRamps
-import geotrellis.server.core.cog.CogUtils
+import geotrellis.raster.Tile
 import geotrellis.server.core.maml._
-import geotrellis.server.core.maml.reification.MamlTmsReification
-import geotrellis.vector.{Projected, Polygon}
-import io.circe._
 import org.http4s._
-import org.http4s.circe._
 import org.http4s.dsl._
-import org.http4s.dsl.io._
-import org.http4s.implicits._
-import org.http4s.server._
-
-import java.net.URI
-import java.util.UUID
 
 class MosaicService(
     interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
@@ -100,14 +84,16 @@ class MosaicService(
                             Some(green),
                             Some(blue),
                             project.isSingleBand,
-                            project.singleBandOptions)
+                            project.singleBandOptions,
+                            false)
               case _ =>
                 ProjectNode(projectId,
                             None,
                             None,
                             None,
                             project.isSingleBand,
-                            project.singleBandOptions)
+                            project.singleBandOptions,
+                            false)
             }
           val paramMap = Map("identity" -> projectNode)
           EitherT(IO.shift(t) *> eval(paramMap, z, x, y).attempt)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -192,7 +192,7 @@ lazy val root = Project("root", file("."))
              tile,
              tool,
              bridge,
-             backsplash)
+    backsplash)
   .settings(commonSettings: _*)
 
 lazy val api = Project("api", file("api"))
@@ -439,8 +439,9 @@ lazy val bridge = Project("bridge", file("bridge"))
 
 // maml / better-abstracted tile server
 lazy val backsplash = Project("backsplash", file("backsplash"))
-  .dependsOn(authentication, geotrellis, db)
+  .dependsOn(authentication, geotrellis, db, tool)
   .settings(commonSettings: _*)
+  .settings(fork in run := true)
   .settings({
     libraryDependencies ++= Seq(
       Dependencies.geotrellisServer,
@@ -448,7 +449,8 @@ lazy val backsplash = Project("backsplash", file("backsplash"))
       Dependencies.http4sBlazeClient,
       Dependencies.http4sCirce,
       Dependencies.http4sDSL,
-      Dependencies.http4sServer
+      Dependencies.http4sServer,
+      "com.azavea" %% "maml-jvm" % "0.0.15"
     )
   })
   .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -192,7 +192,7 @@ lazy val root = Project("root", file("."))
              tile,
              tool,
              bridge,
-    backsplash)
+             backsplash)
   .settings(commonSettings: _*)
 
 lazy val api = Project("api", file("api"))


### PR DESCRIPTION
## Overview

This adds an initial analysis service that builds on the usage of Project nodes. It does not add the histogram support that is necessary for full integration as that is going to be dealt with in https://github.com/raster-foundry/raster-foundry/issues/4151

### Checklist

- [x] Styleguide updated, if necessary
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [x] Symlinks from new migrations present or corrected for any new migrations
- [x] PR has a name that won't get you publicly shamed for vagueness
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [x] Any new SQL strings have tests

### Demo

#### Old Lab
![old-tileserver](https://user-images.githubusercontent.com/898060/46536866-c36d7d80-c87d-11e8-8594-10f9c7d5d844.png)

#### New Lab
![new-tileserver](https://user-images.githubusercontent.com/898060/46536871-c8323180-c87d-11e8-8202-8a3a068ae3d9.png)

#### Single Band Coloring Still Works Too
![singleband-still-works](https://user-images.githubusercontent.com/898060/46536877-d08a6c80-c87d-11e8-9e61-138fa3b99fc9.png)


## Testing Instructions

There is somewhat of a roundabout way for testing since the lab UI doesn't function without a working histogram endpoint. So the first step is to edit `docker-compose.yml` and set the tile server to the old one:
```
TILE_SERVER_LOCATION=http://localhost:9101
```
 * Create a new analysis with a project that has a histogram (if using a COG)
 * Copy a tile request URL from the network inspector
 * Modify the domain of the request to point to the new tile server (`localhost:8081`) and make request
 * Visualization should match

Closes #3905
