### PR TITLE
Agree with the spec where the spec is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Reorganized scala dependencies for package cleanliness and smaller bundles [\#4301](https://github.com/raster-foundry/raster-foundry/pull/4301)
 
+### Fixed
+
+- Made the status code for aoi creation on projects a 201 instead of a 200 [\#4331](https://github.com/raster-foundry/raster-foundry/pull/4331/files)
+
 ## [1.15.0](https://github.com/raster-foundry/raster-foundry/tree/1.15.0) (2018-11-30)
 
 ### Added

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -634,7 +634,7 @@ trait ProjectRoutes
     } {
       entity(as[AnnotationFeatureCollectionCreate]) { fc =>
         val annotationsCreate = fc.features map { _.toAnnotationCreate }
-        onSuccess (
+        onSuccess(
           AnnotationDao
             .insertAnnotations(annotationsCreate.toList, projectId, user)
             .transact(xa)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -634,7 +634,7 @@ trait ProjectRoutes
     } {
       entity(as[AnnotationFeatureCollectionCreate]) { fc =>
         val annotationsCreate = fc.features map { _.toAnnotationCreate }
-        complete {
+        onSuccess (
           AnnotationDao
             .insertAnnotations(annotationsCreate.toList, projectId, user)
             .transact(xa)
@@ -643,6 +643,8 @@ trait ProjectRoutes
               fromSeqToFeatureCollection[Annotation, Annotation.GeoJSON](
                 annotations)
             }
+        ) { createdAnnotation =>
+          complete((StatusCodes.Created, createdAnnotation))
         }
       }
     }


### PR DESCRIPTION
## Overview

This PR changes the API to match what the spec says where the spec has the right idea. I think it's mainly going to be status code changes. It's a companion to https://github.com/raster-foundry/raster-foundry-api-spec/pull/69

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated -- lots of this!

## Testing Instructions

 * note the exception handling in the test script for the linked PR above and confirm that these changes address those exceptions
