### PR TITLE
Protect user email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Reorganized scala dependencies for package cleanliness and smaller bundles [\#4301](https://github.com/raster-foundry/raster-foundry/pull/4301)
+- If users are not requesting their own info, the returned other users' personal info are protected [\#4360](https://github.com/raster-foundry/raster-foundry/pull/4360)
 
 ### Fixed
 

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -49,14 +49,15 @@ object UserDao extends Dao[User] {
     case _ =>
       filterById(id).select map { (user: User) =>
         {
-          user.copy(planetCredential = Credential(Some("")),
-                    dropboxCredential = Credential(Some("")),
-                    name = Email.obfuscate(user.name),
-                    email = Email.obfuscate(user.email),
-                    personalInfo = user.personalInfo.copy(
-                      email = Email.obfuscate(user.personalInfo.email),
-                      phoneNumber = ""
-                    )
+          user.copy(
+            planetCredential = Credential(Some("")),
+            dropboxCredential = Credential(Some("")),
+            name = Email.obfuscate(user.name),
+            email = Email.obfuscate(user.email),
+            personalInfo = user.personalInfo.copy(
+              email = Email.obfuscate(user.personalInfo.email),
+              phoneNumber = ""
+            )
           )
         }
       }

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -23,6 +23,7 @@ import java.util.UUID
 
 import scala.concurrent.Future
 
+import com.rasterfoundry.database.util.Email
 import com.rasterfoundry.database.Implicits._
 
 object UserDao extends Dao[User] {
@@ -49,7 +50,14 @@ object UserDao extends Dao[User] {
       filterById(id).select map { (user: User) =>
         {
           user.copy(planetCredential = Credential(Some("")),
-                    dropboxCredential = Credential(Some("")))
+                    dropboxCredential = Credential(Some("")),
+                    name = Email.obfuscate(user.name),
+                    email = Email.obfuscate(user.email),
+                    personalInfo = user.personalInfo.copy(
+                      email = Email.obfuscate(user.personalInfo.email),
+                      phoneNumber = ""
+                    )
+          )
         }
       }
   }

--- a/app-backend/db/src/main/scala/util/Email.scala
+++ b/app-backend/db/src/main/scala/util/Email.scala
@@ -1,0 +1,8 @@
+package com.rasterfoundry.database.util
+
+object Email {
+  def obfuscate(email: String): String = email.split("@").headOption match {
+    case Some(emailName) if emailName.length != 0 => emailName
+    case _ => "Anonymous"
+  }
+}

--- a/app-backend/db/src/main/scala/util/Email.scala
+++ b/app-backend/db/src/main/scala/util/Email.scala
@@ -3,6 +3,6 @@ package com.rasterfoundry.database.util
 object Email {
   def obfuscate(email: String): String = email.split("@").headOption match {
     case Some(emailName) if emailName.length != 0 => emailName
-    case _ => "Anonymous"
+    case _                                        => "Anonymous"
   }
 }


### PR DESCRIPTION
## Overview

This PR updates the `unsafeGetUserById` method so that if users are not requesting their own info, the returned other users' email info are protected.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

<img width="812" alt="screen shot 2018-12-05 at 6 04 13 pm" src="https://user-images.githubusercontent.com/16109558/49549942-34e69e00-f8b8-11e8-8882-0fa420637dcb.png">

## Testing Instructions

 * In order to test that the issue is resolved by this PR, log into an account with `name` field set as the same as `email` field, and no first and last name in `personalInfo` (so that it will fall to the `name` case, where the name is the same as email in DB, which happens to some user records)
 * Create a new template
 * In DB, change its visibility to `PUBLIC` or modify its `acrs` to share it to another account (directly, through group membership, etc)
 * Log into this other account and go the list of templates
 * Make sure only email user name (without `@domain`) or `Anonymous` is displayed as owner for that shared template

Closes https://github.com/azavea/raster-foundry-platform/issues/568
