### PR TITLE
Fix logo, error handling on project share page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Restored routes missing from backsplash after reintegration into RF main [\#4382](https://github.com/raster-foundry/raster-foundry/pull/4382)
 - Restored color correction [\#4387](https://github.com/raster-foundry/raster-foundry/pull/4387)
 - Address a number of unhandled promise chains on the frontend [\#4380](https://github.com/raster-foundry/raster-foundry/pull/4380)
+- Fix logo on project share page and add error handling [/#4377](https://github.com/raster-foundry/raster-foundry/pull/4377)
 
 ### Removed
 

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -14,26 +14,34 @@ export default class ShareController {
     }
 
     $onInit() {
+        this.assetLogo = assetLogo;
         this.projectId = this.$state.params.projectid;
         this.testNoAuth = false;
         this.sceneList = [];
 
         if (this.projectId) {
-            this.loadingProject = true;
-            this.projectService.query({id: this.projectId}).then(
-                p => {
-                    this.project = p;
-                    this.fitProjectExtent();
-                    this.loadingProject = false;
-                    this.addProjectLayer();
-                },
-                () => {
-                    this.loadingProject = false;
-                    // @TODO: handle displaying an error message
-                }
-            );
+            this.loadProject();
         }
     }
+
+    loadProject() {
+        this.loadingProject = true;
+        this.projectError = false;
+        this.projectService.query({id: this.projectId}).then(
+            p => {
+                this.project = p;
+                this.loadingProject = false;
+                this.projectError = false;
+                this.fitProjectExtent();
+                this.addProjectLayer();
+            },
+            (e) => {
+                this.loadingProject = false;
+                this.projectError = e;
+            }
+        );
+    }
+
     getMap() {
         return this.mapService.getMap('share-map');
     }

--- a/app-frontend/src/app/pages/share/share.html
+++ b/app-frontend/src/app/pages/share/share.html
@@ -1,11 +1,25 @@
 <div class="navbar">
   <div class="navbar-section primary">
     <a href="#" class="brand">
-      <img ng-attr-src="{{$ctrl.logoAsset}}">
+      <img ng-attr-src="{{$ctrl.assetLogo}}" style="max-width: 50px">
     </a>
     <span class="navbar-vertical-divider"></span>
-    <nav>
+    <nav ng-show="$ctrl.project">
       <span class="navbar-text">{{$ctrl.project.name}}</span>
+    </nav>
+    <nav ng-show="$ctrl.projectError">
+      <span class="navbar-text">Error loading project.
+        <span class="icon-warning"
+              tooltip-class="rf-tooltip"
+              tooltip-side="bottom"
+              tooltips tooltip-template="{{$ctrl.projectError.data}}"></span>
+      </span>
+      <button
+          class="btn btn-ghost"
+          ng-click="$ctrl.loadProject()"
+      >
+        <span class="navbar-text">Retry</span>
+      </button>
     </nav>
   </div>
 


### PR DESCRIPTION
## Overview
Fix logo import
Add error handling and button to attempt reloading project in case of errors

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/49892191-585c9c00-fe16-11e8-8edd-ee44f3255969.png)


### Notes
I wasn't actually able to reproduce the error where the project is not zoomed to correctly after an hour of testing in firefox and chrome, so I'm just fixing these issues for now. Reading through the code, I assume that any issues loading the project due to permissions, network errors, etc will cause the map not to zoom, so this will fix silent failures.

## Testing Instructions

 * Load a project share page
* Verify that the RF logo now shows
* Edit the uuid in the navbar so it tries to load a nonexistant project
* Verify that it shows there was an error loading the project
* Verify that you can see the error message by mousing over the icon
* Open dev tools and verify that the retry button tries to reload the project

Closes #4336