### PR TITLE
Allow organization members to create teams if they aren't an admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@
 - Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
 - Restricted sharing with everyone and platforms to superusers and platform admins [\#4166](https://github.com/raster-foundry/raster-foundry/pull/4166)
 - Added sbt configuration for auto-scalafmt [\#4175](https://github.com/raster-foundry/raster-foundry/pull/4175)
-- Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4175), [\#4183](https://github.com/raster-foundry/raster-foundry/pull/4183)
 - Displayed user information on template items when not created by the platform [\#4172](https://github.com/raster-foundry/raster-foundry/pull/4172)
 - Simplified authorization logic in backsplash [\#4176](https://github.com/raster-foundry/raster-foundry/pull/4176)
 - Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4181), [\#4183](https://github.com/raster-foundry/raster-foundry/pull/4183), [\#4186](https://github.com/raster-foundry/raster-foundry/pull/4186)
 - Switched to using `sbt` to resolve dependencies [\#4191](https://github.com/raster-foundry/raster-foundry/pull/4191)
+- Users who are not admins of an organization can now correctly create teams and are automatically added to them [\#4147](https://github.com/raster-foundry/raster-foundry/pull/4171)
 
 ### Deprecated
 

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/color/functions/ApproximationsSpec.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/color/functions/ApproximationsSpec.scala
@@ -4,7 +4,8 @@ import org.apache.commons.math3.util.FastMath
 import org.scalatest._
 
 class ApproximationsSpec extends FunSpec with Matchers {
-  it("Approximations.pow in SaturationAdjust should be +- 0.1 of the FastMath.pow") {
+  it(
+    "Approximations.pow in SaturationAdjust should be +- 0.1 of the FastMath.pow") {
     // Chroma is a Double in the range [0.0, 1.0]. Scale factor is the same as our other gamma corrections:
     // a Double in the range [0.0, 2.0].
     val chromas = 0d to 1d by 0.2
@@ -18,7 +19,8 @@ class ApproximationsSpec extends FunSpec with Matchers {
       val snd = FastMath.pow(chroma, 1d / scaleFactor)
       val thrd = math.pow(chroma, 1d / scaleFactor)
 
-      if(!java.lang.Double.isNaN(fst) && !java.lang.Double.isNaN(snd) && !java.lang.Double.isNaN(thrd)) {
+      if (!java.lang.Double.isNaN(fst) && !java.lang.Double.isNaN(snd) && !java.lang.Double
+            .isNaN(thrd)) {
         fst shouldBe snd +- 0.1
       } else {
         java.lang.Double.isNaN(fst) shouldBe java.lang.Double.isNaN(snd)
@@ -27,7 +29,8 @@ class ApproximationsSpec extends FunSpec with Matchers {
     }
   }
 
-  it("Approximations.exp in SigmoidalContrast should be +- 403 of the FastMath.exp") {
+  it(
+    "Approximations.exp in SigmoidalContrast should be +- 403 of the FastMath.exp") {
     val alphas = 0d to 1d by 0.2
     val betas = 0d to 10d by 0.2
 
@@ -39,7 +42,8 @@ class ApproximationsSpec extends FunSpec with Matchers {
       val snd = FastMath.exp(beta * alpha)
       val thrd = math.exp(beta * alpha)
 
-      if(!java.lang.Double.isNaN(fst) && !java.lang.Double.isNaN(snd) && !java.lang.Double.isNaN(thrd)) {
+      if (!java.lang.Double.isNaN(fst) && !java.lang.Double.isNaN(snd) && !java.lang.Double
+            .isNaN(thrd)) {
         fst shouldBe snd +- 403
       } else {
         java.lang.Double.isNaN(fst) shouldBe java.lang.Double.isNaN(snd)

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -682,17 +682,17 @@ object Generators extends ArbitraryInstances {
       searchName <- possiblyEmptyStringGen
     } yield { SearchQueryParameters(Some(searchName)) }
 
-  private def objectAccessControlRuleGen: Gen[ObjectAccessControlRule] = for {
-    subjectType <- subjectTypeGen
-    subjectId <- uuidGen
-    actionType <- actionTypeGen
-  } yield { ObjectAccessControlRule(
-    subjectType,
-    subjectType match {
-      case SubjectType.All => None
-      case _ => Some(subjectId.toString)
-    },
-    actionType) }
+  private def objectAccessControlRuleGen: Gen[ObjectAccessControlRule] =
+    for {
+      subjectType <- subjectTypeGen
+      subjectId <- uuidGen
+      actionType <- actionTypeGen
+    } yield {
+      ObjectAccessControlRule(subjectType, subjectType match {
+        case SubjectType.All => None
+        case _               => Some(subjectId.toString)
+      }, actionType)
+    }
 
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
@@ -823,13 +823,15 @@ object Generators extends ArbitraryInstances {
     implicit def arbSearchQueryParameters: Arbitrary[SearchQueryParameters] =
       Arbitrary { searchQueryParametersGen }
 
-
-    implicit def arbObjectAccessControlRule : Arbitrary[ObjectAccessControlRule] =
+    implicit def arbObjectAccessControlRule
+      : Arbitrary[ObjectAccessControlRule] =
       Arbitrary { objectAccessControlRuleGen }
 
-    implicit def arbListObjectAccessControlRule: Arbitrary[List[ObjectAccessControlRule]] =
+    implicit def arbListObjectAccessControlRule
+      : Arbitrary[List[ObjectAccessControlRule]] =
       Arbitrary {
-        Gen.nonEmptyListOf[ObjectAccessControlRule](arbitrary[ObjectAccessControlRule])
+        Gen.nonEmptyListOf[ObjectAccessControlRule](
+          arbitrary[ObjectAccessControlRule])
       }
   }
 }

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/TeamDao.scala
@@ -84,6 +84,20 @@ object TeamDao extends Dao[Team] {
       )
   }
 
+  def createWithRole(team: Team, user: User): ConnectionIO[Team] = {
+    for {
+      createdTeam <- create(team)
+      userGroupRoleCreate = UserGroupRole.Create(
+        user.id,
+        GroupType.Team,
+        team.id,
+        GroupRole.Admin
+      )
+      _ <- UserGroupRoleDao.create(
+        userGroupRoleCreate.toUserGroupRole(user, MembershipStatus.Approved))
+    } yield createdTeam
+  }
+
   def listOrgTeams(
       organizationId: UUID,
       page: PageRequest,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
@@ -15,24 +15,41 @@ import org.scalatest.prop.Checkers
 
 import java.util.UUID
 
-class AnnotationGroupDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class AnnotationGroupDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("insert annotation group") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create,
-         annotationGroupCreate: AnnotationGroup.Create) => {
-          val annotationGroupInsertWithUserAndProjectIO = insertUserOrgProject(user, org, project) flatMap {
-            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
-              AnnotationGroupDao.createAnnotationGroup(dbProject.id, annotationGroupCreate, dbUser) map {
-                (_, dbUser, dbProject)
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         annotationGroupCreate: AnnotationGroup.Create) =>
+          {
+            val annotationGroupInsertWithUserAndProjectIO = insertUserOrgProject(
+              user,
+              org,
+              project) flatMap {
+              case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+                AnnotationGroupDao.createAnnotationGroup(dbProject.id,
+                                                         annotationGroupCreate,
+                                                         dbUser) map {
+                  (_, dbUser, dbProject)
+                }
               }
             }
+            val (annotationGroup, dbUser, dbProject) =
+              annotationGroupInsertWithUserAndProjectIO
+                .transact(xa)
+                .unsafeRunSync()
+            assert(annotationGroup.name == annotationGroupCreate.name,
+                   "; Annotation group should be inserted")
+            true
           }
-          val (annotationGroup, dbUser, dbProject) = annotationGroupInsertWithUserAndProjectIO.transact(xa).unsafeRunSync()
-          assert(annotationGroup.name == annotationGroupCreate.name, "; Annotation group should be inserted")
-          true
-        }
       }
     }
   }
@@ -40,88 +57,146 @@ class AnnotationGroupDaoSpec extends FunSuite with Matchers with Checkers with D
   test("list project annotation groups") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create,
-         project1: Project.Create, project2: Project.Create,
-         agc1: AnnotationGroup.Create, agc2: AnnotationGroup.Create, agc3: AnnotationGroup.Create) => {
-          val annotationGroupIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project1)
-            (dbOrg, dbUser, dbProject1) = orgUserProject
-            dbProject2 <- ProjectDao.insertProject(project2, dbUser)
-            agDb1 <- AnnotationGroupDao.createAnnotationGroup(dbProject1.id, agc1, dbUser)
-            agDb2 <- AnnotationGroupDao.createAnnotationGroup(dbProject1.id, agc2, dbUser)
-            agDb3 <- AnnotationGroupDao.createAnnotationGroup(dbProject2.id, agc3, dbUser)
-            p1AnnotationGroups <- AnnotationGroupDao.listAnnotationGroupsForProject(dbProject1.id)
-            p2AnnotationGroups <- AnnotationGroupDao.listAnnotationGroupsForProject(dbProject2.id)
-          } yield (agDb1, agDb2, agDb3, p1AnnotationGroups, p2AnnotationGroups)
+        (user: User.Create,
+         org: Organization.Create,
+         project1: Project.Create,
+         project2: Project.Create,
+         agc1: AnnotationGroup.Create,
+         agc2: AnnotationGroup.Create,
+         agc3: AnnotationGroup.Create) =>
+          {
+            val annotationGroupIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project1)
+              (dbOrg, dbUser, dbProject1) = orgUserProject
+              dbProject2 <- ProjectDao.insertProject(project2, dbUser)
+              agDb1 <- AnnotationGroupDao.createAnnotationGroup(dbProject1.id,
+                                                                agc1,
+                                                                dbUser)
+              agDb2 <- AnnotationGroupDao.createAnnotationGroup(dbProject1.id,
+                                                                agc2,
+                                                                dbUser)
+              agDb3 <- AnnotationGroupDao.createAnnotationGroup(dbProject2.id,
+                                                                agc3,
+                                                                dbUser)
+              p1AnnotationGroups <- AnnotationGroupDao
+                .listAnnotationGroupsForProject(dbProject1.id)
+              p2AnnotationGroups <- AnnotationGroupDao
+                .listAnnotationGroupsForProject(dbProject2.id)
+            } yield
+              (agDb1, agDb2, agDb3, p1AnnotationGroups, p2AnnotationGroups)
 
-          val (ag1, ag2, ag3, p1ag, p2ag) = annotationGroupIO.transact(xa).unsafeRunSync()
+            val (ag1, ag2, ag3, p1ag, p2ag) =
+              annotationGroupIO.transact(xa).unsafeRunSync()
 
-          assert(p1ag.length == 2 && p2ag.length == 1, "; annotation groups are filters to project")
-          true
-        }
+            assert(p1ag.length == 2 && p2ag.length == 1,
+                   "; annotation groups are filters to project")
+            true
+          }
       }
     }
   }
 
-  test ("delete annotation group and associated annotations") {
+  test("delete annotation group and associated annotations") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create,
+        (user: User.Create,
+         org: Organization.Create,
          project1: Project.Create,
-         agc1: AnnotationGroup.Create, agc2: AnnotationGroup.Create,
-         agc1Annotations: List[Annotation.Create], agc2Annotations: List[Annotation.Create]
-        ) => {
-          val annotationGroupIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project1)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            agDb1 <- AnnotationGroupDao.createAnnotationGroup(dbProject.id, agc1, dbUser)
-            agDb2 <- AnnotationGroupDao.createAnnotationGroup(dbProject.id, agc2, dbUser)
-            ag1annotations <- AnnotationDao.insertAnnotations(
-              agc1Annotations.map(_.copy(annotationGroup = Some(agDb1.id))), dbProject.id, dbUser)
-            ag2annotations <- AnnotationDao.insertAnnotations(
-              agc2Annotations.map(_.copy(annotationGroup = Some(agDb2.id))), dbProject.id, dbUser)
-            deleteCount <- AnnotationGroupDao.deleteAnnotationGroup(dbProject.id, agDb1.id)
-            projectAnnotations <- AnnotationDao.query.filter(fr"project_id=${dbProject.id}").list
-            projectAnnotationGroups <- AnnotationGroupDao.listAnnotationGroupsForProject(dbProject.id)
-          } yield (ag1annotations, ag2annotations, projectAnnotations, projectAnnotationGroups, deleteCount)
+         agc1: AnnotationGroup.Create,
+         agc2: AnnotationGroup.Create,
+         agc1Annotations: List[Annotation.Create],
+         agc2Annotations: List[Annotation.Create]) =>
+          {
+            val annotationGroupIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project1)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              agDb1 <- AnnotationGroupDao.createAnnotationGroup(dbProject.id,
+                                                                agc1,
+                                                                dbUser)
+              agDb2 <- AnnotationGroupDao.createAnnotationGroup(dbProject.id,
+                                                                agc2,
+                                                                dbUser)
+              ag1annotations <- AnnotationDao.insertAnnotations(
+                agc1Annotations.map(_.copy(annotationGroup = Some(agDb1.id))),
+                dbProject.id,
+                dbUser)
+              ag2annotations <- AnnotationDao.insertAnnotations(
+                agc2Annotations.map(_.copy(annotationGroup = Some(agDb2.id))),
+                dbProject.id,
+                dbUser)
+              deleteCount <- AnnotationGroupDao.deleteAnnotationGroup(
+                dbProject.id,
+                agDb1.id)
+              projectAnnotations <- AnnotationDao.query
+                .filter(fr"project_id=${dbProject.id}")
+                .list
+              projectAnnotationGroups <- AnnotationGroupDao
+                .listAnnotationGroupsForProject(dbProject.id)
+            } yield
+              (ag1annotations,
+               ag2annotations,
+               projectAnnotations,
+               projectAnnotationGroups,
+               deleteCount)
 
-          val (deletedAnnotations, remainingAnnotations, projectAnnotations, projectAnnotationGroups, deleteCount) = annotationGroupIO.transact(xa).unsafeRunSync()
+            val (deletedAnnotations,
+                 remainingAnnotations,
+                 projectAnnotations,
+                 projectAnnotationGroups,
+                 deleteCount) = annotationGroupIO.transact(xa).unsafeRunSync()
 
-          assert(deleteCount == 1, "; annotation group delete query deleted an annotation group")
-          assert(projectAnnotations.length == remainingAnnotations.length, "; Deleting the annotation group also deletes annotations")
-          assert(projectAnnotationGroups.length == 2, "; Project has default 'Annotations' group and remaining created annotation group")
-          true
-        }
+            assert(
+              deleteCount == 1,
+              "; annotation group delete query deleted an annotation group")
+            assert(projectAnnotations.length == remainingAnnotations.length,
+                   "; Deleting the annotation group also deletes annotations")
+            assert(
+              projectAnnotationGroups.length == 2,
+              "; Project has default 'Annotations' group and remaining created annotation group")
+            true
+          }
       }
     }
   }
 
-  test ("Creating annotations on a project with no annotation groups") {
+  test("Creating annotations on a project with no annotation groups") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create,
+        (user: User.Create,
+         org: Organization.Create,
          project1: Project.Create,
-         annotations: List[Annotation.Create]
-        ) => {
-          val annotationGroupIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project1)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            dbAnnotations <- AnnotationDao.insertAnnotations(
-              annotations, dbProject.id, dbUser
-            )
-            projectAnnotations <- AnnotationDao.query.filter(fr"project_id=${dbProject.id}").list
-            projectAnnotationGroups <- AnnotationGroupDao.listAnnotationGroupsForProject(dbProject.id)
-            updatedProject <- ProjectDao.unsafeGetProjectById(dbProject.id)
-          } yield (projectAnnotationGroups, updatedProject)
+         annotations: List[Annotation.Create]) =>
+          {
+            val annotationGroupIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project1)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              dbAnnotations <- AnnotationDao.insertAnnotations(
+                annotations,
+                dbProject.id,
+                dbUser
+              )
+              projectAnnotations <- AnnotationDao.query
+                .filter(fr"project_id=${dbProject.id}")
+                .list
+              projectAnnotationGroups <- AnnotationGroupDao
+                .listAnnotationGroupsForProject(dbProject.id)
+              updatedProject <- ProjectDao.unsafeGetProjectById(dbProject.id)
+            } yield (projectAnnotationGroups, updatedProject)
 
-          val (projectAnnotationGroups, project) = annotationGroupIO.transact(xa).unsafeRunSync()
+            val (projectAnnotationGroups, project) =
+              annotationGroupIO.transact(xa).unsafeRunSync()
 
-          assert(projectAnnotationGroups.length == 1, "; Project has an annotation group created on it automatically")
-          val defaultAnnotationGroup = projectAnnotationGroups.head
-          assert(Some(defaultAnnotationGroup.id) == project.defaultAnnotationGroup, "; Automatically created annotation group is set as project default")
-          assert(defaultAnnotationGroup.name == "Annotations", "; Default annotation group is named 'Annotations'")
-          true
-        }
+            assert(
+              projectAnnotationGroups.length == 1,
+              "; Project has an annotation group created on it automatically")
+            val defaultAnnotationGroup = projectAnnotationGroups.head
+            assert(
+              Some(defaultAnnotationGroup.id) == project.defaultAnnotationGroup,
+              "; Automatically created annotation group is set as project default")
+            assert(defaultAnnotationGroup.name == "Annotations",
+                   "; Default annotation group is named 'Annotations'")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -19,8 +19,12 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
 
-
-class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class AoiDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("list AOIs") {
     AoiDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
@@ -29,24 +33,37 @@ class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig 
   test("insert an AOI") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create, aoi: AOI.Create, shape: Shape.Create) => {
-          val aoiInsertIO = insertUserOrgProject(user, org, project) flatMap {
-            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
-              for {
-                shape <- ShapeDao.insertShape(shape, dbUser)
-                aoi <- AoiDao.createAOI(fixupAoiCreate(dbUser, dbProject, aoi, shape), dbUser)
-              } yield (shape, aoi)
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         aoi: AOI.Create,
+         shape: Shape.Create) =>
+          {
+            val aoiInsertIO = insertUserOrgProject(user, org, project) flatMap {
+              case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+                for {
+                  shape <- ShapeDao.insertShape(shape, dbUser)
+                  aoi <- AoiDao.createAOI(fixupAoiCreate(dbUser,
+                                                         dbProject,
+                                                         aoi,
+                                                         shape),
+                                          dbUser)
+                } yield (shape, aoi)
+              }
             }
-          }
-          val (insertedShape, insertedAoi) = aoiInsertIO.transact(xa).unsafeRunSync
+            val (insertedShape, insertedAoi) =
+              aoiInsertIO.transact(xa).unsafeRunSync
 
-          assert(insertedAoi.shape == insertedShape.id, "Shape should round trip with equality")
-          assert(insertedAoi.filters == aoi.filters, "Filters should round trip with equality")
-          assert(insertedAoi.startTime == aoi.startTime, "Start time should round trip with equality")
-          assert(insertedAoi.approvalRequired == aoi.approvalRequired,
-                 "Approval required should round trip with equality")
-          true
-        }
+            assert(insertedAoi.shape == insertedShape.id,
+                   "Shape should round trip with equality")
+            assert(insertedAoi.filters == aoi.filters,
+                   "Filters should round trip with equality")
+            assert(insertedAoi.startTime == aoi.startTime,
+                   "Start time should round trip with equality")
+            assert(insertedAoi.approvalRequired == aoi.approvalRequired,
+                   "Approval required should round trip with equality")
+            true
+          }
       }
     }
   }
@@ -54,28 +71,49 @@ class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig 
   test("update an AOI") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create,
-         aoiInsert: AOI.Create, aoiUpdate: AOI.Create, shapeInsert: Shape.Create, shapeUpdate: Shape.Create) => {
-          val aoiInsertWithOrgUserProjectIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            shape <- ShapeDao.insertShape(shapeInsert, dbUser)
-            dbAoi <- AoiDao.createAOI(fixupAoiCreate(dbUser, dbProject, aoiInsert, shape), dbUser)
-            newShape <- ShapeDao.insertShape(shapeUpdate, dbUser)
-            updatedRows <- AoiDao.updateAOI(fixupAoiCreate(dbUser, dbProject, aoiUpdate, newShape).copy(id=dbAoi.id), dbUser)
-            updatedAoi <- AoiDao.unsafeGetAoiById(dbAoi.id)
-          } yield (dbAoi, shape, updatedRows, updatedAoi, newShape) //shape, aoi, dbOrg, dbUser, dbProject, update, updatedRows, updatedAoi)
-          val (originalAoi, originalShape, affectedRows, updatedAoi, updatedShape) =
-            aoiInsertWithOrgUserProjectIO.transact(xa).unsafeRunSync
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         aoiInsert: AOI.Create,
+         aoiUpdate: AOI.Create,
+         shapeInsert: Shape.Create,
+         shapeUpdate: Shape.Create) =>
+          {
+            val aoiInsertWithOrgUserProjectIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              shape <- ShapeDao.insertShape(shapeInsert, dbUser)
+              dbAoi <- AoiDao.createAOI(
+                fixupAoiCreate(dbUser, dbProject, aoiInsert, shape),
+                dbUser)
+              newShape <- ShapeDao.insertShape(shapeUpdate, dbUser)
+              updatedRows <- AoiDao.updateAOI(
+                fixupAoiCreate(dbUser, dbProject, aoiUpdate, newShape).copy(
+                  id = dbAoi.id),
+                dbUser)
+              updatedAoi <- AoiDao.unsafeGetAoiById(dbAoi.id)
+            } yield
+              (dbAoi, shape, updatedRows, updatedAoi, newShape) //shape, aoi, dbOrg, dbUser, dbProject, update, updatedRows, updatedAoi)
+            val (originalAoi,
+                 originalShape,
+                 affectedRows,
+                 updatedAoi,
+                 updatedShape) =
+              aoiInsertWithOrgUserProjectIO.transact(xa).unsafeRunSync
 
-          assert(affectedRows == 1, "Only one row should be updated")
-          assert(updatedAoi.shape == updatedShape.id, "Area should be updated")
-          assert(updatedAoi.filters == aoiUpdate.filters, "Filters should be updated")
-          assert(updatedAoi.isActive == aoiUpdate.isActive, "Active status should be updated")
-          assert(updatedAoi.approvalRequired == aoiUpdate.approvalRequired, "Approval should be updated")
-          assert(updatedAoi.startTime == aoiUpdate.startTime, "Start time should be updated")
-          true
-        }
+            assert(affectedRows == 1, "Only one row should be updated")
+            assert(updatedAoi.shape == updatedShape.id,
+                   "Area should be updated")
+            assert(updatedAoi.filters == aoiUpdate.filters,
+                   "Filters should be updated")
+            assert(updatedAoi.isActive == aoiUpdate.isActive,
+                   "Active status should be updated")
+            assert(updatedAoi.approvalRequired == aoiUpdate.approvalRequired,
+                   "Approval should be updated")
+            assert(updatedAoi.startTime == aoiUpdate.startTime,
+                   "Start time should be updated")
+            true
+          }
       }
     }
   }
@@ -83,19 +121,28 @@ class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig 
   test("delete an AOI") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create, aoi: AOI.Create, shape: Shape.Create) => {
-          val aoiDeleteIO = insertUserOrgProject(user, org, project) flatMap {
-            case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
-              for {
-                dbShape <- ShapeDao.insertShape(shape, dbUser)
-                dbAoi <- AoiDao.createAOI(fixupAoiCreate(dbUser, dbProject, aoi, dbShape), dbUser)
-                deletedShapes <- AoiDao.deleteAOI(dbAoi.id)
-              } yield deletedShapes
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         aoi: AOI.Create,
+         shape: Shape.Create) =>
+          {
+            val aoiDeleteIO = insertUserOrgProject(user, org, project) flatMap {
+              case (dbOrg: Organization, dbUser: User, dbProject: Project) => {
+                for {
+                  dbShape <- ShapeDao.insertShape(shape, dbUser)
+                  dbAoi <- AoiDao.createAOI(fixupAoiCreate(dbUser,
+                                                           dbProject,
+                                                           aoi,
+                                                           dbShape),
+                                            dbUser)
+                  deletedShapes <- AoiDao.deleteAOI(dbAoi.id)
+                } yield deletedShapes
+              }
             }
-          }
 
-          aoiDeleteIO.transact(xa).unsafeRunSync == 1
-        }
+            aoiDeleteIO.transact(xa).unsafeRunSync == 1
+          }
       }
     }
   }
@@ -103,37 +150,56 @@ class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig 
   test("list AOIs for a project") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create,
