### PR TITLE
Don't include name in user object sent to intercom if same as email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Stopped explicitly setting a nodata value in one step of ingest for Sentinel-2 and Landsat [\#4324](https://github.com/raster-foundry/raster-foundry/pull/4234)
 - Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
 - Cleaned up project database tests to prevent a database deadlock [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
+- Don't include name in intercom user init if it's the same as the email [\#4247](https://github.com/raster-foundry/raster-foundry/pull/4247)
 
 ### Security
 

--- a/app-frontend/src/app/services/vendor/intercom.service.js
+++ b/app-frontend/src/app/services/vendor/intercom.service.js
@@ -1,4 +1,5 @@
 /* global Intercom, BUILDCONFIG */
+import _ from 'lodash';
 export default (app) => {
     class IntercomService {
         constructor($resource, $q, $http, APP_CONFIG, angularLoad) {
@@ -19,12 +20,16 @@ export default (app) => {
         }
 
         bootWithUser(user) {
+            let cleanUser = _.clone(user);
+            if (user.email === user.name) {
+                delete cleanUser.name;
+            }
             if (!this.scriptLoaded && this.appId !== 'disabled') {
                 this.load().then(() => {
-                    this.doBoot(user);
+                    this.doBoot(cleanUser);
                 });
             } else if (this.appId !== 'disabled') {
-                this.doBoot(user);
+                this.doBoot(cleanUser);
             }
         }
 


### PR DESCRIPTION
## Overview
See title.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Create a new user on dev and verify that in intercom, it doesn't set the name to the email (all database users have their name set to their email)

Closes #4223 
