### PR TITLE
Update get user roles endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Reorganized scala dependencies for package cleanliness and smaller bundles [\#4301](https://github.com/raster-foundry/raster-foundry/pull/4301)
 - If users are not requesting their own info, the returned other users' personal info are protected [\#4360](https://github.com/raster-foundry/raster-foundry/pull/4360)
+- Changed the data model of the return of `users/me/roles` endpoint [\#4375](https://github.com/raster-foundry/raster-foundry/pull/4375)
 
 ### Fixed
 

--- a/app-backend/datamodel/src/main/scala/UserGroupRole.scala
+++ b/app-backend/datamodel/src/main/scala/UserGroupRole.scala
@@ -65,7 +65,5 @@ object UserGroupRole {
                                  groupId: UUID,
                                  groupRole: GroupRole,
                                  membershipStatus: MembershipStatus,
-                                 platformName: Option[String],
-                                 organizationName: Option[String],
-                                 teamName: Option[String])
+                                 groupName: String)
 }

--- a/app-backend/datamodel/src/main/scala/UserGroupRole.scala
+++ b/app-backend/datamodel/src/main/scala/UserGroupRole.scala
@@ -55,15 +55,15 @@ object UserGroupRole {
 
   @JsonCodec
   final case class WithRelated(id: UUID,
-                                 createdAt: Timestamp,
-                                 createdBy: String,
-                                 modifiedAt: Timestamp,
-                                 modifiedBy: String,
-                                 isActive: Boolean,
-                                 userId: String,
-                                 groupType: GroupType,
-                                 groupId: UUID,
-                                 groupRole: GroupRole,
-                                 membershipStatus: MembershipStatus,
-                                 groupName: String)
+                               createdAt: Timestamp,
+                               createdBy: String,
+                               modifiedAt: Timestamp,
+                               modifiedBy: String,
+                               isActive: Boolean,
+                               userId: String,
+                               groupType: GroupType,
+                               groupId: UUID,
+                               groupRole: GroupRole,
+                               membershipStatus: MembershipStatus,
+                               groupName: String)
 }

--- a/app-backend/db/src/main/scala/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/UserGroupRoleDao.scala
@@ -189,7 +189,12 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
   def listByUserWithRelated(
       user: User): ConnectionIO[List[UserGroupRole.WithRelated]] = {
     fr"""
-    SELECT ugr.*, p.name as platform_name, o.name as organization_name, t.name as team_name
+    SELECT
+    ugr.*,
+    CASE WHEN ugr.group_type = 'PLATFORM' THEN p.name
+         WHEN ugr.group_type = 'ORGANIZATION' THEN o.name
+         WHEN ugr.group_type = 'TEAM' THEN t.name
+    END AS group_name
     FROM user_group_roles as ugr
     LEFT JOIN organizations AS o ON o.id = ugr.group_id
     LEFT JOIN platforms AS p ON p.id = ugr.group_id

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -705,14 +705,9 @@ class UserGroupRoleDaoSpec
             .use(t => getUgrWithNameIO.transact(t))
             .unsafeRunSync
 
-          val groupNames = ugrWithName.map{ ugr =>
-            (ugr.platformName.getOrElse(None), ugr.organizationName.getOrElse(None), ugr.teamName.getOrElse(None))
-          }
-          val realGroupNames = List(
-            (dbPlat.name, None, None),
-            (None, dbOrg.name, None),
-            (None, None, dbTeam.name)
-          )
+          val groupNames = ugrWithName.map(_.groupName)
+
+          val realGroupNames = List(dbPlat.name, dbOrg.name, dbTeam.name)
 
           assert(
             realGroupNames.diff(groupNames).length == 0,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -670,14 +670,18 @@ class UserGroupRoleDaoSpec
          teamCreate: Team.Create,
          ugrCreatePlat: UserGroupRole.Create,
          ugrCreateOrg: UserGroupRole.Create,
-         ugrCreateTeam: UserGroupRole.Create) => {
+         ugrCreateTeam: UserGroupRole.Create) =>
+          {
             val getUgrWithNameIO = for {
-              userOrgPlat <- insertUserOrgPlatform(userCreate, orgCreate,platform, true)
+              userOrgPlat <- insertUserOrgPlatform(userCreate,
+                                                   orgCreate,
+                                                   platform,
+                                                   true)
               (dbUser, dbOrg, dbPlat) = userOrgPlat
               dbTeam <- TeamDao.create(
                 teamCreate
-                .copy(organizationId = dbOrg.id)
-                .toTeam(dbUser))
+                  .copy(organizationId = dbOrg.id)
+                  .toTeam(dbUser))
               _ <- UserGroupRoleDao.create(
                 UserGroupRole
                   .Create(
@@ -687,7 +691,7 @@ class UserGroupRoleDaoSpec
                     GroupRole.Member
                   )
                   .toUserGroupRole(dbUser, MembershipStatus.Approved)
-                )
+              )
               _ <- UserGroupRoleDao.create(
                 UserGroupRole
                   .Create(
@@ -697,23 +701,23 @@ class UserGroupRoleDaoSpec
                     GroupRole.Member
                   )
                   .toUserGroupRole(dbUser, MembershipStatus.Approved)
-                )
+              )
               ugrWithName <- UserGroupRoleDao.listByUserWithRelated(dbUser)
-          } yield { (ugrWithName, dbPlat, dbOrg, dbTeam) }
+            } yield { (ugrWithName, dbPlat, dbOrg, dbTeam) }
 
-          val (ugrWithName, dbPlat, dbOrg, dbTeam) = xa
-            .use(t => getUgrWithNameIO.transact(t))
-            .unsafeRunSync
+            val (ugrWithName, dbPlat, dbOrg, dbTeam) = xa
+              .use(t => getUgrWithNameIO.transact(t))
+              .unsafeRunSync
 
-          val groupNames = ugrWithName.map(_.groupName)
+            val groupNames = ugrWithName.map(_.groupName)
 
-          val realGroupNames = List(dbPlat.name, dbOrg.name, dbTeam.name)
+            val realGroupNames = List(dbPlat.name, dbOrg.name, dbTeam.name)
 
-          assert(
-            realGroupNames.diff(groupNames).length == 0,
-            "Inserted UGR group names should match inserted plat, org, and team names")
-          true
-       }
+            assert(
+              realGroupNames.diff(groupNames).length == 0,
+              "Inserted UGR group names should match inserted plat, org, and team names")
+            true
+          }
       }
     }
   }

--- a/app-frontend/src/app/components/settings/teamModal/teamModal.html
+++ b/app-frontend/src/app/components/settings/teamModal/teamModal.html
@@ -21,7 +21,7 @@
           ng-init="$ctrl.selectedOrganization = $ctrl.organizations[0]"
           ng-model="$ctrl.selectedOrganization"
           ng-change="$ctrl.onSelectOrganizationChange()"
-          ng-options="organization.organizationName for organization in $ctrl.organizations">
+          ng-options="organization.groupName for organization in $ctrl.organizations">
         </select>
       </div>
       <div class="form-group">


### PR DESCRIPTION
## Overview

This PR 
* updates the `users/me/roles` endpoint so that it returns only one `groupName` property
* updates team modal to use this new field on the frontend

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [X] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [X] Any new SQL strings have tests (property test updated)

### Note

Spec is updated in [this PR](https://github.com/raster-foundry/raster-foundry-api-spec/pull/72)

## Testing Instructions

 * `GET` to `api/users/me/roles` should return a `groupName` field
 * Property test should pass
 * Go to your team list. Click on "Create team" button. The modal should have a dropdown with organization names listed for you to specify which organization to add the team to.

Closes #4374 