-         project1: Project.Create, aois1: List[AOI.Create], shape: Shape.Create,
-         project2: Project.Create, aois2: List[AOI.Create]) => {
-          val aoisInsertWithProjectUserIO = for {
-            userOrgProj1 <- insertUserOrgProject(user, org, project1)
-            (dbOrg, dbUser, dbProject1) = userOrgProj1
-            dbProject2 <- ProjectDao.insertProject(fixupProjectCreate(dbUser, project2), dbUser)
-            dbShape <- ShapeDao.insertShape(shape, dbUser)
-            dbAois1 <- aois1.traverse {
-              (aoi: AOI.Create) => {
-                AoiDao.createAOI(fixupAoiCreate(dbUser, dbProject1, aoi, dbShape), dbUser)
+        (user: User.Create,
+         org: Organization.Create,
+         project1: Project.Create,
+         aois1: List[AOI.Create],
+         shape: Shape.Create,
+         project2: Project.Create,
+         aois2: List[AOI.Create]) =>
+          {
+            val aoisInsertWithProjectUserIO = for {
+              userOrgProj1 <- insertUserOrgProject(user, org, project1)
+              (dbOrg, dbUser, dbProject1) = userOrgProj1
+              dbProject2 <- ProjectDao.insertProject(
+                fixupProjectCreate(dbUser, project2),
+                dbUser)
+              dbShape <- ShapeDao.insertShape(shape, dbUser)
+              dbAois1 <- aois1.traverse { (aoi: AOI.Create) =>
+                {
+                  AoiDao.createAOI(fixupAoiCreate(dbUser,
+                                                  dbProject1,
+                                                  aoi,
+                                                  dbShape),
+                                   dbUser)
+                }
               }
-            }
-            _ <- aois2.traverse {
-              (aoi: AOI.Create) => {
-                AoiDao.createAOI(fixupAoiCreate(dbUser, dbProject2, aoi, dbShape), dbUser)
+              _ <- aois2.traverse { (aoi: AOI.Create) =>
+                {
+                  AoiDao.createAOI(fixupAoiCreate(dbUser,
+                                                  dbProject2,
+                                                  aoi,
+                                                  dbShape),
+                                   dbUser)
+                }
               }
-            }
-          } yield { (dbAois1, dbProject1, dbUser) }
+            } yield { (dbAois1, dbProject1, dbUser) }
 
-          val aoisForProject = aoisInsertWithProjectUserIO flatMap {
-            case (dbAois: List[AOI], dbProject: Project, dbUser: User) => {
-              AoiDao.listAOIs(dbProject.id, PageRequest(0, 1000, Map.empty)) map {
-                (dbAois, _)
+            val aoisForProject = aoisInsertWithProjectUserIO flatMap {
+              case (dbAois: List[AOI], dbProject: Project, dbUser: User) => {
+                AoiDao.listAOIs(dbProject.id, PageRequest(0, 1000, Map.empty)) map {
+                  (dbAois, _)
+                }
               }
             }
+
+            val (dbAois, listedAois) = aoisForProject.transact(xa).unsafeRunSync
+            (dbAois.toSet map { (aoi: AOI) =>
+              aoi.id
+            }) == (listedAois.results.toSet map { (aoi: AOI) =>
+              aoi.id
+            })
           }
-
-          val (dbAois, listedAois) = aoisForProject.transact(xa).unsafeRunSync
-          (dbAois.toSet map { (aoi: AOI) => aoi.id }) == (listedAois.results.toSet map { (aoi: AOI) => aoi.id })
-        }
       }
     }
   }
@@ -141,37 +207,59 @@ class AoiDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig 
   test("list authorized AOIs") {
     check {
       forAll {
-        (user1: User.Create, user2: User.Create,
+        (user1: User.Create,
+         user2: User.Create,
          shape: Shape.Create,
-         project1: Project.Create, aois1: List[AOI.Create],
-         project2: Project.Create, aois2: List[AOI.Create],
-         page: PageRequest) => {
-          val aoisInsertAndListIO = for {
-            dbUser1 <- UserDao.create(user1)
-            dbUser2 <- UserDao.create(user2)
-            dbProject1 <- ProjectDao.insertProject(fixupProjectCreate(dbUser1, project1).copy(visibility = Visibility.Private), dbUser1)
-            dbProject2 <- ProjectDao.insertProject(fixupProjectCreate(dbUser2, project2).copy(visibility = Visibility.Private), dbUser2)
-            dbShape <- ShapeDao.insertShape(shape, dbUser1)
-            dbAois1 <- aois1 traverse {
-              (aoi: AOI.Create) => {
-                AoiDao.createAOI(fixupAoiCreate(dbUser1, dbProject1, aoi, dbShape), dbUser1)
+         project1: Project.Create,
+         aois1: List[AOI.Create],
+         project2: Project.Create,
+         aois2: List[AOI.Create],
+         page: PageRequest) =>
+          {
+            val aoisInsertAndListIO = for {
+              dbUser1 <- UserDao.create(user1)
+              dbUser2 <- UserDao.create(user2)
+              dbProject1 <- ProjectDao.insertProject(
+                fixupProjectCreate(dbUser1, project1).copy(
+                  visibility = Visibility.Private),
+                dbUser1)
+              dbProject2 <- ProjectDao.insertProject(
+                fixupProjectCreate(dbUser2, project2).copy(
+                  visibility = Visibility.Private),
+                dbUser2)
+              dbShape <- ShapeDao.insertShape(shape, dbUser1)
+              dbAois1 <- aois1 traverse { (aoi: AOI.Create) =>
+                {
+                  AoiDao.createAOI(fixupAoiCreate(dbUser1,
+                                                  dbProject1,
+                                                  aoi,
+                                                  dbShape),
+                                   dbUser1)
+                }
               }
-            }
-            _ <- aois2 traverse {
-              (aoi: AOI.Create) => {
-                AoiDao.createAOI(fixupAoiCreate(dbUser2, dbProject2, aoi, dbShape), dbUser2)
+              _ <- aois2 traverse { (aoi: AOI.Create) =>
+                {
+                  AoiDao.createAOI(fixupAoiCreate(dbUser2,
+                                                  dbProject2,
+                                                  aoi,
+                                                  dbShape),
+                                   dbUser2)
+                }
               }
-            }
-            listedAois <- AoiDao.listAuthorizedAois(dbUser1, AoiQueryParameters(), page)
-          } yield (dbAois1, listedAois)
-          val (insertedAois, listedAois) = aoisInsertAndListIO.transact(xa).unsafeRunSync
-          val insertedAoiAreaSet = insertedAois map { _.id } toSet
-          val listedAoisAreaSet = listedAois.results map { _.id } toSet
+              listedAois <- AoiDao.listAuthorizedAois(dbUser1,
+                                                      AoiQueryParameters(),
+                                                      page)
+            } yield (dbAois1, listedAois)
+            val (insertedAois, listedAois) =
+              aoisInsertAndListIO.transact(xa).unsafeRunSync
+            val insertedAoiAreaSet = insertedAois map { _.id } toSet
+            val listedAoisAreaSet = listedAois.results map { _.id } toSet
 
-          assert(listedAoisAreaSet.intersect(insertedAoiAreaSet) == listedAoisAreaSet,
-                 "Listed AOI areas are a strict subset of inserted AOI areas")
-          true
-        }
+            assert(listedAoisAreaSet
+                     .intersect(insertedAoiAreaSet) == listedAoisAreaSet,
+                   "Listed AOI areas are a strict subset of inserted AOI areas")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -15,116 +15,192 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
 
-class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTestConfig with PropTestHelpers {
+class AuthorizationSpec
+    extends FunSuite
+    with Checkers
+    with Matchers
+    with DBTestConfig
+    with PropTestHelpers {
 
-  test("authorizing everyone should authorize all users regardless of platforms") {
+  test(
+    "authorizing everyone should authorize all users regardless of platforms") {
     check {
       forAll {
         (userOrgPlatform1: (User.Create, Organization.Create, Platform),
          userOrgPlatform2: (User.Create, Organization.Create, Platform),
-         projectCreate: Project.Create) => {
-          val (userCreate1, orgCreate1, platform1) = userOrgPlatform1
-          val (userCreate2, orgCreate2, platform2) = userOrgPlatform2
+         projectCreate: Project.Create) =>
+          {
+            val (userCreate1, orgCreate1, platform1) = userOrgPlatform1
+            val (userCreate2, orgCreate2, platform2) = userOrgPlatform2
 
-          // insert all the users and orgs and platforms, returning users and org/platform 1
-          val usersWithOrgOneIO: ConnectionIO[(User, User, Organization)] = for {
-            authGalaxy1 <- insertUserOrgPlatform(userCreate1, orgCreate1, platform1)
-            (dbUser1, dbOrg1, _) = authGalaxy1
-            authGalaxy2 <- insertUserOrgPlatform(userCreate2, orgCreate2, platform2)
-            (dbUser2, _, _) = authGalaxy2
-          } yield { (dbUser1, dbUser2, dbOrg1) }
+            // insert all the users and orgs and platforms, returning users and org/platform 1
+            val usersWithOrgOneIO: ConnectionIO[(User, User, Organization)] =
+              for {
+                authGalaxy1 <- insertUserOrgPlatform(userCreate1,
+                                                     orgCreate1,
+                                                     platform1)
+                (dbUser1, dbOrg1, _) = authGalaxy1
+                authGalaxy2 <- insertUserOrgPlatform(userCreate2,
+                                                     orgCreate2,
+                                                     platform2)
+                (dbUser2, _, _) = authGalaxy2
+              } yield { (dbUser1, dbUser2, dbOrg1) }
 
-          val usersAuthedIO: ConnectionIO[(Boolean, Boolean)] = for {
-            users <- usersWithOrgOneIO
-            (user1, user2, dbOrg1) = users
-            project <- ProjectDao.insertProject(
-              fixupProjectCreate(user1, projectCreate).copy(visibility = Visibility.Private),
-              user1
-            )
-            _ <- ProjectDao.addPermission(project.id, ObjectAccessControlRule(SubjectType.All, None, ActionType.View))
-            user1Authorized <- ProjectDao.authorized(user1, ObjectType.Project, project.id, ActionType.View)
-            user2Authorized <- ProjectDao.authorized(user2, ObjectType.Project, project.id, ActionType.View)
-          } yield (user1Authorized, user2Authorized)
+            val usersAuthedIO: ConnectionIO[(Boolean, Boolean)] = for {
+              users <- usersWithOrgOneIO
+              (user1, user2, dbOrg1) = users
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user1, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user1
+              )
+              _ <- ProjectDao.addPermission(
+                project.id,
+                ObjectAccessControlRule(SubjectType.All, None, ActionType.View))
+              user1Authorized <- ProjectDao.authorized(user1,
+                                                       ObjectType.Project,
+                                                       project.id,
+                                                       ActionType.View)
+              user2Authorized <- ProjectDao.authorized(user2,
+                                                       ObjectType.Project,
+                                                       project.id,
+                                                       ActionType.View)
+            } yield (user1Authorized, user2Authorized)
 
-          val (user1Authed, user2Authed) = usersAuthedIO.transact(xa).unsafeRunSync
+            val (user1Authed, user2Authed) =
+              usersAuthedIO.transact(xa).unsafeRunSync
 
-          assert(user1Authed && user2Authed,
-                 "Users from different platforms should be authorized when everyone is authorized")
-          true
+            assert(
+              user1Authed && user2Authed,
+              "Users from different platforms should be authorized when everyone is authorized")
+            true
 
-        }
+          }
       }
     }
   }
 
-  test("authorizing a platform for read access should authorize all users in organizations in that platform but not in other platforms") {
+  test(
+    "authorizing a platform for read access should authorize all users in organizations in that platform but not in other platforms") {
     check {
       forAll {
         (userOrgPlatform1: (User.Create, Organization.Create, Platform),
          userOrgPlatform2: (User.Create, Organization.Create, Platform),
-         projectCreate: Project.Create) => {
-          // destructure for cooperation with PropTestHelpers methods
-          val (userCreate1, orgCreate1, platform1) = userOrgPlatform1
-          val (userCreate2, orgCreate2, platform2) = userOrgPlatform2
+         projectCreate: Project.Create) =>
+          {
+            // destructure for cooperation with PropTestHelpers methods
+            val (userCreate1, orgCreate1, platform1) = userOrgPlatform1
+            val (userCreate2, orgCreate2, platform2) = userOrgPlatform2
 
-          // insert all the users and orgs and platforms, returning users and org/platform 1
-          val usersAndOrgOnePlatformOneIO: ConnectionIO[(User, User, Organization, Platform)] = for {
-            authGalaxy1 <- insertUserOrgPlatform(userCreate1, orgCreate1, platform1)
-            (dbUser1, dbOrg1, dbPlatform1) = authGalaxy1
-            authGalaxy2 <- insertUserOrgPlatform(userCreate2, orgCreate2, platform2)
-            (dbUser2, _, _) = authGalaxy2
-          } yield { (dbUser1, dbUser2, dbOrg1, dbPlatform1) }
+            // insert all the users and orgs and platforms, returning users and org/platform 1
+            val usersAndOrgOnePlatformOneIO
+              : ConnectionIO[(User, User, Organization, Platform)] = for {
+              authGalaxy1 <- insertUserOrgPlatform(userCreate1,
+                                                   orgCreate1,
+                                                   platform1)
+              (dbUser1, dbOrg1, dbPlatform1) = authGalaxy1
+              authGalaxy2 <- insertUserOrgPlatform(userCreate2,
+                                                   orgCreate2,
+                                                   platform2)
+              (dbUser2, _, _) = authGalaxy2
+            } yield { (dbUser1, dbUser2, dbOrg1, dbPlatform1) }
 
-          val usersAuthedIO = for {
-            usersOrgPlatform <- usersAndOrgOnePlatformOneIO
-            (user1, user2, org1, platform1) = usersOrgPlatform
-            project <- ProjectDao.insertProject(fixupProjectCreate(user1, projectCreate).copy(visibility = Visibility.Private), user1)
-            _ <- ProjectDao.addPermission(project.id, ObjectAccessControlRule(SubjectType.Platform, Some(platform1.id.toString), ActionType.View))
-            user1Authorized <- ProjectDao.authorized(user1, ObjectType.Project, project.id, ActionType.View)
-            user2Authorized <- ProjectDao.authorized(user2, ObjectType.Project, project.id, ActionType.View)
-                      } yield { (user1Authorized, user2Authorized) }
+            val usersAuthedIO = for {
+              usersOrgPlatform <- usersAndOrgOnePlatformOneIO
+              (user1, user2, org1, platform1) = usersOrgPlatform
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user1, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user1)
+              _ <- ProjectDao.addPermission(
+                project.id,
+                ObjectAccessControlRule(SubjectType.Platform,
+                                        Some(platform1.id.toString),
+                                        ActionType.View))
+              user1Authorized <- ProjectDao.authorized(user1,
+                                                       ObjectType.Project,
+                                                       project.id,
+                                                       ActionType.View)
+              user2Authorized <- ProjectDao.authorized(user2,
+                                                       ObjectType.Project,
+                                                       project.id,
+                                                       ActionType.View)
+            } yield { (user1Authorized, user2Authorized) }
 
-          val (user1Authed, user2Authed) = usersAuthedIO.transact(xa).unsafeRunSync
+            val (user1Authed, user2Authed) =
+              usersAuthedIO.transact(xa).unsafeRunSync
 
-          assert(user1Authed, "The user in the platform that's been authorized should be authorized")
-          assert(!user2Authed, "The user in the platform that's not been authorized should not be authorized")
-          true
-        }
+            assert(
+              user1Authed,
+              "The user in the platform that's been authorized should be authorized")
+            assert(
+              !user2Authed,
+              "The user in the platform that's not been authorized should not be authorized")
+            true
+          }
       }
     }
   }
 
-  test("authorizing an organization should authorize users in that organization and not in other organizations in that platform") {
+  test(
+    "authorizing an organization should authorize users in that organization and not in other organizations in that platform") {
     check {
       forAll {
-        (platform: Platform, userCreate1: User.Create, userCreate2: User.Create,
-         orgCreate1: Organization.Create, orgCreate2: Organization.Create,
-         projectCreate: Project.Create) => {
-          val usersAuthedIO: ConnectionIO[(Boolean, Boolean)] = for {
-            dbPlatform <- PlatformDao.create(platform)
-            orgUser1 <- insertUserAndOrg(userCreate1, orgCreate1.copy(platformId=dbPlatform.id))
-            (org1, user1) = orgUser1
-            orgUser2 <- insertUserAndOrg(userCreate2, orgCreate2.copy(platformId=dbPlatform.id))
-            (_, user2) = orgUser2
-            project <- ProjectDao.insertProject(fixupProjectCreate(user1, projectCreate).copy(visibility = Visibility.Private), user1)
-            _ <- ProjectDao.addPermission(project.id, ObjectAccessControlRule(SubjectType.Organization, Some(org1.id.toString), ActionType.View))
-            user1Authorized <- ProjectDao.authorized(user1, ObjectType.Project, project.id, ActionType.View)
-            user2Authorized <- ProjectDao.authorized(user2, ObjectType.Project, project.id, ActionType.View)
-          } yield { (user1Authorized, user2Authorized) }
+        (platform: Platform,
+         userCreate1: User.Create,
+         userCreate2: User.Create,
+         orgCreate1: Organization.Create,
+         orgCreate2: Organization.Create,
+         projectCreate: Project.Create) =>
+          {
+            val usersAuthedIO: ConnectionIO[(Boolean, Boolean)] = for {
+              dbPlatform <- PlatformDao.create(platform)
+              orgUser1 <- insertUserAndOrg(
+                userCreate1,
+                orgCreate1.copy(platformId = dbPlatform.id))
+              (org1, user1) = orgUser1
+              orgUser2 <- insertUserAndOrg(
+                userCreate2,
+                orgCreate2.copy(platformId = dbPlatform.id))
+              (_, user2) = orgUser2
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user1, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user1)
+              _ <- ProjectDao.addPermission(
+                project.id,
+                ObjectAccessControlRule(SubjectType.Organization,
+                                        Some(org1.id.toString),
+                                        ActionType.View))
+              user1Authorized <- ProjectDao.authorized(user1,
+                                                       ObjectType.Project,
+                                                       project.id,
+                                                       ActionType.View)
+              user2Authorized <- ProjectDao.authorized(user2,
+                                                       ObjectType.Project,
+                                                       project.id,
+                                                       ActionType.View)
+            } yield { (user1Authorized, user2Authorized) }
 
-          val (user1Authed, user2Authed) = usersAuthedIO.transact(xa).unsafeRunSync
-          assert(user1Authed, "A user in the same org as the authorized org should be authorized")
-          assert(!user2Authed, "A user not in the same org as the authorized org should not be authorized")
-          true
-        }
+            val (user1Authed, user2Authed) =
+              usersAuthedIO.transact(xa).unsafeRunSync
+            assert(
+              user1Authed,
+              "A user in the same org as the authorized org should be authorized")
+            assert(
+              !user2Authed,
+              "A user not in the same org as the authorized org should not be authorized")
+            true
+          }
       }
     }
   }
 
-  test("authorizing a team should authorize users on that team and not on other teams") {
+  test(
+    "authorizing a team should authorize users on that team and not on other teams") {
     check {
-      forAll {
-        (u: Unit) => true
+      forAll { (u: Unit) =>
+        true
       }
     }
   }
@@ -132,125 +208,197 @@ class AuthorizationSpec extends FunSuite with Checkers with Matchers with DBTest
   test("several access control rules should be insertable at the same time") {
     check {
       forAll {
-        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
-          val insertManyAcrsIO = for {
-            dbPlatform <- PlatformDao.create(platform)
-            orgUser <- insertUserAndOrg(userCreate, orgCreate.copy(platformId=dbPlatform.id))
-            (org, user) = orgUser
-            project <- ProjectDao.insertProject(fixupProjectCreate(user, projectCreate).copy(visibility = Visibility.Private), user)
-            acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
-              ObjectAccessControlRule(SubjectType.All, None, _)
-            }
-            _ <- ProjectDao.addPermissionsMany(project.id, acrs)
-            dbAcrs <- ProjectDao.getPermissions(project.id)
-          } yield { (acrs, dbAcrs) }
+        (platform: Platform,
+         userCreate: User.Create,
+         orgCreate: Organization.Create,
+         projectCreate: Project.Create) =>
+          {
+            val insertManyAcrsIO = for {
+              dbPlatform <- PlatformDao.create(platform)
+              orgUser <- insertUserAndOrg(
+                userCreate,
+                orgCreate.copy(platformId = dbPlatform.id))
+              (org, user) = orgUser
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user)
+              acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
+                ObjectAccessControlRule(SubjectType.All, None, _)
+              }
+              _ <- ProjectDao.addPermissionsMany(project.id, acrs)
+              dbAcrs <- ProjectDao.getPermissions(project.id)
+            } yield { (acrs, dbAcrs) }
 
-          val (acrs, dbAcrs) = insertManyAcrsIO.transact(xa).unsafeRunSync
+            val (acrs, dbAcrs) = insertManyAcrsIO.transact(xa).unsafeRunSync
 
-          assert(acrs.toSet == dbAcrs.flatten.toSet, "Inserting many ACRs should make those ACRs available to list")
-          true
-        }
+            assert(
+              acrs.toSet == dbAcrs.flatten.toSet,
+              "Inserting many ACRs should make those ACRs available to list")
+            true
+          }
       }
     }
   }
 
-  test("listing user actions granted by 'ALL' should return a list of permitted actions") {
+  test(
+    "listing user actions granted by 'ALL' should return a list of permitted actions") {
     check {
       forAll {
-        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
-          val listUserActionsIO = for {
-            dbPlatform <- PlatformDao.create(platform)
-            orgUser <- insertUserAndOrg(userCreate, orgCreate.copy(platformId=dbPlatform.id))
-            (org, user) = orgUser
-            project <- ProjectDao.insertProject(fixupProjectCreate(user, projectCreate).copy(visibility = Visibility.Private), user)
-            acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
-              ObjectAccessControlRule(SubjectType.All, None, _)
-            }
-            _ <- ProjectDao.addPermissionsMany(project.id, acrs)
-            listOfActions <- ProjectDao.listUserActions(user, project.id)
-          } yield listOfActions
+        (platform: Platform,
+         userCreate: User.Create,
+         orgCreate: Organization.Create,
+         projectCreate: Project.Create) =>
+          {
+            val listUserActionsIO = for {
+              dbPlatform <- PlatformDao.create(platform)
+              orgUser <- insertUserAndOrg(
+                userCreate,
+                orgCreate.copy(platformId = dbPlatform.id))
+              (org, user) = orgUser
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user)
+              acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
+                ObjectAccessControlRule(SubjectType.All, None, _)
+              }
+              _ <- ProjectDao.addPermissionsMany(project.id, acrs)
+              listOfActions <- ProjectDao.listUserActions(user, project.id)
+            } yield listOfActions
 
-          val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
 
-          assert(listUserActions.length == 3, "; List of permitted actions should be 3")
-          assert(listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty, "; List of permitted actions should intersect with what was provided")
-          true
-        }
+            assert(listUserActions.length == 3,
+                   "; List of permitted actions should be 3")
+            assert(
+              listUserActions
+                .intersect(List("VIEW", "EDIT", "DELETE"))
+                .nonEmpty,
+              "; List of permitted actions should intersect with what was provided")
+            true
+          }
       }
     }
   }
 
-  test("listing user actions granted by platform membership should return an empty list") {
+  test(
+    "listing user actions granted by platform membership should return an empty list") {
     check {
       forAll {
-        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
-          val listUserActionsIO = for {
-            dbPlatform <- PlatformDao.create(platform)
-            orgUser <- insertUserAndOrg(userCreate, orgCreate.copy(platformId=dbPlatform.id))
-            (org, user) = orgUser
-            project <- ProjectDao.insertProject(fixupProjectCreate(user, projectCreate).copy(visibility = Visibility.Private), user)
-            acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
-              ObjectAccessControlRule(SubjectType.Platform, Some(dbPlatform.id.toString()), _)
-            }
-            _ <- ProjectDao.addPermissionsMany(project.id, acrs)
-            listOfActions <- ProjectDao.listUserActions(user, project.id)
-          } yield listOfActions
+        (platform: Platform,
+         userCreate: User.Create,
+         orgCreate: Organization.Create,
+         projectCreate: Project.Create) =>
+          {
+            val listUserActionsIO = for {
+              dbPlatform <- PlatformDao.create(platform)
+              orgUser <- insertUserAndOrg(
+                userCreate,
+                orgCreate.copy(platformId = dbPlatform.id))
+              (org, user) = orgUser
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user)
+              acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
+                ObjectAccessControlRule(SubjectType.Platform,
+                                        Some(dbPlatform.id.toString()),
+                                        _)
+              }
+              _ <- ProjectDao.addPermissionsMany(project.id, acrs)
+              listOfActions <- ProjectDao.listUserActions(user, project.id)
+            } yield listOfActions
 
-          val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
-          listUserActions.length == 0
-        }
+            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            listUserActions.length == 0
+          }
       }
     }
   }
 
-  test("listing user actions granted by organization membership should return a list of permitted actions") {
+  test(
+    "listing user actions granted by organization membership should return a list of permitted actions") {
     check {
       forAll {
-        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
-          val listUserActionsIO = for {
-            dbPlatform <- PlatformDao.create(platform)
-            orgUser <- insertUserAndOrg(userCreate, orgCreate.copy(platformId=dbPlatform.id))
-            (org, user) = orgUser
-            project <- ProjectDao.insertProject(fixupProjectCreate(user, projectCreate).copy(visibility = Visibility.Private), user)
-            acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
-              ObjectAccessControlRule(SubjectType.Organization, Some(org.id.toString()), _)
-            }
-            _ <- ProjectDao.addPermissionsMany(project.id, acrs)
-            listOfActions <- ProjectDao.listUserActions(user, project.id)
-          } yield listOfActions
+        (platform: Platform,
+         userCreate: User.Create,
+         orgCreate: Organization.Create,
+         projectCreate: Project.Create) =>
+          {
+            val listUserActionsIO = for {
+              dbPlatform <- PlatformDao.create(platform)
+              orgUser <- insertUserAndOrg(
+                userCreate,
+                orgCreate.copy(platformId = dbPlatform.id))
+              (org, user) = orgUser
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user)
+              acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
+                ObjectAccessControlRule(SubjectType.Organization,
+                                        Some(org.id.toString()),
+                                        _)
+              }
+              _ <- ProjectDao.addPermissionsMany(project.id, acrs)
+              listOfActions <- ProjectDao.listUserActions(user, project.id)
+            } yield listOfActions
 
-          val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
 
-          assert(listUserActions.length == 3, "; List of permitted actions should be 3")
-          assert(listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty, "; List of permitted actions should intersect with what was provided")
-          true
-        }
+            assert(listUserActions.length == 3,
+                   "; List of permitted actions should be 3")
+            assert(
+              listUserActions
+                .intersect(List("VIEW", "EDIT", "DELETE"))
+                .nonEmpty,
+              "; List of permitted actions should intersect with what was provided")
+            true
+          }
       }
     }
   }
 
