### PR TITLE
Hide project previews with > 30 scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Updated package and assembly jar names [\#3924](https://github.com/raster-foundry/raster-foundry/pull/3924), [\#4222](https://github.com/raster-foundry/raster-foundry/pull/4222)
 - Updated package and assembly jar names [\#3924](https://github.com/raster-foundry/raster-foundry/pull/3924)
 - Change homepage "Create a new Template" button to "Create a new Analysis" [/#4224](https://github.com/raster-foundry/raster-foundry/pull/4224)
+- Projects with > 30 scenes will not show a preview on the project list page [/#4231](https://github.com/raster-foundry/raster-foundry/pull/4231)
 
 ### Deprecated
 

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.html
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.html
@@ -1,7 +1,7 @@
 <div class="panel-body">
   <ng-container ng-if="!$ctrl.slim">
     <rf-status-tag ng-if="$ctrl.status && $ctrl.status != 'CURRENT' " entity-type="project" status="$ctrl.status" class="project-status"></rf-status-tag>
-    <a href ui-sref="projects.edit({projectid: $ctrl.project.id})" class="no-hover">
+    <a href ui-sref="projects.edit.scenes({projectid: $ctrl.project.id})" class="no-hover">
       <img class="avatar tiny" ng-attr-src="{{ $ctrl.project.owner.profileImageUri }}" ng-if="$ctrl.project.owner.profileImageUri"/>
       <h4 class="project-title" data-title="{{$ctrl.project.name}}">{{$ctrl.project.name}}</h4>
     </a>
@@ -20,7 +20,7 @@
       </a>
     </div>
     <div class="project-preview">
-      <a ui-sref="projects.edit({projectid: $ctrl.project.id})" style="text-decoration: none">
+      <a ui-sref="projects.edit.scenes({projectid: $ctrl.project.id})" style="text-decoration: none">
         <!-- IF project has no scenes -->
         <div class="project-preview-container placeholder"
              ng-if="$ctrl.status === 'NOSCENES'"
@@ -29,7 +29,13 @@
 
         <!-- IF not all scenes ingested: -->
         <div class="project-preview-container placeholder"
-             ng-if="$ctrl.status !== 'CURRENT' && $ctrl.status !== 'NOSCENES'"
+             ng-if="$ctrl.status === 'PARTIAL'"
+             style="background-image: url({{$ctrl.projectPlaceholder}})">
+        </div>
+
+        <!-- IF large project -->
+        <div class="project-preview-container placeholder"
+             ng-if="$ctrl.status == 'LARGE'"
              style="background-image: url({{$ctrl.projectPlaceholder}})">
         </div>
 

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -359,7 +359,7 @@ export default (app) => {
                     return 'FAILED';
                 } else if (successScenes.count < allScenes.count) {
                     return 'PARTIAL';
-                } else if (allScenes.count > this.scenePageSize){
+                } else if (allScenes.count > this.scenePageSize) {
                     return 'LARGE';
                 } else if (successScenes.count === allScenes.count && allScenes.count > 0) {
                     return 'CURRENT';

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -359,6 +359,8 @@ export default (app) => {
                     return 'FAILED';
                 } else if (successScenes.count < allScenes.count) {
                     return 'PARTIAL';
+                } else if (allScenes.count > this.scenePageSize){
+                    return 'LARGE';
                 } else if (successScenes.count === allScenes.count && allScenes.count > 0) {
                     return 'CURRENT';
                 }

--- a/app-frontend/src/app/services/settings/status.service.js
+++ b/app-frontend/src/app/services/settings/status.service.js
@@ -85,6 +85,10 @@ const statusMapping = {
             "label": "No scenes",
             "color": "grey"
         },
+        "LARGE": {
+            "label": "Too many scenes to preview",
+            "color": "grey"
+        },
         "PARTIAL": {
             "label": "Not all scenes have been ingested",
             "color": "yellow"


### PR DESCRIPTION
## Overview
Hide project previews with > 30 scenes
Fix routing to project instead of project.scenes

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/47100078-aed99f80-d204-11e8-84b9-8b579e87ac1d.png)


## Testing Instructions

 * Create a project with > 30 ingested scenes
* Verify that the preview doesn't show
* Add an uningested scene to it
* Verify that it now shows that it has uningested scenes instead

Closes #4095