### PR TITLE
Fix org/team frontend permissions, undefined function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Removed
 
 ### Fixed
+- Add user button no longer shows for non-admins of teams and orgs [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
+- Fix undefined function call when selecting project scenes by clicking the map in advanced color correction view [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 
 ### Security
 

--- a/app-frontend/src/app/pages/admin/organization/users/users.html
+++ b/app-frontend/src/app/pages/admin/organization/users/users.html
@@ -18,6 +18,7 @@
       ></rf-search>
       <button type="button" class="btn btn-primary"
               ng-click="$ctrl.addUserModal()"
+              ng-if="$ctrl.isEffectiveAdmin"
               ng-disabled="$ctrl.loading">
         Add Users
       </button>
@@ -32,6 +33,7 @@
       When it does, they'll be shown here.
     </p>
     <button type="button" class="btn btn-primary"
+            ng-if="$ctrl.isEffectiveAdmin"
             ng-click="$ctrl.addUserModal()">
       Add Users
     </button>

--- a/app-frontend/src/app/pages/admin/team/users/users.html
+++ b/app-frontend/src/app/pages/admin/team/users/users.html
@@ -17,6 +17,7 @@
                  placeholder="Search for users"
                  auto-focus="true"></rf-search>
       <button type="button" class="btn btn-primary"
+              ng-if="$ctrl.isEffectiveAdmin"
               ng-click="$ctrl.addUser()" ng-disabled="$ctrl.currentQuery">
         Invite Users
       </button>
@@ -32,9 +33,10 @@
     </p>
 
     <button type="button" class="btn btn-primary"
+            ng-if="$ctrl.isEffectiveAdmin"
             ng-click="$ctrl.addUser()"
     >
-      Add Users
+      Invite Users
     </button>
   </rf-call-to-action-item>
   <rf-call-to-action-item

--- a/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
+++ b/app-frontend/src/app/pages/projects/edit/advancedcolor/advancedcolor.controller.js
@@ -75,15 +75,15 @@ export default class ProjectsAdvancedColorController {
         });
     }
 
-    fetchPage(page = this.$state.params.page || 1) {
+    fetchPage(page = this.$state.params.page || 1, params = {}) {
         delete this.fetchError;
         this.sceneList = [];
         const currentQuery = this.projectService.getProjectScenes(
             this.$parent.projectId,
-            {
+            Object.assign({
                 pageSize: this.projectService.scenePageSize,
                 page: page - 1
-            }
+            }, params)
         ).then((paginatedResponse) => {
             this.sceneList = paginatedResponse.results;
             this.pagination = this.paginationService.buildPagination(paginatedResponse);
@@ -160,10 +160,16 @@ export default class ProjectsAdvancedColorController {
         this.updateGridSelection();
 
         if (this.filterBboxList.length) {
-            this.projectService.getAllProjectScenes({
-                projectId: this.project.id,
-                bbox: this.filterBboxList.map(r => r.toBBoxString()).join(';')
-            }).then(({scenes: selectedScenes}) => {
+            this.projectService.getProjectScenes(
+                this.$parent.projectId,
+                {
+                    pageSize: this.projectService.scenePageSize,
+                    page: 0,
+                    bbox: this.filterBboxList
+                        .map(r => r.toBBoxString())
+                        .join(';')
+                }
+            ).then(({results: selectedScenes}) => {
                 if (this.lastRequest === requestTime) {
                     this.selectNoScenes();
                     selectedScenes.map((scene) => this.setSelected(scene, true));

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -292,35 +292,40 @@ export default (app) => {
             ).$promise;
         }
 
-        getProjectCorners(projectId) {
-            return this.getAllProjectScenes({projectId: projectId}).then(({scenes}) => {
-                let corners = {
-                    lowerLeftLon: null,
-                    lowerLeftLat: null,
-                    upperRightLon: null,
-                    upperRightLat: null
-                };
-                scenes.forEach(scene => {
-                    let metadata = scene.sceneMetadata;
-                    if (metadata.lowerLeftCornerLatitude < corners.lowerLeftLat ||
-                        corners.lowerLeftLat === null) {
-                        corners.lowerLeftLat = metadata.lowerLeftCornerLatitude;
-                    }
-                    if (metadata.lowerLeftCornerLongitude < corners.lowerLeftLon ||
-                        corners.lowerLeftLon === null) {
-                        corners.lowerLeftLon = metadata.lowerLeftCornerLongitude;
-                    }
-                    if (metadata.upperRightCornerLatitude < corners.upperRightLat ||
-                        corners.upperRightLat === null) {
-                        corners.upperRightLat = metadata.upperRightCornerLatitude;
-                    }
-                    if (metadata.upperRightCornerLongitude < corners.upperRightLon ||
-                        corners.upperRightLon === null) {
-                        corners.upperRightLon = metadata.upperRightCornerLongitude;
-                    }
-                });
-                return corners;
-            });
+        getProjectCorners(id) {
+            // TODO Use project extent instead here
+            throw new Error('ERROR: Update project.service getProjectCorners to use the ' +
+                            'project extent. This function was not updated because ' +
+                            'we don\'t seem to use it anywhere right now.');
+            // return this.fetchProject(id).then(({project}) => {
+
+            //     let corners = {
+            //         lowerLeftLon: null,
+            //         lowerLeftLat: null,
+            //         upperRightLon: null,
+            //         upperRightLat: null
+            //     };
+            //     scenes.forEach(scene => {
+            //         let metadata = scene.sceneMetadata;
+            //         if (metadata.lowerLeftCornerLatitude < corners.lowerLeftLat ||
+            //             corners.lowerLeftLat === null) {
+            //             corners.lowerLeftLat = metadata.lowerLeftCornerLatitude;
+            //         }
+            //         if (metadata.lowerLeftCornerLongitude < corners.lowerLeftLon ||
+            //             corners.lowerLeftLon === null) {
+            //             corners.lowerLeftLon = metadata.lowerLeftCornerLongitude;
+            //         }
+            //         if (metadata.upperRightCornerLatitude < corners.upperRightLat ||
+            //             corners.upperRightLat === null) {
+            //             corners.upperRightLat = metadata.upperRightCornerLatitude;
+            //         }
+            //         if (metadata.upperRightCornerLongitude < corners.upperRightLon ||
+            //             corners.upperRightLon === null) {
+            //             corners.upperRightLon = metadata.upperRightCornerLongitude;
+            //         }
+            //     });
+            //     return corners;
+            // });
         }
 
         getProjectScenes(projectId, params = {}) {


### PR DESCRIPTION
## Overview
Add user button no longer shows for non-admins of teams and orgs
Fix undefined function call when selecting project scenes by clicking the map in the advanced color correction view

Add thrown error to function that doesn't seem to be used anywhere and I don't want to spend the time to fix now.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes
getProjectCorners is called in the layer service, but we don't seem to use that function for projects anywhere. I've added an error that's descriptive just in case it shows up.

## Testing Instructions
 * As a non-admin, visit a project and team page that you are a member of. Verify that there is no "add user" button
* As both an org admin, and a platform admin, visit those same pages and verify that you can see the "add user" button
* Visit the project advanced color correction view and verify that you can select scenes by clicking them on the map
Closes #4196 
Closes #4134
