### PR TITLE
Misc fixes

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -261,11 +261,11 @@ module.exports = function (_path) {
                 loaders: [
                     'expose-loader?deferredBootstrapper'
                 ]
-            }, {
-                test: require.resolve('angular'),
-                loaders: [
-                    'expose-loader?angular'
-                ]
+            // }, {
+            //     test: require.resolve('angular'),
+            //     loaders: [
+            //         'expose-loader?angular'
+            //     ]
             }, {
                 test: require.resolve('jquery'),
                 loaders: [
@@ -277,11 +277,11 @@ module.exports = function (_path) {
                 loaders: [
                     'expose-loader?L'
                 ]
-            }, {
-                test: require.resolve('jointjs'),
-                loaders: [
-                    'expose-loader?joint'
-                ]
+            // }, {
+            //     test: require.resolve('jointjs'),
+            //     loaders: [
+            //         'expose-loader?joint'
+            //     ]
             }, {
                 test: require.resolve('moment'),
                 loaders: [

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -55,7 +55,7 @@
     "d3": "5.7.0",
     "gdal-js": "^1.1.0",
     "immutable": "^3.8.2",
-    "jointjs": "~1.1.0",
+    "jointjs": "~2.1.4",
     "jquery": "~3.1.1",
     "leaflet": "1.3.0",
     "leaflet-draw": "~1.0.2",

--- a/app-frontend/src/app/components/datasources/datasourceDeleteModal/datasourceDeleteModal.module.js
+++ b/app-frontend/src/app/components/datasources/datasourceDeleteModal/datasourceDeleteModal.module.js
@@ -22,11 +22,11 @@ class DatasourceDeleteModalController {
         'ngInject';
         $rootScope.autoInject(this, arguments);
 
-        this.datasource = this.resolve.datasource;
         this.uploadProgress = uploadProgress;
     }
 
     $onInit() {
+        this.datasource = this.resolve.datasource;
         this.checkUploadStatus();
     }
 

--- a/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.module.js
+++ b/app-frontend/src/app/components/lab/diagramContainer/diagramContainer.module.js
@@ -1,4 +1,4 @@
-/* global joint */
+import * as joint from 'jointjs';
 import angular from 'angular';
 import _ from 'lodash';
 import diagramContainerTpl from './diagramContainer.html';

--- a/app-frontend/src/app/components/lab/reclassifyModal/reclassifyModal.module.js
+++ b/app-frontend/src/app/components/lab/reclassifyModal/reclassifyModal.module.js
@@ -21,8 +21,6 @@ class ReclassifyModalController {
     constructor($scope, $ngRedux, reclassifyService) {
         'ngInject';
         this.reclassifyService = reclassifyService;
-        this.breaks = this.resolve.breaks;
-        this.nodeId = this.resolve.nodeId;
 
         let unsubscribe = $ngRedux.connect(
             this.mapStateToThis.bind(this),
@@ -35,6 +33,11 @@ class ReclassifyModalController {
                 this.fetchHistogram(id);
             }
         });
+    }
+
+    $onInit() {
+        this.breaks = this.resolve.breaks;
+        this.nodeId = this.resolve.nodeId;
     }
 
     mapStateToThis(state) {

--- a/app-frontend/src/app/components/map/labMap/divider.model.js
+++ b/app-frontend/src/app/components/map/labMap/divider.model.js
@@ -94,7 +94,7 @@ export default class Divider {
     update() {
         $(this._container).css({
             left: `${this._position * 100}%`,
-            top: 0,
+            top: '0px',
             height: '100%',
             width: '2px'
         });

--- a/app-frontend/src/app/components/map/labMap/frame.model.js
+++ b/app-frontend/src/app/components/map/labMap/frame.model.js
@@ -164,10 +164,10 @@ export default class Frame {
         // update element dimensions to match dimensions, if they are different
         let dimensions = this.calculatedDimensions;
         $(this._container).css({
-            width: dimensions.width,
-            height: dimensions.height,
-            top: dimensions.y,
-            left: dimensions.x
+            width: `${dimensions.width}px`,
+            height: `${dimensions.height}px`,
+            top: `${dimensions.y}px`,
+            left: `${dimensions.x}px`
             // transform: `translateX(${dimensions.rotation})`
         });
 

--- a/app-frontend/src/app/components/map/labMap/frameView.model.js
+++ b/app-frontend/src/app/components/map/labMap/frameView.model.js
@@ -21,10 +21,10 @@ export default class FrameView extends Frame {
         }
         let dimensions = this.calculatedDimensions;
         $(this._container).css({
-            width: dimensions.width,
-            height: dimensions.height,
-            top: dimensions.y,
-            left: dimensions.x
+            width: `${dimensions.width}px`,
+            height: `${dimensions.height}px`,
+            top: `${dimensions.y}px`,
+            left: `${dimensions.x}px`
             // transform: `translateX(${dimensions.rotation})`
         });
 

--- a/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.module.js
+++ b/app-frontend/src/app/components/projects/annotateSidebarItem/annotateSidebarItem.module.js
@@ -39,6 +39,7 @@ class AnnotateSidebarItemController {
 
         return {
             annotation,
+            annotations: state.projects.annotations,
             editingAnnotation: state.projects.editingAnnotation,
             sidebarDisabled: state.projects.sidebarDisabled,
             labels: state.projects.labels
@@ -48,6 +49,12 @@ class AnnotateSidebarItemController {
     $onInit() {
         this.minMatchedLabelLength = 3;
         this.maxMatchedLabels = 4;
+        let watch = this.$scope.$watch('$ctrl.annotationId', (annotationId) => {
+            if(annotationId && !this.annotation && this.annotations) {
+                this.annotation = this.annotations.get(annotationId);
+                watch();
+            }
+        });
     }
 
     onAnnotationClone($event) {

--- a/app-frontend/src/app/components/scenes/importList/importList.module.js
+++ b/app-frontend/src/app/components/scenes/importList/importList.module.js
@@ -89,9 +89,9 @@ class ImportListController {
                 exactCount: true
             }
         ).then((sceneResult) => {
+            this.lastSceneResult = sceneResult;
             this.pagination = this.paginationService.buildPagination(sceneResult);
             this.paginationService.updatePageParam(page, '');
-            this.lastSceneResult = sceneResult;
             this.importList = this.lastSceneResult.results;
             this.loading = false;
         }, () => {

--- a/app-frontend/src/app/components/scenes/planetSceneDetailModal/planetSceneDetailModal.controller.js
+++ b/app-frontend/src/app/components/scenes/planetSceneDetailModal/planetSceneDetailModal.controller.js
@@ -5,12 +5,14 @@ export default class PlanetSceneDetailModalController {
         $scope, mapService
     ) {
         'ngInject';
-        this.scene = this.resolve.scene;
-        this.planetThumbnailUrl = this.resolve.planetThumbnailUrl;
         this.getMap = () => mapService.getMap('scene-preview-map');
         $scope.$on('$destroy', () => {
             mapService.deregisterMap('scene-preview-map');
         });
+    }
+    $onInit() {
+        this.scene = this.resolve.scene;
+        this.planetThumbnailUrl = this.resolve.planetThumbnailUrl;
     }
 
     $postLink() {

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -28,12 +28,15 @@ class SceneDetailModalController {
         this.moment = moment;
         this.sceneService = sceneService;
         this.authService = authService;
-        this.scene = this.resolve.scene;
-        this.repository = this.resolve.repository;
         this.getMap = () => mapService.getMap('scene-preview-map');
         $scope.$on('$destroy', () => {
             mapService.deregisterMap('scene-preview-map');
         });
+    }
+
+    $onInit() {
+        this.scene = this.resolve.scene;
+        this.repository = this.resolve.repository;
     }
 
     $postLink() {

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -40,7 +40,12 @@ class SceneItemController {
         this.isDraggable = $attrs.hasOwnProperty('draggable');
         this.isPreviewable = $attrs.hasOwnProperty('previewable');
         this.isClickable = $attrs.hasOwnProperty('clickable');
+    }
+    $onInit(){
         this.datasource = this.scene.datasource;
+        if (this.respository) {
+            this.updateThumbnails();
+        }
     }
 
     $postLink() {
@@ -67,45 +72,51 @@ class SceneItemController {
         }
         if (changes.repository && changes.repository.currentValue) {
             this.repository = changes.repository.currentValue;
-            if (this.scene.sceneType === 'COG') {
-                let redBand = _.findIndex(
-                    this.datasource.bands, (x) => x.name.toLowerCase() === 'red');
-                let greenBand = _.findIndex(
-                    this.datasource.bands, (x) => x.name.toLowerCase() === 'green');
-                let blueBand = _.findIndex(
-                    this.datasource.bands, (x) => x.name.toLowerCase() === 'blue');
-                let bands = {};
-                let atLeastThreeBands = this.datasource.bands.length >= 3;
-                if (atLeastThreeBands) {
-                    bands.red = redBand || 0;
-                    bands.green = greenBand || 1;
-                    bands.blue = blueBand || 2;
-                } else {
-                    bands.red = 0;
-                    bands.green = 0;
-                    bands.blue = 0;
-                }
-                this.sceneService.cogThumbnail(
-                    this.scene.id,
-                    this.authService.token(),
-                    128,
-                    128,
-                    bands.red,
-                    bands.green,
-                    bands.blue
-                ).then(res => {
-                    // Because 504s aren't rejections, apparently
-                    if (_.isString(res)) {
-                        this.thumbnail = `data:image/png;base64,${res}`;
-                    }
-                }).catch(() => {
-                    this.imageError = true;
-                });
-            } else {
-                this.repository.service.getThumbnail(this.scene).then((thumbnail) => {
-                    this.thumbnail = thumbnail;
-                });
+            if (this.datasource) {
+                this.updateThumbnails();
             }
+        }
+    }
+
+    updateThumbnails(){
+        if (this.scene.sceneType === 'COG') {
+            let redBand = _.findIndex(
+                this.datasource.bands, (x) => x.name.toLowerCase() === 'red');
+            let greenBand = _.findIndex(
+                this.datasource.bands, (x) => x.name.toLowerCase() === 'green');
+            let blueBand = _.findIndex(
+                this.datasource.bands, (x) => x.name.toLowerCase() === 'blue');
+            let bands = {};
+            let atLeastThreeBands = this.datasource.bands.length >= 3;
+            if (atLeastThreeBands) {
+                bands.red = redBand || 0;
+                bands.green = greenBand || 1;
+                bands.blue = blueBand || 2;
+            } else {
+                bands.red = 0;
+                bands.green = 0;
+                bands.blue = 0;
+            }
+            this.sceneService.cogThumbnail(
+                this.scene.id,
+                this.authService.token(),
+                128,
+                128,
+                bands.red,
+                bands.green,
+                bands.blue
+            ).then(res => {
+                // Because 504s aren't rejections, apparently
+                if (_.isString(res)) {
+                    this.thumbnail = `data:image/png;base64,${res}`;
+                }
+            }).catch(() => {
+                this.imageError = true;
+            });
+        } else {
+            this.repository.service.getThumbnail(this.scene).then((thumbnail) => {
+                this.thumbnail = thumbnail;
+            });
         }
     }
 

--- a/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
+++ b/app-frontend/src/app/components/settings/addUserModal/addUserModal.module.js
@@ -29,12 +29,13 @@ class AddUserModalController {
         this.teamService = teamService;
         this.userService = userService;
 
-        this.platformId = this.resolve.platformId;
-        this.organizationId = this.resolve.organizationId;
         this.selected = new Map();
     }
 
     $onInit() {
+        this.platformId = this.resolve.platformId;
+        this.organizationId = this.resolve.organizationId;
+
         let debouncedSearch = _.debounce(
             this.onSearch.bind(this),
             500,

--- a/app-frontend/src/app/components/settings/refreshTokenModal/refreshTokenModal.controller.js
+++ b/app-frontend/src/app/components/settings/refreshTokenModal/refreshTokenModal.controller.js
@@ -1,9 +1,13 @@
 export default class refreshTokenModalController {
     constructor() {
         'ngInject';
-        this.refreshToken = this.resolve.refreshToken;
         this.showToken = false;
     }
+
+    $onInit() {
+        this.refreshToken = this.resolve.refreshToken;
+    }
+
     toggleTokenVisibility() {
         this.showToken = !this.showToken;
     }

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -168,7 +168,7 @@ function projectEditStates($stateProvider) {
         })
         .state('projects.edit.browse', {
             title: 'Project Scenes',
-            url: '/browse/:sceneid?' + addScenesQueryParams,
+            url: '/browse/?sceneid' + addScenesQueryParams,
             templateUrl: projectsSceneBrowserTpl,
             controller: 'ProjectsSceneBrowserController',
             controllerAs: '$ctrl',

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.module.js
@@ -224,15 +224,17 @@ class ProjectsScenesController {
     }
 
     removeHoveredScene() {
-        this.$parent.getMap().then((map) => {
-            if (this.hoveredScene.sceneType !== 'COG' &&
-                this.hoveredScene.statusFields.ingestStatus === 'INGESTED') {
-                this.$parent.removeHoveredScene();
-            } else {
-                map.deleteThumbnail();
-            }
-            delete this.hoveredScene;
-        });
+        if (this.hoveredScene) {
+            this.$parent.getMap().then((map) => {
+                if (this.hoveredScene.sceneType !== 'COG' &&
+                    this.hoveredScene.statusFields.ingestStatus === 'INGESTED') {
+                    this.$parent.removeHoveredScene();
+                } else {
+                    map.deleteThumbnail();
+                }
+                delete this.hoveredScene;
+            });
+        }
     }
 
     downloadSceneModal(scene) {

--- a/app-frontend/src/app/services/analysis/labUtils.service.js
+++ b/app-frontend/src/app/services/analysis/labUtils.service.js
@@ -1,7 +1,8 @@
-/* globals joint $ _ */
-// TODO tear out all references to tool run - it should use redux to pull in the correct stuff
+import _ from 'lodash';
+import * as joint from 'jointjs';
 import {Map} from 'immutable';
 import {getNodeArgs} from '_redux/node-utils';
+// TODO tear out all references to tool run - it should use redux to pull in the correct stuff
 
 export default (app) => {
     class LabUtils {
@@ -45,8 +46,8 @@ export default (app) => {
                             y: 0
                         };
                         this.$box.css({
-                            left: bbox.x * this.scale + origin.x,
-                            top: bbox.y * this.scale + origin.y
+                            left: `${bbox.x * this.scale + origin.x}px`,
+                            top: `${bbox.y * this.scale + origin.y}px`
                         });
                     });
                     this.scale = 1;
@@ -58,8 +59,8 @@ export default (app) => {
                             y: 0
                         };
                         this.$box.css({
-                            left: bbox.x * this.scale + origin.x,
-                            top: bbox.y * this.scale + origin.y,
+                            left: `${bbox.x * this.scale + origin.x}px`,
+                            top: `${bbox.y * this.scale + origin.y}px`,
                             transform: `scale(${scale})`,
                             'transform-origin': '0 0'
                         });
@@ -79,10 +80,10 @@ export default (app) => {
                     };
 
                     this.$box.css({
-                        width: bbox.width,
-                        height: bbox.height,
-                        left: bbox.x * this.scale + origin.x,
-                        top: bbox.y * this.scale + origin.y
+                        width: `${bbox.width}px`,
+                        height: `${bbox.height}px`,
+                        left: `${bbox.x * this.scale + origin.x}px`,
+                        top: `${bbox.y * this.scale + origin.y}px`
                     });
 
                     this.scope.updateTick = new Date().getTime();
@@ -98,7 +99,7 @@ export default (app) => {
             let inputList = Array.isArray(inputs) ?
                 inputs : Array(inputs).fill();
 
-            ports = inputList.map((_, idx) => {
+            ports = inputList.map((item, idx) => {
                 return {
                     id: `input-${idx}`,
                     label: `input-${idx}`,

--- a/app-frontend/src/app/services/common/mousetip.service.js
+++ b/app-frontend/src/app/services/common/mousetip.service.js
@@ -39,8 +39,8 @@ export default (app) => {
         setPosition(e) {
             if (e && this.$el && !this.mouseOut) {
                 this.$el.css({
-                    top: e.pageY,
-                    left: e.pageX
+                    top: `${e.pageY}px`,
+                    left: `${e.pageX}px`
                 });
                 this.$el.toggle(true);
             } else if (this.$el) {

--- a/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
+++ b/app-frontend/src/app/services/scenes/rasterFoundryRepository.service.js
@@ -1,4 +1,4 @@
-/* global _*/
+import _ from 'lodash';
 
 import {Map} from 'immutable';
 export default (app) => {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1125,10 +1125,25 @@ nav .btn-group {
 }
 .lab-workspace {
     background-color: $off-white !important;
-    display: flex;
-    flex: 1;
     transition: all 0.1s;
     position: relative;
+    .joint-paper-grid {
+        width: 100%;
+        height: 100%;
+        opacity: 0.5;
+        pointer-events: none;
+    }
+    > svg {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+
+    }
+    g.link-tools {
+        display: none;
+    }
 }
 
 .btn-square.really-square {

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -6969,10 +6969,10 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-jointjs@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/jointjs/-/jointjs-1.1.0.tgz#3c5f0f225c0b3748d77d38000f7f1f7b9634f032"
-  integrity sha1-PF8PIlwLN0jXfTgAD38fe5Y08DI=
+jointjs@~2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/jointjs/-/jointjs-2.1.4.tgz#0f036e9546a5f924be4e7b682ba1dc63b274ac81"
+  integrity sha512-fJRM/dq7XDV2Z61SktIwZbdAPtCP4dSsg2KiQE0xtzQauuVBC2flqkBi/IZZXkRecYxpbIR7eVFbef6mj7P2UA==
   dependencies:
     backbone "1.3.3"
     dagre "0.7.4"


### PR DESCRIPTION
## Overview
* Fix sceneItem and sceneDetailModal
* Fix move this.resolve from constructor to $onInit() in all modals
* Fix annotation item initialization with redux
* Fix project edit browse sceneId param (undefined is no longer a valid nonparam
  route argument)
* Fix projects.edit.scenes removeHoveredScene being called without a hovered
  scene
* Fix lodash being declared as a global instead of import in RF Repo service
* Fix lab styling
* Fix jqlite .css calls broken by update

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions
 * Verify that scene items no longer render incorrectly
* Verify that the scene detail modal now loads
* Verify that when creating an annotation item, you no longer get an error while saving the created annotation
* Verify that you can load the project scene browse view
* Verify that there is not an eslint warning about `_` being defined in an upper scope inside the RF repo service
* Verify that you can load the lab, move nodes around, zoom, and open previews
* Verify that the other places where `<jqlite object>.css()` was called work.

Closes #4202 
Closes #4209 
