### PR TITLE
Do not initialize blog feed or intercom if set to 'disabled' in override file

### DIFF
--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -13,7 +13,9 @@ const DEVELOPMENT = NODE_ENV === 'production' ? false : true;
 const HERE_APP_ID = 'v88MqS5fQgxuHyIWJYX7';
 const HERE_APP_CODE = '5pn07ENomTHOap0u7nQSFA';
 
-const INTERCOM_APP_ID = '';
+// leave this unless you are setting your own
+const INTERCOM_APP_ID = 'disabled';
+const FEED_SOURCE = 'disabled';
 
 const basemaps = JSON.stringify({
     layers: {
@@ -61,7 +63,7 @@ module.exports = function (_path) {
                     LOGOFILE: JSON.stringify('raster-foundry-logo.svg'),
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
-                    FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json')
+                    FEED_SOURCE: JSON.stringify(FEED_SOURCE)
                 },
                 'HELPCONFIG': {
                     HELP_DOCS: JSON.stringify(HELP_DOCS)

--- a/app-frontend/src/app/pages/home/home.controller.js
+++ b/app-frontend/src/app/pages/home/home.controller.js
@@ -11,6 +11,7 @@ class HomeController {
     $onInit() {
         this.BUILDCONFIG = BUILDCONFIG;
         this.HELPCONFIG = HELPCONFIG;
+        this.blogPosts = [];
         this.feedService.getPosts().then(posts => {
             this.blogPosts = posts;
         });

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -82,7 +82,7 @@ export default class ProjectsAdvancedColorController {
             this.$parent.projectId,
             {
                 pageSize: this.projectService.scenePageSize,
-                page : page - 1
+                page: page - 1
             }
         ).then((paginatedResponse) => {
             this.sceneList = paginatedResponse.results;

--- a/app-frontend/src/app/services/common/feed.service.js
+++ b/app-frontend/src/app/services/common/feed.service.js
@@ -11,6 +11,9 @@ export default (app) => {
 
         getPosts() {
             return this.$q((resolve, reject) => {
+                if (!BUILDCONFIG.FEED_SOURCE || BUILDCONFIG.FEED_SOURCE === 'disabled') {
+                    return reject();
+                }
                 this.$http({
                     method: 'GET',
                     url: `${BUILDCONFIG.API_HOST}/api/feed/` +
@@ -21,15 +24,15 @@ export default (app) => {
                         let json = JSON.parse(raw.substring(raw.indexOf('{')));
                         let payload = json.payload;
                         if (payload && payload.posts) {
-                            resolve(payload.posts);
+                            return resolve(payload.posts);
                         } else {
-                            reject();
+                            return reject();
                         }
                     } catch (err) {
-                        reject();
+                        return reject();
                     }
                 }, () => {
-                    reject();
+                    return reject();
                 });
             });
         }

--- a/app-frontend/src/app/services/vendor/intercom.service.js
+++ b/app-frontend/src/app/services/vendor/intercom.service.js
@@ -8,7 +8,6 @@ export default (app) => {
             this.$http = $http;
             this.angularLoad = angularLoad;
             this.scriptLoaded = false;
-            // @TODO: load this value from the APP_CONFIG
             this.appId = BUILDCONFIG.INTERCOM_APP_ID || APP_CONFIG.intercomAppId;
             this.srcUrl = `https://widget.intercom.io/widget/${this.appId}`;
         }
@@ -20,11 +19,11 @@ export default (app) => {
         }
 
         bootWithUser(user) {
-            if (!this.scriptLoaded) {
+            if (!this.scriptLoaded && this.appId !== 'disabled') {
                 this.load().then(() => {
                     this.doBoot(user);
                 });
-            } else {
+            } else if (this.appId !== 'disabled') {
                 this.doBoot(user);
             }
         }


### PR DESCRIPTION
## Overview
Allow setting values in the webpack override file to 'disabled'.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/46482243-3a920b80-c7c3-11e8-878a-8c0b98b2c927.png)

## Testing Instructions

 * Create a webpack override file and set the FEED_SOURCE / INTERCOM_APP_ID variables to `'disabled'`
* Start the frontend dev server, and verify that request are not made for these two features when you load the frontend in the browser

Closes #4113 
Closes #4147 
