### PR TITLE
Include common, tool, and bridge in artifacts to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@
 
 ### Changed
 - Small text edit to the Imports page [\#4198](https://github.com/raster-foundry/raster-foundry/pull/4198)
-- Updated package and assembly jar names [\#3924](https://github.com/raster-foundry/raster-foundry/pull/3924), [\#4222](https://github.com/raster-foundry/raster-foundry/pull/4222)
-- Updated package and assembly jar names [\#3924](https://github.com/raster-foundry/raster-foundry/pull/3924)
+- Updated package and assembly jar names [\#3924](https://github.com/raster-foundry/raster-foundry/pull/3924), [\#4222](https://github.com/raster-foundry/raster-foundry/pull/4222), [\#4240](https://github.com/raster-foundry/raster-foundry/pull/4240)
 - Change homepage "Create a new Template" button to "Create a new Analysis" [/#4224](https://github.com/raster-foundry/raster-foundry/pull/4224)
 - Projects with > 30 scenes will not show a preview on the project list page [/#4231](https://github.com/raster-foundry/raster-foundry/pull/4231)
 

--- a/app-backend/bridge/build.sbt
+++ b/app-backend/bridge/build.sbt
@@ -1,4 +1,4 @@
-name := "raster-foundry-bridge"
+name := "bridge"
 
 scalacOptions ++= Seq("-feature", "-unchecked", "-deprecation")
 

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -58,6 +58,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                     "api" \
                     "authentication" \
                     "batch" \
+                    "common" \
                     "datamodel" \
                     "db" \
                     "tile" \

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -58,10 +58,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                     "api" \
                     "authentication" \
                     "batch" \
+                    "bridge" \
                     "common" \
                     "datamodel" \
                     "db" \
                     "tile" \
+                    "tool"
                 )
 
                 for project in "${projects[@]}"


### PR DESCRIPTION
## Overview

This PR includes `common` in the list of artifacts to publish. Given that even `authentication` was published, I don't think it was excluded for any particular reason, so I'm going to go ahead and merge after I update the changelog.

When I tried fetching one of the artifacts in a repl, I got a complaint that it couldn't find `bridge`, so I renamed that to `bridge` and included it as well as `tool` since there's transitive deps of everything. `common`, `tool`, and `bridge` were the only three missing deps when I tried to load `database`

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * verify that i spelled `common` correctly
