### PR TITLE
Don't use the global execution context for db tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - Cleaned up a project database test [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
 - Don't include name in intercom user init if it's the same as the email [\#4247](https://github.com/raster-foundry/raster-foundry/pull/4247)
 - Kick off ingests for scenes without scene types also [\#4260](https://github.com/raster-foundry/raster-foundry/pull/4260)
-- Separate connection and transaction execution contexts in database tests [\#4264](https://github.com/raster-foundry/raster-foundry/pull/4264)
+- Separated connection and transaction execution contexts in database tests [\#4264](https://github.com/raster-foundry/raster-foundry/pull/4264)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,10 @@
 - Fix visualization of Planet scenes and fix bands used when generating COG scene thumbnails [\#4238](https://github.com/raster-foundry/raster-foundry/pull/4238)
 - Stopped explicitly setting a nodata value in one step of ingest for Sentinel-2 and Landsat [\#4324](https://github.com/raster-foundry/raster-foundry/pull/4234)
 - Stopped combining Landsat 4 / 5 / 7 bands in random orders when converting them to COGs [\#4242](https://github.com/raster-foundry/raster-foundry/pull/4242)
-- Cleaned up project database tests to prevent a database deadlock [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
+- Cleaned up a project database test [\#4248](https://github.com/raster-foundry/raster-foundry/pull/4248)
 - Don't include name in intercom user init if it's the same as the email [\#4247](https://github.com/raster-foundry/raster-foundry/pull/4247)
 - Kick off ingests for scenes without scene types also [\#4260](https://github.com/raster-foundry/raster-foundry/pull/4260)
+- Separate connection and transaction execution contexts in database tests [\#4264](https://github.com/raster-foundry/raster-foundry/pull/4264)
 
 ### Security
 

--- a/app-backend/common/src/main/scala/AWSBatch.scala
+++ b/app-backend/common/src/main/scala/AWSBatch.scala
@@ -49,9 +49,9 @@ trait AWSBatch extends RollbarNotifier with LazyLogging {
           throw e
       }
     } else {
-      logger.warn(
+      logger.info(
         s"Not submitting AWS Batch -- not in production or staging, in ${awsbatchConfig.environment}")
-      logger.warn(
+      logger.info(
         s"Job Request: ${jobName} -- ${jobDefinition} -- ${parameters}")
     }
 

--- a/app-backend/db/src/test/resources/logback-test.xml
+++ b/app-backend/db/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
     <appender-ref ref="STDOUT" />
   </logger>
 
-  <root level="info">
+  <root level="warn">
     <appender-ref ref="STDOUT" />
   </root>
 </configuration>

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -39,8 +39,9 @@ class AnnotationDaoSpec
                 )
               }
             }
-            annotationsInsertIO
-              .transact(xa)
+            xa.use((t: Transactor[IO]) =>
+                annotationsInsertIO
+                  .transact(t))
               .unsafeRunSync
               .length == annotations.length
           }
@@ -69,7 +70,7 @@ class AnnotationDaoSpec
             } yield (insertedAnnotations, labeler)
 
             val (insertedAnnotations, labeler) =
-              annotationsInsertIO.transact(xa).unsafeRunSync
+              xa.use(t => annotationsInsertIO.transact(t)).unsafeRunSync
 
             insertedAnnotations.length == annotations.length &&
             insertedAnnotations.flatMap(_.labeledBy).distinct(0) === labeler.id
@@ -79,7 +80,9 @@ class AnnotationDaoSpec
   }
 
   test("list annotations") {
-    AnnotationDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => AnnotationDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("list annotations for project") {
@@ -114,7 +117,7 @@ class AnnotationDaoSpec
               }
             }
             val (insertedAnnotations, annotationsForProject) =
-              annotationsListForProjectIO.transact(xa).unsafeRunSync
+              xa.use(t => annotationsListForProjectIO.transact(t)).unsafeRunSync
 
             insertedAnnotations.toSet == annotationsForProject.toSet
           }
@@ -169,8 +172,9 @@ class AnnotationDaoSpec
               }
             }
 
-            val (affectedRows, updatedAnnotation, verifier) =
-              annotationsUpdateWithAnnotationIO.transact(xa).unsafeRunSync
+            val (affectedRows, updatedAnnotation, verifier) = xa
+              .use(t => annotationsUpdateWithAnnotationIO.transact(t))
+              .unsafeRunSync
 
             affectedRows == 1 &&
             updatedAnnotation.label == annotationUpdate.label &&
@@ -206,7 +210,11 @@ class AnnotationDaoSpec
               }
             }
 
-            annotationsLabelsIO.transact(xa).unsafeRunSync.toSet ==
+            xa.use(
+                t => annotationsLabelsIO.transact(t)
+              )
+              .unsafeRunSync
+              .toSet ==
               (annotations.toSet map { (annotation: Annotation.Create) =>
                 annotation.label
               })

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
@@ -42,10 +42,11 @@ class AnnotationGroupDaoSpec
                 }
               }
             }
-            val (annotationGroup, dbUser, dbProject) =
-              annotationGroupInsertWithUserAndProjectIO
-                .transact(xa)
-                .unsafeRunSync()
+            val (annotationGroup, dbUser, dbProject) = xa
+              .use(t =>
+                annotationGroupInsertWithUserAndProjectIO
+                  .transact(t))
+              .unsafeRunSync()
             assert(annotationGroup.name == annotationGroupCreate.name,
                    "; Annotation group should be inserted")
             true
@@ -86,7 +87,7 @@ class AnnotationGroupDaoSpec
               (agDb1, agDb2, agDb3, p1AnnotationGroups, p2AnnotationGroups)
 
             val (ag1, ag2, ag3, p1ag, p2ag) =
-              annotationGroupIO.transact(xa).unsafeRunSync()
+              xa.use(t => annotationGroupIO.transact(t)).unsafeRunSync()
 
             assert(p1ag.length == 2 && p2ag.length == 1,
                    "; annotation groups are filters to project")
@@ -143,7 +144,8 @@ class AnnotationGroupDaoSpec
                  remainingAnnotations,
                  projectAnnotations,
                  projectAnnotationGroups,
-                 deleteCount) = annotationGroupIO.transact(xa).unsafeRunSync()
+                 deleteCount) =
+              xa.use(t => annotationGroupIO.transact(t)).unsafeRunSync()
 
             assert(
               deleteCount == 1,
@@ -190,7 +192,7 @@ class AnnotationGroupDaoSpec
             } yield (annotationGroupSummary, annotationsDB)
 
             val (annotationGroupSummary, annotationsDB) =
-              annotationGroupIO.transact(xa).unsafeRunSync()
+              xa.use(t => annotationGroupIO.transact(t)).unsafeRunSync()
 
             assert(annotationGroupSummary.length > 0,
                    "; No summary produced for annotation group")
@@ -245,7 +247,7 @@ class AnnotationGroupDaoSpec
             } yield (projectAnnotationGroups, updatedProject)
 
             val (projectAnnotationGroups, project) =
