### PR TITLE
Improve kicking off scene ingests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
 - Cleaned up project database tests to prevent a database deadlock [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
 - Don't include name in intercom user init if it's the same as the email [\#4247](https://github.com/raster-foundry/raster-foundry/pull/4247)
+- Kick off ingests for scenes without scene types also [\#4260](https://github.com/raster-foundry/raster-foundry/pull/4260)
 
 ### Security
 

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -190,7 +190,7 @@ object ProjectDao
                   (scenes.ingest_status = ${IngestStatus.Ingesting.toString} :: ingest_status AND
                    (now() - modified_at) > '1 day'::interval))
            AND sub.scene_id = scenes.id
-           AND scene_type = 'AVRO' :: scene_type
+           AND (scene_type = 'AVRO' :: scene_type OR scene_type IS NULL)
          """
     updateStatusQuery.update.run
   }

--- a/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
@@ -220,8 +220,7 @@ object SceneWithRelatedDao
     } map { _.head }
   }
 
-  def getScenesToIngest(
-      projectId: UUID): ConnectionIO[List[Scene.WithRelated]] = {
+  def getScenesToIngest(projectId: UUID): ConnectionIO[List[Scene]] = {
     val fragments = List(
       Some(
         fr"""(ingest_status = ${IngestStatus.Queued.toString} :: ingest_status
@@ -231,9 +230,7 @@ object SceneWithRelatedDao
       Some(
         fr"scenes.id IN (SELECT scene_id FROM scenes_to_projects WHERE project_id = ${projectId})")
     )
-    SceneDao.query.filter(fragments).list flatMap { scenes: List[Scene] =>
-      scenesToScenesWithRelated(scenes)
-    }
+    SceneDao.query.filter(fragments).list
   }
 
   def makeFilters[T](myList: List[T])(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
@@ -111,7 +111,7 @@ class ShapeDaoSpec
             }
 
             val shapeByIdIO = shapeInsertWithUserIO flatMap {
-              case (shapes: List[Shape], dbUser: User) => {
+              case (shapes, dbUser) => {
                 // safe because we just put it there -- errors here mean insert is broken
                 val insertedShape = shapes.head.toShape
                 ShapeDao.getShapeById(insertedShape.id) map {


### PR DESCRIPTION
## Overview

Some old scenes don't have a `scene_type` set in the db because the db has a lot of scenes and we just never went back and filled it in. This made it so that our check for `AVRO` scenes only to kick off ingests prevented us from kicking off ingests for scenes that were going to be `AVRO` scenes that we've had for a while (think old Landsat 8 and Sentinel-2 scenes). This PR adds a test to make sure that we kickoff ingest for those scenes and changes the database filter so that we do so.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

### Notes

The test would only have failed sometimes -- you'd have to get a 

## Testing Instructions

 * the testing failure would only happen if you generated a scene with `sceneType = None` and with `ingestStatus = IngestStatus.NotIngested`, so it'd take a minute, but you can at least confirm that we could generate that case
 * confirm that we sometimes generate `None` for `sceneType` in tests -- from `db:test/console`:

```scala
import com.rasterfoundry.datamodel._
Generators.Implicits.arbListSceneCreate.arbitrary.sample map { scenes => scenes map { _.sceneType } }
```
 * check the generator for `IngestStatus` and confirm that we're just picking randomly
 * run tests a bunch and confirm you never get to failure

Closes #4252 
