### PR TITLE
Add additional options for starting development server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added a global cache location for sharing artifacts across CI builds [\#4181](https://github.com/raster-foundry/raster-foundry/pull/4181), [\#4183](https://github.com/raster-foundry/raster-foundry/pull/4183), [\#4186](https://github.com/raster-foundry/raster-foundry/pull/4186)
 - Switched to using `sbt` to resolve dependencies [\#4191](https://github.com/raster-foundry/raster-foundry/pull/4191)
 - Users who are not admins of an organization can now correctly create teams and are automatically added to them [\#4147](https://github.com/raster-foundry/raster-foundry/pull/4171)
+- Added additional options for starting development server [\#4192](https://github.com/raster-foundry/raster-foundry/pull/4192)
 
 ### Deprecated
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     env_file: .env
     environment:
       - RF_LOG_LEVEL=INFO
-      - TILE_SERVER_LOCATION=http://localhost:8081
+      - TILE_SERVER_LOCATION
     ports:
       - "9000:9000"
       - "9010:9010"

--- a/scripts/server
+++ b/scripts/server
@@ -26,8 +26,13 @@ then
         shift
         docker-compose up -d nginx-api nginx-backsplash memcached && \
             docker-compose logs -f --tail 20 api-server "$@"
+    elif [ "${1:-}" = "--backsplash" ]
+    then
+        TILE_SERVER_LOCATION="http://localhost:8081" \
+        docker-compose up nginx-backsplash nginx-api memcached api-server backsplash
     else
-        docker-compose up --remove-orphans
+        TILE_SERVER_LOCATION="http://localhost:9101" \
+        docker-compose up nginx-tiler nginx-api memcached api-server tile-server
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

This PR updates `scripts/server` so that by default, `./scripts/server` will use the tile server, `./scripts/server --backsplash` will use backsplash.

Paired with @notthatbreezy on this one.

## Testing Instructions

 * `./scripts/server` and `./scripts/server --backsplash` and make sure both work as intended

