### PR TITLE
Add "From" field to platform email notification settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Allow platforms to set a "From" email field in order to change notification "From" name [#\4198](Add from field for email) 
 
 ### Changed
 - Small text edit to the Imports page [\#4198](https://github.com/raster-foundry/raster-foundry/pull/4198)

--- a/app-backend/batch/src/main/scala/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/aoi/UpdateAOIProject.scala
@@ -105,7 +105,8 @@ final case class UpdateAOIProject(projectId: UUID)(
                         userEmail,
                         subject,
                         html,
-                        plain)
+                        plain,
+                        pub.emailFrom)
               .map((configuredEmail: Email) => configuredEmail.send)
             logger.info(s"Notified project owner ${user.id} about AOI updates")
           case _ =>

--- a/app-backend/batch/src/main/scala/export/UpdateExportStatus.scala
+++ b/app-backend/batch/src/main/scala/export/UpdateExportStatus.scala
@@ -177,7 +177,8 @@ final case class UpdateExportStatus(
                         userEmail,
                         subject,
                         html,
-                        plain)
+                        plain,
+                        pub.emailFrom)
               .map((configuredEmail: Email) => configuredEmail.send)
             logger.info(s"Notified owner ${user.id} about export ${exportId}.")
           case _ =>

--- a/app-backend/batch/src/main/scala/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/notification/NotifyIngestStatus.scala
@@ -181,7 +181,8 @@ final case class NotifyIngestStatus(sceneId: UUID)(
                           userEmail,
                           ingestEmailSubject,
                           htmlBody,
-                          plainBody)
+                          plainBody,
+                          pU.pubSettings.emailFrom)
                 .map((configuredEmail: Email) => configuredEmail.send)
               logger.info(s"Notified project owner ${pU.uId}.")
             case _ =>
@@ -235,7 +236,8 @@ final case class NotifyIngestStatus(sceneId: UUID)(
                         userEmail,
                         ingestEmailSubject,
                         htmlBody,
-                        plainBody)
+                        plainBody,
+                        pO.pubSettings.emailFrom)
               .map((configuredEmail: Email) => configuredEmail.send)
             logger.info(s"Notified scene owner ${pO.uId}.")
           case _ =>

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -37,8 +37,12 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
       blueBand = 2,
       bandClipping = PerBandClipping(
         enabled = true,
-        redMax = Some(9), greenMax = Some(9), blueMax = Some(9),
-        redMin = None, greenMin = None, blueMin = None
+        redMax = Some(9),
+        greenMax = Some(9),
+        blueMax = Some(9),
+        redMin = None,
+        greenMin = None,
+        blueMin = None
       ),
       gamma = BandGamma(
         enabled = true,
@@ -100,21 +104,20 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
             |    }
           """.stripMargin.parseGeoJson[MultiPolygon]()
 
-
     val expected = ExportDefinition(
       id = UUID.fromString("dda6080f-f7ad-455d-b409-764dd8c57039"),
       input = InputDefinition(
         resolution = 15,
-        style = Left(SimpleInput(
-          layers = Array(
-            ExportLayerDefinition(
+        style = Left(
+          SimpleInput(
+            layers = Array(ExportLayerDefinition(
               layerId = UUID.fromString("8436f7e9-b7f7-4d4f-bda8-76b32c356cff"),
               ingestLocation = new URI("s3://test/"),
               colorCorrections = Some(cc),
               sceneType = SceneType.Avro
             )),
-          mask = Some(mask)
-        ))
+            mask = Some(mask)
+          ))
       ),
       output = outDef
     )
@@ -122,7 +125,7 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
     val actual =
       decode[ExportDefinition](getJson("/export/localJob.json")).toOption match {
         case Some(ed) => ed
-        case _ => throw new Exception("Incorrect json to parse")
+        case _        => throw new Exception("Incorrect json to parse")
       }
 
     expected.asJson shouldBe actual.asJson
@@ -135,7 +138,11 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
 
     val inDef = InputDefinition(
       15,
-      Right(ASTInput(ast, ast.tileSources.map(_ => UUID.randomUUID -> "s3://foo/bar/").toMap, Map.empty))
+      Right(
+        ASTInput(
+          ast,
+          ast.tileSources.map(_ => UUID.randomUUID -> "s3://foo/bar/").toMap,
+          Map.empty))
     )
 
     val ed = ExportDefinition(
@@ -146,22 +153,30 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
 
     decode[ExportDefinition](ed.asJson.spaces2) match {
       case Right(ed2) => ed2 shouldBe ed
-      case Left(err) => throw new Exception(s"EXDEF: ${err}")
+      case Left(err)  => throw new Exception(s"EXDEF: ${err}")
     }
   }
 
   it("ASTInput isomorphism (project nodes)") {
-    val s0 = ProjectRaster(UUID.randomUUID, UUID.randomUUID, Some(5), None, None)
-    val s1 = ProjectRaster(UUID.randomUUID, UUID.randomUUID, Some(5), None, None)
+    val s0 =
+      ProjectRaster(UUID.randomUUID, UUID.randomUUID, Some(5), None, None)
+    val s1 =
+      ProjectRaster(UUID.randomUUID, UUID.randomUUID, Some(5), None, None)
     val ast: MapAlgebraAST = Addition(List(s0, s1), UUID.randomUUID, None)
 
-    val astIn = ASTInput(ast, Map.empty, ast.tileSources.map({ src =>
-      src.id -> List(
-        (UUID.randomUUID,"s3://foo/bar/1"),
-        (UUID.randomUUID,"s3://foo/bar/2"),
-        (UUID.randomUUID,"s3://foo/bar/3")
-      )
-    }).toMap)
+    val astIn = ASTInput(
+      ast,
+      Map.empty,
+      ast.tileSources
+        .map({ src =>
+          src.id -> List(
+            (UUID.randomUUID, "s3://foo/bar/1"),
+            (UUID.randomUUID, "s3://foo/bar/2"),
+            (UUID.randomUUID, "s3://foo/bar/3")
+          )
+        })
+        .toMap
+    )
 
     val inDef = InputDefinition(
       15,
@@ -176,7 +191,7 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
 
     decode[ExportDefinition](ed.asJson.spaces2) match {
       case Right(ed2) => ed2 shouldBe ed
-      case Left(err) => throw new Exception(s"EXDEF: ${err}")
+      case Left(err)  => throw new Exception(s"EXDEF: ${err}")
     }
   }
 }

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/sentinel2/TileInfoSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/sentinel2/TileInfoSpec.scala
@@ -52,7 +52,9 @@ class TileInfoSpec extends FunSpec with Matchers with BatchSpec {
         |      ]
         |    ]
         |  }
-      """.stripMargin.parseGeoJson[Polygon].reproject(CRS.fromName("EPSG:32601"), CRS.fromName("EPSG:3857"))
+      """.stripMargin
+        .parseGeoJson[Polygon]
+        .reproject(CRS.fromName("EPSG:32601"), CRS.fromName("EPSG:3857"))
 
     val tileDataGeometry =
       """
