### PR TITLE
Fix visualization of ingested planet scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [\#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
-- Allow platforms to set a "From" email field in order to change notification "From" name [#\4198](Add from field for email) 
+- Allow platforms to set a "From" email field in order to change notification "From" name [#\4198](Add from field for email)
 - Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
 
 ### Changed
@@ -20,6 +20,7 @@
 ### Fixed
 - Add user button no longer shows for non-admins of teams and orgs [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix undefined function call when selecting project scenes by clicking the map in advanced color correction view [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
+- Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)
 
 ### Security
 

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -234,34 +234,28 @@ object SceneDao
     }
   }
 
-  def getMosaicDefinition(sceneId: UUID, polygonO: Option[Projected[Polygon]])
-    : ConnectionIO[Seq[MosaicDefinition]] = {
+  def getMosaicDefinition(
+    sceneId: UUID,
+    polygonO: Option[Projected[Polygon]],
+    redBand: Int,
+    greenBand: Int,
+    blueBand: Int): ConnectionIO[Seq[MosaicDefinition]] = {
     val polygonF: Fragment = polygonO match {
       case Some(polygon) => fr"ST_Intersects(tile_footprint, ${polygon})"
       case _             => fr""
     }
     for {
       sceneO <- SceneDao.query.filter(sceneId).filter(polygonF).selectOption
-      datasourceO <- sceneO match {
-        case Some(s: Scene) =>
-          DatasourceDao.query.filter(s.datasource).selectOption
-        case _ => None.pure[ConnectionIO]
-      }
     } yield {
-      (sceneO, datasourceO) match {
-        case (Some(scene: Scene), Some(datasource: Datasource)) =>
-          val composites = datasource.composites
-          val redBandPath = root.natural.selectDynamic("value").redBand.int
-          val greenBandPath = root.natural.selectDynamic("value").greenBand.int
-          val blueBandPath = root.natural.selectDynamic("value").blueBand.int
-
+      sceneO match {
+        case Some(scene: Scene) =>
           Seq(
             MosaicDefinition(
               scene.id,
               ColorCorrect.Params(
-                redBandPath.getOption(composites).getOrElse(0),
-                greenBandPath.getOption(composites).getOrElse(1),
-                blueBandPath.getOption(composites).getOrElse(2),
+                redBand,
+                greenBand,
+                blueBand,
                 BandGamma(enabled = false, None, None, None),
                 PerBandClipping(enabled = false,
                                 None,

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -235,11 +235,11 @@ object SceneDao
   }
 
   def getMosaicDefinition(
-    sceneId: UUID,
-    polygonO: Option[Projected[Polygon]],
-    redBand: Int,
-    greenBand: Int,
-    blueBand: Int): ConnectionIO[Seq[MosaicDefinition]] = {
+      sceneId: UUID,
+      polygonO: Option[Projected[Polygon]],
+      redBand: Int,
+      greenBand: Int,
+      blueBand: Int): ConnectionIO[Seq[MosaicDefinition]] = {
     val polygonF: Fragment = polygonO match {
       case Some(polygon) => fr"ST_Intersects(tile_footprint, ${polygon})"
       case _             => fr""

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -64,6 +64,9 @@ object Mosaic extends LazyLogging with KamonTrace {
       zoom: Int,
       col: Int,
       row: Int,
+      redband: Int,
+      greenBand: Int,
+      blueBand: Int,
       isScene: Boolean
   )(implicit xa: Transactor[IO]): OptionT[Future, MultibandTile] =
     traceName(s"Mosaic.apply($id)") {
@@ -75,7 +78,7 @@ object Mosaic extends LazyLogging with KamonTrace {
             .transact(xa)
             .unsafeToFuture) flatMap { scene =>
           logger.debug(s"Constructing MultiBand Mosaic ${scene}")
-          MultiBandMosaic(id, zoom, col, row, true)
+          MultiBandMosaic(id, zoom, col, row, redband, greenBand, blueBand, true)
         }
       } else {
         apply(id, zoom, col, row)

--- a/app-backend/tile/src/main/scala/image/Mosaic.scala
+++ b/app-backend/tile/src/main/scala/image/Mosaic.scala
@@ -78,7 +78,14 @@ object Mosaic extends LazyLogging with KamonTrace {
             .transact(xa)
             .unsafeToFuture) flatMap { scene =>
           logger.debug(s"Constructing MultiBand Mosaic ${scene}")
-          MultiBandMosaic(id, zoom, col, row, redband, greenBand, blueBand, true)
+          MultiBandMosaic(id,
+                          zoom,
+                          col,
+                          row,
+                          redband,
+                          greenBand,
+                          blueBand,
+                          true)
         }
       } else {
         apply(id, zoom, col, row)

--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -337,7 +337,12 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
         val polygonBbox: Projected[Polygon] =
           TileUtils.getTileBounds(zoom, col, row)
         val md: Future[Seq[MosaicDefinition]] =
-          mosaicDefinition(id, Option(polygonBbox), redband, greenBand, blueBand, true)
+          mosaicDefinition(id,
+                           Option(polygonBbox),
+                           redband,
+                           greenBand,
+                           blueBand,
+                           true)
         OptionT(
           mergeTiles(
             renderForBbox(md,

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -37,30 +37,7 @@ class SceneDetailModalController {
     }
 
     $postLink() {
-        this.getMap().then(mapWrapper => {
-            if (this.scene.sceneType === 'COG') {
-                mapWrapper.setLayer(
-                  'Browse Scene',
-                  L.tileLayer(
-                    this.sceneService.getSceneLayerURL(
-                        this.scene,
-                        {token: this.authService.token()}
-                    ),
-                    {maxZoom: 30}
-                  ),
-                  true
-                );
-            } else {
-                mapWrapper.setThumbnail(
-                    this.scene,
-                    this.repository,
-                    {
-                        persist: true
-                    }
-                );
-            }
-            mapWrapper.map.fitBounds(this.getSceneBounds());
-        });
+        this.setThumbnail();
         this.repository.service.getDatasource(this.scene).then(d => {
             this.datasource = d;
         });
@@ -71,6 +48,38 @@ class SceneDetailModalController {
         this.accDateDisplay = this.setAccDateDisplay();
         this.isUploadDone = true;
         this.isOwner = this.scene.owner === this.authService.getProfile().sub;
+    }
+
+    setThumbnail() {
+        this.getMap().then(mapWrapper => {
+            if (this.scene.sceneType === 'COG') {
+                this.setCOGThumbnail(mapWrapper);
+            } else {
+                mapWrapper.setThumbnail(this.scene, this.repository, {persist: true});
+            }
+            mapWrapper.map.fitBounds(this.getSceneBounds());
+        });
+    }
+
+    setCOGThumbnail(mapWrapper) {
+        this.repository.service.getDatasourceBands(this.scene).then(rgbBands => {
+            mapWrapper.setLayer(
+              'Browse Scene',
+              L.tileLayer(
+                this.sceneService.getSceneLayerURL(
+                    this.scene,
+                    {
+                        token: this.authService.token(),
+                        redBand: rgbBands.RED,
+                        greenBand: rgbBands.GREEN,
+                        blueBand: rgbBands.BLUE
+                    }
+                ),
+                {maxZoom: 30}
+              ),
+              true
+            );
+        });
     }
 
     openDownloadModal() {

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -68,18 +68,21 @@ class SceneItemController {
         if (changes.repository && changes.repository.currentValue) {
             this.repository = changes.repository.currentValue;
             if (this.scene.sceneType === 'COG') {
-                let redBand = _.findIndex(
-                    this.datasource.bands, (x) => x.name.toLowerCase() === 'red');
-                let greenBand = _.findIndex(
-                    this.datasource.bands, (x) => x.name.toLowerCase() === 'green');
-                let blueBand = _.findIndex(
-                    this.datasource.bands, (x) => x.name.toLowerCase() === 'blue');
+                let redBand = this.datasource.bands.find(x => {
+                    return x.name.toLowerCase() === 'red';
+                }).number;
+                let greenBand = this.datasource.bands.find(x => {
+                    return x.name.toLowerCase() === 'green';
+                }).number;
+                let blueBand = this.datasource.bands.find(x => {
+                    return x.name.toLowerCase() === 'blue';
+                }).number;
                 let bands = {};
                 let atLeastThreeBands = this.datasource.bands.length >= 3;
                 if (atLeastThreeBands) {
-                    bands.red = redBand || 0;
-                    bands.green = greenBand || 1;
-                    bands.blue = blueBand || 2;
+                    bands.red = parseInt(redBand || 0, 10);
+                    bands.green = parseInt(greenBand || 1, 10);
+                    bands.blue = parseInt(blueBand || 2, 10);
                 } else {
                     bands.red = 0;
                     bands.green = 0;

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -218,18 +218,29 @@ class ProjectsSceneBrowserController {
                 if (scene.sceneType !== 'COG') {
                     map.setThumbnail(scene, this.currentRepository);
                 } else {
-                    map.setLayer(
-                      'Hovered Scene',
-                      L.tileLayer(
-                        this.sceneService.getSceneLayerURL(
-                            scene,
-                            {token: this.authService.token()}
-                        ),
-                        {maxZoom: 30})
-                    );
+                    this.setCOGThumbnail(scene, map);
                 }
             });
         }
+    }
+
+    setCOGThumbnail(scene, map) {
+        this.currentRepository.service.getDatasourceBands(scene).then(rgbBands => {
+            map.setLayer(
+              'Hovered Scene',
+              L.tileLayer(
+                this.sceneService.getSceneLayerURL(
+                    scene,
+                    {
+                        token: this.authService.token(),
+                        redBand: rgbBands.RED,
+                        greenBand: rgbBands.GREEN,
+                        blueBand: rgbBands.BLUE
+                    }
+                ),
+                {maxZoom: 30})
+            );
+        });
     }
 
     removeHoveredScene() {

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -208,6 +208,23 @@ export default (app) => {
             return this.$q((resolve) => resolve(scene.datasource));
         }
 
+        getDatasourceBands(scene) {
+            return this.$q((resolve) => {
+                return resolve(scene.datasource.bands.reduce((acc, band) => {
+                    if (band.name.toUpperCase() === 'RED' ||
+                        band.name.toUpperCase() === 'GREEN' ||
+                        band.name.toUpperCase() === 'BLUE') {
+                        acc[band.name.toUpperCase()] = parseInt(band.number, 10);
+                    }
+                    return acc;
+                }, {
+                    RED: 0,
+                    GREEN: 1,
+                    BLUE: 2
+                }));
+            });
+        }
+
 
         /*
           Returns a function which adds the given RF scenes to the project


### PR DESCRIPTION
## Overview

This PR 
- passes correct RGB band numbers when browsing COG scenes (not added to a project yet) and when visualizing scene in scene detail modal
- turns on color correction with the passed bands when getting COG scene tiles when scenes are not in a project yet
- fixes bands used for generating COG thumbnails

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![planet](https://raw.githubusercontent.com/aaronxsu/MyData/master/gifs/rf-pr-gifs/planet-scene-detail.gif)

<img width="1042" alt="screen shot 2018-10-18 at 2 56 11 pm" src="https://user-images.githubusercontent.com/16109558/47177338-26cbc680-d2e6-11e8-864a-f8c378aba88b.png">

<img width="400" alt="screen shot 2018-10-18 at 2 56 44 pm" src="https://user-images.githubusercontent.com/16109558/47177348-2af7e400-d2e6-11e8-8f31-81c67f99a804.png">


## Testing Instructions

 * Get a planet scene id
 * Upload it and get the upload id.
 * `rf process-upload <upload id>`
 * View the scene from scene detail modal
 * Check the generated COG thumbnail's color
 * Add the scene to a project

Closes #4010 