-              annotationGroupIO.transact(xa).unsafeRunSync()
+              xa.use(t => annotationGroupIO.transact(t)).unsafeRunSync()
 
             assert(
               projectAnnotationGroups.length == 1,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -27,7 +27,9 @@ class AoiDaoSpec
     with PropTestHelpers {
 
   test("list AOIs") {
-    AoiDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => AoiDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("insert an AOI") {
@@ -52,7 +54,7 @@ class AoiDaoSpec
               }
             }
             val (insertedShape, insertedAoi) =
-              aoiInsertIO.transact(xa).unsafeRunSync
+              xa.use(t => aoiInsertIO.transact(t)).unsafeRunSync
 
             assert(insertedAoi.shape == insertedShape.id,
                    "Shape should round trip with equality")
@@ -98,8 +100,9 @@ class AoiDaoSpec
                  originalShape,
                  affectedRows,
                  updatedAoi,
-                 updatedShape) =
-              aoiInsertWithOrgUserProjectIO.transact(xa).unsafeRunSync
+                 updatedShape) = xa
+              .use(t => aoiInsertWithOrgUserProjectIO.transact(t))
+              .unsafeRunSync
 
             assert(affectedRows == 1, "Only one row should be updated")
             assert(updatedAoi.shape == updatedShape.id,
@@ -141,7 +144,7 @@ class AoiDaoSpec
               }
             }
 
-            aoiDeleteIO.transact(xa).unsafeRunSync == 1
+            xa.use(t => aoiDeleteIO.transact(t)).unsafeRunSync == 1
           }
       }
     }
@@ -193,7 +196,8 @@ class AoiDaoSpec
               }
             }
 
-            val (dbAois, listedAois) = aoisForProject.transact(xa).unsafeRunSync
+            val (dbAois, listedAois) =
+              xa.use(t => aoisForProject.transact(t)).unsafeRunSync
             (dbAois.toSet map { (aoi: AOI) =>
               aoi.id
             }) == (listedAois.results.toSet map { (aoi: AOI) =>
@@ -251,7 +255,7 @@ class AoiDaoSpec
                                                       page)
             } yield (dbAois1, listedAois)
             val (insertedAois, listedAois) =
-              aoisInsertAndListIO.transact(xa).unsafeRunSync
+              xa.use(t => aoisInsertAndListIO.transact(t)).unsafeRunSync
             val insertedAoiAreaSet = insertedAois map { _.id } toSet
             val listedAoisAreaSet = listedAois.results map { _.id } toSet
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -68,7 +68,7 @@ class AuthorizationSpec
             } yield (user1Authorized, user2Authorized)
 
             val (user1Authed, user2Authed) =
-              usersAuthedIO.transact(xa).unsafeRunSync
+              xa.use(t => usersAuthedIO.transact(t)).unsafeRunSync
 
             assert(
               user1Authed && user2Authed,
@@ -128,7 +128,7 @@ class AuthorizationSpec
             } yield { (user1Authorized, user2Authorized) }
 
             val (user1Authed, user2Authed) =
-              usersAuthedIO.transact(xa).unsafeRunSync
+              xa.use(t => usersAuthedIO.transact(t)).unsafeRunSync
 
             assert(
               user1Authed,
@@ -183,7 +183,7 @@ class AuthorizationSpec
             } yield { (user1Authorized, user2Authorized) }
 
             val (user1Authed, user2Authed) =
-              usersAuthedIO.transact(xa).unsafeRunSync
+              xa.use(t => usersAuthedIO.transact(t)).unsafeRunSync
             assert(
               user1Authed,
               "A user in the same org as the authorized org should be authorized")
@@ -230,7 +230,8 @@ class AuthorizationSpec
               dbAcrs <- ProjectDao.getPermissions(project.id)
             } yield { (acrs, dbAcrs) }
 
-            val (acrs, dbAcrs) = insertManyAcrsIO.transact(xa).unsafeRunSync
+            val (acrs, dbAcrs) =
+              xa.use(t => insertManyAcrsIO.transact(t)).unsafeRunSync
 
             assert(
               acrs.toSet == dbAcrs.flatten.toSet,
@@ -267,7 +268,8 @@ class AuthorizationSpec
               listOfActions <- ProjectDao.listUserActions(user, project.id)
             } yield listOfActions
 
-            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions =
+              xa.use(t => listUserActionsIO.transact(t)).unsafeRunSync
 
             assert(listUserActions.length == 3,
                    "; List of permitted actions should be 3")
@@ -310,7 +312,8 @@ class AuthorizationSpec
               listOfActions <- ProjectDao.listUserActions(user, project.id)
             } yield listOfActions
 
-            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions =
+              xa.use(t => listUserActionsIO.transact(t)).unsafeRunSync
             listUserActions.length == 0
           }
       }
@@ -345,7 +348,8 @@ class AuthorizationSpec
               listOfActions <- ProjectDao.listUserActions(user, project.id)
             } yield listOfActions
 
-            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions =
+              xa.use(t => listUserActionsIO.transact(t)).unsafeRunSync
 
             assert(listUserActions.length == 3,
                    "; List of permitted actions should be 3")
@@ -388,7 +392,8 @@ class AuthorizationSpec
               listOfActions <- ProjectDao.listUserActions(user, project.id)
             } yield listOfActions
 
-            val listUserActions = listUserActionsIO.transact(xa).unsafeRunSync
+            val listUserActions =
+              xa.use(t => listUserActionsIO.transact(t)).unsafeRunSync
 
             assert(listUserActions.length == 3,
                    "; List of permitted actions should be 3")

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
@@ -20,6 +20,8 @@ class BandDaoSpec extends FunSuite with Matchers with DBTestConfig {
 
   // list bands
   test("list bands") {
-    BandDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => BandDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -7,18 +7,25 @@ import doobie.hikari._
 import doobie.hikari.implicits._
 import doobie.postgres._
 import doobie.postgres.implicits._
+import doobie.util.ExecutionContexts
 import cats._
 import cats.data._
 import cats.effect._
 import cats.implicits._
 
 import java.util.UUID
+import java.util.concurrent._
 import scala.concurrent.ExecutionContext
 
 trait DBTestConfig {
 
+  val executorService = Executors.newFixedThreadPool(16)
+  val ec = ExecutionContext.fromExecutorService(
+    executorService,
+    ExecutionContext.defaultReporter)
+
   implicit val cs: ContextShift[IO] =
-    IO.contextShift(ExecutionContext.Implicits.global)
+    IO.contextShift(ec)
 
   val xa: Transactor[IO] =
     Transactor.after.set(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
@@ -14,11 +14,15 @@ import org.scalatest._
 import io.circe._
 import io.circe.syntax._
 
-class ExportDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
+class ExportDaoSpec extends FunSuite with Matchers with DBTestConfig {
 
-  test("types") { check(ExportDao.selectF.query[Export]) }
+  test("types") {
+    xa.use(
+        t => {
+          ExportDao.query.list.transact(t)
+        }
+      )
+      .unsafeRunSync
+      .length should be >= 0
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/FeatureFlagDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/FeatureFlagDaoSpec.scala
@@ -10,10 +10,10 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class FeatureFlagDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
-  test("types") { check(FeatureFlagDao.selectF.query[FeatureFlag]) }
+class FeatureFlagDaoSpec extends FunSuite with Matchers with DBTestConfig {
+  test("types") {
+    xa.use(t => FeatureFlagDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
@@ -55,7 +55,8 @@ class ImageDaoSpec
               )
             }
           }
-          val insertedImage = imageInsertIO.transact(xa).unsafeRunSync.get
+          val insertedImage =
+            xa.use(t => imageInsertIO.transact(t)).unsafeRunSync.get
           insertedImage.rawDataBytes == image.rawDataBytes &&
           insertedImage.visibility == image.visibility &&
           insertedImage.filename == image.filename &&
@@ -114,7 +115,7 @@ class ImageDaoSpec
           }
 
           val (affectedRows, updatedImage) =
-            imageUpdateWithUpdatedImageIO.transact(xa).unsafeRunSync
+            xa.use(t => imageUpdateWithUpdatedImageIO.transact(t)).unsafeRunSync
           affectedRows == 1 &&
           updatedImage.rawDataBytes == imageUpdate.rawDataBytes &&
           updatedImage.visibility == imageUpdate.visibility &&
@@ -129,6 +130,6 @@ class ImageDaoSpec
   }
 
   test("list images") {
-    ImageDao.query.list.transact(xa).unsafeRunSync
+    xa.use(t => ImageDao.query.list.transact(t)).unsafeRunSync
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
@@ -21,13 +21,17 @@ class LayerAttributeDaoSpec
     with DBTestConfig {
 
   test("list all layer ids") {
-    LayerAttributeDao.layerIds.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => LayerAttributeDao.layerIds.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("get max zooms for layers") {
-    LayerAttributeDao
-      .maxZoomsForLayers(Set.empty[String])
-      .transact(xa)
+    xa.use(
+        t =>
+          LayerAttributeDao
+            .maxZoomsForLayers(Set.empty[String])
+            .transact(t))
       .unsafeRunSync
       .length should be >= 0
   }
@@ -42,7 +46,7 @@ class LayerAttributeDaoSpec
             layerAttribute) flatMap { _ =>
             LayerAttributeDao.unsafeGetAttribute(layerId, layerAttribute.name)
           }
-          attributeIO.transact(xa).unsafeRunSync == layerAttribute
+          xa.use(t => attributeIO.transact(t)).unsafeRunSync == layerAttribute
         }
       }
     }
@@ -61,7 +65,7 @@ class LayerAttributeDaoSpec
             LayerAttributeDao.listAllAttributes(layerAttributes.head.name)
           }
 
-          attributesIO.transact(xa).unsafeRunSync.length ==
+          xa.use(t => attributesIO.transact(t)).unsafeRunSync.length ==
             layerAttributes.filter(_.name == layerAttributes.head.name).length
         }
       }
