### PR TITLE
Fix formatting problems forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Switched to [keepachangelog](https://keepachangelog.com/en/1.0.0/) CHANGELOG format [\#4159](https://github.com/raster-foundry/raster-foundry/pull/4159)
 - Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
 - Restricted sharing with everyone and platforms to superusers and platform admins [\#4166](https://github.com/raster-foundry/raster-foundry/pull/4166)
+- Added sbt configuration for auto-scalafmt [\#4175](https://github.com/raster-foundry/raster-foundry/pull/4175)
 
 ### Deprecated
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -10,6 +10,7 @@ git.gitTagToVersionNumber in ThisBuild := { tag: String =>
 }
 
 lazy val commonSettings = Seq(
+  scalafmtOnCompile := true,
   // Add the default sonatype repository setting
   publishTo := sonatypePublishTo.value,
   organization := "com.rasterfoundry",

--- a/app-backend/common/src/main/scala/utils/Shapefile.scala
+++ b/app-backend/common/src/main/scala/utils/Shapefile.scala
@@ -15,7 +15,7 @@ object Shapefile {
       case Nil =>
         errorIndices match {
           case Nil => Right(accum)
-          case _ => Left(errorIndices)
+          case _   => Left(errorIndices)
         }
       case h +: t =>
         f(h, props, userId, prj) match {

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/Annotation.scala
@@ -203,7 +203,7 @@ object Annotation extends LazyLogging {
         properties.owner,
         properties.label match {
           case "" => "Unlabeled"
-          case _ => properties.label
+          case _  => properties.label
         },
         properties.description,
         properties.machineGenerated,
@@ -245,7 +245,7 @@ object Annotation extends LazyLogging {
         ownerId, // owner
         label match {
           case "" => "Unlabeled"
-          case _ => label
+          case _  => label
         },
         description,
         machineGenerated,
@@ -338,7 +338,7 @@ object AnnotationShapefileService extends LazyLogging {
           ("id", annotation.id),
           ("label", annotation.label match {
             case "" => "Unlabeled"
-            case _ => annotation.label
+            case _  => annotation.label
           }),
           ("desc", annotation.description.getOrElse("")),
           ("machinegen", annotation.machineGenerated.getOrElse(false)),

--- a/app-backend/geotrellis/src/main/scala/PostgresAttributeStore.scala
+++ b/app-backend/geotrellis/src/main/scala/PostgresAttributeStore.scala
@@ -29,56 +29,83 @@ object PostgresAttributeStoreThreadPool {
     ExecutionContext.fromExecutor(
       Executors.newFixedThreadPool(
         Config.geotrellis.postgresAttributeStoreThreads,
-        new ThreadFactoryBuilder().setNameFormat("gt-postgres-attrstore-%d").build()
+        new ThreadFactoryBuilder()
+          .setNameFormat("gt-postgres-attrstore-%d")
+          .build()
       )
     )
 }
 
 object PostgresAttributeStore {
-  def apply(attributeTable: String = "layer_attributes")(implicit xa: Transactor[IO]): PostgresAttributeStore =
+  def apply(attributeTable: String = "layer_attributes")(
+      implicit xa: Transactor[IO]): PostgresAttributeStore =
     new PostgresAttributeStore(attributeTable)
 }
 
 /** A blocking GeoTrellis attribute store */
-class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(implicit xa: Transactor[IO])
-  extends DiscreteLayerAttributeStore with HistogramJsonFormats with LazyLogging {
+class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(
+    implicit xa: Transactor[IO])
+    extends DiscreteLayerAttributeStore
+    with HistogramJsonFormats
+    with LazyLogging {
 
   import PostgresAttributeStoreThreadPool._
 
-  val awaitTimeout: FiniteDuration = Config.geotrellis.postgresAttributeStoreTimeout
+  val awaitTimeout: FiniteDuration =
+    Config.geotrellis.postgresAttributeStoreTimeout
 
   def read[T: JsonFormat](layerId: LayerId, attributeName: String): T = {
     logger.debug(s"read($layerId-$attributeName)")
-    Await.result(LayerAttributeDao.unsafeGetAttribute(layerId, attributeName).transact(xa).unsafeToFuture
-      .map(_.value.noSpaces.parseJson.convertTo[T]), awaitTimeout)
+    Await.result(LayerAttributeDao
+                   .unsafeGetAttribute(layerId, attributeName)
+                   .transact(xa)
+                   .unsafeToFuture
+                   .map(_.value.noSpaces.parseJson.convertTo[T]),
+                 awaitTimeout)
   }
 
   def readAll[T: JsonFormat](attributeName: String): Map[LayerId, T] = {
     logger.debug(s"readAll($attributeName)")
     Await.result(
-      LayerAttributeDao.listAllAttributes(attributeName).transact(xa).unsafeToFuture.map {
-        _.map { attribute =>
-          attribute.layerId -> attribute.value.noSpaces.parseJson.convertTo[T]
-        }.toMap
-      }, awaitTimeout
+      LayerAttributeDao
+        .listAllAttributes(attributeName)
+        .transact(xa)
+        .unsafeToFuture
+        .map {
+          _.map { attribute =>
+            attribute.layerId -> attribute.value.noSpaces.parseJson.convertTo[T]
+          }.toMap
+        },
+      awaitTimeout
     )
   }
 
-  def write[T: JsonFormat](layerId: LayerId, attributeName: String, value: T): Unit = {
+  def write[T: JsonFormat](layerId: LayerId,
+                           attributeName: String,
+                           value: T): Unit = {
     logger.debug(s"write($layerId-$attributeName)")
-    Await.result(LayerAttributeDao.insertLayerAttribute(
-      LayerAttribute(
-        layerName = layerId.name,
-        zoom = layerId.zoom,
-        name = attributeName,
-        value = parse(value.toJson.toString).valueOr(throw _)
-      )
-    ).transact(xa).unsafeToFuture, awaitTimeout)
+    Await.result(
+      LayerAttributeDao
+        .insertLayerAttribute(
+          LayerAttribute(
+            layerName = layerId.name,
+            zoom = layerId.zoom,
+            name = attributeName,
+            value = parse(value.toJson.toString).valueOr(throw _)
+          )
+        )
+        .transact(xa)
+        .unsafeToFuture,
+      awaitTimeout
+    )
   }
 
   def getHistogram[T: JsonFormat](layerId: LayerId): Future[Option[T]] = {
     logger.debug(s"getHistogram($layerId)")
-    LayerAttributeDao.unsafeGetAttribute(layerId, "histogram").transact(xa).unsafeToFuture
+    LayerAttributeDao
+      .unsafeGetAttribute(layerId, "histogram")
+      .transact(xa)
+      .unsafeToFuture
       .map { attribute =>
         Option(attribute.value.noSpaces.parseJson.convertTo[T])
       }
@@ -86,23 +113,32 @@ class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(im
 
   def layerExists(layerId: LayerId): Boolean = {
     logger.debug(s"layerExists($layerId)")
-    Await.result(LayerAttributeDao.layerExists(layerId).transact(xa).unsafeToFuture, awaitTimeout)
+    Await.result(
+      LayerAttributeDao.layerExists(layerId).transact(xa).unsafeToFuture,
+      awaitTimeout)
   }
 
   def delete(layerId: LayerId): Unit = {
     logger.debug(s"delete($layerId)")
-    Await.result(LayerAttributeDao.delete(layerId).transact(xa).unsafeToFuture, awaitTimeout)
+    Await.result(LayerAttributeDao.delete(layerId).transact(xa).unsafeToFuture,
+                 awaitTimeout)
   }
 
   def delete(layerId: LayerId, attributeName: String): Unit = {
     logger.debug(s"delete($layerId-$attributeName)")
-    Await.result(LayerAttributeDao.delete(layerId, attributeName).transact(xa).unsafeToFuture, awaitTimeout)
+    Await.result(LayerAttributeDao
+                   .delete(layerId, attributeName)
+                   .transact(xa)
+                   .unsafeToFuture,
+                 awaitTimeout)
   }
 
   def layerIds: Seq[LayerId] = {
     logger.debug(s"layerIds($layerIds)")
     Await.result(
-      LayerAttributeDao.layerIds.transact(xa).unsafeToFuture
+      LayerAttributeDao.layerIds
+        .transact(xa)
+        .unsafeToFuture
         .map(_.map { case (name, zoom) => LayerId(name, zoom) }.toSeq),
       awaitTimeout
     )
@@ -111,25 +147,35 @@ class PostgresAttributeStore(val attributeTable: String = "layer_attributes")(im
   def layerIds(layerNames: Set[String]): Seq[LayerId] = {
     logger.debug(s"layerIdsWithLayerNames($layerNames)")
     Await.result(
-      LayerAttributeDao.layerIds(layerNames).transact(xa).unsafeToFuture
+      LayerAttributeDao
+        .layerIds(layerNames)
+        .transact(xa)
+        .unsafeToFuture
         .map { _.map { case (name, zoom) => LayerId(name, zoom) }.toSeq },
       awaitTimeout
     )
   }
 
-  def maxZoomsForLayers(layerNames: Set[String]): Future[Option[Map[String, Int]]] = {
+  def maxZoomsForLayers(
+      layerNames: Set[String]): Future[Option[Map[String, Int]]] = {
     logger.debug(s"maxZoomsForLayers($layerNames)")
-    LayerAttributeDao.maxZoomsForLayers(layerNames).transact(xa).unsafeToFuture
+    LayerAttributeDao
+      .maxZoomsForLayers(layerNames)
+      .transact(xa)
+      .unsafeToFuture
       .map {
         case seq if seq.length > 0 => seq.toMap.some
-        case _ => None
+        case _                     => None
       }
   }
 
   def availableAttributes(id: LayerId): Seq[String] = {
     logger.debug(s"availableAttributes($id")
     Await.result(
-      LayerAttributeDao.availableAttributes(id).transact(xa).unsafeToFuture
+      LayerAttributeDao
+        .availableAttributes(id)
+        .transact(xa)
+        .unsafeToFuture
         .map(_.toSeq),
       awaitTimeout
     )


### PR DESCRIPTION
## Overview

This PR fixes some formatting errors I introduced in #4166 and sets `scalafmtOnCompile` to `true` for all projects with `commonSettings`, so that it'll run when you compile from `root` or within individual subprojects.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

The downside of running on every compile is time -- in my GCP instance that I'm developing on right now, it added 10 seconds to the no-changes compile time for compiling from `root`. I think that's an acceptable cost to avoid the pr / jenkins / what's wrong? / scalafmt commit cycle, but I'm open to removing that configuration change if others disagree.

## Testing Instructions

 * make a change that you know scalafmt won't like
 * compile
 * watch it go away
