### PR TITLE
Let platform admins set upload owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Added
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [\#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
-- Allow platforms to set a "From" email field in order to change notification "From" name [#\4198](Add from field for email)
 - Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
+- Administration
+  - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214) 
+  - Allow platform administrators to create uploads for other users within their platforms [\#4237](https://github.com/raster-foundry/raster-foundry/pull/4237)
 
 ### Changed
 - Small text edit to the Imports page [\#4198](https://github.com/raster-foundry/raster-foundry/pull/4198)

--- a/app-backend/datamodel/src/main/scala/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/Upload.scala
@@ -47,13 +47,15 @@ object Upload {
       val now = new Timestamp(new java.util.Date().getTime)
       // This logic isn't in OwnerCheck because we don't know that we want to let Platform Admins set owners on
       // everything in the universe yet. If that does become the case we can move it to the trait.
-      val ownerId = (owner, ownerPlatform, user.id, userPlatformAdmin) match {
+      val ownerId = (owner, ownerPlatform, user, userPlatformAdmin) match {
         // if no intended owner, the acting user is the owner
-        case (None, None, userId, _) =>
-          userId
+        case (intendedOwnerO, _, user, _) if user.isSuperuser =>
+          intendedOwnerO.getOrElse(user.id)
+        case (None, None, user, _) =>
+          user.id
         // if intended owner and acting user are the same, then the other conditions shake out in the wash
-        case (Some(intendedOwner), _, userId, _) if userId == intendedOwner =>
-          userId
+        case (Some(intendedOwner), _, user, _) if user.id == intendedOwner =>
+          user.id
         // when intendedOwner and user are different people, we check that both the two users' platforms
         // match and that the acting user is an admin of that platform
         case (Some(intendedOwner),

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/UploadSpec.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/UploadSpec.scala
@@ -1,0 +1,107 @@
+package com.rasterfoundry.datamodel
+
+import io.circe._
+import io.circe.syntax._
+
+import java.util.UUID
+import org.scalatest._
+
+class UploadTestSuite extends FunSuite with Matchers {
+
+  test(
+    "non-platform admins should not be able to create uploads for other users") {
+    val uploadCreate = Upload.Create(
+      UploadStatus.Uploaded,
+      FileType.Geotiff,
+      UploadType.Dropbox,
+      List.empty,
+      UUID.randomUUID,
+      ().asJson,
+      Some("foo"), // proposed owner
+      Visibility.Private,
+      None,
+      None
+    )
+    // note the id is not "foo"
+    val user = User.Create("bar").toUser
+    val platformId = UUID.randomUUID
+    an[IllegalArgumentException] should be thrownBy (
+      uploadCreate.toUpload(user,
+                            (platformId, false),
+                            Some(platformId))
+    )
+  }
+
+  test(
+    "platform admins should be able to create uploads for other users in the same platform") {
+    val uploadCreate = Upload.Create(
+      UploadStatus.Uploaded,
+      FileType.Geotiff,
+      UploadType.Dropbox,
+      List.empty,
+      UUID.randomUUID,
+      ().asJson,
+      Some("foo"), // proposed owner
+      Visibility.Private,
+      None,
+      None
+    )
+    // note the id is not "foo"
+    val user = User.Create("bar").toUser
+    val platformId = UUID.randomUUID
+    Some(
+      uploadCreate
+        .toUpload(user, (platformId, true), Some(platformId))
+        .owner) shouldEqual uploadCreate.owner
+  }
+
+  test(
+    "platform admins should not be able to create uploads for other users in different platforms") {
+    val uploadCreate = Upload.Create(
+      UploadStatus.Uploaded,
+      FileType.Geotiff,
+      UploadType.Dropbox,
+      List.empty,
+      UUID.randomUUID,
+      ().asJson,
+      Some("foo"), // proposed owner
+      Visibility.Private,
+      None,
+      None
+    )
+    // note the id is not "foo"
+    val user = User.Create("bar").toUser
+    an[IllegalArgumentException] should be thrownBy (
+      uploadCreate.toUpload(user,
+                            (UUID.randomUUID, false),
+                            Some(UUID.randomUUID))
+    )
+  }
+
+  test(
+    "superusers should also be able to create uploads for other users regardless of platform") {
+    val uploadCreate = Upload.Create(
+      UploadStatus.Uploaded,
+      FileType.Geotiff,
+      UploadType.Dropbox,
+      List.empty,
+      UUID.randomUUID,
+      ().asJson,
+      Some("foo"), // proposed owner
+      Visibility.Private,
+      None,
+      None
+    )
+    // note the id is not "foo"
+    val user = User
+      .Create("bar")
+      .toUser
+      .copy(
+        isSuperuser = true
+      )
+    Some(
+      uploadCreate
+        .toUpload(user, (UUID.randomUUID, true), Some(UUID.randomUUID))
+        .owner) shouldEqual uploadCreate.owner
+  }
+}

--- a/app-backend/db/src/main/scala/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/PlatformDao.scala
@@ -2,7 +2,6 @@ package com.rasterfoundry.database
 
 import java.util.UUID
 
-import cats.free.Free
 import com.rasterfoundry.database.filter.Filters._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
@@ -177,8 +176,7 @@ object PlatformDao extends Dao[Platform] {
       )
   """
 
-  def userIsAdmin(user: User,
-                  platformId: UUID): Free[connection.ConnectionOp, Boolean] =
+  def userIsAdmin(user: User, platformId: UUID): ConnectionIO[Boolean] =
     userIsAdminF(user, platformId).query[Boolean].option.map(_.getOrElse(false))
 
   def delete(platformId: UUID): ConnectionIO[Int] =


### PR DESCRIPTION
## Overview

This PR makes it so that platform admins can set owners who aren't them on upload objects while preserving that power for superusers.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Weird heavy case sequence is tested

## Testing Instructions

 * look at the tests

Closes #4226