@@ -78,7 +82,7 @@ class LayerAttributeDaoSpec
             layerAttribute) flatMap { _ =>
             LayerAttributeDao.layerExists(layerId)
           }
-          attributesIO.transact(xa).unsafeRunSync
+          xa.use(t => attributesIO.transact(t)).unsafeRunSync
         }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LicenseDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LicenseDaoSpec.scala
@@ -4,18 +4,17 @@ import com.rasterfoundry.datamodel._
 import com.rasterfoundry.database.Implicits._
 
 import doobie._
+import doobie.implicits._
 import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.scalatest.imports._
 
 import org.scalatest._
 
-class LicenseDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
+class LicenseDaoSpec extends FunSuite with Matchers with DBTestConfig {
   test("selection types") {
-    check(LicenseDao.selectF.query[License])
+    xa.use(t => LicenseDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
@@ -10,11 +10,11 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class MapTokenDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
+class MapTokenDaoSpec extends FunSuite with Matchers with DBTestConfig {
 
-  test("types") { check(MapTokenDao.selectF.query[MapToken]) }
+  test("types") {
+    xa.use(t => MapTokenDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
@@ -37,7 +37,7 @@ class OrganizationDaoSpec
                 .toOrganization(true))
           } yield (newOrg, insertedPlatform)
           val (insertedOrg, insertedPlatform) =
-            orgInsertIO.transact(xa).unsafeRunSync
+            xa.use(t => orgInsertIO.transact(t)).unsafeRunSync
 
           insertedOrg.platformId == insertedPlatform.id &&
           insertedOrg.name == orgCreate.name
@@ -60,7 +60,9 @@ class OrganizationDaoSpec
               }
             }
           }
-          retrievedNameIO.transact(xa).unsafeRunSync.get == orgCreate.name
+          xa.use(t => retrievedNameIO.transact(t))
+            .unsafeRunSync
+            .get == orgCreate.name
         }
       )
     }
@@ -88,7 +90,7 @@ class OrganizationDaoSpec
               }
           }
           val (affectedRows, updatedName, updatedStatus) =
-            insertAndUpdateIO.transact(xa).unsafeRunSync
+            xa.use(t => insertAndUpdateIO.transact(t)).unsafeRunSync
           (affectedRows == 1) && (updatedName == withoutNull) && (updatedStatus == orgCreate.status)
         }
       )
@@ -97,7 +99,9 @@ class OrganizationDaoSpec
 
   // list organizations
   test("list organizations") {
-    OrganizationDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => OrganizationDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("list authorized organizations") {
@@ -190,7 +194,7 @@ class OrganizationDaoSpec
                u1orgs,
                u2orgs,
                u3orgs,
-               u2orgsAdmin) = orgsIO.transact(xa).unsafeRunSync
+               u2orgsAdmin) = xa.use(t => orgsIO.transact(t)).unsafeRunSync
           val u1orgids = u1orgs.toSet.map { o: Organization =>
             o.id
           }
@@ -246,7 +250,8 @@ class OrganizationDaoSpec
             } yield { (org, byIdUserGroupRole) }
 
             val (dbOrg, dbUserGroupRole) =
-              addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
+              xa.use(t => addPlatformRoleWithPlatformIO.transact(t))
+                .unsafeRunSync
             dbUserGroupRole match {
               case Some(ugr) =>
                 assert(
@@ -298,7 +303,7 @@ class OrganizationDaoSpec
             } yield { (originalUserGroupRole, updatedUserGroupRoles) }
 
             val (dbOldUGR, dbUpdatedUGRs) =
-              setPlatformRoleIO.transact(xa).unsafeRunSync
+              xa.use(t => setPlatformRoleIO.transact(t)).unsafeRunSync
 
             assert(dbUpdatedUGRs.size === 1, "; A single UGR should be updated")
             assert(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationFeatureDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationFeatureDaoSpec.scala
@@ -4,6 +4,7 @@ import com.rasterfoundry.datamodel._
 import com.rasterfoundry.database.Implicits._
 
 import doobie._
+import doobie.implicits._
 import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.scalatest.imports._
@@ -13,9 +14,10 @@ import org.scalatest._
 class OrganizationFeatureDaoSpec
     extends FunSuite
     with Matchers
-    with IOChecker
     with DBTestConfig {
   test("selection types") {
-    check(OrganizationFeatureDao.selectF.query[OrgFeatures])
+    xa.use(t => OrganizationFeatureDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -30,9 +30,11 @@ class PlatformDaoSpec
     check {
       forAll { (pageRequest: PageRequest) =>
         {
-          PlatformDao
-            .listPlatforms(pageRequest)
-            .transact(xa)
+          xa.use(
+              t =>
+                PlatformDao
+                  .listPlatforms(pageRequest)
+                  .transact(t))
             .unsafeRunSync
             .results
             .length >= 0
@@ -54,7 +56,8 @@ class PlatformDaoSpec
               insertedPlatform <- PlatformDao.create(platform)
             } yield { insertedPlatform }
 
-            val dbPlatform = insertPlatformIO.transact(xa).unsafeRunSync
+            val dbPlatform =
+              xa.use(t => insertPlatformIO.transact(t)).unsafeRunSync
 
             dbPlatform.name == platform.name &&
             dbPlatform.publicSettings == platform.publicSettings &&
@@ -92,8 +95,9 @@ class PlatformDaoSpec
             }
 
             val (affectedRows, updatedPlatform) =
-              updatePlatformWithPlatformAndAffectedRowsIO
-                .transact(xa)
+              xa.use(t =>
+                  updatePlatformWithPlatformAndAffectedRowsIO
+                    .transact(t))
                 .unsafeRunSync
             affectedRows == 1 &&
             updatedPlatform.name == platformUpdate.name &&
@@ -120,7 +124,8 @@ class PlatformDaoSpec
             } yield { (deletePlatform, byIdPlatform) }
 
             val (rowsAffected, platformById) =
-              deletePlatformWithPlatformIO.transact(xa).unsafeRunSync
+              xa.use(t => deletePlatformWithPlatformIO.transact(t))
+                .unsafeRunSync
             rowsAffected == 1 && platformById == None
           }
       }
@@ -151,7 +156,8 @@ class PlatformDaoSpec
             } yield { (insertedPlatform, byIdUserGroupRole) }
 
             val (dbPlatform, dbUserGroupRole) =
-              addPlatformRoleWithPlatformIO.transact(xa).unsafeRunSync
+              xa.use(t => addPlatformRoleWithPlatformIO.transact(t))
+                .unsafeRunSync
             dbUserGroupRole match {
               case Some(ugr) =>
                 assert(ugr.isActive, "; Added role should be active")
@@ -198,7 +204,7 @@ class PlatformDaoSpec
             }
 
             val (dbPlatform, dbOldUGR, dbNewUGRs) =
-              setPlatformRoleIO.transact(xa).unsafeRunSync
+              xa.use(t => setPlatformRoleIO.transact(t)).unsafeRunSync
 
             assert(dbNewUGRs.filter((ugr) => ugr.isActive == true).size == 1,
                    "; Updated UGRs should have one set to active")
@@ -249,7 +255,7 @@ class PlatformDaoSpec
             }
 
             val (dbPlatform, dbOldUGR, dbNewUGRs) =
-              setPlatformRoleIO.transact(xa).unsafeRunSync
+              xa.use(t => setPlatformRoleIO.transact(t)).unsafeRunSync
 
             assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
                    "; The updated UGR should be inactive")
