### PR TITLE
Add timeout middleware to services in backsplash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reorganized scala dependencies for package cleanliness and smaller bundles [\#4301](https://github.com/raster-foundry/raster-foundry/pull/4301)
 - If users are not requesting their own info, the returned other users' personal info are protected [\#4360](https://github.com/raster-foundry/raster-foundry/pull/4360)
 - Changed the data model of the return of `users/me/roles` endpoint [\#4375](https://github.com/raster-foundry/raster-foundry/pull/4375)
+- Added more aggressive timeout to backsplash for improved thread recovery [\#4383](https://github.com/raster-foundry/raster-foundry/pull/4383)
 
 ### Fixed
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -58,8 +58,8 @@ object Server extends IOApp {
 
   val httpApp =
     Router(
-      "/" -> GZip(AutoSlash(withCORS(mosaicService))),
-      "/tools" -> GZip(AutoSlash(withCORS(analysisService))),
+      "/" -> GZip(AutoSlash(withCORS(withTimeout(mosaicService)))),
+      "/tools" -> GZip(AutoSlash(withCORS(withTimeout(analysisService)))),
       "/healthcheck" -> AutoSlash(new HealthcheckService[IO]().routes)
     )
 


### PR DESCRIPTION
## Overview

This PR adds a timeout middleware that sets a 15-second timeout to services in backsplash.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions

One way to test this PR:
 * Go to `MosaicService` or `AnalysisService`
 * Import `scala.concurrent.duration._`, `cats.effect.Timer`
 * Add a `timer: Timer[IO]` implicit parameter
 * Append below case to the routes:
```scala
case GET -> Root/"sleep"/IntVar(duration) =>
  IO.sleep(duration.seconds) flatMap {_ => Ok("message")}
```
 * `GET` to `<your-root-here>/sleep/3` will give you `message`
 * `GET` to `<your-root-here>/sleep/17` will give you a gateway timeout
