### PR TITLE
Restore missing backsplash routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Used the correct field as outgoing email source in platform email settings [\#4353](https://github.com/raster-foundry/raster-foundry/pull/4353)
 - Fix deprecated use of route change listeners which caused window title to break [\#4365](https://github.com/raster-foundry/raster-foundry/pull/4365)
 - Fix project ownership filter persistance across pages [\#4376](https://github.com/raster-foundry/raster-foundry/pull/4376)
+- Restored routes missing from backsplash after reintegration into RF main [\#4382](https://github.com/raster-foundry/raster-foundry/pull/4382)
 
 ### Removed
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -4,12 +4,15 @@ import com.rasterfoundry.backsplash.Parameters._
 
 import cats.data.Validated._
 import cats.effect.{ContextShift, IO}
+import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.render.ColorRamps
+import geotrellis.raster.io.geotiff._
 import io.circe.syntax._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.circe._
+import org.http4s.util.CaseInsensitiveString
 
 import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.Implicits._
@@ -46,6 +49,40 @@ class AnalysisService[Param: ToolStore](analyses: Param)(
                `Content-Type`(MediaType.image.png))
           case Invalid(e) =>
             BadRequest(s"Unable to produce tile for $analysisId: $e")
+        }
+      } yield resp
+
+    case req @ GET -> Root / UUIDWrapper(analysisId) / "raw"
+          :? ExtentQueryParamMatcher(extent)
+          :? ZoomQueryParamMatcher(zoom)
+          :? NodeQueryParamMatcher(node) =>
+      val projectedExtent = extent.reproject(LatLng, WebMercator)
+      val respType =
+        req.headers
+          .get(CaseInsensitiveString("Accept")) match {
+          case Some(Header(_, "image/tiff")) =>
+            `Content-Type`(MediaType.image.tiff)
+          case _ => `Content-Type`(MediaType.image.png)
+        }
+      val pngType = `Content-Type`(MediaType.image.png)
+      val tiffType = `Content-Type`(MediaType.image.tiff)
+      for {
+        paintableTool <- analyses.read(analysisId, node)
+        tileValidated <- paintableTool.extent(
+          projectedExtent,
+          BacksplashImage.tmsLevels(zoom).cellSize)
+        // TODO: restore render def coloring
+        resp <- tileValidated match {
+          case Valid(tile) =>
+            if (respType == tiffType) {
+              Ok(
+                SinglebandGeoTiff(tile.band(0), projectedExtent, WebMercator).toByteArray,
+                tiffType)
+            } else {
+              Ok(tile.band(0).renderPng(ColorRamps.Viridis).bytes,
+                 `Content-Type`(MediaType.image.png))
+            }
+          case Invalid(e) => BadRequest(s"Could not produce extent: $e")
         }
       } yield resp
   }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
@@ -1,0 +1,20 @@
+package com.rasterfoundry.backsplash.server
+
+import cats.data.OptionT
+import cats.effect.Effect
+import io.circe.Json
+import org.http4s._
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
+
+class HealthcheckService[F[_]: Effect] extends Http4sDsl[F] {
+  val routes: HttpRoutes[F] = {
+    HttpRoutes.of {
+      case GET -> Root => {
+        Ok(
+          Json.obj("message" -> Json.fromString("Healthy"),
+                   "reason" -> Json.fromString("A-ok")))
+      }
+    }
+  }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -48,7 +48,8 @@ object Server extends IOApp {
   val httpApp =
     Router(
       "/" -> GZip(AutoSlash(withCORS(mosaicService))),
-      "/tools" -> GZip(AutoSlash(withCORS(analysisService)))
+      "/tools" -> GZip(AutoSlash(withCORS(analysisService))),
+      "/healthcheck" -> AutoSlash(new HealthcheckService[IO]().routes)
     )
 
   def stream =

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
     volumes:
       - $HOME/.sbt:/root/.sbt
       - ./app-backend/:/opt/raster-foundry/app-backend/
-      - $HOME/.coursier-gt-server:/root/.coursier
+      - $HOME/.coursier:/root/.coursier
       - ./.bintray:/root/.bintray
       - $HOME/.aws:/root/.aws:ro
       - $HOME/.ivy2:/root/.ivy2


### PR DESCRIPTION
## Overview

This PR restores the healthcheck and analysis export routes that were removed by accident during reintegration.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * find a nice bbox to do an analysis quick export
 * export an analysis with png or geotiff encoding for that bbox with a zoom (the only thing that shouldn't work is painting anything other than viridis)
 * ping the healthcheck endpoint