### PR TITLE
Add rf command for reprocessing landsat historical scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Fix undefined function call when selecting project scenes by clicking the map in advanced color correction view [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)
 - Stopped explicitly setting a nodata value in one step of ingest for Sentinel-2 and Landsat [\#4324](https://github.com/raster-foundry/raster-foundry/pull/4234)
-- Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
+- Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs and added command to fix existing Landsat 4 / 5 / 7 scenes [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242), [\#4261](https://github.com/raster-foundry/raster-foundry/pull/4261)
 - Cleaned up project database tests to prevent a database deadlock [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
 - Don't include name in intercom user init if it's the same as the email [\#4247](https://github.com/raster-foundry/raster-foundry/pull/4247)
 

--- a/app-tasks/completion.bash
+++ b/app-tasks/completion.bash
@@ -1,3 +1,5 @@
 
 # Completion for rf cli
-complete -W "export find-aoi-projects ingest-scene process-upload update-aoi-project" rf
+complete -W \
+         "export find-aoi-projects ingest-scene process-upload update-aoi-project reprocess-landsat-h" \
+         rf

--- a/app-tasks/rf/src/rf/cli.py
+++ b/app-tasks/rf/src/rf/cli.py
@@ -11,6 +11,7 @@ from .commands import (
     find_aoi_projects,
     ingest_scene,
     process_upload,
+    reprocess_landsat_h,
     update_aoi_project
 )
 
@@ -32,4 +33,5 @@ run.add_command(export)
 run.add_command(process_upload)
 run.add_command(ingest_scene)
 run.add_command(find_aoi_projects)
+run.add_command(reprocess_landsat_h)
 run.add_command(update_aoi_project)

--- a/app-tasks/rf/src/rf/commands/__init__.py
+++ b/app-tasks/rf/src/rf/commands/__init__.py
@@ -2,4 +2,5 @@ from .find_aoi_projects import find_aoi_projects
 from .export import export
 from .ingest_scene import ingest_scene
 from .process_upload import process_upload
+from .reprocess_landsat_h import reprocess_landsat_h
 from .update_aoi_project import update_aoi_project

--- a/app-tasks/rf/src/rf/commands/reprocess_landsat_h.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_landsat_h.py
@@ -1,0 +1,39 @@
+import logging
+
+
+import click
+
+
+from ..models import Scene
+from ..utils.exception_reporting import wrap_rollbar
+from ..uploads.landsat_historical.factories import (
+    process_to_cog,
+    upload_file,
+    MultiSpectralScannerConfig,
+    ThematicMapperConfig,
+    EnhancedThematicMapperConfig
+)
+from rf.utils import io
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name='reprocess-landsat-h')
+@click.argument('scene_id')
+@wrap_rollbar
+def reprocess_landsat_h(scene_id):
+    logger.info('Fetching scene to reprocess with correct band order: %s', scene_id)
+    scene = Scene.from_id(scene_id)
+    upload_dst = scene.ingestLocation.split('/')[-1]
+    landsat_id = scene.name
+    gcs_prefix = io.gcs_path_for_landsat_id(landsat_id)
+    path_meta = io.base_metadata_for_landsat_id(landsat_id)
+    sensor = path_meta['sensor_id']
+    config = {
+        'M': MultiSpectralScannerConfig,
+        'T': ThematicMapperConfig,
+        'E': EnhancedThematicMapperConfig
+    }[sensor]
+    with io.get_tempdir() as prefix:
+        (local_path, _) = process_to_cog(prefix, gcs_prefix, landsat_id, config)
+        upload_file(scene.owner, local_path, upload_dst)


### PR DESCRIPTION
## Overview

This PR adds a command to `rf` to reprocess the cogs for any Landsat 4 / 5 / 7 tif.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * if you don't have any badly processed landsat 4 / 5 scenes, let me know, and I can give you an ingest location for one and you can add it as a COG with the landsat 4 / 5 tm datasource and manually set its name to the right landsat id
 * otherwise:
 * rebuild the batch container
 * view a badly cog-ified landsat 4 / 5 scene
 * add another landsat 4 / 5 scene to the same project nearby
 * process that upload
 * reprocess the scene that is bad -- `rf reprocess-landsat-h <scene id>`
 * view the project with both scenes and switch through some color modes
 * the colors in the scenes should look similar in each color mode
