### PR TITLE
Make exports and landsat 8 import start and stop again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Ensured tiles of non-standard sizes get resampled to the appropriate size before reaching users [\#4281](https://github.com/raster-foundry/raster-foundry/pull/4281)
 - Specifically handled bad paths to COGs when users create scenes [\#4295](https://github.com/raster-foundry/raster-foundry/pull/4295)
+- Fixed regressions causing non-termination of export and Landsat 8 import jobs [\#4312](https://github.com/raster-foundry/raster-foundry/pull/4312)
 
 ### Security
 

--- a/app-backend/batch/src/main/scala/ast/RfmlRddResolver.scala
+++ b/app-backend/batch/src/main/scala/ast/RfmlRddResolver.scala
@@ -27,8 +27,6 @@ import org.apache.spark.SparkContext
 /** This interpreter handles resource resolution and compilation of MapAlgebra ASTs */
 object RfmlRddResolver extends LazyLogging {
 
-  implicit val xa = RFTransactor.xa
-
   val intNdTile = IntConstantTile(NODATA, 256, 256)
 
   def resolveRdd(

--- a/app-backend/batch/src/main/scala/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/landsat8/ImportLandsat8C1.scala
@@ -348,15 +348,13 @@ object ImportLandsat8C1 extends Job {
     RFTransactor.xaResource
       .use { xa =>
         implicit val transactor = xa
-        threadPoolResource.use { pool =>
-          val job = args.toList match {
-            case List(date, threshold) =>
-              ImportLandsat8C1(LocalDate.parse(date), threshold.toInt)
-            case List(date) => ImportLandsat8C1(LocalDate.parse(date))
-            case _          => ImportLandsat8C1()
-          }
-          job.insertIO
+        val job = args.toList match {
+          case List(date, threshold) =>
+            ImportLandsat8C1(LocalDate.parse(date), threshold.toInt)
+          case List(date) => ImportLandsat8C1(LocalDate.parse(date))
+          case _          => ImportLandsat8C1()
         }
+        job.insertIO
       }
   }
 }

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -187,8 +187,7 @@ def run_export(export_s3_uri, export_id):
                '--class', 'com.rasterfoundry.batch.export.spark.Export',
                '/opt/raster-foundry/jars/batch-assembly.jar',
                '-j', export_s3_uri, '-b', status_uri]
-    output = subprocess.check_output(command)
-    logger.info('Output from export command was:\n%s', output)
+    subprocess.check_call(command)
     logger.info('Finished exporting %s in spark local', export_s3_uri)
     return status_uri
 


### PR DESCRIPTION
## Overview

This PR separately handles system shutdown for exports, since we somehow wound up with an extra connection pool in a thread somewhere that didn't shutdown after running the spark job.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * assemble batch jar
 * create an export of a small area somewhere (project or ast, doesn't matter)
 * `rf export <your export id>` from the batch container
 * also pick a recent date, and `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main import_landsat8_c1 <your date>`
 * about 9 minutes later you should have a bunch of new landsat scenes

Closes azavea/raster-foundry-platform#557

Closes azavea/raster-foundry-platform#556