### PR TITLE
Bump geotrellis server to 0.10.0

### DIFF
--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -27,7 +27,7 @@ object Version {
   val gatling = "2.2.4"
   val geotools = "17.1"
   val geotrellis = "2.1.0"
-  val geotrellisServer = "0.0.8"
+  val geotrellisServer = "0.0.10"
   val hadoop = "2.8.4"
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M1"


### PR DESCRIPTION
## Overview

This PR bumps geotrellis-server to 0.10.0, which eliminates the horrifying logging that was sneaking in through a logback classic dependency somewhere upstream.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Bring up backsplash
 * Make some tile requests
 * Observe that the heat death of the universe has not yet occurred and you're already done printing log messages 