-  test("listing user actions granted to a specific user should return a list of permitted actions") {
+  test(
+    "listing user actions granted to a specific user should return a list of permitted actions") {
     check {
       forAll {
-        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create, projectCreate: Project.Create) => {
-          val listUserActionsIO = for {
-            dbPlatform <- PlatformDao.create(platform)
-            orgUser <- insertUserAndOrg(userCreate, orgCreate.copy(platformId=dbPlatform.id))
-            (org, user) = orgUser
-            project <- ProjectDao.insertProject(fixupProjectCreate(user, projectCreate).copy(visibility = Visibility.Private), user)
-            acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
-              ObjectAccessControlRule(SubjectType.User, Some(user.id.toString()), _)
-            }
-            _ <- ProjectDao.addPermissionsMany(project.id, acrs)
-            listOfActions <- ProjectDao.listUserActions(user, project.id)
-          } yield listOfActions
+        (platform: Platform,
+         userCreate: User.Create,
+         orgCreate: Organization.Create,
+         projectCreate: Project.Create) =>
+          {
+            val listUserActionsIO = for {
+              dbPlatform <- PlatformDao.create(platform)
+              orgUser <- insertUserAndOrg(
+                userCreate,
+                orgCreate.copy(platformId = dbPlatform.id))
+              (org, user) = orgUser
+              project <- ProjectDao.insertProject(
+                fixupProjectCreate(user, projectCreate).copy(
+                  visibility = Visibility.Private),
+                user)
+              acrs = List(ActionType.View, ActionType.Edit, ActionType.Delete) map {
+                ObjectAccessControlRule(SubjectType.User,
+                                        Some(user.id.toString()),
+                                        _)
+              }
+              _ <- ProjectDao.addPermissionsMany(project.id, acrs)
+              listOfActions <- ProjectDao.listUserActions(user, project.id)
+            } yield listOfActions
 
-          val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
 
-          assert(listUserActions.length == 3, "; List of permitted actions should be 3")
-          assert(listUserActions.intersect(List("VIEW", "EDIT", "DELETE")).nonEmpty, "; List of permitted actions should intersect with what was provided")
-          true
-        }
+            assert(listUserActions.length == 3,
+                   "; List of permitted actions should be 3")
+            assert(
+              listUserActions
+                .intersect(List("VIEW", "EDIT", "DELETE"))
+                .nonEmpty,
+              "; List of permitted actions should intersect with what was provided")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
@@ -13,7 +13,6 @@ import org.scalatest._
 
 import java.util.UUID
 
-
 /** We only need to test the list query, since insertion is checked when creating a
   * scene from a Scene.Create
   */
@@ -24,4 +23,3 @@ class BandDaoSpec extends FunSuite with Matchers with DBTestConfig {
     BandDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
   }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -9,7 +9,6 @@ import cats._, cats.data._, cats.effect.IO, cats.implicits._
 
 import java.util.UUID
 
-
 trait DBTestConfig {
 
   val xa: Transactor[IO] =
@@ -25,10 +24,18 @@ trait DBTestConfig {
 
   implicit val transactor = xa
 
-  val defaultPlatformId = UUID.fromString("31277626-968b-4e40-840b-559d9c67863c")
+  val defaultPlatformId =
+    UUID.fromString("31277626-968b-4e40-840b-559d9c67863c")
 
   val defaultUserQ = UserDao.unsafeGetUserById("default")
-  val rootOrgQ = OrganizationDao.query.filter(UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")).selectQ.unique
-  val defaultPlatformQ = PlatformDao.query.filter(defaultPlatformId).selectQ.unique
-  val changeDetectionProjQ = ProjectDao.query.filter(fr"id = ${UUID.fromString("30fd336a-d360-4c9f-9f99-bb7ac4b372c4")}").selectQ.unique
+  val rootOrgQ = OrganizationDao.query
+    .filter(UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840"))
+    .selectQ
+    .unique
+  val defaultPlatformQ =
+    PlatformDao.query.filter(defaultPlatformId).selectQ.unique
+  val changeDetectionProjQ = ProjectDao.query
+    .filter(fr"id = ${UUID.fromString("30fd336a-d360-4c9f-9f99-bb7ac4b372c4")}")
+    .selectQ
+    .unique
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DataSourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DataSourceDaoSpec.scala
@@ -21,13 +21,19 @@ import io.circe.syntax._
 import java.util.UUID
 import scala.util.Random
 
-
-class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class DatasourceDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("inserting a datasource") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create) => {
           val createDsIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
@@ -42,8 +48,10 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
 
   test("getting a datasource by id") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create) => {
           val getDsIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
@@ -59,8 +67,10 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
 
   test("getting a datasource by id unsafely") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create) => {
           val getDsUnsafeIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
@@ -76,23 +86,28 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
 
   test("updating a datasource") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create, dsUpdate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create,
+         dsUpdate: Datasource.Create) => {
           val updateDsIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
             dsInsert <- fixupDatasource(dsCreate, userInsert)
             dsUpdated <- fixupDatasource(dsUpdate, userInsert)
-            rowUpdated <- DatasourceDao.updateDatasource(dsUpdated, dsInsert.id, userInsert)
+            rowUpdated <- DatasourceDao.updateDatasource(dsUpdated,
+                                                         dsInsert.id,
+                                                         userInsert)
           } yield (rowUpdated, dsUpdated)
           val (rowUpdated, dsUpdated) = updateDsIO.transact(xa).unsafeRunSync
           rowUpdated == 1 &&
-            dsUpdated.name == dsUpdate.name &&
-            dsUpdated.visibility == dsUpdate.visibility &&
-            dsUpdated.composites == dsUpdate.composites &&
-            dsUpdated.extras == dsUpdate.extras &&
-            dsUpdated.bands == dsUpdate.bands &&
-            dsUpdated.licenseName == dsUpdate.licenseName
+          dsUpdated.name == dsUpdate.name &&
+          dsUpdated.visibility == dsUpdate.visibility &&
+          dsUpdated.composites == dsUpdate.composites &&
+          dsUpdated.extras == dsUpdate.extras &&
+          dsUpdated.bands == dsUpdate.bands &&
+          dsUpdated.licenseName == dsUpdate.licenseName
         }
       )
     }
@@ -100,8 +115,10 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
 
   test("deleting a datasource") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create) => {
           val deleteDsIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
@@ -119,27 +136,32 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
     DatasourceDao.query.list.transact(xa).unsafeRunSync.length >= 0
   }
 
-  test("only owner of a datasource can delete a datasource"){
+  test("only owner of a datasource can delete a datasource") {
     check {
-      forAll (
-        (userCreate: User.Create, ownerCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         ownerCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create) => {
           val isDsDeletableIO = for {
             orgAndOwnerInsert <- insertUserAndOrg(ownerCreate, orgCreate)
             (orgInsert, ownerInsert) = orgAndOwnerInsert
             userInsert <- UserDao.create(userCreate)
             dsInsert <- fixupDatasource(dsCreate, ownerInsert)
-            isDeletableUser <- DatasourceDao.isDeletable(dsInsert.id, userInsert)
-            isDeletableOwner <- DatasourceDao.isDeletable(dsInsert.id, ownerInsert)
+            isDeletableUser <- DatasourceDao.isDeletable(dsInsert.id,
+                                                         userInsert)
+            isDeletableOwner <- DatasourceDao.isDeletable(dsInsert.id,
+                                                          ownerInsert)
           } yield { (isDeletableUser, isDeletableOwner) }
 
-          val (isDeletableUser, isDeletableOwner) = isDsDeletableIO.transact(xa).unsafeRunSync
+          val (isDeletableUser, isDeletableOwner) =
+            isDsDeletableIO.transact(xa).unsafeRunSync
 
           assert(
             !isDeletableUser,
             "Non-owner of a datasource should not be able to delete a datasource")
-          assert(
-            isDeletableOwner,
-            "Owner of a datasource should be able to delete a datasource")
+          assert(isDeletableOwner,
+                 "Owner of a datasource should be able to delete a datasource")
           true
         }
       )
@@ -148,43 +170,64 @@ class DatasourceDaoSpec extends FunSuite with Matchers with Checkers with DBTest
 
   test("isDeletable should return false if a datasource is shared") {
     check {
-      forAll (
-        (userCreate: User.Create, ownerCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         ownerCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create) => {
           val isDsDeletableIO = for {
             orgAndOwnerInsert <- insertUserAndOrg(ownerCreate, orgCreate)
             (orgInsert, ownerInsert) = orgAndOwnerInsert
             dsInsert <- fixupDatasource(dsCreate, ownerInsert)
-            _ <- DatasourceDao.addPermission(dsInsert.id, ObjectAccessControlRule(SubjectType.All, None, ActionType.View))
+            _ <- DatasourceDao.addPermission(
+              dsInsert.id,
+              ObjectAccessControlRule(SubjectType.All, None, ActionType.View))
             isDeletable <- DatasourceDao.isDeletable(dsInsert.id, ownerInsert)
           } yield { isDeletable }
 
           val isDeletable = isDsDeletableIO.transact(xa).unsafeRunSync
-          assert(
-            !isDeletable,
-            "isDeletable should return false if a datasource is shared")
+          assert(!isDeletable,
+                 "isDeletable should return false if a datasource is shared")
           true
         }
       )
     }
   }
 
-  test("isDeletable should return false if a datasource has an upload not completed/failed/aborted") {
+  test(
+    "isDeletable should return false if a datasource has an upload not completed/failed/aborted") {
     check {
-      forAll (
-        (userCreate: User.Create, ownerCreate: User.Create, orgCreate: Organization.Create, dsCreate: Datasource.Create, project: Project.Create, upload: Upload.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         ownerCreate: User.Create,
+         orgCreate: Organization.Create,
+         dsCreate: Datasource.Create,
+         project: Project.Create,
+         upload: Upload.Create) => {
           @SuppressWarnings(Array("TraversableHead"))
           val isDsDeletableIO = for {
-            orgUserProject <- insertUserOrgProject(userCreate, orgCreate, project)
+            orgUserProject <- insertUserOrgProject(userCreate,
+                                                   orgCreate,
+                                                   project)
             (dbOrg, dbUser, dbProject) = orgUserProject
             datasource <- fixupDatasource(dsCreate, dbUser)
-            statuses = List(UploadStatus.Created, UploadStatus.Uploading, UploadStatus.Uploaded, UploadStatus.Queued, UploadStatus.Processing)
+            statuses = List(UploadStatus.Created,
+                            UploadStatus.Uploading,
+                            UploadStatus.Uploaded,
+                            UploadStatus.Queued,
+                            UploadStatus.Processing)
             status = Random.shuffle(statuses).head
-            _ <- UploadDao.insert(fixupUploadCreate(dbUser, dbProject, datasource, upload.copy(uploadStatus=status)), dbUser)
+            _ <- UploadDao.insert(
+              fixupUploadCreate(dbUser,
+                                dbProject,
+                                datasource,
+                                upload.copy(uploadStatus = status)),
+              dbUser)
             isDeletable <- DatasourceDao.isDeletable(datasource.id, dbUser)
           } yield { isDeletable }
 
           val isDeletable = isDsDeletableIO.transact(xa).unsafeRunSync
-          
+
           assert(
             !isDeletable,
             "isDeletable should return false if a datasource has an upload not in completed/failed/aborted")

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
@@ -12,9 +12,11 @@ import org.scalatest._
 import io.circe._
 import io.circe.syntax._
 
-
-class ExportDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ExportDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
 
   test("types") { check(ExportDao.selectF.query[Export]) }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/FeatureFlagDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/FeatureFlagDaoSpec.scala
@@ -10,8 +10,10 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-
-class FeatureFlagDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class FeatureFlagDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
   test("types") { check(FeatureFlagDao.selectF.query[FeatureFlag]) }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
@@ -21,22 +21,30 @@ import io.circe._
 import io.circe.syntax._
 import java.util.UUID
 
-
 /** We only need to test inserting a single image and listing images because inserting
   *  many is tested in inserting a scene from a Scene.Create
   */
-class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class ImageDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("insert a single image") {
     check {
       forAll(
-        (user: User.Create, org: Organization.Create, scene: Scene.Create, image: Image.Banded) => {
+        (user: User.Create,
+         org: Organization.Create,
+         scene: Scene.Create,
+         image: Image.Banded) => {
           val sceneInsertIO = for {
             orgAndUser <- insertUserAndOrg(user, org)
             (insertedOrg, insertedUser) = orgAndUser
             datasource <- unsafeGetRandomDatasource
             insertedScene <- SceneDao.insert(
-              fixupSceneCreate(insertedUser, datasource, scene), insertedUser
+              fixupSceneCreate(insertedUser, datasource, scene),
+              insertedUser
             )
           } yield (insertedScene, insertedUser)
           val imageInsertIO = sceneInsertIO flatMap {
@@ -49,12 +57,12 @@ class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
           }
           val insertedImage = imageInsertIO.transact(xa).unsafeRunSync.get
           insertedImage.rawDataBytes == image.rawDataBytes &&
-            insertedImage.visibility == image.visibility &&
-            insertedImage.filename == image.filename &&
-            insertedImage.sourceUri == image.sourceUri &&
-            insertedImage.imageMetadata == image.imageMetadata &&
-            insertedImage.resolutionMeters == image.resolutionMeters &&
-            insertedImage.metadataFiles == image.metadataFiles
+          insertedImage.visibility == image.visibility &&
+          insertedImage.filename == image.filename &&
+          insertedImage.sourceUri == image.sourceUri &&
+          insertedImage.imageMetadata == image.imageMetadata &&
+          insertedImage.resolutionMeters == image.resolutionMeters &&
+          insertedImage.metadataFiles == image.metadataFiles
         }
       )
     }
@@ -63,13 +71,18 @@ class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
   test("update an image") {
     check {
       forAll(
-        (user: User.Create, org: Organization.Create, scene: Scene.Create, imageBanded: Image.Banded, imageUpdate: Image) => {
+        (user: User.Create,
+         org: Organization.Create,
+         scene: Scene.Create,
+         imageBanded: Image.Banded,
+         imageUpdate: Image) => {
           val sceneInsertIO = for {
             orgAndUser <- insertUserAndOrg(user, org)
             (insertedOrg, insertedUser) = orgAndUser
             datasource <- unsafeGetRandomDatasource
             insertedScene <- SceneDao.insert(
-              fixupSceneCreate(insertedUser, datasource, scene), insertedUser
+              fixupSceneCreate(insertedUser, datasource, scene),
+              insertedUser
             )
           } yield (insertedScene, insertedUser)
           val imageInsertIO = sceneInsertIO flatMap {
@@ -88,9 +101,11 @@ class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
               val origOwner = inserted.owner
               val fixedUp = fixupImage(origOwner, sceneId, imageUpdate)
               ImageDao.updateImage(
-                fixedUp, imageId, dbUser
-              ) flatMap {
-                (affectedRows: Int) => {
+                fixedUp,
+                imageId,
+                dbUser
+              ) flatMap { (affectedRows: Int) =>
+                {
                   val updatedImage = ImageDao.unsafeGetImage(imageId)
                   updatedImage map { (affectedRows, _) }
                 }
@@ -98,15 +113,16 @@ class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
             }
           }
 
-          val (affectedRows, updatedImage) = imageUpdateWithUpdatedImageIO.transact(xa).unsafeRunSync
+          val (affectedRows, updatedImage) =
+            imageUpdateWithUpdatedImageIO.transact(xa).unsafeRunSync
           affectedRows == 1 &&
-            updatedImage.rawDataBytes == imageUpdate.rawDataBytes &&
-            updatedImage.visibility == imageUpdate.visibility &&
-            updatedImage.filename == imageUpdate.filename &&
-            updatedImage.sourceUri == imageUpdate.sourceUri &&
-            updatedImage.imageMetadata == imageUpdate.imageMetadata &&
-            updatedImage.resolutionMeters == imageUpdate.resolutionMeters &&
-            updatedImage.metadataFiles == imageUpdate.metadataFiles
+          updatedImage.rawDataBytes == imageUpdate.rawDataBytes &&
+          updatedImage.visibility == imageUpdate.visibility &&
+          updatedImage.filename == imageUpdate.filename &&
+          updatedImage.sourceUri == imageUpdate.sourceUri &&
+          updatedImage.imageMetadata == imageUpdate.imageMetadata &&
+          updatedImage.resolutionMeters == imageUpdate.resolutionMeters &&
+          updatedImage.metadataFiles == imageUpdate.metadataFiles
         }
       )
     }
@@ -116,4 +132,3 @@ class ImageDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfi
     ImageDao.query.list.transact(xa).unsafeRunSync
   }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
@@ -14,25 +14,33 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
 
-
-class LayerAttributeDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig {
+class LayerAttributeDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig {
 
   test("list all layer ids") {
     LayerAttributeDao.layerIds.transact(xa).unsafeRunSync.length should be >= 0
   }
 
   test("get max zooms for layers") {
-    LayerAttributeDao.maxZoomsForLayers(Set.empty[String]).transact(xa).unsafeRunSync.length should be >= 0
+    LayerAttributeDao
+      .maxZoomsForLayers(Set.empty[String])
+      .transact(xa)
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   // insertLayerAttribute
   test("insert a layer attribute") {
     check {
-      forAll {
-        (layerAttribute: LayerAttribute) => {
+      forAll { (layerAttribute: LayerAttribute) =>
+        {
           val layerId = layerAttribute.layerId
-          val attributeIO = LayerAttributeDao.insertLayerAttribute(layerAttribute) flatMap {
-            _ => LayerAttributeDao.unsafeGetAttribute(layerId, layerAttribute.name)
+          val attributeIO = LayerAttributeDao.insertLayerAttribute(
+            layerAttribute) flatMap { _ =>
+            LayerAttributeDao.unsafeGetAttribute(layerId, layerAttribute.name)
           }
           attributeIO.transact(xa).unsafeRunSync == layerAttribute
         }
@@ -43,14 +51,14 @@ class LayerAttributeDaoSpec extends FunSuite with Matchers with Checkers with DB
   // listAllAttributes
   test("list layers for an attribute name") {
     check {
-      forAll {
-        (layerAttributes: List[LayerAttribute]) => {
+      forAll { (layerAttributes: List[LayerAttribute]) =>
+        {
           val attributesIO = layerAttributes.traverse(
             (attr: LayerAttribute) => {
               LayerAttributeDao.insertLayerAttribute(attr)
             }
-          ) flatMap {
-            _ => LayerAttributeDao.listAllAttributes(layerAttributes.head.name)
+          ) flatMap { _ =>
+            LayerAttributeDao.listAllAttributes(layerAttributes.head.name)
           }
 
           attributesIO.transact(xa).unsafeRunSync.length ==
@@ -63,11 +71,12 @@ class LayerAttributeDaoSpec extends FunSuite with Matchers with Checkers with DB
   // layerExists
   test("check layer existence") {
     check {
-      forAll {
-        (layerAttribute: LayerAttribute) => {
+      forAll { (layerAttribute: LayerAttribute) =>
+        {
           val layerId = layerAttribute.layerId
-          val attributesIO = LayerAttributeDao.insertLayerAttribute(layerAttribute) flatMap {
-            _ => LayerAttributeDao.layerExists(layerId)
+          val attributesIO = LayerAttributeDao.insertLayerAttribute(
+            layerAttribute) flatMap { _ =>
+            LayerAttributeDao.layerExists(layerId)
           }
           attributesIO.transact(xa).unsafeRunSync
         }
@@ -75,4 +84,3 @@ class LayerAttributeDaoSpec extends FunSuite with Matchers with Checkers with DB
     }
   }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LicenseDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LicenseDaoSpec.scala
@@ -10,7 +10,11 @@ import doobie.scalatest.imports._
 
 import org.scalatest._
 
-class LicenseDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class LicenseDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
   test("selection types") {
     check(LicenseDao.selectF.query[License])
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
@@ -10,9 +10,11 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-
-class MapTokenDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig{
+class MapTokenDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
 
   test("types") { check(MapTokenDao.selectF.query[MapToken]) }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
@@ -13,24 +13,34 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
 
-
-class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class OrganizationDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   // createOrganization
   test("insert an organization from an Organization.Create") {
     check {
       forAll(
-        (rootUserCreate: User.Create, orgCreate: Organization.Create, platform: Platform) => {
+        (rootUserCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform) => {
           val orgInsertIO = for {
             rootOrg <- rootOrgQ
             insertedUser <- UserDao.create(rootUserCreate)
             insertedPlatform <- PlatformDao.create(platform)
-            newOrg <- OrganizationDao.create(orgCreate.copy(platformId = insertedPlatform.id).toOrganization(true))
+            newOrg <- OrganizationDao.create(
+              orgCreate
+                .copy(platformId = insertedPlatform.id)
+                .toOrganization(true))
           } yield (newOrg, insertedPlatform)
-          val (insertedOrg, insertedPlatform) = orgInsertIO.transact(xa).unsafeRunSync
+          val (insertedOrg, insertedPlatform) =
+            orgInsertIO.transact(xa).unsafeRunSync
 
           insertedOrg.platformId == insertedPlatform.id &&
-            insertedOrg.name == orgCreate.name
+          insertedOrg.name == orgCreate.name
         }
       )
     }
@@ -41,10 +51,12 @@ class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTe
     check {
       forAll(
         (orgCreate: Organization.Create) => {
-          val retrievedNameIO = OrganizationDao.createOrganization(orgCreate) flatMap {
-            (org: Organization) => {
+          val retrievedNameIO = OrganizationDao
+            .createOrganization(orgCreate) flatMap { (org: Organization) =>
+            {
               OrganizationDao.getOrganizationById(org.id) map {
-                (retrievedO: Option[Organization]) => retrievedO map { _.name }
+                (retrievedO: Option[Organization]) =>
+                  retrievedO map { _.name }
               }
             }
           }
@@ -59,20 +71,24 @@ class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTe
     check {
       forAll(
         (orgCreate: Organization.Create, newName: String) => {
-          val withoutNull = newName.filter( _ != '\u0000' ).mkString
+          val withoutNull = newName.filter(_ != '\u0000').mkString
           val insertOrgIO = OrganizationDao.createOrganization(orgCreate)
-          val insertAndUpdateIO =  insertOrgIO flatMap {
-            (org: Organization) => {
-              OrganizationDao.update(org.copy(name = withoutNull), org.id) flatMap {
-                case (affectedRows: Int) => {
-                  OrganizationDao.unsafeGetOrganizationById(org.id) map {
-                    (retrievedOrg: Organization) => (affectedRows, retrievedOrg.name, retrievedOrg.status)
+          val insertAndUpdateIO = insertOrgIO flatMap {
+            (org: Organization) =>
+              {
+                OrganizationDao
+                  .update(org.copy(name = withoutNull), org.id) flatMap {
+                  case (affectedRows: Int) => {
+                    OrganizationDao.unsafeGetOrganizationById(org.id) map {
+                      (retrievedOrg: Organization) =>
+                        (affectedRows, retrievedOrg.name, retrievedOrg.status)
+                    }
                   }
                 }
               }
-            }
           }
-          val (affectedRows, updatedName, updatedStatus) = insertAndUpdateIO.transact(xa).unsafeRunSync
+          val (affectedRows, updatedName, updatedStatus) =
+            insertAndUpdateIO.transact(xa).unsafeRunSync
           (affectedRows == 1) && (updatedName == withoutNull) && (updatedStatus == orgCreate.status)
         }
       )
@@ -87,68 +103,120 @@ class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTe
   test("list authorized organizations") {
     check {
       forAll(
-        (uc1: User.Create, uc2: User.Create,
-         uc3: User.Create, pc1: Platform, pc2: Platform,
-         org1: Organization.Create, org2: Organization.Create, org3: Organization.Create) => {
+        (uc1: User.Create,
+         uc2: User.Create,
+         uc3: User.Create,
+         pc1: Platform,
+         pc2: Platform,
+         org1: Organization.Create,
+         org2: Organization.Create,
+         org3: Organization.Create) => {
           val defaultUser = uc1.toUser.copy(id = "default")
           val orgsIO = for {
             p1 <- PlatformDao.create(pc1)
             p2 <- PlatformDao.create(pc2)
             org1 <- OrganizationDao.createOrganization(
-              org1.copy(platformId = p1.id, visibility = Some(Visibility.Private)))
+              org1.copy(platformId = p1.id,
+                        visibility = Some(Visibility.Private)))
             org2 <- OrganizationDao.createOrganization(
-              org2.copy(platformId = p1.id, visibility = Some(Visibility.Public)))
+              org2.copy(platformId = p1.id,
+                        visibility = Some(Visibility.Public)))
             org3 <- OrganizationDao.createOrganization(
-              org3.copy(platformId = p2.id, visibility = Some(Visibility.Public)))
+              org3.copy(platformId = p2.id,
+                        visibility = Some(Visibility.Public)))
             u1 <- UserDao.create(uc1)
             u2 <- UserDao.create(uc2)
             u3 <- UserDao.create(uc3)
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u1.id, GroupType.Platform, p1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u1.id, GroupType.Platform, p1.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u1.id, GroupType.Organization, org1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u1.id,
+                        GroupType.Organization,
+                        org1.id,
+                        GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             u2platugr <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u2.id, GroupType.Platform, p1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u2.id, GroupType.Platform, p1.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u2.id, GroupType.Organization, org2.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u2.id,
+                        GroupType.Organization,
+                        org2.id,
+                        GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u3.id, GroupType.Platform, p2.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u3.id, GroupType.Platform, p2.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u3.id, GroupType.Organization, org3.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u3.id,
+                        GroupType.Organization,
+                        org3.id,
+                        GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             u1VisibleOrgs <- OrganizationDao.viewFilter(u1).list
             u2VisibleOrgs <- OrganizationDao.viewFilter(u2).list
             u3VisibleOrgs <- OrganizationDao.viewFilter(u3).list
-            _ <- UserGroupRoleDao.update(u2platugr.copy(groupRole = GroupRole.Admin), u2platugr.id, u2)
+            _ <- UserGroupRoleDao.update(
+              u2platugr.copy(groupRole = GroupRole.Admin),
+              u2platugr.id,
+              u2)
             u2AdminVisibleOrgs <- OrganizationDao.viewFilter(u2).list
-          } yield { (org1, org2, org3, u1VisibleOrgs, u2VisibleOrgs, u3VisibleOrgs, u2AdminVisibleOrgs) }
+          } yield {
+            (org1,
+             org2,
+             org3,
+             u1VisibleOrgs,
+             u2VisibleOrgs,
+             u3VisibleOrgs,
+             u2AdminVisibleOrgs)
+          }
 
-          val (hiddenOrg, visibleOrg, otherPlatformOrg, u1orgs, u2orgs, u3orgs, u2orgsAdmin) = orgsIO.transact(xa).unsafeRunSync
-          val u1orgids = u1orgs.toSet.map { o:Organization =>  o.id }
-          val u2orgids = u2orgs.toSet.map { o:Organization => o.id }
-          val u3orgids = u3orgs.toSet.map { o: Organization => o.id }
-          val u2orgidsAdmin = u2orgsAdmin.toSet.map {o: Organization =>  o.id }
-          assert(u1orgids.contains(hiddenOrg.id), "; members of private orgs should be able to see it")
+          val (hiddenOrg,
+               visibleOrg,
+               otherPlatformOrg,
+               u1orgs,
+               u2orgs,
+               u3orgs,
+               u2orgsAdmin) = orgsIO.transact(xa).unsafeRunSync
+          val u1orgids = u1orgs.toSet.map { o: Organization =>
+            o.id
+          }
+          val u2orgids = u2orgs.toSet.map { o: Organization =>
+            o.id
+          }
+          val u3orgids = u3orgs.toSet.map { o: Organization =>
+            o.id
+          }
+          val u2orgidsAdmin = u2orgsAdmin.toSet.map { o: Organization =>
+            o.id
+          }
+          assert(u1orgids.contains(hiddenOrg.id),
+                 "; members of private orgs should be able to see it")
           assert(
             !u1orgids.contains(otherPlatformOrg.id) &&
               !u2orgids.contains(otherPlatformOrg.id) &&
               !u3orgids.contains(visibleOrg.id),
-            "; members should not be able to view orgs on other platforms")
-          assert(u1orgids.contains(visibleOrg.id) &&
-                   u2orgids.contains(visibleOrg.id) &&
-                   u3orgids.contains(otherPlatformOrg.id),
-                 "; members should be able to view public orgs on their own platform")
+            "; members should not be able to view orgs on other platforms"
+          )
+          assert(
+            u1orgids.contains(visibleOrg.id) &&
+              u2orgids.contains(visibleOrg.id) &&
+              u3orgids.contains(otherPlatformOrg.id),
+            "; members should be able to view public orgs on their own platform"
+          )
           assert(u2orgidsAdmin.contains(hiddenOrg.id),
                  "; platform admins should be able to see hidden orgs")
           true
@@ -159,62 +227,94 @@ class OrganizationDaoSpec extends FunSuite with Matchers with Checkers with DBTe
 
   test("add a user role") {
     check {
-      forAll{
-        (userCreate: User.Create, orgCreate: Organization.Create, userRole: GroupRole) => {
-          val addPlatformRoleWithPlatformIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
-            (org, dbUser) = orgAndUser
-            insertedUserGroupRole <- OrganizationDao.addUserRole(org.platformId, dbUser, dbUser.id, org.id, userRole)
-            byIdUserGroupRole <- UserGroupRoleDao.getOption(insertedUserGroupRole.id)
-          } yield { (org, byIdUserGroupRole) }
+      forAll {
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         userRole: GroupRole) =>
+          {
+            val addPlatformRoleWithPlatformIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
+              (org, dbUser) = orgAndUser
+              insertedUserGroupRole <- OrganizationDao.addUserRole(
+                org.platformId,
+                dbUser,
+                dbUser.id,
+                org.id,
+                userRole)
+              byIdUserGroupRole <- UserGroupRoleDao.getOption(
+                insertedUserGroupRole.id)
+            } yield { (org, byIdUserGroupRole) }
 
-          val (dbOrg, dbUserGroupRole) = addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
-          dbUserGroupRole match {
-            case Some(ugr) =>
-              assert(
-                ugr.isActive, "; Added role should be active"
-              )
-              assert(
-                ugr.groupType == GroupType.Organization, "; Added role should be for an Organization"
-              )
-              assert(
-                ugr.groupId == dbOrg.id, "; Added role should be for the correct Organization"
-              )
-              assert(
-                ugr.groupRole == userRole, "; Added role should have the correct role"
-              )
-              true
-            case _ => false
+            val (dbOrg, dbUserGroupRole) =
+              addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
+            dbUserGroupRole match {
+              case Some(ugr) =>
+                assert(
+                  ugr.isActive,
+                  "; Added role should be active"
+                )
+                assert(
+                  ugr.groupType == GroupType.Organization,
+                  "; Added role should be for an Organization"
+                )
+                assert(
+                  ugr.groupId == dbOrg.id,
+                  "; Added role should be for the correct Organization"
+                )
+                assert(
+                  ugr.groupRole == userRole,
+                  "; Added role should have the correct role"
+                )
+                true
+              case _ => false
+            }
           }
-        }
       }
     }
   }
 
   test("deactivate a user's roles") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create, orgCreate: Organization.Create, userRole: GroupRole
-        ) => {
-          val setPlatformRoleIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
-            (org, dbUser) = orgAndUser
-            originalUserGroupRole <- OrganizationDao.addUserRole(org.platformId, dbUser, dbUser.id, org.id, userRole)
-            updatedUserGroupRoles <- OrganizationDao.deactivateUserRoles(dbUser, dbUser.id, org.id)
-          } yield { (originalUserGroupRole, updatedUserGroupRoles) }
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            userRole: GroupRole
+        ) =>
+          {
+            val setPlatformRoleIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
+              (org, dbUser) = orgAndUser
+              originalUserGroupRole <- OrganizationDao.addUserRole(
+                org.platformId,
+                dbUser,
+                dbUser.id,
+                org.id,
+                userRole)
+              updatedUserGroupRoles <- OrganizationDao.deactivateUserRoles(
+                dbUser,
+                dbUser.id,
+                org.id)
+            } yield { (originalUserGroupRole, updatedUserGroupRoles) }
 
-          val (dbOldUGR, dbUpdatedUGRs) = setPlatformRoleIO.transact(xa).unsafeRunSync
+            val (dbOldUGR, dbUpdatedUGRs) =
+              setPlatformRoleIO.transact(xa).unsafeRunSync
 
-          assert(dbUpdatedUGRs.size === 1, "; A single UGR should be updated")
-          assert(dbUpdatedUGRs.filter((ugr) => ugr.isActive == true).size == 0,
-                 "; There should be no active UGRs")
-          assert(dbUpdatedUGRs.filter((ugr) => ugr.isActive == false).size == dbUpdatedUGRs.size,
-                 "; The updated  UGRs should all be deactivated")
-          assert(dbUpdatedUGRs.filter((ugr) => ugr.id == dbOldUGR.id && ugr.isActive == false).size == 1,
-                 "; The originally created UGR should be updated to be inactive")
-          true
-        }
+            assert(dbUpdatedUGRs.size === 1, "; A single UGR should be updated")
+            assert(
+              dbUpdatedUGRs.filter((ugr) => ugr.isActive == true).size == 0,
+              "; There should be no active UGRs")
+            assert(dbUpdatedUGRs
+                     .filter((ugr) => ugr.isActive == false)
+                     .size == dbUpdatedUGRs.size,
+                   "; The updated  UGRs should all be deactivated")
+            assert(
+              dbUpdatedUGRs
+                .filter((ugr) => ugr.id == dbOldUGR.id && ugr.isActive == false)
+                .size == 1,
+              "; The originally created UGR should be updated to be inactive")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationFeatureDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationFeatureDaoSpec.scala
@@ -10,7 +10,11 @@ import doobie.scalatest.imports._
 
 import org.scalatest._
 
-class OrganizationFeatureDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class OrganizationFeatureDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
   test("selection types") {
     check(OrganizationFeatureDao.selectF.query[OrgFeatures])
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -19,13 +19,23 @@ import io.circe.syntax._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import java.util.UUID
 
-class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class PlatformDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("list platforms") {
     check {
-      forAll {
-        (pageRequest: PageRequest) => {
-          PlatformDao.listPlatforms(pageRequest).transact(xa).unsafeRunSync.results.length >= 0
+      forAll { (pageRequest: PageRequest) =>
+        {
+          PlatformDao
+            .listPlatforms(pageRequest)
+            .transact(xa)
+            .unsafeRunSync
+            .results
+            .length >= 0
         }
       }
     }
@@ -34,19 +44,22 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
   test("insert a platform") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, platform: Platform) => {
-          val insertPlatformIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (_, dbUser) = orgAndUser
-            insertedPlatform <- PlatformDao.create(platform)
-          } yield { insertedPlatform }
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform) =>
+          {
+            val insertPlatformIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (_, dbUser) = orgAndUser
+              insertedPlatform <- PlatformDao.create(platform)
+            } yield { insertedPlatform }
 
-          val dbPlatform = insertPlatformIO.transact(xa).unsafeRunSync
+            val dbPlatform = insertPlatformIO.transact(xa).unsafeRunSync
 
-          dbPlatform.name == platform.name &&
+            dbPlatform.name == platform.name &&
             dbPlatform.publicSettings == platform.publicSettings &&
             dbPlatform.privateSettings == platform.privateSettings
-        }
+          }
       }
     }
   }
@@ -54,29 +67,39 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
   test("update a platform") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, platform: Platform, platformUpdate: Platform) => {
-          val insertPlatformWithUserIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (_, dbUser) = orgAndUser
-            insertedPlatform <- PlatformDao.create(platform)
-          } yield { (insertedPlatform, dbUser) }
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform,
+         platformUpdate: Platform) =>
+          {
+            val insertPlatformWithUserIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (_, dbUser) = orgAndUser
+              insertedPlatform <- PlatformDao.create(platform)
+            } yield { (insertedPlatform, dbUser) }
 
-          val updatePlatformWithPlatformAndAffectedRowsIO = insertPlatformWithUserIO flatMap {
-            case (dbPlatform: Platform, dbUser: User) => {
-              PlatformDao.update(platformUpdate, dbPlatform.id) flatMap {
-                (affectedRows: Int) => {
-                  PlatformDao.unsafeGetPlatformById(dbPlatform.id) map { (affectedRows, _) }
+            val updatePlatformWithPlatformAndAffectedRowsIO = insertPlatformWithUserIO flatMap {
+              case (dbPlatform: Platform, dbUser: User) => {
+                PlatformDao.update(platformUpdate, dbPlatform.id) flatMap {
+                  (affectedRows: Int) =>
+                    {
+                      PlatformDao.unsafeGetPlatformById(dbPlatform.id) map {
+                        (affectedRows, _)
+                      }
+                    }
                 }
               }
             }
-          }
 
-        val (affectedRows, updatedPlatform) = updatePlatformWithPlatformAndAffectedRowsIO.transact(xa).unsafeRunSync
-          affectedRows == 1 &&
+            val (affectedRows, updatedPlatform) =
+              updatePlatformWithPlatformAndAffectedRowsIO
+                .transact(xa)
+                .unsafeRunSync
+            affectedRows == 1 &&
             updatedPlatform.name == platformUpdate.name &&
             updatedPlatform.publicSettings == platformUpdate.publicSettings &&
             updatedPlatform.privateSettings == platformUpdate.privateSettings
-        }
+          }
       }
     }
   }
@@ -84,267 +107,405 @@ class PlatformDaoSpec extends FunSuite with Matchers with Checkers with DBTestCo
   test("delete a platform") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, platform: Platform) => {
-          val deletePlatformWithPlatformIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (_, dbUser) = orgAndUser
-            insertedPlatform <- PlatformDao.create(platform)
-            deletePlatform <- PlatformDao.delete(insertedPlatform.id)
-            byIdPlatform <- PlatformDao.getPlatformById(insertedPlatform.id)
-          } yield { (deletePlatform, byIdPlatform) }
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform) =>
+          {
+            val deletePlatformWithPlatformIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (_, dbUser) = orgAndUser
+              insertedPlatform <- PlatformDao.create(platform)
+              deletePlatform <- PlatformDao.delete(insertedPlatform.id)
+              byIdPlatform <- PlatformDao.getPlatformById(insertedPlatform.id)
+            } yield { (deletePlatform, byIdPlatform) }
 
-          val (rowsAffected, platformById) = deletePlatformWithPlatformIO.transact(xa).unsafeRunSync
-          rowsAffected == 1 && platformById == None
-        }
+            val (rowsAffected, platformById) =
+              deletePlatformWithPlatformIO.transact(xa).unsafeRunSync
+            rowsAffected == 1 && platformById == None
+          }
       }
     }
   }
 
   test("add a user role") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create, orgCreate: Organization.Create, platform: Platform,
-          userRole: GroupRole
-        ) => {
-          val addPlatformRoleWithPlatformIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-                                          (org, dbUser) = orgAndUser
-            insertedPlatform <- PlatformDao.create(platform)
-            insertedUserGroupRole <- PlatformDao.addUserRole(dbUser, dbUser.id, insertedPlatform.id, userRole)
-            byIdUserGroupRole <- UserGroupRoleDao.getOption(insertedUserGroupRole.id)
-          } yield { (insertedPlatform, byIdUserGroupRole) }
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            userRole: GroupRole
+        ) =>
+          {
+            val addPlatformRoleWithPlatformIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (org, dbUser) = orgAndUser
+              insertedPlatform <- PlatformDao.create(platform)
+              insertedUserGroupRole <- PlatformDao.addUserRole(
+                dbUser,
+                dbUser.id,
+                insertedPlatform.id,
+                userRole)
+              byIdUserGroupRole <- UserGroupRoleDao.getOption(
+                insertedUserGroupRole.id)
+            } yield { (insertedPlatform, byIdUserGroupRole) }
 
-          val (dbPlatform, dbUserGroupRole) = addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
-          dbUserGroupRole match {
-            case Some(ugr) =>
-              assert(ugr.isActive, "; Added role should be active")
-              assert(ugr.groupType == GroupType.Platform, "; Added role should be for a Platform")
-              assert(ugr.groupId == dbPlatform.id, "; Added role should be for the correct Platform")
-              assert(ugr.groupRole == userRole, "; Added role should have the correct role")
-              true
-            case _ => false
+            val (dbPlatform, dbUserGroupRole) =
+              addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
+            dbUserGroupRole match {
+              case Some(ugr) =>
+                assert(ugr.isActive, "; Added role should be active")
+                assert(ugr.groupType == GroupType.Platform,
+                       "; Added role should be for a Platform")
+                assert(ugr.groupId == dbPlatform.id,
+                       "; Added role should be for the correct Platform")
+                assert(ugr.groupRole == userRole,
+                       "; Added role should have the correct role")
+                true
+              case _ => false
+            }
           }
-        }
       }
     }
   }
 
   test("replace a user's roles") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create, orgCreate: Organization.Create, platform: Platform,
-          userRole: GroupRole
-        ) => {
-          val setPlatformRoleIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (org, dbUser) = orgAndUser
-            insertedPlatform <- PlatformDao.create(platform)
-            originalUserGroupRole <- PlatformDao.addUserRole(dbUser, dbUser.id, insertedPlatform.id, userRole)
-            updatedUserGroupRoles <- PlatformDao.setUserRole(dbUser, dbUser.id, insertedPlatform.id, userRole)
-          } yield { (insertedPlatform, originalUserGroupRole, updatedUserGroupRoles ) }
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            userRole: GroupRole
+        ) =>
+          {
+            val setPlatformRoleIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (org, dbUser) = orgAndUser
+              insertedPlatform <- PlatformDao.create(platform)
+              originalUserGroupRole <- PlatformDao.addUserRole(
+                dbUser,
+                dbUser.id,
+                insertedPlatform.id,
+                userRole)
+              updatedUserGroupRoles <- PlatformDao.setUserRole(
+                dbUser,
+                dbUser.id,
+                insertedPlatform.id,
+                userRole)
+            } yield {
+              (insertedPlatform, originalUserGroupRole, updatedUserGroupRoles)
+            }
 
-          val (dbPlatform, dbOldUGR, dbNewUGRs) = setPlatformRoleIO.transact(xa).unsafeRunSync
+            val (dbPlatform, dbOldUGR, dbNewUGRs) =
+              setPlatformRoleIO.transact(xa).unsafeRunSync
 
-          assert(dbNewUGRs.filter((ugr) => ugr.isActive == true).size == 1,
-                 "; Updated UGRs should have one set to active")
-          assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
-                 "; Updated UGRs should have one set to inactive")
-          assert(dbNewUGRs.filter((ugr) => ugr.id == dbOldUGR.id && ugr.isActive == false).size == 1,
-                 "; Old UGR should be set to inactive")
-          assert(dbNewUGRs.filter((ugr) => ugr.id != dbOldUGR.id && ugr.isActive == true).size == 1,
-                 "; New UGR should be set to active")
-          assert(dbNewUGRs.size == 2, "; Update should have old and new UGRs")
-          true
-        }
+            assert(dbNewUGRs.filter((ugr) => ugr.isActive == true).size == 1,
+                   "; Updated UGRs should have one set to active")
+            assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
+                   "; Updated UGRs should have one set to inactive")
+            assert(
+              dbNewUGRs
+                .filter((ugr) => ugr.id == dbOldUGR.id && ugr.isActive == false)
+                .size == 1,
+              "; Old UGR should be set to inactive")
+            assert(
+              dbNewUGRs
+                .filter((ugr) => ugr.id != dbOldUGR.id && ugr.isActive == true)
+                .size == 1,
+              "; New UGR should be set to active")
+            assert(dbNewUGRs.size == 2, "; Update should have old and new UGRs")
+            true
+          }
       }
     }
   }
 
   test("deactivate a user's roles") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create, orgCreate: Organization.Create, platform: Platform,
-          userRole: GroupRole
-        ) => {
-          val setPlatformRoleIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (org, dbUser) = orgAndUser
-            insertedPlatform <- PlatformDao.create(platform)
-            originalUserGroupRole <- PlatformDao.addUserRole(dbUser, dbUser.id, insertedPlatform.id, userRole)
-            updatedUserGroupRoles <- PlatformDao.deactivateUserRoles(dbUser, dbUser.id, insertedPlatform.id)
-          } yield { (insertedPlatform, originalUserGroupRole, updatedUserGroupRoles ) }
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            userRole: GroupRole
+        ) =>
+          {
+            val setPlatformRoleIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (org, dbUser) = orgAndUser
+              insertedPlatform <- PlatformDao.create(platform)
+              originalUserGroupRole <- PlatformDao.addUserRole(
+                dbUser,
+                dbUser.id,
+                insertedPlatform.id,
+                userRole)
+              updatedUserGroupRoles <- PlatformDao.deactivateUserRoles(
+                dbUser,
+                dbUser.id,
+                insertedPlatform.id)
+            } yield {
+              (insertedPlatform, originalUserGroupRole, updatedUserGroupRoles)
+            }
 
-          val (dbPlatform, dbOldUGR, dbNewUGRs) = setPlatformRoleIO.transact(xa).unsafeRunSync
+            val (dbPlatform, dbOldUGR, dbNewUGRs) =
+              setPlatformRoleIO.transact(xa).unsafeRunSync
 
-          assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
-                 "; The updated UGR should be inactive")
-          assert(dbNewUGRs.size == 1, "; There should only be a single UGR updated")
-          true
-        }
+            assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
+                   "; The updated UGR should be inactive")
+            assert(dbNewUGRs.size == 1,
+                   "; There should only be a single UGR updated")
+            true
+          }
       }
     }
   }
 
   test("get Platform Users And Projests By Consumers And Scene IDs") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create,
-          userCreateAnother: User.Create,
-          orgCreate: Organization.Create,
-          platform: Platform,
-          projectCreate: Project.Create,
-          projectCreateAnother: Project.Create,
-          sceneCreate: Scene.Create
-        ) => {
-          val listOfPwuIO = for {
-            userOrgPlatProject <- insertUserOrgPlatProject(userCreate, orgCreate, platform, projectCreate)
-            (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
-            userProjectAnother <- insertUserProject(userCreateAnother, dbOrg, dbPlatform, projectCreateAnother)
-            (dbUserAnother, dbProjectAnother) = userProjectAnother
-            datasource <- unsafeGetRandomDatasource
-            sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser, datasource, sceneCreate), dbUser)
-            _ <- ProjectDao.addScenesToProject(List(sceneInsert.id), dbProject.id)
-            _ <- ProjectDao.addScenesToProject(List(sceneInsert.id), dbProjectAnother.id)
-            listOfUserIds = List(dbUser.id, dbUserAnother.id)
-            listOfPUSP <- PlatformDao.getPlatUsersAndProjByConsumerAndSceneID(listOfUserIds, sceneInsert.id)
-          } yield (dbUser, dbUserAnother, dbPlatform, dbProject, dbProjectAnother, listOfPUSP)
+            userCreate: User.Create,
+            userCreateAnother: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            projectCreateAnother: Project.Create,
+            sceneCreate: Scene.Create
+        ) =>
+          {
+            val listOfPwuIO = for {
+              userOrgPlatProject <- insertUserOrgPlatProject(userCreate,
+                                                             orgCreate,
+                                                             platform,
+                                                             projectCreate)
+              (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
+              userProjectAnother <- insertUserProject(userCreateAnother,
+                                                      dbOrg,
+                                                      dbPlatform,
+                                                      projectCreateAnother)
+              (dbUserAnother, dbProjectAnother) = userProjectAnother
+              datasource <- unsafeGetRandomDatasource
+              sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser,
+                                                              datasource,
+                                                              sceneCreate),
+                                             dbUser)
+              _ <- ProjectDao.addScenesToProject(List(sceneInsert.id),
+                                                 dbProject.id)
+              _ <- ProjectDao.addScenesToProject(List(sceneInsert.id),
+                                                 dbProjectAnother.id)
+              listOfUserIds = List(dbUser.id, dbUserAnother.id)
+              listOfPUSP <- PlatformDao.getPlatUsersAndProjByConsumerAndSceneID(
+                listOfUserIds,
+                sceneInsert.id)
+            } yield
+              (dbUser,
+               dbUserAnother,
+               dbPlatform,
+               dbProject,
+               dbProjectAnother,
+               listOfPUSP)
 
-          val (dbUser, dbUserAnother, dbPlatform, dbProject, dbProjectAnother, listOfPUSP) = listOfPwuIO.transact(xa).unsafeRunSync
+            val (dbUser,
+                 dbUserAnother,
+                 dbPlatform,
+                 dbProject,
+                 dbProjectAnother,
+                 listOfPUSP) = listOfPwuIO.transact(xa).unsafeRunSync
 
-          assert(listOfPUSP.length == 2, "; list of return length is not 2")
-          assert(listOfPUSP(0).platId == dbPlatform.id &&
-            listOfPUSP(1).platId == dbPlatform.id, "; platform ID don't match")
-          assert(listOfPUSP(0).platName == dbPlatform.name &&
-            listOfPUSP(1).platName == dbPlatform.name, "; platform name don't match")
-          assert((listOfPUSP(0).uId == dbUser.id || listOfPUSP(0).uId == dbUserAnother.id) &&
-            (listOfPUSP(1).uId == dbUser.id || listOfPUSP(1).uId == dbUserAnother.id), "; user ID don't match")
-          assert((listOfPUSP(0).uName == dbUser.name || listOfPUSP(0).uName == dbUserAnother.name) &&
-            (listOfPUSP(1).uName == dbUser.name || listOfPUSP(1).uName == dbUserAnother.name), "; user name don't match")
-          assert(listOfPUSP(0).pubSettings == dbPlatform.publicSettings &&
-            listOfPUSP(1).pubSettings == dbPlatform.publicSettings, "; platform public settings don't match")
-          assert(listOfPUSP(0).priSettings == dbPlatform.privateSettings &&
-            listOfPUSP(1).priSettings == dbPlatform.privateSettings, "; platform private settings don't match")
-          assert((listOfPUSP(0).email == dbUser.email || listOfPUSP(0).email == dbUserAnother.email) &&
-            (listOfPUSP(1).email == dbUser.email || listOfPUSP(1).email == dbUserAnother.email), "; user email don't match")
-          assert((listOfPUSP(0).emailNotifications == dbUser.emailNotifications || listOfPUSP(0).emailNotifications == dbUserAnother.emailNotifications) &&
-            listOfPUSP(1).emailNotifications == dbUser.emailNotifications || listOfPUSP(1).emailNotifications == dbUserAnother.emailNotifications, "; user email notification don't match")
-          assert((listOfPUSP(0).projectId == dbProject.id || listOfPUSP(0).projectId == dbProjectAnother.id) &&
-            listOfPUSP(1).projectId == dbProject.id || listOfPUSP(1).projectId == dbProjectAnother.id, "; project ID don't match")
-          assert((listOfPUSP(0).projectName == dbProject.name || listOfPUSP(0).projectName == dbProjectAnother.name) &&
-            (listOfPUSP(1).projectName == dbProject.name || listOfPUSP(1).projectName == dbProjectAnother.name), "; project name don't match")
-          assert((listOfPUSP(0).personalInfo == dbUser.personalInfo || listOfPUSP(0).personalInfo == dbUserAnother.personalInfo) &&
-            (listOfPUSP(1).personalInfo == dbUser.personalInfo || listOfPUSP(1).personalInfo == dbUserAnother.personalInfo), "; user personal info don't match")
-          true
-        }
+            assert(listOfPUSP.length == 2, "; list of return length is not 2")
+            assert(listOfPUSP(0).platId == dbPlatform.id &&
+                     listOfPUSP(1).platId == dbPlatform.id,
+                   "; platform ID don't match")
+            assert(listOfPUSP(0).platName == dbPlatform.name &&
+                     listOfPUSP(1).platName == dbPlatform.name,
+                   "; platform name don't match")
+            assert(
+              (listOfPUSP(0).uId == dbUser.id || listOfPUSP(0).uId == dbUserAnother.id) &&
+                (listOfPUSP(1).uId == dbUser.id || listOfPUSP(1).uId == dbUserAnother.id),
+              "; user ID don't match"
+            )
+            assert(
+              (listOfPUSP(0).uName == dbUser.name || listOfPUSP(0).uName == dbUserAnother.name) &&
+                (listOfPUSP(1).uName == dbUser.name || listOfPUSP(1).uName == dbUserAnother.name),
+              "; user name don't match"
+            )
+            assert(listOfPUSP(0).pubSettings == dbPlatform.publicSettings &&
+                     listOfPUSP(1).pubSettings == dbPlatform.publicSettings,
+                   "; platform public settings don't match")
+            assert(
+              listOfPUSP(0).priSettings == dbPlatform.privateSettings &&
+                listOfPUSP(1).priSettings == dbPlatform.privateSettings,
+              "; platform private settings don't match"
+            )
+            assert(
+              (listOfPUSP(0).email == dbUser.email || listOfPUSP(0).email == dbUserAnother.email) &&
+                (listOfPUSP(1).email == dbUser.email || listOfPUSP(1).email == dbUserAnother.email),
+              "; user email don't match"
+            )
+            assert(
+              (listOfPUSP(0).emailNotifications == dbUser.emailNotifications || listOfPUSP(
+                0).emailNotifications == dbUserAnother.emailNotifications) &&
+                listOfPUSP(1).emailNotifications == dbUser.emailNotifications || listOfPUSP(
+                1).emailNotifications == dbUserAnother.emailNotifications,
+              "; user email notification don't match"
+            )
+            assert(
+              (listOfPUSP(0).projectId == dbProject.id || listOfPUSP(0).projectId == dbProjectAnother.id) &&
+                listOfPUSP(1).projectId == dbProject.id || listOfPUSP(1).projectId == dbProjectAnother.id,
+              "; project ID don't match"
+            )
+            assert(
+              (listOfPUSP(0).projectName == dbProject.name || listOfPUSP(0).projectName == dbProjectAnother.name) &&
+                (listOfPUSP(1).projectName == dbProject.name || listOfPUSP(1).projectName == dbProjectAnother.name),
+              "; project name don't match"
+            )
+            assert(
+              (listOfPUSP(0).personalInfo == dbUser.personalInfo || listOfPUSP(
+                0).personalInfo == dbUserAnother.personalInfo) &&
+                (listOfPUSP(1).personalInfo == dbUser.personalInfo || listOfPUSP(
+                  1).personalInfo == dbUserAnother.personalInfo),
+              "; user personal info don't match"
+            )
+            true
+          }
       }
     }
   }
 
   test("get Platform And Users By Scene Owner Id") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create,
