### PR TITLE
Implements a handful of styling fixes within projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
 - Fixed shapefile annotations export [\#4300](https://github.com/raster-foundry/raster-foundry/pull/4300)
 - Made s3 client tolerate buckets outside of its configured region [\#4319](https://github.com/raster-foundry/raster-foundry/pull/4319)
 - Fixed logging dependency stack to eliminate painfully verbose logging in backsplash [\#4326](https://github.com/raster-foundry/raster-foundry/pull/4326)
+- Fix thumbnail loading placeholder size [\#4355](https://github.com/raster-foundry/raster-foundry/pull/4355)
+- Fix hidden text field for scene image sources [\#4355](https://github.com/raster-foundry/raster-foundry/pull/4355)
+- Fix long source names for scenes [\#4355](https://github.com/raster-foundry/raster-foundry/pull/4355)
 
 ## [1.14.2](https://github.com/raster-foundry/raster-foundry/tree/1.14.2) (2018-11-19)
 

--- a/app-frontend/src/assets/styles/sass/components/_image.scss
+++ b/app-frontend/src/assets/styles/sass/components/_image.scss
@@ -25,6 +25,9 @@
     border: 1px solid $border-color-default;
     display: flex;
     justify-content: center;
+    overflow: hidden;
+    flex: none;
+    border-radius: 4px;
 
     &.previewable {
         cursor: zoom-in;

--- a/app-frontend/src/assets/styles/sass/components/_list-group.scss
+++ b/app-frontend/src/assets/styles/sass/components/_list-group.scss
@@ -159,6 +159,7 @@
   white-space: nowrap;
   word-wrap: normal !important;
   padding-right: 1rem;
+  flex: 1;
 
   p, span {
     display: inline;

--- a/app-frontend/src/assets/styles/sass/components/_searchselect.scss
+++ b/app-frontend/src/assets/styles/sass/components/_searchselect.scss
@@ -97,7 +97,7 @@
   background: none !important;
   line-height: inherit !important;
   box-shadow: none !important;
-  color: $shade-dark;
+  color: $white;
 }
 
 .selectize-input > input:focus {

--- a/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_filter.scss
+++ b/app-frontend/src/assets/styles/sass/theme/high-contrast/components/_filter.scss
@@ -21,6 +21,10 @@
     border: 1px solid $shade-light;
     background-color: $white;
     color: $text-base;
+
+    > input {
+      color: $text-base;
+    }
   }
 
   .searchselect-clear {

--- a/app-frontend/src/assets/styles/sass/theme/un-global-platform/components/_filter.scss
+++ b/app-frontend/src/assets/styles/sass/theme/un-global-platform/components/_filter.scss
@@ -18,6 +18,10 @@
     border: 1px solid $border-color-default;
     background-color: $white;
     color: $text-base;
+
+    > input {
+      color: $text-base;
+    }
   }
 
   .searchselect-clear {


### PR DESCRIPTION
## Overview
- fixes #4350
- fixes thumbnail loading size issue on list-groups
- fixes flex issue in list-groups for long source names

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
**1: List group issue, before:**
<img width="400" alt="screen shot 2018-12-05 at 11 12 24 am" src="https://user-images.githubusercontent.com/1928955/49527100-334cb400-f87f-11e8-9783-e4b58491c0da.png">

**1: List group after fix, all themes**
<img width="397" alt="screen shot 2018-12-05 at 11 09 25 am" src="https://user-images.githubusercontent.com/1928955/49527164-4d869200-f87f-11e8-89b8-8b0e4a41081d.png">
<img width="398" alt="screen shot 2018-12-05 at 11 11 09 am" src="https://user-images.githubusercontent.com/1928955/49527165-4d869200-f87f-11e8-85e8-7405a088a825.png">
<img width="399" alt="screen shot 2018-12-05 at 11 12 03 am" src="https://user-images.githubusercontent.com/1928955/49527166-4d869200-f87f-11e8-9ded-168825edbdae.png">

**2: Search select invisble text, before:**
<img width="389" alt="screen shot 2018-12-05 at 11 18 56 am" src="https://user-images.githubusercontent.com/1928955/49527280-93dbf100-f87f-11e8-8abc-caeb0f121935.png">

**2: Search select text after fix, all themes:**
<img width="395" alt="screen shot 2018-12-05 at 11 04 16 am" src="https://user-images.githubusercontent.com/1928955/49527333-af46fc00-f87f-11e8-82ac-15e7354bbe63.png">
<img width="395" alt="screen shot 2018-12-05 at 11 09 22 am" src="https://user-images.githubusercontent.com/1928955/49527335-af46fc00-f87f-11e8-90ff-6da33ac0ac5b.png">
<img width="394" alt="screen shot 2018-12-05 at 11 11 22 am" src="https://user-images.githubusercontent.com/1928955/49527341-b2da8300-f87f-11e8-8011-13221501bced.png">

## Testing Instructions

 * Open project
 * Check scene list as they load to check for thumbnail load issue
 * Check scene list item that contains a long image source name to make sure buttons don't go on two lines
 * Type into the imagery source searchbox. Make sure the typed text is visible