### PR TITLE
Only use active UGRs in query for emails to send during ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix thumbnail loading placeholder size [\#4355](https://github.com/raster-foundry/raster-foundry/pull/4355)
 - Fix hidden text field for scene image sources [\#4355](https://github.com/raster-foundry/raster-foundry/pull/4355)
 - Fix long source names for scenes [\#4355](https://github.com/raster-foundry/raster-foundry/pull/4355)
+- Duplicate ingest emails for users with inactive platform UGRs [\#4359](https://github.com/raster-foundry/raster-foundry/pull/4359)
 
 ## [1.14.2](https://github.com/raster-foundry/raster-foundry/tree/1.14.2) (2018-11-19)
 

--- a/app-backend/db/src/main/scala/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/PlatformDao.scala
@@ -264,6 +264,7 @@ object PlatformDao extends Dao[Platform] {
           ON prj.id = stp.project_id
         WHERE stp.scene_id = ${sceneIdString}
           AND u.id IN ${userIdsString}
+          AND ugr.is_active = true
       """).query[PlatformWithUsersSceneProjects].to[List]
   }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -275,6 +275,7 @@ class PlatformDaoSpec
             userCreateAnother: User.Create,
             orgCreate: Organization.Create,
             platform: Platform,
+            platform2: Platform,
             projectCreate: Project.Create,
             projectCreateAnother: Project.Create,
             sceneCreate: Scene.Create
@@ -286,6 +287,12 @@ class PlatformDaoSpec
                                                              platform,
                                                              projectCreate)
               (dbUser, dbOrg, dbPlatform, dbProject) = userOrgPlatProject
+              secondPlatform <- PlatformDao.create(platform2)
+              deactivatedRole <- PlatformDao.addUserRole(dbUser,
+                                                         dbUser.id,
+                                                         secondPlatform.id,
+                                                         GroupRole.Member)
+              _ <- UserGroupRoleDao.deactivate(deactivatedRole.id, dbUser)
               userProjectAnother <- insertUserProject(userCreateAnother,
                                                       dbOrg,
                                                       dbPlatform,


### PR DESCRIPTION
## Overview
Fix duplicate emails when a user has inactive platform UGRs

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

## Testing Instructions

 * Add an inactive platform UGR to a user with email notifications enabled 
* Add an uningested scene to a project owned by that user
* Ingest the scene
* Verify in logging that only one email is sent

Closes #4005