-          orgCreate: Organization.Create,
-          platform: Platform,
-          projectCreate: Project.Create,
-          sceneCreate: Scene.Create
-        ) => {
-          val puIO = for {
-            userOrgPlatProject <- insertUserOrgPlatProject(userCreate, orgCreate, platform, projectCreate)
-            (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
-            datasource <- unsafeGetRandomDatasource
-            sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser, datasource, sceneCreate), dbUser)
-            _ <- ProjectDao.addScenesToProject(List(sceneInsert.id), dbProject.id)
-            pUO <- PlatformDao.getPlatAndUsersBySceneOwnerId(sceneInsert.owner)
-          } yield (dbUser, dbPlatform, dbProject, pUO)
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            sceneCreate: Scene.Create
+        ) =>
+          {
+            val puIO = for {
+              userOrgPlatProject <- insertUserOrgPlatProject(userCreate,
+                                                             orgCreate,
+                                                             platform,
+                                                             projectCreate)
+              (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
+              datasource <- unsafeGetRandomDatasource
+              sceneInsert <- SceneDao.insert(fixupSceneCreate(dbUser,
+                                                              datasource,
+                                                              sceneCreate),
+                                             dbUser)
+              _ <- ProjectDao.addScenesToProject(List(sceneInsert.id),
+                                                 dbProject.id)
+              pUO <- PlatformDao.getPlatAndUsersBySceneOwnerId(
+                sceneInsert.owner)
+            } yield (dbUser, dbPlatform, dbProject, pUO)
 
-          val (dbUser, dbPlatform, dbProject, pU) = puIO.transact(xa).unsafeRunSync
+            val (dbUser, dbPlatform, dbProject, pU) =
+              puIO.transact(xa).unsafeRunSync
 
-          assert(pU.platId == dbPlatform.id, "; platform ID don't match")
-          assert(pU.platName == dbPlatform.name, "; platform name don't match")
-          assert(pU.uId == dbUser.id, "; user ID don't match")
-          assert(pU.uName == dbUser.name, "; user name don't match")
-          assert(pU.pubSettings == dbPlatform.publicSettings, "; platform public settings don't match")
-          assert(pU.priSettings == dbPlatform.privateSettings, "; platform private settings don't match")
-          assert(pU.email == dbUser.email, "; user email don't match")
-          assert(pU.emailNotifications == dbUser.emailNotifications, "; user email notification don't match")
-          assert(pU.personalInfo == dbUser.personalInfo, "; user personal info don't match")
-          true
-        }
+            assert(pU.platId == dbPlatform.id, "; platform ID don't match")
+            assert(pU.platName == dbPlatform.name,
+                   "; platform name don't match")
+            assert(pU.uId == dbUser.id, "; user ID don't match")
+            assert(pU.uName == dbUser.name, "; user name don't match")
+            assert(pU.pubSettings == dbPlatform.publicSettings,
+                   "; platform public settings don't match")
+            assert(pU.priSettings == dbPlatform.privateSettings,
+                   "; platform private settings don't match")
+            assert(pU.email == dbUser.email, "; user email don't match")
+            assert(pU.emailNotifications == dbUser.emailNotifications,
+                   "; user email notification don't match")
+            assert(pU.personalInfo == dbUser.personalInfo,
+                   "; user personal info don't match")
+            true
+          }
       }
     }
   }
 