@@ -165,24 +167,31 @@ class TileInfoSpec extends FunSpec with Matchers with BatchSpec {
         |      ]
         |    ]
         |  }
-      """.stripMargin.parseGeoJson[Polygon].reproject(CRS.fromName("EPSG:32601"), CRS.fromName("EPSG:3857"))
+      """.stripMargin
+        .parseGeoJson[Polygon]
+        .reproject(CRS.fromName("EPSG:32601"), CRS.fromName("EPSG:3857"))
 
     val sceneMetadata =
       Map(
-        "path"                   -> "tiles/1/X/CA/2017/4/20/0",
-        "cloudyPixelPercentage"  -> "12.96",
-        "gridSquare"             -> "CA",
-        "timeStamp"              -> "2017-04-20T00:26:08.456Z",
-        "utmZone"                -> "1",
-        "productPath"            -> "products/2017/4/20/S2A_MSIL1C_20170420T002611_N0204_R102_T01XCA_20170420T002608",
-        "productName"            -> "S2A_MSIL1C_20170420T002611_N0204_R102_T01XCA_20170420T002608",
-        "latitudeBand"           -> "X",
+        "path" -> "tiles/1/X/CA/2017/4/20/0",
+        "cloudyPixelPercentage" -> "12.96",
+        "gridSquare" -> "CA",
+        "timeStamp" -> "2017-04-20T00:26:08.456Z",
+        "utmZone" -> "1",
+        "productPath" -> "products/2017/4/20/S2A_MSIL1C_20170420T002611_N0204_R102_T01XCA_20170420T002608",
+        "productName" -> "S2A_MSIL1C_20170420T002611_N0204_R102_T01XCA_20170420T002608",
+        "latitudeBand" -> "X",
         "dataCoveragePercentage" -> "51.98"
       )
 
     json.map { tileInfo =>
-      ImportSentinel2.multiPolygonFromJson(tileInfo, "tileDataGeometry").get.vertices shouldBe MultiPolygon(tileDataGeometry).vertices
-      ImportSentinel2.multiPolygonFromJson(tileInfo, "tileGeometry").get shouldBe MultiPolygon(tileGeometry)
+      ImportSentinel2
+        .multiPolygonFromJson(tileInfo, "tileDataGeometry")
+        .get
+        .vertices shouldBe MultiPolygon(tileDataGeometry).vertices
+      ImportSentinel2
+        .multiPolygonFromJson(tileInfo, "tileGeometry")
+        .get shouldBe MultiPolygon(tileGeometry)
 
       ImportSentinel2.getSceneMetadata(tileInfo) shouldBe sceneMetadata
     }

