### PR TITLE
Fix favicons, missing styles, scene thumbnails for webpack upgrade

### DIFF
--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -1,5 +1,5 @@
 'use strict';
-/* globals process module */
+/* globals process module __dirname */
 /* eslint no-process-env: 0
  no-console: 0
  */
@@ -45,13 +45,14 @@ const basemaps = JSON.stringify({
             }
         },
         Aerial: {
-            url: 'https://{s}.{base}.maps.cit.api.here.com/maptile/2.1/{type}/{mapID}/hybrid.day/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}',
+            url: 'https://{s}.{base}.maps.cit.api.here.com/maptile/2.1/{type}/{mapID}/hybrid.day' +
+                '/{z}/{x}/{y}/{size}/{format}?app_id={app_id}&app_code={app_code}&lg={language}',
             properties: {
                 attribution: 'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
                 subdomains: '1234',
                 mapID: 'newest',
-                app_id: HERE_APP_ID,
-                app_code: HERE_APP_CODE,
+                'app_id': HERE_APP_ID,
+                'app_code': HERE_APP_CODE,
                 base: 'aerial',
                 maxZoom: 30,
                 maxNativeZoom: 20,
@@ -62,12 +63,13 @@ const basemaps = JSON.stringify({
             }
         },
         Streets: {
-            url: 'https://{s}.base.maps.cit.api.here.com/maptile/2.1/maptile/newest/normal.day/{z}/{x}/{y}/256/png8?app_id={app_id}&app_code={app_code}',
+            url: 'https://{s}.base.maps.cit.api.here.com/maptile/2.1/maptile/newest/normal.day/' +
+                '{z}/{x}/{y}/256/png8?app_id={app_id}&app_code={app_code}',
             properties: {
                 attribution: 'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
                 subdomains: '1234',
-                app_id: HERE_APP_ID,
-                app_code: HERE_APP_CODE
+                'app_id': HERE_APP_ID,
+                'app_code': HERE_APP_CODE
             }
         }
     },
@@ -81,7 +83,7 @@ module.exports = function (_path) {
         // entry points
         entry: {
             // vendor: _path + '/src/app/index.vendor.js',
-            app: _path + '/src/app/index.bootstrap.js',
+            app: _path + '/src/app/index.bootstrap.js'
             // wasm: _path + '/node_modules/gdal-js/gdal.wasm'
             // polyfill: _path + '/node_modules/babel-polyfill'
         },
@@ -117,7 +119,7 @@ module.exports = function (_path) {
                 gdalJs: path.join(_path, 'node_modules', 'gdal-js'),
                 moment: 'moment/moment.js'
             },
-            mainFields: ['module', 'jsnext:main', 'main'],
+            mainFields: ['module', 'jsnext:main', 'main']
         },
 
         // modules resolvers
@@ -159,8 +161,8 @@ module.exports = function (_path) {
                 loader: 'babel-loader',
                 query: {
                     cacheDirectory: true,
-                    plugins: ['@babel/plugin-transform-runtime'],//, '@babel/syntax-dynamic-import'],
-                    presets: ['@babel/env'] // , 'module:angular']
+                    plugins: ['@babel/plugin-transform-runtime'],
+                    presets: ['@babel/env']
                 }
             }, {
                 test: /\.css$/,
@@ -223,7 +225,7 @@ module.exports = function (_path) {
                 // loader: DEVELOPMENT ? 'style-loader!' + stylesLoader
                 //     : ExtractTextPlugin.extract('style-loader', stylesLoader)
             }, {
-                test: /\.(woff2|woff|ttf|eot|svg)(\?[a-z0-9]+)?$/,
+                test: /\.(woff2|woff|ttf|eot)(\?[a-z0-9]+)?$/,
                 loaders: [
                     'url-loader?name=assets/fonts/[name]_[hash].[ext]'
                 ]
@@ -261,11 +263,6 @@ module.exports = function (_path) {
                 loaders: [
                     'expose-loader?deferredBootstrapper'
                 ]
-            // }, {
-            //     test: require.resolve('angular'),
-            //     loaders: [
-            //         'expose-loader?angular'
-            //     ]
             }, {
                 test: require.resolve('jquery'),
                 loaders: [
@@ -277,11 +274,6 @@ module.exports = function (_path) {
                 loaders: [
                     'expose-loader?L'
                 ]
-            // }, {
-            //     test: require.resolve('jointjs'),
-            //     loaders: [
-            //         'expose-loader?joint'
-            //     ]
             }, {
                 test: require.resolve('moment'),
                 loaders: [
@@ -371,15 +363,21 @@ module.exports = function (_path) {
                     LOGOFILE: JSON.stringify('raster-foundry-logo.svg'),
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
-                    FEED_SOURCE: JSON.stringify('https://blog.rasterfoundry.com/latest?format=json'),
+                    FEED_SOURCE: JSON.stringify(
+                        'https://blog.rasterfoundry.com/latest?format=json'
+                    ),
                     MAP_CENTER: JSON.stringify([-6.8, 39.2]),
                     MAP_ZOOM: 5
                 },
                 'HELPCONFIG': {
                     API_DOCS_URL: JSON.stringify('https://docs.rasterfoundry.com/'),
                     HELP_HOME: JSON.stringify('https://help.rasterfoundry.com/'),
-                    GETTING_STARTED_WITH_PROJECTS: JSON.stringify('https://help.rasterfoundry.com/creating-projects'),
-                    DEVELOPER_RESOURCES: JSON.stringify('https://help.rasterfoundry.com/developer-resources')
+                    GETTING_STARTED_WITH_PROJECTS: JSON.stringify(
+                        'https://help.rasterfoundry.com/creating-projects'
+                    ),
+                    DEVELOPER_RESOURCES: JSON.stringify(
+                        'https://help.rasterfoundry.com/developer-resources'
+                    )
                 }
             })
         ],
@@ -387,7 +385,7 @@ module.exports = function (_path) {
             dgram: 'empty',
             fs: 'empty',
             net: 'empty',
-            tls: 'empty',
+            tls: 'empty'
         }
     };
 

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -91,7 +91,7 @@ module.exports = function (_path) {
         // output system
         output: {
             path: path.resolve(__dirname, 'dist'),
-            filename: '[name].js',
+            filename: '[name].[hash].js',
             publicPath: '/'
         },
         target: 'web',

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -33,7 +33,7 @@ class SceneItemController {
         this.isClickable = this.$attrs.hasOwnProperty('clickable');
 
         this.datasource = this.scene.datasource;
-        if (this.respository) {
+        if (this.repository) {
             this.updateThumbnails();
         }
     }

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.module.js
@@ -70,15 +70,15 @@ class SceneItemController {
 
     updateThumbnails() {
         if (this.scene.sceneType === 'COG') {
-            let redBand = this.datasource.bands.find(x => {
+            let redBand = _.get(this.datasource.bands.find(x => {
                 return x.name.toLowerCase() === 'red';
-            }).number;
-            let greenBand = this.datasource.bands.find(x => {
+            }), 'number');
+            let greenBand = _.get(this.datasource.bands.find(x => {
                 return x.name.toLowerCase() === 'green';
-            }).number;
-            let blueBand = this.datasource.bands.find(x => {
+            }), 'number');
+            let blueBand = _.get(this.datasource.bands.find(x => {
                 return x.name.toLowerCase() === 'blue';
-            }).number;
+            }), 'number');
             let bands = {};
             let atLeastThreeBands = this.datasource.bands.length >= 3;
             if (atLeastThreeBands) {

--- a/app-frontend/src/app/index.bootstrap.js
+++ b/app-frontend/src/app/index.bootstrap.js
@@ -1,13 +1,14 @@
 /* globals document BUILDCONFIG */
 import angular from 'angular';
 
-// const faviconsContext = require.context(
-//     `!!file-loader?name=favicons/[name].[ext]!..${BUILDCONFIG.FAVICON_DIR || '/favicon'}`,
-//     true,
-//     /\.(svg|png|ico|xml|json)$/
-// );
+const faviconsContext = require.context(
+    `!!file-loader?name=favicons/[name].[ext]!..${BUILDCONFIG.FAVICON_DIR || '/favicon'}`,
+    true,
+    /\.(svg|png|ico|xml)$/
+);
+require(`..${BUILDCONFIG.FAVICON_DIR || '/favicon'}/manifest.json`);
 
-// faviconsContext.keys().forEach(faviconsContext);
+faviconsContext.keys().forEach(faviconsContext);
 
 // main App module
 import './index.module';

--- a/app-frontend/src/app/index.module.js
+++ b/app-frontend/src/app/index.module.js
@@ -10,6 +10,9 @@ import IndexController from './index.controller';
 })();
 import angular from 'angular';
 
+require('ui-select/dist/select.css');
+require('angularjs-slider/dist/rzslider.css');
+
 const App = angular.module(
     'rasterFoundry', [
         // plugins


### PR DESCRIPTION
## Overview
Fix favicons
Fix missing styles for scene filter pane components
Fix scene thumbnails for cogs

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ cover in anchor pr
- ~Styleguide updated, if necessary~
- ~Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/48571780-bfe60100-e8d5-11e8-9272-bf0178bc7dab.png)
![image](https://user-images.githubusercontent.com/4392704/48571811-ceccb380-e8d5-11e8-96b6-752c45191e08.png)

### Notes
The manifest plugin we were using wasn't updated to support webpack 4, but it seems to be handling hashing etc of images fine. I don't think we were actually using the plugin in a way that took advantage of what it was supposed to offer, so no reason to dig farther into it.

## Testing Instructions

 * Verify thumbnails for scenes (both cog and avro) now load correctly
* Verify that styles on the scene browse filter pane are no longer wonky
* Verify that imports for favicons are fixed

Closes #4250 
Closes #4251 
Closes #4203
