### PR TITLE
Frontend support to disable datasource deletion if it has ACRs

### DIFF
--- a/app-frontend/src/app/components/datasources/datasourceDeleteModal/datasourceDeleteModal.module.js
+++ b/app-frontend/src/app/components/datasources/datasourceDeleteModal/datasourceDeleteModal.module.js
@@ -17,7 +17,7 @@ const uploadProgress = 'CREATED,UPLOADING,UPLOADED,QUEUED,PROCESSING';
 class DatasourceDeleteModalController {
     constructor(
         $rootScope, $scope, $log,
-        uploadService, sceneService
+        uploadService, sceneService, datasourceService
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -27,7 +27,20 @@ class DatasourceDeleteModalController {
     }
 
     $onInit() {
-        this.checkUploadStatus();
+        this.checkPermissions();
+    }
+
+    checkPermissions() {
+        this.checkInProgress = true;
+        this.datasourceService.getPermissions(this.datasource.id).then(permissions => {
+            if (permissions.length === 0) {
+                this.checkUploadStatus();
+            } else {
+                this.checkInProgress = false;
+                this.allowDelete = false;
+                this.displayPermissionMsg(permissions.length);
+            }
+        });
     }
 
     checkUploadStatus() {
@@ -80,6 +93,14 @@ class DatasourceDeleteModalController {
             + 'Scenes using this datasource will no longer be accessible. '
             + 'This action is not reversible. '
             + 'Are you sure you wish to continue?</p>'
+            + '</div>';
+    }
+
+    displayPermissionMsg(acrCount) {
+        const text = acrCount === 1 ? 'permission is' : 'permissions are';
+        this.deleteMsg = '<div class="color-danger">'
+            + `<p>${acrCount} ${text} granted on this datasource.</p>`
+            + '<p>Datasource cannot be deleted at this time.</p>'
             + '</div>';
     }
 }

--- a/app-frontend/src/app/components/datasources/datasourceDeleteModal/datasourceDeleteModal.module.js
+++ b/app-frontend/src/app/components/datasources/datasourceDeleteModal/datasourceDeleteModal.module.js
@@ -27,20 +27,7 @@ class DatasourceDeleteModalController {
     }
 
     $onInit() {
-        this.checkPermissions();
-    }
-
-    checkPermissions() {
-        this.checkInProgress = true;
-        this.datasourceService.getPermissions(this.datasource.id).then(permissions => {
-            if (permissions.length === 0) {
-                this.checkUploadStatus();
-            } else {
-                this.checkInProgress = false;
-                this.allowDelete = false;
-                this.displayPermissionMsg(permissions.length);
-            }
-        });
+        this.checkUploadStatus();
     }
 
     checkUploadStatus() {
@@ -93,14 +80,6 @@ class DatasourceDeleteModalController {
             + 'Scenes using this datasource will no longer be accessible. '
             + 'This action is not reversible. '
             + 'Are you sure you wish to continue?</p>'
-            + '</div>';
-    }
-
-    displayPermissionMsg(acrCount) {
-        const text = acrCount === 1 ? 'permission is' : 'permissions are';
-        this.deleteMsg = '<div class="color-danger">'
-            + `<p>${acrCount} ${text} granted on this datasource.</p>`
-            + '<p>Datasource cannot be deleted at this time.</p>'
             + '</div>';
     }
 }

--- a/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
+++ b/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
@@ -26,22 +26,23 @@
          <span class="sr-only">View</span>
          <i class="icon-eye"></i>
       </a>
-      <button
-        type="button"
-        class="btn btn-small btn-danger"
-        ng-click="$ctrl.onOpenDatasourceDeleteModal()"
-        ng-if="$ctrl.isOwner"
-        ng-class="{'btn-danger-disabled': $ctrl.isShared}">
-        <span class="sr-only">Delete</span>
-        <i class="icon-trash" ng-if="!$ctrl.isShared"></i>
-        <i class="icon-trash"
-           ng-if="$ctrl.isShared"
-           tooltips
+      <div tooltips
            tooltip-template="Datasource cannot be deleted at this time because it is being shared."
            tooltop-size="small"
            tooltip-class="rf-tooltip"
-           tooltip-side="right"></i>
-      </button>
+           tooltip-side="right"
+           tooltip-hidden="{{!$ctrl.isShared}}"
+           ng-class="{'btn-group-tooltip-disabled': $ctrl.isShared}">
+        <button type="button"
+                class="btn btn-small btn-danger btn-group-danger-delete"
+                ng-class="{'btn-group-danger-delete-disabled': $ctrl.isShared}"
+                ng-click="$ctrl.onOpenDatasourceDeleteModal()"
+                ng-if="$ctrl.isOwner"
+                ng-disabled="$ctrl.isShared">
+         <span class="sr-only">Delete</span>
+         <i class="icon-trash"></i>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
+++ b/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
@@ -30,10 +30,17 @@
         type="button"
         class="btn btn-small btn-danger"
         ng-click="$ctrl.onOpenDatasourceDeleteModal()"
-        ng-if="$ctrl.isOwner && !$ctrl.isShared"
-        uib-tooltip="After today restriction">
+        ng-if="$ctrl.isOwner"
+        ng-class="{'btn-danger-disabled': $ctrl.isShared}">
         <span class="sr-only">Delete</span>
-        <i class="icon-trash"></i>
+        <i class="icon-trash" ng-if="!$ctrl.isShared"></i>
+        <i class="icon-trash"
+           ng-if="$ctrl.isShared"
+           tooltips
+           tooltip-template="Datasource cannot be deleted at this time because it is being shared."
+           tooltop-size="small"
+           tooltip-class="rf-tooltip"
+           tooltip-side="right"></i>
       </button>
     </div>
   </div>

--- a/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.module.js
+++ b/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.module.js
@@ -49,20 +49,18 @@ class DatasourceItemController {
     }
 
     onOpenDatasourceDeleteModal() {
-        if (!this.isShared) {
-            this.modalService.open({
-                component: 'rfDatasourceDeleteModal',
-                resolve: {
-                    datasource: () => this.datasource
-                }
-            }).result.then(() => {
-                this.datasourceService.deleteDatasource(this.datasource.id).then(res => {
-                    this.$state.reload();
-                }, (err) => {
-                    this.$log.debug('error deleting datasource', err);
-                });
+        this.modalService.open({
+            component: 'rfDatasourceDeleteModal',
+            resolve: {
+                datasource: () => this.datasource
+            }
+        }).result.then(() => {
+            this.datasourceService.deleteDatasource(this.datasource.id).then(res => {
+                this.$state.reload();
+            }, (err) => {
+                this.$log.debug('error deleting datasource', err);
             });
-        }
+        });
     }
 }
 

--- a/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.module.js
+++ b/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.module.js
@@ -38,7 +38,7 @@ class DatasourceItemController {
     checkSharing() {
         if (this.isOwner) {
             this.datasourceService.getPermissions(this.datasource.id).then(permissions => {
-                this.isShared = !!permissions.find(permission => permission.isActive);
+                this.isShared = permissions.length;
             });
         }
     }
@@ -49,18 +49,20 @@ class DatasourceItemController {
     }
 
     onOpenDatasourceDeleteModal() {
-        this.modalService.open({
-            component: 'rfDatasourceDeleteModal',
-            resolve: {
-                datasource: () => this.datasource
-            }
-        }).result.then(() => {
-            this.datasourceService.deleteDatasource(this.datasource.id).then(res => {
-                this.$state.reload();
-            }, (err) => {
-                this.$log.debug('error deleting datasource', err);
+        if (!this.isShared) {
+            this.modalService.open({
+                component: 'rfDatasourceDeleteModal',
+                resolve: {
+                    datasource: () => this.datasource
+                }
+            }).result.then(() => {
+                this.datasourceService.deleteDatasource(this.datasource.id).then(res => {
+                    this.$state.reload();
+                }, (err) => {
+                    this.$log.debug('error deleting datasource', err);
+                });
             });
-        });
+        }
     }
 }
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3171,3 +3171,8 @@ rf-navbar-search {
         padding: 0.5em;
     }
 }
+
+// datasource item
+.btn-group-tooltip-disabled {
+  cursor: not-allowed;
+}

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -363,10 +363,13 @@
     border-bottom-left-radius: 0;
   }
 
-  .btn-danger-disabled {
-    background-color: rgba($danger, 0.5);
-    border-color: rgba(darken($danger, 5%), 0.5);
-    cursor: not-allowed;
+  .btn-group-danger-delete {
+    border-top-left-radius: 0px;
+    border-bottom-left-radius: 0px;
+  }
+
+  .btn-group-danger-delete-disabled {
+    z-index: -1;
   }
 }
 

--- a/app-frontend/src/assets/styles/sass/components/_button.scss
+++ b/app-frontend/src/assets/styles/sass/components/_button.scss
@@ -362,6 +362,12 @@
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
   }
+
+  .btn-danger-disabled {
+    background-color: rgba($danger, 0.5);
+    border-color: rgba(darken($danger, 5%), 0.5);
+    cursor: not-allowed;
+  }
 }
 
 .btn-dropdown-transitional {


### PR DESCRIPTION
## Overview

This PR adds frontend support that disables datasource deletion when there is any ACR on the datasource. This check is consistent with the datasource deletion backend.

### Checklist

- [X] PR has a name that won't get you publicly shamed for vagueness

### Notes

Datasource deletion backend bug fix is in https://github.com/raster-foundry/raster-foundry/pull/4140

## Testing Instructions

 * Create your own datasource
 * Go to datasource list page. Try to delete it. The delete button should be enabled.
 * Get into a sql shell and do
```sql
UPDATE datasources
SET acrs = ARRAY['ALL;;VIEW']
WHERE id = '<datasource_id>';
```
 * Go to datasource list page. Try to delete it. The delete button should be disabled. (Hitting the delete endpoint will also give you 403, which reflects that our backend disables such deletion under this circumstance as well.)

Closes #4142 
