### PR TITLE
Enable global bucket access for s3 range reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Ensured tiles of non-standard sizes get resampled to the appropriate size before reaching users [\#4281](https://github.com/raster-foundry/raster-foundry/pull/4281)
 - Specifically handled bad paths to COGs when users create scenes [\#4295](https://github.com/raster-foundry/raster-foundry/pull/4295)
+- Made s3 client tolerate buckets outside of its configured region [\#4319](https://github.com/raster-foundry/raster-foundry/pull/4319)
 
 ### Security
 

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -27,7 +27,7 @@ package object S3 {
   lazy val client = AmazonS3ClientBuilder
     .standard()
     .withCredentials(new DefaultAWSCredentialsProviderChain())
-    .withRegion(Regions.US_EAST_1)
+    .withForceGlobalBucketAccessEnabled(true)
     .build()
 
   def clientWithRegion(region: Regions): AmazonS3 =

--- a/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
+++ b/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
@@ -1,13 +1,13 @@
 package com.rasterfoundry.common.utils
 
+import com.rasterfoundry.common.S3
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.util.{FileRangeReader, RangeReader}
 import geotrellis.spark.io.s3.util.S3RangeReader
 import geotrellis.spark.io.s3.AmazonS3Client
 import geotrellis.spark.io.http.util.HttpRangeReader
 
-import com.amazonaws.services.s3.{AmazonS3URI, AmazonS3ClientBuilder}
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.services.s3.AmazonS3URI
 import org.apache.http.client.utils.URLEncodedUtils
 
 import java.nio.file.Paths
@@ -44,7 +44,7 @@ object RangeReaderUtils extends LazyLogging {
 
       case "s3" =>
         val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))
-        val s3Client = new AmazonS3Client(AmazonS3ClientBuilder.defaultClient())
+        val s3Client = AmazonS3Client(S3.client)
         Some(S3RangeReader(s3Uri.getBucket, s3Uri.getKey, s3Client))
 
       case scheme =>


### PR DESCRIPTION
## Overview

This PR makes the s3 client we use in `RangeReaderUtils` tolerate buckets outside of the configured region.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Get an ingest location for an iserv scene from prod, or use this one: `s3://radiant-nasa-iserv/2014/01/03/IPR201401031604353415N11718W/IPR201401031604353415N11718W-COG.tif`
 * do a remote cog import with that s3 path
 * it should succeed and you should get tiles

Closes #4315 
