### PR TITLE
Fix searchQP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Added map token and authorization header authentication to backsplash [\#4271](https://github.com/raster-foundry/raster-foundry/pull/4271)
 - Added service-level and total error-handling to backsplash tile server [\#4258](https://github.com/raster-foundry/raster-foundry/pull/4258)
 - Administration
-  - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214) 
+  - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214)
   - Allow platform administrators to create uploads for other users within their platforms [\#4237](https://github.com/raster-foundry/raster-foundry/pull/4237)
 
 ### Changed
@@ -36,6 +36,7 @@
 - Kick off ingests for scenes without scene types also [\#4260](https://github.com/raster-foundry/raster-foundry/pull/4260)
 - Separated connection and transaction execution contexts in database tests [\#4264](https://github.com/raster-foundry/raster-foundry/pull/4264)
 - More carefully managed system resources to prevent non-terminating asynchronous workflows [\#4268](https://github.com/raster-foundry/raster-foundry/pull/4268)
+- Make search feature more secure for endpoints that supply such query parameter [\#4280](https://github.com/raster-foundry/raster-foundry/pull/4280)
 
 ### Security
 

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -76,21 +76,19 @@ object Filters {
     )
   }
 
-  def searchQP(searchParams: SearchQueryParameters,
-               cols: List[String]): List[Option[Fragment]] = {
+  def searchQP(searchParams: SearchQueryParameters, cols: List[String]): List[Option[Fragment]] =
     List(
-      searchParams.search.map(valueToMatch => {
-        Fragment.const(
-          "(" ++ cols
-            .map(col => {
-              val namePattern: String = "'%" + valueToMatch.toUpperCase() + "%'"
-              s"UPPER($col) LIKE $namePattern"
-            })
-            .mkString(" OR ") ++ ")"
-        )
-      })
+      searchParams.search.getOrElse("") match {
+        case ""  => None
+        case searchString =>
+          val searchF: List[Option[Fragment]] = cols.map(col => {
+            val patternString: String = "%" + searchString.toUpperCase() + "%"
+            Some(Fragment.const(s"UPPER($col)") ++ fr"LIKE ${patternString}")
+          })
+          Some(Fragment.const("(") ++ Fragments
+            .orOpt(searchF: _*) ++ Fragment.const(")"))
+      }
     )
-  }
 
   def activationQP(
       activationParams: ActivationQueryParameters): List[Option[Fragment]] = {

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -76,17 +76,19 @@ object Filters {
     )
   }
 
-  def searchQP(searchParams: SearchQueryParameters, cols: List[String]): List[Option[Fragment]] =
+  def searchQP(searchParams: SearchQueryParameters,
+               cols: List[String]): List[Option[Fragment]] =
     List(
       searchParams.search.getOrElse("") match {
-        case ""  => None
+        case "" => None
         case searchString =>
           val searchF: List[Option[Fragment]] = cols.map(col => {
             val patternString: String = "%" + searchString.toUpperCase() + "%"
             Some(Fragment.const(s"UPPER($col)") ++ fr"LIKE ${patternString}")
           })
-          Some(Fragment.const("(") ++ Fragments
-            .orOpt(searchF: _*) ++ Fragment.const(")"))
+          Some(
+            Fragment.const("(") ++ Fragments
+              .orOpt(searchF: _*) ++ Fragment.const(")"))
       }
     )
 


### PR DESCRIPTION
## Overview

This PR fixes `searchQP` function to make it more secure and escape quotation marks.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Property tests should pass
 * Use search functions on frontend or by sending `?search=<something>` request to endpoints that supplies this query parameter (like search for plat/org/team members, search for orgs/teams/projects/datasources/templates, etc. )
 * Send search strings like `'uav%20-%203%20Band'`, `'uav%20-%203%20Band`, `"uav%20-%203%20Band` with quotation marks and make sure it just does not give you matching results rather than giving postgres errors
 * Do something similar as mentioned in https://github.com/azavea/raster-foundry-platform/issues/547

Closes https://github.com/azavea/raster-foundry-platform/issues/547
Closes https://github.com/azavea/raster-foundry-platform/issues/530