--- a/app-backend/common/src/main/scala/notification/Email.scala
+++ b/app-backend/common/src/main/scala/notification/Email.scala
@@ -41,7 +41,8 @@ class NotificationEmail extends RollbarNotifier {
                to: String,
                subject: String,
                bodyHtml: String,
-               bodyPlain: String): Either[Unit, Email] = {
+               bodyPlain: String,
+               emailFrom: Option[String] = None): Either[Unit, Email] = {
 
     val email = new HtmlEmail()
 
@@ -56,7 +57,10 @@ class NotificationEmail extends RollbarNotifier {
         email.setSslSmtpPort(port.toString)
       }
       email.setAuthenticator(new DefaultAuthenticator(uName, uPw))
-      email.setFrom(uName)
+      emailFrom match {
+        case Some(from) if from.length > 0 => email.setFrom(uName, from)
+        case _                             => email.setFrom(uName)
+      }
       email.setSubject(subject)
       email.setHtmlMsg(bodyHtml)
       email.setTextMsg(bodyPlain)

--- a/app-backend/datamodel/src/main/scala/Platform.scala
+++ b/app-backend/datamodel/src/main/scala/Platform.scala
@@ -25,7 +25,8 @@ object Platform {
                                   emailIngestNotification: Boolean,
                                   emailAoiNotification: Boolean,
                                   emailExportNotification: Boolean,
-                                  platformHost: Option[String])
+                                  platformHost: Option[String],
+                                  emailFrom: Option[String])
 
   @JsonCodec
   final case class PrivateSettings(emailPassword: String)

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -630,6 +630,7 @@ object Generators extends ArbitraryInstances {
       emailAoiNotification <- arbitrary[Boolean]
       emailExportNotification <- arbitrary[Boolean]
       platformHost <- Gen.const(None)
+      emailFrom <- arbitrary[Option[String]]
     } yield {
       Platform.PublicSettings(
         emailUser,
@@ -639,7 +640,8 @@ object Generators extends ArbitraryInstances {
         emailIngestNotification,
         emailAoiNotification,
         emailExportNotification,
-        platformHost
+        platformHost,
+        emailFrom
       )
     }
 

--- a/app-backend/db/src/main/scala/notification/Notify.scala
+++ b/app-backend/db/src/main/scala/notification/Notify.scala
@@ -35,7 +35,8 @@ object Notify extends RollbarNotifier {
             to,
             subject,
             messageRich,
-            messagePlain
+            messagePlain,
+            publicSettings.emailFrom
           )
           try {
             preparedEmail

--- a/app-backend/tile/src/test/scala/RenderDefinitionSpec.scala
+++ b/app-backend/tile/src/test/scala/RenderDefinitionSpec.scala
@@ -14,26 +14,31 @@ import geotrellis.raster.render._
 
 import scala.util.Try
 
-
 class RenderDefinitionSpec extends FunSpec with Matchers {
 
   ignore("should clip both sides (double)") {
     val renderDef = RenderDefinition(
-      Map(0.1 -> RGBA(0, 255, 0, 255), 0.2 -> RGBA(255, 0, 0, 255), 0.325 -> RGBA(0, 0, 255, 255)),
+      Map(0.1 -> RGBA(0, 255, 0, 255),
+          0.2 -> RGBA(255, 0, 0, 255),
+          0.325 -> RGBA(0, 0, 255, 255)),
       Continuous,
       ClipLeft
     )
-    val tile = DoubleArrayTile((0 to 9999 by 1 toArray).map { num => (num.toDouble / 1000.0) % .5}, 500, 20)
+    val tile = DoubleArrayTile((0 to 9999 by 1 toArray).map { num =>
+      (num.toDouble / 1000.0) % .5
+    }, 500, 20)
     DisplayTile(tile.renderPng(renderDef).bytes, tile.cols, tile.rows)
   }
 
   ignore("should clip both sides (integer)") {
     val renderDef = RenderDefinition(
-      Map(100.0 -> RGBA(0, 255, 0, 255), 200.0 -> RGBA(255, 0, 0, 255), 325.0 -> RGBA(0, 0, 255, 255)),
+      Map(100.0 -> RGBA(0, 255, 0, 255),
+          200.0 -> RGBA(255, 0, 0, 255),
+          325.0 -> RGBA(0, 0, 255, 255)),
       Continuous,
       ClipLeft
     )
-    val tile = IntArrayTile((0 to 9999 by 1 toArray).map { _ % 500}, 500, 20)
+    val tile = IntArrayTile((0 to 9999 by 1 toArray).map { _ % 500 }, 500, 20)
     DisplayTile(tile.renderPng(renderDef).bytes, tile.cols, tile.rows)
   }
 }
@@ -53,7 +58,7 @@ object DisplayTile {
 
   def apply(bytes: Array[Byte], cols: Int, rows: Int) = {
     val icon: ImageIcon = new ImageIcon(bytes);
-    val frame: JFrame =new JFrame();
+    val frame: JFrame = new JFrame();
     frame.setLayout(new FlowLayout());
     frame.setSize(cols + 20, rows + 40);
 
@@ -64,4 +69,3 @@ object DisplayTile {
     frame.setVisible(true);
   }
 }
-

--- a/app-backend/tile/src/test/scala/auth/AuthSpec.scala
+++ b/app-backend/tile/src/test/scala/auth/AuthSpec.scala
@@ -3,9 +3,7 @@ package com.rasterfoundry.tile
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.scalatest.{Matchers, WordSpec}
 
-class AuthSpec extends WordSpec
-    with Matchers
-    with ScalatestRouteTest {
+class AuthSpec extends WordSpec with Matchers with ScalatestRouteTest {
 
   val router = new Router()
 

--- a/app-backend/tile/src/test/scala/tool/TileResolverSpec.scala
+++ b/app-backend/tile/src/test/scala/tool/TileResolverSpec.scala
@@ -40,17 +40,18 @@ import com.rasterfoundry.common.utils.CogUtils
 
 import scala.concurrent.{ExecutionContext, Future}
 
-
 /** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */
 class TileResolverSpec extends WordSpec with Matchers {
   implicit val xa = RFTransactor.xa
-  val resolver = new TileResolver(implicitly[Transactor[IO]], ExecutionContext.global)
+  val resolver =
+    new TileResolver(implicitly[Transactor[IO]], ExecutionContext.global)
 
   "The tile resolver" when {
     "resolving literal tiles" should {
       "handle the COG case specially" in {
 
-        val cogUri = "http://radiant-nasa-iserv.s3-us-west-2.amazonaws.com/2014/11/12/IPR201411121933360530S07841W/IPR201411121933360530S07841W-COG.tif"
+        val cogUri =
+          "http://radiant-nasa-iserv.s3-us-west-2.amazonaws.com/2014/11/12/IPR201411121933360530S07841W/IPR201411121933360530S07841W-COG.tif"
         val ast = CogRaster(
           UUID.randomUUID(),
           Some(0),
@@ -59,25 +60,38 @@ class TileResolverSpec extends WordSpec with Matchers {
         )
 
         val cogExtent = CogUtils.getTiffExtent(cogUri)
-        val publicOrgId = UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
+        val publicOrgId =
+          UUID.fromString("dfac6307-b5ef-43f7-beda-b9f208bb7726")
         val landsatId = UUID.fromString("697a0b91-b7a8-446e-842c-97cda155554d")
 
-        val cogScene = Scene.
-          Create(
-          None, Visibility.Public, List("Test", "Public", "Low Resolution"), landsatId,
+        val cogScene = Scene.Create(
+          None,
+          Visibility.Public,
+          List("Test", "Public", "Low Resolution"),
+          landsatId,
           Map("instrument type" -> "satellite", "splines reticulated" -> "0").asJson,
-          "test scene datasource 1", None,
-            cogExtent, cogExtent, List.empty[String], List.empty[Image.Banded], List.empty[Thumbnail.Identified],
+          "test scene datasource 1",
+          None,
+          cogExtent,
+          cogExtent,
+          List.empty[String],
+          List.empty[Image.Banded],
+          List.empty[Thumbnail.Identified],
           Some(cogUri),
-          SceneFilterFields(None,
-                            Some(Timestamp.from(Instant.parse("2016-09-19T14:41:58.408544Z"))),
-                            None,
-                            None),
-          SceneStatusFields(JobStatus.Processing, JobStatus.Processing, IngestStatus.NotIngested),
+          SceneFilterFields(
+            None,
+            Some(Timestamp.from(Instant.parse("2016-09-19T14:41:58.408544Z"))),
+            None,
+            None),
+          SceneStatusFields(JobStatus.Processing,
+                            JobStatus.Processing,
+                            IngestStatus.NotIngested),
           Some(SceneType.COG)
         )
 
-        val response = Await.result(resolver.resolveBuffered(ast)(12, 1155, 2108), 10.seconds)
+        val response =
+          Await.result(resolver.resolveBuffered(ast)(12, 1155, 2108),
+                       10.seconds)
         response.isValid shouldBe true
       }
     }

--- a/app-backend/tool/src/test/scala/Generators.scala
+++ b/app-backend/tool/src/test/scala/Generators.scala
@@ -16,19 +16,23 @@ import geotrellis.vector._
 import scala.util.Random
 import java.util.UUID
 
-
 object Generators {
 
   implicit lazy val arbUUID: Arbitrary[UUID] = Arbitrary(UUID.randomUUID)
 
   implicit lazy val arbHistogram: Arbitrary[Histogram[Double]] = Arbitrary {
     val hist = StreamingHistogram()
-    1 to Random.nextInt(500) foreach(hist.countItem(_))
+    1 to Random.nextInt(500) foreach (hist.countItem(_))
     hist
   }
 
   lazy val genClassMapOptions: Gen[ClassMap.Options] = for {
-    bounds <- Gen.lzy(Gen.oneOf(LessThanOrEqualTo, LessThan, Exact, GreaterThan, GreaterThanOrEqualTo))
+    bounds <- Gen.lzy(
+      Gen.oneOf(LessThanOrEqualTo,
+                LessThan,
+                Exact,
+                GreaterThan,
+                GreaterThanOrEqualTo))
     ndVal <- arbitrary[Int]
     fallback <- arbitrary[Int]
   } yield ClassMap.Options(bounds, ndVal, fallback)
@@ -47,26 +51,46 @@ object Generators {
 
   lazy val genNodeMetadata: Gen[NodeMetadata] = for {
     label <- Gen.option(arbitrary[String])
-    desc  <- Gen.option(arbitrary[String])
-    hist  <- Gen.option(arbitrary[Histogram[Double]])
-    cRamp <- Gen.lzy(Gen.option(Gen.oneOf(ColorRamps.Viridis, ColorRamps.Inferno, ColorRamps.Magma)))
-    cMap  <- Gen.option(genClassMap)
+    desc <- Gen.option(arbitrary[String])
+    hist <- Gen.option(arbitrary[Histogram[Double]])
+    cRamp <- Gen.lzy(
+      Gen.option(
+        Gen.oneOf(ColorRamps.Viridis, ColorRamps.Inferno, ColorRamps.Magma)))
+    cMap <- Gen.option(genClassMap)
   } yield NodeMetadata(label, desc, hist, cRamp, cMap)
 
   lazy val genRFMLRaster: Gen[RFMLRaster] = for {
     band <- arbitrary[Int]
     id <- arbitrary[UUID]
     imageId <- arbitrary[UUID]
-    constructor <- Gen.lzy(Gen.oneOf(MapAlgebraAST.SceneRaster.apply _, MapAlgebraAST.ProjectRaster.apply _))
-    celltype <- Gen.lzy(Gen.oneOf(
-      BitCellType, ByteCellType, UByteCellType, ShortCellType, UShortCellType, IntCellType,
-      FloatCellType, DoubleCellType, ByteConstantNoDataCellType, UByteConstantNoDataCellType,
-      ShortConstantNoDataCellType, UShortConstantNoDataCellType, IntConstantNoDataCellType,
-      FloatConstantNoDataCellType, DoubleConstantNoDataCellType, ByteUserDefinedNoDataCellType(42),
-      UByteUserDefinedNoDataCellType(42), ShortUserDefinedNoDataCellType(42),
-      UShortUserDefinedNoDataCellType(42), IntUserDefinedNoDataCellType(42),
-      FloatUserDefinedNoDataCellType(42), DoubleUserDefinedNoDataCellType(42)
-    ))
+    constructor <- Gen.lzy(
+      Gen.oneOf(MapAlgebraAST.SceneRaster.apply _,
+                MapAlgebraAST.ProjectRaster.apply _))
+    celltype <- Gen.lzy(
+      Gen.oneOf(
+        BitCellType,
+        ByteCellType,
+        UByteCellType,
+        ShortCellType,
+        UShortCellType,
+        IntCellType,
+        FloatCellType,
+        DoubleCellType,
+        ByteConstantNoDataCellType,
+        UByteConstantNoDataCellType,
+        ShortConstantNoDataCellType,
+        UShortConstantNoDataCellType,
+        IntConstantNoDataCellType,
+        FloatConstantNoDataCellType,
+        DoubleConstantNoDataCellType,
+        ByteUserDefinedNoDataCellType(42),
+        UByteUserDefinedNoDataCellType(42),
+        ShortUserDefinedNoDataCellType(42),
+        UShortUserDefinedNoDataCellType(42),
+        IntUserDefinedNoDataCellType(42),
+        FloatUserDefinedNoDataCellType(42),
+        DoubleUserDefinedNoDataCellType(42)
+      ))
     nmd <- Gen.option(genNodeMetadata)
   } yield constructor(id, imageId, Some(band), None, nmd)
 
@@ -86,58 +110,64 @@ object Generators {
     toolId <- arbitrary[UUID]
   } yield MapAlgebraAST.ToolReference(id, toolId)
 
-  def genBinaryOpAST(depth: Int) = for {
-    constructor <- Gen.lzy(Gen.oneOf(
-                     MapAlgebraAST.Addition.apply _,
-                     MapAlgebraAST.Subtraction.apply _,
-                     MapAlgebraAST.Multiplication.apply _,
-                     MapAlgebraAST.Division.apply _,
-                     MapAlgebraAST.Max.apply _,
-                     MapAlgebraAST.Min.apply _
-                   ))
-    args <- containerOfN[List, MapAlgebraAST](2, genMapAlgebraAST(depth))
-    id <- arbitrary[UUID]
-    nmd <- Gen.option(genNodeMetadata)
-  } yield constructor(args, id, nmd)
+  def genBinaryOpAST(depth: Int) =
+    for {
+      constructor <- Gen.lzy(
+        Gen.oneOf(
+          MapAlgebraAST.Addition.apply _,
+          MapAlgebraAST.Subtraction.apply _,
+          MapAlgebraAST.Multiplication.apply _,
+          MapAlgebraAST.Division.apply _,
+          MapAlgebraAST.Max.apply _,
+          MapAlgebraAST.Min.apply _
+        ))
+      args <- containerOfN[List, MapAlgebraAST](2, genMapAlgebraAST(depth))
+      id <- arbitrary[UUID]
+      nmd <- Gen.option(genNodeMetadata)
+    } yield constructor(args, id, nmd)
 
-  def genClassificationAST(depth: Int) = for {
-    args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
-    id <- arbitrary[UUID]
-    nmd <- Gen.option(genNodeMetadata)
-    cmap <- genClassMap
-  } yield MapAlgebraAST.Classification(args, id, nmd, cmap)
+  def genClassificationAST(depth: Int) =
+    for {
+      args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
+      id <- arbitrary[UUID]
+      nmd <- Gen.option(genNodeMetadata)
+      cmap <- genClassMap
+    } yield MapAlgebraAST.Classification(args, id, nmd, cmap)
 
-  def genMaskingAST(depth: Int) = for {
-    args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
-    id <- arbitrary[UUID]
-    nmd <- Gen.option(genNodeMetadata)
-  } yield {
-    val mp = MultiPolygon(Polygon((0, 0), (0, 10), (10, 10), (10, 0), (0, 0)))
+  def genMaskingAST(depth: Int) =
+    for {
+      args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
+      id <- arbitrary[UUID]
+      nmd <- Gen.option(genNodeMetadata)
+    } yield {
+      val mp = MultiPolygon(Polygon((0, 0), (0, 10), (10, 10), (10, 0), (0, 0)))
 
-    MapAlgebraAST.Masking(args, id, nmd, mp)
-  }
+      MapAlgebraAST.Masking(args, id, nmd, mp)
+    }
 
-  def genFocalOpAST(depth: Int) = for {
-    constructor  <- Gen.lzy(Gen.oneOf(
-                      MapAlgebraAST.FocalMax.apply _,
-                      MapAlgebraAST.FocalMin.apply _,
-                      MapAlgebraAST.FocalStdDev.apply _,
-                      MapAlgebraAST.FocalMean.apply _,
-                      MapAlgebraAST.FocalMedian.apply _,
-                      MapAlgebraAST.FocalMode.apply _,
-                      MapAlgebraAST.FocalSum.apply _
-                    ))
-    args         <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
-    id           <- arbitrary[UUID]
-    nmd          <- Gen.option(genNodeMetadata)
-    neighborhood <- Gen.oneOf(
-                      Square(123),
-                      Circle(123.4),
-                      Nesw(123),
-                      Wedge(42.2, 45.1, 51.3),
-                      Annulus(123.0, 123.4)
-                    )
-  } yield constructor(args, id, nmd, neighborhood)
+  def genFocalOpAST(depth: Int) =
+    for {
+      constructor <- Gen.lzy(
+        Gen.oneOf(
+          MapAlgebraAST.FocalMax.apply _,
+          MapAlgebraAST.FocalMin.apply _,
+          MapAlgebraAST.FocalStdDev.apply _,
+          MapAlgebraAST.FocalMean.apply _,
+          MapAlgebraAST.FocalMedian.apply _,
+          MapAlgebraAST.FocalMode.apply _,
+          MapAlgebraAST.FocalSum.apply _
+        ))
+      args <- containerOfN[List, MapAlgebraAST](1, genMapAlgebraAST(depth))
+      id <- arbitrary[UUID]
+      nmd <- Gen.option(genNodeMetadata)
+      neighborhood <- Gen.oneOf(
+        Square(123),
+        Circle(123.4),
+        Nesw(123),
+        Wedge(42.2, 45.1, 51.3),
+        Annulus(123.0, 123.4)
+      )
+    } yield constructor(args, id, nmd, neighborhood)
 
   // TODO: If `genMaskingAST` is included, AST generation diverges!
   def genOpAST(depth: Int) = Gen.frequency(

--- a/app-backend/tool/src/test/scala/ast/CanonicalTools.scala
+++ b/app-backend/tool/src/test/scala/ast/CanonicalTools.scala
@@ -8,58 +8,85 @@ import io.circe.syntax._
 
 import java.util.UUID
 
-
 class CanonicalTools extends FunSpec with Matchers {
   import MapAlgebraAST._
 
   val B1 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_1".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Blue"),
-      Some("Wavelength: 0.45-0.52 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Blue"),
+        Some("Wavelength: 0.45-0.52 μm"),
+        None,
+        None,
+        None
+      ))
   )
   val B2 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_2".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Green"),
-      Some("Wavelength: 0.52-0.60 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Green"),
+        Some("Wavelength: 0.52-0.60 μm"),
+        None,
+        None,
+        None
+      ))
   )
   val B3 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_3".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Red"),
-      Some("Wavelength: 0.63-0.69 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Red"),
+        Some("Wavelength: 0.63-0.69 μm"),
+        None,
+        None,
+        None
+      ))
   )
   val B4 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_4".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Near Infrared (NIR)"),