@@ -311,7 +317,8 @@ class PlatformDaoSpec
                  dbPlatform,
                  dbProject,
                  dbProjectAnother,
-                 listOfPUSP) = listOfPwuIO.transact(xa).unsafeRunSync
+                 listOfPUSP) =
+              xa.use(t => listOfPwuIO.transact(t)).unsafeRunSync
 
             assert(listOfPUSP.length == 2, "; list of return length is not 2")
             assert(listOfPUSP(0).platId == dbPlatform.id &&
@@ -402,7 +409,7 @@ class PlatformDaoSpec
             } yield (dbUser, dbPlatform, dbProject, pUO)
 
             val (dbUser, dbPlatform, dbProject, pU) =
-              puIO.transact(xa).unsafeRunSync
+              xa.use(t => puIO.transact(t)).unsafeRunSync
 
             assert(pU.platId == dbPlatform.id, "; platform ID don't match")
             assert(pU.platName == dbPlatform.name,
@@ -494,7 +501,7 @@ class PlatformDaoSpec
             } yield (teamInsert1, teamInsert2, teamInsert3, searchedTeams)
 
             val (teamInsert1, teamInsert2, teamInsert3, searchedTeams) =
-              createAndGetTeamsIO.transact(xa).unsafeRunSync
+              xa.use(t => createAndGetTeamsIO.transact(t)).unsafeRunSync
 
             val teams = List(teamInsert1, teamInsert2, teamInsert3)
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -45,7 +45,8 @@ class ProjectDaoSpec
                                          user)
               }
             }
-            val insertedProject = projInsertIO.transact(xa).unsafeRunSync
+            val insertedProject =
+              xa.use(t => projInsertIO.transact(t)).unsafeRunSync
             insertedProject.name == project.name &&
             insertedProject.description == project.description &&
             insertedProject.visibility == project.visibility &&
@@ -96,7 +97,7 @@ class ProjectDaoSpec
             }
 
             val (affectedRows, updatedProject) =
-              updateProjectWithUpdatedIO.transact(xa).unsafeRunSync
+              xa.use(t => updateProjectWithUpdatedIO.transact(t)).unsafeRunSync
 
             affectedRows == 1 &&
             updatedProject.owner == user.id &&
@@ -139,7 +140,7 @@ class ProjectDaoSpec
               }
             }
 
-            projDeleteIO.transact(xa).unsafeRunSync == None
+            xa.use(t => projDeleteIO.transact(t)).unsafeRunSync == None
           }
       }
     }
@@ -169,7 +170,11 @@ class ProjectDaoSpec
             } yield { listedProjects }
 
             val returnedThinUser =
-              projectsListIO.transact(xa).unsafeRunSync.results.head.owner
+              xa.use(t => projectsListIO.transact(t))
+                .unsafeRunSync
+                .results
+                .head
+                .owner
             assert(
               returnedThinUser.id == user.id,
               "Listed project's owner should be the same as the creating user")
@@ -209,7 +214,7 @@ class ProjectDaoSpec
                 CombinedSceneQueryParams())
             } yield scenesInProject.results
 
-            val addedScenes = addScenesIO.transact(xa).unsafeRunSync
+            val addedScenes = xa.use(t => addScenesIO.transact(t)).unsafeRunSync
 
             assert(
               (Set(addedScenes filter {
@@ -298,7 +303,7 @@ class ProjectDaoSpec
               }
             }
             val (foundScenes, createdScenes) =
-              listAddedSceneIDsIO.transact(xa).unsafeRunSync
+              xa.use(t => listAddedSceneIDsIO.transact(t)).unsafeRunSync
             foundScenes.toSet == createdScenes.toSet
           }
       }
@@ -334,7 +339,8 @@ class ProjectDaoSpec
               ) map { _.results }
             } yield listedScenes
 
-            val scenesInProject = listScenesIO.transact(xa).unsafeRunSync
+            val scenesInProject =
+              xa.use(t => listScenesIO.transact(t)).unsafeRunSync
 
             assert(
               scenesInProject == Nil,
@@ -369,7 +375,7 @@ class ProjectDaoSpec
             } yield { (permissions, acrInsert) }
 
             val (permissions, acrInsert) =
-              projectPermissionIO.transact(xa).unsafeRunSync
+              xa.use(t => projectPermissionIO.transact(t)).unsafeRunSync
 
             assert(
               permissions.flatten.headOption == Some(acrInsert),
@@ -407,7 +413,7 @@ class ProjectDaoSpec
             } yield { (permissionsInsert, permissionsBack) }
 
             val (permissionsInsert, permissionsBack) =
-              projectPermissionsIO.transact(xa).unsafeRunSync
+              xa.use(t => projectPermissionsIO.transact(t)).unsafeRunSync
 
             assert(
               permissionsInsert.diff(permissionsBack).length == 0,
@@ -447,7 +453,7 @@ class ProjectDaoSpec
             } yield { (permReplaced, permissionsBack) }
 
             val (permReplaced, permissionsBack) =
-              projectReplacePermissionsIO.transact(xa).unsafeRunSync
+              xa.use(t => projectReplacePermissionsIO.transact(t)).unsafeRunSync
 
             assert(
               permReplaced.diff(permissionsBack).length == 0,
@@ -485,7 +491,7 @@ class ProjectDaoSpec
             } yield { (permsDeleted, permissionsBack) }
 
             val (permsDeleted, permissionsBack) =
-              projectDeletePermissionsIO.transact(xa).unsafeRunSync
+              xa.use(t => projectDeletePermissionsIO.transact(t)).unsafeRunSync
 
             assert(
               permsDeleted == 1,
@@ -551,7 +557,7 @@ class ProjectDaoSpec
             } yield { (actions, permissionsBack) }
 
             val (userActions, permissionsBack) =
-              userActionsIO.transact(xa).unsafeRunSync
+              xa.use(t => userActionsIO.transact(t)).unsafeRunSync
 
             val acrActionsDistinct =
               permissionsBack.flatten.map(_.actionType.toString).distinct
