### PR TITLE
Fix return of ACR delete action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Removed duplicate emails for repeated failures of the same upload [\#4130](https://github.com/raster-foundry/raster-foundry/pull/4130)
 - Use safer options for large tifs when processing uploads and ingests [\#4131](https://github.com/raster-foundry/raster-foundry/pull/4131)
 - Re-enable datasource deletion and disable it if there is permission attached [\#4140](https://github.com/raster-foundry/raster-foundry/pull/4140), [\#4158](https://github.com/raster-foundry/raster-foundry/pull/4158)
+- Fix permission modal bug so that it won't hang after deleting permissions [\#4174](https://github.com/raster-foundry/raster-foundry/pull/4174)
 
 ### Security
 

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -164,11 +164,10 @@ trait ObjectPermissions[Model] {
     : ConnectionIO[List[Option[ObjectAccessControlRule]]] =
     addPermissionsMany(id, acrList, true)
 
-  def deletePermissions(
-      id: UUID): ConnectionIO[List[Option[ObjectAccessControlRule]]] =
-    updatePermissionsF(id, List[ObjectAccessControlRule]()).update
-      .withUniqueGeneratedKeys[List[String]]("acrs")
-      .map(acrStringsToList(_))
+  def deletePermissions(id: UUID): ConnectionIO[Int] =
+    updatePermissionsF(id, List[ObjectAccessControlRule]())
+      .update
+      .run
 
   def listUserActions(user: User, id: UUID): ConnectionIO[List[String]] =
     for {

--- a/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/com/azavea/rf/database/ObjectPermissions.scala
@@ -165,9 +165,7 @@ trait ObjectPermissions[Model] {
     addPermissionsMany(id, acrList, true)
 
   def deletePermissions(id: UUID): ConnectionIO[Int] =
-    updatePermissionsF(id, List[ObjectAccessControlRule]())
-      .update
-      .run
+    updatePermissionsF(id, List[ObjectAccessControlRule]()).update.run
 
   def listUserActions(user: User, id: UUID): ConnectionIO[List[String]] =
     for {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -507,8 +507,8 @@ class ProjectDaoSpec
               projectDeletePermissionsIO.transact(xa).unsafeRunSync
 
             assert(
-              permsDeleted.length == 0,
-              "Deleting project permissions should get an empty list back.")
+              permsDeleted == 1,
+              "Deleting project permissions should give number of rows updated.")
             assert(
               permissionsBack.length == 0,
               "Getting back permissions after deletion should return an empty list.")


### PR DESCRIPTION
## Overview

This PR fixes the return of first class objects' permission delete action so that it returns the number of rows affected (should be 1, since `acrs` are on object level) instead of an empty array (used to represent granted permissions).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [X] Any new SQL strings have tests (_test updated_)

## Testing Instructions

 * Open up the permissions modal of a shared project or scene
 * Delete one or more permissions and save
 * It should succeed and close the modal

Closes #4173 
