### PR TITLE
Use metadata to avoid nodata patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Increase nginx buffer size & count for Scene, Tool, and Thumbnail requests [\#4170](https://github.com/raster-foundry/raster-foundry/pull/4170)
 - Add user button no longer shows for non-admins of teams and orgs [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
 - Fix undefined function call when selecting project scenes by clicking the map in advanced color correction view [\#4212](https://github.com/raster-foundry/raster-foundry/pull/4212)
-- Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)
+- Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238), [\#4262](https://github.com/raster-foundry/raster-foundry/pull/4262)
 - Stopped explicitly setting a nodata value in one step of ingest for Sentinel-2 and Landsat [\#4324](https://github.com/raster-foundry/raster-foundry/pull/4234)
 - Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
 - Cleaned up a project database test [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -158,7 +158,7 @@ trait SceneRoutes
       val histogram: OptionT[Future, Array[Histogram[Double]]] =
         (newScene.sceneType, newScene.ingestLocation) match {
           case (Some(SceneType.COG), Some(ingestLocation)) =>
-            CogUtils.fromUri(ingestLocation) map { geoTiff =>
+            CogUtils.fromUri(ingestLocation) map { _._1 } map { geoTiff =>
               CogUtils.geoTiffDoubleHistogram(geoTiff)
             }
           case _ => OptionT.fromOption(None)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -158,7 +158,7 @@ trait SceneRoutes
       val histogram: OptionT[Future, Array[Histogram[Double]]] =
         (newScene.sceneType, newScene.ingestLocation) match {
           case (Some(SceneType.COG), Some(ingestLocation)) =>
-            CogUtils.fromUri(ingestLocation) map { _._1 } map { geoTiff =>
+            CogUtils.fromUri(ingestLocation) map { _.tiff } map { geoTiff =>
               CogUtils.geoTiffDoubleHistogram(geoTiff)
             }
           case _ => OptionT.fromOption(None)

--- a/app-backend/backsplash/src/main/scala/io/Avro.scala
+++ b/app-backend/backsplash/src/main/scala/io/Avro.scala
@@ -125,7 +125,7 @@ object Avro extends RollbarNotifier with HistogramJsonFormats {
               val cols = mbTile.cols / resolutionDiff
               val rows = mbTile.rows / resolutionDiff
               val corrected =
-                md.colorCorrections.colorCorrect(mbTile, histograms.toSeq)
+                md.colorCorrections.colorCorrect(mbTile, histograms.toSeq, None)
               Raster(corrected.color, extent).resample(256, 256)
             }
         }).toOption

--- a/app-backend/backsplash/src/main/scala/io/Cog.scala
+++ b/app-backend/backsplash/src/main/scala/io/Cog.scala
@@ -108,7 +108,9 @@ object Cog extends RollbarNotifier {
       val subsetBands = raster.tile.subsetBands(bandOrder)
       val subsetHistograms = bandOrder map histograms
       val colored =
-        md.colorCorrections.colorCorrect(subsetBands, subsetHistograms).color
+        md.colorCorrections
+          .colorCorrect(subsetBands, subsetHistograms, None)
+          .color
       Raster(colored, extent).resample(256, 256)
     }
     OptionT(tileIO.attempt.map(_.toOption))

--- a/app-backend/backsplash/src/main/scala/io/Histogram.scala
+++ b/app-backend/backsplash/src/main/scala/io/Histogram.scala
@@ -70,7 +70,8 @@ object Histogram {
           val subsetTile =
             globalMbTile.subsetBands(rgbBands._1, rgbBands._2, rgbBands._3)
           md.colorCorrections.colorCorrect(subsetTile,
-                                           subsetTile.histogramDouble)
+                                           subsetTile.histogramDouble,
+                                           None)
       }
     } yield {
       correctedTiles.foldLeft(Vector.fill(3)(IntHistogram(): Histogram[Int]))(

--- a/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
@@ -2,7 +2,12 @@ package com.rasterfoundry.batch.cogMetadata
 
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.utils.CogUtils
-import com.rasterfoundry.datamodel.{LayerAttribute, Scene, SceneType}
+import com.rasterfoundry.datamodel.{
+  LayerAttribute,
+  Scene,
+  SceneType,
+  TiffWithMetadata
+}
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.{LayerAttributeDao, SceneDao}
@@ -90,7 +95,7 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
     IO.fromFuture {
       IO(
         (CogUtils.fromUri(ingestLocation) map {
-          case (tiff, _) =>
+          case TiffWithMetadata(tiff, _) =>
             CogUtils.geoTiffDoubleHistogram(tiff).toList
         }).value
       )

--- a/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
@@ -90,7 +90,8 @@ object HistogramBackfill extends RollbarNotifier with HistogramJsonFormats {
     IO.fromFuture {
       IO(
         (CogUtils.fromUri(ingestLocation) map {
-          CogUtils.geoTiffDoubleHistogram(_).toList
+          case (tiff, _) =>
+            CogUtils.geoTiffDoubleHistogram(tiff).toList
         }).value
       )
     } recoverWith ({

--- a/app-backend/batch/src/main/scala/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/export/spark/Export.scala
@@ -156,7 +156,7 @@ object Export extends SparkJob with Config with RollbarNotifier {
               rdd.mapValues(
                 { tile =>
                   val ctile = (eld.colorCorrections, hist) mapN {
-                    _.colorCorrect(tile, _)
+                    _.colorCorrect(tile, _, None)
                   } getOrElse tile
 
                   ed.output.render.flatMap(_.bands.map(_.toSeq)) match {

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -51,8 +51,8 @@ memcached {
   threads = 16
   threads = ${?MEMCACHED_THREADS}
 
-  enabled = true
-  enabled = ${?MEMCACHED_ENABLED}
+  enabled = false
+  # enabled = ${?MEMCACHED_ENABLED}
 
   keySize = 250
   keySize = ${?MEMCACHED_KEY_SIZE}

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -51,8 +51,8 @@ memcached {
   threads = 16
   threads = ${?MEMCACHED_THREADS}
 
-  enabled = false
-  # enabled = ${?MEMCACHED_ENABLED}
+  enabled = true
+  enabled = ${?MEMCACHED_ENABLED}
 
   keySize = 250
   keySize = ${?MEMCACHED_KEY_SIZE}

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.common.utils
 import com.rasterfoundry.common.cache._
 import com.rasterfoundry.common.cache.kryo._
 import com.rasterfoundry.common.{Config => CommonConfig}
+import com.rasterfoundry.datamodel.TiffWithMetadata
 
 import com.amazonaws.services.s3.AmazonS3URI
 import geotrellis.vector._
@@ -12,7 +13,6 @@ import geotrellis.raster.resample._
 import geotrellis.raster.histogram._
 import geotrellis.raster.reproject._
 import geotrellis.raster.io.geotiff._
-import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.io.geotiff.reader.{GeoTiffReader, TiffTagsReader}
 import geotrellis.util._
 import geotrellis.proj4._
@@ -43,8 +43,8 @@ object CogUtils {
   }.toArray
 
   /** Read GeoTiff from URI while caching the header bytes in memcache */
-  def fromUri(uri: String)(implicit ec: ExecutionContext)
-    : OptionT[Future, (GeoTiff[MultibandTile], TiffTags)] = {
+  def fromUri(uri: String)(
+      implicit ec: ExecutionContext): OptionT[Future, TiffWithMetadata] = {
     val cacheKey = s"cog-header-${URIUtils.withNoParams(uri)}"
     val cacheSize = 1 << 18
 
@@ -59,8 +59,8 @@ object CogUtils {
       .mapFilter { headerBytes =>
         RangeReaderUtils.fromUri(uri).map { rr =>
           val crr = CacheRangeReader(rr, headerBytes)
-          (GeoTiffReader.readMultiband(crr, streaming = true),
-           TiffTagsReader.read(crr))
+          TiffWithMetadata(GeoTiffReader.readMultiband(crr, streaming = true),
+                           TiffTagsReader.read(crr))
         }
       }
   }
@@ -131,7 +131,7 @@ object CogUtils {
       s"cog-tile-${zoom}-${x}-${y}-${URIUtils.withNoParams(uri)}")(
       CogUtils
         .fromUri(uri)
-        .map(_._1)
+        .map(_.tiff)
         .mapFilter { tiff =>
           val transform = Proj4Transform(tiff.crs, WebMercator)
           val inverseTransform = Proj4Transform(WebMercator, tiff.crs)
@@ -177,7 +177,7 @@ object CogUtils {
     val floor = floorO.getOrElse(25)
     rfCache.cachingOptionT(s"cog-thumbnail-${width}-${height}-${URIUtils
       .withNoParams(uri)}-${red}-${green}-${blue}-${floor}")(
-      CogUtils.fromUri(uri).map(_._1) mapFilter {
+      CogUtils.fromUri(uri).map(_.tiff) mapFilter {
         tiff =>
           val cellSize = CellSize(tiff.extent, width, height)
           val overview =

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -12,7 +12,8 @@ import geotrellis.raster.resample._
 import geotrellis.raster.histogram._
 import geotrellis.raster.reproject._
 import geotrellis.raster.io.geotiff._
-import geotrellis.raster.io.geotiff.reader.GeoTiffReader
+import geotrellis.raster.io.geotiff.tags.TiffTags
+import geotrellis.raster.io.geotiff.reader.{GeoTiffReader, TiffTagsReader}
 import geotrellis.util._
 import geotrellis.proj4._
 import geotrellis.spark._
@@ -43,7 +44,7 @@ object CogUtils {
 
   /** Read GeoTiff from URI while caching the header bytes in memcache */
   def fromUri(uri: String)(implicit ec: ExecutionContext)
-    : OptionT[Future, GeoTiff[MultibandTile]] = {
+    : OptionT[Future, (GeoTiff[MultibandTile], TiffTags)] = {
     val cacheKey = s"cog-header-${URIUtils.withNoParams(uri)}"
     val cacheSize = 1 << 18
 
@@ -58,7 +59,8 @@ object CogUtils {
       .mapFilter { headerBytes =>
         RangeReaderUtils.fromUri(uri).map { rr =>
           val crr = CacheRangeReader(rr, headerBytes)
-          GeoTiffReader.readMultiband(crr, streaming = true)
+          (GeoTiffReader.readMultiband(crr, streaming = true),
+           TiffTagsReader.read(crr))
         }
       }
   }
@@ -127,21 +129,24 @@ object CogUtils {
       implicit ec: ExecutionContext): OptionT[Future, MultibandTile] =
     rfCache.cachingOptionT(
       s"cog-tile-${zoom}-${x}-${y}-${URIUtils.withNoParams(uri)}")(
-      CogUtils.fromUri(uri).mapFilter { tiff =>
-        val transform = Proj4Transform(tiff.crs, WebMercator)
-        val inverseTransform = Proj4Transform(WebMercator, tiff.crs)
-        val tmsTileRE = RasterExtent(
-          extent = TmsLevels(zoom).mapTransform.keyToExtent(x, y),
-          cols = 256,
-          rows = 256
-        )
-        val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
-        val overview =
-          closestTiffOverview(tiff, tiffTileRE.cellSize, AutoHigherResolution)
-        cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
-          raster.reproject(tmsTileRE, transform, inverseTransform).tile
+      CogUtils
+        .fromUri(uri)
+        .map(_._1)
+        .mapFilter { tiff =>
+          val transform = Proj4Transform(tiff.crs, WebMercator)
+          val inverseTransform = Proj4Transform(WebMercator, tiff.crs)
+          val tmsTileRE = RasterExtent(
+            extent = TmsLevels(zoom).mapTransform.keyToExtent(x, y),
+            cols = 256,
+            rows = 256
+          )
+          val tiffTileRE = ReprojectRasterExtent(tmsTileRE, inverseTransform)
+          val overview =
+            closestTiffOverview(tiff, tiffTileRE.cellSize, AutoHigherResolution)
+          cropGeoTiff(overview, tiffTileRE.extent).map { raster =>
+            raster.reproject(tmsTileRE, transform, inverseTransform).tile
+          }
         }
-      }
     )
 
   // To construct a multiband geotiff, we have to have more than one band, so the fact that
@@ -172,7 +177,7 @@ object CogUtils {
     val floor = floorO.getOrElse(25)
     rfCache.cachingOptionT(s"cog-thumbnail-${width}-${height}-${URIUtils
       .withNoParams(uri)}-${red}-${green}-${blue}-${floor}")(
-      CogUtils.fromUri(uri).mapFilter {
+      CogUtils.fromUri(uri).map(_._1) mapFilter {
         tiff =>
           val cellSize = CellSize(tiff.extent, width, height)
           val overview =

--- a/app-backend/datamodel/src/main/scala/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/ColorCorrect.scala
@@ -60,9 +60,10 @@ object ColorCorrect extends LazyLogging {
     }
 
     def colorCorrect(tile: MultibandTile,
-                     hist: Seq[Histogram[Double]]): MultibandTile = {
+                     hist: Seq[Histogram[Double]],
+                     nodataValue: Option[Double]): MultibandTile = {
       val (rgbTile, rgbHist) = reorderBands(tile, hist)
-      ColorCorrect(rgbTile, rgbHist, this)
+      ColorCorrect(rgbTile, rgbHist, this, nodataValue)
     }
   }
 
@@ -124,7 +125,8 @@ object ColorCorrect extends LazyLogging {
       gammas: Map[Int, Option[Double]]
   )(sigmoidalContrast: SigmoidalContrast)(
       colorCorrectArgs: Map[Int, MaybeClipBounds],
-      tileClipping: MultiBandClipping
+      tileClipping: MultiBandClipping,
+      nodataValue: Option[Double]
   ): MultibandTile = {
     val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
     val (gr, gg, gb) = (gammas(0), gammas(1), gammas(2))
@@ -240,7 +242,8 @@ object ColorCorrect extends LazyLogging {
 
   def apply(rgbTile: MultibandTile,
             rgbHist: Array[Histogram[Double]],
-            params: Params): MultibandTile = {
+            params: Params,
+            nodataValue: Option[Double]): MultibandTile = {
     var _rgbTile = rgbTile
     var _rgbHist = rgbHist
     val gammas = params.getGamma
@@ -300,7 +303,9 @@ object ColorCorrect extends LazyLogging {
     complexColorCorrect(_rgbTile, params.saturation)(
       layerNormalizeArgs,
       gammas
-    )(params.sigmoidalContrast)(colorCorrectArgs, params.tileClipping)
+    )(params.sigmoidalContrast)(colorCorrectArgs,
+                                params.tileClipping,
+                                nodataValue)
   }
 
   @inline def clampColor(z: Int): Int = {

--- a/app-backend/datamodel/src/main/scala/ColorCorrect.scala
+++ b/app-backend/datamodel/src/main/scala/ColorCorrect.scala
@@ -140,9 +140,13 @@ object ColorCorrect extends LazyLogging {
     val ClipBounds(gmin, gmax) = layerNormalizeArgs(1)
     val ClipBounds(bmin, bmax) = layerNormalizeArgs(2)
 
-    val (rclipMin, rclipMax, rnewMin, rnewMax) = (rmin, rmax, 0, 255)
-    val (gclipMin, gclipMax, gnewMin, gnewMax) = (gmin, gmax, 0, 255)
-    val (bclipMin, bclipMax, bnewMin, bnewMax) = (bmin, bmax, 0, 255)
+    val tileMin = nodataValue match {
+      case Some(0) => 1
+      case _       => 0
+    }
+    val (rclipMin, rclipMax, rnewMin, rnewMax) = (rmin, rmax, tileMin, 255)
+    val (gclipMin, gclipMax, gnewMin, gnewMax) = (gmin, gmax, tileMin, 255)
+    val (bclipMin, bclipMax, bnewMin, bnewMax) = (bmin, bmax, tileMin, 255)
 
     val sigmoidal: Double => Double =
       (

--- a/app-backend/datamodel/src/main/scala/TiffWithMetadata.scala
+++ b/app-backend/datamodel/src/main/scala/TiffWithMetadata.scala
@@ -1,0 +1,9 @@
+package com.rasterfoundry.datamodel
+import geotrellis.raster._
+import geotrellis.raster.io.geotiff._
+import geotrellis.raster.io.geotiff.tags.TiffTags
+
+case class TiffWithMetadata(
+    tiff: GeoTiff[MultibandTile],
+    tiffTags: TiffTags
+)

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -74,7 +74,7 @@ object GlobalSummary extends LazyLogging {
     // This is currently somewhat hacky because Tiffs are quite different than fleshed out layers
     // In particular, the `int` here is not a zoom but an index to this Cog's least resolute overview
     for {
-      tiff <- CogUtils.fromUri(uri)
+      tiff <- CogUtils.fromUri(uri) map { _._1 }
       minOverview <- OptionT.fromOption[Future] {
         tiff.overviews.headOption.map { _ =>
           tiff.overviews.maxBy(_.cellSize.resolution)

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -74,7 +74,7 @@ object GlobalSummary extends LazyLogging {
     // This is currently somewhat hacky because Tiffs are quite different than fleshed out layers
     // In particular, the `int` here is not a zoom but an index to this Cog's least resolute overview
     for {
-      tiff <- CogUtils.fromUri(uri) map { _._1 }
+      tiff <- CogUtils.fromUri(uri) map { _.tiff }
       minOverview <- OptionT.fromOption[Future] {
         tiff.overviews.headOption.map { _ =>
           tiff.overviews.maxBy(_.cellSize.resolution)

--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -8,6 +8,7 @@ import com.rasterfoundry.datamodel.{
   ColorCorrect,
   MosaicDefinition,
   SceneType,
+  TiffWithMetadata,
   WhiteBalance
 }
 import com.rasterfoundry.common.cache.CacheClient
@@ -461,7 +462,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
 
     rfCache.cachingOptionT(cacheKey)(
       CogUtils.fromUri(ingestLocation).flatMap {
-        case (tiff, metadata) =>
+        case TiffWithMetadata(tiff, metadata) =>
           CogUtils.cropForZoomExtent(tiff, zoom, extent).flatMap {
             cropped: MultibandTile =>
               if (colorCorrect) {

--- a/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
@@ -82,7 +82,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
 
     rfCache
       .cachingOptionT(cacheKey)(
-        CogUtils.fromUri(ingestLocation).flatMap { tiff =>
+        CogUtils.fromUri(ingestLocation) map { _._1 } flatMap { tiff =>
           CogUtils.cropForZoomExtent(tiff, zoom, extent).flatMap {
             cropped: MultibandTile =>
               val hist = CogUtils.geoTiffDoubleHistogram(tiff)

--- a/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
@@ -82,7 +82,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
 
     rfCache
       .cachingOptionT(cacheKey)(
-        CogUtils.fromUri(ingestLocation) map { _._1 } flatMap { tiff =>
+        CogUtils.fromUri(ingestLocation) map { _.tiff } flatMap { tiff =>
           CogUtils.cropForZoomExtent(tiff, zoom, extent).flatMap {
             cropped: MultibandTile =>
               val hist = CogUtils.geoTiffDoubleHistogram(tiff)

--- a/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
+++ b/app-backend/tile/src/main/scala/routes/MosaicRoutes.scala
@@ -193,7 +193,8 @@ object MosaicRoutes extends LazyLogging with KamonTrace {
       } yield {
         val (rgbBands, rgbHist) =
           params.reorderBands(tile, tile.histogramDouble)
-        val sceneBands = ColorCorrect(rgbBands, rgbHist, params).bands
+        // Ok to use None here because this is non-COGs only right now
+        val sceneBands = ColorCorrect(rgbBands, rgbHist, params, None).bands
         sceneBands.map(tile => tile.histogram)
       }
     }

--- a/app-backend/tile/src/main/scala/tool/TileResolver.scala
+++ b/app-backend/tile/src/main/scala/tool/TileResolver.scala
@@ -462,7 +462,7 @@ class TileResolver(xaa: Transactor[IO], ec: ExecutionContext)
       case cr @ CogRaster(_, Some(band), celltype, location) =>
         CogUtils
           .fromUri(location)
-          .map(_._1)
+          .map(_.tiff)
           .flatMap { tiff =>
             CogUtils.cropForZoomExtent(tiff, zoom, Some(extent)).map {
               tile: MultibandTile =>

--- a/app-backend/tile/src/main/scala/tool/TileResolver.scala
+++ b/app-backend/tile/src/main/scala/tool/TileResolver.scala
@@ -462,6 +462,7 @@ class TileResolver(xaa: Transactor[IO], ec: ExecutionContext)
       case cr @ CogRaster(_, Some(band), celltype, location) =>
         CogUtils
           .fromUri(location)
+          .map(_._1)
           .flatMap { tiff =>
             CogUtils.cropForZoomExtent(tiff, zoom, Some(extent)).map {
               tile: MultibandTile =>


### PR DESCRIPTION
## Overview

This PR uses tiff metadata to determine what range to normalize imagery to. If the nodata value is zero (looking at you, Planet), it normalizes to the range `[1, 255]` instead of `[0, 255]`, because otherwise it gets confused and thinks there's a bunch of nodata in the middle of the scene. If the nodata value _isn't_ 0, it normalizes to 0 -> 255

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/5702984/47579364-0a660480-d94c-11e8-8e25-75a7131dc490.png)

![image](https://user-images.githubusercontent.com/5702984/47579396-28cc0000-d94c-11e8-8cb3-51eca6ded8a3.png)

## Testing Instructions

 * turn your tile server cache off
 * visualize a planet cog -- it should not have patches
 * visualize a non-planet cog -- it should not have a thick black border

Closes #4053 

Closes #4246 