### PR TITLE
Fix shapefile annotations export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Ensured tiles of non-standard sizes get resampled to the appropriate size before reaching users [\#4281](https://github.com/raster-foundry/raster-foundry/pull/4281)
 - Specifically handled bad paths to COGs when users create scenes [\#4295](https://github.com/raster-foundry/raster-foundry/pull/4295)
+- Fixed shapefile annotations export [\#4300](https://github.com/raster-foundry/raster-foundry/pull/4300)
 
 ### Security
 

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -667,12 +667,12 @@ trait ProjectRoutes
             AnnotationShapefileService.annotationsToShapefile(annotations)
           val cal: Calendar = Calendar.getInstance()
           cal.add(Calendar.DAY_OF_YEAR, 1)
-          val key: AmazonS3URI = new AmazonS3URI(
+          val s3Uri: AmazonS3URI = new AmazonS3URI(
             user.getDefaultAnnotationShapefileSource(dataBucket))
-          putObject(dataBucket, key.toString, zipfile.toJava)
+          putObject(dataBucket, s3Uri.getKey, zipfile.toJava)
             .setExpirationTime(cal.getTime)
           zipfile.delete(true)
-          complete(getSignedUrl(dataBucket, key.toString).toString())
+          complete(getSignedUrl(dataBucket, s3Uri.getKey).toString())
         }
         case _ =>
           complete(


### PR DESCRIPTION
## Overview

The annotations shapefile export was being written to an S3 object with the scheme and bucket name included in the object name. Things worked, but object names were misleading.

```
https://rasterfoundry-development-data-us-east-1.s3.amazonaws.com/s3%3A/%2Frasterfoundry-development-data-us-east-1/user-exports/.../annotations/.../annotations.zip
```

This change makes it so that the scheme and bucket name are no longer part of the annotations export object name.

```
https://rasterfoundry-development-data-us-east-1.s3.amazonaws.com/user-exports/.../annotations/.../annotations.zip
```

Fixes https://github.com/azavea/raster-foundry-platform/issues/551

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Notes

As part of this task, we may also need to synchronize all of the data in these obscure paths to their intended path.

## Testing Instructions

- Create at least one annotation on an existing project
- Attempt to export the annotations as a shapefile
- Confirm the object name in the signed URL; ensure that it doesn't include the bucket name twice