@@ -632,7 +638,8 @@ class ProjectDaoSpec
             val (projectInsert1,
                  projectInsert2,
                  permissionsBack,
-                 paginatedProjects) = listProjectsIO.transact(xa).unsafeRunSync
+                 paginatedProjects) =
+              xa.use(t => listProjectsIO.transact(t)).unsafeRunSync
 
             val hasViewPermission =
               permissionsBack.flatten.exists(_.actionType == ActionType.View)
@@ -749,7 +756,7 @@ class ProjectDaoSpec
             } yield { (action, projectInsert2, isPermitted1, isPermitted2) }
 
             val (action, projectInsert2, isPermitted1, isPermitted2) =
-              isUserPermittedIO.transact(xa).unsafeRunSync
+              xa.use(t => isUserPermittedIO.transact(t)).unsafeRunSync
 
             if (projectInsert2.visibility == Visibility.Public) {
               (action) match {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -70,7 +70,7 @@ class ProjectDatasourcesDaoSpec
               projectDatasources <- ProjectDatasourcesDao
                 .listProjectDatasources(dbProject.id)
             } yield (projectDatasources)
-            val (pd) = createDsIO.transact(xa).unsafeRunSync
+            val pd = xa.use(t => createDsIO.transact(t)).unsafeRunSync
             assert(pd.size == expected,
                    "; Datasources are not duplicated in request")
             true

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
@@ -64,7 +64,7 @@ class ProjectScenesDaoSpec
             }
 
             val (insertedScenes, listedScenes) =
-              scenesListIO.transact(xa).unsafeRunSync
+              xa.use(t => scenesListIO.transact(t)).unsafeRunSync
             val insertedIds = insertedScenes.toSet map {
               (scene: Scene.WithRelated) =>
                 scene.id

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
@@ -19,7 +19,9 @@ class SceneDaoSpec
     with DBTestConfig
     with PropTestHelpers {
   test("list scenes") {
-    SceneDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => SceneDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("insert a scene") {
@@ -35,7 +37,7 @@ class SceneDaoSpec
               sceneInsert <- SceneDao.insert(fixedUpSceneCreate, dbUser)
             } yield (fixedUpSceneCreate, sceneInsert)
             val (fixedUpSceneCreate, insertedScene) =
-              sceneInsertIO.transact(xa).unsafeRunSync
+              xa.use(t => sceneInsertIO.transact(t)).unsafeRunSync
 
             assert(insertedScene.visibility == fixedUpSceneCreate.visibility,
                    "Visibilities match")
@@ -81,7 +83,7 @@ class SceneDaoSpec
               sceneInsert <- SceneDao.insertMaybe(fixedUpSceneCreate, dbUser)
             } yield (fixedUpSceneCreate, sceneInsert)
             val (fixedUpSceneCreate, insertedSceneO) =
-              sceneInsertIO.transact(xa).unsafeRunSync
+              xa.use(t => sceneInsertIO.transact(t)).unsafeRunSync
             // our expectation is that this should succeed so this should be safe -- if it fails that indicates
             // something else was wrong
             val insertedScene = insertedSceneO.get
@@ -144,7 +146,7 @@ class SceneDaoSpec
             } yield (affectedRows, fixedUpUpdateScene, endScene)
 
             val (affectedRows, fixedUpUpdateScene, updatedScene) =
-              sceneUpdateIO.transact(xa).unsafeRunSync
+              xa.use(t => sceneUpdateIO.transact(t)).unsafeRunSync
 
             assert(affectedRows == 1, "Number of affected rows is correct")
             assert(updatedScene.visibility == fixedUpUpdateScene.visibility,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
@@ -56,7 +56,7 @@ class SceneToProjectDaoSpec
             } yield (acceptedSceneCount, stps)
 
             val (acceptedSceneCount, stps) =
-              acceptedSceneAndStpIO.transact(xa).unsafeRunSync
+              xa.use(t => acceptedSceneAndStpIO.transact(t)).unsafeRunSync
 
             acceptedSceneCount == scenes.length &&
             stps.length == scenes.length &&
@@ -106,7 +106,7 @@ class SceneToProjectDaoSpec
             } yield (mds, stps, selectedSceneIds)
 
             val (mds, stps, selectedIds) =
-              mdAndStpsIO.transact(xa).unsafeRunSync
+              xa.use(t => mdAndStpsIO.transact(t)).unsafeRunSync
 
             // Mapping of scene ids to scene order
             val sceneMap =

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -64,7 +64,7 @@ class SceneWithRelatedDaoSpec
             } yield { (dbScenes1, listedScenes) }
 
             val (insertedScenes, listedScenes) =
-              scenesIO.transact(xa).unsafeRunSync
+              xa.use(t => scenesIO.transact(t)).unsafeRunSync
             val insertedNamesSet = insertedScenes.toSet map {
               (scene: Scene.WithRelated) =>
                 scene.name
@@ -112,7 +112,7 @@ class SceneWithRelatedDaoSpec
             } yield { (dbScenes, retrievedScenes) }
 
             val (insertedScenes, scenesInProject) =
-              scenesToIngestIO.transact(xa).unsafeRunSync
+              xa.use(t => scenesToIngestIO.transact(t)).unsafeRunSync
             val ingestableScenesIds = scenesInProject filter { scene =>
               (scene.statusFields.ingestStatus, scene.sceneType) match {
                 case (_, Some(SceneType.COG))       => false

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
@@ -24,7 +24,9 @@ class ShapeDaoSpec
     with PropTestHelpers {
 
   test("list shapes") {
-    ShapeDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => ShapeDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("insert shapes") {
@@ -41,7 +43,9 @@ class ShapeDaoSpec
                   dbUser)
               }
             }
-            shapeInsertIO.transact(xa).unsafeRunSync.length == shapes.length
+            xa.use(t => shapeInsertIO.transact(t))
+              .unsafeRunSync
+              .length == shapes.length
           }
       }
     }
@@ -81,7 +85,7 @@ class ShapeDaoSpec
             }
 
             val (affectedRows, updatedShape) =
-              updateWithShapeIO.transact(xa).unsafeRunSync
+              xa.use(t => updateWithShapeIO.transact(t)).unsafeRunSync
 
             val shapeUpdateShape = shapeUpdate.toShape
 
@@ -120,7 +124,7 @@ class ShapeDaoSpec
               }
             }
 
-            shapeByIdIO.transact(xa).unsafeRunSync
+            xa.use(t => shapeByIdIO.transact(t)).unsafeRunSync
           }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -30,7 +30,7 @@ class TeamDaoSpec
     with PropTestHelpers {
 
   test("listing teams") {
-    TeamDao.query.list.transact(xa).unsafeRunSync.length >= 0
+    xa.use(t => TeamDao.query.list.transact(t)).unsafeRunSync.length >= 0
   }
 
   test("getting a team by ID") {
@@ -52,7 +52,8 @@ class TeamDaoSpec
             }
           }
 
-          val (getTeamOp, org) = getTeamAndOrgIO.transact(xa).unsafeRunSync
+          val (getTeamOp, org) =
+            xa.use(t => getTeamAndOrgIO.transact(t)).unsafeRunSync
           val getTeam = getTeamOp.get
 
           getTeam.name == teamCreate.name &&
@@ -83,7 +84,8 @@ class TeamDaoSpec
             }
           }
 
-          val (getTeam, org) = getTeamAndOrgIO.transact(xa).unsafeRunSync
+          val (getTeam, org) =
+            xa.use(t => getTeamAndOrgIO.transact(t)).unsafeRunSync
 
           getTeam.name == teamCreate.name &&
           getTeam.organizationId == org.id &&
