### PR TITLE
Fix nginx proxy-settings directives

### DIFF
--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -15,20 +15,20 @@ server {
     include /etc/nginx/includes/api-security-headers.conf;
 
     location /api {
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
 
         proxy_pass http://api-server-upstream;
     }
 
     location /api/shapes/upload {
         client_max_body_size 20m;
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
 
         proxy_pass http://api-server-upstream;
     }
 
     location /api/scenes {
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
         proxy_buffers 24 4k;
 
         proxy_pass http://api-server-upstream;
@@ -37,34 +37,34 @@ server {
     location ~* ^\/api/exports/.*/files/.* {
         limit_req zone=download_req;
 
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
 
         proxy_pass http://api-server-upstream;
     }
 
     location /api/thumbnails {
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
         proxy_buffers 4 64k;
 
         proxy_pass http://api-server-upstream;
     }
 
     location = /healthcheck/ {
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
 
         proxy_pass http://api-server-upstream;
     }
 
     # Angular config
     location = /config {
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
 
         proxy_pass http://api-server-upstream;
     }
 
     # Angular per-user feature flags
     location = /feature-flags {
-        include /etc/nginx/includes/proxy-settings.conf
+        include /etc/nginx/includes/proxy-settings.conf;
 
         proxy_pass http://api-server-upstream;
     }

--- a/nginx/etc/nginx/conf.d/backsplash.conf
+++ b/nginx/etc/nginx/conf.d/backsplash.conf
@@ -21,21 +21,21 @@ server {
 	}
 
 	location ~* ^/tools/.*/\d+/\d+/\d+  {
-		include /etc/nginx/includes/proxy_settings.conf
+		include /etc/nginx/includes/proxy-settings.conf;
 		proxy_buffers 16 16k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location ~* ^/(scenes/)?.*/\d+/\d+/\d+  {
-		include /etc/nginx/includes/proxy_settings.conf
+		include /etc/nginx/includes/proxy-settings.conf;
 		proxy_buffers 24 4k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location / {
-		include /etc/nginx/includes/proxy_settings.conf
+		include /etc/nginx/includes/proxy-settings.conf;
 
 		proxy_pass http://tile-server-upstream;
 	}

--- a/nginx/etc/nginx/conf.d/tiler.conf
+++ b/nginx/etc/nginx/conf.d/tiler.conf
@@ -21,21 +21,21 @@ server {
 	}
 
 	location ~* ^/tools/.*/\d+/\d+/\d+  {
-		include /etc/nginx/includes/proxy_settings.conf
+		include /etc/nginx/includes/proxy-settings.conf;
 		proxy_buffers 16 16k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location ~* ^/(scenes/)?.*/\d+/\d+/\d+  {
-		include /etc/nginx/includes/proxy_settings.conf
+		include /etc/nginx/includes/proxy-settings.conf;
 		proxy_buffers 24 4k;
 
 		proxy_pass http://tile-server-upstream;
 	}
 
 	location / {
-		include /etc/nginx/includes/proxy_settings.conf
+		include /etc/nginx/includes/proxy-settings.conf;
 
 		proxy_pass http://tile-server-upstream;
 	}


### PR DESCRIPTION
## Overview

This PR fixes some mistakes I made when tweaking the nginx configuration for #4170. I added missing semicolons and changed references to `proxy_settings.conf` to `proxy-settings.conf`

### Checklist

~- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ I didn't update the CHANGELOG because I'm just fixing a mistake.
~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

N/A
### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions
- From inside of your VM, run:
```bash
$ docker-compose build nginx

# Start containers in the background, then kill the Log tailing job.
$ ./scripts/server --quiet
^C
$ docker-compose up -d nginx                                 
```
And make sure that the API and Tiler nginx containers are up and running:

```bash
$ docker-compose ps | grep nginx
raster-foundry_nginx-api_1          nginx -g daemon off;             Up             0.0.0.0:9100->443/tcp, 80/tcp                 
raster-foundry_nginx-backsplash_1   nginx -g daemon off;             Up             0.0.0.0:8081->443/tcp, 80/tcp                 
raster-foundry_nginx-tiler_1        nginx -g daemon off;             Exit 0         
```
- Check Papertrail and verify that there are no logs like this being generated:
```bash
2018-10-24T11:23:49-04:00 52.207.133.116 staging/backsplash/nginx nginx: [emerg] invalid number of arguments in "include" directive in /etc/nginx/conf.d/default.conf:25
```
- This change has been deployed to Staging. See https://app.staging.rasterfoundry.com.
