### PR TITLE
Fix expecting ']', found ')' in Jenkinsfile.release

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -21,7 +21,7 @@ node {
       string(defaultValue: 'rasterfoundry-production-config-us-east-1', description: 'Location of terraform state & vars files.', name: 'RF_SETTINGS_BUCKET', trim: false),
       string(defaultValue: 'Production', description: 'Environment name, used to target Batch Compute Environments.', name: 'RF_DEPLOYMENT_ENVIRONMENT', trim: false),
       string(defaultValue: 'master', description: 'Branch of azavea/raster-foundry-deployment used for deployment.', name: 'RF_DEPLOYMENT_BRANCH', trim: false)
-    )
+    ])
   ])
     
   try {


### PR DESCRIPTION
## Overview

Fix `expecting ']', found ')'` in `Jenkinsfile.release`

## Testing Instructions

We'll have to merge this, since it's used within the context of the release pipeline. This is just adding a `]` though.