### PR TITLE
Don't infinitely recurse in exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Ensured tiles of non-standard sizes get resampled to the appropriate size before reaching users [\#4281](https://github.com/raster-foundry/raster-foundry/pull/4281)
+- Repaired short-lived infinite recursion in export async job [\#4297](https://github.com/raster-foundry/raster-foundry/pull/4297)
 
 ### Security
 

--- a/app-backend/batch/src/main/scala/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/export/spark/Export.scala
@@ -396,5 +396,5 @@ object Export extends SparkJob with Config with RollbarNotifier with IOApp {
     runIO
   }
 
-  def run(args: List[String]) = run(args).as(ExitCode.Success)
+  def run(args: List[String]): IO[ExitCode] = runJob(args).as(ExitCode.Success)
 }


### PR DESCRIPTION
## Overview

Why didn't scala get mad that I didn't include the type annotation for my
recursive function call? I don't know! I wish it had. Oops. Anyway, the costs of :cowboy_hat_face: 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible