### PR TITLE
Enable advanced color correction for cogs 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format [\#4159](https://github.com/raster-foundry/raster-foundry/pull/4159)
+- Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
 
 ### Deprecated
 

--- a/app-backend/backsplash/src/main/scala/io/Cog.scala
+++ b/app-backend/backsplash/src/main/scala/io/Cog.scala
@@ -78,19 +78,9 @@ object Cog extends RollbarNotifier {
       )
       val subsetBands = raster.tile.subsetBands(bandOrder)
       val subsetHistograms = bandOrder map histograms
-      val normalized =
-        subsetBands.mapBands { (i: Int, tile: Tile) =>
-          {
-            (subsetHistograms(i).minValue, subsetHistograms(i).maxValue) match {
-              case (Some(min), Some(max)) => tile.normalize(min, max, 0, 255)
-              case _ =>
-                throw new Exception(
-                  "Histogram bands don't match up with tile bands")
-            }
-          }
-        }
-
-      Raster(normalized.color, extent).resample(256, 256)
+      val colored =
+        md.colorCorrections.colorCorrect(subsetBands, subsetHistograms).color
+      Raster(colored, extent).resample(256, 256)
     }
     OptionT(tileIO.attempt.map(_.toOption))
   }

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -82,7 +82,7 @@ export default class ProjectsAdvancedColorController {
             this.$parent.projectId,
             {
                 pageSize: this.projectService.scenePageSize,
-                page : page - 1
+                page: page - 1
             }
         ).then((paginatedResponse) => {
             this.sceneList = paginatedResponse.results;


### PR DESCRIPTION
## Overview

This PR uses `ColorCorrect.Params.colorCorrect` instead of a bunch of ad hoc color correction to color multiband COG tiles.

### Checklist

- [x] PR has a name that won't get you publicly shamed for vagueness

## Notes

holding off on merge even though it's small until changelog changes are in

## Testing Instructions

 * view a project with a COG in it
 * do advanced color correction to it
 * watch it go
 * :racing_car: 

Closes #4149 