-  test("list teams a platform user belongs to or can see due to organization memberships") {
+  test(
+    "list teams a platform user belongs to or can see due to organization memberships") {
     check {
-      forAll{
+      forAll {
         (
-          orgCreate1: Organization.Create,
-          orgCreate2: Organization.Create,
-          orgCreate3: Organization.Create,
-          teamCreate1: Team.Create,
-          teamCreate2: Team.Create,
-          teamCreate3: Team.Create,
-          userCreate: User.Create,
-          teamNamePartial: SearchQueryParameters
-        ) => {
-          val createAndGetTeamsIO =  for {
-            // Team# is in Org#
-            // User belongs to Org1 and Team1
-            orgUserInserted1 <- insertUserAndOrg(userCreate, orgCreate1, true)
-            (org1, user) = orgUserInserted1
-            teamInsert1 <- TeamDao.create(fixupTeam(
-              fixTeamName(teamCreate1, teamNamePartial), org1, user))
-            _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                user.id,
-                GroupType.Team,
-                teamInsert1.id,
-                GroupRole.Member
-              ).toUserGroupRole(user, MembershipStatus.Approved))
+            orgCreate1: Organization.Create,
+            orgCreate2: Organization.Create,
+            orgCreate3: Organization.Create,
+            teamCreate1: Team.Create,
+            teamCreate2: Team.Create,
+            teamCreate3: Team.Create,
+            userCreate: User.Create,
+            teamNamePartial: SearchQueryParameters
+        ) =>
+          {
+            val createAndGetTeamsIO = for {
+              // Team# is in Org#
+              // User belongs to Org1 and Team1
+              orgUserInserted1 <- insertUserAndOrg(userCreate, orgCreate1, true)
+              (org1, user) = orgUserInserted1
+              teamInsert1 <- TeamDao.create(
+                fixupTeam(fixTeamName(teamCreate1, teamNamePartial),
+                          org1,
+                          user))
+              _ <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(
+                    user.id,
+                    GroupType.Team,
+                    teamInsert1.id,
+                    GroupRole.Member
+                  )
+                  .toUserGroupRole(user, MembershipStatus.Approved))
 
-            // User belongs to Org2 but not Team2
-            org2 <- OrganizationDao.createOrganization(orgCreate2)
-            _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                user.id,
-                GroupType.Organization,
-                org2.id,
-                GroupRole.Member
-              ).toUserGroupRole(user, MembershipStatus.Approved))
-            teamInsert2 <- TeamDao.create(fixupTeam(
-              fixTeamName(teamCreate2, teamNamePartial), org2, user))
+              // User belongs to Org2 but not Team2
+              org2 <- OrganizationDao.createOrganization(orgCreate2)
+              _ <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(
+                    user.id,
+                    GroupType.Organization,
+                    org2.id,
+                    GroupRole.Member
+                  )
+                  .toUserGroupRole(user, MembershipStatus.Approved))
+              teamInsert2 <- TeamDao.create(
+                fixupTeam(fixTeamName(teamCreate2, teamNamePartial),
+                          org2,
+                          user))
 
-            // User belongs to Team3 but not Org3
-            org3 <- OrganizationDao.createOrganization(orgCreate3)
-            teamInsert3 <- TeamDao.create(fixupTeam(teamCreate3, org3, user))
-            _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                user.id,
-                GroupType.Team,
-                teamInsert3.id,
-                GroupRole.Member
-              ).toUserGroupRole(user, MembershipStatus.Approved))
+              // User belongs to Team3 but not Org3
+              org3 <- OrganizationDao.createOrganization(orgCreate3)
+              teamInsert3 <- TeamDao.create(fixupTeam(teamCreate3, org3, user))
+              _ <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(
+                    user.id,
+                    GroupType.Team,
+                    teamInsert3.id,
+                    GroupRole.Member
+                  )
+                  .toUserGroupRole(user, MembershipStatus.Approved))
 
-            searchedTeams <- PlatformDao.listPlatformUserTeams(user, teamNamePartial)
+              searchedTeams <- PlatformDao.listPlatformUserTeams(
+                user,
+                teamNamePartial)
 
-          } yield (teamInsert1, teamInsert2, teamInsert3, searchedTeams)
+            } yield (teamInsert1, teamInsert2, teamInsert3, searchedTeams)
 
-          val (teamInsert1, teamInsert2, teamInsert3, searchedTeams) = createAndGetTeamsIO.transact(xa).unsafeRunSync
+            val (teamInsert1, teamInsert2, teamInsert3, searchedTeams) =
+              createAndGetTeamsIO.transact(xa).unsafeRunSync
 
-          val teams = List(teamInsert1, teamInsert2, teamInsert3)
+            val teams = List(teamInsert1, teamInsert2, teamInsert3)
 
-          teamNamePartial.search match {
-            case Some(teamName) if teamName.length != 0 =>
-              teams.filter(_.name.toUpperCase.contains(teamName.toUpperCase)).length == searchedTeams.length
-            case _ => searchedTeams.length == 3
+            teamNamePartial.search match {
+              case Some(teamName) if teamName.length != 0 =>
+                teams
+                  .filter(_.name.toUpperCase.contains(teamName.toUpperCase))
+                  .length == searchedTeams.length
+              case _ => searchedTeams.length == 3
+            }
           }
-        }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -18,36 +18,53 @@ import org.scalatest.prop.Checkers
 import java.sql.Timestamp
 import java.time.LocalDate
 
-
-
-class ProjectDatasourcesDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class ProjectDatasourcesDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
   test("list datasources for a project") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, project: Project.Create,
-         dsCreate1: Datasource.Create, dsCreate2: Datasource.Create, dsCreate3: Datasource.Create,
-         scenes1: List[Scene.Create], scenes2: List[Scene.Create]
-        ) => {
-          val createDsIO = for {
-            orgUserProjectInsert <- insertUserOrgProject(userCreate, orgCreate, project)
-            (dbOrg, dbUser, dbProject) = orgUserProjectInsert
-            dsInsert1 <- fixupDatasource(dsCreate1, dbUser)
-            dsInsert2 <- fixupDatasource(dsCreate2, dbUser)
-            dsInsert3 <- fixupDatasource(dsCreate3, dbUser)
-            scenesInsert1 <- (scenes1 map { fixupSceneCreate(dbUser, dsInsert1, _) }).traverse(
-              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-            )
-            scenesInsert2 <- (scenes2 map { fixupSceneCreate(dbUser, dsInsert2, _) }).traverse(
-              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-            )
-            _ <- ProjectDao.addScenesToProject(scenesInsert1 map {_.id}, dbProject.id)
-            _ <- ProjectDao.addScenesToProject(scenesInsert2 map {_.id}, dbProject.id)
-            projectDatasources <- ProjectDatasourcesDao.listProjectDatasources(dbProject.id)
-          } yield (projectDatasources)
-          val (pd) = createDsIO.transact(xa).unsafeRunSync
-          assert(pd.size == 2, "; Datasources are not duplicated in request")
-          true
-        }
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         project: Project.Create,
+         dsCreate1: Datasource.Create,
+         dsCreate2: Datasource.Create,
+         dsCreate3: Datasource.Create,
+         scenes1: List[Scene.Create],
+         scenes2: List[Scene.Create]) =>
+          {
+            val createDsIO = for {
+              orgUserProjectInsert <- insertUserOrgProject(userCreate,
+                                                           orgCreate,
+                                                           project)
+              (dbOrg, dbUser, dbProject) = orgUserProjectInsert
+              dsInsert1 <- fixupDatasource(dsCreate1, dbUser)
+              dsInsert2 <- fixupDatasource(dsCreate2, dbUser)
+              dsInsert3 <- fixupDatasource(dsCreate3, dbUser)
+              scenesInsert1 <- (scenes1 map {
+                fixupSceneCreate(dbUser, dsInsert1, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+              scenesInsert2 <- (scenes2 map {
+                fixupSceneCreate(dbUser, dsInsert2, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+              _ <- ProjectDao.addScenesToProject(scenesInsert1 map { _.id },
+                                                 dbProject.id)
+              _ <- ProjectDao.addScenesToProject(scenesInsert2 map { _.id },
+                                                 dbProject.id)
+              projectDatasources <- ProjectDatasourcesDao
+                .listProjectDatasources(dbProject.id)
+            } yield (projectDatasources)
+            val (pd) = createDsIO.transact(xa).unsafeRunSync
+            assert(pd.size == 2, "; Datasources are not duplicated in request")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
@@ -17,38 +17,64 @@ import org.scalatest.prop.Checkers
 import java.sql.Timestamp
 import java.time.LocalDate
 
-class ProjectScenesDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class ProjectScenesDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
   test("list scenes for a project") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create, scenes: List[Scene.Create],
-         dsCreate: Datasource.Create, page: PageRequest, csq: CombinedSceneQueryParams) => {
-          val scenesInsertWithUserProjectIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser), dbUser)
-            scenesInsert <- (scenes map { fixupSceneCreate(dbUser, datasource, _) }).traverse(
-              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-            )
-          } yield (scenesInsert, dbUser, dbProject)
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         scenes: List[Scene.Create],
+         dsCreate: Datasource.Create,
+         page: PageRequest,
+         csq: CombinedSceneQueryParams) =>
+          {
+            val scenesInsertWithUserProjectIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
+                                                 dbUser)
+              scenesInsert <- (scenes map {
+                fixupSceneCreate(dbUser, datasource, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+            } yield (scenesInsert, dbUser, dbProject)
 
-          val scenesListIO = scenesInsertWithUserProjectIO flatMap {
-            case (dbScenes: List[Scene.WithRelated], dbUser: User, dbProject: Project) => {
-              ProjectDao.addScenesToProject(dbScenes map { _.id }, dbProject.id) flatMap {
-                _ => {
-                  ProjectScenesDao.listProjectScenes(dbProject.id, page, csq) map {
-                    (paginatedResponse: PaginatedResponse[Scene.ProjectScene]) => (dbScenes, paginatedResponse.results)
+            val scenesListIO = scenesInsertWithUserProjectIO flatMap {
+              case (dbScenes: List[Scene.WithRelated],
+                    dbUser: User,
+                    dbProject: Project) => {
+                ProjectDao.addScenesToProject(dbScenes map { _.id },
+                                              dbProject.id) flatMap { _ =>
+                  {
+                    ProjectScenesDao.listProjectScenes(dbProject.id, page, csq) map {
+                      (paginatedResponse: PaginatedResponse[
+                        Scene.ProjectScene]) =>
+                        (dbScenes, paginatedResponse.results)
+                    }
                   }
                 }
               }
             }
-          }
 
-          val (insertedScenes, listedScenes) = scenesListIO.transact(xa).unsafeRunSync
-          val insertedIds = insertedScenes.toSet map { (scene: Scene.WithRelated) => scene.id }
-          val listedIds = listedScenes.toSet map { (scene: Scene.ProjectScene) => scene.id }
-          insertedIds == listedIds
-        }
+            val (insertedScenes, listedScenes) =
+              scenesListIO.transact(xa).unsafeRunSync
+            val insertedIds = insertedScenes.toSet map {
+              (scene: Scene.WithRelated) =>
+                scene.id
+            }
+            val listedIds = listedScenes.toSet map {
+              (scene: Scene.ProjectScene) =>
+                scene.id
+            }
+            insertedIds == listedIds
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -220,28 +220,33 @@ trait PropTestHelpers {
     }
   }
 
-  def fixTeamName(teamCreate: Team.Create, searchParams: SearchQueryParameters): Team.Create = searchParams.search match {
-    case Some(teamName) if teamName.length != 0 => teamCreate.copy(name = teamName)
-    case _ => teamCreate
-  }
+  def fixTeamName(teamCreate: Team.Create,
+                  searchParams: SearchQueryParameters): Team.Create =
+    searchParams.search match {
+      case Some(teamName) if teamName.length != 0 =>
+        teamCreate.copy(name = teamName)
+      case _ => teamCreate
+    }
 
   def fixUpObjectAcr(
-    acr: ObjectAccessControlRule,
-    userTeamOrgPlat: (User, Team, Organization, Platform)
+      acr: ObjectAccessControlRule,
+      userTeamOrgPlat: (User, Team, Organization, Platform)
   ): ObjectAccessControlRule = {
     val (user, team, org, platform) = userTeamOrgPlat
     acr.subjectType match {
-    case SubjectType.All => acr
-    case SubjectType.Platform => acr.copy(subjectId = Some(platform.id.toString))
-    case SubjectType.Organization => acr.copy(subjectId = Some(org.id.toString))
-    case SubjectType.Team => acr.copy(subjectId = Some(team.id.toString))
-    case SubjectType.User => acr.copy(subjectId = Some(user.id))
+      case SubjectType.All => acr
+      case SubjectType.Platform =>
+        acr.copy(subjectId = Some(platform.id.toString))
+      case SubjectType.Organization =>
+        acr.copy(subjectId = Some(org.id.toString))
+      case SubjectType.Team => acr.copy(subjectId = Some(team.id.toString))
+      case SubjectType.User => acr.copy(subjectId = Some(user.id))
     }
   }
 
   def fixUpProjMiscInsert(
-    userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
-    project: Project.Create
+      userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+      project: Project.Create
   ): ConnectionIO[(Project, (User, Team, Organization, Platform))] = {
     val (user, team, org, platform) = userTeamOrgPlat
     for {
@@ -249,8 +254,11 @@ trait PropTestHelpers {
       dbPlatform <- PlatformDao.create(platform)
       orgInsert <- OrganizationDao.createOrganization(org)
       dbOrg = orgInsert.copy(platformId = dbPlatform.id)
-      dbTeam <- TeamDao.create(team.copy(organizationId = dbOrg.id).toTeam(dbUser))
-      projectInsert <- ProjectDao.insertProject(fixupProjectCreate(dbUser, project), dbUser)
+      dbTeam <- TeamDao.create(
+        team.copy(organizationId = dbOrg.id).toTeam(dbUser))
+      projectInsert <- ProjectDao.insertProject(
+        fixupProjectCreate(dbUser, project),
+        dbUser)
       dbUserTeamOrgPlat = (dbUser, dbTeam, dbOrg, dbPlatform)
     } yield { (projectInsert, dbUserTeamOrgPlat) }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
@@ -17,31 +17,51 @@ import org.scalatest.prop.Checkers
 import java.sql.Timestamp
 import java.time.LocalDate
 
-
-class SceneToProjectDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class SceneToProjectDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
   test("Insert scenes to projects and accept them") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create, scenes: List[Scene.Create],
-         dsCreate: Datasource.Create, page: PageRequest, csq: CombinedSceneQueryParams) => {
-          val acceptedSceneAndStpIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser), dbUser)
-            scenesInsert <- (scenes map { fixupSceneCreate(dbUser, datasource, _) }).traverse(
-              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-            )
-            _ <- ProjectDao.addScenesToProject(scenesInsert map { _.id }, dbProject.id, false)
-            acceptedSceneCount <- SceneToProjectDao.acceptScenes(dbProject.id, scenesInsert map { _.id })
-            stps <- SceneToProjectDao.query.filter(fr"project_id = ${dbProject.id}").list
-          } yield (acceptedSceneCount, stps)
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         scenes: List[Scene.Create],
+         dsCreate: Datasource.Create,
+         page: PageRequest,
+         csq: CombinedSceneQueryParams) =>
+          {
+            val acceptedSceneAndStpIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
+                                                 dbUser)
+              scenesInsert <- (scenes map {
+                fixupSceneCreate(dbUser, datasource, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+              _ <- ProjectDao.addScenesToProject(scenesInsert map { _.id },
+                                                 dbProject.id,
+                                                 false)
+              acceptedSceneCount <- SceneToProjectDao.acceptScenes(
+                dbProject.id,
+                scenesInsert map { _.id })
+              stps <- SceneToProjectDao.query
+                .filter(fr"project_id = ${dbProject.id}")
+                .list
+            } yield (acceptedSceneCount, stps)
 
-          val (acceptedSceneCount, stps) = acceptedSceneAndStpIO.transact(xa).unsafeRunSync
+            val (acceptedSceneCount, stps) =
+              acceptedSceneAndStpIO.transact(xa).unsafeRunSync
 
-          acceptedSceneCount == scenes.length &&
+            acceptedSceneCount == scenes.length &&
             stps.length == scenes.length &&
             stps.filter(_.accepted).length == scenes.length
-        }
+          }
       }
     }
   }
@@ -49,33 +69,48 @@ class SceneToProjectDaoSpec extends FunSuite with Matchers with Checkers with DB
   test("Verify scenes are returned in correct order for mosaic definition") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create, scenes: List[Scene.Create],
-         dsCreate: Datasource.Create, page: PageRequest, csq: CombinedSceneQueryParams) => {
-          val mdAndStpsIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser), dbUser)
-            scenesInsert <- (scenes map { fixupSceneCreate(dbUser, datasource, _) }).traverse(
-              (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-            )
-            _ <- ProjectDao.addScenesToProject(scenesInsert map { _.id }, dbProject.id, false)
-            _ <- SceneToProjectDao.setManualOrder(dbProject.id, scenesInsert map { _.id })
-            mds <- SceneToProjectDao.getMosaicDefinition(dbProject.id, None)
-            stps <- SceneToProjectDao.query.filter(fr"project_id = ${dbProject.id}").list
-          } yield (mds, stps)
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         scenes: List[Scene.Create],
+         dsCreate: Datasource.Create,
+         page: PageRequest,
+         csq: CombinedSceneQueryParams) =>
+          {
+            val mdAndStpsIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
+                                                 dbUser)
+              scenesInsert <- (scenes map {
+                fixupSceneCreate(dbUser, datasource, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+              _ <- ProjectDao.addScenesToProject(scenesInsert map { _.id },
+                                                 dbProject.id,
+                                                 false)
+              _ <- SceneToProjectDao.setManualOrder(dbProject.id,
+                                                    scenesInsert map { _.id })
+              mds <- SceneToProjectDao.getMosaicDefinition(dbProject.id, None)
+              stps <- SceneToProjectDao.query
+                .filter(fr"project_id = ${dbProject.id}")
+                .list
+            } yield (mds, stps)
 
-          val (mds, stps) = mdAndStpsIO.transact(xa).unsafeRunSync
+            val (mds, stps) = mdAndStpsIO.transact(xa).unsafeRunSync
 
-          // Mapping of scene ids to scene order
-          val sceneMap = stps.map(s => (s.sceneId, s.sceneOrder.getOrElse(-1))).toMap
+            // Mapping of scene ids to scene order
+            val sceneMap =
+              stps.map(s => (s.sceneId, s.sceneOrder.getOrElse(-1))).toMap
 
-          // List of scene orders, ordered by the mosaic definitions
-          val sceneOrders = mds.map(md => sceneMap.getOrElse(md.sceneId, -1))
+            // List of scene orders, ordered by the mosaic definitions
+            val sceneOrders = mds.map(md => sceneMap.getOrElse(md.sceneId, -1))
 
-          // If the scenes are returned in the correct order,
-          // the scene orders of the mosaic definitions will be in order
-          sceneOrders.sameElements(sceneOrders.sorted)
-        }
+            // If the scenes are returned in the correct order,
+            // the scene orders of the mosaic definitions will be in order
+            sceneOrders.sameElements(sceneOrders.sorted)
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -70,7 +70,8 @@ class SceneWithRelatedDaoSpec
                 scene.name
             }
             val listedNamesSet = listedScenes.results.toSet map {
-              (scene: Scene.Browse) => scene.name
+              (scene: Scene.Browse) =>
+                scene.name
             }
             assert(
               listedNamesSet.intersect(insertedNamesSet) == listedNamesSet,
@@ -114,9 +115,9 @@ class SceneWithRelatedDaoSpec
               scenesToIngestIO.transact(xa).unsafeRunSync
             val ingestableScenesIds = scenesInProject filter { scene =>
               (scene.statusFields.ingestStatus, scene.sceneType) match {
-                case (_, Some(SceneType.COG)) => false
+                case (_, Some(SceneType.COG))       => false
                 case (IngestStatus.ToBeIngested, _) => true
-                case _ => false
+                case _                              => false
               }
             } map { _.id }
             val ingestableIdsFromInserted = insertedScenes

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -22,7 +22,12 @@ import io.circe.syntax._
 import java.util.UUID
 import com.lonelyplanet.akka.http.extensions.PageRequest
 
-class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class TeamDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("listing teams") {
     TeamDao.query.list.transact(xa).unsafeRunSync.length >= 0
@@ -30,12 +35,15 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
 
   test("getting a team by ID") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+            teamInsert <- TeamDao.create(
+              fixupTeam(teamCreate, orgInsert, userInsert))
           } yield (teamInsert, orgInsert)
 
           val getTeamAndOrgIO = createTeamIO flatMap {
@@ -48,9 +56,9 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
           val getTeam = getTeamOp.get
 
           getTeam.name == teamCreate.name &&
-            getTeam.organizationId == org.id &&
-            getTeam.settings == teamCreate.settings &&
-            getTeam.isActive == true
+          getTeam.organizationId == org.id &&
+          getTeam.settings == teamCreate.settings &&
+          getTeam.isActive == true
         }
       )
     }
