### PR TITLE
Add tool store

### DIFF
--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Implicits.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Implicits.scala
@@ -12,9 +12,11 @@ import com.azavea.maml.eval._
 import cats._
 import cats.implicits._
 import cats.data.{NonEmptyList => NEL}
+import cats.data.Validated._
 import cats.effect._
 
 import ProjectStore._
+import ToolStore._
 import ExtentReification._
 import HasRasterExtents._
 import TmsReification._
@@ -23,7 +25,65 @@ trait Implicits
     extends ToTmsReificationOps
     with ToExtentReificationOps
     with ToHasRasterExtentsOps
-    with ToProjectStoreOps {
+    with ToProjectStoreOps
+    with ToToolStoreOps {
+
+  implicit def paintableToolTmsReification[B: TmsReification] =
+    new TmsReification[PaintableTool[B]] {
+      def kind(self: PaintableTool[B]): MamlKind = MamlKind.Image
+
+      def tmsReification(self: PaintableTool[B], buffer: Int)(
+          implicit contextShfit: ContextShift[IO]
+      ): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
+        val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
+        val layerEval = LayerTms.apply(IO.pure(self.expr),
+                                       IO.pure(self.paramMap),
+                                       self.interpreter)
+        layerEval(z, x, y) map {
+          case Valid(tile) => RasterLit(Raster(self.painter(tile), extent))
+          case Invalid(e)  => throw new Exception(s"Unresolvable tile: $e")
+        }
+      }
+    }
+
+  implicit def paintableToolExtentReification[B: ExtentReification] =
+    new ExtentReification[PaintableTool[B]] {
+      def kind(self: PaintableTool[B]): MamlKind = MamlKind.Image
+      def extentReification(self: PaintableTool[B])(
+          implicit contextShift: ContextShift[IO]) = {
+        val layerEval = LayerExtent.apply(IO.pure(self.expr),
+                                          IO.pure(self.paramMap),
+                                          self.interpreter)
+        (extent: Extent, cellSize: CellSize) =>
+          layerEval(extent, cellSize) map {
+            case Valid(tile) =>
+              if (self.paint) {
+                RasterLit(Raster(self.painter(tile), extent))
+              } else {
+                RasterLit(Raster(tile, extent))
+              }
+            case Invalid(e) => throw new Exception(s"Unresolvable extent: $e")
+          }
+      }
+    }
+
+  implicit def paintableToolHasRasterExtents[B: HasRasterExtents] =
+    new HasRasterExtents[PaintableTool[B]] {
+      def rasterExtents(self: PaintableTool[B])(
+          implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] = {
+        (self.paramMap mapValues { param =>
+          param.rasterExtents
+        } reduce { (kv1, kv2) =>
+          {
+            val (_, extentsIO1) = kv1
+            val (_, extentsIO2) = kv2
+            ("ignored",
+             Applicative[IO].map2(extentsIO1, extentsIO2)((nel1, nel2) =>
+               nel1 concatNel nel2))
+          }
+        })._2
+      }
+    }
 
   implicit val mosaicTmsReification = new TmsReification[BacksplashMosaic] {
     def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
@@ -31,28 +91,29 @@ trait Implicits
     def tmsReification(self: BacksplashMosaic, buffer: Int)(
         implicit contextShift: ContextShift[IO])
       : (Int, Int, Int) => IO[Literal] =
-      (z: Int, x: Int, y: Int) => for {
-        bandCount <- self
-                       .take(1)
-                       .map(_.subsetBands.length)
-                       .compile
-                       .fold(0)(_ + _)
-        extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
-        ndtile: MultibandTile = ArrayMultibandTile.empty(
-                                  IntConstantNoDataCellType,
-                                  bandCount,
-                                  256,
-                                  256
-                                )
-        mosaic <- BacksplashMosaic
-                    .filterRelevant(self)
-                    .map(_.read(z, x, y))
-                    .collect({ case Some(mbtile) => Raster(mbtile, extent) })
-                    .compile
-                    .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
-                      mbr1.merge(mbr2, NearestNeighbor)
-                    })
-      } yield RasterLit(mosaic)
+      (z: Int, x: Int, y: Int) =>
+        for {
+          bandCount <- self
+            .take(1)
+            .map(_.subsetBands.length)
+            .compile
+            .fold(0)(_ + _)
+          extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
+          ndtile: MultibandTile = ArrayMultibandTile.empty(
+            IntConstantNoDataCellType,
+            bandCount,
+            256,
+            256
+          )
+          mosaic <- BacksplashMosaic
+            .filterRelevant(self)
+            .map(_.read(z, x, y))
+            .collect({ case Some(mbtile) => Raster(mbtile, extent) })
+            .compile
+            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+              mbr1.merge(mbr2, NearestNeighbor)
+            })
+        } yield RasterLit(mosaic)
   }
 
   implicit val mosaicExtentReification: ExtentReification[BacksplashMosaic] =