-      Some("Wavelength: 0.76-0.90 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Near Infrared (NIR)"),
+        Some("Wavelength: 0.76-0.90 μm"),
+        None,
+        None,
+        None
+      ))
   )
   val B5 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_5".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Shortwave Infrared (SWIR) 1"),
-      Some("Wavelength: 1.55-1.75 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Shortwave Infrared (SWIR) 1"),
+        Some("Wavelength: 1.55-1.75 μm"),
+        None,
+        None,
+        None
+      ))
   )
   val B6 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_6".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Thermal"),
-      Some("Wavelength: 10.40-12.50 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Thermal"),
+        Some("Wavelength: 10.40-12.50 μm"),
+        None,
+        None,
+        None
+      ))
   )
   val B7 = Source(
     UUID.nameUUIDFromBytes("LANDSAT_BAND_7".getBytes),
-    Some(NodeMetadata(
-      Some("Landsat Shortwave Infrared (SWIR) 2"),
-      Some("Wavelength: 2.08-2.35 μm"), None, None, None
-    ))
+    Some(
+      NodeMetadata(
+        Some("Landsat Shortwave Infrared (SWIR) 2"),
+        Some("Wavelength: 2.08-2.35 μm"),
+        None,
+        None,
+        None
+      ))
   )
 
   val phycocyanin =
