### PR TITLE
Add environment variable for cache in migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased(https://github.com/raster-foundry/raster-foundry/tree/develop)
+## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
 - Disable blog feed and intercom initialization using webpack override file [\#4162](https://github.com/raster-foundry/raster-foundry/pull/4162)
@@ -12,7 +12,7 @@
 - Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
 - Restricted sharing with everyone and platforms to superusers and platform admins [\#4166](https://github.com/raster-foundry/raster-foundry/pull/4166)
 - Added sbt configuration for auto-scalafmt [\#4175](https://github.com/raster-foundry/raster-foundry/pull/4175)
-- Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4175)
+- Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4175), [\#4183](https://github.com/raster-foundry/raster-foundry/pull/4183)
 
 ### Deprecated
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -56,6 +56,8 @@ services:
 
   app-migrations:
     image: raster-foundry-app-migrations:${GIT_COMMIT:-latest}
+    environment:
+      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
     build:
       context: ./app-backend
       dockerfile: Dockerfile

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -81,9 +81,9 @@ services:
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./scratch/:/opt/raster-foundry/scratch/
-      - ./.sbt:/root/.sbt
       - ./.git:/opt/raster-foundry/.git
       - ./.bintray:/root/.bintray
+      - $HOME/.sbt:/root/.sbt
       - $HOME/.aws:/root/.aws:ro
       - $HOME/.gnupg:/root/.gnupg
       - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache


### PR DESCRIPTION
## Overview

Adds a missing environment variable for setting the cache location while building the migrations artifact

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible