### PR TITLE
Fill in missing auth methods for backsplash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [\#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
-- Added project histogram support for COG and Avro scenes [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
+- Added project histogram support for COG and Avro scenes in backsplash [\#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)
+- Added map token and authorization header authentication to backsplash [\#4271](https://github.com/raster-foundry/raster-foundry/pull/4271)
 - Added service-level and total error-handling to backsplash tile server [\#4258](https://github.com/raster-foundry/raster-foundry/pull/4258)
 - Administration
   - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214) 

--- a/app-backend/backsplash/src/main/scala/Server.scala
+++ b/app-backend/backsplash/src/main/scala/Server.scala
@@ -46,9 +46,9 @@ object BacksplashServer extends IOApp {
 
   def healthCheckService = new HealthCheckService[IO].service
   def analysisService =
-    Authenticators.queryParamAuthMiddleware(new AnalysisService().service)
+    Authenticators.tokensAuthMiddleware(new AnalysisService().service)
   def mosaicService =
-    Authenticators.queryParamAuthMiddleware(new MosaicService().service)
+    Authenticators.tokensAuthMiddleware(new MosaicService().service)
 
   val httpApp =
     Router(

--- a/app-backend/backsplash/src/main/scala/auth/Authenticators.scala
+++ b/app-backend/backsplash/src/main/scala/auth/Authenticators.scala
@@ -1,41 +1,94 @@
 package com.rasterfoundry.backsplash.auth
 
 import com.rasterfoundry.authentication.Authentication
-import com.rasterfoundry.database.UserDao
+import com.rasterfoundry.backsplash.parameters.Parameters._
+import com.rasterfoundry.database.{UserDao, MapTokenDao}
 import com.rasterfoundry.database.util.RFTransactor
-import com.rasterfoundry.datamodel.User
+import com.rasterfoundry.datamodel.{MapToken, User}
 
 import cats.data._
 import cats.effect.IO
 import cats.implicits._
+import doobie.ConnectionIO
 import doobie.implicits._
 import org.http4s._
-import org.http4s.server._
 import org.http4s.dsl.io._
+import org.http4s.server._
+import org.http4s.util.CaseInsensitiveString
 
-object TokenQueryParamMatcher extends QueryParamDecoderMatcher[String]("token")
+import java.util.UUID
+
+object TokenQueryParamMatcher
+    extends OptionalQueryParamDecoderMatcher[String]("token")
+object MapTokenQueryParamMatcher
+    extends OptionalQueryParamDecoderMatcher[UUID]("mapToken")
 
 object Authenticators extends Authentication {
   implicit val xa = RFTransactor.xa
 
-  val queryParamAuthenticator = Kleisli[OptionT[IO, ?], Request[IO], User](
+  val tokensAuthenticator = Kleisli[OptionT[IO, ?], Request[IO], User](
     {
-      case req @ _ :? TokenQueryParamMatcher(token) => {
-        verifyJWT(token) match {
-          case Right((_, jwtClaims)) =>
-            OptionT(
-              UserDao
-                .getUserById(jwtClaims.getStringClaim("sub"))
-                .transact(xa)
-            )
-          case Left(e) =>
-            OptionT(IO(None: Option[User]))
-        }
+      case req @ _ -> "tools" /: UUIDWrapper(analysisId) /: _
+            :? TokenQueryParamMatcher(tokenQP)
+            :? MapTokenQueryParamMatcher(mapTokenQP) =>
+        val authHeader: OptionT[IO, Header] =
+          OptionT.fromOption(
+            req.headers.get(CaseInsensitiveString("Authorization")))
+        checkTokenAndHeader(tokenQP, authHeader) :+
+          (
+            OptionT.fromOption[IO](mapTokenQP) flatMap { (mapToken: UUID) =>
+              userFromMapToken(MapTokenDao.checkAnalysis(analysisId), mapToken)
+            }
+          ) reduce { _ orElse _ }
+
+      case req @ _ -> UUIDWrapper(projectId) /: _
+            :? TokenQueryParamMatcher(tokenQP)
+            :? MapTokenQueryParamMatcher(mapTokenQP) => {
+        val authHeader: OptionT[IO, Header] =
+          OptionT.fromOption(
+            req.headers.get(CaseInsensitiveString("Authorization")))
+        checkTokenAndHeader(tokenQP, authHeader) :+
+          (
+            OptionT.fromOption[IO](mapTokenQP) flatMap { (mapToken: UUID) =>
+              userFromMapToken(MapTokenDao.checkProject(projectId), mapToken)
+            }
+          ) reduce { _ orElse _ }
       }
-      case _ =>
-        OptionT(IO(None: Option[User]))
+
+      case _ => OptionT.none[IO, User]
     }
   )
 
-  val queryParamAuthMiddleware = AuthMiddleware(queryParamAuthenticator)
+  private def checkTokenAndHeader(
+      tokenQP: Option[String],
+      authHeader: OptionT[IO, Header]): List[OptionT[IO, User]] = {
+    List(
+      authHeader flatMap { (header: Header) =>
+        userFromToken(header.value.replace("Bearer ", ""))
+      },
+      OptionT.fromOption[IO](tokenQP) flatMap { (token: String) =>
+        userFromToken(token)
+      }
+    )
+  }
+
+  private def userFromMapToken(func: UUID => ConnectionIO[Option[MapToken]],
+                               mapTokenId: UUID): OptionT[IO, User] =
+    OptionT(func(mapTokenId).transact(xa)) flatMap { mapToken =>
+      OptionT(UserDao.getUserById(mapToken.owner).transact(xa))
+    }
+
+  private def userFromToken(token: String): OptionT[IO, User] =
+    verifyJWT(token) match {
+      case Right((_, jwtClaims)) =>
+        OptionT(
+          UserDao
+            .getUserById(jwtClaims.getStringClaim("sub"))
+            .transact(xa)
+        )
+      case Left(e) =>
+        OptionT(IO(None: Option[User]))
+    }
+
+  val tokensAuthMiddleware = AuthMiddleware(tokensAuthenticator)
 }

--- a/app-backend/backsplash/src/main/scala/parameters/PathParameters.scala
+++ b/app-backend/backsplash/src/main/scala/parameters/PathParameters.scala
@@ -2,11 +2,17 @@ package com.rasterfoundry.backsplash.parameters
 
 import com.rasterfoundry.backsplash.nodes.ProjectNode
 
+import org.http4s._
+
 import scala.util.Try
 
 import java.util.UUID
 
-object PathParameters {
+object Parameters {
+
+  implicit val uuidQueryParamDecoder: QueryParamDecoder[UUID] =
+    QueryParamDecoder[String].map(UUID.fromString)
+
   object UUIDWrapper {
     def unapply(s: String): Option[UUID] = {
       if (!s.isEmpty) Try(UUID.fromString(s)).toOption else None

--- a/app-backend/backsplash/src/main/scala/services/AnalysisService.scala
+++ b/app-backend/backsplash/src/main/scala/services/AnalysisService.scala
@@ -11,7 +11,7 @@ import com.rasterfoundry.authentication.Authentication
 import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.maml.BacksplashMamlAdapter
-import com.rasterfoundry.backsplash.parameters.PathParameters._
+import com.rasterfoundry.backsplash.parameters.Parameters._
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.datamodel.User
 import com.rasterfoundry.database.ToolRunDao

--- a/app-backend/backsplash/src/main/scala/services/MosaicService.scala
+++ b/app-backend/backsplash/src/main/scala/services/MosaicService.scala
@@ -6,7 +6,7 @@ import com.rasterfoundry.authentication.Authentication
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.io.Histogram
 import com.rasterfoundry.backsplash.nodes.ProjectNode
-import com.rasterfoundry.backsplash.parameters.PathParameters._
+import com.rasterfoundry.backsplash.parameters.Parameters._
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.{ProjectDao, UserDao}

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -705,6 +705,19 @@ object Generators extends ArbitraryInstances {
       }, actionType)
     }
 
+  private def toolRunCreateGen: Gen[ToolRun.Create] =
+    for {
+      name <- Gen.option(nonEmptyStringGen)
+      visibility <- visibilityGen
+      executionParameters <- Gen.const(().asJson)
+      owner <- Gen.const(None)
+    } yield { ToolRun.Create(name, visibility, executionParameters, owner) }
+
+  private def mapTokenCreateGen: Gen[MapToken.Create] =
+    nonEmptyStringGen map { name =>
+      MapToken.Create(name, None, None, None)
+    }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
       credentialGen
@@ -847,5 +860,11 @@ object Generators extends ArbitraryInstances {
         Gen.nonEmptyListOf[ObjectAccessControlRule](
           arbitrary[ObjectAccessControlRule])
       }
+
+    implicit def arbToolRunCreate: Arbitrary[ToolRun.Create] =
+      Arbitrary { toolRunCreateGen }
+
+    implicit def arbMapTokenCreate: Arbitrary[MapToken.Create] =
+      Arbitrary { mapTokenCreateGen }
   }
 }

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -138,4 +138,18 @@ object MapTokenDao extends Dao[MapToken] {
     val newMapToken = MapToken.Create(name, project, toolRun, Some(ownerId))
     insert(newMapToken, user)
   }
+
+  def checkProject(projectId: UUID)(
+      mapToken: UUID): ConnectionIO[Option[MapToken]] =
+    query
+      .filter(fr"project_id=${projectId}")
+      .filter(fr"id=${mapToken}")
+      .selectOption
+
+  def checkAnalysis(analysisId: UUID)(
+      mapToken: UUID): ConnectionIO[Option[MapToken]] =
+    query
+      .filter(fr"toolrun_id=${analysisId}")
+      .filter(fr"id=${mapToken}")
+      .selectOption
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
@@ -1,6 +1,7 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.datamodel.MapToken
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
 
 import doobie._, doobie.implicits._
@@ -9,12 +10,101 @@ import cats.syntax.either._
 import doobie.postgres._, doobie.postgres.implicits._
 import doobie.scalatest.imports._
 import org.scalatest._
+import org.scalacheck.Prop.forAll
+import org.scalatest.prop.Checkers
 
-class MapTokenDaoSpec extends FunSuite with Matchers with DBTestConfig {
+import java.util.UUID
+
+class MapTokenDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
 
   test("types") {
     xa.use(t => MapTokenDao.query.list.transact(t))
       .unsafeRunSync
       .length should be >= 0
+  }
+
+  test("Retrieve a map token for a project") {
+    check {
+      forAll {
+        (mapTokenCreate: MapToken.Create,
+         user: User.Create,
+         project: Project.Create) =>
+          {
+            val retrievedMapTokensIO =
+              for {
+                dbUser <- UserDao.create(user)
+                dbProject <- ProjectDao.insertProject(project, dbUser)
+                dbMapToken <- MapTokenDao.insert(
+                  fixupMapToken(mapTokenCreate, dbUser, Some(dbProject), None),
+                  dbUser
+                )
+                retrievedGood <- MapTokenDao.checkProject(dbProject.id)(
+                  dbMapToken.id)
+                retrievedBad <- MapTokenDao.checkProject(UUID.randomUUID)(
+                  dbMapToken.id)
+              } yield { (dbMapToken, retrievedGood, retrievedBad) }
+
+            val (mapToken, shouldBeSome, shouldBeNone) = xa.use { t =>
+              retrievedMapTokensIO.transact(t)
+            } unsafeRunSync
+
+            assert(
+              Some(mapToken) == shouldBeSome,
+              "; Inserted and retrieved map tokens should be the same"
+            )
+            assert(
+              shouldBeNone == None,
+              "; Bogus IDs should not return a map token"
+            )
+
+            true
+          }
+      }
+    }
+  }
+
+  test("Retrieve a map token for an analysis") {
+    check {
+      forAll {
+        (mapTokenCreate: MapToken.Create,
+         user: User.Create,
+         analysis: ToolRun.Create) =>
+          {
+            val retrievedMapTokensIO =
+              for {
+                dbUser <- UserDao.create(user)
+                dbAnalysis <- ToolRunDao.insertToolRun(analysis, dbUser)
+                dbMapToken <- MapTokenDao.insert(
+                  fixupMapToken(mapTokenCreate, dbUser, None, Some(dbAnalysis)),
+                  dbUser
+                )
+                retrievedGood <- MapTokenDao.checkAnalysis(dbAnalysis.id)(
+                  dbMapToken.id)
+                retrievedBad <- MapTokenDao.checkAnalysis(UUID.randomUUID)(
+                  dbMapToken.id)
+              } yield { (dbMapToken, retrievedGood, retrievedBad) }
+
+            val (mapToken, shouldBeSome, shouldBeNone) = xa.use { t =>
+              retrievedMapTokensIO.transact(t)
+            } unsafeRunSync
+
+            assert(
+              Some(mapToken) == shouldBeSome,
+              "; Inserted and retrieved map tokens should be the same"
+            )
+            assert(
+              shouldBeNone == None,
+              "; Bogus IDs should not return a map token"
+            )
+
+            true
+          }
+      }
+    }
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -260,4 +260,12 @@ trait PropTestHelpers {
       dbUserTeamOrgPlat = (dbUser, dbTeam, dbOrg, dbPlatform)
     } yield { (projectInsert, dbUserTeamOrgPlat) }
   }
+
+  def fixupMapToken(mapTokenCreate: MapToken.Create,
+                    user: User,
+                    project: Option[Project],
+                    analysis: Option[ToolRun]): MapToken.Create =
+    mapTokenCreate.copy(project = project map { _.id }, toolRun = analysis map {
+      _.id
+    }, owner = Some(user.id))
 }


### PR DESCRIPTION
## Overview

This PR fills in map token and auth header authentication methods for backsplash.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Notes

`/:` is a right-associative path separator -- you can read the match from right to left to understand what the `case` will match, e.g.:

```scala
case req @ _ -> "tools" /: UUIDWrapper(analysisId) /: _ => ...
```

means "ending in literally anything, preceded by a UUID, preceded by "tools", do the following. It's also why the tools match needs to come first, because with the exception of being a project id instead of an analysis id, the project routes matcher is the same

## Testing Instructions

Testing instructions assume you're a cool kid who uses `httpie` because writing out `curl` commands makes me tired.

 * get a bearer token
 * `http :8081/a-project-id/z/x/y Authorization:'Bearer ...'`
 * `http :8081/a-project-id/z/x/y token=='ey978234...'`
 * create a map token for your project
 * `http :8081/a-project-id/z/x/y mapToken=='map token uuid'`
 * confirm logic looks the same for tools
 * extra credit: test auth with a tool run / analysis / whatever you feel like calling them

Closes #4180 