### PR TITLE
Restrict platform / all sharing to platform admins and superusers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format [\#4159](https://github.com/raster-foundry/raster-foundry/pull/4159)
 - Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
+- Restricted sharing with everyone and platforms to superusers and platform admins [\#4166](https://github.com/raster-foundry/raster-foundry/pull/4166)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -16,6 +16,7 @@ import kamon.akka.http.KamonTraceDirectives
 
 import java.util.UUID
 import scala.util.{Success, Failure}
+import cats.implicits._
 import doobie._
 import doobie.implicits._
 import doobie.Fragments.in
@@ -174,14 +175,20 @@ trait DatasourceRoutes
 
   def replaceDatasourcePermissions(datasourceId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
-        DatasourceDao.query
-          .ownedBy(user, datasourceId)
-          .exists
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[List[ObjectAccessControlRule]]) { acrList =>
+      entity(as[List[ObjectAccessControlRule]]) { acrList =>
+        authorizeAsync {
+          (DatasourceDao.query
+             .ownedBy(user, datasourceId)
+             .exists,
+           acrList traverse { acr =>
+             DatasourceDao.isValidPermission(acr, user)
+           } map { _.foldLeft(true)(_ && _) }).tupled
+            .map({ authTup =>
+              authTup._1 && authTup._2
+            })
+            .transact(xa)
+            .unsafeToFuture
+        } {
           complete {
             DatasourceDao
               .replacePermissions(datasourceId, acrList)
@@ -194,14 +201,18 @@ trait DatasourceRoutes
 
   def addDatasourcePermission(datasourceId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
-        DatasourceDao.query
-          .ownedBy(user, datasourceId)
-          .exists
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[ObjectAccessControlRule]) { acr =>
+      entity(as[ObjectAccessControlRule]) { acr =>
+        authorizeAsync {
+          (DatasourceDao.query
+             .ownedBy(user, datasourceId)
+             .exists,
+           DatasourceDao.isValidPermission(acr, user)).tupled
+            .map({ authTup =>
+              authTup._1 && authTup._2
+            })
+            .transact(xa)
+            .unsafeToFuture
+        } {
           complete {
             DatasourceDao
               .addPermission(datasourceId, acr)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -1102,7 +1102,14 @@ trait ProjectRoutes
         (ProjectDao.query
            .ownedBy(user, projectId)
            .exists,
-         acrList traverse { acr => ProjectDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _ ) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+         acrList traverse { acr =>
+           ProjectDao.isValidPermission(acr, user)
+         } map { _.foldLeft(true)(_ && _) }).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ProjectDao
@@ -1120,7 +1127,12 @@ trait ProjectRoutes
         (ProjectDao.query
            .ownedBy(user, projectId)
            .exists,
-         ProjectDao.isValidPermission(acr, user)).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+         ProjectDao.isValidPermission(acr, user)).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ProjectDao

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -308,8 +308,14 @@ trait SceneRoutes
   def replaceScenePermissions(sceneId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (SceneDao.query.ownedBy(user, sceneId).exists,
-         acrList traverse { acr => SceneDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+        (SceneDao.query.ownedBy(user, sceneId).exists, acrList traverse { acr =>
+          SceneDao.isValidPermission(acr, user)
+        } map { _.foldLeft(true)(_ && _) }).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           SceneDao
@@ -325,8 +331,11 @@ trait SceneRoutes
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
         (SceneDao.query.ownedBy(user, sceneId).exists,
-         SceneDao.isValidPermission(acr, user)).tupled.map(authTup => authTup._1 && authTup._2).transact(xa).unsafeToFuture
-        } {
+         SceneDao.isValidPermission(acr, user)).tupled
+          .map(authTup => authTup._1 && authTup._2)
+          .transact(xa)
+          .unsafeToFuture
+      } {
         complete {
           SceneDao
             .addPermission(sceneId, acr)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -306,10 +306,11 @@ trait SceneRoutes
   }
 
   def replaceScenePermissions(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
-      SceneDao.query.ownedBy(user, sceneId).exists.transact(xa).unsafeToFuture
-    } {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
+    entity(as[List[ObjectAccessControlRule]]) { acrList =>
+      authorizeAsync {
+        (SceneDao.query.ownedBy(user, sceneId).exists,
+         acrList traverse { acr => SceneDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+      } {
         complete {
           SceneDao
             .replacePermissions(sceneId, acrList)
@@ -321,10 +322,11 @@ trait SceneRoutes
   }
 
   def addScenePermission(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
-      SceneDao.query.ownedBy(user, sceneId).exists.transact(xa).unsafeToFuture
-    } {
-      entity(as[ObjectAccessControlRule]) { acr =>
+    entity(as[ObjectAccessControlRule]) { acr =>
+      authorizeAsync {
+        (SceneDao.query.ownedBy(user, sceneId).exists,
+         SceneDao.isValidPermission(acr, user)).tupled.map(authTup => authTup._1 && authTup._2).transact(xa).unsafeToFuture
+        } {
         complete {
           SceneDao
             .addPermission(sceneId, acr)

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -254,8 +254,14 @@ trait ShapeRoutes
   def replaceShapePermissions(shapeId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (ShapeDao.query.ownedBy(user, shapeId).exists,
-         acrList traverse { acr => ShapeDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+        (ShapeDao.query.ownedBy(user, shapeId).exists, acrList traverse { acr =>
+          ShapeDao.isValidPermission(acr, user)
+        } map { _.foldLeft(true)(_ && _) }).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ShapeDao
@@ -271,7 +277,12 @@ trait ShapeRoutes
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
         (ShapeDao.query.ownedBy(user, shapeId).exists,
-         ShapeDao.isValidPermission(acr, user)).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+         ShapeDao.isValidPermission(acr, user)).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ShapeDao

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -7,6 +7,7 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.FileInfo
 import better.files.{File => ScalaFile}
 import cats.effect.IO
+import cats.implicits._
 import com.azavea.rf.api.utils.queryparams.QueryParametersCommon
 import com.azavea.rf.authentication.Authentication
 import com.azavea.rf.common._
@@ -251,10 +252,11 @@ trait ShapeRoutes
   }
 
   def replaceShapePermissions(shapeId: UUID): Route = authenticate { user =>
-    authorizeAsync {
-      ShapeDao.query.ownedBy(user, shapeId).exists.transact(xa).unsafeToFuture
-    } {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
+    entity(as[List[ObjectAccessControlRule]]) { acrList =>
+      authorizeAsync {
+        (ShapeDao.query.ownedBy(user, shapeId).exists,
+         acrList traverse { acr => ShapeDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+      } {
         complete {
           ShapeDao
             .replacePermissions(shapeId, acrList)
@@ -266,10 +268,11 @@ trait ShapeRoutes
   }
 
   def addShapePermission(shapeId: UUID): Route = authenticate { user =>
-    authorizeAsync {
-      ShapeDao.query.ownedBy(user, shapeId).exists.transact(xa).unsafeToFuture
-    } {
-      entity(as[ObjectAccessControlRule]) { acr =>
+    entity(as[ObjectAccessControlRule]) { acr =>
+      authorizeAsync {
+        (ShapeDao.query.ownedBy(user, shapeId).exists,
+         ShapeDao.isValidPermission(acr, user)).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+      } {
         complete {
           ShapeDao
             .addPermission(shapeId, acr)

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -175,9 +175,16 @@ trait ToolRunRoutes
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
         (ToolRunDao.query
-          .ownedBy(user, toolRunId)
+           .ownedBy(user, toolRunId)
            .exists,
-         acrList traverse { acr => ToolRunDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+         acrList traverse { acr =>
+           ToolRunDao.isValidPermission(acr, user)
+         } map { _.foldLeft(true)(_ && _) }).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ToolRunDao
@@ -193,9 +200,14 @@ trait ToolRunRoutes
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
         (ToolRunDao.query
-          .ownedBy(user, toolRunId)
+           .ownedBy(user, toolRunId)
            .exists,
-         ToolRunDao.isValidPermission(acr, user)).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+         ToolRunDao.isValidPermission(acr, user)).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ToolRunDao

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -172,14 +172,13 @@ trait ToolRunRoutes
   }
 
   def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
-    authorizeAsync {
-      ToolRunDao.query
-        .ownedBy(user, toolRunId)
-        .exists
-        .transact(xa)
-        .unsafeToFuture
-    } {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
+    entity(as[List[ObjectAccessControlRule]]) { acrList =>
+      authorizeAsync {
+        (ToolRunDao.query
+          .ownedBy(user, toolRunId)
+           .exists,
+         acrList traverse { acr => ToolRunDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+      } {
         complete {
           ToolRunDao
             .replacePermissions(toolRunId, acrList)
@@ -191,14 +190,13 @@ trait ToolRunRoutes
   }
 
   def addToolRunPermission(toolRunId: UUID): Route = authenticate { user =>
-    authorizeAsync {
-      ToolRunDao.query
-        .ownedBy(user, toolRunId)
-        .exists
-        .transact(xa)
-        .unsafeToFuture
-    } {
-      entity(as[ObjectAccessControlRule]) { acr =>
+    entity(as[ObjectAccessControlRule]) { acr =>
+      authorizeAsync {
+        (ToolRunDao.query
+          .ownedBy(user, toolRunId)
+           .exists,
+         ToolRunDao.isValidPermission(acr, user)).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+      } {
         complete {
           ToolRunDao
             .addPermission(toolRunId, acr)

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -244,8 +244,14 @@ trait ToolRoutes
   def replaceToolPermissions(toolId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (ToolDao.query.ownedBy(user, toolId).exists,
-         acrList traverse { acr => ToolDao.isValidPermission(acr, user) } map { _.foldLeft(true)(_ && _) }).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+        (ToolDao.query.ownedBy(user, toolId).exists, acrList traverse { acr =>
+          ToolDao.isValidPermission(acr, user)
+        } map { _.foldLeft(true)(_ && _) }).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ToolDao
@@ -261,7 +267,12 @@ trait ToolRoutes
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
         (ToolDao.query.ownedBy(user, toolId).exists,
-         ToolDao.isValidPermission(acr, user)).tupled.map({authTup => authTup._1 && authTup._2}).transact(xa).unsafeToFuture
+         ToolDao.isValidPermission(acr, user)).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
       } {
         complete {
           ToolDao

--- a/app-backend/common/src/main/scala/utils/Shapefile.scala
+++ b/app-backend/common/src/main/scala/utils/Shapefile.scala
@@ -13,8 +13,8 @@ object Shapefile {
       prj: String): Either[List[Int], List[T2]] =
     accumulateFrom match {
       case Nil =>
-        errorIndices.length match {
-          case 0 => Right(accum)
+        errorIndices match {
+          case Nil => Right(accum)
           case _ => Left(errorIndices)
         }
       case h +: t =>

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -201,8 +201,8 @@ object Annotation extends LazyLogging {
         properties.modifiedAt,
         properties.modifiedBy,
         properties.owner,
-        properties.label.length match {
-          case 0 => "Unlabeled"
+        properties.label match {
+          case "" => "Unlabeled"
           case _ => properties.label
         },
         properties.description,
@@ -243,8 +243,8 @@ object Annotation extends LazyLogging {
         now, // modifiedAt
         user.id, // modifiedBy
         ownerId, // owner
-        label.length match {
-          case 0 => "Unlabeled"
+        label match {
+          case "" => "Unlabeled"
           case _ => label
         },
         description,
@@ -336,8 +336,8 @@ object AnnotationShapefileService extends LazyLogging {
 
         val data = Seq(
           ("id", annotation.id),
-          ("label", annotation.label.length match {
-            case 0 => "Unlabeled"
+          ("label", annotation.label match {
+            case "" => "Unlabeled"
             case _ => annotation.label
           }),
           ("desc", annotation.description.getOrElse("")),

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ObjectAccessControlRule.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ObjectAccessControlRule.scala
@@ -28,8 +28,8 @@ object ObjectAccessControlRule {
   def fromObjAcrString(objAcrString: String): Option[ObjectAccessControlRule] =
     objAcrString.split(";") match {
       case Array(subjectType, subjectId, actionType) =>
-        (subjectType, subjectId.length) match {
-          case ("ALL", 0) =>
+        (subjectType, subjectId) match {
+          case ("ALL", "") =>
             Some(
               ObjectAccessControlRule(SubjectType.All,
                                       None,
@@ -37,7 +37,7 @@ object ObjectAccessControlRule {
           case ("ALL", _) =>
             throw new Exception(
               s"Invalid subjectId for subjectType All: ${subjectId}")
-          case (_, 0) =>
+          case (_, "") =>
             throw new Exception(
               s"No subject Id provided for subject type: ${subjectType}")
           case (_, _) =>

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -144,7 +144,7 @@ trait ObjectPermissions[Model] {
 
   def deletePermissions(
       id: UUID): ConnectionIO[List[Option[ObjectAccessControlRule]]] =
-    updatePermissionsF(id, List[ObjectAccessControlRule](), replace = true).update
+    updatePermissionsF(id, List[ObjectAccessControlRule]()).update
       .withUniqueGeneratedKeys[List[String]]("acrs")
       .map(acrStringsToList(_))
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -38,7 +38,8 @@ trait ObjectPermissions[Model] {
         throw new Exception(s"${tableName} not yet supported")
     }).query.filter(id).exists
 
-  def isValidPermission(acr: ObjectAccessControlRule, user: User): ConnectionIO[Boolean] =
+  def isValidPermission(acr: ObjectAccessControlRule,
+                        user: User): ConnectionIO[Boolean] =
     (acr.subjectType, acr.subjectId, user) match {
       case (SubjectType.All, _, u) => u.isSuperuser.pure[ConnectionIO]
       case (SubjectType.Platform, Some(subjectId), user) =>

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -38,19 +38,19 @@ trait ObjectPermissions[Model] {
         throw new Exception(s"${tableName} not yet supported")
     }).query.filter(id).exists
 
-  def isValidPermission(acr: ObjectAccessControlRule): ConnectionIO[Boolean] =
-    (acr.subjectType, acr.subjectId) match {
-      case (SubjectType.All, _) => true.pure[ConnectionIO]
-      case (SubjectType.Platform, Some(subjectId)) =>
-        PlatformDao.query.filter(UUID.fromString(subjectId)).exists
-      case (SubjectType.Organization, Some(subjectId)) =>
+  def isValidPermission(acr: ObjectAccessControlRule, user: User): ConnectionIO[Boolean] =
+    (acr.subjectType, acr.subjectId, user) match {
+      case (SubjectType.All, _, u) => u.isSuperuser.pure[ConnectionIO]
+      case (SubjectType.Platform, Some(subjectId), user) =>
+        PlatformDao.userIsAdmin(user, UUID.fromString(subjectId))
+      case (SubjectType.Organization, Some(subjectId), _) =>
         OrganizationDao.query.filter(UUID.fromString(subjectId)).exists
-      case (SubjectType.Team, Some(subjectId)) =>
+      case (SubjectType.Team, Some(subjectId), _) =>
         TeamDao.query.filter(UUID.fromString(subjectId)).exists
-      case (SubjectType.User, Some(subjectId)) =>
+      case (SubjectType.User, Some(subjectId), _) =>
         UserDao.filterById(subjectId).exists
       case _ =>
-        throw new Exception("Subject id required and but not provided in")
+        false.pure[ConnectionIO]
     }
 
   def getPermissionsF(id: UUID): Fragment =
@@ -104,56 +104,33 @@ trait ObjectPermissions[Model] {
 
   def addPermission(id: UUID, acr: ObjectAccessControlRule)
     : ConnectionIO[List[Option[ObjectAccessControlRule]]] =
-    isValidPermission(acr) flatMap { isValidPermission =>
-      isValidPermission match {
-        case false => throw new Exception(s"${acr.toObjAcrString} is invalid!")
+    for {
+      permissions <- getPermissions(id)
+      permExists = permissions.contains(Some(acr))
+      addPermission <- permExists match {
         case true =>
-          for {
-            permissions <- getPermissions(id)
-            permExists = permissions.contains(Some(acr))
-            addPermission <- permExists match {
-              case true =>
-                throw new Exception(
-                  s"${acr.toObjAcrString} exists for ${tableName} ${id}")
-              case false =>
-                appendPermissionF(id, acr).update
-                  .withUniqueGeneratedKeys[List[String]]("acrs")
-                  .map(acrStringsToList(_))
-            }
-          } yield { addPermission }
+          throw new Exception(
+            s"${acr.toObjAcrString} exists for ${tableName} ${id}")
+        case false =>
+          appendPermissionF(id, acr).update
+            .withUniqueGeneratedKeys[List[String]]("acrs")
+            .map(acrStringsToList(_))
       }
-    }
+    } yield { addPermission }
 
   def addPermissionsMany(id: UUID,
                          acrList: List[ObjectAccessControlRule],
                          replace: Boolean = false)
     : ConnectionIO[List[Option[ObjectAccessControlRule]]] = {
-    val isAcrListPermittedIO: ConnectionIO[List[Boolean]] =
-      acrList.traverse(isValidPermission(_))
     for {
-      isAcrListPermitted <- isAcrListPermittedIO
       permissions <- getPermissions(id)
-      acrListFiltered: List[ObjectAccessControlRule] = isAcrListPermitted.zipWithIndex
-        .foldLeft(List[ObjectAccessControlRule]()) { (acc, perm) =>
-          {
-            val (permitted, idx): (Boolean, Int) = perm
-            (replace, permitted) match {
-              case (true, true) => acrList(perm._2) :: acc
-              case (false, true)
-                  if !permissions.contains(Some(acrList(perm._2))) =>
-                acrList(perm._2) :: acc
-              case _ =>
-                acc
-            }
-          }
-        }
-      addPermissionsMany <- acrListFiltered.length match {
-        case 0 if !replace =>
+      addPermissionsMany <- acrList match {
+        case Nil if !replace =>
           throw new Exception(s"All permissions exist for ${tableName} ${id}")
-        case 0 if replace =>
+        case Nil if replace =>
           throw new Exception("List of permissions do not have valid subjects")
         case _ =>
-          updatePermissionsF(id, acrListFiltered, replace).update
+          updatePermissionsF(id, acrList, replace).update
             .withUniqueGeneratedKeys[List[String]]("acrs")
             .map(acrStringsToList(_))
       }
@@ -166,7 +143,7 @@ trait ObjectPermissions[Model] {
 
   def deletePermissions(
       id: UUID): ConnectionIO[List[Option[ObjectAccessControlRule]]] =
-    updatePermissionsF(id, List[ObjectAccessControlRule]()).update
+    updatePermissionsF(id, List[ObjectAccessControlRule](), replace = true).update
       .withUniqueGeneratedKeys[List[String]]("acrs")
       .map(acrStringsToList(_))
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -67,8 +67,8 @@ trait ObjectPermissions[Model] {
   def updatePermissionsF(id: UUID,
                          acrList: List[ObjectAccessControlRule],
                          replace: Boolean = false): Fragment = {
-    val newAcrs: String = acrList.length match {
-      case 0 => "'{}'::text[]"
+    val newAcrs: String = acrList match {
+      case Nil => "'{}'::text[]"
       case _ =>
         val acrTextArray: String =
           s"ARRAY[${acrList.map("'" ++ _.toObjAcrString ++ "'").mkString(",")}]"

--- a/app-frontend/src/app/components/permissions/permissionModal/permissionModal.js
+++ b/app-frontend/src/app/components/permissions/permissionModal/permissionModal.js
@@ -75,8 +75,12 @@ class PermissionModalController {
                     target: 'PLATFORM',
                     id: 0,
                     applies: () =>
-                        !this.actionsBuffer.PLATFORM ||
-                        !Object.keys(this.actionsBuffer.PLATFORM).length
+                        this.authService.user.isSuperuser ||
+                        _.find(
+                            this.authService.getUserRoles(),
+                            (userRole) => userRole.groupType === 'PLATFORM' &&
+                                userRole.groupRole === 'ADMIN'
+                        )
                 }, {
                     name: 'An organization',
                     singular: 'organization',


### PR DESCRIPTION
## Overview

This PR locks down sharing that's likely to affect huge numbers of users to only users with certain privilege levels. In pursuit of that, it also moves ACR validity checks into authorization and fully rejects requests where some of the ACRs in a list aren't valid.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Datasources
- [x] Scenes
- [x] Projects
- [x] Tools
- [x] Tool runs
- [x] Shapes
- [x] `Everyone` and `Platform` options hidden for users who can't do them

## Testing Instructions

 * sign in as the dev user and note that you can't share with everyone in the sharing modal
 * update the dev user in the db to be a super user, refresh the page, and note that then you can
 * update the dev user to set them back to not being a super user
 * modify the dev user's platform role to be an `'ADMIN'`
 * refresh the page and note that you can see `'Everyone'` sharing again
 * save some permissions to confirm I didn't ruin that

Closes #4096 