@@ -71,61 +98,82 @@ class CanonicalTools extends FunSpec with Matchers {
             Constant(UUID.nameUUIDFromBytes("-9.21".getBytes), -9.21, None),
             Division(
               List(B4, B2),
-              UUID.nameUUIDFromBytes("div1".getBytes), None
+              UUID.nameUUIDFromBytes("div1".getBytes),
+              None
             )
-          ), UUID.nameUUIDFromBytes("mult1".getBytes), None
+          ),
+          UUID.nameUUIDFromBytes("mult1".getBytes),
+          None
         ),
         Multiplication(
           List(
             Constant(UUID.nameUUIDFromBytes("29.7".getBytes), 29.7, None),
             Division(
               List(B5, B2),
-              UUID.nameUUIDFromBytes("div2".getBytes), None
+              UUID.nameUUIDFromBytes("div2".getBytes),
+              None
             )
-          ), UUID.nameUUIDFromBytes("mult2".getBytes), None
+          ),
+          UUID.nameUUIDFromBytes("mult2".getBytes),
+          None
         ),
         Multiplication(
           List(
             Constant(UUID.nameUUIDFromBytes("-118".getBytes), -118, None),
             Division(
               List(B5, B4),
-              UUID.nameUUIDFromBytes("div3".getBytes), None
+              UUID.nameUUIDFromBytes("div3".getBytes),
+              None
             )
-          ), UUID.nameUUIDFromBytes("mult3".getBytes), None
+          ),
+          UUID.nameUUIDFromBytes("mult3".getBytes),
+          None
         ),
         Multiplication(
           List(
             Constant(UUID.nameUUIDFromBytes("-6.81".getBytes), -6.81, None),
             Division(
               List(B6, B4),
-              UUID.nameUUIDFromBytes("div4".getBytes), None
+              UUID.nameUUIDFromBytes("div4".getBytes),
+              None
             )
-          ), UUID.nameUUIDFromBytes("mult4".getBytes), None
+          ),
+          UUID.nameUUIDFromBytes("mult4".getBytes),
+          None
         ),
         Multiplication(
           List(
             Constant(UUID.nameUUIDFromBytes("41.9".getBytes), 41.9, None),
             Division(
               List(B7, B4),
-              UUID.nameUUIDFromBytes("div5".getBytes), None
+              UUID.nameUUIDFromBytes("div5".getBytes),
+              None
             )
-          ), UUID.nameUUIDFromBytes("mult5".getBytes), None
+          ),
+          UUID.nameUUIDFromBytes("mult5".getBytes),
+          None
         ),
         Multiplication(
           List(
             Constant(UUID.nameUUIDFromBytes("-14.7".getBytes), -14.7, None),
             Division(
               List(B7, B5),
-              UUID.nameUUIDFromBytes("div6".getBytes), None
+              UUID.nameUUIDFromBytes("div6".getBytes),
+              None
             )
-          ), UUID.nameUUIDFromBytes("mult6".getBytes), None
+          ),
+          UUID.nameUUIDFromBytes("mult6".getBytes),
+          None
         )
       ),
       UUID.nameUUIDFromBytes("add".getBytes),
       Some(NodeMetadata(
         Some("Phycocyanin Detection"),
-        Some("http://www.sciencedirect.com/science/article/pii/S0034425716304928"),
-        None, None, None
+        Some(
+          "http://www.sciencedirect.com/science/article/pii/S0034425716304928"),
+        None,
+        None,
+        None
       ))
     )
 
