### PR TITLE
Allow users to decline invitations or leave groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Fixed
 
-- Made the status code for aoi creation on projects a 201 instead of a 200 [\#4331](https://github.com/raster-foundry/raster-foundry/pull/4331/files)
+- Made the status code for aoi creation on projects a 201 instead of a 200 [\#4331](https://github.com/raster-foundry/raster-foundry/pull/4331)
+- Opened access for group members to remove their group memberships [\#4358](https://github.com/raster-foundry/raster-foundry/pull/4358)
 
 ## [1.15.0](https://github.com/raster-foundry/raster-foundry/tree/1.15.0) (2018-11-30)
 

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -495,7 +495,16 @@ trait PlatformRoutes
                                  orgId: UUID,
                                  userId: String): Route = authenticate { user =>
     authorizeAsync {
-      OrganizationDao.userIsAdmin(user, orgId).transact(xa).unsafeToFuture
+      val authCheck = (
+        OrganizationDao.userIsAdmin(user, orgId),
+        (userId == user.id).pure[ConnectionIO]
+      ).tupled.map(
+        {
+          case (true, _) | (_, true) => true
+          case _                     => false
+        }
+      )
+      authCheck.transact(xa).unsafeToFuture
     } {
       complete {
         OrganizationDao
@@ -650,7 +659,16 @@ trait PlatformRoutes
                          teamId: UUID,
                          userId: String): Route = authenticate { user =>
     authorizeAsync {
-      TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
+      val authCheck = (
+        TeamDao.userIsAdmin(user, teamId),
+        (userId == user.id).pure[ConnectionIO]
+      ).tupled.map(
+        {
+          case (true, _) | (_, true) => true
+          case _                     => false
+        }
+      )
+      authCheck.transact(xa).unsafeToFuture
     } {
       complete {
         TeamDao


### PR DESCRIPTION
## Overview

This PR updates authorization checks on team and organization member endpoints, so that, in addition to admins, if the acting user matches the user to be removed, the acting user is allowed to decline a team or organization invitation, or to leave a team or an organization.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

The original issue changed a tiny bit per the comment in there.

## Testing Instructions

 * Log in as a platform admin
 * Create an organization
 * Add your other account as organization member
 * Log in to the other account
 * Go to the list of your organizations
 * Check if both accept and decline work. If you accepted, you should be able to leave the organization as well.
 * Test the team scenario following similar instructions as above and check if it works.

Closes #4327 
Closes #4213