### PR TITLE
Prototype Sonatype Nexus configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dist/
 # Patch files
 *.patch
 scratch/
+
+# Nexus
+nexus-data

--- a/app-backend/.sbtopts
+++ b/app-backend/.sbtopts
@@ -1,3 +1,5 @@
 -Dsbt.global.base=project/.sbtboot
 -Dsbt.boot.directory=project/.boot
 -Dsbt.ivy.home=project/.ivy
+-Dsbt.override.build.repos=true
+-Dsbt.repository.config=project/repositories

--- a/app-backend/project/repositories
+++ b/app-backend/project/repositories
@@ -1,0 +1,4 @@
+[repositories]
+  local
+  ivy-proxy-releases: http://host.docker.internal:8081/repository/ivy-public/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  maven-proxy-releases: http://host.docker.internal:8081/repository/maven-public/

--- a/docker-compose.nexus.yml
+++ b/docker-compose.nexus.yml
@@ -1,0 +1,9 @@
+version: "3"
+services:
+  nexus:
+    image: "sonatype/nexus3:3.13.0"
+    ports:
+      - "8081:8081"
+    volumes:
+      - "./nexus-data:/nexus-data"
+    restart: on-failure


### PR DESCRIPTION
## Overview

Being blocked by Maven Central is a thing that can happen. This is a prototype of adding support to target a centralized repository manager (in this case, Sonatype Nexus OSS).

I don't expect this PR to be merged. This is mostly a vehicle to make it easier for others to reproduce what I did.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Styleguide updated, if necessary
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [ ] Symlinks from new migrations present or corrected for any new migrations
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

### Notes

- The `repositories` file in this PR targets `host.docker.internal`, which is a magic FQDN provided by Docker for Mac. Might need to use your workstation hostname is you're using a different environment.
- You can browse the Nexus UI by navigating to http://localhost:8081/. Login credentials are `admin:admin123`.
- I added all of the repositories used by the project to Nexus in the recommended way (split Maven and Ivy repositories). See: https://www.scala-sbt.org/1.x/docs/Proxy-Repositories.html

## Testing Instructions

First, pull down a backup of Nexus complete with configuration and blob store data:

```bash
$ aws s3 cp s3://rasterfoundry-development-data-us-east-1/nexus-data-backup.tar.gz - | tar xvzf -
```

Next, bring up a local instance of Nexus and wait for it to initialize:

```bash
$ docker-compose -f docker-compose.nexus.yml up
```

Then, ensure that all of our local repositories are removed and launch a clean OpenJDK8 container:

```bash
$ rm -rf app-backend/project/.ivy
$ cd app-backend
$ docker run --rm -ti -v $PWD:/usr/src/app -w /usr/src/app openjdk:8-jre /bin/bash
```

Once inside, launch the `sbt` shell and use the `update` subcommand to pull down dependencies. Ensure that the URLs scrolling by reference `http://host.docker.internal`.

```bash
root@34fa31c4ff63:/usr/src/app# ./sbt
root > update
```

(The download of the `sbt` launcher will bypass Nexus unless you use the `-sbt-launch-repo` flag).

Lastly, compile the project and ensure that it completes cleanly:

```bash
root > compile
```

Fixes https://github.com/azavea/raster-foundry-platform/issues/461