### PR TITLE
Use error-handling ADT for backsplash errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [\#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
 - Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
-- Added semi-fancy error-handling to backsplash [\#4258](https://github.com/raster-foundry/raster-foundry/pull/4258)
+- Added service-level and total error-handling to backsplash tile server [\#4258](https://github.com/raster-foundry/raster-foundry/pull/4258)
 - Administration
   - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214) 
   - Allow platform administrators to create uploads for other users within their platforms [\#4237](https://github.com/raster-foundry/raster-foundry/pull/4237)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [\#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
 - Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
+- Added semi-fancy error-handling to backsplash [\#4258](https://github.com/raster-foundry/raster-foundry/pull/4258)
 - Administration
   - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214) 
   - Allow platform administrators to create uploads for other users within their platforms [\#4237](https://github.com/raster-foundry/raster-foundry/pull/4237)

--- a/app-backend/backsplash/src/main/scala/error/ErrorHandling.scala
+++ b/app-backend/backsplash/src/main/scala/error/ErrorHandling.scala
@@ -29,7 +29,10 @@ final case class BadAnalysisASTException(message: String)
 final case class WrappedDoobieException(message: String)
     extends BacksplashException
 final case class WrappedS3Exception(message: String) extends BacksplashException
-final case class UnknownException(message: String) extends BacksplashException
+// Private so no one can deliberately throw an UnknownException elsewhere --
+// only exists to catch the fall-through case in the foreign error handler
+private[error] final case class UnknownException(message: String)
+    extends BacksplashException
 
 class ForeignErrorHandler[F[_], E <: Throwable](implicit M: MonadError[F, E])
     extends RollbarNotifier

--- a/app-backend/backsplash/src/main/scala/services/HealthCheckService.scala
+++ b/app-backend/backsplash/src/main/scala/services/HealthCheckService.scala
@@ -1,5 +1,6 @@
 package com.rasterfoundry.backsplash.services
 
+import cats.data.OptionT
 import cats.effect.Effect
 import io.circe.Json
 import org.http4s._

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -448,6 +448,7 @@ lazy val backsplash = Project("backsplash", file("backsplash"))
     libraryDependencies ++= Seq(
       Dependencies.catsCore,
       Dependencies.catsEffect,
+      Dependencies.catsMeow,
       Dependencies.geotrellisServer,
       Dependencies.http4sBlaze,
       Dependencies.http4sBlazeClient,


### PR DESCRIPTION
## Overview

This PR uses an error-handling ADT for backsplash and wraps services in a handler for that type of errors and a translator between "foreign" errors and backsplash errors.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

"I was promised magic!" you say, "why do you have to explicitly wrap the services?"

Well for two reasons. Reason 1 is that the example given in the blog post in the linked issue does fancy error-handling on HTTPRoutes, not on an (`Authed`)`HttpService`. Why that matters is that I wasn't sure how to apply middleware to `HttpRoutes`. While they're still `Kleisli`s, I didn't think the story was as clear, especially because...

Reason 2 -- we have errors that don't originate in our code. The database and S3 are two places where we can have errors that we want to catch with our fancy error handler that we _can't_ make extend `BacksplashException` because we don't own the types (and we can't `newtype` them, because opaque types aren't coming until dotty). So as a compromise, `ForeignErrorHandler` translates between non-backsplash errors and backsplash errors, and then backsplash error-handling is a total function of all possible backsplash errors (and the compiler complains if it's not).

Also, I think something odd is going on with how we read things from S3, because instead of getting S3 errors, I'm getting 200s of empty tiles. I'm pretty confused about that but can't see anything we've done in backsplash that would cause it.

## Testing Instructions

 * revert 00eae3fa (not strictly necessary, but necessary to suppress the insane logging that we have currently)
 * `./scripts/server --backsplash`
 * try browsing around -- this should work basically normally
 * set a project's single band options to `null` and `is_single_band` to `true` in the db and request tiles for it -- you should get a helpful message
 * try to request tiles for a project that doesn't exist and a project that you don't own -- you should get a 403, and fast
 * set an ingested scene's ingest locaton to `null` -- you should get a nice 404 telling you the scene isn't ingested
 * throw some bogus exception somewhere else -- you should get an internal server error

Closes #3957 