@@ -58,12 +66,15 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
 
   test("getting a team by ID unsafely") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+            teamInsert <- TeamDao.create(
+              fixupTeam(teamCreate, orgInsert, userInsert))
           } yield (teamInsert, orgInsert)
 
           val getTeamAndOrgIO = createTeamIO flatMap {
@@ -75,9 +86,9 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
           val (getTeam, org) = getTeamAndOrgIO.transact(xa).unsafeRunSync
 
           getTeam.name == teamCreate.name &&
-            getTeam.organizationId == org.id &&
-            getTeam.settings == teamCreate.settings &&
-            getTeam.isActive == true
+          getTeam.organizationId == org.id &&
+          getTeam.settings == teamCreate.settings &&
+          getTeam.isActive == true
         }
       )
     }
@@ -85,20 +96,23 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
 
   test("creating a team") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+            teamInsert <- TeamDao.create(
+              fixupTeam(teamCreate, orgInsert, userInsert))
           } yield (teamInsert, orgInsert)
 
           val (createdTeam, org) = createTeamIO.transact(xa).unsafeRunSync
 
           createdTeam.name == teamCreate.name &&
-            createdTeam.organizationId == org.id &&
-            createdTeam.settings == teamCreate.settings &&
-            createdTeam.isActive == true
+          createdTeam.organizationId == org.id &&
+          createdTeam.settings == teamCreate.settings &&
+          createdTeam.isActive == true
         }
       )
     }
@@ -106,34 +120,49 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
 
   test("creating a team with role") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.createWithRole(fixupTeam(teamCreate, orgInsert, userInsert), userInsert)
-            users <- TeamDao.listMembers(teamInsert.id, PageRequest(0, 30, Map.empty), SearchQueryParameters(), userInsert)
-          } yield (teamInsert, orgInsert, users)
+            teamInsert <- TeamDao.createWithRole(fixupTeam(teamCreate,
+                                                           orgInsert,
+                                                           userInsert),
+                                                 userInsert)
+            users <- TeamDao.listMembers(teamInsert.id,
+                                         PageRequest(0, 30, Map.empty),
+                                         SearchQueryParameters(),
+                                         userInsert)
+            isAdmin <- TeamDao.userIsAdmin(userInsert, teamInsert.id)
+          } yield (teamInsert, orgInsert, users, isAdmin)
 
-          val (createdTeam, org, teamusers) = createTeamIO.transact(xa).unsafeRunSync
+          val (createdTeam, org, teamusers, isAdmin) =
+            createTeamIO.transact(xa).unsafeRunSync
 
           createdTeam.name == teamCreate.name &&
-            createdTeam.organizationId == org.id &&
-            createdTeam.settings == teamCreate.settings &&
-            createdTeam.isActive == true && teamusers.count == 1
+          createdTeam.organizationId == org.id &&
+          createdTeam.settings == teamCreate.settings &&
+          createdTeam.isActive == true && teamusers.count == 1 &&
+          isAdmin
         }
       )
     }
   }
 
-  test("updating a team"){
+  test("updating a team") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create, teamUpdate: Team.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create,
+         teamUpdate: Team.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+            teamInsert <- TeamDao.create(
+              fixupTeam(teamCreate, orgInsert, userInsert))
           } yield (teamInsert, orgInsert, userInsert)
 
           val updateTeamIO = createTeamIO flatMap {
@@ -151,9 +180,9 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
           val (updatedTeam, org) = updateTeamIO.transact(xa).unsafeRunSync
 
           updatedTeam.name == teamUpdate.name &&
-            updatedTeam.settings == teamUpdate.settings &&
-            updatedTeam.organizationId == org.id &&
-            updatedTeam.isActive == true
+          updatedTeam.settings == teamUpdate.settings &&
+          updatedTeam.organizationId == org.id &&
+          updatedTeam.isActive == true
         }
       )
     }
@@ -161,12 +190,15 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
 
   test("deleting a team by ID") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+            teamInsert <- TeamDao.create(
+              fixupTeam(teamCreate, orgInsert, userInsert))
           } yield teamInsert
 
           val deleteTeamIO = createTeamIO flatMap {
@@ -182,26 +214,50 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
   // ACR deactivation upon team deactivation needs to be reconsidered in issue 4020
   test("Deactivated teams are not listed") {
     check {
-      forAll (
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
-         acr: ObjectAccessControlRule, project: Project.Create) => {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create,
+         acr: ObjectAccessControlRule,
+         project: Project.Create) => {
           val createTeamIO = for {
             orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
             (orgInsert, userInsert) = orgAndUserInsert
-            teamInsert <- TeamDao.create(fixupTeam(teamCreate, orgInsert, userInsert))
+            teamInsert <- TeamDao.create(
+              fixupTeam(teamCreate, orgInsert, userInsert))
             insertedProject <- ProjectDao.insertProject(project, userInsert)
-            acrToInsert = acr.copy(subjectType = SubjectType.Team, subjectId = Some(teamInsert.id.toString()))
+            acrToInsert = acr.copy(subjectType = SubjectType.Team,
+                                   subjectId = Some(teamInsert.id.toString()))
             _ <- ProjectDao.addPermission(insertedProject.id, acrToInsert)
             deactivateTeam <- TeamDao.deactivate(teamInsert.id)
-            permissionAfterTeamDeactivate <- ProjectDao.getPermissions(insertedProject.id)
-            deactivatedTeams <- TeamDao.query.filter(fr"is_active = false").filter(fr"modified_by=${userInsert.id}").list
-            activatedTeams <- TeamDao.listOrgTeams(orgInsert.id, PageRequest(0, 30, Map.empty), TeamQueryParameters())
-          } yield { (deactivatedTeams, activatedTeams, acrToInsert, permissionAfterTeamDeactivate) }
-          val (deactivatedTeams, activatedTeams, acrToInsert, permissionAfterTeamDeactivate) = createTeamIO.transact(xa).unsafeRunSync
+            permissionAfterTeamDeactivate <- ProjectDao.getPermissions(
+              insertedProject.id)
+            deactivatedTeams <- TeamDao.query
+              .filter(fr"is_active = false")
+              .filter(fr"modified_by=${userInsert.id}")
+              .list
+            activatedTeams <- TeamDao.listOrgTeams(orgInsert.id,
+                                                   PageRequest(0,
+                                                               30,
+                                                               Map.empty),
+                                                   TeamQueryParameters())
+          } yield {
+            (deactivatedTeams,
+             activatedTeams,
+             acrToInsert,
+             permissionAfterTeamDeactivate)
+          }
+          val (deactivatedTeams,
+               activatedTeams,
+               acrToInsert,
+               permissionAfterTeamDeactivate) =
+            createTeamIO.transact(xa).unsafeRunSync
 
           assert(deactivatedTeams.size == 1, "Deactivated team should exist")
           assert(activatedTeams.results.size == 0, "No team is active")
-          assert(Set(acrToInsert) == permissionAfterTeamDeactivate.flatten.toSet, "Permissions exists after team deactivation")
+          assert(
+            Set(acrToInsert) == permissionAfterTeamDeactivate.flatten.toSet,
+            "Permissions exists after team deactivation")
           true
         }
       )
@@ -210,56 +266,79 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
 
   test("add a user role") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
-          userRole: GroupRole
-        ) => {
-          val addUserTeamRoleIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (org, dbUser) = orgAndUser
-            insertedTeam <- TeamDao.create(fixupTeam(teamCreate, org, dbUser))
-            insertedUserGroupRole <- TeamDao.addUserRole(org.platformId, dbUser, dbUser.id, insertedTeam.id, userRole)
-            byIdUserGroupRole <- UserGroupRoleDao.getOption(insertedUserGroupRole.id)
-          } yield { (insertedTeam, byIdUserGroupRole) }
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            teamCreate: Team.Create,
+            userRole: GroupRole
+        ) =>
+          {
+            val addUserTeamRoleIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (org, dbUser) = orgAndUser
+              insertedTeam <- TeamDao.create(fixupTeam(teamCreate, org, dbUser))
+              insertedUserGroupRole <- TeamDao.addUserRole(org.platformId,
+                                                           dbUser,
+                                                           dbUser.id,
+                                                           insertedTeam.id,
+                                                           userRole)
+              byIdUserGroupRole <- UserGroupRoleDao.getOption(
+                insertedUserGroupRole.id)
+            } yield { (insertedTeam, byIdUserGroupRole) }
 
-          val (dbTeam, dbUserGroupRole) = addUserTeamRoleIO.transact(xa).unsafeRunSync
-          dbUserGroupRole match {
-            case Some(ugr) =>
-              assert(ugr.isActive, "; Added role should be active")
-              assert(ugr.groupType == GroupType.Team, "; Added role should be for a Team")
-              assert(ugr.groupId == dbTeam.id, "; Added role should be for the correct Team")
-              assert(ugr.groupRole == userRole, "; Added role should have the correct role")
-              true
-            case _ => false
+            val (dbTeam, dbUserGroupRole) =
+              addUserTeamRoleIO.transact(xa).unsafeRunSync
+            dbUserGroupRole match {
+              case Some(ugr) =>
+                assert(ugr.isActive, "; Added role should be active")
+                assert(ugr.groupType == GroupType.Team,
+                       "; Added role should be for a Team")
+                assert(ugr.groupId == dbTeam.id,
+                       "; Added role should be for the correct Team")
+                assert(ugr.groupRole == userRole,
+                       "; Added role should have the correct role")
+                true
+              case _ => false
+            }
           }
-        }
       }
     }
   }
 
   test("deactivate a user's roles") {
     check {
-      forAll{
+      forAll {
         (
-          userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
-          userRole: GroupRole
-        ) => {
-          val setTeamRoleIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
-            (org, dbUser) = orgAndUser
-            insertedTeam <- TeamDao.create(fixupTeam(teamCreate, org, dbUser))
-            originalUserGroupRole <- TeamDao.addUserRole(org.platformId, dbUser, dbUser.id, insertedTeam.id, userRole)
-            updatedUserGroupRoles <- TeamDao.deactivateUserRoles(dbUser, dbUser.id, insertedTeam.id)
-          } yield { (originalUserGroupRole, updatedUserGroupRoles ) }
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            teamCreate: Team.Create,
+            userRole: GroupRole
+        ) =>
+          {
+            val setTeamRoleIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate)
+              (org, dbUser) = orgAndUser
+              insertedTeam <- TeamDao.create(fixupTeam(teamCreate, org, dbUser))
+              originalUserGroupRole <- TeamDao.addUserRole(org.platformId,
+                                                           dbUser,
+                                                           dbUser.id,
+                                                           insertedTeam.id,
+                                                           userRole)
+              updatedUserGroupRoles <- TeamDao.deactivateUserRoles(
+                dbUser,
+                dbUser.id,
+                insertedTeam.id)
+            } yield { (originalUserGroupRole, updatedUserGroupRoles) }
 
-          val (dbOldUGR, dbNewUGRs) = setTeamRoleIO.transact(xa).unsafeRunSync
+            val (dbOldUGR, dbNewUGRs) = setTeamRoleIO.transact(xa).unsafeRunSync
 
-          assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
-                 "; The updated UGR should be inactive")
-          assert(dbNewUGRs.size == 1, "; There should only be a single UGR updated")
-          true
-        }
+            assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
+                   "; The updated UGR should be inactive")
+            assert(dbNewUGRs.size == 1,
+                   "; There should only be a single UGR updated")
+            true
+          }
       }
     }
   }
@@ -267,31 +346,49 @@ class TeamDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig
   test("listing teams for a user") {
     check {
       forAll {
-        (platform: Platform, userCreate: User.Create, orgCreate: Organization.Create,
-         teamCreate1: Team.Create, teamCreate2: Team.Create) => {
-          val groupRole = GroupRole.Member
-          val teamsForUserIO = for {
-            userOrgPlatform <- insertUserOrgPlatform(userCreate, orgCreate, platform)
-            (dbUser, dbOrg, dbPlatform) = userOrgPlatform
-            team1 <- TeamDao.create(fixupTeam(teamCreate1, dbOrg, dbUser))
-            team2 <- TeamDao.create(fixupTeam(teamCreate2, dbOrg, dbUser))
-            _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbUser.id, GroupType.Team, team1.id, groupRole
-              ).toUserGroupRole(dbUser, MembershipStatus.Approved)
-            )
-            _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbUser.id, GroupType.Team, team2.id, groupRole
-              ).toUserGroupRole(dbUser, MembershipStatus.Approved)
-            )
-            listedTeams <- TeamDao.teamsForUser(dbUser)
-          } yield { (List(team1, team2), listedTeams) }
-          val (insertedTeams, listedTeams) = teamsForUserIO.transact(xa).unsafeRunSync
-          assert(insertedTeams.map( _.name ).toSet == listedTeams.map( _.name ).toSet,
-                 "Inserted and listed teams for this user should be the same")
-          true
-        }
+        (platform: Platform,
+         userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate1: Team.Create,
+         teamCreate2: Team.Create) =>
+          {
+            val groupRole = GroupRole.Member
+            val teamsForUserIO = for {
+              userOrgPlatform <- insertUserOrgPlatform(userCreate,
+                                                       orgCreate,
+                                                       platform)
+              (dbUser, dbOrg, dbPlatform) = userOrgPlatform
+              team1 <- TeamDao.create(fixupTeam(teamCreate1, dbOrg, dbUser))
+              team2 <- TeamDao.create(fixupTeam(teamCreate2, dbOrg, dbUser))
+              _ <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(
+                    dbUser.id,
+                    GroupType.Team,
+                    team1.id,
+                    groupRole
+                  )
+                  .toUserGroupRole(dbUser, MembershipStatus.Approved)
+              )
+              _ <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(
+                    dbUser.id,
+                    GroupType.Team,
+                    team2.id,
+                    groupRole
+                  )
+                  .toUserGroupRole(dbUser, MembershipStatus.Approved)
+              )
+              listedTeams <- TeamDao.teamsForUser(dbUser)
+            } yield { (List(team1, team2), listedTeams) }
+            val (insertedTeams, listedTeams) =
+              teamsForUserIO.transact(xa).unsafeRunSync
+            assert(
+              insertedTeams.map(_.name).toSet == listedTeams.map(_.name).toSet,
+              "Inserted and listed teams for this user should be the same")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
@@ -12,8 +12,12 @@ import org.scalatest._
 import org.scalatest.prop.Checkers
 import java.util.UUID
 
