### PR TITLE
Enable template deletion on frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 - Add Ansible role to install Nexus Repo Manager [\#4277](https://github.com/raster-foundry/raster-foundry/pull/4277)
-
 - Added S3 path suggestions in scene import modal when users upload imageries from S3 buckets [\#4290](https://github.com/raster-foundry/raster-foundry/pull/4290)
 - Upgraded maml to 0.0.15 and circe to 0.10.0 and make async jobs use cats-effect IOApp [\#4288](https://github.com/raster-foundry/raster-foundry/pull/4288)
+- Enabled deleting lab templates on the frontend [\#4287](https://github.com/raster-foundry/raster-foundry/pull/4287)
 
 ### Changed
 

--- a/app-frontend/src/app/components/lab/templateItem/templateItem.html
+++ b/app-frontend/src/app/components/lab/templateItem/templateItem.html
@@ -22,4 +22,14 @@
       <strong>Created by: {{$ctrl.templateOwner}}</strong>
     </div>
   </div>
+  <div uib-dropdown class="dropdown template-delete-dropdown" ng-if="$ctrl.showDelete">
+    <button class="btn btn-tiny btn-ghost" uib-dropdown-toggle>
+      <i class="icon-menu"></i>
+    </button>
+    <ul class="dropdown-menu dropdown-menu-light dropdown-menu-right" uib-dropdown-menu role="menu">
+      <li>
+        <a class="color-danger" ng-click="$ctrl.onClickDeleteTemplate()">Delete</a>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/app-frontend/src/app/components/lab/templateItem/templateItem.html
+++ b/app-frontend/src/app/components/lab/templateItem/templateItem.html
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div uib-dropdown class="dropdown template-delete-dropdown" ng-if="$ctrl.showDelete">
-    <button class="btn btn-tiny btn-ghost" uib-dropdown-toggle>
+    <button class="btn btn-tiny" uib-dropdown-toggle>
       <i class="icon-menu"></i>
     </button>
     <ul class="dropdown-menu dropdown-menu-light dropdown-menu-right" uib-dropdown-menu role="menu">

--- a/app-frontend/src/app/components/lab/templateItem/templateItem.module.js
+++ b/app-frontend/src/app/components/lab/templateItem/templateItem.module.js
@@ -1,16 +1,17 @@
-/* global BUILDCONFIG */
+/* global BUILDCONFIG, _ */
 import angular from 'angular';
 import templateItemTpl from './templateItem.html';
 const TemplateItemComponent = {
     templateUrl: templateItemTpl,
     controller: 'TemplateItemController',
     bindings: {
-        templateData: '<'
+        templateData: '<',
+        onTemplateDelete: '&'
     }
 };
 
 class TemplateItemController {
-    constructor($rootScope, $log, userService) {
+    constructor($rootScope, $log, userService, analysisService) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
         this.BUILDCONFIG = BUILDCONFIG;
@@ -18,6 +19,7 @@ class TemplateItemController {
 
     $onInit() {
         this.getTemplateOwner();
+        this.getUserTemplateActions();
     }
 
     getTemplateOwner() {
@@ -31,6 +33,18 @@ class TemplateItemController {
                 this.templateOwner = this.BUILDCONFIG.APP_NAME;
             });
         }
+    }
+
+    getUserTemplateActions() {
+        this.analysisService.getTemplateActions(this.templateData.id).then(actionsArray => {
+            if (_.get(_.intersection(actionsArray, ['*', 'DELETE']), 'length')) {
+                this.showDelete = true;
+            }
+        });
+    }
+
+    onClickDeleteTemplate() {
+        this.onTemplateDelete({templateId: this.templateData.id});
     }
 
     setTemplateOwnerDisplay(user) {

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.html
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.html
@@ -44,7 +44,7 @@
             class="panel panel-off-white"
             ng-repeat="template in $ctrl.results"
             template-data="template"
-            ng-click=""
+            on-template-delete="$ctrl.onTemplateDelete(templateId)"
         ></rf-template-item>
         <div ng-if="!$ctrl.currentQuery && !$ctrl.search && $ctrl.pagination && !$ctrl.pagination.count"
           <rf-call-to-action-item title="You haven't created any analysis templates yet" class="panel panel-off-white">

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.js
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.js
@@ -60,6 +60,14 @@ class LabBrowseTemplatesController {
             component: 'rfTemplateCreateModal'
         });
     }
+
+    onTemplateDelete(templateId) {
+        this.analysisService.deleteTemplate(templateId).then(() => {
+            this.fetchPage();
+        }, err => {
+            this.$log.error(`There is an error deleting template ${templateId}`, err);
+        });
+    }
 }
 
 export default angular.module('pages.lab.browse.results', [])

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -21,6 +21,15 @@ export default (app) => {
                     },
                     create: {
                         method: 'POST'
+                    },
+                    delete: {
+                        method: 'DELETE'
+                    },
+                    actions: {
+                        url: `${BUILDCONFIG.API_HOST}/api/tools/:id/actions/`,
+                        method: 'GET',
+                        cache: false,
+                        isArray: true
                     }
                 }
             );
@@ -118,6 +127,14 @@ export default (app) => {
 
         getTemplate(id) {
             return this.Template.get({id}).$promise;
+        }
+
+        deleteTemplate(id) {
+            return this.Template.delete({id}).$promise;
+        }
+
+        getTemplateActions(id) {
+            return this.Template.actions({id}).$promise;
         }
 
         deleteAnalysis(id) {

--- a/app-frontend/src/assets/styles/sass/components/_dropdown.scss
+++ b/app-frontend/src/assets/styles/sass/components/_dropdown.scss
@@ -6,6 +6,12 @@
 .dropup,
 .dropdown {
   position: relative;
+
+  &.template-delete-dropdown {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+  }
 }
 
 // Prevent the focus on the dropdown toggle when closing dropdowns


### PR DESCRIPTION
## Overview

This PR enables template deletion on frontend after checking the operating user's allowed actions on it.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

<img width="870" alt="screen shot 2018-11-08 at 5 03 36 pm" src="https://user-images.githubusercontent.com/16109558/48230296-8282f000-e378-11e8-9ad4-a03723a6c515.png">


## Testing Instructions

 * Log in as user1 and grab `userOneId`
 * Create a new template
 * Go to template list. Expand the options button and delete the template. It should succeed.
 * Log into user2's account and create a template there. Grab the `templateId`.
 * In DB, do the following or something similar:
```sql
UPDATE tools SET acrs = ARRAY['USER;<userOneId>;DELETE'] where id = '<templateId>';
```
 * Log back in to user1's account
 * Go to template list. You should see the template user2 shared with you. Expand the options button and delete the template. It should succeed.
 * Check that deletion is not enabled for templates not owned by or shared to you.

Closes https://github.com/raster-foundry/raster-foundry/issues/3018