@@ -107,7 +109,8 @@ class TeamDaoSpec
               fixupTeam(teamCreate, orgInsert, userInsert))
           } yield (teamInsert, orgInsert)
 
-          val (createdTeam, org) = createTeamIO.transact(xa).unsafeRunSync
+          val (createdTeam, org) =
+            xa.use(t => createTeamIO.transact(t)).unsafeRunSync
 
           createdTeam.name == teamCreate.name &&
           createdTeam.organizationId == org.id &&
@@ -139,7 +142,7 @@ class TeamDaoSpec
           } yield (teamInsert, orgInsert, users, isAdmin)
 
           val (createdTeam, org, teamusers, isAdmin) =
-            createTeamIO.transact(xa).unsafeRunSync
+            xa.use(t => createTeamIO.transact(t)).unsafeRunSync
 
           createdTeam.name == teamCreate.name &&
           createdTeam.organizationId == org.id &&
@@ -177,7 +180,8 @@ class TeamDaoSpec
             }
           }
 
-          val (updatedTeam, org) = updateTeamIO.transact(xa).unsafeRunSync
+          val (updatedTeam, org) =
+            xa.use(t => updateTeamIO.transact(t)).unsafeRunSync
 
           updatedTeam.name == teamUpdate.name &&
           updatedTeam.settings == teamUpdate.settings &&
@@ -205,7 +209,7 @@ class TeamDaoSpec
             case (team: Team) => TeamDao.delete(team.id)
           }
 
-          deleteTeamIO.transact(xa).unsafeRunSync == 1
+          xa.use(t => deleteTeamIO.transact(t)).unsafeRunSync == 1
         }
       )
     }
@@ -251,7 +255,7 @@ class TeamDaoSpec
                activatedTeams,
                acrToInsert,
                permissionAfterTeamDeactivate) =
-            createTeamIO.transact(xa).unsafeRunSync
+            xa.use(t => createTeamIO.transact(t)).unsafeRunSync
 
           assert(deactivatedTeams.size == 1, "Deactivated team should exist")
           assert(activatedTeams.results.size == 0, "No team is active")
@@ -288,7 +292,7 @@ class TeamDaoSpec
             } yield { (insertedTeam, byIdUserGroupRole) }
 
             val (dbTeam, dbUserGroupRole) =
-              addUserTeamRoleIO.transact(xa).unsafeRunSync
+              xa.use(t => addUserTeamRoleIO.transact(t)).unsafeRunSync
             dbUserGroupRole match {
               case Some(ugr) =>
                 assert(ugr.isActive, "; Added role should be active")
@@ -331,7 +335,8 @@ class TeamDaoSpec
                 insertedTeam.id)
             } yield { (originalUserGroupRole, updatedUserGroupRoles) }
 
-            val (dbOldUGR, dbNewUGRs) = setTeamRoleIO.transact(xa).unsafeRunSync
+            val (dbOldUGR, dbNewUGRs) =
+              xa.use(t => setTeamRoleIO.transact(t)).unsafeRunSync
 
             assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
                    "; The updated UGR should be inactive")
@@ -383,7 +388,7 @@ class TeamDaoSpec
               listedTeams <- TeamDao.teamsForUser(dbUser)
             } yield { (List(team1, team2), listedTeams) }
             val (insertedTeams, listedTeams) =
-              teamsForUserIO.transact(xa).unsafeRunSync
+              xa.use(t => teamsForUserIO.transact(t)).unsafeRunSync
             assert(
               insertedTeams.map(_.name).toSet == listedTeams.map(_.name).toSet,
               "Inserted and listed teams for this user should be the same")

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
@@ -20,7 +20,9 @@ class ThumbnailDaoSpec
     with PropTestHelpers {
 
   test("list thumbnails") {
-    ThumbnailDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => ThumbnailDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("insert a thumbnail") {
@@ -38,7 +40,8 @@ class ThumbnailDaoSpec
                 ThumbnailDao.insert(fixupThumbnail(dbScene, thumbnail))
               }
             }
-            val insertedThumbnail = thumbnailInsertIO.transact(xa).unsafeRunSync
+            val insertedThumbnail =
+              xa.use(t => thumbnailInsertIO.transact(t)).unsafeRunSync
 
             insertedThumbnail.widthPx == thumbnail.widthPx &&
             insertedThumbnail.heightPx == thumbnail.heightPx &&
@@ -66,7 +69,8 @@ class ThumbnailDaoSpec
                 })
               }
             }
-            thumbnailsInsertIO.transact(xa).unsafeRunSync == thumbnails.length
+            xa.use(t => thumbnailsInsertIO.transact(t))
+              .unsafeRunSync == thumbnails.length
           }
       }
     }
@@ -108,7 +112,8 @@ class ThumbnailDaoSpec
             }
 
             val (affectedRows, updatedThumbnail) =