-
-class ThumbnailDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class ThumbnailDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("list thumbnails") {
     ThumbnailDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
@@ -22,19 +26,25 @@ class ThumbnailDaoSpec extends FunSuite with Matchers with Checkers with DBTestC
   test("insert a thumbnail") {
     check {
       forAll {
-        (org: Organization.Create, user: User.Create, scene: Scene.Create, thumbnail: Thumbnail) => {
-          val thumbnailInsertIO = insertUserOrgScene(user, org, scene) flatMap {
-            case (dbOrg: Organization, dbUser: User, dbScene: Scene.WithRelated) => {
-              ThumbnailDao.insert(fixupThumbnail(dbScene, thumbnail))
+        (org: Organization.Create,
+         user: User.Create,
+         scene: Scene.Create,
+         thumbnail: Thumbnail) =>
+          {
+            val thumbnailInsertIO = insertUserOrgScene(user, org, scene) flatMap {
+              case (dbOrg: Organization,
+                    dbUser: User,
+                    dbScene: Scene.WithRelated) => {
+                ThumbnailDao.insert(fixupThumbnail(dbScene, thumbnail))
+              }
             }
-          }
-          val insertedThumbnail = thumbnailInsertIO.transact(xa).unsafeRunSync
+            val insertedThumbnail = thumbnailInsertIO.transact(xa).unsafeRunSync
 
-          insertedThumbnail.widthPx == thumbnail.widthPx &&
+            insertedThumbnail.widthPx == thumbnail.widthPx &&
             insertedThumbnail.heightPx == thumbnail.heightPx &&
             insertedThumbnail.url == thumbnail.url &&
             insertedThumbnail.thumbnailSize == thumbnail.thumbnailSize
-        }
+          }
       }
     }
   }
@@ -42,14 +52,22 @@ class ThumbnailDaoSpec extends FunSuite with Matchers with Checkers with DBTestC
   test("insert many thumbnails") {
     check {
       forAll {
-        (org: Organization.Create, user: User.Create, scene: Scene.Create, thumbnails: List[Thumbnail]) => {
-          val thumbnailsInsertIO = insertUserOrgScene(user, org, scene) flatMap {
-            case (dbOrg: Organization, dbUser: User, dbScene: Scene.WithRelated) => {
-              ThumbnailDao.insertMany(thumbnails map { fixupThumbnail(dbScene, _) })
+        (org: Organization.Create,
+         user: User.Create,
+         scene: Scene.Create,
+         thumbnails: List[Thumbnail]) =>
+          {
+            val thumbnailsInsertIO = insertUserOrgScene(user, org, scene) flatMap {
+              case (dbOrg: Organization,
+                    dbUser: User,
+                    dbScene: Scene.WithRelated) => {
+                ThumbnailDao.insertMany(thumbnails map {
+                  fixupThumbnail(dbScene, _)
+                })
+              }
             }
+            thumbnailsInsertIO.transact(xa).unsafeRunSync == thumbnails.length
           }
-          thumbnailsInsertIO.transact(xa).unsafeRunSync == thumbnails.length
-        }
       }
     }
   }
@@ -57,37 +75,48 @@ class ThumbnailDaoSpec extends FunSuite with Matchers with Checkers with DBTestC
   test("update a thumbnail") {
     check {
       forAll {
-        (org: Organization.Create, user: User.Create, scene: Scene.Create, insertThumbnail: Thumbnail, updateThumbnail: Thumbnail) => {
-          val thumbnailInsertIO = insertUserOrgScene(user, org, scene) flatMap {
-            case (dbOrg: Organization, dbUser: User, dbScene: Scene.WithRelated) => {
-              ThumbnailDao.insert(fixupThumbnail(dbScene, insertThumbnail))
-            }
-          }
-
-          val thumbnailUpdateWithThumbnailIO = thumbnailInsertIO flatMap {
-            (dbThumbnail: Thumbnail) => {
-              val withFks = updateThumbnail.copy(
-                id = dbThumbnail.id,
-                sceneId = dbThumbnail.sceneId
-              )
-              ThumbnailDao.update(withFks, dbThumbnail.id) flatMap {
-                (affectedRows: Int) => {
-                  ThumbnailDao.unsafeGetThumbnailById(dbThumbnail.id) map { (affectedRows, _) }
-                }
+        (org: Organization.Create,
+         user: User.Create,
+         scene: Scene.Create,
+         insertThumbnail: Thumbnail,
+         updateThumbnail: Thumbnail) =>
+          {
+            val thumbnailInsertIO = insertUserOrgScene(user, org, scene) flatMap {
+              case (dbOrg: Organization,
+                    dbUser: User,
+                    dbScene: Scene.WithRelated) => {
+                ThumbnailDao.insert(fixupThumbnail(dbScene, insertThumbnail))
               }
             }
-          }
 
-          val (affectedRows, updatedThumbnail) = thumbnailUpdateWithThumbnailIO.transact(xa).unsafeRunSync
-          affectedRows == 1 &&
+            val thumbnailUpdateWithThumbnailIO = thumbnailInsertIO flatMap {
+              (dbThumbnail: Thumbnail) =>
+                {
+                  val withFks = updateThumbnail.copy(
+                    id = dbThumbnail.id,
+                    sceneId = dbThumbnail.sceneId
+                  )
+                  ThumbnailDao.update(withFks, dbThumbnail.id) flatMap {
+                    (affectedRows: Int) =>
+                      {
+                        ThumbnailDao.unsafeGetThumbnailById(dbThumbnail.id) map {
+                          (affectedRows, _)
+                        }
+                      }
+                  }
+                }
+            }
+
+            val (affectedRows, updatedThumbnail) =
+              thumbnailUpdateWithThumbnailIO.transact(xa).unsafeRunSync
+            affectedRows == 1 &&
             updatedThumbnail.widthPx == updateThumbnail.widthPx &&
             updatedThumbnail.heightPx == updateThumbnail.heightPx &&
             updatedThumbnail.url == updateThumbnail.url &&
             updatedThumbnail.thumbnailSize == updateThumbnail.thumbnailSize
-        }
+          }
       }
     }
   }
 
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryDaoSpec.scala
@@ -10,21 +10,25 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-
-class ToolCategoryDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ToolCategoryDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
 
   test("types") { check(ToolCategoryDao.selectF.query[ToolCategory]) }
 
   test("insertion") {
     val category = "A good, reasonably specific category"
-    val makeToolCategory = (user : User) => {
+    val makeToolCategory = (user: User) => {
       ToolCategory.Create(category).toToolCategory(user.id)
     }
 
     val transaction = for {
       user <- defaultUserQ
       toolCategoryIn <- ToolCategoryDao.insertToolCategory(
-        makeToolCategory(user), user
+        makeToolCategory(user),
+        user
       )
     } yield (toolCategoryIn)
 
@@ -33,4 +37,3 @@ class ToolCategoryDaoSpec extends FunSuite with Matchers with IOChecker with DBT
     result.category shouldBe category
   }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryToToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryToToolDaoSpec.scala
@@ -10,6 +10,12 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class ToolCategoryToToolDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
-  test("selection types") { check(ToolCategoryToToolDao.selectF.query[ToolCategoryToTool]) }
+class ToolCategoryToToolDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
+  test("selection types") {
+    check(ToolCategoryToToolDao.selectF.query[ToolCategoryToTool])
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
@@ -10,6 +10,10 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class ToolDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ToolDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
   test("selection types") { check(ToolDao.selectF.query[Tool]) }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolTagDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolTagDaoSpec.scala
@@ -10,6 +10,10 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class ToolTagDaoSpec extends FunSuite with Matchers with IOChecker with DBTestConfig {
+class ToolTagDaoSpec
+    extends FunSuite
+    with Matchers
+    with IOChecker
+    with DBTestConfig {
   test("selection types") { check(ToolTagDao.selectF.query[ToolTag]) }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
@@ -12,7 +12,12 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
 
-class UploadDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class UploadDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
   test("list uploads") {
     UploadDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
   }
@@ -20,23 +25,29 @@ class UploadDaoSpec extends FunSuite with Matchers with Checkers with DBTestConf
   test("insert an upload") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, project: Project.Create, upload: Upload.Create) => {
-          val uploadInsertIO = for {
-            orgUserProject <- insertUserOrgProject(user, org, project)
-            (dbOrg, dbUser, dbProject) = orgUserProject
-            datasource <- unsafeGetRandomDatasource
-            insertedUpload <- UploadDao.insert(fixupUploadCreate(dbUser, dbProject, datasource, upload), dbUser)
-          } yield insertedUpload
+        (user: User.Create,
+         org: Organization.Create,
+         project: Project.Create,
+         upload: Upload.Create) =>
+          {
+            val uploadInsertIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              datasource <- unsafeGetRandomDatasource
+              insertedUpload <- UploadDao.insert(
+                fixupUploadCreate(dbUser, dbProject, datasource, upload),
+                dbUser)
+            } yield insertedUpload
 
-          val dbUpload = uploadInsertIO.transact(xa).unsafeRunSync
+            val dbUpload = uploadInsertIO.transact(xa).unsafeRunSync
 
-          dbUpload.uploadStatus == upload.uploadStatus &&
+            dbUpload.uploadStatus == upload.uploadStatus &&
             dbUpload.fileType == upload.fileType &&
             dbUpload.files == upload.files &&
             dbUpload.metadata == upload.metadata &&
             dbUpload.visibility == upload.visibility &&
             dbUpload.source == upload.source
-        }
+          }
       }
     }
   }
@@ -44,31 +55,52 @@ class UploadDaoSpec extends FunSuite with Matchers with Checkers with DBTestConf
   test("update an upload") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, platform: Platform, project: Project.Create,
-         insertUpload: Upload.Create, updateUpload: Upload.Create) => {
-          val uploadInsertWithUserOrgProjectDatasourceIO = for {
-            userOrgPlatProject <- insertUserOrgPlatProject(user, org, platform, project)
-            (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
-            datasource <- unsafeGetRandomDatasource
-            insertedUpload <- UploadDao.insert(fixupUploadCreate(dbUser, dbProject, datasource, insertUpload), dbUser)
-          } yield (insertedUpload, dbUser, dbOrg, dbProject, datasource)
+        (user: User.Create,
+         org: Organization.Create,
+         platform: Platform,
+         project: Project.Create,
+         insertUpload: Upload.Create,
+         updateUpload: Upload.Create) =>
+          {
+            val uploadInsertWithUserOrgProjectDatasourceIO = for {
+              userOrgPlatProject <- insertUserOrgPlatProject(user,
+                                                             org,
+                                                             platform,
+                                                             project)
+              (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
+              datasource <- unsafeGetRandomDatasource
+              insertedUpload <- UploadDao.insert(
+                fixupUploadCreate(dbUser, dbProject, datasource, insertUpload),
+                dbUser)
+            } yield (insertedUpload, dbUser, dbOrg, dbProject, datasource)
 
-          val uploadUpdateWithUploadIO = uploadInsertWithUserOrgProjectDatasourceIO flatMap {
-            case (dbUpload: Upload, dbUser: User, dbOrg: Organization, dbProject: Project, dbDatasource: Datasource) => {
-              val uploadId = dbUpload.id
-              val fixedUpUpdateUpload =
-                fixupUploadCreate(dbUser, dbProject, dbDatasource, updateUpload).toUpload(dbUser)
-              UploadDao.update(fixedUpUpdateUpload, uploadId, dbUser) flatMap {
-                (affectedRows: Int) => {
-                  UploadDao.unsafeGetUploadById(uploadId) map { (affectedRows, _) }
+            val uploadUpdateWithUploadIO = uploadInsertWithUserOrgProjectDatasourceIO flatMap {
+              case (dbUpload: Upload,
+                    dbUser: User,
+                    dbOrg: Organization,
+                    dbProject: Project,
+                    dbDatasource: Datasource) => {
+                val uploadId = dbUpload.id
+                val fixedUpUpdateUpload =
+                  fixupUploadCreate(dbUser,
+                                    dbProject,
+                                    dbDatasource,
+                                    updateUpload).toUpload(dbUser)
+                UploadDao.update(fixedUpUpdateUpload, uploadId, dbUser) flatMap {
+                  (affectedRows: Int) =>
+                    {
+                      UploadDao.unsafeGetUploadById(uploadId) map {
+                        (affectedRows, _)
+                      }
+                    }
                 }
               }
             }
-          }
 
-          val (affectedRows, updatedUpload) = uploadUpdateWithUploadIO.transact(xa).unsafeRunSync
+            val (affectedRows, updatedUpload) =
+              uploadUpdateWithUploadIO.transact(xa).unsafeRunSync
 
-          affectedRows == 1 &&
+            affectedRows == 1 &&
             updatedUpload.uploadStatus == updateUpload.uploadStatus &&
             updatedUpload.fileType == updateUpload.fileType &&
             updatedUpload.uploadType == updateUpload.uploadType &&
@@ -76,7 +108,7 @@ class UploadDaoSpec extends FunSuite with Matchers with Checkers with DBTestConf
             updatedUpload.visibility == updateUpload.visibility &&
             updatedUpload.projectId == updateUpload.projectId &&
             updatedUpload.source == updateUpload.source
-        }
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -16,7 +16,8 @@ import scala.util.Random
 
 import com.typesafe.scalalogging.LazyLogging
 
-class UserDaoSpec extends FunSuite
+class UserDaoSpec
+    extends FunSuite
     with Matchers
     with Checkers
     with DBTestConfig
@@ -44,24 +45,34 @@ class UserDaoSpec extends FunSuite
     check(
       forAll(
         (
-          creatingUser: User.Create, jwtFields: User.JwtFields,
-          orgCreate: Organization.Create, platform: Platform
+            creatingUser: User.Create,
+            jwtFields: User.JwtFields,
+            orgCreate: Organization.Create,
+            platform: Platform
         ) => {
           val insertedUserIO = for {
             creatingUser <- UserDao.create(creatingUser)
             insertedPlatform <- PlatformDao.create(platform)
-            insertedOrg <- OrganizationDao.create(orgCreate.copy(platformId = insertedPlatform.id).toOrganization(true))
+            insertedOrg <- OrganizationDao.create(
+              orgCreate
+                .copy(platformId = insertedPlatform.id)
+                .toOrganization(true))
             newUserAndRoles <- {
-              val newUserFields = jwtFields.copy(platformId = insertedPlatform.id, organizationId = insertedOrg.id)
+              val newUserFields =
+                jwtFields.copy(platformId = insertedPlatform.id,
+                               organizationId = insertedOrg.id)
               UserDao.createUserWithJWT(creatingUser, newUserFields)
             }
             (newUser, roles) = newUserAndRoles
             userRoles <- UserGroupRoleDao.listByUser(newUser)
           } yield (newUser, userRoles)
 
-          val (insertedUser, insertedUserRoles) = insertedUserIO.transact(xa).unsafeRunSync
-          assert(insertedUser.id == jwtFields.id, "Inserted user should have the same ID as the jwt fields")
-          assert(insertedUserRoles.length == 2, "Inserted user should have a role for the org and platform")
+          val (insertedUser, insertedUserRoles) =
+            insertedUserIO.transact(xa).unsafeRunSync
+          assert(insertedUser.id == jwtFields.id,
+                 "Inserted user should have the same ID as the jwt fields")
+          assert(insertedUserRoles.length == 2,
+                 "Inserted user should have a role for the org and platform")
           true
         }
       )
@@ -89,33 +100,44 @@ class UserDaoSpec extends FunSuite
   test("update users by id") {
     check(
       forAll(
-        (user: User.Create, emailNotifications: Boolean, dropboxCredential: Credential, planetCredential: Credential) => {
+        (user: User.Create,
+         emailNotifications: Boolean,
+         dropboxCredential: Credential,
+         planetCredential: Credential) => {
           val insertedUserIO = for {
             org <- rootOrgQ
             created <- UserDao.create(user)
           } yield (created)
-          val (affectedRows, updatedEmailNotifications, updatedDropboxToken, updatedPlanetToken) = (insertedUserIO flatMap {
+          val (affectedRows,
+               updatedEmailNotifications,
+               updatedDropboxToken,
+               updatedPlanetToken) = (insertedUserIO flatMap {
             case (insertUser: User) => {
               UserDao.updateUser(
-                insertUser.copy(planetCredential=planetCredential, dropboxCredential=dropboxCredential, emailNotifications=emailNotifications),
+                insertUser.copy(planetCredential = planetCredential,
+                                dropboxCredential = dropboxCredential,
+                                emailNotifications = emailNotifications),
                 insertUser.id
               ) flatMap {
                 case (affectedRows: Int) => {
-                  val updatedPlanetTokenIO = UserDao.unsafeGetUserById(insertUser.id) map {
-                    (usr: User) =>
-                      ( usr.emailNotifications, usr.dropboxCredential, usr.planetCredential)
+                  val updatedPlanetTokenIO = UserDao.unsafeGetUserById(
+                    insertUser.id) map { (usr: User) =>
+                    (usr.emailNotifications,
+                     usr.dropboxCredential,
+                     usr.planetCredential)
                   }
                   updatedPlanetTokenIO map {
-                    (t: (Boolean, Credential, Credential)) => (affectedRows, t._1, t._2, t._3)
+                    (t: (Boolean, Credential, Credential)) =>
+                      (affectedRows, t._1, t._2, t._3)
                   }
                 }
               }
             }
           }).transact(xa).unsafeRunSync
           (affectedRows == 1) &&
-            (updatedEmailNotifications == emailNotifications) &&
-            (updatedDropboxToken == dropboxCredential) &&
-            (updatedPlanetToken == planetCredential)
+          (updatedEmailNotifications == emailNotifications) &&
+          (updatedDropboxToken == dropboxCredential) &&
+          (updatedPlanetToken == planetCredential)
         }
       )
     )
@@ -125,9 +147,11 @@ class UserDaoSpec extends FunSuite
   test("Updating your own user fields should only update certain ones") {
     check(
       forAll(
-        (user: User.Create, planetCredential: Credential, isEmail: Boolean,
-          visibility: UserVisibility, email: String
-        ) => {
+        (user: User.Create,
+         planetCredential: Credential,
+         isEmail: Boolean,
+         visibility: UserVisibility,
+         email: String) => {
           val insertedUserIO = for {
             org <- rootOrgQ
             created <- UserDao.create(user)
@@ -150,11 +174,11 @@ class UserDaoSpec extends FunSuite
           }).transact(xa).unsafeRunSync
 
           affectedRows == 1 &&
-            updatedUser.emailNotifications == isEmail &&
-            updatedUser.visibility == visibility &&
-            updatedUser.planetCredential.token == planetCredential.token &&
-            updatedUser.email != email &&
-            updatedUser.email == user.email
+          updatedUser.emailNotifications == isEmail &&
+          updatedUser.visibility == visibility &&
+          updatedUser.planetCredential.token == planetCredential.token &&
+          updatedUser.email != email &&
+          updatedUser.email == user.email
         }
       )
     )
@@ -173,7 +197,8 @@ class UserDaoSpec extends FunSuite
             case (insertUser: User) => {
               UserDao.storeDropboxAccessToken(insertUser.id, dropboxCredential) flatMap {
                 case (affectedRows: Int) => {
-                  val updatedDbxTokenIO = UserDao.unsafeGetUserById(insertUser.id) map { _.dropboxCredential }
+                  val updatedDbxTokenIO = UserDao.unsafeGetUserById(
+                    insertUser.id) map { _.dropboxCredential }
                   updatedDbxTokenIO map { (affectedRows, _) }
                 }
               }
@@ -188,72 +213,116 @@ class UserDaoSpec extends FunSuite
   test("list visibile users") {
     check {
       forAll(
-        (uc1: User.Create, uc2: User.Create,
-         uc3: User.Create, uc4: User.Create,
-         pc1: Platform, pc2: Platform,
-         org1: Organization.Create, org2: Organization.Create) => {
+        (uc1: User.Create,
+         uc2: User.Create,
+         uc3: User.Create,
+         uc4: User.Create,
+         pc1: Platform,
+         pc2: Platform,
+         org1: Organization.Create,
+         org2: Organization.Create) => {
           val defaultUser = uc1.toUser.copy(id = "default")
           val orgsIO = for {
             p1 <- PlatformDao.create(pc1)
             p2 <- PlatformDao.create(pc2)
-            org1 <- OrganizationDao.createOrganization(org1.copy(platformId = p1.id))
-            org2 <- OrganizationDao.createOrganization(org2.copy(platformId = p2.id))
+            org1 <- OrganizationDao.createOrganization(
+              org1.copy(platformId = p1.id))
+            org2 <- OrganizationDao.createOrganization(
+              org2.copy(platformId = p2.id))
             u1i <- UserDao.create(uc1)
-            u1 = u1i.copy(visibility=UserVisibility.Private)
+            u1 = u1i.copy(visibility = UserVisibility.Private)
             u2 <- UserDao.create(uc2)
             u3i <- UserDao.create(uc3)
-            u3 = u3i.copy(visibility=UserVisibility.Public)
+            u3 = u3i.copy(visibility = UserVisibility.Public)
             _ <- UserDao.updateUser(u3, u3i.id)
             u4i <- UserDao.create(uc4)
-            u4 = u4i.copy(visibility=UserVisibility.Public)
+            u4 = u4i.copy(visibility = UserVisibility.Public)
             _ <- UserDao.updateUser(u4, u4i.id)
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u1.id, GroupType.Platform, p1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u1.id, GroupType.Platform, p1.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u1.id, GroupType.Organization, org1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u1.id,
+                        GroupType.Organization,
+                        org1.id,
+                        GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u2.id, GroupType.Platform, p1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u2.id, GroupType.Platform, p1.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u2.id, GroupType.Organization, org1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u2.id,
+                        GroupType.Organization,
+                        org1.id,
+                        GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             u3platugr <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u3.id, GroupType.Platform, p1.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u3.id, GroupType.Platform, p1.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(u3.id, GroupType.Platform, p2.id, GroupRole.Member)
+              UserGroupRole
+                .Create(u3.id, GroupType.Platform, p2.id, GroupRole.Member)
                 .toUserGroupRole(defaultUser, MembershipStatus.Approved)
             )
             u1VisibleUsers <- UserDao.viewFilter(u1).list
             u2VisibleUsers <- UserDao.viewFilter(u2).list
             u3VisibleUsers <- UserDao.viewFilter(u3).list
-            _ <- UserGroupRoleDao.update(u3platugr.copy(groupRole = GroupRole.Admin), u3platugr.id, u2)
+            _ <- UserGroupRoleDao.update(
+              u3platugr.copy(groupRole = GroupRole.Admin),
+              u3platugr.id,
+              u2)
             u3AdminVisibleUsers <- UserDao.viewFilter(u3).list
-          } yield { (u1, u2, u3, u4, u1VisibleUsers, u2VisibleUsers, u3VisibleUsers, u3AdminVisibleUsers) }
+          } yield {
+            (u1,
+             u2,
+             u3,
+             u4,
+             u1VisibleUsers,
+             u2VisibleUsers,
+             u3VisibleUsers,
+             u3AdminVisibleUsers)
+          }
           orgsIO.transact(xa).unsafeRunSync
 
-          val (u1, u2, u3, u4, u1users, u2users, u3users, u3usersAdmin) = orgsIO.transact(xa).unsafeRunSync
-          val u1userids = u1users.toSet.map { u: User =>  u.id }
-          val u2userids = u2users.toSet.map { u: User => u.id }
-          val u3userids = u3users.toSet.map { u: User => u.id }
-          val u3useridsAdmin = u3usersAdmin.toSet.map {u: User =>  u.id }
-          assert(u2userids.contains(u1.id),
-                 "; members of orgs should be able to see each other if they are hidden")
-          assert(u1userids.contains(u3.id),
-                 "; members should be able to see public users on the same platform")
-          assert(!u1userids.contains(u4.id),
-                 "; members should not be able to see public users on other platforms")
-          assert(!u3userids.contains(u1.id),
-                 "; platform members should not see hidden users on the same platform")
-          assert(u3useridsAdmin.contains(u1.id),
-                 "; platform admins should be able to see hidden users on their platform")
+          val (u1, u2, u3, u4, u1users, u2users, u3users, u3usersAdmin) =
+            orgsIO.transact(xa).unsafeRunSync
+          val u1userids = u1users.toSet.map { u: User =>
+            u.id
+          }
+          val u2userids = u2users.toSet.map { u: User =>
+            u.id
+          }
+          val u3userids = u3users.toSet.map { u: User =>
+            u.id
+          }
+          val u3useridsAdmin = u3usersAdmin.toSet.map { u: User =>
+            u.id
+          }
+          assert(
+            u2userids.contains(u1.id),
+            "; members of orgs should be able to see each other if they are hidden")
+          assert(
+            u1userids.contains(u3.id),
+            "; members should be able to see public users on the same platform")
+          assert(
+            !u1userids.contains(u4.id),
+            "; members should not be able to see public users on other platforms")
+          assert(
+            !u3userids.contains(u1.id),
+            "; platform members should not see hidden users on the same platform")
+          assert(
+            u3useridsAdmin.contains(u1.id),
+            "; platform admins should be able to see hidden users on their platform")
           true
         }
       )
@@ -264,36 +333,40 @@ class UserDaoSpec extends FunSuite
   test("bulk lookup users by id") {
     check {
       forAll {
-        (user1: User.Create, user2: User.Create, user3: User.Create, org: Organization.Create) => {
-          val outUsersIO = for {
-            orgAndUser <- insertUserAndOrg(user1, org)
-            (_, dbUser1) = orgAndUser
-            dbUser2 <- UserDao.create(user2)
-            _ <- UserDao.create(user3)
-            listedUsers <- UserDao.getUsersByIds(List(dbUser1.id, dbUser2.id))
-          } yield { listedUsers }
+        (user1: User.Create,
+         user2: User.Create,
+         user3: User.Create,
+         org: Organization.Create) =>
+          {
+            val outUsersIO = for {
+              orgAndUser <- insertUserAndOrg(user1, org)
+              (_, dbUser1) = orgAndUser
+              dbUser2 <- UserDao.create(user2)
+              _ <- UserDao.create(user3)
+              listedUsers <- UserDao.getUsersByIds(List(dbUser1.id, dbUser2.id))
+            } yield { listedUsers }
 
-          val outUsers = outUsersIO.transact(xa).unsafeRunSync
-          assert(outUsers.map( _.id ).toSet == Set(user1.id, user2.id),
-                 "Lookup by ids should return the correct set of users")
-          true
-        }
+            val outUsers = outUsersIO.transact(xa).unsafeRunSync
+            assert(outUsers.map(_.id).toSet == Set(user1.id, user2.id),
+                   "Lookup by ids should return the correct set of users")
+            true
+          }
       }
     }
   }
 
   test("Getting another user's info should not return credentials") {
     check {
-      forAll {
-        (user: User.Create, org: Organization.Create) => {
+      forAll { (user: User.Create, org: Organization.Create) =>
+        {
           val createdUserIO = for {
             orgAndUser <- insertUserAndOrg(user, org)
             (_, dbUser) = orgAndUser
             createdUser <- UserDao.unsafeGetUserById(dbUser.id, Some(false))
-          } yield(createdUser)
+          } yield (createdUser)
           val createdUser = createdUserIO.transact(xa).unsafeRunSync
           createdUser.planetCredential == Credential(Some("")) &&
-            createdUser.dropboxCredential == Credential(Some(""))
+          createdUser.dropboxCredential == Credential(Some(""))
         }
       }
     }
@@ -302,18 +375,20 @@ class UserDaoSpec extends FunSuite
   test("Lookup a user's platform") {
     check {
       forAll {
-        (user: User.Create, org: Organization.Create, platform: Platform) => {
-          val platformsIO = for {
-            userOrgPlat <- insertUserOrgPlatform(user, org, platform, true)
-            (dbUser, _, insertedPlatform) = userOrgPlat
-            listedPlatform <- UserDao.unsafeGetUserPlatform(dbUser.id)
-          } yield (insertedPlatform, listedPlatform)
+        (user: User.Create, org: Organization.Create, platform: Platform) =>
+          {
+            val platformsIO = for {
+              userOrgPlat <- insertUserOrgPlatform(user, org, platform, true)
+              (dbUser, _, insertedPlatform) = userOrgPlat
+              listedPlatform <- UserDao.unsafeGetUserPlatform(dbUser.id)
+            } yield (insertedPlatform, listedPlatform)
 
-          val (inserted, listed) = platformsIO.transact(xa).unsafeRunSync
-          assert(inserted == listed,
-                 "Unsafe get of a user's platform should return the user's platform")
-          true
-        }
+            val (inserted, listed) = platformsIO.transact(xa).unsafeRunSync
+            assert(
+              inserted == listed,
+              "Unsafe get of a user's platform should return the user's platform")
+            true
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -21,7 +21,12 @@ import io.circe.syntax._
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBTestConfig with PropTestHelpers {
+class UserGroupRoleDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("list user group roles") {
     UserGroupRoleDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
@@ -30,374 +35,427 @@ class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBT
   test("insert a user group role") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
-         platform: Platform, ugrCreate: UserGroupRole.Create) => {
-          val insertUgrIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
-            (insertedOrg, insertedUser) = orgAndUser
-            insertedTeam <- TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(insertedUser))
-            insertedPlatform <- PlatformDao.create(platform)
-            insertedUgr <- UserGroupRoleDao.create(
-              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
-                .toUserGroupRole(insertedUser, MembershipStatus.Approved)
-            )
-          } yield { insertedUgr }
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create,
+         platform: Platform,
+         ugrCreate: UserGroupRole.Create) =>
+          {
+            val insertUgrIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
+              (insertedOrg, insertedUser) = orgAndUser
+              insertedTeam <- TeamDao.create(
+                teamCreate
+                  .copy(organizationId = insertedOrg.id)
+                  .toTeam(insertedUser))
+              insertedPlatform <- PlatformDao.create(platform)
+              insertedUgr <- UserGroupRoleDao.create(
+                fixupUserGroupRole(insertedUser,
+                                   insertedOrg,
+                                   insertedTeam,
+                                   insertedPlatform,
+                                   ugrCreate)
+                  .toUserGroupRole(insertedUser, MembershipStatus.Approved)
+              )
+            } yield { insertedUgr }
 
-          val insertedUgr = insertUgrIO.transact(xa).unsafeRunSync
+            val insertedUgr = insertUgrIO.transact(xa).unsafeRunSync
 
-          insertedUgr.userId == userCreate.id &&
+            insertedUgr.userId == userCreate.id &&
             insertedUgr.groupType == ugrCreate.groupType &&
             insertedUgr.groupRole == ugrCreate.groupRole &&
             insertedUgr.modifiedBy == userCreate.id &&
             insertedUgr.createdBy == userCreate.id
-        }
+          }
       }
     }
   }
 
-  test("list users by group: private users are not viewable by those outside of their organization") {
+  test(
+    "list users by group: private users are not viewable by those outside of their organization") {
     check {
       forAll {
         (
-          platform: Platform,
-          mainOrg: Organization.Create,
-          altOrg: Organization.Create,
-          testingUser: User.Create,
-          privateUser: User.Create,
-          publicUser: User.Create,
-          page: PageRequest
-        ) => {
-          val usersInPlatformIO = for {
-            // Create necessary groups
-            dbPlatform <- PlatformDao.create(platform)
-            dbMainOrg <- OrganizationDao.create(mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
-            dbAltOrg <- OrganizationDao.create(altOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+            platform: Platform,
+            mainOrg: Organization.Create,
+            altOrg: Organization.Create,
+            testingUser: User.Create,
+            privateUser: User.Create,
+            publicUser: User.Create,
+            page: PageRequest
+        ) =>
+          {
+            val usersInPlatformIO = for {
+              // Create necessary groups
+              dbPlatform <- PlatformDao.create(platform)
+              dbMainOrg <- OrganizationDao.create(
+                mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+              dbAltOrg <- OrganizationDao.create(
+                altOrg.copy(platformId = dbPlatform.id).toOrganization(true))
 
-            // Create necessary users
-            dbTestingUser <- UserDao.create(testingUser)
-            dbPublicUser <- UserDao.create(publicUser)
-            dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
-              visibility = UserVisibility.Public
-            ), dbPublicUser.id)
-            dbPrivateUser <- UserDao.create(privateUser)
+              // Create necessary users
+              dbTestingUser <- UserDao.create(testingUser)
+              dbPublicUser <- UserDao.create(publicUser)
+              dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
+                                                         visibility =
+                                                           UserVisibility.Public
+                                                       ),
+                                                       dbPublicUser.id)
+              dbPrivateUser <- UserDao.create(privateUser)
 
-            // Create user group roles
-            ugr1 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
+              // Create user group roles
+              ugr1 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr2 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr3 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Organization,
+                          dbMainOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr4 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Organization,
+                          dbAltOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
                 GroupType.Platform,
                 dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+                page,
+                SearchQueryParameters(Some("")),
+                dbPublicUser
+              )
+            } yield { usersInPlatform }
+
+            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+
+            assert(
+              usersInPlatform.count == 1,
+              "The private user should not be visible outside of the organization"
             )
 
-            ugr2 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Platform,
-                dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr3 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
-                GroupType.Organization,
-                dbMainOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr4 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Organization,
-                dbAltOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
-              GroupType.Platform,
-              dbPlatform.id,
-              page,
-              SearchQueryParameters(Some("")),
-              dbPublicUser
-            )
-          } yield { usersInPlatform }
-
-          val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
-
-          assert(
-            usersInPlatform.count == 1,
-            "The private user should not be visible outside of the organization"
-          )
-
-          true
-        }
+            true
+          }
       }
     }
   }
 
-  test("list users by group: private users are viewable by those within their organization") {
+  test(
+    "list users by group: private users are viewable by those within their organization") {
     check {
       forAll {
         (
-          platform: Platform,
-          mainOrg: Organization.Create,
-          altOrg: Organization.Create,
-          testingUser: User.Create,
-          privateUser: User.Create,
-          publicUser: User.Create,
-          page: PageRequest
-        ) => {
-          val usersInPlatformIO = for {
-            // Create necessary groups
-            dbPlatform <- PlatformDao.create(platform)
-            dbMainOrg <- OrganizationDao.create(mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+            platform: Platform,
+            mainOrg: Organization.Create,
+            altOrg: Organization.Create,
+            testingUser: User.Create,
+            privateUser: User.Create,
+            publicUser: User.Create,
+            page: PageRequest
+        ) =>
+          {
+            val usersInPlatformIO = for {
+              // Create necessary groups
+              dbPlatform <- PlatformDao.create(platform)
+              dbMainOrg <- OrganizationDao.create(
+                mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
 
-            // Create necessary users
-            dbTestingUser <- UserDao.create(testingUser)
-            dbPublicUser <- UserDao.create(publicUser)
-            dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
-              visibility = UserVisibility.Public
-            ), dbPublicUser.id)
-            dbPrivateUser <- UserDao.create(privateUser)
+              // Create necessary users
+              dbTestingUser <- UserDao.create(testingUser)
+              dbPublicUser <- UserDao.create(publicUser)
+              dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
+                                                         visibility =
+                                                           UserVisibility.Public
+                                                       ),
+                                                       dbPublicUser.id)
+              dbPrivateUser <- UserDao.create(privateUser)
 
-            // Create user group roles
-            ugr1 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
+              // Create user group roles
+              ugr1 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr2 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr3 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Organization,
+                          dbMainOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr4 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Organization,
+                          dbMainOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
                 GroupType.Platform,
                 dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+                page,
+                SearchQueryParameters(Some("")),
+                dbPublicUser
+              )
+            } yield { usersInPlatform }
+
+            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+
+            assert(
+              usersInPlatform.count == 2,
+              "The private user should be visible to those within their organization"
             )
 
-            ugr2 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Platform,
-                dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr3 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
-                GroupType.Organization,
-                dbMainOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr4 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Organization,
-                dbMainOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
-              GroupType.Platform,
-              dbPlatform.id,
-              page,
-              SearchQueryParameters(Some("")),
-              dbPublicUser
-            )
-          } yield { usersInPlatform }
-
-          val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
-
-          assert(
-            usersInPlatform.count == 2,
-            "The private user should be visible to those within their organization"
-          )
-
-          true
-        }
+            true
+          }
       }
     }
   }
 
-  test("list users by group: public users are viewable by those outside of their organization") {
+  test(
+    "list users by group: public users are viewable by those outside of their organization") {
     check {
       forAll {
         (
-          platform: Platform,
-          mainOrg: Organization.Create,
-          altOrg: Organization.Create,
-          testingUser: User.Create,
-          privateUser: User.Create,
-          publicUser: User.Create,
-          page: PageRequest
-        ) => {
-          val usersInPlatformIO = for {
-            // TODO: this could technically be cleaned up by at least starting with the
-            // insertUserOrgPlatform and insertUserOrg helpers in PropTestHelpers, but we're
-            // a bit under the gun. Future reader from the lands beyond June 2018, if you
-            // find this, please consider opening an issue for improving test readability
+            platform: Platform,
+            mainOrg: Organization.Create,
+            altOrg: Organization.Create,
+            testingUser: User.Create,
+            privateUser: User.Create,
+            publicUser: User.Create,
+            page: PageRequest
+        ) =>
+          {
+            val usersInPlatformIO = for {
+              // TODO: this could technically be cleaned up by at least starting with the
+              // insertUserOrgPlatform and insertUserOrg helpers in PropTestHelpers, but we're
+              // a bit under the gun. Future reader from the lands beyond June 2018, if you
+              // find this, please consider opening an issue for improving test readability
 
-            // Create necessary groups
-            dbPlatform <- PlatformDao.create(platform)
-            dbMainOrg <- OrganizationDao.create(mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
-            dbAltOrg <- OrganizationDao.create(altOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+              // Create necessary groups
+              dbPlatform <- PlatformDao.create(platform)
+              dbMainOrg <- OrganizationDao.create(
+                mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+              dbAltOrg <- OrganizationDao.create(
+                altOrg.copy(platformId = dbPlatform.id).toOrganization(true))
 
-            // Create necessary users
-            dbTestingUser <- UserDao.create(testingUser)
-            dbPublicUser <- UserDao.create(publicUser)
-            dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
-              visibility = UserVisibility.Public
-            ), dbPublicUser.id)
-            dbPrivateUser <- UserDao.create(privateUser)
+              // Create necessary users
+              dbTestingUser <- UserDao.create(testingUser)
+              dbPublicUser <- UserDao.create(publicUser)
+              dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
+                                                         visibility =
+                                                           UserVisibility.Public
+                                                       ),
+                                                       dbPublicUser.id)
+              dbPrivateUser <- UserDao.create(privateUser)
 
-            // Create user group roles
-            ugr1 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
+              // Create user group roles
+              ugr1 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr2 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr3 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Organization,
+                          dbMainOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr4 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Organization,
+                          dbAltOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
                 GroupType.Platform,
                 dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+                page,
+                SearchQueryParameters(Some("")),
+                dbPrivateUser
+              )
+            } yield { usersInPlatform }
+
+            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+
+            assert(
+              usersInPlatform.count == 2,
+              "The private user should not be visible outside of the organization"
             )
 
-            ugr2 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Platform,
-                dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr3 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
-                GroupType.Organization,
-                dbMainOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr4 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Organization,
-                dbAltOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
-              GroupType.Platform,
-              dbPlatform.id,
-              page,
-              SearchQueryParameters(Some("")),
-              dbPrivateUser
-            )
-          } yield { usersInPlatform }
-
-          val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
-
-          assert(
-            usersInPlatform.count == 2,
-            "The private user should not be visible outside of the organization"
-          )
-
-          true
-        }
+            true
+          }
       }
     }
   }
 
-  test("list users by group: private users are viewable by those on the same team") {
+  test(
+    "list users by group: private users are viewable by those on the same team") {
     check {
       forAll {
         (
-          platform: Platform,
-          mainOrg: Organization.Create,
-          altOrg: Organization.Create,
-          team: Team.Create,
-          testingUser: User.Create,
-          privateUser: User.Create,
-          publicUser: User.Create,
-          page: PageRequest
-        ) => {
-          val usersInPlatformIO = for {
-            dbTestingUser <- UserDao.create(testingUser)
+            platform: Platform,
+            mainOrg: Organization.Create,
+            altOrg: Organization.Create,
+            team: Team.Create,
+            testingUser: User.Create,
+            privateUser: User.Create,
+            publicUser: User.Create,
+            page: PageRequest
+        ) =>
+          {
+            val usersInPlatformIO = for {
+              dbTestingUser <- UserDao.create(testingUser)
 
-            // Create necessary groups
-            dbPlatform <- PlatformDao.create(platform)
-            dbMainOrg <- OrganizationDao.create(mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
-            dbAltOrg <- OrganizationDao.create(altOrg.copy(platformId = dbPlatform.id).toOrganization(true))
-            dbTeam <- TeamDao.create(team.copy(organizationId = dbMainOrg.id).toTeam(dbTestingUser))
+              // Create necessary groups
+              dbPlatform <- PlatformDao.create(platform)
+              dbMainOrg <- OrganizationDao.create(
+                mainOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+              dbAltOrg <- OrganizationDao.create(
+                altOrg.copy(platformId = dbPlatform.id).toOrganization(true))
+              dbTeam <- TeamDao.create(
+                team.copy(organizationId = dbMainOrg.id).toTeam(dbTestingUser))
 
-            // Create necessary users
-            dbPublicUser <- UserDao.create(publicUser)
-            dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
-              visibility = UserVisibility.Public
-            ), dbPublicUser.id)
-            dbPrivateUser <- UserDao.create(privateUser)
+              // Create necessary users
+              dbPublicUser <- UserDao.create(publicUser)
+              dbPublicUserUpdate <- UserDao.updateUser(dbPublicUser.copy(
+                                                         visibility =
+                                                           UserVisibility.Public
+                                                       ),
+                                                       dbPublicUser.id)
+              dbPrivateUser <- UserDao.create(privateUser)
 
-            // Create user group roles
-            ugr1 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
+              // Create user group roles
+              ugr1 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr2 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Platform,
+                          dbPlatform.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr3 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Organization,
+                          dbMainOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr4 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Organization,
+                          dbAltOrg.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr5 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPublicUser.id,
+                          GroupType.Team,
+                          dbTeam.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              ugr6 <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(dbPrivateUser.id,
+                          GroupType.Team,
+                          dbTeam.id,
+                          GroupRole.Member)
+                  .toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+              )
+
+              usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
                 GroupType.Platform,
                 dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
+                page,
+                SearchQueryParameters(Some("")),
+                dbPublicUser
+              )
+            } yield { usersInPlatform }
+
+            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+
+            assert(
+              usersInPlatform.count == 2,
+              "The private user should be visible by those sharing team membership with them"
             )
 
-            ugr2 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Platform,
-                dbPlatform.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr3 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
-                GroupType.Organization,
-                dbMainOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr4 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Organization,
-                dbAltOrg.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr5 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPublicUser.id,
-                GroupType.Team,
-                dbTeam.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            ugr6 <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                dbPrivateUser.id,
-                GroupType.Team,
-                dbTeam.id,
-                GroupRole.Member).toUserGroupRole(dbTestingUser, MembershipStatus.Approved)
-            )
-
-            usersInPlatform <- UserGroupRoleDao.listUsersByGroup(
-              GroupType.Platform,
-              dbPlatform.id,
-              page,
-              SearchQueryParameters(Some("")),
-              dbPublicUser
-            )
-          } yield { usersInPlatform }
-
-          val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
-
-          assert(
-            usersInPlatform.count == 2,
-            "The private user should be visible by those sharing team membership with them"
-          )
-
-          true
-        }
+            true
+          }
       }
     }
   }
@@ -405,46 +463,83 @@ class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBT
   test("update a user group role") {
     check {
       forAll {
-        (userCreate: User.Create, manager: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create,
-         platform: Platform, ugrCreate: UserGroupRole.Create, ugrUpdate: UserGroupRole.Create) => {
-          val insertUgrWithRelationsIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
-            (insertedOrg, insertedUser) = orgAndUser
-            managerUser <- UserDao.create(manager)
-            _ <- UserGroupRoleDao.create(
-              UserGroupRole.Create(
-                managerUser.id, GroupType.Organization, insertedOrg.id, GroupRole.Admin
-              ).toUserGroupRole(managerUser, MembershipStatus.Approved)
-            )
-            insertedTeam <- TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(insertedUser))
-            insertedPlatform <- PlatformDao.create(platform)
-            insertedUgr <- UserGroupRoleDao.create(
-              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
-                .toUserGroupRole(managerUser, MembershipStatus.Approved)
-            )
-          } yield (insertedUgr, insertedUser, managerUser, insertedOrg, insertedTeam, insertedPlatform)
+        (userCreate: User.Create,
+         manager: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create,
+         platform: Platform,
+         ugrCreate: UserGroupRole.Create,
+         ugrUpdate: UserGroupRole.Create) =>
+          {
+            val insertUgrWithRelationsIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
+              (insertedOrg, insertedUser) = orgAndUser
+              managerUser <- UserDao.create(manager)
+              _ <- UserGroupRoleDao.create(
+                UserGroupRole
+                  .Create(
+                    managerUser.id,
+                    GroupType.Organization,
+                    insertedOrg.id,
+                    GroupRole.Admin
+                  )
+                  .toUserGroupRole(managerUser, MembershipStatus.Approved)
+              )
+              insertedTeam <- TeamDao.create(
+                teamCreate
+                  .copy(organizationId = insertedOrg.id)
+                  .toTeam(insertedUser))
+              insertedPlatform <- PlatformDao.create(platform)
+              insertedUgr <- UserGroupRoleDao.create(
+                fixupUserGroupRole(insertedUser,
+                                   insertedOrg,
+                                   insertedTeam,
+                                   insertedPlatform,
+                                   ugrCreate)
+                  .toUserGroupRole(managerUser, MembershipStatus.Approved)
+              )
+            } yield
+              (insertedUgr,
+               insertedUser,
+               managerUser,
+               insertedOrg,
+               insertedTeam,
+               insertedPlatform)
 
-          val updateUgrWithUpdatedAndAffectedRowsIO = insertUgrWithRelationsIO flatMap {
-            case (dbUgr: UserGroupRole, dbMember: User, dbAdmin: User, dbOrg: Organization, dbTeam: Team, dbPlatform: Platform) => {
-              val fixedUpUgrUpdate = fixupUserGroupRole(dbMember, dbOrg, dbTeam, dbPlatform, ugrUpdate)
-                .toUserGroupRole(dbAdmin, MembershipStatus.Approved)
-              UserGroupRoleDao.update(fixedUpUgrUpdate, dbUgr.id, dbAdmin) flatMap {
-                (affectedRows: Int) => {
-                  UserGroupRoleDao.unsafeGetUserGroupRoleById(dbUgr.id, dbMember) map { (affectedRows, _) }
+            val updateUgrWithUpdatedAndAffectedRowsIO = insertUgrWithRelationsIO flatMap {
+              case (dbUgr: UserGroupRole,
+                    dbMember: User,
+                    dbAdmin: User,
+                    dbOrg: Organization,
+                    dbTeam: Team,
+                    dbPlatform: Platform) => {
+                val fixedUpUgrUpdate = fixupUserGroupRole(dbMember,
+                                                          dbOrg,
+                                                          dbTeam,
+                                                          dbPlatform,
+                                                          ugrUpdate)
+                  .toUserGroupRole(dbAdmin, MembershipStatus.Approved)
+                UserGroupRoleDao.update(fixedUpUgrUpdate, dbUgr.id, dbAdmin) flatMap {
+                  (affectedRows: Int) =>
+                    {
+                      UserGroupRoleDao.unsafeGetUserGroupRoleById(
+                        dbUgr.id,
+                        dbMember) map { (affectedRows, _) }
+                    }
                 }
               }
             }
-          }
 
-          val (affectedRows, updatedUgr) = updateUgrWithUpdatedAndAffectedRowsIO.transact(xa).unsafeRunSync
-          // isActive should always be true since it doesn't exist on UserGroupRole.Creates and is set
-          // to true when those are turned into UserGroupRoles
-          affectedRows == 1 &&
+            val (affectedRows, updatedUgr) =
+              updateUgrWithUpdatedAndAffectedRowsIO.transact(xa).unsafeRunSync
+            // isActive should always be true since it doesn't exist on UserGroupRole.Creates and is set
+            // to true when those are turned into UserGroupRoles
+            affectedRows == 1 &&
             updatedUgr.isActive == true &&
             updatedUgr.modifiedBy == manager.id &&
             (updatedUgr.groupType == ugrUpdate.groupType) == (ugrUpdate.groupType == ugrCreate.groupType) &&
             updatedUgr.groupRole == ugrUpdate.groupRole
-        }
+          }
       }
     }
   }
@@ -452,35 +547,52 @@ class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBT
   test("deactivate a user group role") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create, platform: Platform, ugrCreate: UserGroupRole.Create) => {
-          val insertUgrWithUserIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
-            (insertedOrg, insertedUser) = orgAndUser
-            insertedTeam <- TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(insertedUser))
-            insertedPlatform <- PlatformDao.create(platform)
-            insertedUgr <- UserGroupRoleDao.create(
-              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
-                .toUserGroupRole(insertedUser, MembershipStatus.Approved)
-            )
-          } yield (insertedUgr, insertedUser)
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create,
+         platform: Platform,
+         ugrCreate: UserGroupRole.Create) =>
+          {
+            val insertUgrWithUserIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
+              (insertedOrg, insertedUser) = orgAndUser
+              insertedTeam <- TeamDao.create(
+                teamCreate
+                  .copy(organizationId = insertedOrg.id)
+                  .toTeam(insertedUser))
+              insertedPlatform <- PlatformDao.create(platform)
+              insertedUgr <- UserGroupRoleDao.create(
+                fixupUserGroupRole(insertedUser,
+                                   insertedOrg,
+                                   insertedTeam,
+                                   insertedPlatform,
+                                   ugrCreate)
+                  .toUserGroupRole(insertedUser, MembershipStatus.Approved)
+              )
+            } yield (insertedUgr, insertedUser)
 
-          val deactivateWithDeactivatedUgrIO = insertUgrWithUserIO flatMap {
-            case (dbUgr: UserGroupRole, dbUser: User) => {
-              UserGroupRoleDao.deactivate(dbUgr.id, dbUser) flatMap {
-                (affectedRows: Int) => {
-                  UserGroupRoleDao.unsafeGetUserGroupRoleById(dbUgr.id, dbUser) map { (affectedRows, _) }
+            val deactivateWithDeactivatedUgrIO = insertUgrWithUserIO flatMap {
+              case (dbUgr: UserGroupRole, dbUser: User) => {
+                UserGroupRoleDao.deactivate(dbUgr.id, dbUser) flatMap {
+                  (affectedRows: Int) =>
+                    {
+                      UserGroupRoleDao.unsafeGetUserGroupRoleById(dbUgr.id,
+                                                                  dbUser) map {
+                        (affectedRows, _)
+                      }
+                    }
                 }
               }
             }
-          }
 
-          val (affectedRows, updatedUgr) = deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
-          affectedRows == 1 &&
+            val (affectedRows, updatedUgr) =
+              deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
+            affectedRows == 1 &&
             updatedUgr.isActive == false &&
             updatedUgr.modifiedBy == userCreate.id &&
             updatedUgr.groupType == ugrCreate.groupType &&
             updatedUgr.groupRole == ugrCreate.groupRole
-        }
+          }
       }
     }
   }
