### PR TITLE
Add script for reprocessing sentinel scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Added S3 path suggestions in scene import modal when users upload imageries from S3 buckets [\#4290](https://github.com/raster-foundry/raster-foundry/pull/4290)
 - Enabled deleting lab templates on the frontend [\#4287](https://github.com/raster-foundry/raster-foundry/pull/4287)
 - Added support for viewing public projects using backsplash [\#4299](https://github.com/raster-foundry/raster-foundry/pull/4299)
+- Added script for reprocessing sentinel 2 scenes which were imported with the wrong number of bands [\4349](https://github.com/raster-foundry/raster-foundry/pull/4349
 
 ### Changed
 - Populate user profiles from their identity tokens more intelligently [\#4298](https://github.com/raster-foundry/raster-foundry/pull/4298)

--- a/app-tasks/completion.bash
+++ b/app-tasks/completion.bash
@@ -1,5 +1,5 @@
 
 # Completion for rf cli
 complete -W \
-         "export find-aoi-projects ingest-scene process-upload update-aoi-project reprocess-landsat-h" \
+         "export find-aoi-projects ingest-scene process-upload update-aoi-project reprocess-landsat-h reprocess-sentinel" \
          rf

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -13,3 +13,4 @@ retrying==1.3.3
 click==6.7
 dropbox==9.0.0
 rasterfoundry==0.7.1
+psycopg2-binary==2.7.6

--- a/app-tasks/rf/src/rf/cli.py
+++ b/app-tasks/rf/src/rf/cli.py
@@ -12,7 +12,8 @@ from .commands import (
     ingest_scene,
     process_upload,
     reprocess_landsat_h,
-    update_aoi_project
+    reprocess_sentinel,
+    update_aoi_project,
 )
 
 logger = logging.getLogger('rf')
@@ -34,4 +35,5 @@ run.add_command(process_upload)
 run.add_command(ingest_scene)
 run.add_command(find_aoi_projects)
 run.add_command(reprocess_landsat_h)
+run.add_command(reprocess_sentinel)
 run.add_command(update_aoi_project)

--- a/app-tasks/rf/src/rf/commands/__init__.py
+++ b/app-tasks/rf/src/rf/commands/__init__.py
@@ -4,3 +4,4 @@ from .ingest_scene import ingest_scene
 from .process_upload import process_upload
 from .reprocess_landsat_h import reprocess_landsat_h
 from .update_aoi_project import update_aoi_project
+from .reprocess_sentinel import reprocess_sentinel

--- a/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
@@ -20,7 +20,8 @@ def reprocess_sentinel(scene_id):
         scene_id (str): Scene id to reprocess
     """
     print("Starting reprocessing scene: %s" % (scene_id, ))
-    conn = psycopg2.connect("host=postgres dbname=%s user=%s password=%s" % (
+    conn = psycopg2.connect("host=%s dbname=%s user=%s password=%s" % (
+        os.environ.get('POSTGRES_HOST', 'postgres'),
         os.environ['POSTGRES_DB'], os.environ['POSTGRES_USER'], os.environ['POSTGRES_PASSWORD']))
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
     # nondict_cur = conn.cursor()

--- a/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
@@ -36,11 +36,11 @@ def reprocess_sentinel(scene_ids):
         logger.info('Starting reprocessing scene: %s', scene_id)
         try:
             reprocess_scene_id(cur, conn, scene_id)
-        except Exception as e:
+        except Exception:
             conn.rollback()
-            logger.error(
-                'Rolling back transaction. \n' +
-                'There was an error while reprocessing scene id "%s",\n%s', scene_id, e
+            logger.exception(
+                'Rolling back transaction. ' +
+                'There was an error while reprocessing scene id "%s"', scene_id
             )
     conn.close()
 

--- a/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
@@ -1,0 +1,142 @@
+import logging
+import click
+import os
+import uuid
+import psycopg2
+import psycopg2.extras
+from ..utils.exception_reporting import wrap_rollbar
+from ingest_scene import ingest_scene
+
+logger = logging.getLogger(__name__)
+
+
+@click.command(name='reprocess-sentinel')
+@click.argument('scene_id')
+@wrap_rollbar
+def reprocess_sentinel(scene_id):
+    """Fix a sentinel 2 scene by replacing scene metadata bands and Images
+
+    Args:
+        scene_id (str): Scene id to reprocess
+    """
+    print("Starting reprocessing scene: %s" % (scene_id, ))
+    conn = psycopg2.connect("host=postgres dbname=%s user=%s password=%s" % (
+        os.environ['POSTGRES_DB'], os.environ['POSTGRES_USER'], os.environ['POSTGRES_PASSWORD']))
+    cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+    # nondict_cur = conn.cursor()
+    print("Connected to db")
+    scene = get_scene(cur, scene_id)
+    if check_if_broken(cur, scene_id):
+        print("Re-importing sentinel scene: %s" % (scene['id']))
+        # delete_images(cur, scene_id) # not necessary, just add images for 11 and 12
+        band11_id = str(uuid.uuid4())
+        band12_id = str(uuid.uuid4())
+        print("Updating images")
+        update_images(cur, scene, band11_id, band12_id)
+        print("Updating bands")
+        update_bands(cur, scene, band11_id, band12_id)
+        print("Updating scene")
+        update_scene(cur, scene)
+        conn.commit()
+        if scene['ingest_status'] == 'INGESTED':
+            print("Re-ingesting scene")
+            ingest_scene(scene_id)
+    else:
+        print("Skipping re-import for Scene: %s . Scene is not broken." % (scene['id']))
+
+
+def get_scene(cur, scene_id):
+    """Fetch scene as using psycopg"""
+    cur.execute("""
+    SELECT
+    s.id, s.ingest_status, s.ingest_location, s.scene_type, s.scene_metadata, s.metadata_files
+    FROM scenes s join images on images.scene = s.id
+    WHERE s.id = %s""", (scene_id,))
+    scene = cur.fetchone()
+    return scene
+
+
+def update_images(cur, scene, band11_id, band12_id):
+    """
+    Using psycopg:
+    Update existing images to have a raw_data_bytes value of 0
+    Create new scene images for scene with the same users as the other images
+    """
+    cur.execute("""
+    UPDATE images SET raw_data_bytes = 0 where scene = %s;
+    """, (scene["id"],))
+    cur.execute("""
+        SELECT
+        id, created_by, visibility, filename, sourceuri,
+        image_metadata, resolution_meters, metadata_files
+        FROM images WHERE scene = %s;""",
+                (scene["id"],))
+    existing_image = cur.fetchone()
+    print("Fetched existing image %s", existing_image)
+    base_uri = os.path.dirname(existing_image["sourceuri"])
+    band11 = {
+        "id": band11_id, "created_by": existing_image["created_by"],
+        "visibility": existing_image["visibility"], "owner": existing_image["created_by"],
+        "filename": "B11.jp2", "sourceuri": base_uri + "/B11.jp2", "scene": scene["id"], "resolution_meters": "20"
+    }
+    band12 = {
+        "id": band12_id, "created_by": existing_image["created_by"],
+        "visibility": existing_image["visibility"],
+        "filename": "B12.jp2", "sourceuri": base_uri + "/B12.jp2", "scene": scene["id"], "resolution_meters": "20"
+    }
+    bands = (band11, band12)
+    print("Inserting images: %s %s" % bands)
+    cur.executemany("""
+    INSERT INTO images (
+    id, created_at, modified_at, created_by, modified_by,
+    owner, raw_data_bytes, visibility, filename, sourceuri,
+    scene, resolution_meters, metadata_files, image_metadata
+    ) values (
+    %(id)s, now(), now(), %(created_by)s, %(created_by)s,
+    %(created_by)s, 0, %(visibility)s, %(filename)s, %(sourceuri)s,
+    %(scene)s, %(resolution_meters)s, '{}', '{}'
+    );
+    """, bands)
+
+
+def update_bands(cur, scene, band11_id, band12_id):
+    """Update the bands so ingest work correctly"""
+    bands = (
+        {
+            "id": str(uuid.uuid4()), "image_id": band11_id, "name": "short-wave infrared - 11",
+            "wavelength": "{1565,1655}"
+        }, {
+            "id": str(uuid.uuid4()), "image_id": band12_id, "name": "short-wave infrared - 12",
+            "wavelength": "{2100,2280}"
+        }
+    )
+    print("Inserting bands %s %s" % bands)
+    cur.executemany("""
+    INSERT INTO bands (id, image_id, name, number, wavelength)
+    VALUES (%(id)s, %(image_id)s, %(name)s, 0, %(wavelength)s)
+    """, bands)
+
+
+def update_scene(cur, scene):
+    """Update band metadata for scene using psycopg
+       For ingested scenes, change the ingest status back to uningested
+       and the scene_type to COG if necessary. We will be re-ingesting avro
+       scenes as COGs
+
+    Args:
+        scene (Scene): Scene to update
+    """
+    cur.execute("""
+    UPDATE SCENES
+    SET scene_type = 'COG', ingest_status = 'NOTINGESTED', ingest_location = null
+    WHERE id = %s""", (scene["id"],))
+
+
+def check_if_broken(cur, scene_id):
+    """If the scene has 11 images instead of 13"""
+    cur.execute("""
+    SELECT count(id) from images where scene = %s
+    """, (scene_id,))
+    image_count = cur.fetchone()[0]
+    print("Scene has %s images" % (image_count,))
+    return image_count < 13

--- a/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
@@ -19,75 +19,89 @@ def reprocess_sentinel(scene_id):
     Args:
         scene_id (str): Scene id to reprocess
     """
-    print("Starting reprocessing scene: %s" % (scene_id, ))
-    conn = psycopg2.connect("host=%s dbname=%s user=%s password=%s" % (
+    logger.info('Starting reprocessing scene: {}'.format(scene_id))
+    conn = psycopg2.connect('host={} dbname={} user={} password={}'.format(
         os.environ.get('POSTGRES_HOST', 'postgres'),
-        os.environ['POSTGRES_DB'], os.environ['POSTGRES_USER'], os.environ['POSTGRES_PASSWORD']))
+        os.environ['POSTGRES_DB'],
+        os.environ['POSTGRES_USER'],
+        os.environ['POSTGRES_PASSWORD'])
+    )
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-    # nondict_cur = conn.cursor()
-    print("Connected to db")
+    logger.info('Connected to db')
     scene = get_scene(cur, scene_id)
     if check_if_broken(cur, scene_id):
-        print("Re-importing sentinel scene: %s" % (scene['id']))
-        # delete_images(cur, scene_id) # not necessary, just add images for 11 and 12
+        logger.info('Re-importing sentinel scene: {}'.format(scene['id']))
         band11_id = str(uuid.uuid4())
         band12_id = str(uuid.uuid4())
-        print("Updating images")
+        logger.info('Updating images')
         update_images(cur, scene, band11_id, band12_id)
-        print("Updating bands")
+        logger.info('Updating bands')
         update_bands(cur, scene, band11_id, band12_id)
-        print("Updating scene")
+        logger.info('Updating scene')
         update_scene(cur, scene)
         conn.commit()
         if scene['ingest_status'] == 'INGESTED':
-            print("Re-ingesting scene")
+            logger.info('Re-ingesting scene')
             ingest_scene(scene_id)
     else:
-        print("Skipping re-import for Scene: %s . Scene is not broken." % (scene['id']))
+        logger.info('Skipping re-import for Scene: {} . Scene is not broken.'.format(scene['id']))
 
 
 def get_scene(cur, scene_id):
-    """Fetch scene as using psycopg"""
-    cur.execute("""
+    """Fetch scene as using psycopg
+
+    Args:
+        cur (psycopg2.Cursor)
+        scene_id (string)
+
+    Returns: scene dict {"id", "ingest_status", "ingest_location", "scene_type", "scene_metadata", "metadata_files"}
+    """
+    cur.execute('''
     SELECT
     s.id, s.ingest_status, s.ingest_location, s.scene_type, s.scene_metadata, s.metadata_files
     FROM scenes s join images on images.scene = s.id
-    WHERE s.id = %s""", (scene_id,))
+    WHERE s.id = %s''', (scene_id,))
     scene = cur.fetchone()
     return scene
 
 
 def update_images(cur, scene, band11_id, band12_id):
+    """Update existing images
+
+    Set raw_data_bytes value of 0,
+    Create new images for scene using paths / user of the other images
+
+    Args:
+        cur (psycopg2.Cursor)
+        scene (dict)
+        band11_id (string)
+        band12_id (string
     """
-    Using psycopg:
-    Update existing images to have a raw_data_bytes value of 0
-    Create new scene images for scene with the same users as the other images
-    """
-    cur.execute("""
+    cur.execute('''
     UPDATE images SET raw_data_bytes = 0 where scene = %s;
-    """, (scene["id"],))
-    cur.execute("""
+    ''', (scene['id'],))
+    cur.execute('''
         SELECT
         id, created_by, visibility, filename, sourceuri,
         image_metadata, resolution_meters, metadata_files
-        FROM images WHERE scene = %s;""",
-                (scene["id"],))
+        FROM images WHERE scene = %s;''',
+                (scene['id'],))
     existing_image = cur.fetchone()
-    print("Fetched existing image %s", existing_image)
-    base_uri = os.path.dirname(existing_image["sourceuri"])
+    logger.info('Fetched existing image {}'.format(existing_image))
+    base_uri = os.path.dirname(existing_image['sourceuri'])
     band11 = {
-        "id": band11_id, "created_by": existing_image["created_by"],
-        "visibility": existing_image["visibility"], "owner": existing_image["created_by"],
-        "filename": "B11.jp2", "sourceuri": base_uri + "/B11.jp2", "scene": scene["id"], "resolution_meters": "20"
+        'id': band11_id, 'created_by': existing_image['created_by'],
+        'visibility': existing_image['visibility'], 'owner': existing_image['created_by'],
+        'filename': 'B11.jp2', 'sourceuri': base_uri + '/B11.jp2', 'scene': scene['id'], 'resolution_meters': '20'
     }
     band12 = {
-        "id": band12_id, "created_by": existing_image["created_by"],
-        "visibility": existing_image["visibility"],
-        "filename": "B12.jp2", "sourceuri": base_uri + "/B12.jp2", "scene": scene["id"], "resolution_meters": "20"
+        'id': band12_id, 'created_by': existing_image['created_by'],
+        'visibility': existing_image['visibility'],
+        'filename': 'B12.jp2', 'sourceuri': base_uri + '/B12.jp2', 'scene': scene['id'], 'resolution_meters': '20'
     }
     bands = (band11, band12)
-    print("Inserting images: %s %s" % bands)
-    cur.executemany("""
+    logger.info('Inserting images: {} {}'.format(bands))
+    cur.executemany('''
     INSERT INTO images (
     id, created_at, modified_at, created_by, modified_by,
     owner, raw_data_bytes, visibility, filename, sourceuri,
@@ -97,47 +111,56 @@ def update_images(cur, scene, band11_id, band12_id):
     %(created_by)s, 0, %(visibility)s, %(filename)s, %(sourceuri)s,
     %(scene)s, %(resolution_meters)s, '{}', '{}'
     );
-    """, bands)
+    ''', bands)
 
 
 def update_bands(cur, scene, band11_id, band12_id):
-    """Update the bands so ingest work correctly"""
+    """Update the bands so ingest work correctly
+
+    Args:
+        cur (psycopg2.Cursor)
+        scene (dict)
+        band11_id (string)
+        band12_id (string)
+    """
     bands = (
         {
-            "id": str(uuid.uuid4()), "image_id": band11_id, "name": "short-wave infrared - 11",
-            "wavelength": "{1565,1655}"
+            'id': str(uuid.uuid4()), 'image_id': band11_id, 'name': 'short-wave infrared - 11',
+            'wavelength': '{1565,1655}'
         }, {
-            "id": str(uuid.uuid4()), "image_id": band12_id, "name": "short-wave infrared - 12",
-            "wavelength": "{2100,2280}"
+            'id': str(uuid.uuid4()), 'image_id': band12_id, 'name': 'short-wave infrared - 12',
+            'wavelength': '{2100,2280}'
         }
     )
-    print("Inserting bands %s %s" % bands)
-    cur.executemany("""
+    logger.info('Inserting bands {} {}'.format(bands))
+    cur.executemany('''
     INSERT INTO bands (id, image_id, name, number, wavelength)
     VALUES (%(id)s, %(image_id)s, %(name)s, 0, %(wavelength)s)
-    """, bands)
+    ''', bands)
 
 
 def update_scene(cur, scene):
     """Update band metadata for scene using psycopg
+
        For ingested scenes, change the ingest status back to uningested
        and the scene_type to COG if necessary. We will be re-ingesting avro
        scenes as COGs
 
     Args:
+        cur (psycopg2.Cursor)
         scene (Scene): Scene to update
     """
-    cur.execute("""
+    cur.execute('''
     UPDATE SCENES
     SET scene_type = 'COG', ingest_status = 'NOTINGESTED', ingest_location = null
-    WHERE id = %s""", (scene["id"],))
+    WHERE id = %s''', (scene['id'],))
 
 
 def check_if_broken(cur, scene_id):
-    """If the scene has 11 images instead of 13"""
-    cur.execute("""
+    """A scene is broken if the scene has 11 images instead of 13"""
+    cur.execute('''
     SELECT count(id) from images where scene = %s
-    """, (scene_id,))
+    ''', (scene_id,))
     image_count = cur.fetchone()[0]
-    print("Scene has %s images" % (image_count,))
+    logger.info('Scene has {} images'.format(image_count))
     return image_count < 13


### PR DESCRIPTION
## Overview
Write a script which takes a single scene id to reprocess

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
```
> $ ./scripts/console batch bash                                                                                         [±feature/lk/remaining-import-fixes ●●]
Starting raster-foundry_postgres_1 ... done
root@47a8ed9c279d:/# rf reprocess-sentinel 1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d
Starting reprocessing scene: 1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d
Connected to db
Scene has 11 images
Re-importing sentinel scene: 1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d
Updating images
('Fetched existing image %s', ['399ed0ba-2728-4d1f-9460-61f2fc07b500', 'rf|airflow-user', 'PUBLIC', 'B02.jp2', 'https://sentinel-s2-l1c.s3.amazonaws.com/tiles/29/U/MB/2017/4/1/0/B02.jp2', None, 10.0, []])
Inserting images: {'scene': '1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d', 'visibility': 'PUBLIC', 'sourceuri': 'https://sentinel-s2-l1c.s3.amazonaws.com/tiles/29/U/MB/2017/4/1/0/B11.jp2', 'owner': 'rf|airflow-user', 'resolution_meters': '20', 'id': '7306c362-4f14-4891-a444-53afc1914194', 'created_by': 'rf|airflow-user', 'filename': 'B11.jp2'} {'sourceuri': 'https://sentinel-s2-l1c.s3.amazonaws.com/tiles/29/U/MB/2017/4/1/0/B12.jp2', 'scene': '1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d', 'visibility': 'PUBLIC', 'filename': 'B12.jp2', 'created_by': 'rf|airflow-user', 'resolution_meters': '20', 'id': '75c2316a-edd0-4145-8548-4117e91f5a5b'}
Updating bands
Inserting bands {'wavelength': '{1565,1655}', 'image_id': '7306c362-4f14-4891-a444-53afc1914194', 'id': '252f6a64-5f8d-434a-aced-f68581ec1c5e', 'name': 'short-wave infrared - 11'} {'wavelength': '{2100,2280}', 'image_id': '75c2316a-edd0-4145-8548-4117e91f5a5b', 'id': '6a575023-d557-41c6-b5f3-b8c14108461d', 'name': 'short-wave infrared - 12'}
Updating scene


root@47a8ed9c279d:/# rf reprocess-sentinel 1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d
Starting reprocessing scene: 1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d
Connected to db
Scene has 13 images
Skipping re-import for Scene: 1ab221fc-8d6b-4d8b-ae7f-ae1fde7f820d . Scene is not broken.
```

## Testing Instructions

* Rebuild your assembly jar
* Rebuild your bash container
* in the bash container:
  * `./scripts/console batch bash`
  * search the database for an uningested sentinel 2 scene with 11 bands
  * run `rf reprocess-sentinel {scene_id}`
  * verify that the scene now has the correct bands, images, metadata, etc by comparing it to a correct one
  * Do the same with an ingested sentinel 2 scene and verify that it works, and additionally ingests it

Closes https://github.com/azavea/raster-foundry-platform/issues/565