### PR TITLE
Solve implicit resolution for BacksplashMosaic

### DIFF
--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -14,6 +14,7 @@ import cats.implicits._
 import cats.data.{NonEmptyList => NEL}
 import cats.effect._
 
+
 object BacksplashMosaic {
 
   /** Filter out images that don't need to be included  */
@@ -40,62 +41,5 @@ object BacksplashMosaic {
       }
     })
   }
-
-  val backsplashMosaicReification = new TmsReification[BacksplashMosaic] {
-    def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
-
-    def tmsReification(self: BacksplashMosaic, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] =
-      (z: Int, x: Int, y: Int) => {
-        val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
-        val bandCount = self.take(1).map(_.subsetBands.length).compile.fold(0)(_ + _).unsafeRunSync
-        val ndtile: MultibandTile = ArrayMultibandTile.empty(IntConstantNoDataCellType, bandCount, 256, 256)
-        filterRelevant(self)
-          .map(_.read(z, x, y))
-          .map({ maybeMBTile =>
-            val mbtile = maybeMBTile.getOrElse {
-              throw new Exception(s"really expected to find a tile at $z, $x, $y for $self")
-            }
-            Raster(mbtile, extent)
-          }).compile
-            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
-            mbr1.merge(mbr2, NearestNeighbor)
-          }).map(RasterLit(_))
-    }
-  }
-
-  implicit val extentReification: ExtentReification[BacksplashMosaic] = new ExtentReification[BacksplashMosaic] {
-    def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
-
-    def extentReification(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]) =
-      (extent: Extent, cs: CellSize) => {
-        val bands = self.take(1).map(_.subsetBands).compile.toList.map(_.flatten).unsafeRunSync
-        val ndtile: MultibandTile = ArrayMultibandTile.empty(IntConstantNoDataCellType, bands.length, 256, 256)
-        filterRelevant(self)
-          .map(_.read(extent, cs))
-          .map({ maybeMBTile =>
-            val mbtile = maybeMBTile.getOrElse {
-              throw new Exception(s"really expected to find a tile for $extent and $cs for $self")
-            }
-            Raster(mbtile, extent)
-          }).compile
-            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
-            mbr1.merge(mbr2, NearestNeighbor)
-          }).map(RasterLit(_))
-      }
-  }
-
-  implicit val hasRasterExtents: HasRasterExtents[BacksplashMosaic] = new HasRasterExtents[BacksplashMosaic] {
-    def rasterExtents(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] = {
-      filterRelevant(self)
-        .flatMap({ img => fs2.Stream.eval(BacksplashImage.getRasterExtents(img.uri)) })
-        .compile
-        .toList
-        .map(_.reduceLeft({ (nel1: NEL[RasterExtent], nel2: NEL[RasterExtent])  => nel1 concatNel nel2 }))
-    }
-
-    def crs(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]): IO[CRS] = ???
-  }
-  val impl = implicitly[ExtentReification[BacksplashMosaic]]
-  //val impl = implicitly[HasRasterExtents[BacksplashMosaic]]
 }
 

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Implicits.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Implicits.scala
@@ -1,0 +1,80 @@
+package com.rasterfoundry.backsplash
+
+import geotrellis.vector._
+import geotrellis.raster._
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.proj4.CRS
+import geotrellis.server._
+
+import com.azavea.maml.ast._
+import com.azavea.maml.eval._
+
+import cats._
+import cats.implicits._
+import cats.data.{NonEmptyList => NEL}
+import cats.effect._
+
+import TmsReification._
+import ExtentReification._
+import HasRasterExtents._
+
+trait Implicits extends ToTmsReificationOps with ToExtentReificationOps with ToHasRasterExtentsOps {
+
+  implicit val mosaicTmsReification = new TmsReification[BacksplashMosaic] {
+    def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
+
+    def tmsReification(self: BacksplashMosaic, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] =
+      (z: Int, x: Int, y: Int) => {
+        val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
+        val bandCount = self.take(1).map(_.subsetBands.length).compile.fold(0)(_ + _).unsafeRunSync
+        val ndtile: MultibandTile = ArrayMultibandTile.empty(IntConstantNoDataCellType, bandCount, 256, 256)
+        BacksplashMosaic.filterRelevant(self)
+          .map(_.read(z, x, y))
+          .map({ maybeMBTile =>
+            val mbtile = maybeMBTile.getOrElse {
+              throw new Exception(s"really expected to find a tile at $z, $x, $y for $self")
+            }
+            Raster(mbtile, extent)
+          }).compile
+            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+            mbr1.merge(mbr2, NearestNeighbor)
+          }).map(RasterLit(_))
+    }
+  }
+
+  implicit val mosaicExtentReification: ExtentReification[BacksplashMosaic] = new ExtentReification[BacksplashMosaic] {
+    def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
+
+    def extentReification(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]) =
+      (extent: Extent, cs: CellSize) => {
+        val bands = self.take(1).map(_.subsetBands).compile.toList.map(_.flatten).unsafeRunSync
+        val ndtile: MultibandTile = ArrayMultibandTile.empty(IntConstantNoDataCellType, bands.length, 256, 256)
+        BacksplashMosaic.filterRelevant(self)
+          .map(_.read(extent, cs))
+          .map({ maybeMBTile =>
+            val mbtile = maybeMBTile.getOrElse {
+              throw new Exception(s"really expected to find a tile for $extent and $cs for $self")
+            }
+            Raster(mbtile, extent)
+          }).compile
+            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+            mbr1.merge(mbr2, NearestNeighbor)
+          }).map(RasterLit(_))
+      }
+  }
+
+  implicit val mosaicHasRasterExtents: HasRasterExtents[BacksplashMosaic] = new HasRasterExtents[BacksplashMosaic] {
+    def rasterExtents(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] = {
+      BacksplashMosaic.filterRelevant(self)
+        .flatMap({ img => fs2.Stream.eval(BacksplashImage.getRasterExtents(img.uri)) })
+        .compile
+        .toList
+        .map(_.reduceLeft({ (nel1: NEL[RasterExtent], nel2: NEL[RasterExtent])  => nel1 concatNel nel2 }))
+    }
+
+    def crs(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]): IO[CRS] = ???
+  }
+}
+
+object Implicits extends Implicits
+

