### PR TITLE
Restore missing classes in batch assembly jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Projects with > 30 scenes will not show a preview on the project list page [/#4231](https://github.com/raster-foundry/raster-foundry/pull/4231)
 - Upgraded scala typelevel ecosystem [\#4215](https://github.com/raster-foundry/raster-foundry/pull/4215)
 - Images no longer require a non-empty list of bands when creating scenes [\#4241](https://github.com/raster-foundry/raster-foundry/pull/4241)
+- Switched to semi-automatic json codec derivation for query parameters [\#4267](https://github.com/raster-foundry/raster-foundry/pull/4267)
 
 ### Deprecated
 

--- a/app-backend/batch/src/main/scala/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/export/spark/Export.scala
@@ -260,7 +260,7 @@ object Export extends SparkJob with Config with RollbarNotifier {
         dropboxConfig.client(ed.output.dropboxCredential.getOrElse(""))
 
       try {
-        client.files.createFolder(ed.output.source.getPath)
+        client.files.createFolderV2(ed.output.source.getPath, false)
       } catch {
         case e: CreateFolderErrorException =>
           logger.warn(s"Target Path already exists, ${e.errorValue}")

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -3,32 +3,35 @@ package com.rasterfoundry.datamodel
 import java.sql.Timestamp
 import java.util.UUID
 
-import io.circe.generic.JsonCodec
+import io.circe._
+import io.circe.generic.semiauto._
 import geotrellis.proj4._
 import geotrellis.vector.{Extent, Point, Polygon, Projected}
 
 /** Case class representing all /thumbnail query parameters */
-@JsonCodec
 final case class ThumbnailQueryParameters(sceneId: Option[UUID] = None)
 
-/** Case class for combined params for images */
-@JsonCodec
-final case class CombinedImageQueryParams(
-    orgParams: OrgQueryParameters = OrgQueryParameters(),
-    timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
-    imageParams: ImageQueryParameters = ImageQueryParameters()
-)
+object ThumbnailQueryParameters {
+  implicit def encThumbnailQueryParameters =
+    deriveEncoder[ThumbnailQueryParameters]
+  implicit def decThumbnailQueryParameters =
+    deriveDecoder[ThumbnailQueryParameters]
+}
 
+/** Case class for combined params for images */
 /** Query parameters specific to image files */
-@JsonCodec
 final case class ImageQueryParameters(minRawDataBytes: Option[Long] = None,
                                       maxRawDataBytes: Option[Long] = None,
                                       minResolution: Option[Float] = None,
                                       maxResolution: Option[Float] = None,
                                       scene: Iterable[UUID] = Seq.empty[UUID])
 
+object ImageQueryParameters {
+  implicit def encImageQueryParameters = deriveEncoder[ImageQueryParameters]
+  implicit def decImageQueryParameters = deriveDecoder[ImageQueryParameters]
+}
+
 /** Case class representing all possible query parameters */
-@JsonCodec
 @SuppressWarnings(Array("CatchException"))
 final case class SceneQueryParameters(
     maxCloudCover: Option[Float] = None,
@@ -68,32 +71,23 @@ final case class SceneQueryParameters(
   }
 }
 
-/** Case class for Grid query parameters */
-@JsonCodec
-final case class GridQueryParameters(
-    maxCloudCover: Option[Float] = None,
-    minCloudCover: Option[Float] = None,
-    minAcquisitionDatetime: Option[Timestamp] = None,
-    maxAcquisitionDatetime: Option[Timestamp] = None,
-    datasource: Iterable[UUID] = Seq.empty[UUID],
-    month: Iterable[Int] = Seq.empty[Int],
-    minDayOfMonth: Option[Int] = None,
-    maxDayOfMonth: Option[Int] = None,
-    maxSunAzimuth: Option[Float] = None,
-    minSunAzimuth: Option[Float] = None,
-    maxSunElevation: Option[Float] = None,
-    minSunElevation: Option[Float] = None,
-    ingested: Option[Boolean] = None,
-    ingestStatus: Iterable[String] = Seq.empty[String]
-)
+object SceneQueryParameters {
+  implicit def encSceneQueryParameters = deriveEncoder[SceneQueryParameters]
+  implicit def decSceneQueryParameters = deriveDecoder[SceneQueryParameters]
+}
 
-@JsonCodec
 final case class SceneSearchModeQueryParams(
     exactCount: Option[Boolean] = None
 )
 
+object SceneSearchModeQueryParams {
+  implicit def encSceneSearchModeQueryParams =
+    deriveEncoder[SceneSearchModeQueryParams]
+  implicit def decSceneSearchModeQueryParams =
+    deriveDecoder[SceneSearchModeQueryParams]
+}
+
 /** Combined all query parameters */
-@JsonCodec
 final case class CombinedSceneQueryParams(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
@@ -106,18 +100,14 @@ final case class CombinedSceneQueryParams(
       SceneSearchModeQueryParams()
 )
 
-/** Combined all query parameters for grids */
-@JsonCodec
-final case class CombinedGridQueryParams(
-    orgParams: OrgQueryParameters = OrgQueryParameters(),
-    userParams: UserQueryParameters = UserQueryParameters(),
-    timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
-    gridParams: GridQueryParameters = GridQueryParameters(),
-    imageParams: ImageQueryParameters = ImageQueryParameters()
-)
+object CombinedSceneQueryParams {
+  implicit def encCombinedSceneQueryParams =
+    deriveEncoder[CombinedSceneQueryParams]
+  implicit def decCombinedSceneQueryParams =
+    deriveDecoder[CombinedSceneQueryParams]
+}
 
 /** Case class for project query parameters */
-@JsonCodec
 final case class ProjectQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
@@ -129,15 +119,23 @@ final case class ProjectQueryParameters(
     tagQueryParameters: TagQueryParameters = TagQueryParameters()
 )
 
-@JsonCodec
+object ProjectQueryParameters {
+  implicit def encProjectQueryParameters = deriveEncoder[ProjectQueryParameters]
+  implicit def decProjectQueryParameters = deriveDecoder[ProjectQueryParameters]
+}
+
 final case class AoiQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
     timestampParams: TimestampQueryParameters = TimestampQueryParameters()
 )
 
+object AoiQueryParameters {
+  implicit def encAoiQueryParameters = deriveEncoder[AoiQueryParameters]
+  implicit def decAoiQueryParameters = deriveDecoder[AoiQueryParameters]
+}
+
 /** Combined tool query parameters */
-@JsonCodec
 final case class CombinedToolQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
@@ -148,31 +146,64 @@ final case class CombinedToolQueryParameters(
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
-@JsonCodec
+object CombinedToolQueryParameters {
+  implicit def encCombinedToolQueryParameters =
+    deriveEncoder[CombinedToolQueryParameters]
+  implicit def decCombinedToolQueryParameters =
+    deriveDecoder[CombinedToolQueryParameters]
+}
+
 final case class FootprintQueryParameters(x: Option[Double] = None,
                                           y: Option[Double] = None,
                                           bbox: Option[String] = None)
 
-@JsonCodec
+object FootprintQueryParameters {
+  implicit def encFootprintQueryParameters =
+    deriveEncoder[FootprintQueryParameters]
+  implicit def decFootprintQueryParameters =
+    deriveDecoder[FootprintQueryParameters]
+}
+
 final case class CombinedFootprintQueryParams(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
     footprintParams: FootprintQueryParameters = FootprintQueryParameters()
 )
 
+object CombinedFootprintQueryParams {
+  implicit def encCombinedFootprintQueryParams =
+    deriveEncoder[CombinedFootprintQueryParams]
+  implicit def decCombinedFootprintQueryParams =
+    deriveDecoder[CombinedFootprintQueryParams]
+}
+
 /** Common query parameters for models that have organization attributes */
-@JsonCodec
 final case class OrgQueryParameters(
     organizations: Iterable[UUID] = Seq.empty[UUID])
 
+object OrgQueryParameters {
+  implicit def encOrgQueryParameters = deriveEncoder[OrgQueryParameters]
+  implicit def decOrgQueryParameters = deriveDecoder[OrgQueryParameters]
+}
+
 /** Query parameters to filter by only users */
-@JsonCodec
 final case class UserAuditQueryParameters(createdBy: Option[String] = None,
                                           modifiedBy: Option[String] = None)
 
+object UserAuditQueryParameters {
+  implicit def encUserAuditQueryParameters =
+    deriveEncoder[UserAuditQueryParameters]
+  implicit def decUserAuditQueryParameters =
+    deriveDecoder[UserAuditQueryParameters]
+}
+
 /** Query parameters to filter by owners */
-@JsonCodec
 final case class OwnerQueryParameters(owner: Option[String] = None)
+
+object OwnerQueryParameters {
+  implicit def encOwnerQueryParameters = deriveEncoder[OwnerQueryParameters]
+  implicit def decOwnerQueryParameters = deriveDecoder[OwnerQueryParameters]
+}
 
 /** Query parameters to filter by ownership type:
   *- owned by the requesting user only: owned
@@ -180,26 +211,39 @@ final case class OwnerQueryParameters(owner: Option[String] = None)
   *- shared to the requesting user directly, across platform, or due to group membership: shared
   *- both the above: none, this is default
   */
-@JsonCodec
 final case class OwnershipTypeQueryParameters(
     ownershipType: Option[String] = None
 )
 
+object OwnershipTypeQueryParameters {
+  implicit def encOwnershipTypeQueryParameters =
+    deriveEncoder[OwnershipTypeQueryParameters]
+  implicit def decOwnershipTypeQueryParameters =
+    deriveDecoder[OwnershipTypeQueryParameters]
+}
+
 /** Query parameters to filter by group membership*/
-@JsonCodec
 final case class GroupQueryParameters(groupType: Option[GroupType] = None,
                                       groupId: Option[UUID] = None)
 
+object GroupQueryParameters {
+  implicit def encGroupQueryParameters = deriveEncoder[GroupQueryParameters]
+  implicit def decGroupQueryParameters = deriveDecoder[GroupQueryParameters]
+}
+
 /** Query parameters to filter by users */
-@JsonCodec
 final case class UserQueryParameters(
     onlyUserParams: UserAuditQueryParameters = UserAuditQueryParameters(),
     ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
     activationParams: ActivationQueryParameters = ActivationQueryParameters()
 )
 
+object UserQueryParameters {
+  implicit def encUserQueryParameters = deriveEncoder[UserQueryParameters]
+  implicit def decUserQueryParameters = deriveDecoder[UserQueryParameters]
+}
+
 /** Query parameters to filter by modified/created times */
-@JsonCodec
 final case class TimestampQueryParameters(
     minCreateDatetime: Option[Timestamp] = None,
     maxCreateDatetime: Option[Timestamp] = None,
@@ -207,15 +251,31 @@ final case class TimestampQueryParameters(
     maxModifiedDatetime: Option[Timestamp] = None
 )
 
-@JsonCodec
+object TimestampQueryParameters {
+  implicit def encTimestampQueryParameters =
+    deriveEncoder[TimestampQueryParameters]
+  implicit def decTimestampQueryParameters =
+    deriveDecoder[TimestampQueryParameters]
+}
+
 final case class ToolCategoryQueryParameters(search: Option[String] = None)
 
-@JsonCodec
+object ToolCategoryQueryParameters {
+  implicit def encToolCategoryQueryParameters =
+    deriveEncoder[ToolCategoryQueryParameters]
+  implicit def decToolCategoryQueryParameters =
+    deriveDecoder[ToolCategoryQueryParameters]
+}
+
 final case class ToolRunQueryParameters(createdBy: Option[String] = None,
                                         projectId: Option[UUID] = None,
                                         toolId: Option[UUID] = None)
 
-@JsonCodec
+object ToolRunQueryParameters {
+  implicit def encToolRunQueryParameters = deriveEncoder[ToolRunQueryParameters]
+  implicit def decToolRunQueryParameters = deriveDecoder[ToolRunQueryParameters]
+}
+
 final case class CombinedToolRunQueryParameters(
     toolRunParams: ToolRunQueryParameters = ToolRunQueryParameters(),
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
@@ -226,14 +286,26 @@ final case class CombinedToolRunQueryParameters(
     searchParams: SearchQueryParameters = SearchQueryParameters()
 )
 
-@JsonCodec
+object CombinedToolRunQueryParameters {
+  implicit def encCombinedToolRunQueryParameters =
+    deriveEncoder[CombinedToolRunQueryParameters]
+  implicit def decCombinedToolRunQueryParameters =
+    deriveDecoder[CombinedToolRunQueryParameters]
+}
+
 final case class CombinedToolCategoryQueryParams(
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
     toolCategoryParams: ToolCategoryQueryParameters =
       ToolCategoryQueryParameters()
 )
 
-@JsonCodec
+object CombinedToolCategoryQueryParams {
+  implicit def encCombinedToolCategoryQueryParams =
+    deriveEncoder[CombinedToolCategoryQueryParams]
+  implicit def decCombinedToolCategoryQueryParams =
+    deriveDecoder[CombinedToolCategoryQueryParams]
+}
+
 final case class DatasourceQueryParameters(
     userParams: UserQueryParameters = UserQueryParameters(),
     searchParams: SearchQueryParameters = SearchQueryParameters(),
@@ -242,33 +314,65 @@ final case class DatasourceQueryParameters(
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
 )
 
-@JsonCodec
+object DatasourceQueryParameters {
+  implicit def encDatasourceQueryParameters =
+    deriveEncoder[DatasourceQueryParameters]
+  implicit def decDatasourceQueryParameters =
+    deriveDecoder[DatasourceQueryParameters]
+}
+
 final case class MapTokenQueryParameters(name: Option[String] = None,
                                          projectId: Option[UUID] = None)
 
-@JsonCodec
+object MapTokenQueryParameters {
+  implicit def encMapTokenQueryParameters =
+    deriveEncoder[MapTokenQueryParameters]
+  implicit def decMapTokenQueryParameters =
+    deriveDecoder[MapTokenQueryParameters]
+}
+
 final case class CombinedMapTokenQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
     mapTokenParams: MapTokenQueryParameters = MapTokenQueryParameters()
 )
 
-@JsonCodec
+object CombinedMapTokenQueryParameters {
+  implicit def encCombinedMapTokenQueryParameters =
+    deriveEncoder[CombinedMapTokenQueryParameters]
+  implicit def decCombinedMapTokenQueryParameters =
+    deriveDecoder[CombinedMapTokenQueryParameters]
+}
+
 final case class UploadQueryParameters(datasource: Option[UUID] = None,
                                        uploadStatus: Option[String] = None,
                                        projectId: Option[UUID] = None)
 
-@JsonCodec
+object UploadQueryParameters {
+  implicit def encUploadQueryParameters = deriveEncoder[UploadQueryParameters]
+  implicit def decUploadQueryParameters = deriveDecoder[UploadQueryParameters]
+}
+
 final case class ExportQueryParameters(organization: Option[UUID] = None,
                                        project: Option[UUID] = None,
                                        analysis: Option[UUID] = None,
                                        exportStatus: Iterable[String] =
                                          Seq.empty[String])
 
-@JsonCodec
+object ExportQueryParameters {
+  implicit def encExportQueryParameters = deriveEncoder[ExportQueryParameters]
+  implicit def decExportQueryParameters = deriveDecoder[ExportQueryParameters]
+}
+
 final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
-@JsonCodec
+object DropboxAuthQueryParameters {
+  implicit def encDropboxAuthQueryParameters =
+    deriveEncoder[DropboxAuthQueryParameters]
+  implicit def decDropboxAuthQueryParameters =
+    deriveDecoder[DropboxAuthQueryParameters]
+}
+
 final case class AnnotationQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
@@ -284,7 +388,12 @@ final case class AnnotationQueryParameters(
     BboxUtil.toBboxPolygon(bbox)
 }
 
-@JsonCodec
+object AnnotationQueryParameters {
+  implicit def encAnnotationQueryParameters =
+    deriveEncoder[AnnotationQueryParameters]
+  implicit def decAnnotationQueryParameters =
+    deriveDecoder[AnnotationQueryParameters]
+}
 final case class ShapeQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
@@ -295,16 +404,34 @@ final case class ShapeQueryParameters(
     searchParams: SearchQueryParameters = SearchQueryParameters()
 )
 
-@JsonCodec
+object ShapeQueryParameters {
+  implicit def encShapeQueryParameters = deriveEncoder[ShapeQueryParameters]
+  implicit def decShapeQueryParameters = deriveDecoder[ShapeQueryParameters]
+}
+
 final case class FeedQueryParameters(source: Option[String] = None)
 
-@JsonCodec
+object FeedQueryParameters {
+  implicit def encFeedQueryParameters = deriveEncoder[FeedQueryParameters]
+  implicit def decFeedQueryParameters = deriveDecoder[FeedQueryParameters]
+}
+
 final case class SearchQueryParameters(search: Option[String] = None)
 
-@JsonCodec
+object SearchQueryParameters {
+  implicit def encSearchQueryParameters = deriveEncoder[SearchQueryParameters]
+  implicit def decSearchQueryParameters = deriveDecoder[SearchQueryParameters]
+}
+
 final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
-@JsonCodec
+object ActivationQueryParameters {
+  implicit def encActivationQueryParameters =
+    deriveEncoder[ActivationQueryParameters]
+  implicit def decActivationQueryParameters =
+    deriveDecoder[ActivationQueryParameters]
+}
+
 final case class TeamQueryParameters(
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
     orgParams: OrgQueryParameters = OrgQueryParameters(),
@@ -313,7 +440,11 @@ final case class TeamQueryParameters(
     activationParams: ActivationQueryParameters = ActivationQueryParameters()
 )
 
-@JsonCodec
+object TeamQueryParameters {
+  implicit def encTeamQueryParameters = deriveEncoder[TeamQueryParameters]
+  implicit def decTeamQueryParameters = deriveDecoder[TeamQueryParameters]
+}
+
 final case class PlatformQueryParameters(
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
     onlyUserParams: UserAuditQueryParameters = UserAuditQueryParameters(),
@@ -321,10 +452,22 @@ final case class PlatformQueryParameters(
     activationParams: ActivationQueryParameters = ActivationQueryParameters()
 )
 
-@JsonCodec
+object PlatformQueryParameters {
+  implicit def encPlatformQueryParameters =
+    deriveEncoder[PlatformQueryParameters]
+  implicit def decPlatformQueryParameters =
+    deriveDecoder[PlatformQueryParameters]
+}
+
 final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
-@JsonCodec
+object PlatformIdQueryParameters {
+  implicit def encPlatformIdQueryParameters =
+    deriveEncoder[PlatformIdQueryParameters]
+  implicit def decPlatformIdQueryParameters =
+    deriveDecoder[PlatformIdQueryParameters]
+}
+
 final case class OrganizationQueryParameters(
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
     searchParams: SearchQueryParameters = SearchQueryParameters(),
@@ -332,7 +475,13 @@ final case class OrganizationQueryParameters(
     platformIdParams: PlatformIdQueryParameters = PlatformIdQueryParameters()
 )
 
-@JsonCodec
+object OrganizationQueryParameters {
+  implicit def encOrganizationQueryParameters =
+    deriveEncoder[OrganizationQueryParameters]
+  implicit def decOrganizationQueryParameters =
+    deriveDecoder[OrganizationQueryParameters]
+}
+
 final case class SceneThumbnailQueryParameters(width: Option[Int],
                                                height: Option[Int],
                                                token: String,
@@ -341,11 +490,22 @@ final case class SceneThumbnailQueryParameters(width: Option[Int],
                                                blue: Option[Int],
                                                floor: Option[Int])
 
-@JsonCodec
+object SceneThumbnailQueryParameters {
+  implicit def encSceneThumbnailQueryParameters =
+    deriveEncoder[SceneThumbnailQueryParameters]
+  implicit def decSceneThumbnailQueryParameters =
+    deriveDecoder[SceneThumbnailQueryParameters]
+}
+
 final case class TagQueryParameters(
     tagsInclude: Iterable[String] = Seq.empty[String],
     tagsExclude: Iterable[String] = Seq.empty[String]
 )
+
+object TagQueryParameters {
+  implicit def encTagQueryParameters = deriveEncoder[TagQueryParameters]
+  implicit def decTagQueryParameters = deriveDecoder[TagQueryParameters]
+}
 
 object BboxUtil {
   @SuppressWarnings(Array("CatchException"))

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -12,9 +12,9 @@ import geotrellis.vector.{Extent, Point, Polygon, Projected}
 final case class ThumbnailQueryParameters(sceneId: Option[UUID] = None)
 
 object ThumbnailQueryParameters {
-  implicit def encThumbnailQueryParameters =
+  implicit def encThumbnailQueryParameters: Encoder[ThumbnailQueryParameters] =
     deriveEncoder[ThumbnailQueryParameters]
-  implicit def decThumbnailQueryParameters =
+  implicit def decThumbnailQueryParameters: Decoder[ThumbnailQueryParameters] =
     deriveDecoder[ThumbnailQueryParameters]
 }
 
@@ -27,8 +27,10 @@ final case class ImageQueryParameters(minRawDataBytes: Option[Long] = None,
                                       scene: Iterable[UUID] = Seq.empty[UUID])
 
 object ImageQueryParameters {
-  implicit def encImageQueryParameters = deriveEncoder[ImageQueryParameters]
-  implicit def decImageQueryParameters = deriveDecoder[ImageQueryParameters]
+  implicit def encImageQueryParameters: Encoder[ImageQueryParameters] =
+    deriveEncoder[ImageQueryParameters]
+  implicit def decImageQueryParameters: Decoder[ImageQueryParameters] =
+    deriveDecoder[ImageQueryParameters]
 }
 
 /** Case class representing all possible query parameters */
@@ -72,8 +74,10 @@ final case class SceneQueryParameters(
 }
 
 object SceneQueryParameters {
-  implicit def encSceneQueryParameters = deriveEncoder[SceneQueryParameters]
-  implicit def decSceneQueryParameters = deriveDecoder[SceneQueryParameters]
+  implicit def encSceneQueryParameters: Encoder[SceneQueryParameters] =
+    deriveEncoder[SceneQueryParameters]
+  implicit def decSceneQueryParameters: Decoder[SceneQueryParameters] =
+    deriveDecoder[SceneQueryParameters]
 }
 
 final case class SceneSearchModeQueryParams(
@@ -81,9 +85,11 @@ final case class SceneSearchModeQueryParams(
 )
 
 object SceneSearchModeQueryParams {
-  implicit def encSceneSearchModeQueryParams =
+  implicit def encSceneSearchModeQueryParams
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
-  implicit def decSceneSearchModeQueryParams =
+  implicit def decSceneSearchModeQueryParams
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -101,9 +107,9 @@ final case class CombinedSceneQueryParams(
 )
 
 object CombinedSceneQueryParams {
-  implicit def encCombinedSceneQueryParams =
+  implicit def encCombinedSceneQueryParams: Encoder[CombinedSceneQueryParams] =
     deriveEncoder[CombinedSceneQueryParams]
-  implicit def decCombinedSceneQueryParams =
+  implicit def decCombinedSceneQueryParams: Decoder[CombinedSceneQueryParams] =
     deriveDecoder[CombinedSceneQueryParams]
 }
 
@@ -120,8 +126,10 @@ final case class ProjectQueryParameters(
 )
 
 object ProjectQueryParameters {
-  implicit def encProjectQueryParameters = deriveEncoder[ProjectQueryParameters]
-  implicit def decProjectQueryParameters = deriveDecoder[ProjectQueryParameters]
+  implicit def encProjectQueryParameters: Encoder[ProjectQueryParameters] =
+    deriveEncoder[ProjectQueryParameters]
+  implicit def decProjectQueryParameters: Decoder[ProjectQueryParameters] =
+    deriveDecoder[ProjectQueryParameters]
 }
 
 final case class AoiQueryParameters(
@@ -131,8 +139,10 @@ final case class AoiQueryParameters(
 )
 
 object AoiQueryParameters {
-  implicit def encAoiQueryParameters = deriveEncoder[AoiQueryParameters]
-  implicit def decAoiQueryParameters = deriveDecoder[AoiQueryParameters]
+  implicit def encAoiQueryParameters: Encoder[AoiQueryParameters] =
+    deriveEncoder[AoiQueryParameters]
+  implicit def decAoiQueryParameters: Decoder[AoiQueryParameters] =
+    deriveDecoder[AoiQueryParameters]
 }
 
 /** Combined tool query parameters */
@@ -147,9 +157,11 @@ final case class CombinedToolQueryParameters(
 )
 
 object CombinedToolQueryParameters {
-  implicit def encCombinedToolQueryParameters =
+  implicit def encCombinedToolQueryParameters
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
-  implicit def decCombinedToolQueryParameters =
+  implicit def decCombinedToolQueryParameters
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -158,9 +170,9 @@ final case class FootprintQueryParameters(x: Option[Double] = None,
                                           bbox: Option[String] = None)
 
 object FootprintQueryParameters {
-  implicit def encFootprintQueryParameters =
+  implicit def encFootprintQueryParameters: Encoder[FootprintQueryParameters] =
     deriveEncoder[FootprintQueryParameters]
-  implicit def decFootprintQueryParameters =
+  implicit def decFootprintQueryParameters: Decoder[FootprintQueryParameters] =
     deriveDecoder[FootprintQueryParameters]
 }
 
@@ -171,9 +183,11 @@ final case class CombinedFootprintQueryParams(
 )
 
 object CombinedFootprintQueryParams {
-  implicit def encCombinedFootprintQueryParams =
+  implicit def encCombinedFootprintQueryParams
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
-  implicit def decCombinedFootprintQueryParams =
+  implicit def decCombinedFootprintQueryParams
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -182,8 +196,10 @@ final case class OrgQueryParameters(
     organizations: Iterable[UUID] = Seq.empty[UUID])
 
 object OrgQueryParameters {
-  implicit def encOrgQueryParameters = deriveEncoder[OrgQueryParameters]
-  implicit def decOrgQueryParameters = deriveDecoder[OrgQueryParameters]
+  implicit def encOrgQueryParameters: Encoder[OrgQueryParameters] =
+    deriveEncoder[OrgQueryParameters]
+  implicit def decOrgQueryParameters: Decoder[OrgQueryParameters] =
+    deriveDecoder[OrgQueryParameters]
 }
 
 /** Query parameters to filter by only users */
@@ -191,9 +207,9 @@ final case class UserAuditQueryParameters(createdBy: Option[String] = None,
                                           modifiedBy: Option[String] = None)
 
 object UserAuditQueryParameters {
-  implicit def encUserAuditQueryParameters =
+  implicit def encUserAuditQueryParameters: Encoder[UserAuditQueryParameters] =
     deriveEncoder[UserAuditQueryParameters]
-  implicit def decUserAuditQueryParameters =
+  implicit def decUserAuditQueryParameters: Decoder[UserAuditQueryParameters] =
     deriveDecoder[UserAuditQueryParameters]
 }
 
@@ -201,8 +217,10 @@ object UserAuditQueryParameters {
 final case class OwnerQueryParameters(owner: Option[String] = None)
 
 object OwnerQueryParameters {
-  implicit def encOwnerQueryParameters = deriveEncoder[OwnerQueryParameters]
-  implicit def decOwnerQueryParameters = deriveDecoder[OwnerQueryParameters]
+  implicit def encOwnerQueryParameters: Encoder[OwnerQueryParameters] =
+    deriveEncoder[OwnerQueryParameters]
+  implicit def decOwnerQueryParameters: Decoder[OwnerQueryParameters] =
+    deriveDecoder[OwnerQueryParameters]
 }
 
 /** Query parameters to filter by ownership type:
@@ -216,9 +234,11 @@ final case class OwnershipTypeQueryParameters(
 )
 
 object OwnershipTypeQueryParameters {
-  implicit def encOwnershipTypeQueryParameters =
+  implicit def encOwnershipTypeQueryParameters
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
-  implicit def decOwnershipTypeQueryParameters =
+  implicit def decOwnershipTypeQueryParameters
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -227,8 +247,10 @@ final case class GroupQueryParameters(groupType: Option[GroupType] = None,
                                       groupId: Option[UUID] = None)
 
 object GroupQueryParameters {
-  implicit def encGroupQueryParameters = deriveEncoder[GroupQueryParameters]
-  implicit def decGroupQueryParameters = deriveDecoder[GroupQueryParameters]
+  implicit def encGroupQueryParameters: Encoder[GroupQueryParameters] =
+    deriveEncoder[GroupQueryParameters]
+  implicit def decGroupQueryParameters: Decoder[GroupQueryParameters] =
+    deriveDecoder[GroupQueryParameters]
 }
 
 /** Query parameters to filter by users */
@@ -239,8 +261,10 @@ final case class UserQueryParameters(
 )
 
 object UserQueryParameters {
-  implicit def encUserQueryParameters = deriveEncoder[UserQueryParameters]
-  implicit def decUserQueryParameters = deriveDecoder[UserQueryParameters]
+  implicit def encUserQueryParameters: Encoder[UserQueryParameters] =
+    deriveEncoder[UserQueryParameters]
+  implicit def decUserQueryParameters: Decoder[UserQueryParameters] =
+    deriveDecoder[UserQueryParameters]
 }
 
 /** Query parameters to filter by modified/created times */
@@ -252,18 +276,20 @@ final case class TimestampQueryParameters(
 )
 
 object TimestampQueryParameters {
-  implicit def encTimestampQueryParameters =
+  implicit def encTimestampQueryParameters: Encoder[TimestampQueryParameters] =
     deriveEncoder[TimestampQueryParameters]
-  implicit def decTimestampQueryParameters =
+  implicit def decTimestampQueryParameters: Decoder[TimestampQueryParameters] =
     deriveDecoder[TimestampQueryParameters]
 }
 
 final case class ToolCategoryQueryParameters(search: Option[String] = None)
 
 object ToolCategoryQueryParameters {
-  implicit def encToolCategoryQueryParameters =
+  implicit def encToolCategoryQueryParameters
+    : Encoder[ToolCategoryQueryParameters] =
     deriveEncoder[ToolCategoryQueryParameters]
-  implicit def decToolCategoryQueryParameters =
+  implicit def decToolCategoryQueryParameters
+    : Decoder[ToolCategoryQueryParameters] =
     deriveDecoder[ToolCategoryQueryParameters]
 }
 
@@ -272,8 +298,10 @@ final case class ToolRunQueryParameters(createdBy: Option[String] = None,
                                         toolId: Option[UUID] = None)
 
 object ToolRunQueryParameters {
-  implicit def encToolRunQueryParameters = deriveEncoder[ToolRunQueryParameters]
-  implicit def decToolRunQueryParameters = deriveDecoder[ToolRunQueryParameters]
+  implicit def encToolRunQueryParameters: Encoder[ToolRunQueryParameters] =
+    deriveEncoder[ToolRunQueryParameters]
+  implicit def decToolRunQueryParameters: Decoder[ToolRunQueryParameters] =
+    deriveDecoder[ToolRunQueryParameters]
 }
 
 final case class CombinedToolRunQueryParameters(
@@ -287,9 +315,11 @@ final case class CombinedToolRunQueryParameters(
 )
 
 object CombinedToolRunQueryParameters {
-  implicit def encCombinedToolRunQueryParameters =
+  implicit def encCombinedToolRunQueryParameters
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
-  implicit def decCombinedToolRunQueryParameters =
+  implicit def decCombinedToolRunQueryParameters
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -300,9 +330,11 @@ final case class CombinedToolCategoryQueryParams(
 )
 
 object CombinedToolCategoryQueryParams {
-  implicit def encCombinedToolCategoryQueryParams =
+  implicit def encCombinedToolCategoryQueryParams
+    : Encoder[CombinedToolCategoryQueryParams] =
     deriveEncoder[CombinedToolCategoryQueryParams]
-  implicit def decCombinedToolCategoryQueryParams =
+  implicit def decCombinedToolCategoryQueryParams
+    : Decoder[CombinedToolCategoryQueryParams] =
     deriveDecoder[CombinedToolCategoryQueryParams]
 }
 
@@ -315,9 +347,11 @@ final case class DatasourceQueryParameters(
 )
 
 object DatasourceQueryParameters {
-  implicit def encDatasourceQueryParameters =
+  implicit def encDatasourceQueryParameters
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
-  implicit def decDatasourceQueryParameters =
+  implicit def decDatasourceQueryParameters
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -325,9 +359,9 @@ final case class MapTokenQueryParameters(name: Option[String] = None,
                                          projectId: Option[UUID] = None)
 
 object MapTokenQueryParameters {
-  implicit def encMapTokenQueryParameters =
+  implicit def encMapTokenQueryParameters: Encoder[MapTokenQueryParameters] =
     deriveEncoder[MapTokenQueryParameters]
-  implicit def decMapTokenQueryParameters =
+  implicit def decMapTokenQueryParameters: Decoder[MapTokenQueryParameters] =
     deriveDecoder[MapTokenQueryParameters]
 }
 
@@ -338,9 +372,11 @@ final case class CombinedMapTokenQueryParameters(
 )
 
 object CombinedMapTokenQueryParameters {
-  implicit def encCombinedMapTokenQueryParameters =
+  implicit def encCombinedMapTokenQueryParameters
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
-  implicit def decCombinedMapTokenQueryParameters =
+  implicit def decCombinedMapTokenQueryParameters
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -349,8 +385,10 @@ final case class UploadQueryParameters(datasource: Option[UUID] = None,
                                        projectId: Option[UUID] = None)
 
 object UploadQueryParameters {
-  implicit def encUploadQueryParameters = deriveEncoder[UploadQueryParameters]
-  implicit def decUploadQueryParameters = deriveDecoder[UploadQueryParameters]
+  implicit def encUploadQueryParameters: Encoder[UploadQueryParameters] =
+    deriveEncoder[UploadQueryParameters]
+  implicit def decUploadQueryParameters: Decoder[UploadQueryParameters] =
+    deriveDecoder[UploadQueryParameters]
 }
 
 final case class ExportQueryParameters(organization: Option[UUID] = None,
@@ -360,16 +398,20 @@ final case class ExportQueryParameters(organization: Option[UUID] = None,
                                          Seq.empty[String])
 
 object ExportQueryParameters {
-  implicit def encExportQueryParameters = deriveEncoder[ExportQueryParameters]
-  implicit def decExportQueryParameters = deriveDecoder[ExportQueryParameters]
+  implicit def encExportQueryParameters: Encoder[ExportQueryParameters] =
+    deriveEncoder[ExportQueryParameters]
+  implicit def decExportQueryParameters: Decoder[ExportQueryParameters] =
+    deriveDecoder[ExportQueryParameters]
 }
 
 final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
-  implicit def encDropboxAuthQueryParameters =
+  implicit def encDropboxAuthQueryParameters
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
-  implicit def decDropboxAuthQueryParameters =
+  implicit def decDropboxAuthQueryParameters
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -389,9 +431,11 @@ final case class AnnotationQueryParameters(
 }
 
 object AnnotationQueryParameters {
-  implicit def encAnnotationQueryParameters =
+  implicit def encAnnotationQueryParameters
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
-  implicit def decAnnotationQueryParameters =
+  implicit def decAnnotationQueryParameters
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 final case class ShapeQueryParameters(
@@ -405,30 +449,38 @@ final case class ShapeQueryParameters(
 )
 
 object ShapeQueryParameters {
-  implicit def encShapeQueryParameters = deriveEncoder[ShapeQueryParameters]
-  implicit def decShapeQueryParameters = deriveDecoder[ShapeQueryParameters]
+  implicit def encShapeQueryParameters: Encoder[ShapeQueryParameters] =
+    deriveEncoder[ShapeQueryParameters]
+  implicit def decShapeQueryParameters: Decoder[ShapeQueryParameters] =
+    deriveDecoder[ShapeQueryParameters]
 }
 
 final case class FeedQueryParameters(source: Option[String] = None)
 
 object FeedQueryParameters {
-  implicit def encFeedQueryParameters = deriveEncoder[FeedQueryParameters]
-  implicit def decFeedQueryParameters = deriveDecoder[FeedQueryParameters]
+  implicit def encFeedQueryParameters: Encoder[FeedQueryParameters] =
+    deriveEncoder[FeedQueryParameters]
+  implicit def decFeedQueryParameters: Decoder[FeedQueryParameters] =
+    deriveDecoder[FeedQueryParameters]
 }
 
 final case class SearchQueryParameters(search: Option[String] = None)
 
 object SearchQueryParameters {
-  implicit def encSearchQueryParameters = deriveEncoder[SearchQueryParameters]
-  implicit def decSearchQueryParameters = deriveDecoder[SearchQueryParameters]
+  implicit def encSearchQueryParameters: Encoder[SearchQueryParameters] =
+    deriveEncoder[SearchQueryParameters]
+  implicit def decSearchQueryParameters: Decoder[SearchQueryParameters] =
+    deriveDecoder[SearchQueryParameters]
 }
 
 final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
-  implicit def encActivationQueryParameters =
+  implicit def encActivationQueryParameters
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
-  implicit def decActivationQueryParameters =
+  implicit def decActivationQueryParameters
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -441,8 +493,10 @@ final case class TeamQueryParameters(
 )
 
 object TeamQueryParameters {
-  implicit def encTeamQueryParameters = deriveEncoder[TeamQueryParameters]
-  implicit def decTeamQueryParameters = deriveDecoder[TeamQueryParameters]
+  implicit def encTeamQueryParameters: Encoder[TeamQueryParameters] =
+    deriveEncoder[TeamQueryParameters]
+  implicit def decTeamQueryParameters: Decoder[TeamQueryParameters] =
+    deriveDecoder[TeamQueryParameters]
 }
 
 final case class PlatformQueryParameters(
@@ -453,18 +507,20 @@ final case class PlatformQueryParameters(
 )
 
 object PlatformQueryParameters {
-  implicit def encPlatformQueryParameters =
+  implicit def encPlatformQueryParameters: Encoder[PlatformQueryParameters] =
     deriveEncoder[PlatformQueryParameters]
-  implicit def decPlatformQueryParameters =
+  implicit def decPlatformQueryParameters: Decoder[PlatformQueryParameters] =
     deriveDecoder[PlatformQueryParameters]
 }
 
 final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
-  implicit def encPlatformIdQueryParameters =
+  implicit def encPlatformIdQueryParameters
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
-  implicit def decPlatformIdQueryParameters =
+  implicit def decPlatformIdQueryParameters
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -476,9 +532,11 @@ final case class OrganizationQueryParameters(
 )
 
 object OrganizationQueryParameters {
-  implicit def encOrganizationQueryParameters =
+  implicit def encOrganizationQueryParameters
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
-  implicit def decOrganizationQueryParameters =
+  implicit def decOrganizationQueryParameters
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -491,9 +549,11 @@ final case class SceneThumbnailQueryParameters(width: Option[Int],
                                                floor: Option[Int])
 
 object SceneThumbnailQueryParameters {
-  implicit def encSceneThumbnailQueryParameters =
+  implicit def encSceneThumbnailQueryParameters
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
-  implicit def decSceneThumbnailQueryParameters =
+  implicit def decSceneThumbnailQueryParameters
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -503,8 +563,10 @@ final case class TagQueryParameters(
 )
 
 object TagQueryParameters {
-  implicit def encTagQueryParameters = deriveEncoder[TagQueryParameters]
-  implicit def decTagQueryParameters = deriveDecoder[TagQueryParameters]
+  implicit def encTagQueryParameters: Encoder[TagQueryParameters] =
+    deriveEncoder[TagQueryParameters]
+  implicit def decTagQueryParameters: Decoder[TagQueryParameters] =
+    deriveDecoder[TagQueryParameters]
 }
 
 object BboxUtil {

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -326,15 +326,6 @@ trait Filterables extends RFMeta with LazyLogging {
 
     }
 
-  implicit val combinedImageQueryparamsFilter
-    : Filterable[Any, CombinedImageQueryParams] =
-    Filterable[Any, CombinedImageQueryParams] {
-      cips: CombinedImageQueryParams =>
-        Filters.timestampQP(cips.timestampParams) ++ Filters.imageQP(
-          cips.imageParams
-        )
-    }
-
   implicit val thumbnailParamsFilter
     : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {


### PR DESCRIPTION
## Overview

This PR ensures the batch assembly jar includes json codecs for query parameter classes.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Why did they go away? I don't know. Maybe the code generator in macro paradise got tired. Maybe because everything was used only implicitly, assembly thought we didn't need it. Maybe our deprecated dropbox call caused assembly to get confused, like [this unfortunate soul](https://stackoverflow.com/a/37608677). Anyway, it's fixed. :heart: assembly

## Testing Instructions

 * assemble your batch jar on develop
 * run the commands in the test script in the linked issue from ammonite, or `scala -cp /abs/path/to/batch-assembly.jar` and just run the non-ammonite parts
 * you should get errors when you try to initialize the combined scene query params
 * reassemble your batch jar with this branch
 * run the same commands
 * you should be fine

Closes azavea/raster-foundry-platform#535