### PR TITLE
Add activity indicator for creation of annotations

### DIFF
--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.html
@@ -69,7 +69,7 @@
     </div>
     <div class="content"
          ng-if="$ctrl.fetchingAnnotationsError">
-      <div class="alert alert-default">
+      <div class="alert alert-warning">
         <div class="alert-message">There was an error fetching your annotations</div>
         <button class="alert-action"
                 ng-click="$ctrl.retryFetches()"
@@ -79,10 +79,26 @@
       </div>
     </div>
     <div class="content"
-         ng-if="$ctrl.fetchingAnnotations">
+         ng-if="$ctrl.creatingAnnotationsError">
+      <div class="alert alert-warning">
+        <div class="alert-message">There was an error creating your annotations</div>
+      </div>
+    </div>
+    <div class="content"
+         ng-if="$ctrl.fetchingAnnotations"
+    >
       <div class="alert alert-default">
         <p class="">Loading Annotations
           <span class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetchingAnnotations}"></span>
+        </p>
+      </div>
+    </div>
+    <div class="content"
+         ng-if="$ctrl.creatingAnnotations"
+    >
+      <div class="alert alert-default">
+        <p>Creating Annotations
+          <span class="icon-load animate-spin"></span>
         </p>
       </div>
     </div>
@@ -92,7 +108,8 @@
                                   ng-attr-id="{{'anchor' + annotation.id}}"
                                   ng-click="$ctrl.doPanToAnnotation(annotation)"
                                   annotation-id="annotation.id"
-        </rf-annotate-sidebar-item>
+        ></rf-annotate-sidebar-item>
+
       </div>
   </div>
 </div>

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -53,6 +53,8 @@ class AnnotateController {
             filter,
             fetchingAnnotations: state.projects.fetchingAnnotations,
             fetchingAnnotationsError: state.projects.fetchingAnnotationsError,
+            creatingAnnotations: state.projects.creatingAnnotations,
+            creatingAnnotationsError: state.projects.creatingAnnotationsError,
             editingAnnotation: state.projects.editingAnnotation,
             annotationTemplate: state.projects.annotationTemplate,
             annotationShapefileProps

--- a/app-frontend/src/app/redux/reducers/annotation-reducer.js
+++ b/app-frontend/src/app/redux/reducers/annotation-reducer.js
@@ -28,6 +28,7 @@ export const annotationReducer = typeToReducer({
             annotations: new OrderedMap(), editingAnnotation: null,
             fetchingAnnotations: false, fetchingAnnotationsError: null,
             sidebarDisabled: false, annotationTemplate: null,
+            creatingAnnotations: false, creatingAnnotationsError: false,
 
             labels: [], filter: 'All'
         });
@@ -145,12 +146,19 @@ export const annotationReducer = typeToReducer({
     },
     [ANNOTATIONS_CREATE]: {
         PENDING: (state) => {
-            return state;
+            return Object.assign({}, state, {
+                creatingAnnotations: true,
+                creatingAnnotationsError: false
+            });
         },
         REJECTED: (state, action) => {
             // eslint-disable-next-line
             console.error('Error creating annotations', action.payload);
-            return state;
+
+            return Object.assign({}, state, {
+                creatingAnnotations: false,
+                creatingAnnotationsError: true
+            });
         },
         FULFILLED: (state, action) => {
             let newAnnotations = action.payload.data.features;
@@ -172,6 +180,8 @@ export const annotationReducer = typeToReducer({
                 {},
                 state,
                 {
+                    creatingAnnotations: false,
+                    creatingAnnotationsError: false,
                     annotations,
                     labels: labels.toArray()
                 }


### PR DESCRIPTION
## Overview

Adds some extra state to track request status when creating annotations via drawing or importing.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

### Demo

![image](https://user-images.githubusercontent.com/2442245/46422742-f6d7cd00-c702-11e8-8b73-52aeb545fb67.png)

![image](https://user-images.githubusercontent.com/2442245/46422760-01926200-c703-11e8-9f1d-c21a746f8ed1.png)

## Testing Instructions
- create an annotation and use the redux dev tools to see the indicator if it disappears too fast
- set your network throttling to offline and try to create an annotation, see the error message
- create some annotations via import and do the same thing as above

Closes #3729 