-              thumbnailUpdateWithThumbnailIO.transact(xa).unsafeRunSync
+              xa.use(t => thumbnailUpdateWithThumbnailIO.transact(t))
+                .unsafeRunSync
             affectedRows == 1 &&
             updatedThumbnail.widthPx == updateThumbnail.widthPx &&
             updatedThumbnail.heightPx == updateThumbnail.heightPx &&

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryDaoSpec.scala
@@ -10,13 +10,13 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class ToolCategoryDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
+class ToolCategoryDaoSpec extends FunSuite with Matchers with DBTestConfig {
 
-  test("types") { check(ToolCategoryDao.selectF.query[ToolCategory]) }
+  test("types") {
+    xa.use(t => ToolCategoryDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
+  }
 
   test("insertion") {
     val category = "A good, reasonably specific category"
@@ -32,7 +32,7 @@ class ToolCategoryDaoSpec
       )
     } yield (toolCategoryIn)
 
-    val result = transaction.transact(xa).unsafeRunSync
+    val result = xa.use(t => transaction.transact(t)).unsafeRunSync
 
     result.category shouldBe category
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryToToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryToToolDaoSpec.scala
@@ -13,9 +13,10 @@ import org.scalatest._
 class ToolCategoryToToolDaoSpec
     extends FunSuite
     with Matchers
-    with IOChecker
     with DBTestConfig {
   test("selection types") {
-    check(ToolCategoryToToolDao.selectF.query[ToolCategoryToTool])
+    xa.use(t => ToolCategoryToToolDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
@@ -12,10 +12,10 @@ import doobie.postgres.circe.jsonb.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class ToolDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
-  test("selection types") { check(ToolDao.selectF.query[Tool]) }
+class ToolDaoSpec extends FunSuite with Matchers with DBTestConfig {
+  test("selection types") {
+    xa.use(t => ToolDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolTagDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolTagDaoSpec.scala
@@ -10,10 +10,10 @@ import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
 
-class ToolTagDaoSpec
-    extends FunSuite
-    with Matchers
-    with IOChecker
-    with DBTestConfig {
-  test("selection types") { check(ToolTagDao.selectF.query[ToolTag]) }
+class ToolTagDaoSpec extends FunSuite with Matchers with DBTestConfig {
+  test("selection types") {
+    xa.use(t => ToolTagDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
@@ -19,7 +19,9 @@ class UploadDaoSpec
     with DBTestConfig
     with PropTestHelpers {
   test("list uploads") {
-    UploadDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => UploadDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("insert an upload") {
@@ -43,7 +45,7 @@ class UploadDaoSpec
                 dbUser)
             } yield insertedUpload
 
-            val dbUpload = uploadInsertIO.transact(xa).unsafeRunSync
+            val dbUpload = xa.use(t => uploadInsertIO.transact(t)).unsafeRunSync
 
             dbUpload.uploadStatus == upload.uploadStatus &&
             dbUpload.fileType == upload.fileType &&
@@ -107,7 +109,7 @@ class UploadDaoSpec
             }
 
             val (affectedRows, updatedUpload) =
-              uploadUpdateWithUploadIO.transact(xa).unsafeRunSync
+              xa.use(t => uploadUpdateWithUploadIO.transact(t)).unsafeRunSync
 
             affectedRows == 1 &&
             updatedUpload.uploadStatus == updateUpload.uploadStatus &&

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -33,7 +33,8 @@ class UserDaoSpec
             org <- rootOrgQ
             created <- UserDao.create(user)
           } yield (created)
-          val insertedUser = insertedUserIO.transact(xa).unsafeRunSync
+          val insertedUser =
+            xa.use(t => insertedUserIO.transact(t)).unsafeRunSync
           insertedUser.id == user.id
         }
       )
@@ -68,7 +69,7 @@ class UserDaoSpec
           } yield (newUser, userRoles)
 
           val (insertedUser, insertedUserRoles) =
-            insertedUserIO.transact(xa).unsafeRunSync
+            xa.use(t => insertedUserIO.transact(t)).unsafeRunSync
           assert(insertedUser.id == jwtFields.id,
                  "Inserted user should have the same ID as the jwt fields")
           assert(insertedUserRoles.length == 2,
@@ -90,7 +91,11 @@ class UserDaoSpec
             inserted <- UserDao.create(userWithOrg)
             byId <- UserDao.getUserById(inserted.id)
           } yield (byId)
-          userCreate.id == (createdIdIO.transact(xa).unsafeRunSync.get.id)
+          userCreate.id == (xa
+            .use(t => createdIdIO.transact(t))
+            .unsafeRunSync
+            .get
+            .id)
         }
       )
     )
@@ -111,29 +116,32 @@ class UserDaoSpec
           val (affectedRows,
                updatedEmailNotifications,
                updatedDropboxToken,
-               updatedPlanetToken) = (insertedUserIO flatMap {
-            case (insertUser: User) => {
-              UserDao.updateUser(
-                insertUser.copy(planetCredential = planetCredential,
-                                dropboxCredential = dropboxCredential,
-                                emailNotifications = emailNotifications),
-                insertUser.id
-              ) flatMap {
-                case (affectedRows: Int) => {
-                  val updatedPlanetTokenIO = UserDao.unsafeGetUserById(
-                    insertUser.id) map { (usr: User) =>
-                    (usr.emailNotifications,
-                     usr.dropboxCredential,
-                     usr.planetCredential)
-                  }
-                  updatedPlanetTokenIO map {
-                    (t: (Boolean, Credential, Credential)) =>
-                      (affectedRows, t._1, t._2, t._3)
+               updatedPlanetToken) = xa
+            .use(t =>
+              (insertedUserIO flatMap {
+                case (insertUser: User) => {
+                  UserDao.updateUser(
+                    insertUser.copy(planetCredential = planetCredential,
+                                    dropboxCredential = dropboxCredential,
+                                    emailNotifications = emailNotifications),
+                    insertUser.id
+                  ) flatMap {
+                    case (affectedRows: Int) => {
+                      val updatedPlanetTokenIO = UserDao.unsafeGetUserById(
+                        insertUser.id) map { (usr: User) =>
+                        (usr.emailNotifications,
+                         usr.dropboxCredential,
+                         usr.planetCredential)
+                      }
+                      updatedPlanetTokenIO map {
+                        (t: (Boolean, Credential, Credential)) =>
+                          (affectedRows, t._1, t._2, t._3)
+                      }
+                    }
                   }
                 }
-              }
-            }
-          }).transact(xa).unsafeRunSync
+              }).transact(t))
+            .unsafeRunSync
           (affectedRows == 1) &&
           (updatedEmailNotifications == emailNotifications) &&
           (updatedDropboxToken == dropboxCredential) &&
@@ -156,22 +164,26 @@ class UserDaoSpec
             org <- rootOrgQ
             created <- UserDao.create(user)
           } yield (created)
-          val (affectedRows, updatedUser) = (insertedUserIO flatMap {
-            case (created: User) => {
-              val updatedUser = created.copy(
-                email = email,
-                planetCredential = planetCredential,
-                emailNotifications = isEmail,
-                visibility = visibility
-              )
-              UserDao.updateOwnUser(updatedUser) flatMap {
-                case (affectedRows: Int) => {
-                  val updatedUserIO = UserDao.unsafeGetUserById(updatedUser.id)
-                  updatedUserIO map { (affectedRows, _) }
+          val (affectedRows, updatedUser) = xa
+            .use(t =>
+              (insertedUserIO flatMap {
+                case (created: User) => {
+                  val updatedUser = created.copy(
+                    email = email,
+                    planetCredential = planetCredential,
+                    emailNotifications = isEmail,
+                    visibility = visibility
+                  )
+                  UserDao.updateOwnUser(updatedUser) flatMap {
+                    case (affectedRows: Int) => {
+                      val updatedUserIO =
+                        UserDao.unsafeGetUserById(updatedUser.id)
+                      updatedUserIO map { (affectedRows, _) }
+                    }
+                  }
                 }
-              }
-            }
-          }).transact(xa).unsafeRunSync
+              }).transact(t))
+            .unsafeRunSync
 
           affectedRows == 1 &&
           updatedUser.emailNotifications == isEmail &&
@@ -193,17 +205,21 @@ class UserDaoSpec
             org <- rootOrgQ
             created <- UserDao.create(user)
           } yield (created)
-          val (affectedRows, updatedToken) = (insertedUserIO flatMap {
-            case (insertUser: User) => {
-              UserDao.storeDropboxAccessToken(insertUser.id, dropboxCredential) flatMap {
-                case (affectedRows: Int) => {
-                  val updatedDbxTokenIO = UserDao.unsafeGetUserById(
-                    insertUser.id) map { _.dropboxCredential }
-                  updatedDbxTokenIO map { (affectedRows, _) }
+          val (affectedRows, updatedToken) = xa
+            .use(t =>
+              (insertedUserIO flatMap {
+                case (insertUser: User) => {
+                  UserDao.storeDropboxAccessToken(insertUser.id,
+                                                  dropboxCredential) flatMap {
+                    case (affectedRows: Int) => {
+                      val updatedDbxTokenIO = UserDao.unsafeGetUserById(
+                        insertUser.id) map { _.dropboxCredential }
+                      updatedDbxTokenIO map { (affectedRows, _) }
+                    }
+                  }
                 }
-              }
-            }
-          }).transact(xa).unsafeRunSync
+              }).transact(t))
+            .unsafeRunSync
           (updatedToken.token == dropboxCredential.token) && (affectedRows == 1)
         }
       )
@@ -292,10 +308,10 @@ class UserDaoSpec
              u3VisibleUsers,
              u3AdminVisibleUsers)
           }
-          orgsIO.transact(xa).unsafeRunSync
+          xa.use(t => orgsIO.transact(t)).unsafeRunSync
 
           val (u1, u2, u3, u4, u1users, u2users, u3users, u3usersAdmin) =
-            orgsIO.transact(xa).unsafeRunSync
+            xa.use(t => orgsIO.transact(t)).unsafeRunSync
           val u1userids = u1users.toSet.map { u: User =>
             u.id
           }
@@ -346,7 +362,7 @@ class UserDaoSpec
               listedUsers <- UserDao.getUsersByIds(List(dbUser1.id, dbUser2.id))
             } yield { listedUsers }
 