@@ -488,36 +600,54 @@ class UserGroupRoleDaoSpec extends FunSuite with Matchers with Checkers with DBT
   test("deactivate a user's group roles using UserGroupRole.UserGroup") {
     check {
       forAll {
-        (userCreate: User.Create, orgCreate: Organization.Create, teamCreate: Team.Create, platform: Platform, ugrCreate: UserGroupRole.Create) => {
-          val insertUgrWithUserIO = for {
-            orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
-            (insertedOrg, insertedUser) = orgAndUser
-            insertedTeam <- TeamDao.create(teamCreate.copy(organizationId = insertedOrg.id).toTeam(insertedUser))
-            insertedPlatform <- PlatformDao.create(platform)
-            insertedUgr <- UserGroupRoleDao.create(
-              fixupUserGroupRole(insertedUser, insertedOrg, insertedTeam, insertedPlatform, ugrCreate)
-                .toUserGroupRole(insertedUser, MembershipStatus.Approved)
-            )
-          } yield (insertedUgr, insertedUser)
-
-          val deactivateWithDeactivatedUgrIO = insertUgrWithUserIO flatMap {
-            case (dbUgr: UserGroupRole, dbUser: User) => {
-              UserGroupRoleDao.deactivateUserGroupRoles(
-                UserGroupRole.UserGroup(dbUser.id, dbUgr.groupType, dbUgr.groupId),
-                dbUser
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         teamCreate: Team.Create,
+         platform: Platform,
+         ugrCreate: UserGroupRole.Create) =>
+          {
+            val insertUgrWithUserIO = for {
+              orgAndUser <- insertUserAndOrg(userCreate, orgCreate, false)
+              (insertedOrg, insertedUser) = orgAndUser
+              insertedTeam <- TeamDao.create(
+                teamCreate
+                  .copy(organizationId = insertedOrg.id)
+                  .toTeam(insertedUser))
+              insertedPlatform <- PlatformDao.create(platform)
+              insertedUgr <- UserGroupRoleDao.create(
+                fixupUserGroupRole(insertedUser,
+                                   insertedOrg,
+                                   insertedTeam,
+                                   insertedPlatform,
+                                   ugrCreate)
+                  .toUserGroupRole(insertedUser, MembershipStatus.Approved)
               )
-            }
-          }
+            } yield (insertedUgr, insertedUser)
 
-          val updatedUGRs = deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
-          updatedUGRs.size == 1 &&
-            updatedUGRs.filter(
-              (ugr) => ugr.isActive == false &&
-                ugr.modifiedBy == userCreate.id &&
-                ugr.groupType == ugrCreate.groupType &&
-                ugr.groupRole == ugrCreate.groupRole
-            ).size == 1
-        }
+            val deactivateWithDeactivatedUgrIO = insertUgrWithUserIO flatMap {
+              case (dbUgr: UserGroupRole, dbUser: User) => {
+                UserGroupRoleDao.deactivateUserGroupRoles(
+                  UserGroupRole.UserGroup(dbUser.id,
+                                          dbUgr.groupType,
+                                          dbUgr.groupId),
+                  dbUser
+                )
+              }
+            }
+
+            val updatedUGRs =
+              deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
+            updatedUGRs.size == 1 &&
+            updatedUGRs
+              .filter(
+                (ugr) =>
+                  ugr.isActive == false &&
+                    ugr.modifiedBy == userCreate.id &&
+                    ugr.groupType == ugrCreate.groupType &&
+                    ugr.groupRole == ugrCreate.groupRole
+              )
+              .size == 1
+          }
       }
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/meta/CirceJsonbMetaSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/meta/CirceJsonbMetaSpec.scala
@@ -14,13 +14,12 @@ import doobie.util.invariant.InvalidObjectMapping
 import doobie.scalatest.imports._
 import org.scalatest._
 
-
 class CirceJsonbMetaSpec extends FunSpec with Matchers with DBTestConfig {
 
   case class JsonClass(id: Int, json: Json)
 
   val drop: Update0 =
-  sql"""
+    sql"""
     DROP TABLE IF EXISTS jsonb_test_table
   """.update
 
@@ -44,12 +43,11 @@ class CirceJsonbMetaSpec extends FunSpec with Matchers with DBTestConfig {
     val jsonIn = List(123, 234, 345).asJson
 
     val jsonOut = for {
-      _  <- createTable.run
-      _  <- insert(JsonClass(123, jsonIn)).run
+      _ <- createTable.run
+      _ <- insert(JsonClass(123, jsonIn)).run
       js <- select(123)
     } yield js
 
     jsonOut.transact(xa).unsafeRunSync shouldBe jsonIn
   }
 }
-

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/meta/GtVectorMetaSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/meta/GtVectorMetaSpec.scala
@@ -12,19 +12,18 @@ import doobie.scalatest.imports._
 import org.scalatest._
 import geotrellis.vector._
 
-
 class GtVectorMetaSpec extends FunSpec with Matchers with DBTestConfig {
 
   case class GeometryClass(
-    id: Int,
-    point: Projected[Point],
-    line: Projected[Line],
-    poly: Projected[Polygon],
-    multipoly: Projected[MultiPolygon]
+      id: Int,
+      point: Projected[Point],
+      line: Projected[Line],
+      poly: Projected[Polygon],
+      multipoly: Projected[MultiPolygon]
   )
 
   val drop: Update0 =
-  sql"""
+    sql"""
     DROP TABLE IF EXISTS geom_test_table
   """.update
 
@@ -50,23 +49,26 @@ class GtVectorMetaSpec extends FunSpec with Matchers with DBTestConfig {
   it("should be able to go in and then come back out") {
     //val point = new Point(1, 2)
     val point = Projected(Point(1, 2), 3857)
-    val line = Projected(Line(Point(0, 1), Point(123, 412), Point(51, 12)), 3857)
+    val line =
+      Projected(Line(Point(0, 1), Point(123, 412), Point(51, 12)), 3857)
     val poly = Projected(
       Polygon(Array(Point(0, 0), Point(0, 1), Point(1, 1), Point(0, 0))),
       3857
     )
     val mpoly = Projected(
-      MultiPolygon(Array(
-        Polygon(Array(Point(0, 0), Point(0, 1), Point(1, 1), Point(0, 0))),
-        Polygon(Array(Point(1, 0), Point(10, 1), Point(1, 1), Point(1, 0))),
-        Polygon(Array(Point(10, 0), Point(10, 1), Point(100, 1), Point(10, 0)))
-      )),
+      MultiPolygon(
+        Array(
+          Polygon(Array(Point(0, 0), Point(0, 1), Point(1, 1), Point(0, 0))),
+          Polygon(Array(Point(1, 0), Point(10, 1), Point(1, 1), Point(1, 0))),
+          Polygon(
+            Array(Point(10, 0), Point(10, 1), Point(100, 1), Point(10, 0)))
+        )),
       3857
     )
 
     val geomOut = for {
-      _  <- createTable.run
-      _  <- insert(GeometryClass(123, point, line, poly, mpoly)).run
+      _ <- createTable.run
+      _ <- insert(GeometryClass(123, point, line, poly, mpoly)).run
       js <- select(123)
     } yield js
 


### PR DESCRIPTION
## Overview
Automatically add them to the team as a team admin so they can manage it if they
are not an organization admin

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

## Testing Instructions

 * As a non-admin in an organization, create a team and verify that you are placed in it automatically
* As an admin of an organization, verify that creating a team does not place you inside it automatically.

Closes #4135 
