### PR TITLE
Remove deadlock from delete scenes test in project dao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Updated package and assembly jar names [\#3924](https://github.com/raster-foundry/raster-foundry/pull/3924), [\#4222](https://github.com/raster-foundry/raster-foundry/pull/4222), [\#4240](https://github.com/raster-foundry/raster-foundry/pull/4240)
 - Change homepage "Create a new Template" button to "Create a new Analysis" [/#4224](https://github.com/raster-foundry/raster-foundry/pull/4224)
 - Projects with > 30 scenes will not show a preview on the project list page [/#4231](https://github.com/raster-foundry/raster-foundry/pull/4231)
+- Upgraded scala typelevel ecosystem [\#4215](https://github.com/raster-foundry/raster-foundry/pull/4215)
 
 ### Deprecated
 
@@ -25,6 +26,7 @@
 - Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)
 - Stopped explicitly setting a nodata value in one step of ingest for Sentinel-2 and Landsat [\#4324](https://github.com/raster-foundry/raster-foundry/pull/4234)
 - Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
+- Cleaned up project database tests to prevent a database deadlock [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
 
 ### Security
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -55,16 +55,14 @@ class ProjectDatasourcesDaoSpec
               dsInsert1 <- fixupDatasource(dsCreate1, dbUser)
               dsInsert2 <- fixupDatasource(dsCreate2, dbUser)
               dsInsert3 <- fixupDatasource(dsCreate3, dbUser)
-              scenesInsert1 <- (scenes1 map {
-                fixupSceneCreate(dbUser, dsInsert1, _)
-              }).traverse(
-                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-              )
-              scenesInsert2 <- (scenes2 map {
-                fixupSceneCreate(dbUser, dsInsert2, _)
-              }).traverse(
-                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
-              )
+              scenesInsert1 <- scenes1 traverse { scene =>
+                SceneDao.insert(fixupSceneCreate(dbUser, dsInsert1, scene),
+                                dbUser)
+              }
+              scenesInsert2 <- scenes2 traverse { scene =>
+                SceneDao.insert(fixupSceneCreate(dbUser, dsInsert2, scene),
+                                dbUser)
+              }
               _ <- ProjectDao.addScenesToProject(scenesInsert1 map { _.id },
                                                  dbProject.id)
               _ <- ProjectDao.addScenesToProject(scenesInsert2 map { _.id },

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -169,12 +169,8 @@ trait PropTestHelpers {
     image.copy(createdBy = ownerId, owner = ownerId, scene = sceneId)
 
   def fixupDatasource(dsCreate: Datasource.Create,
-                      user: User): ConnectionIO[Datasource] = {
-    for {
-      ds <- DatasourceDao.createDatasource(dsCreate.copy(owner = Some(user.id)),
-                                           user)
-    } yield ds
-  }
+                      user: User): ConnectionIO[Datasource] =
+    DatasourceDao.createDatasource(dsCreate.copy(owner = Some(user.id)), user)
 
   def fixupThumbnail(scene: Scene.WithRelated,
                      thumbnail: Thumbnail): Thumbnail =


### PR DESCRIPTION
## Overview

This PR cleans up the deletion test in the `ProjectDaoSpec` in an effort to eliminate a deadlock condition when running tests. What I think was happening is the ConnectionIO resulting from the mess of flatmaps didn't correctly encapsulate the real world (database-side) data dependencies between the IOs, and some things were running simultaneously that needed to run in sequence. Yesterday I was able to replicate the deadlock consistently, and with this change I haven't hit it in several attempts.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I'm separately opening an issue to clean tests up, since the style that I wrote those tests in originally is kind of a drag.

## Testing Instructions

 * jenkins