### PR TITLE
Fix annotation edit bug when uploaded from a zipped shapefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 - Kick off ingests for scenes without scene types also [\#4260](https://github.com/raster-foundry/raster-foundry/pull/4260)
 - Separated connection and transaction execution contexts in database tests [\#4264](https://github.com/raster-foundry/raster-foundry/pull/4264)
 - More carefully managed system resources to prevent non-terminating asynchronous workflows [\#4268](https://github.com/raster-foundry/raster-foundry/pull/4268)
-- Make search feature more secure for endpoints that supply such query parameter [\#4280](https://github.com/raster-foundry/raster-foundry/pull/4280)
+- Made search feature more secure for endpoints that supply such query parameter [\#4280](https://github.com/raster-foundry/raster-foundry/pull/4280)
+- Fixed annotation click and edit bug when the annotation is uploaded from a zipped shapefile [\#4282](https://github.com/raster-foundry/raster-foundry/pull/4282)
 
 ### Security
 

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -374,9 +374,7 @@ class AnnotateController {
         if (!this.sidebarDisabled) {
             this.getMap().then(mapWrapper => {
                 let panTo = annotation;
-                if (annotation.geometry.type === 'Polygon') {
-                    panTo = turfCenter(annotation);
-                }
+                panTo = turfCenter(annotation);
                 mapWrapper.map.panTo([
                     panTo.geometry.coordinates[1],
                     panTo.geometry.coordinates[0]

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -376,8 +376,7 @@ class AnnotateController {
     doPanToAnnotation(annotation) {
         if (!this.sidebarDisabled) {
             this.getMap().then(mapWrapper => {
-                let panTo = annotation;
-                panTo = turfCenter(annotation);
+                let panTo = turfCenter(annotation);
                 mapWrapper.map.panTo([
                     panTo.geometry.coordinates[1],
                     panTo.geometry.coordinates[0]

--- a/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
+++ b/app-frontend/src/app/pages/projects/edit/annotate/annotate.module.js
@@ -345,7 +345,10 @@ class AnnotateController {
     /* eslint-enable no-underscore-dangle */
 
     setLayerStyle(target, color, iconClass) {
-        if (target.feature.geometry.type === 'Polygon') {
+        if (
+            target.feature.geometry.type === 'Polygon' ||
+            target.feature.geometry.type === 'MultiPolygon'
+          ) {
             target.setStyle({'color': color});
         } else if (target.feature.geometry.type === 'Point') {
             target.setIcon(L.divIcon({'className': iconClass}));

--- a/app-frontend/src/app/redux/reducers/project-reducer.js
+++ b/app-frontend/src/app/redux/reducers/project-reducer.js
@@ -33,8 +33,10 @@ export const projectReducer = typeToReducer({
             }, action.payload.options);
             const mapWrapper = state.projectMap;
             let editHandler;
-            if (geometry.type === 'Polygon') {
-                let coordinates = geometry.coordinates[0].map(c => [c[1], c[0]]);
+            if (geometry.type === 'Polygon' || geometry.type === 'MultiPolygon') {
+                let coordinates = geometry.type === 'Polygon' ?
+                    geometry.coordinates[0].map(c => [c[1], c[0]]) :
+                    geometry.coordinates[0][0].map(c => [c[1], c[0]]);
                 let polygonLayer = L.polygon(
                     coordinates,
                     options


### PR DESCRIPTION
## Overview

This PR fixes a bug in annotation sidebar item click and on annotation item edit when the annotation is from a zipped shapefile upload, so that it takes into consideration of `MultiPolygon` in addition to `Polygon`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Go to a project and upload annotations from a zipped shapefile (select right fields to match though)
 * Go to annotation list on the sidebar -- clicking on an annotation item on sidebar should pan the map to it
 * Click on the annotation item dropdown and select edit -- the shape to be edited should appear on the map. Saving the shape should succeed.

Closes https://github.com/raster-foundry/raster-foundry/issues/4279
