### PR TITLE
Add Ansible role to install Nexus Repo Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Add Ansible role to install Nexus Repo Manager [\#4277](https://github.com/raster-foundry/raster-foundry/pull/4277)
 
 ### Changed
 

--- a/app-backend/project/ci/repositories
+++ b/app-backend/project/ci/repositories
@@ -1,0 +1,4 @@
+[repositories]
+  local
+  ivy-proxy-releases: http://nexus.rasterfoundry.internal/repository/ivy-public/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  maven-proxy-releases: http://nexus.rasterfoundry.internal/repository/maven-public/

--- a/app-backend/project/development/repositories
+++ b/app-backend/project/development/repositories
@@ -1,0 +1,4 @@
+[repositories]
+  local
+  ivy-proxy-releases: http://nexus.internal.azavea.com/repository/ivy-public/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  maven-proxy-releases: http://nexus.internal.azavea.com/repository/maven-public/

--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -8,3 +8,5 @@ shellcheck_version: "0.3.*"
 
 docker_users:
   - "vagrant"
+
+pyyaml_version: "3.13"

--- a/deployment/ansible/group_vars/nexus.yml
+++ b/deployment/ansible/group_vars/nexus.yml
@@ -1,0 +1,2 @@
+---
+nexus_server_name: nexus.internal.azavea.com

--- a/deployment/ansible/inventory/nexus
+++ b/deployment/ansible/inventory/nexus
@@ -1,0 +1,2 @@
+[nexus]
+nexus_azavea ansible_host=nexus.internal.azavea.com ansible_user=azavea ansible_python_interpreter=/usr/bin/python3

--- a/deployment/ansible/raster-foundry-jenkins.yml
+++ b/deployment/ansible/raster-foundry-jenkins.yml
@@ -14,3 +14,4 @@
     - { role: raster-foundry.docker }
     - { role: raster-foundry.shellcheck }
     - { role: raster-foundry.jenkins }
+    - { role: raster-foundry.nexus }

--- a/deployment/ansible/raster-foundry-nexus.yml
+++ b/deployment/ansible/raster-foundry-nexus.yml
@@ -1,0 +1,12 @@
+---
+- hosts: nexus
+  connection: ssh
+  become: True
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes cache_valid_time=3600
+
+  roles:
+    - { role: azavea.ntp }
+    - { role: raster-foundry.nexus }

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -2,7 +2,7 @@
   version: 4.0.0
 
 - src: azavea.pip
-  version: 1.0.0
+  version: 1.0.1
 
 - src: azavea.jenkins
   version: 1.2.0

--- a/deployment/ansible/roles/raster-foundry.nexus/defaults/main.yml
+++ b/deployment/ansible/roles/raster-foundry.nexus/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+nexus_server_name: "nexus.staging.rasterfoundry.com nexus.rasterfoundry.internal"
+nexus_http_port: "8081"

--- a/deployment/ansible/roles/raster-foundry.nexus/meta/main.yml
+++ b/deployment/ansible/roles/raster-foundry.nexus/meta/main.yml
@@ -1,0 +1,5 @@
+---
+dependencies: 
+  - { role: azavea.nginx, nginx_delete_default_site: True }
+  - { role: azavea.pip }
+  - { role: raster-foundry.docker }

--- a/deployment/ansible/roles/raster-foundry.nexus/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.nexus/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Install PyYAML
+  pip: name=pyyaml version={{ pyyaml_version }}
+
+- name: Create directory for persistant Nexus data
+  file: name=/opt/nexus-data state=directory
+        mode=755 owner=200 group=200
+        recurse=true
+
+- name: Add Nexus Nginx config
+  template: src=nexus.conf.j2
+            dest=/etc/nginx/sites-available/nexus.conf
+  notify:
+    - Restart Nginx
+
+- name: Enable Nexus Nginx config
+  file: src=/etc/nginx/sites-available/nexus.conf
+        dest=/etc/nginx/sites-enabled/nexus
+        state=link
+  notify:
+    - Restart Nginx
+
+- name: Configure Nexus Docker Compose service
+  docker_service:
+    build: yes
+    project_name: nexus
+    state: present
+    definition: 
+      version: "3"
+      services:
+        nexus-server:
+          image: sonatype/nexus3:3.13.0
+          ports:
+            - "{{ nexus_http_port }}:8081"
+          volumes:
+            - "/opt/nexus-data:/nexus-data"
+          restart: on-failure
+          logging:
+            driver: syslog
+            options:
+              tag: nexus-server
+

--- a/deployment/ansible/roles/raster-foundry.nexus/templates/nexus.conf.j2
+++ b/deployment/ansible/roles/raster-foundry.nexus/templates/nexus.conf.j2
@@ -1,0 +1,23 @@
+server {
+  listen 80;
+  server_name {{ nexus_server_name }};
+
+  # allow large uploads of files
+  client_max_body_size 1G;
+
+  # optimize downloading files larger than 1G
+  ##proxy_max_temp_file_size 2G;
+
+  proxy_send_timeout 120;
+  proxy_read_timeout 300;
+  proxy_buffering    off;
+  keepalive_timeout  5 5;
+  tcp_nodelay        on;
+
+  location / {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_pass http://127.0.0.1:{{ nexus_http_port }};
+  }
+}

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -28,6 +28,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         echo "Pulling down configuration settings for test environment"
         pushd "${DIR}/.."
         aws s3 cp "s3://${RF_SETTINGS_BUCKET}/.env" ".env"
+        
+        aws s3 cp "s3://${RF_SETTINGS_BUCKET}/.sbtopts" - >> app-backend/.sbtopts
+        sort app-backend/.sbtopts | uniq > cleaned_sbtopts
+        mv cleaned_sbtopts app-backend/.sbtopts
+        
         popd
 
         echo "Building static asset bundle"


### PR DESCRIPTION
## Overview

Adds an Ansible role to provision an instance of Nexus Repo Manager, prepopulated with a Nexus backup from S3. Using Nexus will help speed up dependency downloads and keep us from being throttled by Maven Central.

You can login to the admin console using the `Nexus` credentials on LastPass:

* http://nexus.internal.azavea.com/
* http://nexus.staging.rasterfoundry.com/

Resolves azavea/raster-foundry-platform#519
Resolves azavea/raster-foundry-platform#518
Resolves azavea/raster-foundry-platform#517

## Notes

I created a private hosted zone for the Jenkins VPC, and added a record for `nexus.rasterfoundry.internal`.

I did this because NAT loopback for `nexus.staging.rasterfoundry.com` didn't work, and I thought it would be beneficial if we ever add Jenkins slave instances.

## Testing Instructions

First, SCP the `nexus-data-backup.tar.gz` tarball to the instance from the `rasterfoundry-development-data-us-east-1` bucket:

```bash
$ AWS_PROFILE=raster-foundry \
  aws s3 cp s3://rasterfoundry-development-data-us-east-1/nexus-data-backup.tar.gz /tmp/nexus-data-backup-tar.gz
$ scp /tmp/nexus-data-backup-tar.gz azavea@nexus:~/nexus-data-backup.tar.gz
```

Next, unpack and `chown`:

```bash
$ ssh azavea@nexus
$ sudo tar xf nexus-data-backup.tar.gz -C /opt
$ sudo chown 200:200 /opt/nexus-data
```

Provision the instance using the Ansible playbook:

```bash
$ ansible-playbook -i deployment/ansible/inventory -K deployment/ansible/raster-foundry-nexus.yml
```

After about 2 minutes (Nexus takes a moment to initialize), verify that the Nexus UI is up at http://nexus.internal.azavea.com. 

 Follow the [wiki instructions](https://github.com/azavea/raster-foundry-deployment/wiki/Using-the-Internal-Nexus-Instance-in-Development) to configure your dev environment to use Nexus, then run `scripts/update`. Check the `sbt update` output to verify that you are indeed downloading from `nexus.internal.azavea.com`:

```bash
vagrant@vagrant:/opt/raster-foundry$ ./scripts/update
Updating Scala dependencies
raster-foundry_postgres_1 is up-to-date
raster-foundry_memcached_1 is up-to-date
Starting raster-foundry_api-server_1 ... done
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /opt/raster-foundry/app-backend/project
[info] Updating ProjectRef(uri("file:/opt/raster-foundry/app-backend/project/"), "app-backend-build")...
[info] downloading http://nexus.internal.azavea.com/repository/maven-public/org/codehaus/plexus/plexus-classworlds/2.5.2/plexus-classworlds-2.5.2.jar ...
[info] downloading http://nexus.internal.azavea.com/repository/maven-public/org/json4s/json4s-scalap_2.12/3.4.2/json4s-scalap_2.12-3.4.2.jar ...
[info] downloading http://nexus.internal.azavea.com/repository/maven-public/org/apache/httpcomponents/httpcore/4.3.3/httpcore-4.3.3.jar ...
[info] downloading http://nexus.internal.azavea.com/repository/maven-public/org/bouncycastle/bcprov-jdk15on/1.51/bcprov-jdk15on-1.51.jar ...
[info] downloading http://nexus.internal.azavea.com/repository/maven-public/org/slf4j/slf4j-nop/1.7.7/slf4j-nop-1.7.7.jar ...
[info] downloading http://nexus.internal.azavea.com/repository/maven-public/org/apache/ant/ant-launcher/1.9.9/ant-launcher-1.9.9.jar ...
[info] downloading http://nexus.internal.azavea.com/repository/ivy-public/com.jsuereth/sbt-pgp/scala_2.12/sbt_1.0/1.1.0/jars/sbt-pgp.jar ...
[info] 	[SUCCESSFUL ] org.codehaus.plexus#plexus-classworlds;2.5.2!plexus-classworlds.jar(bundle) (339ms)
[info] 	[SUCCESSFUL ] org.json4s#json4s-scalap_2.12;3.4.2!json4s-scalap_2.12.jar (412ms)
[info] 	[SUCCESSFUL ] org.apache.httpcomponents#httpcore;4.3.3!httpcore.jar (359ms)
[info] 	[SUCCESSFUL ] org.slf4j#slf4j-nop;1.7.7!slf4j-nop.jar (250ms)
...
```