@@ -138,28 +186,38 @@ class CanonicalTools extends FunSpec with Matchers {
             Constant(UUID.nameUUIDFromBytes("-1.03".getBytes), -1.03, None),
             B6
           ),
-          UUID.nameUUIDFromBytes("div1".getBytes), None
+          UUID.nameUUIDFromBytes("div1".getBytes),
+          None
         )
       ),
       UUID.nameUUIDFromBytes("sub1".getBytes),
-      Some(NodeMetadata(
-        Some("Improved NIR with SAC"),
-        Some("The most performant index from http://www.sciencedirect.com/science/article/pii/S0034425716304928"),
-        None, None, None
-      ))
+      Some(
+        NodeMetadata(
+          Some("Improved NIR with SAC"),
+          Some(
+            "The most performant index from http://www.sciencedirect.com/science/article/pii/S0034425716304928"),
+          None,
+          None,
+          None
+        ))
     )
 
   val NIRoverRedWithSAC =
     Division(
       List(
-        Subtraction(List(B4, B5), UUID.nameUUIDFromBytes("sub1".getBytes), None),
+        Subtraction(List(B4, B5),
+                    UUID.nameUUIDFromBytes("sub1".getBytes),
+                    None),
         Subtraction(List(B3, B5), UUID.nameUUIDFromBytes("sub2".getBytes), None)
       ),
       UUID.nameUUIDFromBytes("div1".getBytes),
       Some(NodeMetadata(
         Some("NIR over red, with SAC"),
-        Some("http://www.sciencedirect.com/science/article/pii/S0034425716304928"),
-        None, None, None
+        Some(
+          "http://www.sciencedirect.com/science/article/pii/S0034425716304928"),
+        None,
+        None,
+        None
       ))
     )
 

