### PR TITLE
Let import modal guess and suggest S3 path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added S3 path suggestions in scene import modal when users upload imageries from S3 buckets [\#4290](https://github.com/raster-foundry/raster-foundry/pull/4290)
+
 ### Changed
 
 ### Deprecated

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -704,20 +704,14 @@ export default class SceneImportModalController {
         let segments = path.replace(protocol, '').split('/');
 
         if (_.get(segments, 'length') === 1) {
-            this.suggestedPaths = [{
-                bestGuess: false,
-                path
-            }];
+            this.suggestedPaths = [path];
         }
 
         if (_.get(segments, 'length') > 1) {
             let cleanSegs = segments.filter(seg => !seg.includes('s3.amazonaws.com'));
-            this.suggestedPaths = cleanSegs.map((seg, idx) => {
-                return {
-                    bestGuess: false,
-                    path: `s3://${cleanSegs.slice(0, idx + 1).join('/')}`
-                };
-            });
+            this.suggestedPaths = cleanSegs.map((seg, idx) =>
+                `s3://${cleanSegs.slice(0, idx + 1).join('/')}`
+            );
         }
     }
 

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -157,7 +157,12 @@ export default class SceneImportModalController {
             previous: () => 'IMPORT',
             next: () => 'IMPORT_SUCCESS',
             onEnter: () => this.startS3Upload(),
-            onExit: () => this.finishUpload()
+            onExit: () => {
+                if (!this.isProcessS3Failed) {
+                    this.finishUpload();
+                }
+                this.isProcessS3Failed = !this.isProcessS3Failed;
+            }
         }, {
             name: 'IMPORT_SUCCESS',
             allowDone: () => true
@@ -329,11 +334,13 @@ export default class SceneImportModalController {
             .getCurrentUser()
             .then(this.createUpload.bind(this))
             .then(upload => {
+                this.isProcessS3Failed = false;
+                delete this.error;
                 this.upload = upload;
                 this.uploadsDone();
                 return upload;
             }, err => {
-                this.handleNext();
+                this.isProcessS3Failed = true;
                 this.uploadError(err);
             }).finally(() => {
                 this.allowInterruptions();
@@ -669,5 +676,9 @@ export default class SceneImportModalController {
         if (this.resolve.origin === 'datasource') {
             this.$state.go('imports.rasters');
         }
+    }
+
+    backToImport() {
+        this.setCurrentStep(this.getStep('IMPORT'));
     }
 }

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -143,20 +143,21 @@
           <form>
             <div class="form-group">
               <label for="name">S3 Bucket</label>
-              <input id="name" type="url" class="form-control"
-                     placeholder="s3://<bucket>/<prefix>/" ng-model="$ctrl.s3Config.bucket"
-                     ng-change="$ctrl.onPathChange($ctrl.s3Config.bucket)">
+              <input
+                id="name"
+                type="url"
+                class="form-control"
+                placeholder="s3://<bucket>/<prefix>/ OR s3://<bucket>/<prefix>/object.tif"
+                ng-model="$ctrl.s3Config.bucket"
+                ng-change="$ctrl.onPathChange($ctrl.s3Config.bucket)">
               <div ng-if="$ctrl.suggestedPaths && $ctrl.suggestedPaths.length">
                 <div class="import-s3-msg">Not sure about the format? Here are some suggestions:</div>
-                <div ng-repeat="pathObj in $ctrl.suggestedPaths track by $index">
+                <div ng-repeat="path in $ctrl.suggestedPaths track by $index">
                   <div class="import-s3-suggestions">
-                    <button type="button" class="btn btn-primary" ng-click="$ctrl.usePath(pathObj.path)">
+                    <button type="button" class="btn btn-primary" ng-click="$ctrl.usePath(path)">
                       Use
                     </button>
-                    <span>{{pathObj.path}}</span>
-                    <div class="import-s3-best-guess" ng-if="pathObj.bestGuess">
-                      Best Guess
-                    </div>
+                    <span>{{path}}</span>
                   </div>
                 </div>
               </div>

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -144,7 +144,22 @@
             <div class="form-group">
               <label for="name">S3 Bucket</label>
               <input id="name" type="url" class="form-control"
-                     placeholder="s3://<bucket>/<prefix>/" ng-model="$ctrl.s3Config.bucket">
+                     placeholder="s3://<bucket>/<prefix>/" ng-model="$ctrl.s3Config.bucket"
+                     ng-change="$ctrl.onPathChange($ctrl.s3Config.bucket)">
+              <div ng-if="$ctrl.suggestedPaths && $ctrl.suggestedPaths.length">
+                <div class="import-s3-msg">Not sure about the format? Here are some suggestions:</div>
+                <div ng-repeat="pathObj in $ctrl.suggestedPaths track by $index">
+                  <div class="import-s3-suggestions">
+                    <button type="button" class="btn btn-primary" ng-click="$ctrl.usePath(pathObj.path)">
+                      Use
+                    </button>
+                    <span>{{pathObj.path}}</span>
+                    <div class="import-s3-best-guess" ng-if="pathObj.bestGuess">
+                      Best Guess
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
             <div class="form-group color-danger"
                  ng-if="$ctrl.showProjectCreateError && $ctrl.projectCreateErrorText"

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.html
@@ -376,6 +376,12 @@
     <div class="content">
       <h3 class="no-margin text-center">Processing your S3 import</h3>
     </div>
+    <br/>
+    <div class="color-danger text-center" ng-if="$ctrl.isProcessS3Failed">
+      <p>
+        Something went wrong. <a ng-click="$ctrl.backToImport()">Double check S3 path.</a>
+      </p>
+    </div>
   </div>
 
   <!--Body for Planet IMPORT_SUCCESS-->

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3176,3 +3176,24 @@ rf-navbar-search {
 .btn-group-tooltip-disabled {
   cursor: not-allowed;
 }
+
+// sceneImportModal
+.import-s3-msg {
+  margin: 1em 0;
+}
+.import-s3-suggestions {
+  margin-bottom: 1em;
+
+  button {
+    margin-right: 1em;
+  }
+}
+.import-s3-best-guess {
+  display: inline-block;
+  margin: 0 0.5em;
+  padding: .25em 0.5em;
+  border-radius: 3px;
+  text-transform: capitalize;
+  color: $green;
+  border: 1px solid $green;
+}

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3188,12 +3188,3 @@ rf-navbar-search {
     margin-right: 1em;
   }
 }
-.import-s3-best-guess {
-  display: inline-block;
-  margin: 0 0.5em;
-  padding: .25em 0.5em;
-  border-radius: 3px;
-  text-transform: capitalize;
-  color: $green;
-  border: 1px solid $green;
-}


### PR DESCRIPTION
## Overview

This PR updates the scene import modal to let it give user suggestions on S3 path based on guesses generated from user input.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

1. `https://` or `http://` paths with `.tif` or `.tiff` file extensions:
<img width="952" alt="screen shot 2018-11-09 at 6 27 41 pm" src="https://user-images.githubusercontent.com/16109558/48293496-6735e480-e44d-11e8-9039-3bf7a46f24f6.png">

2. `https://` or `http://` paths without `.tif` or `.tiff` file extensions:

<img width="960" alt="screen shot 2018-11-09 at 6 28 03 pm" src="https://user-images.githubusercontent.com/16109558/48293501-6dc45c00-e44d-11e8-90c5-06c463800858.png">


3. `s3://` path:
<img width="962" alt="screen shot 2018-11-09 at 6 28 24 pm" src="https://user-images.githubusercontent.com/16109558/48293492-5f764000-e44d-11e8-9eda-741cbac281e5.png">

4. If it still can't get through:
<img width="1041" alt="screen shot 2018-11-09 at 6 28 51 pm" src="https://user-images.githubusercontent.com/16109558/48293509-7026b600-e44d-11e8-9c07-0ccbd52ed8dc.png">


## Testing Instructions

 * Go to scene import page
 * Use S3 import option

Closes https://github.com/raster-foundry/raster-foundry/issues/4284
