### PR TITLE
Include pow in MapAlgebraAST codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Removed duplicate emails for repeated failures of the same upload [\#4130](https://github.com/raster-foundry/raster-foundry/pull/4130)
 - Use safer options for large tifs when processing uploads and ingests [\#4131](https://github.com/raster-foundry/raster-foundry/pull/4131)
 - Re-enable datasource deletion and disable it if there is permission attached [\#4140](https://github.com/raster-foundry/raster-foundry/pull/4140), [\#4158](https://github.com/raster-foundry/raster-foundry/pull/4158)
+- Included missing `pow` operation for decoding json representations of analyses [\#4179](https://github.com/raster-foundry/raster-foundry/pull/4140), [\#4158](https://github.com/raster-foundry/raster-foundry/pull/4179)
 
 ### Security
 

--- a/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/tool/src/main/scala/ast/MapAlgebraAST.scala
@@ -1,7 +1,6 @@
 package com.azavea.rf.tool.ast
 
 import com.azavea.maml.eval.tile.LazyTile
-import io.circe.generic.JsonCodec
 import cats.implicits._
 import geotrellis.vector.MultiPolygon
 import geotrellis.raster._

--- a/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/tool/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -36,6 +36,7 @@ trait MapAlgebraOperationCodecs extends MapAlgebraUtilityCodecs {
         case Some("or")          => ma.as[MapAlgebraAST.Or]
         case Some("xor")         => ma.as[MapAlgebraAST.Xor]
         case Some("^")           => ma.as[MapAlgebraAST.Pow]
+        case Some("pow")         => ma.as[MapAlgebraAST.Pow]
         case Some("abs")         => ma.as[MapAlgebraAST.Abs]
         case Some(">")           => ma.as[MapAlgebraAST.Greater]
         case Some(">=")          => ma.as[MapAlgebraAST.GreaterOrEqual]


### PR DESCRIPTION
## Overview

This PR includes the `pow` node type in the `MapAlgebraAST` codec, which makes analyses including exponents possible to visualize.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

It's an MSAVI-2!

![image](https://user-images.githubusercontent.com/5702984/46611667-b4512e80-cb0e-11e8-8afe-f08cc7141cf0.png)

### Notes

I didn't audit for more missing operations. It seems pretty likely that we'd have run into them by now if they were A Thing :tm:.

## Testing Instructions

 * Point tile server location to old tile server
 * Make an `msavi` json payload with the python function we have for that
 * Post it to `api/tool-runs/`
 * Try to check out some histograms and/or maps
 * It should work (or fail normally on a timeout instead of with the empty histogram box)

Closes #4155 