@@ -61,28 +122,29 @@ trait Implicits
 
       def extentReification(self: BacksplashMosaic)(
           implicit contextShift: ContextShift[IO]) =
-        (extent: Extent, cs: CellSize) => for {
-          bands <- self
-                     .take(1)
-                     .map(_.subsetBands)
-                     .compile
-                     .toList
-                     .map(_.flatten)
-          ndtile: MultibandTile = ArrayMultibandTile.empty(
-                                    IntConstantNoDataCellType,
-                                    bands.length,
-                                    256,
-                                    256
-                                  )
-          mosaic <- BacksplashMosaic
-                      .filterRelevant(self)
-                      .map(_.read(extent, cs))
-                      .collect({ case Some(mbtile) => Raster(mbtile, extent) })
-                      .compile
-                      .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
-                        mbr1.merge(mbr2, NearestNeighbor)
-                      })
-        } yield RasterLit(mosaic)
+        (extent: Extent, cs: CellSize) =>
+          for {
+            bands <- self
+              .take(1)
+              .map(_.subsetBands)
+              .compile
+              .toList
+              .map(_.flatten)
+            ndtile: MultibandTile = ArrayMultibandTile.empty(
+              IntConstantNoDataCellType,
+              bands.length,
+              256,
+              256
+            )
+            mosaic <- BacksplashMosaic
+              .filterRelevant(self)
+              .map(_.read(extent, cs))
+              .collect({ case Some(mbtile) => Raster(mbtile, extent) })
+              .compile
+              .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+                mbr1.merge(mbr2, NearestNeighbor)
+              })
+          } yield RasterLit(mosaic)
     }
 
   implicit val mosaicHasRasterExtents: HasRasterExtents[BacksplashMosaic] =

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -5,20 +5,10 @@ import com.azavea.maml.eval.BufferingInterpreter
 import geotrellis.raster.MultibandTile
 import geotrellis.server.{TmsReification, ExtentReification, HasRasterExtents}
 
