### PR TITLE
Populate user name field with multiple fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Enabled deleting lab templates on the frontend [\#4287](https://github.com/raster-foundry/raster-foundry/pull/4287)
 
 ### Changed
+- Populate user profiles from their identity tokens more intelligently [\#4298](https://github.com/raster-foundry/raster-foundry/pull/4298)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -136,9 +136,6 @@ trait Router
       } ~
       pathPrefix("feature-flags") {
         featureFlagRoutes
-      } ~
-      pathPrefix("thumbnails") {
-        thumbnailImageRoutes
       }
   }
 }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -149,6 +149,7 @@ trait UserRoutes
   def getUserTeams: Route = authenticate { user =>
     complete { TeamDao.teamsForUser(user).transact(xa).unsafeToFuture }
   }
+
   def updateUserByEncodedAuthId(authIdEncoded: String): Route =
     authenticateSuperUser { root =>
       entity(as[User]) { updatedUser =>

--- a/app-backend/authentication/src/main/scala/Authentication.scala
+++ b/app-backend/authentication/src/main/scala/Authentication.scala
@@ -78,15 +78,13 @@ trait Authentication extends Directives with LazyLogging {
     val compareToEmail = (field: String) =>
       (Option(claims.getStringClaim(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
-        case (fld @ Some(_), None)              => fld
-        case _                                  => None
+        case (f, _)                             => f
     }
 
     val compareDelegatedToEmail = (field: String) =>
       (delegatedProfile.map(_.getAsString(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
-        case (fld @ Some(_), None)              => fld
-        case _                                  => None
+        case (f, _)                             => f
     }
 
     compareToEmail("name")

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -161,7 +161,8 @@ object UserDao extends Dao[User] {
          email = ${user.email},
          name = ${user.name},
          profile_image_uri = ${user.profileImageUri},
-         visibility = ${user.visibility}
+         visibility = ${user.visibility},
+         personal_info = ${user.personalInfo}
        """ ++ Fragments.whereAndOpt(Some(idFilter))).update.run
   }
 

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -371,7 +371,7 @@ trait Filterables extends RFMeta with LazyLogging {
   implicit val userSearchQueryParamsFilter
     : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
-      Filters.searchQP(params, List("name", "email"))
+      Filters.searchQP(params, List("name", "email", "id"))
     }
 
   implicit def projectedGeometryFilter: Filterable[Any, Projected[Geometry]] =

--- a/app-frontend/src/app/components/common/navBar/navBar.html
+++ b/app-frontend/src/app/components/common/navBar/navBar.html
@@ -102,7 +102,7 @@
         <a href uib-dropdown-toggle>
           <img ng-if="$ctrl.authService.getProfile().picture" class="avatar tiny" ng-src="{{$ctrl.authService.getProfile().picture}}">
           <div class="avatar image-placeholder" ng-if="$ctrl.authService.getProfile() && !$ctrl.authService.getProfile().picture"></div>
-          <span class="username">{{$ctrl.authService.getProfile().nickname}}</span>
+          <span class="username">{{$ctrl.authService.getName()}}</span>
           <i class="icon-caret-down"></i>
         </a>
         <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="dLabel">

--- a/app-frontend/src/app/pages/home/home.html
+++ b/app-frontend/src/app/pages/home/home.html
@@ -51,7 +51,7 @@
           <section>
             <h5>Account</h5>
             <p>
-              Hello, <strong>{{$ctrl.authService.getProfile().nickname}}</strong>
+              Hello, <strong>{{$ctrl.authService.getName()}}</strong>
             </p>
             <a class="btn btn-light" ui-sref="user.settings.profile">Manage account</a>
           </section>

--- a/app-frontend/src/app/pages/lab/browse/analyses/analyses.js
+++ b/app-frontend/src/app/pages/lab/browse/analyses/analyses.js
@@ -100,12 +100,12 @@ class LabBrowseAnalysesController {
     }
 
     fetchSorting() {
-        const k = `${this.authService.getProfile().nickname}-analysis-sort`;
+        const k = `${this.authService.getName()}-analysis-sort`;
         return this.localStorage.getString(k);
     }
 
     storeSorting() {
-        const k = `${this.authService.getProfile().nickname}-analysis-sort`;
+        const k = `${this.authService.getName()}-analysis-sort`;
         return this.localStorage.setString(k, this.serializeSort());
     }
 

--- a/app-frontend/src/app/pages/share/share.html
+++ b/app-frontend/src/app/pages/share/share.html
@@ -15,7 +15,7 @@
         <a href uib-dropdown-toggle>
           <img ng-if="$ctrl.authService.getProfile().picture" class="avatar tiny" ng-src="{{$ctrl.authService.getProfile().picture}}">
           <div class="avatar image-placeholder" ng-if="$ctrl.authService.getProfile() && !$ctrl.authService.getProfile().picture"></div>
-          <span class="username">{{$ctrl.authService.getProfile().nickname}}</span>
+          <span class="username">{{$ctrl.authService.getName()}}</span>
           <i class="icon-caret-down"></i>
         </a>
         <ul class="dropdown-menu" aria-labelledby="dLabel">

--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -360,6 +360,19 @@ export default (app) => {
             return this.profile;
         }
 
+        getName() {
+            let profileName = (profile, dpr) =>
+                (dpr.name !== profile.email ? dpr.name : null) ||
+                (dpr.nickname !== profile.email ? dpr.nickname : null) ||
+                (dpr.given_name || '' + dpr.family_name || '') || null;
+
+            let p = this.getProfile();
+            return profileName(p, p) ||
+                p.delegatedProfile && profileName(p, p.delegatedProfile) ||
+                p.email || p.delegatedProfile && p.delegatedProfile.email ||
+                p.id;
+        }
+
         token(force = false) {
             if (!this.idToken || force) {
                 this.idToken = this.localStorage.get('idToken');

--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -370,7 +370,7 @@ export default (app) => {
             return profileName(p, p) ||
                 p.delegatedProfile && profileName(p, p.delegatedProfile) ||
                 p.email || p.delegatedProfile && p.delegatedProfile.email ||
-                p.id;
+                p.sub;
         }
 
         token(force = false) {


### PR DESCRIPTION
## Overview
Populate the user's name fields using multiple fallbacks on the frontend and backend. Avoid using email if anything else is available.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/48443637-d36f5b80-e75f-11e8-9bab-2d5b9d1dd3a3.png)

### Notes
name is populated from the following fallbacks:
1) name if not same as email 
2) nickname if not same as email
3) given name + family name
4) delegated profile name if not same as email
5) delegated profile nickname if not same as email
6) delegated profile given name + family name
7) email
8) id

## Testing Instructions
 * Verify that the fallbacks work by creating users which utilize each of the fields and logging in as them.
* Verify that First name, Last name, and email are filled out in the personal information field when a user logs in if they are blank

Closes #4232 
