### PR TITLE
Handle COGs missing at ingest location specially

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -54,9 +54,11 @@ trait SceneRoutes
           listScenes
         }
       } ~
-        post {
-          traceName("scenes-create") {
-            createScene
+        handleExceptions(cogMissingHandler) {
+          post {
+            traceName("scenes-create") {
+              createScene
+            }
           }
         }
     } ~

--- a/app-backend/common/src/main/scala/UserErrorHandler.scala
+++ b/app-backend/common/src/main/scala/UserErrorHandler.scala
@@ -2,7 +2,9 @@ package com.rasterfoundry.common
 
 import akka.http.scaladsl.server.{ExceptionHandler, Directives}
 import akka.http.scaladsl.model.{IllegalRequestException, StatusCodes}
+import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.typesafe.scalalogging.LazyLogging
+import java.lang.{IllegalArgumentException, UnsupportedOperationException}
 import java.security.InvalidParameterException
 import org.postgresql.util.PSQLException
 
@@ -30,5 +32,20 @@ trait UserErrorHandler
       logger.error(RfStackTrace(e))
       sendError(e)
       complete(StatusCodes.ServerError(501)("An unknown error occurred", ""))
+  }
+
+  val cogMissingHandler = ExceptionHandler {
+    case e: IllegalArgumentException =>
+      logger.error(RfStackTrace(e))
+      complete(
+        StatusCodes.ClientError(400)("Bad Request", "No COG found at URI"))
+    case e: UnsupportedOperationException =>
+      logger.error(RfStackTrace(e))
+      complete(
+        StatusCodes.ClientError(400)("Bad Request", "No COG found at URI"))
+    case e: AmazonS3Exception =>
+      logger.error(RfStackTrace(e))
+      complete(
+        StatusCodes.ClientError(400)("Bad Request", "No COG found at URI"))
   }
 }


### PR DESCRIPTION
## Overview

This PR specially handles what happens when a user tries to create a COG scene pointing to an ingest location where we can't read a tif. More information about test cases is available in the linked issue.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Run through the test cases in the linked issue
 * You should always get 400s back instead of 501s

Closes #4080 