--- a/app-backend/tool/src/test/scala/ast/MapAlgebraASTSpec.scala
+++ b/app-backend/tool/src/test/scala/ast/MapAlgebraASTSpec.scala
@@ -19,7 +19,7 @@ class MapAlgebraASTSpec extends FunSpec with Matchers {
     val src6 = randomSourceAST
     val uberAst = src1 + src2 * src3 / src4 max src5 min src6
 
-    uberAst.find(src4.id) should be (Some(src4))
+    uberAst.find(src4.id) should be(Some(src4))
   }
 
   it("Can substitute ToolRef branches") {
@@ -29,6 +29,7 @@ class MapAlgebraASTSpec extends FunSpec with Matchers {
     val preSub = src1 + ref
     val postSub = src1 + replacement
 
-    preSub.substitute(Map(ref.toolId -> replacement)).get.args.toSeq should be (postSub.args.toSeq)
+    preSub.substitute(Map(ref.toolId -> replacement)).get.args.toSeq should be(
+      postSub.args.toSeq)
   }
 }

--- a/app-backend/tool/src/test/scala/ast/codec/MapAlgebraASTCodecSpec.scala
+++ b/app-backend/tool/src/test/scala/ast/codec/MapAlgebraASTCodecSpec.scala
@@ -8,7 +8,6 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop._
 