-            val outUsers = outUsersIO.transact(xa).unsafeRunSync
+            val outUsers = xa.use(t => outUsersIO.transact(t)).unsafeRunSync
             assert(outUsers.map(_.id).toSet == Set(user1.id, user2.id),
                    "Lookup by ids should return the correct set of users")
             true
@@ -364,7 +380,7 @@ class UserDaoSpec
             (_, dbUser) = orgAndUser
             createdUser <- UserDao.unsafeGetUserById(dbUser.id, Some(false))
           } yield (createdUser)
-          val createdUser = createdUserIO.transact(xa).unsafeRunSync
+          val createdUser = xa.use(t => createdUserIO.transact(t)).unsafeRunSync
           createdUser.planetCredential == Credential(Some("")) &&
           createdUser.dropboxCredential == Credential(Some(""))
         }
@@ -383,7 +399,8 @@ class UserDaoSpec
               listedPlatform <- UserDao.unsafeGetUserPlatform(dbUser.id)
             } yield (insertedPlatform, listedPlatform)
 
-            val (inserted, listed) = platformsIO.transact(xa).unsafeRunSync
+            val (inserted, listed) =
+              xa.use(t => platformsIO.transact(t)).unsafeRunSync
             assert(
               inserted == listed,
               "Unsafe get of a user's platform should return the user's platform")

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -29,7 +29,9 @@ class UserGroupRoleDaoSpec
     with PropTestHelpers {
 
   test("list user group roles") {
-    UserGroupRoleDao.query.list.transact(xa).unsafeRunSync.length should be >= 0
+    xa.use(t => UserGroupRoleDao.query.list.transact(t))
+      .unsafeRunSync
+      .length should be >= 0
   }
 
   test("insert a user group role") {
@@ -59,7 +61,7 @@ class UserGroupRoleDaoSpec
               )
             } yield { insertedUgr }
 
-            val insertedUgr = insertUgrIO.transact(xa).unsafeRunSync
+            val insertedUgr = xa.use(t => insertUgrIO.transact(t)).unsafeRunSync
 
             insertedUgr.userId == userCreate.id &&
             insertedUgr.groupType == ugrCreate.groupType &&
@@ -149,7 +151,8 @@ class UserGroupRoleDaoSpec
               )
             } yield { usersInPlatform }
 
-            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+            val usersInPlatform =
+              xa.use(t => usersInPlatformIO.transact(t)).unsafeRunSync
 
             assert(
               usersInPlatform.count == 1,
@@ -238,7 +241,8 @@ class UserGroupRoleDaoSpec
               )
             } yield { usersInPlatform }
 
-            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+            val usersInPlatform =
+              xa.use(t => usersInPlatformIO.transact(t)).unsafeRunSync
 
             assert(
               usersInPlatform.count == 2,
@@ -334,7 +338,8 @@ class UserGroupRoleDaoSpec
               )
             } yield { usersInPlatform }
 
-            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+            val usersInPlatform =
+              xa.use(t => usersInPlatformIO.transact(t)).unsafeRunSync
 
             assert(
               usersInPlatform.count == 2,
@@ -447,7 +452,8 @@ class UserGroupRoleDaoSpec
               )
             } yield { usersInPlatform }
 
-            val usersInPlatform = usersInPlatformIO.transact(xa).unsafeRunSync
+            val usersInPlatform =
+              xa.use(t => usersInPlatformIO.transact(t)).unsafeRunSync
 
             assert(
               usersInPlatform.count == 2,
@@ -530,8 +536,9 @@ class UserGroupRoleDaoSpec
               }
             }
 
-            val (affectedRows, updatedUgr) =
-              updateUgrWithUpdatedAndAffectedRowsIO.transact(xa).unsafeRunSync
+            val (affectedRows, updatedUgr) = xa
+              .use(t => updateUgrWithUpdatedAndAffectedRowsIO.transact(t))
+              .unsafeRunSync
             // isActive should always be true since it doesn't exist on UserGroupRole.Creates and is set
             // to true when those are turned into UserGroupRoles
             affectedRows == 1 &&
@@ -585,8 +592,9 @@ class UserGroupRoleDaoSpec
               }
             }
 
-            val (affectedRows, updatedUgr) =
-              deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
+            val (affectedRows, updatedUgr) = xa
+              .use(t => deactivateWithDeactivatedUgrIO.transact(t))
+              .unsafeRunSync
             affectedRows == 1 &&
             updatedUgr.isActive == false &&
             updatedUgr.modifiedBy == userCreate.id &&
@@ -635,8 +643,9 @@ class UserGroupRoleDaoSpec
               }
             }
 
-            val updatedUGRs =
-              deactivateWithDeactivatedUgrIO.transact(xa).unsafeRunSync
+            val updatedUGRs = xa
+              .use(t => deactivateWithDeactivatedUgrIO.transact(t))
+              .unsafeRunSync
             updatedUGRs.size == 1 &&
             updatedUGRs
               .filter(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/meta/CirceJsonbMetaSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/meta/CirceJsonbMetaSpec.scala
@@ -50,6 +50,6 @@ class CirceJsonbMetaSpec extends FunSpec with Matchers with DBTestConfig {
       js <- select(123)
     } yield js
 
-    jsonOut.transact(xa).unsafeRunSync shouldBe jsonIn
+    xa.use(t => jsonOut.transact(t)).unsafeRunSync shouldBe jsonIn
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/meta/GtVectorMetaSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/meta/GtVectorMetaSpec.scala
@@ -72,7 +72,7 @@ class GtVectorMetaSpec extends FunSpec with Matchers with DBTestConfig {
       js <- select(123)
     } yield js
 
-    val results = geomOut.transact(xa).unsafeRunSync
+    val results = xa.use(t => geomOut.transact(t)).unsafeRunSync
     results.point shouldBe point
     results.line shouldBe line
     results.poly shouldBe poly

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
+      - $HOME/.ivy2:/root/.ivy2
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:
@@ -144,6 +145,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
+      - $HOME/.ivy2:/root/.ivy2
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:
@@ -172,6 +174,7 @@ services:
       - ./.sbt:/root/.sbt
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
+      - $HOME/.ivy2:/root/.ivy2
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
     command:


### PR DESCRIPTION
## Overview

Doobie 0.6.x docs say:

>  Requesting a JDBC connection is a blocking operation, so to avoid deadlock these requests cannot be placed in competition with running programs (which need to make progress in order to finish up and return their connections to the pool). Therefore we need a distinct, bounded, blocking execution context for the single purpose of awaiting database connections. All transactors that use a connection pool will require this execution context to be specified.Requesting a JDBC connection is a blocking operation, so to avoid deadlock these requests cannot be placed in competition with running programs (which need to make progress in order to finish up and return their connections to the pool). Therefore we need a distinct, bounded, blocking execution context for the single purpose of awaiting database connections. All transactors that use a connection pool will require this execution context to be specified.

I _think_ that, since we're inheriting from `DBTestConfig` with every test, we're trying to acquire JDBC connections in the same execution context as our running IO programs, which is why we're seeing deadlocks sometimes in tests.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I've run tests five times in a row locally to test the expectation that this works, but it's a little bit difficult to confirm since the deadlocks weren't (for me at least) an every-time phenomenon.

Also I made test logging quieter because I really don't think it helps to see "not submitting aws batch" a thousand times.

Also also -- I shared the ivy cache across containers / builds so that we won't have to create a new 540mb directory every time we run tests.

## Testing Instructions

 * :man_shrugging:

Closes raster-foundry/raster-foundry-platform#534