### PR TITLE
Add project histogram endpoint to backsplash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [\#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
 - Allow platforms to set a "From" email field in order to change notification "From" name [#\4198](Add from field for email) 
+- Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
 
 ### Changed
 - Small text edit to the Imports page [\#4198](https://github.com/raster-foundry/raster-foundry/pull/4198)
@@ -28,7 +29,6 @@
 - Disable blog feed and intercom initialization using webpack override file [\#4162](https://github.com/raster-foundry/raster-foundry/pull/4162)
 - Add support for google tag manager via webpack overrides [\#4165](https://github.com/raster-foundry/raster-foundry/pull/4165)
 - Added support for additional/future Planet asset types [\#4184](https://github.com/raster-foundry/raster-foundry/pull/4184)
-- Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Disable blog feed and intercom initialization using webpack override file [\#4162](https://github.com/raster-foundry/raster-foundry/pull/4162)
 - Add support for google tag manager via webpack overrides [\#4165](https://github.com/raster-foundry/raster-foundry/pull/4165)
 - Added support for additional/future Planet asset types [\#4184](https://github.com/raster-foundry/raster-foundry/pull/4184)
+- Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
 
 ### Changed
 

--- a/app-backend/backsplash/src/main/scala/io/Avro.scala
+++ b/app-backend/backsplash/src/main/scala/io/Avro.scala
@@ -18,7 +18,7 @@ import geotrellis.spark.io.postgres.PostgresAttributeStore
 import geotrellis.spark.io.s3.{S3CollectionLayerReader, S3ValueReader}
 import geotrellis.spark.tiling.LayoutLevel
 import geotrellis.spark.{SpatialKey, TileLayerMetadata, io => _, _}
-import geotrellis.vector.Extent
+import geotrellis.vector.{Extent, Polygon, Projected}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -29,6 +29,12 @@ object Avro extends RollbarNotifier with HistogramJsonFormats {
   import com.rasterfoundry.database.util.RFTransactor.xa
 
   val store = PostgresAttributeStore()
+
+  def fetchGlobalTile(mosaicDefinition: MosaicDefinition,
+                      extent: Option[Projected[Polygon]],
+                      redBand: Int,
+                      greenBand: Int,
+                      blueBand: Int): IO[MultibandTile] = ???
 
   // TODO: this essentially inlines a bunch of logic from LayerCache, which isn't super cool
   // it would be nice to get that logic somewhere more appropriate, especially since a lot of

--- a/app-backend/backsplash/src/main/scala/io/Avro.scala
+++ b/app-backend/backsplash/src/main/scala/io/Avro.scala
@@ -10,10 +10,11 @@ import com.rasterfoundry.database.LayerAttributeDao
 import com.rasterfoundry.datamodel.{MosaicDefinition, SingleBandOptions}
 import com.rf.azavea.backsplash.Color
 import doobie.implicits._
+import geotrellis.proj4.{WebMercator, LatLng}
 import geotrellis.raster.histogram._
-import geotrellis.raster.io.json.HistogramJsonFormats
 import geotrellis.raster.{Raster, io => _, _}
 import geotrellis.spark.io._
+import geotrellis.raster.io.json._
 import geotrellis.spark.io.postgres.PostgresAttributeStore
 import geotrellis.spark.io.s3.{S3CollectionLayerReader, S3ValueReader}
 import geotrellis.spark.tiling.LayoutLevel
@@ -30,11 +31,59 @@ object Avro extends RollbarNotifier with HistogramJsonFormats {
 
   val store = PostgresAttributeStore()
 
-  def fetchGlobalTile(mosaicDefinition: MosaicDefinition,
-                      extent: Option[Projected[Polygon]],
-                      redBand: Int,
-                      greenBand: Int,
-                      blueBand: Int): IO[MultibandTile] = ???
+  def fetchGlobalTile(
+      mosaicDefinition: MosaicDefinition,
+      extent: Option[Projected[Polygon]],
+      redBand: Int,
+      greenBand: Int,
+      blueBand: Int,
+      size: Int = 64,
+      attributeStore: AttributeStore = store): IO[MultibandTile] = IO {
+    require(size < 4096, s"$size is too large to stitch")
+    minZoomLevel(attributeStore, mosaicDefinition.sceneId.toString, size).map {
+      case (layerId, re) =>
+        S3CollectionLayerReader(store)
+          .query[SpatialKey, MultibandTile, TileLayerMetadata[SpatialKey]](
+            layerId)
+          .where(Intersects(re.extent))
+          .result
+          .stitch
+          .crop(re.extent)
+    } match {
+      case Success(raster) =>
+        raster.tile.subsetBands(redBand, greenBand, blueBand)
+      case Failure(e) => throw e
+    }
+  }
+
+  def minZoomLevel(store: AttributeStore,
+                   layerName: String,
+                   size: Int): Try[(LayerId, RasterExtent)] = {
+    def forZoom(zoom: Int): Try[(LayerId, RasterExtent)] = {
+      val currentId = LayerId(layerName, zoom)
+      val meta = Try {
+        store.readMetadata[TileLayerMetadata[SpatialKey]](currentId)
+      }
+      val rasterExtent = meta.map { tlm =>
+        (tlm, dataRasterExtent(tlm))
+      }
+      rasterExtent.map {
+        case (tlm, re) =>
+          logger.debug(s"$currentId has (${re.cols},${re.rows}) pixels")
+          if (re.cols >= size || re.rows >= size) (currentId, re)
+          else forZoom(zoom + 1).getOrElse((currentId, re))
+      }
+    }
+    forZoom(1)
+  }
+
+  def dataRasterExtent(md: TileLayerMetadata[_]): RasterExtent = {
+    val re = RasterExtent(md.layout.extent,
+                          md.layout.tileLayout.totalCols.toInt,
+                          md.layout.tileLayout.totalRows.toInt)
+    val gb = re.gridBoundsFor(md.extent)
+    re.rasterExtentFor(gb).toRasterExtent
+  }
 
   // TODO: this essentially inlines a bunch of logic from LayerCache, which isn't super cool
   // it would be nice to get that logic somewhere more appropriate, especially since a lot of

--- a/app-backend/backsplash/src/main/scala/io/Cog.scala
+++ b/app-backend/backsplash/src/main/scala/io/Cog.scala
@@ -7,12 +7,43 @@ import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.datamodel.{MosaicDefinition, SingleBandOptions}
 import com.rf.azavea.backsplash.Color
-import geotrellis.raster.{Raster, io => _, _}
+import geotrellis.proj4.WebMercator
+import geotrellis.raster.{CellSize, Raster, RasterExtent, io => _, _}
+import geotrellis.raster.io.geotiff.AutoHigherResolution
 import geotrellis.server.core.cog.CogUtils
 import geotrellis.spark.{io => _}
-import geotrellis.vector.Extent
+import geotrellis.vector.{Extent, Polygon, Projected}
 
 object Cog extends RollbarNotifier {
+
+  /** Fetch a downsampled global tile of a tif. The target resolution is (for now) 1/16th
+    * the native resolution of the image.
+    */
+  def fetchGlobalTile(mosaicDefinition: MosaicDefinition,
+                      poly: Option[Projected[Polygon]],
+                      redBand: Int,
+                      greenBand: Int,
+                      blueBand: Int): IO[MultibandTile] =
+    for {
+      tiff <- mosaicDefinition.ingestLocation map {
+        CogUtils.fromUri(_)
+      } getOrElse {
+        throw UningestedScenesException(
+          s"Scene ${mosaicDefinition.sceneId} has no ingest location")
+      }
+      // target a cellsize in an overview that would up being about a 256 / 256 tile
+      downsampleFactor = (tiff.cols * tiff.rows / (256 * 256)) max 1
+      cellSize = CellSize(tiff.cellSize.width * downsampleFactor,
+                          tiff.cellSize.height * downsampleFactor)
+      overview = CogUtils.closestTiffOverview(tiff,
+                                              cellSize,
+                                              AutoHigherResolution)
+    } yield {
+      val cropped = (poly map { polygon: Projected[Polygon] =>
+        overview.crop(RasterExtent(polygon.envelope, cellSize)).tile
+      } getOrElse overview.tile)
+      cropped.subsetBands(redBand, greenBand, blueBand)
+    }
 
   def fetchSingleBandCogTile(
       md: MosaicDefinition,

--- a/app-backend/backsplash/src/main/scala/io/Histogram.scala
+++ b/app-backend/backsplash/src/main/scala/io/Histogram.scala
@@ -1,0 +1,83 @@
+package com.azavea.rf.backsplash.io
+
+import com.azavea.rf.database.SceneToProjectDao
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.datamodel.SceneType
+
+import cats.data.OptionT
+import cats.effect.IO
+import cats.implicits._
+import doobie.implicits._
+import geotrellis.raster.MultibandTile
+import geotrellis.raster.histogram._
+import geotrellis.vector.{Projected, Polygon}
+
+import java.util.UUID
+
+object Histogram {
+
+  implicit val xa = RFTransactor.xa
+
+  def getRGBProjectHistogram(
+      projectId: UUID,
+      polygonOption: Option[Projected[Polygon]],
+      redBand: Option[Int] = None,
+      greenBand: Option[Int] = None,
+      blueBand: Option[Int] = None,
+      scenesSubset: List[UUID] = List.empty): IO[Vector[Histogram[Int]]] =
+    for {
+      mosaicDefinitions <- SceneToProjectDao
+        .getMosaicDefinition(projectId,
+                             polygonOption,
+                             redBand,
+                             greenBand,
+                             blueBand,
+                             scenesSubset)
+        .transact(xa) map { _.toList } // needs to be a list for cats instances
+      rgbs = (redBand, greenBand, blueBand).tupled match {
+        case Some((red, green, blue)) =>
+          List.fill(mosaicDefinitions.length)((red, green, blue))
+        case _ =>
+          mosaicDefinitions map { md =>
+            (md.colorCorrections.redBand,
+             md.colorCorrections.greenBand,
+             md.colorCorrections.blueBand)
+          }
+      }
+      globalTiles <- (mosaicDefinitions zip rgbs) parTraverse {
+        case (mosaicDefinition, rgb) =>
+          if (mosaicDefinition.sceneType == Some(SceneType.COG))
+            Cog.fetchGlobalTile(mosaicDefinition,
+                                polygonOption,
+                                rgb._1,
+                                rgb._2,
+                                rgb._3)
+          else
+            // TODO: how?
+            Avro.fetchGlobalTile(mosaicDefinition,
+                                 polygonOption,
+                                 rgb._1,
+                                 rgb._2,
+                                 rgb._3)
+      }
+      correctedTiles: List[MultibandTile] = mosaicDefinitions.zip(globalTiles) map {
+        case (md, globalMbTile) =>
+          val rgbBands = (redBand, greenBand, blueBand).tupled getOrElse {
+            (md.colorCorrections.redBand,
+             md.colorCorrections.greenBand,
+             md.colorCorrections.blueBand)
+          }
+          val subsetTile =
+            globalMbTile.subsetBands(rgbBands._1, rgbBands._2, rgbBands._3)
+          md.colorCorrections.colorCorrect(subsetTile,
+                                           subsetTile.histogramDouble)
+      }
+    } yield {
+      correctedTiles.foldLeft(Vector.fill(3)(IntHistogram(): Histogram[Int]))(
+        (hists: Vector[Histogram[Int]], mbTile: MultibandTile) => {
+          (hists zip mbTile.histogram) map {
+            case (h1, h2) => h1 merge h2
+          }
+        })
+    }
+}

--- a/app-backend/backsplash/src/main/scala/io/Histogram.scala
+++ b/app-backend/backsplash/src/main/scala/io/Histogram.scala
@@ -1,8 +1,8 @@
-package com.azavea.rf.backsplash.io
+package com.rasterfoundry.backsplash.io
 
-import com.azavea.rf.database.SceneToProjectDao
-import com.azavea.rf.database.util.RFTransactor
-import com.azavea.rf.datamodel.SceneType
+import com.rasterfoundry.database.SceneToProjectDao
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.datamodel.SceneType
 
 import cats.data.OptionT
 import cats.effect.IO

--- a/app-backend/backsplash/src/main/scala/services/MosaicService.scala
+++ b/app-backend/backsplash/src/main/scala/services/MosaicService.scala
@@ -2,15 +2,15 @@ package com.rasterfoundry.backsplash.services
 
 import com.azavea.maml.error.Interpreted
 import com.azavea.maml.eval.BufferingInterpreter
-import com.azavea.rf.authentication.Authentication
-import com.azavea.rf.backsplash.error._
-import com.azavea.rf.backsplash.io.Histogram
-import com.azavea.rf.backsplash.nodes.ProjectNode
-import com.azavea.rf.backsplash.parameters.PathParameters._
-import com.azavea.rf.common.RollbarNotifier
-import com.azavea.rf.database.util.RFTransactor
-import com.azavea.rf.database.{ProjectDao, UserDao}
-import com.azavea.rf.datamodel._
+import com.rasterfoundry.authentication.Authentication
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.backsplash.io.Histogram
+import com.rasterfoundry.backsplash.nodes.ProjectNode
+import com.rasterfoundry.backsplash.parameters.PathParameters._
+import com.rasterfoundry.common.RollbarNotifier
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.database.{ProjectDao, UserDao}
+import com.rasterfoundry.datamodel._
 
 import cats.data.Validated._
 import cats.data._

--- a/app-backend/backsplash/src/main/scala/services/MosaicService.scala
+++ b/app-backend/backsplash/src/main/scala/services/MosaicService.scala
@@ -2,14 +2,15 @@ package com.rasterfoundry.backsplash.services
 
 import com.azavea.maml.error.Interpreted
 import com.azavea.maml.eval.BufferingInterpreter
-import com.rasterfoundry.authentication.Authentication
-import com.rasterfoundry.backsplash.error._
-import com.rasterfoundry.backsplash.nodes.ProjectNode
-import com.rasterfoundry.backsplash.parameters.PathParameters._
-import com.rasterfoundry.common.RollbarNotifier
-import com.rasterfoundry.database.util.RFTransactor
-import com.rasterfoundry.database.{ProjectDao, UserDao}
-import com.rasterfoundry.datamodel._
+import com.azavea.rf.authentication.Authentication
+import com.azavea.rf.backsplash.error._
+import com.azavea.rf.backsplash.io.Histogram
+import com.azavea.rf.backsplash.nodes.ProjectNode
+import com.azavea.rf.backsplash.parameters.PathParameters._
+import com.azavea.rf.common.RollbarNotifier
+import com.azavea.rf.database.util.RFTransactor
+import com.azavea.rf.database.{ProjectDao, UserDao}
+import com.azavea.rf.datamodel._
 
 import cats.data.Validated._
 import cats.data._
@@ -18,9 +19,22 @@ import cats.implicits._
 import doobie.implicits._
 import geotrellis.raster.Tile
 import geotrellis.server.core.maml._
+import geotrellis.server.core.maml.reification.MamlTmsReification
+import geotrellis.vector.{Projected, Polygon}
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
 import org.http4s._
 import org.http4s.dsl._
+import org.http4s.dsl.io._
 import org.http4s.headers._
+import org.http4s.implicits._
+import org.http4s.server._
+import org.http4s.util.CaseInsensitiveString
+
+import java.net.URI
+import java.util.UUID
+import java.util.Base64
 
 class MosaicService(
     interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
@@ -97,5 +111,46 @@ class MosaicService(
           }
         } yield resp
         respIO.handleErrorWith(handleErrors _)
+
+      case GET -> Root / UUIDWrapper(projectId) / "histogram" / _
+            :? RedBandOptionalQueryParamMatcher(redOverride)
+            :? GreenBandOptionalQueryParamMatcher(greenOverride)
+            :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+        val respIO = for {
+          histograms <- Histogram.getRGBProjectHistogram(projectId,
+                                                         None,
+                                                         None,
+                                                         None,
+                                                         None,
+                                                         List.empty[UUID])
+          resp <- Ok((histograms map { _.binCounts.toMap } asJson).noSpaces)
+        } yield resp
+        respIO handleErrorWith { handleErrors _ }
+
+      case authedReq @ POST -> Root / UUIDWrapper(projectId) / "histogram" / _
+            :? RedBandOptionalQueryParamMatcher(redOverride)
+            :? GreenBandOptionalQueryParamMatcher(greenOverride)
+            :? BlueBandOptionalQueryParamMatcher(blueOverride) as user => {
+        // Compile to a byte array, decode that as a string, and do something with the results
+        authedReq.req.body.compile.to[Array] flatMap { uuids =>
+          decode[List[UUID]](
+            uuids map { _.toChar } mkString
+          ) match {
+            case Right(uuids) =>
+              logger.info(s"How many uuids: ${uuids.length}")
+              for {
+                histograms <- Histogram.getRGBProjectHistogram(projectId,
+                                                               None,
+                                                               redOverride,
+                                                               greenOverride,
+                                                               blueOverride,
+                                                               uuids)
+                resp <- Ok(
+                  (histograms map { _.binCounts.toMap } asJson).noSpaces)
+              } yield resp
+            case _ => BadRequest("Could not decode body as sequence of UUIDs")
+          }
+        } handleErrorWith (handleErrors _)
+      }
     }
 }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -18,6 +18,11 @@ object Generators extends ArbitraryInstances {
   val defaultPlatformId: UUID =
     UUID.fromString("31277626-968b-4e40-840b-559d9c67863c")
 
+  private def stringOptionGen: Gen[Option[String]] =
+    Gen.oneOf(
+      Gen.const(Option.empty[String]), nonEmptyStringGen map { Some(_) }
+    )
+
   private def stringListGen: Gen[List[String]] =
     Gen.oneOf(0, 15) flatMap { Gen.listOfN(_, nonEmptyStringGen) }
 
@@ -317,7 +322,7 @@ object Generators extends ArbitraryInstances {
       sourceUri <- nonEmptyStringGen
       scene <- uuidGen
       imageMetadata <- Gen.const(().asJson)
-      owner <- arbitrary[Option[String]]
+      owner <- stringOptionGen
       resolutionMeters <- Gen.choose(0.25f, 1000f)
       metadataFiles <- stringListGen
     } yield
@@ -341,7 +346,7 @@ object Generators extends ArbitraryInstances {
       sourceUri <- nonEmptyStringGen
       scene <- uuidGen
       imageMetadata <- Gen.const(().asJson)
-      owner <- arbitrary[Option[String]]
+      owner <- stringOptionGen
       resolutionMeters <- Gen.choose(0.25f, 1000f)
       metadataFiles <- stringListGen
       bands <- Gen.listOfN(3, bandCreateGen)
@@ -456,7 +461,7 @@ object Generators extends ArbitraryInstances {
       datasource <- uuidGen
       sceneMetadata <- Gen.const(().asJson)
       name <- nonEmptyStringGen
-      owner <- arbitrary[Option[String]]
+      owner <- stringOptionGen
       tileFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
       dataFootprint <- projectedMultiPolygonGen3857 map { Some(_) }
       metadataFiles <- stringListGen
@@ -632,7 +637,7 @@ object Generators extends ArbitraryInstances {
       emailAoiNotification <- arbitrary[Boolean]
       emailExportNotification <- arbitrary[Boolean]
       platformHost <- Gen.const(None)
-      emailFrom <- arbitrary[Option[String]]
+      emailFrom <- stringOptionGen
     } yield {
       Platform.PublicSettings(
         emailUser,

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -768,7 +768,10 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbListSceneCreate: Arbitrary[List[Scene.Create]] = Arbitrary {
-      Gen.listOfN(3, sceneCreateGen)
+      Gen.oneOf(
+        Gen.listOfN(7, sceneCreateGen),
+        Gen.listOfN(0, sceneCreateGen)
+      )
     }
 
     implicit def arbThumbnail: Arbitrary[Thumbnail] = Arbitrary { thumbnailGen }

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -336,9 +336,13 @@ object ProjectDao
   def deleteScenesFromProject(sceneIds: List[UUID],
                               projectId: UUID): ConnectionIO[Int] = {
     val f: Option[Fragment] = sceneIds.toNel.map(Fragments.in(fr"scene_id", _))
-    val deleteQuery = fr"DELETE FROM scenes_to_projects" ++
-      Fragments.whereAndOpt(f, Some(fr"project_id = ${projectId}"))
-    deleteQuery.update.run
+    f match {
+      case fragO @ Some(_) =>
+        val deleteQuery = fr"DELETE FROM scenes_to_projects" ++
+          Fragments.whereAndOpt(f, Some(fr"project_id = ${projectId}"))
+        deleteQuery.update.run
+      case _ => 0.pure[ConnectionIO]
+    }
   }
 
   def addScenesToProjectFromQuery(sceneParams: CombinedSceneQueryParams,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -216,8 +216,7 @@ class ProjectDaoSpec
                     dbScenes: List[Scene.WithRelated],
                     dbUser: User) => {
                 ProjectDao.addScenesToProject(
-                  // this.get is safe because the arbitrary instance only produces NELs
-                  (dbScenes map { _.id }).toNel.get,
+                  (dbScenes map { _.id }),
                   dbProject.id,
                   true
                 )
@@ -334,9 +333,7 @@ class ProjectDaoSpec
                     dbScenes: List[Scene.WithRelated],
                     dbUser: User) => {
                 val sceneIds = dbScenes map { _.id }
-                ProjectDao.addScenesToProject(
-                                              // this.get is safe because the arbitrary instance only produces NELs
-                                              (dbScenes map { _.id }).toNel.get,
+                ProjectDao.addScenesToProject((dbScenes map { _.id }),
                                               dbProject.id,
                                               true) flatMap { _ =>
                   ProjectDao.deleteScenesFromProject(dbScenes map { _.id },

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -36,6 +36,17 @@ class ProjectDatasourcesDaoSpec
          scenes1: List[Scene.Create],
          scenes2: List[Scene.Create]) =>
           {
+
+            val expected1 = scenes1 match {
+              case Nil => 0
+              case _   => 1
+            }
+            val expected2 = scenes2 match {
+              case Nil => 0
+              case _   => 1
+            }
+            val expected = expected1 + expected2
+
             val createDsIO = for {
               orgUserProjectInsert <- insertUserOrgProject(userCreate,
                                                            orgCreate,
@@ -62,7 +73,8 @@ class ProjectDatasourcesDaoSpec
                 .listProjectDatasources(dbProject.id)
             } yield (projectDatasources)
             val (pd) = createDsIO.transact(xa).unsafeRunSync
-            assert(pd.size == 2, "; Datasources are not duplicated in request")
+            assert(pd.size == expected,
+                   "; Datasources are not duplicated in request")
             true
           }
       }

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/adjust/adjust.html
@@ -36,6 +36,7 @@
           <div class="list-group" ng-show="!$ctrl.loadingHistogram && $ctrl.histogramData && !$ctrl.histogramData.length">
             Scenes in this project do not support histograms,<br />
             or they contain no data.<br />
+            <!-- can't yet remove this since we don't know when backsplash will be deployed, but soon -->
             Cloud optimized geotif support is coming soon.
           </div>
           <div class="list-group" ng-show="!$ctrl.histogramData || $ctrl.loadingHistogram">


### PR DESCRIPTION
## Overview

This PR adds a `histogram` endpoint off of projects to backsplash.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

It doesn't use `MAMLHistogram` from `geotrellis-server` because `MAMLHistogram` is required to produce an `IO[Histogram]`, while our endpoint _must_ produce an `F[Vector[Histogram]]`.

## Testing Instructions

 * add a COG scene and an Avro scene to a project in the same datasource (good way to do this is to ingest a Landsat 8 scene near the already ingested Landsat 8 avro scenes in Tunisia or Australia)
 * go to advanced color correction
 * try to color correct them both

Closes #4153 