-
 class MapAlgebraASTCodecSpec extends PropSpec with Checkers {
   property("bijective serialization") {
     check(forAll(genMapAlgebraAST()) { (ast: MapAlgebraAST) =>

--- a/app-frontend/src/app/pages/admin/platform/settings/email/email.html
+++ b/app-frontend/src/app/pages/admin/platform/settings/email/email.html
@@ -40,6 +40,16 @@
       <span class="error color-danger" ng-show="emailSettings.password.$error.required">required</span>
     </div>
     <div class="form-group">
+      <label for="emailfrom">From</label>
+      <input id="emailfrom"
+             type="text"
+             class="form-control"
+             name="emailfrom"
+             ng-attr-placeholder="{{$ctrl.platformBuffer.publicSettings.emailFrom ?
+                 $ctrl.platformBuffer.publicSettings.emailFrom : 'Default'}}"
+             ng-model="$ctrl.platformBuffer.publicSettings.emailFrom">
+    </div>
+    <div class="form-group">
       <label for="smtp">SMTP Host</label>
       <input id="smtp"
              type="text"


### PR DESCRIPTION
## Overview
* Allow setting the "From" name for emails set by a platform
* Some scalafmt changes
### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Demo
![image](https://user-images.githubusercontent.com/4392704/46974978-723a6680-d093-11e8-87ff-1880141616fe.png)


## Testing Instructions

 * As a platform admin, go to the email settings page and add a name to the "From" field
* Verify that it persists through reloads
* Make sure all the other fields are set up to work on dev and then invite a user to an organization. Verify that the email is set up correctly and the "From" field is used to populate the name for the email

Closes #3677 