-case class PaintableTool[Param](
+case class PaintableTool[Param: TmsReification: ExtentReification: HasRasterExtents](
     expr: Expression,
     painter: MultibandTile => MultibandTile,
     paramMap: Map[String, Param],
     interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
     paint: Boolean // whether to paint the tile or return raw values
 )
-
-object PaintableTool {
-  def safely[Param: TmsReification: ExtentReification: HasRasterExtents](
-      expr: Expression,
-      painter: MultibandTile => MultibandTile,
-      paramMap: Map[String, Param],
-      interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
-      paint: Boolean): PaintableTool[Param] =
-    PaintableTool(expr, painter, paramMap, interpreter, paint)
-}

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -1,0 +1,24 @@
+package com.rasterfoundry.backsplash
+
+import com.azavea.maml.ast.Expression
+import com.azavea.maml.eval.BufferingInterpreter
+import geotrellis.raster.MultibandTile
+import geotrellis.server.{TmsReification, ExtentReification, HasRasterExtents}
+
+case class PaintableTool[Param](
+    expr: Expression,
+    painter: MultibandTile => MultibandTile,
+    paramMap: Map[String, Param],
+    interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
+    paint: Boolean // whether to paint the tile or return raw values
+)
+
+object PaintableTool {
+  def safely[Param: TmsReification: ExtentReification: HasRasterExtents](
+      expr: Expression,
+      painter: MultibandTile => MultibandTile,
+      paramMap: Map[String, Param],
+      interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
+      paint: Boolean): PaintableTool[Param] =
+    PaintableTool(expr, painter, paramMap, interpreter, paint)
+}

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -10,44 +10,56 @@ import geotrellis.server._
 import cats.effect._
 import cats.implicits._
 
-
 sealed trait PaintableTool {
-  def tms(z: Int, x: Int, y: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
-  def extent(extent: Extent, cellsize: CellSize)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
-  def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[List[Histogram[Double]]]]
+  def tms(z: Int, x: Int, y: Int)(
+      implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
+  def extent(extent: Extent, cellsize: CellSize)(
+      implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
+  def histogram(maxCellsSampled: Int)(
+      implicit cs: ContextShift[IO]): IO[Interpreted[List[Histogram[Double]]]]
 }
 
 object PaintableTool {
-  def apply[Param: TmsReification : ExtentReification : HasRasterExtents](
-    expr: Expression,
-    painter: MultibandTile => MultibandTile,
-    paramMap: Map[String, Param],
-    interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
-    paint: Boolean // whether to paint the tile or return raw values
+  def apply[Param: TmsReification: ExtentReification: HasRasterExtents](
+      expr: Expression,
+      painter: MultibandTile => MultibandTile,
+      paramMap: Map[String, Param],
+      interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
+      paint: Boolean // whether to paint the tile or return raw values
   ): PaintableTool = new PaintableTool {
 
-    def tms(z: Int, x: Int, y: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
+    def tms(z: Int, x: Int, y: Int)(
+        implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
       val eval = LayerTms(IO.pure(expr), IO.pure(paramMap), interpreter)
       val raw = eval(z, x, y)
       if (paint) {
-        raw.map({ validated => validated.map(painter(_)) })
+        raw.map({ validated =>
+          validated.map(painter(_))
+        })
       } else {
         raw
       }
     }
 
-    def extent(extent: Extent, cellsize: CellSize)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
+    def extent(extent: Extent, cellsize: CellSize)(
+        implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
       val eval = LayerExtent(IO.pure(expr), IO.pure(paramMap), interpreter)
       val raw = eval(extent, cellsize)
       if (paint) {
-        raw.map({ validated => validated.map(painter(_)) })
+        raw.map({ validated =>
+          validated.map(painter(_))
+        })
       } else {
         raw
       }
     }
 
-    def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[List[Histogram[Double]]]] =
-      LayerHistogram(IO.pure(expr), IO.pure(paramMap), interpreter, maxCellsSampled)
+    def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO])
+      : IO[Interpreted[List[Histogram[Double]]]] =
+      LayerHistogram(IO.pure(expr),
+                     IO.pure(paramMap),
+                     interpreter,
+                     maxCellsSampled)
   }
 
 }

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -1,14 +1,53 @@
 package com.rasterfoundry.backsplash
 
 import com.azavea.maml.ast.Expression
+import com.azavea.maml.error.Interpreted
 import com.azavea.maml.eval.BufferingInterpreter
-import geotrellis.raster.MultibandTile
-import geotrellis.server.{TmsReification, ExtentReification, HasRasterExtents}
+import geotrellis.raster.histogram.Histogram
+import geotrellis.raster._
+import geotrellis.vector._
+import geotrellis.server._
+import cats.effect._
+import cats.implicits._
 
-case class PaintableTool[Param: TmsReification: ExtentReification: HasRasterExtents](
+
+sealed trait PaintableTool {
+  def tms(z: Int, x: Int, y: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
+  def extent(extent: Extent, cellsize: CellSize)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
+  def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[List[Histogram[Double]]]]
+}
+
+object PaintableTool {
+  def apply[Param: TmsReification : ExtentReification : HasRasterExtents](
     expr: Expression,
     painter: MultibandTile => MultibandTile,
     paramMap: Map[String, Param],
     interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
     paint: Boolean // whether to paint the tile or return raw values
-)
+  ): PaintableTool = new PaintableTool {
+
+    def tms(z: Int, x: Int, y: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
+      val eval = LayerTms(IO.pure(expr), IO.pure(paramMap), interpreter)
+      val raw = eval(z, x, y)
+      if (paint) {
+        raw.map({ validated => validated.map(painter(_)) })
+      } else {
+        raw
+      }
+    }
+
+    def extent(extent: Extent, cellsize: CellSize)(implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
+      val eval = LayerExtent(IO.pure(expr), IO.pure(paramMap), interpreter)
+      val raw = eval(extent, cellsize)
+      if (paint) {
+        raw.map({ validated => validated.map(painter(_)) })
+      } else {
+        raw
+      }
+    }
+
+    def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO]): IO[Interpreted[List[Histogram[Double]]]] =
+      LayerHistogram(IO.pure(expr), IO.pure(paramMap), interpreter, maxCellsSampled)
+  }
+
+}

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ToolStore.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ToolStore.scala
@@ -6,5 +6,5 @@ import simulacrum._
 import java.util.UUID
 
 @typeclass trait ToolStore[A] {
-  @op("read") def read[B](self: A, analysisId: UUID): IO[PaintableTool[B]]
+  @op("read") def read(self: A, analysisId: UUID): IO[PaintableTool]
 }

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ToolStore.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ToolStore.scala
@@ -1,0 +1,10 @@
+package com.rasterfoundry.backsplash
+
+import cats.effect.IO
+import simulacrum._
+
+import java.util.UUID
+
+@typeclass trait ToolStore[A] {
+  @op("read") def read[B](self: A, analysisId: UUID): IO[PaintableTool[B]]
+}

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -1,10 +1,6 @@
 package com.rasterfoundry
 
 import cats.effect._
-import com.azavea.maml.ast.Expression
-import geotrellis.raster.Tile
-import geotrellis.raster.render.Png
-import geotrellis.server.TmsReification
 import io.circe.KeyEncoder
 
 package object backsplash {

--- a/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -1,6 +1,10 @@
 package com.rasterfoundry
 
 import cats.effect._
+import com.azavea.maml.ast.Expression
+import geotrellis.raster.Tile
+import geotrellis.raster.render.Png
+import geotrellis.server.TmsReification
 import io.circe.KeyEncoder
 
 package object backsplash {


### PR DESCRIPTION
## Overview

This PR adds a tool store, which is a way to translate between analyses and the types of case class that backsplash-core wants to turn into analysis tiles.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ skipping, since it's not a change, but catch-up

### Notes

I considered including a dummy example in this PR, but am going to move on to integration instead

## Testing Instructions

 * compilation, tragically