### PR TITLE
Move coursier cache outside of app-backed mounted volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Used production-hardened existing color correction for backsplash COGs instead of hand-rolled ad hoc color correction [\#4160](https://github.com/raster-foundry/raster-foundry/pull/4160)
 - Restricted sharing with everyone and platforms to superusers and platform admins [\#4166](https://github.com/raster-foundry/raster-foundry/pull/4166)
 - Added sbt configuration for auto-scalafmt [\#4175](https://github.com/raster-foundry/raster-foundry/pull/4175)
-- Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4175), [\#4183](https://github.com/raster-foundry/raster-foundry/pull/4183)
+- Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4175), [\#4183](https://github.com/raster-foundry/raster-foundry/pull/4183), [\#4186](https://github.com/raster-foundry/raster-foundry/pull/4186)
 
 ### Deprecated
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -57,10 +57,12 @@ services:
   app-migrations:
     image: raster-foundry-app-migrations:${GIT_COMMIT:-latest}
     environment:
-      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+      - COURSIER_CACHE=/root/.coursier-cache
     build:
       context: ./app-backend
       dockerfile: Dockerfile
+    volumes:
+      - $HOME/.coursier-cache:/root/.coursier-cache
 
   batch:
     image: raster-foundry-batch:${GIT_COMMIT:-latest}
@@ -77,7 +79,7 @@ services:
       dockerfile: Dockerfile.build
     env_file: .env
     environment:
-      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+      - COURSIER_CACHE=/root/.coursier-cache
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./scratch/:/opt/raster-foundry/scratch/
@@ -86,6 +88,6 @@ services:
       - $HOME/.sbt:/root/.sbt
       - $HOME/.aws:/root/.aws:ro
       - $HOME/.gnupg:/root/.gnupg
-      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
+      - $HOME/.coursier-cache:/root/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
         condition: service_healthy
     env_file: .env
     environment:
-      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+      - COURSIER_CACHE=/root/.coursier-cache
       - RF_LOG_LEVEL=INFO
       - TILE_SERVER_LOCATION=http://localhost:8081
     ports:
@@ -93,7 +93,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
-      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
+      - $HOME/.coursier-cache:/root/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:
@@ -137,7 +137,7 @@ services:
       - statsd
     env_file: .env
     environment:
-      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+      - COURSIER_CACHE=/root/.coursier-cache
       - RF_LOG_LEVEL=INFO
     ports:
       - "9900:9900"
@@ -147,7 +147,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
-      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
+      - $HOME/.coursier-cache:/root/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:
@@ -166,7 +166,7 @@ services:
       - postgres:database.service.rasterfoundry.internal
     env_file: .env
     environment:
-      - COURSIER_CACHE=/opt/raster-foundry/app-backend/.coursier-cache
+      - COURSIER_CACHE=/root/.coursier-cache
       - RF_LOG_LEVEL=INFO
       - SBT_OPTS="-Xmx2G -XX:MaxPermSize=2G"
     ports:
@@ -177,7 +177,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
-      - $HOME/.coursier-cache:/opt/raster-foundry/app-backend/.coursier-cache
+      - $HOME/.coursier-cache:/root/.coursier-cache
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:


### PR DESCRIPTION
## Overview

This PR makes it so the app no longer maintains a distinct copy of the coursier-cache. Because `app-backend/` is a mounted volume _and_ `$HOME/.coursier-cache` was mounted into `app-backend/.coursier-cache`, each build made an extra copy of the coursier cache, which is about 400mb on my local machine. This PR makes it so we don't pay 400mb / build on a cache. 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * `rm -rf app-backend/.coursier-cache`
 * `./scripts/console api-server './sbt api/update'`
 * `./scripts/console tile-server './sbt tile/update'`
 * `./scripts/console backsplash './sbt backsplash/update'`
 * add a `-f "${DIR}/../docker-compose.test.yml` to `scripts/console` to make `build` available
 * `./scripts/console build './sbt update'`
 * shouldn't fetch any dependencies except for things that don't already have dependencies in the cache (for me that was batch and migrations)
