### PR TITLE
Update heuristic for determining if clamping/normalizing is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Removed duplicate emails for repeated failures of the same upload [\#4130](https://github.com/raster-foundry/raster-foundry/pull/4130)
 - Use safer options for large tifs when processing uploads and ingests [\#4131](https://github.com/raster-foundry/raster-foundry/pull/4131)
 - Re-enable datasource deletion and disable it if there is permission attached [\#4140](https://github.com/raster-foundry/raster-foundry/pull/4140), [\#4158](https://github.com/raster-foundry/raster-foundry/pull/4158)
+- Fixed issue with clamping imagery whose range was greater than, but included values between 0 and 255 [\#4177](https://github.com/raster-foundry/raster-foundry/pull/4177)
 
 ### Security
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -346,6 +346,7 @@ lazy val tile = Project("tile", file("tile"))
              geotrellis)
   .dependsOn(tool)
   .enablePlugins(GatlingPlugin)
+  .settings(fork in run := true)
   .settings(commonSettings: _*)
   .settings({
     libraryDependencies ++= loggingDependencies ++ testDependencies ++

--- a/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/com/azavea/rf/datamodel/ColorCorrect.scala
@@ -51,10 +51,12 @@ object ColorCorrect extends LazyLogging {
         tile: MultibandTile,
         hist: Seq[Histogram[Double]]
     ): (MultibandTile, Array[Histogram[Double]]) = {
-      logger.debug(s"RedBand: ${redBand}, GreenBand: ${greenBand}, BlueBand: ${blueBand}")
-      logger.debug(s"RedHist: ${hist(redBand).statistics()}\n GreenHist: ${hist(greenBand).statistics()}\n BlueHist: ${hist(blueBand).statistics()}")
+      logger.debug(
+        s"RedBand: ${redBand}, GreenBand: ${greenBand}, BlueBand: ${blueBand}")
+      logger.debug(s"RedHist: ${hist(redBand).statistics()}\n GreenHist: ${hist(
+        greenBand).statistics()}\n BlueHist: ${hist(blueBand).statistics()}")
       (tile.subsetBands(redBand, greenBand, blueBand),
-        Array(hist(redBand), hist(greenBand), hist(blueBand)))
+       Array(hist(redBand), hist(greenBand), hist(blueBand)))
     }
 
     def colorCorrect(tile: MultibandTile,
@@ -181,7 +183,9 @@ object ColorCorrect extends LazyLogging {
       )
     }
 
-    logger.debug(s"Red (Clip Min: ${rclipMin}, Max: ${rclipMax}) (New Min: ${rnewMin}, ${rnewMax})")
+    logger.debug(
+      s"Red (Clip Min: ${rclipMin}, Max: ${rclipMax}) (New Min: ${rnewMin}, ${rnewMax})")
+
     /** In this case for some reason with this func wrap it works faster ¯\_(ツ)_/¯ (it was micro benchmarked) */
     lazyWrapper {
       cfor(0)(_ < rgbTile.cols, _ + 1) { col =>


### PR DESCRIPTION
## Overview

Prior to this commit the logic for determining if it was necessary to
clamp was incorrect/not strict enough. If either the minimum or
maximum value in the histogram was between 0 and 255 redistributing
values was not performed. This causes issues when the range of values
includes 0-255, but the maximum greatly exceeds that value.

After this commit both the minimum and maximum of original values must
be between 0 and 255.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

## Testing Instructions

 * Take the attached tif [planet-test-tif.zip](https://github.com/raster-foundry/raster-foundry/files/2455807/planet-test-tif.zip)
 (have to unzip it) and run process upload
 * Ensure that it looks normal-ish (compared to view in #4164

Connects #4164 (not closing until it's deployed)

