### PR TITLE
Add template UNRELEASED section to changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,10 @@ Brief description of what this PR does, and why it is needed.
 
 ### Checklist
 
+- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md)
 - [ ] Styleguide updated, if necessary
 - [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
 - [ ] Symlinks from new migrations present or corrected for any new migrations
-- [ ] PR has a name that won't get you publicly shamed for vagueness
 - [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
 - [ ] Any new SQL strings have tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## Unreleased(https://github.com/raster-foundry/raster-foundry/tree/develop)
+
+### Added
+
+### Changed
+
+- Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [1.12.0](https://github.com/raster-foundry/raster-foundry/tree/1.12.0) (2018-10-03)
 
 [Full Changelog](https://github.com/raster-foundry/raster-foundry/compare/1.11.0...1.12.0)


### PR DESCRIPTION
## Overview

This PR updates the PR template to include a more helpful CHANGELOG-generating step than making sure the PR name is good.

### Checklist

- [x] Description of the PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

Closes #3824 