### PR TITLE
Don't log below WARN when running spark job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - Ensured tiles of non-standard sizes get resampled to the appropriate size before reaching users [\#4281](https://github.com/raster-foundry/raster-foundry/pull/4281)
 - Specifically handled bad paths to COGs when users create scenes [\#4295](https://github.com/raster-foundry/raster-foundry/pull/4295)
-- Fixed regressions causing non-termination of export and Landsat 8 import jobs [\#4312](https://github.com/raster-foundry/raster-foundry/pull/4312)
+- Fixed regressions causing non-termination of export and Landsat 8 import jobs [\#4312](https://github.com/raster-foundry/raster-foundry/pull/4312), [\#4313](https://github.com/raster-foundry/raster-foundry/pull/4313)
 
 ### Security
 

--- a/app-backend/batch/src/main/scala/export/spark/Export.scala
+++ b/app-backend/batch/src/main/scala/export/spark/Export.scala
@@ -360,6 +360,7 @@ object Export extends SparkJob with Config {
       S3ExportStatus(exportDef.id, status).asJson.noSpaces
 
     scResource.use { sparkContext =>
+      sparkContext.setLogLevel("WARN")
       implicit val sc = sparkContext
       for {
         _ <- logger.debug("Fetching system user").pure[IO]


### PR DESCRIPTION
## Overview

This PR sets the log level on the spark context when running exports. Every other attempt to affect the log level in spark seemed to be ignored entirely, so this will have to be fine for now. It doesn't affect debug logging during startup... but it _does_ prevent the incredibly verbose `org.apache.http.wire` logs from hitting us, which is _really great_.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Logs from the end of spark context initialization to the end of the export task:

```
2018-11-16 22:18:18 DEBUG ServletHolder:615 - Servlet.init org.apache.spark.ui.JettyUtils$$anon$3@65778079 for org.apache.spark.ui.JettyUtils$$anon$3-313c3917
2018-11-16 22:18:18 INFO  ContextHandler:744 - Started o.s.j.s.ServletContextHandler@58524763{/metrics/json,null,AVAILABLE}
2018-11-16 22:18:18 DEBUG AbstractLifeCycle:177 - STARTED @4370ms o.s.j.s.ServletContextHandler@58524763{/metrics/json,null,AVAILABLE}
2018-11-16 22:18:18 DEBUG SparkContext:58 - Adding shutdown hook
INFO:rf.commands.export:Finished exporting file:///tmp/tmp5u9QMX/export_definition.json in spark local
```
 
## Testing Instructions

 * Run an export
 * Confirm that you get under 30k lines of logging
