### PR TITLE
Use a global .coursier-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
 - Restricted sharing with everyone and platforms to superusers and platform admins [\#4166](https://github.com/raster-foundry/raster-foundry/pull/4166)
 - Added sbt configuration for auto-scalafmt [\#4175](https://github.com/raster-foundry/raster-foundry/pull/4175)
+- Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4175)
 
 ### Deprecated
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -84,5 +84,6 @@ services:
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
       - $HOME/.gnupg:/root/.gnupg
+      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
+      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:
@@ -146,6 +147,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
+      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:
@@ -175,6 +177,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
+      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:


### PR DESCRIPTION
## Overview

This PR tries out using a global `.coursier-cache`, which should help with maven throttling issues.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * `./scripts/console api-server './sbt api/update'` -- it'll go all the way down to the bottom and reload all dependencies
 * `./scripts/console tile-server './sbt tile/udpate'` -- it'll have everything available in the cache from `api/update` a minute ago and so only fetch tile dependencies
 * clone another copy of rasterfoundry somewhere else
 * fetch this branch over there
 * `mkdir -p nginx/srv/dist` from its root, `AWS_PROFILE=raster-foundry RF_SETTINGS_BUCKET=<fill this in> ./scripts/bootstrap`
 * `./scripts/console api-server './sbt api/update'` -- it shouldn't fetch anything at all since it'll use the cache