### PR TITLE
Increase nginx buffer size & count for Scene, Tool, and Thumbnail req…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Removed
 
 ### Fixed
+- Increase nginx buffer size & count for Scene, Tool, and Thumbnail requests [\#4170](https://github.com/raster-foundry/raster-foundry/pull/4170)
 - Add user button no longer shows for non-admins of teams and orgs [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix undefined function call when selecting project scenes by clicking the map in advanced color correction view [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -34,7 +34,17 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
-    location ~* ^\/api\/exports\/.*\/files\/.* {
+    location /api/scenes {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_read_timeout 20s;
+        proxy_redirect off;
+        proxy_buffers 24 4k;
+
+        proxy_pass http://api-server-upstream;
+    }
+
+    location ~* ^\/api/exports/.*/files/.* {
         limit_req zone=download_req;
 
         proxy_set_header Host $http_host;
@@ -45,11 +55,12 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
-    location /thumbnails {
+    location /api/thumbnails {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_read_timeout 20s;
         proxy_redirect off;
+        proxy_buffers 4 64k;
 
         proxy_pass http://api-server-upstream;
     }

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -15,30 +15,20 @@ server {
     include /etc/nginx/includes/api-security-headers.conf;
 
     location /api {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
 
         proxy_pass http://api-server-upstream;
     }
 
     location /api/shapes/upload {
         client_max_body_size 20m;
-
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
 
         proxy_pass http://api-server-upstream;
     }
 
     location /api/scenes {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
         proxy_buffers 24 4k;
 
         proxy_pass http://api-server-upstream;
@@ -47,49 +37,34 @@ server {
     location ~* ^\/api/exports/.*/files/.* {
         limit_req zone=download_req;
 
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
 
         proxy_pass http://api-server-upstream;
     }
 
     location /api/thumbnails {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
         proxy_buffers 4 64k;
 
         proxy_pass http://api-server-upstream;
     }
 
     location = /healthcheck/ {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
 
         proxy_pass http://api-server-upstream;
     }
 
     # Angular config
     location = /config {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
 
         proxy_pass http://api-server-upstream;
     }
 
     # Angular per-user feature flags
     location = /feature-flags {
-        proxy_set_header Host $http_host;
-        proxy_set_header X-Forwarded-For $remote_addr;
-        proxy_read_timeout 20s;
-        proxy_redirect off;
+        include /etc/nginx/includes/proxy-settings.conf
 
         proxy_pass http://api-server-upstream;
     }

--- a/nginx/etc/nginx/conf.d/backsplash.conf
+++ b/nginx/etc/nginx/conf.d/backsplash.conf
@@ -20,6 +20,27 @@ server {
 		rewrite /tiles/(.*) /$1 last;
 	}
 
+	location ~* ^/tools/.*/\d+/\d+/\d+  {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 20s;
+		proxy_redirect off;
+		proxy_buffers 16 16k;
+
+		proxy_pass http://tile-server-upstream;
+	}
+
+	location ~* ^/(scenes/)?.*/\d+/\d+/\d+  {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 20s;
+		proxy_redirect off;
+		proxy_buffers 24 4k;
+
+		proxy_pass http://tile-server-upstream;
+	}
+
+
 	location / {
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/etc/nginx/conf.d/backsplash.conf
+++ b/nginx/etc/nginx/conf.d/backsplash.conf
@@ -21,31 +21,21 @@ server {
 	}
 
 	location ~* ^/tools/.*/\d+/\d+/\d+  {
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_read_timeout 20s;
-		proxy_redirect off;
+		include /etc/nginx/includes/proxy_settings.conf
 		proxy_buffers 16 16k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location ~* ^/(scenes/)?.*/\d+/\d+/\d+  {
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_read_timeout 20s;
-		proxy_redirect off;
+		include /etc/nginx/includes/proxy_settings.conf
 		proxy_buffers 24 4k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
-
 	location / {
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_read_timeout 20s;
-		proxy_redirect off;
+		include /etc/nginx/includes/proxy_settings.conf
 
 		proxy_pass http://tile-server-upstream;
 	}

--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -20,6 +20,26 @@ server {
 		rewrite /tiles/(.*) /$1 last;
 	}
 
+	location ~* ^/tools/.*/\d+/\d+/\d+  {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 20s;
+		proxy_redirect off;
+		proxy_buffers 16 16k;
+
+		proxy_pass http://tile-server-upstream;
+	}
+
+	location ~* ^/(scenes/)?.*/\d+/\d+/\d+  {
+		proxy_set_header Host $http_host;
+		proxy_set_header X-Forwarded-For $remote_addr;
+		proxy_read_timeout 20s;
+		proxy_redirect off;
+		proxy_buffers 24 4k;
+
+		proxy_pass http://tile-server-upstream;
+	}
+
 	location / {
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Forwarded-For $remote_addr;

--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -21,30 +21,21 @@ server {
 	}
 
 	location ~* ^/tools/.*/\d+/\d+/\d+  {
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_read_timeout 20s;
-		proxy_redirect off;
+		include /etc/nginx/includes/proxy_settings.conf
 		proxy_buffers 16 16k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location ~* ^/(scenes/)?.*/\d+/\d+/\d+  {
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_read_timeout 20s;
-		proxy_redirect off;
+		include /etc/nginx/includes/proxy_settings.conf
 		proxy_buffers 24 4k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location / {
-		proxy_set_header Host $http_host;
-		proxy_set_header X-Forwarded-For $remote_addr;
-		proxy_read_timeout 20s;
-		proxy_redirect off;
+		include /etc/nginx/includes/proxy_settings.conf
 
 		proxy_pass http://tile-server-upstream;
 	}

--- a/nginx/etc/nginx/includes/proxy-settings.conf
+++ b/nginx/etc/nginx/includes/proxy-settings.conf
@@ -1,0 +1,8 @@
+#
+# A set of commonly used proxy settings
+#
+
+proxy_set_header Host $http_host;
+proxy_set_header X-Forwarded-For $remote_addr;
+proxy_read_timeout 20s;
+proxy_redirect off;


### PR DESCRIPTION
## Overview

This PR increases the nginx `buffer_size` configuration for endpoints that generate larger responses. The increased buffer counts and sizes should prevent nginx from buffering responses to disk, which improve response speeds.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

See https://github.com/azavea/raster-foundry-platform/issues/464#issuecomment-427130156 for an explanation of why I picked the endpoints, buffer sizes and counts that I did.


## Testing Instructions
This has been deployed to staging. The following instructions will test `/api/scene/x/y/z`, `/api/thumbnail`, on the API server, and `/<SCENE_UUID>/x/y/z` and `/scene/<SCENE_UUID>/x/y/z` on the Tile server. I was unable to successfully run an analysis because requests returned a Java OOM error.


 * Visit https://app.staging.rasterfoundry.com/share/4cf4c1a1-5356-4d15-ab2d-6cd1aa4f801a
 *  Zoom in on the red tile to about zoom level 12.
 * Verify that there are no nginx buffer warnings in the Staging papertrail logs

Closes https://github.com/azavea/raster-foundry-platform/issues/464
