### PR TITLE
Fix cogification for historical landsat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@
 - Add user button no longer shows for non-admins of teams and orgs [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix undefined function call when selecting project scenes by clicking the map in advanced color correction view [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)
-
 - Stopped explicitly setting a nodata value in one step of ingest for Sentinel-2 and Landsat [\#4324](https://github.com/raster-foundry/raster-foundry/pull/4234)
+- Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
 
 ### Security
 

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -97,7 +97,8 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
         'COG': os.path.join(prefix, cog_fname),
         'STACKED': os.path.join(prefix, stacked_fname)
     }
-    local_paths = glob.glob('/{}/{}*.TIF'.format(prefix, landsat_id))
+    local_paths = sorted(glob.glob('/{}/{}*.TIF'.format(prefix, landsat_id)))
+    print(local_paths)
     warped_paths = cog.warp_tifs(local_paths, prefix)
     merged = cog.merge_tifs(warped_paths, prefix)
     cog.add_overviews(merged)

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -98,7 +98,6 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
         'STACKED': os.path.join(prefix, stacked_fname)
     }
     local_paths = sorted(glob.glob('/{}/{}*.TIF'.format(prefix, landsat_id)))
-    print(local_paths)
     warped_paths = cog.warp_tifs(local_paths, prefix)
     merged = cog.merge_tifs(warped_paths, prefix)
     cog.add_overviews(merged)


### PR DESCRIPTION
## Overview

This PR sorts the landsat 4 / 5 / 7 bands before merging them.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/5702984/47227134-67007700-d3c2-11e8-94fb-737c717dd835.png)

### Notes

No I don't understand why `glob.glob` wouldn't sort when what it's emulating does either thanks for asking. If you need me I'll be hiding somewhere where no one can ask me about why I was so sure it sorted.

For a long time I thought "huh that's weird I guess the sensor must be messed up like Landsat 7" and now actually I understand that these data are _great_

## Testing Instructions

 * check out the 22725cdb31ab1e8ecfbd89851b89a3646ff088f3
 * rebuild batch container
 * add a landsat 4 / 5 TM scene over an island that intersects land and water to a project (it's not necessary, but you'll be happy you did)
 * `rf process-upload` that upload id
 * note that the paths printed are in order from 1 -> 7
 * view the scene in your project with atmospheric removal
