### PR TITLE
Support viewing public projects in backsplash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added S3 path suggestions in scene import modal when users upload imageries from S3 buckets [\#4290](https://github.com/raster-foundry/raster-foundry/pull/4290)
 - Upgraded maml to 0.0.15 and circe to 0.10.0 and make async jobs use cats-effect IOApp [\#4288](https://github.com/raster-foundry/raster-foundry/pull/4288)
 - Enabled deleting lab templates on the frontend [\#4287](https://github.com/raster-foundry/raster-foundry/pull/4287)
+- Added support for viewing public projects using backsplash [\#4299](https://github.com/raster-foundry/raster-foundry/pull/4299)
 
 ### Changed
 

--- a/app-backend/backsplash/src/main/scala/auth/Authenticators.scala
+++ b/app-backend/backsplash/src/main/scala/auth/Authenticators.scala
@@ -2,9 +2,10 @@ package com.rasterfoundry.backsplash.auth
 
 import com.rasterfoundry.authentication.Authentication
 import com.rasterfoundry.backsplash.parameters.Parameters._
-import com.rasterfoundry.database.{UserDao, MapTokenDao}
+import com.rasterfoundry.database.{UserDao, MapTokenDao, ProjectDao}
 import com.rasterfoundry.database.util.RFTransactor
-import com.rasterfoundry.datamodel.{MapToken, User}
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.datamodel.{MapToken, User, Visibility}
 
 import cats.data._
 import cats.effect.IO
@@ -39,18 +40,23 @@ object Authenticators extends Authentication {
       case req @ _ -> UUIDWrapper(projectId) /: _
             :? TokenQueryParamMatcher(tokenQP)
             :? MapTokenQueryParamMatcher(mapTokenQP) => {
-        val authHeader: OptionT[IO, Header] =
-          OptionT.fromOption(
-            req.headers.get(CaseInsensitiveString("Authorization")))
-        checkTokenAndHeader(tokenQP, authHeader) :+
-          (
-            OptionT.fromOption[IO](mapTokenQP) flatMap { (mapToken: UUID) =>
-              userFromMapToken(MapTokenDao.checkProject(projectId), mapToken)
-            }
-          ) reduce { _ orElse _ }
+        val authHeaderO: Option[Header] = req.headers.get(CaseInsensitiveString("Authorization"))
+        (authHeaderO, tokenQP, mapTokenQP) match {
+          case (None, None, None) =>
+            userFromPublicProject(projectId)
+          case _ =>
+            val authHeader: OptionT[IO, Header] =OptionT.fromOption(authHeaderO)
+            checkTokenAndHeader(tokenQP, authHeader) :+
+              (
+                OptionT.fromOption[IO](mapTokenQP) flatMap { (mapToken: UUID) =>
+                  userFromMapToken(MapTokenDao.checkProject(projectId), mapToken)
+                }
+              ) reduce { _ orElse _ }
+        }
       }
 
-      case _ => OptionT.none[IO, User]
+      case _ =>
+        OptionT.none[IO, User]
     }
   )
 
@@ -84,6 +90,22 @@ object Authenticators extends Authentication {
       case Left(e) =>
         OptionT(IO(None: Option[User]))
     }
+
+  private def userFromPublicProject(id: UUID): OptionT[IO, User] = {
+    val userIO: ConnectionIO[Option[User]] = for {
+      projectO <- ProjectDao.query
+        .filter(id)
+        .filter(fr"tile_visibility=${Visibility.Public.toString}::visibility")
+        .selectOption
+      user <- projectO match {
+        case Some(project) => UserDao.getUserById(project.owner)
+        case _ => None.pure[ConnectionIO]
+      }
+    } yield user
+
+    OptionT(userIO.transact(xa))
+  }
+
 
   val tokensAuthMiddleware = AuthMiddleware(tokensAuthenticator)
 }

--- a/app-backend/backsplash/src/main/scala/auth/Authenticators.scala
+++ b/app-backend/backsplash/src/main/scala/auth/Authenticators.scala
@@ -96,12 +96,12 @@ object Authenticators extends Authentication {
 
   private def userFromPublicProject(id: UUID): OptionT[IO, User] =
     for {
-      project <- OptionT[IO, Project](ProjectDao.query
-        .filter(id)
-        .filter(fr"tile_visibility=${Visibility.Public.toString}::visibility")
-        .selectOption
-        .transact(xa)
-      )
+      project <- OptionT[IO, Project](
+        ProjectDao.query
+          .filter(id)
+          .filter(fr"tile_visibility=${Visibility.Public.toString}::visibility")
+          .selectOption
+          .transact(xa))
       user <- OptionT(UserDao.getUserById(project.owner).transact(xa))
     } yield user
 


### PR DESCRIPTION
## Overview

This PR updates authentication for getting project tiles from backsplash so that it supports viewing public projects.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * `./scripts/server --backsplash`
 * Go to a project
 * Under `Publish` tab, change `Project Visibility` to `Public`
 * Copy `ZXY Tile Layer URL`
 * View the tile layer somewhere, like @Lknechtli 's https://lknechtli.github.io/react-map-compare/

Closes https://github.com/raster-foundry/raster-foundry/issues/4285
