### PR TITLE
Remove form validation for user name in platform email settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Removed
 
+- Removed email form validation from platform email settings page [\#4294](https://github.com/raster-foundry/raster-foundry/pull/4294)
+
 ### Fixed
 
 - Ensured tiles of non-standard sizes get resampled to the appropriate size before reaching users [\#4281](https://github.com/raster-foundry/raster-foundry/pull/4281)

--- a/app-frontend/src/app/pages/admin/platform/settings/email/email.html
+++ b/app-frontend/src/app/pages/admin/platform/settings/email/email.html
@@ -18,7 +18,7 @@
     <div class="form-group">
       <label for="name">User Name</label>
       <input id="name"
-             type="email"
+             type="text"
              class="form-control"
              name="email"
              ng-attr-placeholder="{{$ctrl.platformBuffer.publicSettings.emailUser.length ?
@@ -26,7 +26,6 @@
              ng-model="$ctrl.platformBuffer.publicSettings.emailUser"
              required>
       <span class="error color-danger" ng-show="emailSettings.email.$error.required">required</span>
-      <span class="error color-danger" ng-show="emailSettings.email.$error.email">invalid email</span>
     </div>
     <div class="form-group">
       <label for="password">Password</label>
@@ -94,7 +93,6 @@
                    class="encryption-toggle">
         <span>STARTTLS</span>
         </rf-toggle>
-     <span class="error color-danger" ng-show="emailSettings.port.$error.required">required</span>
     </div>
     <div class="form-group">
       <div class="label">Subscriptions</div>
@@ -119,9 +117,9 @@
               ng-click="$ctrl.onSubmit()"
               ng-disabled="
                 emailSettings.email.$error.required ||
-                emailSettings.email.$error.email ||
                 emailSettings.password.$error.required ||
-                emailSettings.smtp.$error.required">
+                emailSettings.smtp.$error.required ||
+                emailSettings.port.$error.required">
         {{$ctrl.getButtonText()}}
       </button>
     </div>

--- a/app-frontend/src/app/pages/admin/platform/settings/email/email.module.js
+++ b/app-frontend/src/app/pages/admin/platform/settings/email/email.module.js
@@ -23,8 +23,11 @@ class PlatformEmailController {
                 this.platformBuffer = _.cloneDeep(this.platform);
                 this.platformBuffer.privateSettings = {emailPassword: ''};
                 this.platformBuffer.publicSettings.platformHost =
-                  this.platformBuffer.publicSettings.platformHost ||
-                  'app.rasterfoundry.com';
+                    this.platformBuffer.publicSettings.platformHost ||
+                    'app.rasterfoundry.com';
+                this.platformBuffer.publicSettings.emailSmtpEncryption =
+                    this.platformBuffer.publicSettings.emailSmtpEncryption ||
+                    'ssl';
             });
     }
 


### PR DESCRIPTION
## Overview

This PR removes form validation for user name in platform email settings. It also enables/disables save button based on the presence of port number. It sets a default value on encryption method if there is no such setting.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Log in as a platform admin
 * Go to platform settings
 * Make sure you can specify any string as user name
 * Make sure you cannot use `Save` button if there is no port number set

Closes https://github.com/raster-foundry/raster-foundry/issues/4292