--- a/backsplash-core/src/test/scala/com/rasterfoundry/backsplash/BacksplashMosaicSpec.scala
+++ b/backsplash-core/src/test/scala/com/rasterfoundry/backsplash/BacksplashMosaicSpec.scala
@@ -11,6 +11,7 @@ import org.scalacheck.Prop.forAll
 import com.azavea.maml.ast._
 
 import BacksplashImageGen._
+import Implicits._
 
 import scala.concurrent.ExecutionContext
 
@@ -40,17 +41,29 @@ class BacksplashMosaicSpec extends FunSuite with Checkers with Matchers {
     }
   }
 
-  test("cheating") {
+  ignore("writeExtent") {
     check {
       forAll {
         (mosaic: BacksplashMosaic) =>
-          //val RasterExtents = implicitly[HasRasterExtents[BacksplashMosaic]]
-          //val ExtentReification = implicitly[ExtentReification[BacksplashMosaic]]
-          //val re = BacksplashMosaic.impl.rasterExtents(mosaic).map(println(_)).unsafeRunSync
-          val eval = BacksplashMosaic.impl.extentReification(mosaic)
+          val eval = mosaic.extentReification
           val e = Extent(-147.34863281250003,20.014645445341365,-83.40820312500001,49.97948776108648)
-          val r = eval(e, CellSize(10, 10)).unsafeRunSync
-          MultibandGeoTiff(r.asInstanceOf[RasterLit[Raster[MultibandTile]]].raster, geotrellis.proj4.WebMercator).write(s"/tmp/${java.util.UUID.randomUUID}")
+          val rlit = eval(e, CellSize(10, 10)).unsafeRunSync
+          MultibandGeoTiff(rlit.asInstanceOf[RasterLit[Raster[MultibandTile]]].raster, geotrellis.proj4.WebMercator)
+            .write(s"/tmp/${java.util.UUID.randomUUID}")
+          println("DID ONE")
+          true
+      }
+    }
+  }
+
+  test("writeTMS") {
+    check {
+      forAll {
+        (mosaic: BacksplashMosaic) =>
+          val eval = mosaic.tmsReification(0)
+          val rlit = eval(7, 24, 48).unsafeRunSync
+          MultibandGeoTiff(rlit.asInstanceOf[RasterLit[Raster[MultibandTile]]].raster, geotrellis.proj4.WebMercator)
+            .write(s"/tmp/${java.util.UUID.randomUUID}.tif")
           println("DID ONE")
           true
       }
@@ -58,3 +71,4 @@ class BacksplashMosaicSpec extends FunSuite with Checkers with Matchers {
   }
 
 }
+

--- a/backsplash-core/src/test/scala/com/rasterfoundry/backsplash/BacksplashMosaicSpec.scala
+++ b/backsplash-core/src/test/scala/com/rasterfoundry/backsplash/BacksplashMosaicSpec.scala
@@ -56,7 +56,7 @@ class BacksplashMosaicSpec extends FunSuite with Checkers with Matchers {
     }
   }
 
-  test("writeTMS") {
+  ignore("writeTMS") {
     check {
       forAll {
         (mosaic: BacksplashMosaic) =>

--- a/backsplash-core/src/test/scala/com/rasterfoundry/backsplash/GtImplicits.scala
+++ b/backsplash-core/src/test/scala/com/rasterfoundry/backsplash/GtImplicits.scala
@@ -1,0 +1,99 @@
+package com.rasterfoundry.backsplash
+
+import geotrellis.vector._
+import geotrellis.raster._
+import geotrellis.raster.resample.NearestNeighbor
+import geotrellis.proj4.{CRS, WebMercator, LatLng}
+import geotrellis.spark.SpatialKey
+import geotrellis.server._
+import geotrellis.contrib.vlm._
+import geotrellis.contrib.vlm.geotiff._
+
+import com.azavea.maml.ast._
+import com.azavea.maml.eval._
+
+import cats._
+import cats.implicits._
+import cats.data.{NonEmptyList => NEL}
+import cats.effect._
+
+import TmsReification._
+import ExtentReification._
+import HasRasterExtents._
+
+trait GtImplicits extends ToTmsReificationOps with ToExtentReificationOps with ToHasRasterExtentsOps {
+
+  def readWithGt(img: BacksplashImage, z: Int, x: Int, y: Int): Option[MultibandTile] = {
+    val rs = new GeoTiffRasterSource(img.uri)
+    val layoutDefinition = BacksplashImage.tmsLevels(z)
+    rs.reproject(WebMercator)
+      .tileToLayout(layoutDefinition, NearestNeighbor)
+      .read(SpatialKey(x, y), img.subsetBands)
+  }
+  def readWithGt(img: BacksplashImage, extent: Extent, cs: CellSize): Option[MultibandTile] = {
+    val rs = new GeoTiffRasterSource(img.uri)
+    val destinationExtent = extent.reproject(LatLng, WebMercator)
+    rs.reproject(WebMercator)
+      .resample(TargetRegion(RasterExtent(extent, cs)), NearestNeighbor)
+      .read(destinationExtent, img.subsetBands.toSeq)
+      .map(_.tile)
+  }
+
+  implicit val mosaicTmsReification = new TmsReification[BacksplashMosaic] {
+    def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
+
+    def tmsReification(self: BacksplashMosaic, buffer: Int)(implicit contextShift: ContextShift[IO]): (Int, Int, Int) => IO[Literal] =
+      (z: Int, x: Int, y: Int) => {
+        val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
+        val bandCount = self.take(1).map(_.subsetBands.length).compile.fold(0)(_ + _).unsafeRunSync
+        val ndtile: MultibandTile = ArrayMultibandTile.empty(IntConstantNoDataCellType, bandCount, 256, 256)
+        BacksplashMosaic.filterRelevant(self)
+          .map(readWithGt(_, z, x, y))
+          .map({ maybeMBTile =>
+            val mbtile = maybeMBTile.getOrElse {
+              throw new Exception(s"really expected to find a tile at $z, $x, $y for $self")
+            }
+            Raster(mbtile, extent)
+          }).compile
+            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+            mbr1.merge(mbr2, NearestNeighbor)
+          }).map(RasterLit(_))
+    }
+  }
+
+  implicit val mosaicExtentReification: ExtentReification[BacksplashMosaic] = new ExtentReification[BacksplashMosaic] {
+    def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
+
+    def extentReification(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]) =
+      (extent: Extent, cs: CellSize) => {
+        val bands = self.take(1).map(_.subsetBands).compile.toList.map(_.flatten).unsafeRunSync
+        val ndtile: MultibandTile = ArrayMultibandTile.empty(IntConstantNoDataCellType, bands.length, 256, 256)
+        BacksplashMosaic.filterRelevant(self)
+          .map(readWithGt(_, extent, cs))
+          .map({ maybeMBTile =>
+            val mbtile = maybeMBTile.getOrElse {
+              throw new Exception(s"really expected to find a tile for $extent and $cs for $self")
+            }
+            Raster(mbtile, extent)
+          }).compile
+            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+            mbr1.merge(mbr2, NearestNeighbor)
+          }).map(RasterLit(_))
+      }
+  }
+
+  implicit val mosaicHasRasterExtents: HasRasterExtents[BacksplashMosaic] = new HasRasterExtents[BacksplashMosaic] {
+    def rasterExtents(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] = {
+      BacksplashMosaic.filterRelevant(self)
+        .flatMap({ img => fs2.Stream.eval(BacksplashImage.getRasterExtents(img.uri)) })
+        .compile
+        .toList
+        .map(_.reduceLeft({ (nel1: NEL[RasterExtent], nel2: NEL[RasterExtent])  => nel1 concatNel nel2 }))
+    }
+
+    def crs(self: BacksplashMosaic)(implicit contextShift: ContextShift[IO]): IO[CRS] = ???
+  }
+}
+
+object GtImplicits extends GtImplicits
+


### PR DESCRIPTION
This PR cleans up the implementation of implicit values so that only a single import will be required to bring in available type class instances. Additionally, it adds an alternative set of implicits which provide a JVM-only path for tile resolution