### PR TITLE
Restore color correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Fix deprecated use of route change listeners which caused window title to break [\#4365](https://github.com/raster-foundry/raster-foundry/pull/4365)
 - Fix project ownership filter persistance across pages [\#4376](https://github.com/raster-foundry/raster-foundry/pull/4376)
 - Restored routes missing from backsplash after reintegration into RF main [\#4382](https://github.com/raster-foundry/raster-foundry/pull/4382)
+- Restored color correction [\#4387](https://github.com/raster-foundry/raster-foundry/pull/4387)
 
 ### Removed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -1,8 +1,10 @@
 package com.rasterfoundry.backsplash
 
-import geotrellis.vector._
-import geotrellis.raster._
+import com.rasterfoundry.backsplash.color._
+import geotrellis.vector.{io => _, _}
+import geotrellis.raster.{io => _, _}
 import geotrellis.vector.io.readWktOrWkb
+import geotrellis.raster.histogram._
 import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.spark.SpatialKey
 import geotrellis.proj4.{WebMercator, LatLng}
@@ -13,12 +15,16 @@ import geotrellis.contrib.vlm.gdal._
 
 import cats.data.{NonEmptyList => NEL}
 import cats.effect.IO
+import io.circe.syntax._
 
 import java.util.UUID
 
-case class BacksplashImage(uri: String,
-                           footprint: MultiPolygon,
-                           subsetBands: List[Int]) {
+case class BacksplashImage(
+    uri: String,
+    footprint: MultiPolygon,
+    subsetBands: List[Int],
+    corrections: ColorCorrect.Params,
+    singleBandOptions: Option[SingleBandOptions.Params]) {
   def read(extent: Extent, cs: CellSize): Option[MultibandTile] = {
     val rs = BacksplashImage.getRasterSource(uri)
     val destinationExtent = extent.reproject(rs.crs, WebMercator)
@@ -36,6 +42,23 @@ case class BacksplashImage(uri: String,
       .tileToLayout(layoutDefinition, NearestNeighbor)
       .read(SpatialKey(x, y), subsetBands)
   }
+
+  def colorCorrect(z: Int,
+                   x: Int,
+                   y: Int,
+                   hists: Seq[Histogram[Double]],
+                   nodataValue: Option[Double]): Option[MultibandTile] =
+    read(z, x, y) map {
+      corrections.colorCorrect(_, hists, nodataValue)
+    }
+
+  def colorCorrect(extent: Extent,
+                   cs: CellSize,
+                   hists: Seq[Histogram[Double]],
+                   nodataValue: Option[Double]) =
+    read(extent, cs) map {
+      corrections.colorCorrect(_, hists, nodataValue)
+    }
 }
 
 object BacksplashImage extends RasterSourceUtils {
@@ -48,7 +71,11 @@ object BacksplashImage extends RasterSourceUtils {
     readWktOrWkb(wkt)
       .as[Polygon]
       .map { poly =>
-        BacksplashImage(uri, MultiPolygon(poly), subsetBands)
+        BacksplashImage(uri,
+                        MultiPolygon(poly),
+                        subsetBands,
+                        ColorCorrect.paramsFromBandSpecOnly(0, 1, 2),
+                        None)
       }
       .getOrElse(throw new Exception("Provided WKT/WKB must be a multipolygon"))
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -42,4 +42,11 @@ object BacksplashMosaic {
       }
     })
   }
+
+  def layerHistogram(mosaic: BacksplashMosaic)(
+      implicit hasRasterExtents: HasRasterExtents[BacksplashMosaic],
+      extentReification: ExtentReification[BacksplashMosaic],
+      cs: ContextShift[IO]) = {
+    LayerHistogram.identity(mosaic, 4000)
+  }
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -1,5 +1,8 @@
 package com.rasterfoundry.backsplash
 
+import com.rasterfoundry.backsplash.color._
+import com.rasterfoundry.backsplash.error._
+
 import geotrellis.vector._
 import geotrellis.raster._
 import geotrellis.raster.resample.NearestNeighbor
@@ -47,38 +50,97 @@ class MosaicImplicits(mtr: MetricsRegistrator)
             .take(1)
             .map(_.subsetBands.length)
             .compile
-            .fold(0)(_ + _)
+            .toList
+            .map(_.fold(0)(_ + _))
+          filtered = BacksplashMosaic.filterRelevant(self)
+          // This is a stop gap -- we know we don't want to fetch the histogram from the raw data
+          // all the time, and that actually it lives in the database or a cache or whatever. A
+          // HistogramStore[Param] would solve this problem, but we're putting that off because there
+          // are other things to do to get back to parity to start the work we actually care about,
+          // which is making things fast (and this will be a layup for "hmm I wonder what could be faster")
+          layerHist <- BacksplashMosaic.layerHistogram(self) map {
+            case Valid(hists) => hists
+            case Invalid(e) =>
+              throw MetadataException(s"Could not resolve histograms: $e")
+          }
           extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
+          // for single band imagery, after color correction we have RGBA, so
+          // the empty tile needs to be four band as well
           ndtile: MultibandTile = ArrayMultibandTile.empty(
             IntConstantNoDataCellType,
-            bandCount,
+            if (bandCount == 1) 4 else bandCount,
             256,
             256
           )
-          mosaic = BacksplashMosaic
-            .filterRelevant(self)
-            .map({ relevant =>
-              val time = readSceneTmsTimer.time()
-              val img = relevant.read(z, x, y)
-              time.stop()
-              img
-            })
-            .collect({ case Some(mbtile) => Raster(mbtile, extent) })
-            .compile
-            .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
-              mbr1.merge(mbr2, NearestNeighbor)
-            })
+          mosaic = if (bandCount == 3) {
+            filtered
+              .map({ relevant =>
+                val time = readSceneTmsTimer.time()
+                val img = relevant.colorCorrect(z, x, y, layerHist, None)
+                time.stop()
+                img
+              })
+              .collect({ case Some(mbtile) => Raster(mbtile, extent) })
+              .compile
+              .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+                mbr1.merge(mbr2, NearestNeighbor)
+              })
+          } else {
+            // Assume that we're in a single band case. It isn't obvious what it would
+            // mean if the band count weren't 3 or 1, so just make the assumption that we
+            // wouldn't do that to ourselves and don't handle the remainder
+            BacksplashMosaic
+              .filterRelevant(self)
+              .map({ relevant =>
+                val time = readSceneTmsTimer.time()
+                val img = relevant.read(z, x, y) map {
+                  ColorRampMosaic.colorTile(
+                    _,
+                    layerHist,
+                    relevant.singleBandOptions getOrElse {
+                      throw SingleBandOptionsException(
+                        "Must specify single band options when requesting single band visualization.")
+                    }
+                  )
+                }
+                time.stop()
+                println(
+                  s"Img corrected, number of bands: ${img map { _.bands.length }}")
+                img
+              })
+              .collect({ case Some(mbtile) => Raster(mbtile, extent) })
+              .compile
+              .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+                mbr1.merge(mbr2, NearestNeighbor)
+              })
+          }
           timedMosaic <- mtr.timedIO(mosaic, readMosaicTimer)
-        } yield RasterLit(timedMosaic)
+        } yield {
+          println(
+            s"Number of bands in timed mosaic: ${timedMosaic.tile.bands.length}")
+          RasterLit(timedMosaic)
+      }
   }
 
-  implicit val mosaicExtentReification: ExtentReification[BacksplashMosaic] =
+  // We need to be able to pass information about whether scenes should paint themselves while
+  // we're working through the stream from the route into the extent reification. The solution
+  // we (Nathan Zimmerman and I) came up with that is the least painful is two implicits, choosing
+  // which one to use based on the information we have in the route. That solution can go away if:
+  //
+  // 1. color correction becomes a local op in MAML and we don't have to care about it in RF anymore
+  // 2. all color correction options (single and multiband) move onto backsplash images and
+  //    BacksplashImage gets a paint attribute telling it whether to apply color correction
+  //
+  // Neither of those changes really fits in the scope of backsplash performance work, so we're doing
+  // this for now instead.
+  val paintedMosaicExtentReification: ExtentReification[BacksplashMosaic] =
     new ExtentReification[BacksplashMosaic] {
       def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
 
       def extentReification(self: BacksplashMosaic)(
           implicit contextShift: ContextShift[IO]) =
-        (extent: Extent, cs: CellSize) =>
+        (extent: Extent, cs: CellSize) => {
+          val filtered = BacksplashMosaic.filterRelevant(self)
           for {
             bands <- self
               .take(1)
@@ -89,6 +151,72 @@ class MosaicImplicits(mtr: MetricsRegistrator)
             ndtile: MultibandTile = ArrayMultibandTile.empty(
               IntConstantNoDataCellType,
               bands.length,
+              256,
+              256
+            )
+            layerHist <- BacksplashMosaic.layerHistogram(filtered) map {
+              case Valid(hists) => hists
+              case Invalid(e) =>
+                throw MetadataException(s"Could not resolve histograms: $e")
+            }
+            mosaic = if (bands.length == 3) {
+              filtered
+                .map({ relevant =>
+                  val time = readSceneExtentTimer.time()
+                  val img = relevant.colorCorrect(extent, cs, layerHist, None)
+                  time.stop()
+                  img
+                })
+                .collect({ case Some(mbtile) => Raster(mbtile, extent) })
+                .compile
+                .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+                  mbr1.merge(mbr2, NearestNeighbor)
+                })
+            } else {
+              filtered
+                .map({ relevant =>
+                  val time = readSceneExtentTimer.time()
+                  val img = relevant.read(extent, cs) map {
+                    ColorRampMosaic
+                      .colorTile(
+                        _,
+                        layerHist,
+                        relevant.singleBandOptions getOrElse {
+                          throw SingleBandOptionsException(
+                            "Must specify single band options when requesting single band visualization.")
+                        }
+                      )
+                  }
+                  time.stop()
+                  img
+                })
+                .collect({ case Some(mbtile) => Raster(mbtile, extent) })
+                .compile
+                .fold(Raster(ndtile, extent))({ (mbr1, mbr2) =>
+                  mbr1.merge(mbr2, NearestNeighbor)
+                })
+            }
+            timedMosaic <- mtr.timedIO(mosaic, readMosaicTimer)
+          } yield RasterLit(timedMosaic)
+        }
+    }
+
+  implicit val rawMosaicExtentReification: ExtentReification[BacksplashMosaic] =
+    new ExtentReification[BacksplashMosaic] {
+      def kind(self: BacksplashMosaic): MamlKind = MamlKind.Image
+
+      def extentReification(self: BacksplashMosaic)(
+          implicit contextShift: ContextShift[IO]) =
+        (extent: Extent, cs: CellSize) => {
+          for {
+            bands <- self
+              .take(1)
+              .map(_.subsetBands.length)
+              .compile
+              .fold(0)(_ + _)
+            ndtile: MultibandTile = ArrayMultibandTile.empty(
+              IntConstantNoDataCellType,
+              bands,
               256,
               256
             )
@@ -107,6 +235,7 @@ class MosaicImplicits(mtr: MetricsRegistrator)
               })
             timedMosaic <- mtr.timedIO(mosaic, readMosaicTimer)
           } yield RasterLit(timedMosaic)
+        }
     }
 
   implicit val mosaicHasRasterExtents: HasRasterExtents[BacksplashMosaic] =

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -104,8 +104,6 @@ class MosaicImplicits(mtr: MetricsRegistrator)
                   )
                 }
                 time.stop()
-                println(
-                  s"Img corrected, number of bands: ${img map { _.bands.length }}")
                 img
               })
               .collect({ case Some(mbtile) => Raster(mbtile, extent) })
@@ -116,8 +114,6 @@ class MosaicImplicits(mtr: MetricsRegistrator)
           }
           timedMosaic <- mtr.timedIO(mosaic, readMosaicTimer)
         } yield {
-          println(
-            s"Number of bands in timed mosaic: ${timedMosaic.tile.bands.length}")
           RasterLit(timedMosaic)
       }
   }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -1,5 +1,8 @@
 package com.rasterfoundry.backsplash
 
+import com.rasterfoundry.backsplash.color._
+import com.rasterfoundry.backsplash.color.{Implicits => ColorImplicits}
+
 import com.azavea.maml.ast.Expression
 import com.azavea.maml.error.Interpreted
 import com.azavea.maml.eval.BufferingInterpreter
@@ -10,20 +13,22 @@ import geotrellis.server._
 import cats.effect._
 import cats.implicits._
 
-sealed trait PaintableTool {
+sealed trait PaintableTool extends ColorImplicits {
   def tms(z: Int, x: Int, y: Int)(
       implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
   def extent(extent: Extent, cellsize: CellSize)(
       implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
   def histogram(maxCellsSampled: Int)(
       implicit cs: ContextShift[IO]): IO[Interpreted[List[Histogram[Double]]]]
+
+  def renderDefinition: Option[RenderDefinition]
 }
 
 object PaintableTool {
   def apply[Param: TmsReification: ExtentReification: HasRasterExtents](
       expr: Expression,
-      painter: MultibandTile => MultibandTile,
       paramMap: Map[String, Param],
+      renderDef: Option[RenderDefinition],
       interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
       paint: Boolean = true // whether to paint the tile or return raw values
   ): PaintableTool = new PaintableTool {
@@ -31,27 +36,13 @@ object PaintableTool {
     def tms(z: Int, x: Int, y: Int)(
         implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
       val eval = LayerTms(IO.pure(expr), IO.pure(paramMap), interpreter)
-      val raw = eval(z, x, y)
-      if (paint) {
-        raw.map({ validated =>
-          validated.map(painter(_))
-        })
-      } else {
-        raw
-      }
+      eval(z, x, y)
     }
 
     def extent(extent: Extent, cellsize: CellSize)(
         implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
       val eval = LayerExtent(IO.pure(expr), IO.pure(paramMap), interpreter)
-      val raw = eval(extent, cellsize)
-      if (paint) {
-        raw.map({ validated =>
-          validated.map(painter(_))
-        })
-      } else {
-        raw
-      }
+      eval(extent, cellsize)
     }
 
     def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO])
@@ -60,6 +51,7 @@ object PaintableTool {
                      IO.pure(paramMap),
                      interpreter,
                      maxCellsSampled)
-  }
 
+    def renderDefinition: Option[RenderDefinition] = renderDef
+  }
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/BandDataType.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/BandDataType.scala
@@ -1,0 +1,28 @@
+package com.rasterfoundry.backsplash.color
+
+import io.circe._
+import cats.syntax.either._
+
+sealed abstract class BandDataType(val repr: String) {
+  override def toString = repr
+}
+
+object BandDataType {
+  case object Diverging extends BandDataType("DIVERGING")
+  case object Sequential extends BandDataType("SEQUENTIAL")
+  case object Categorical extends BandDataType("CATEGORICAL")
+
+  def fromString(s: String): BandDataType = s.toUpperCase match {
+    case "DIVERGING"   => Diverging
+    case "SEQUENTIAL"  => Sequential
+    case "CATEGORICAL" => Categorical
+  }
+
+  implicit val bandDataTypeEncoder: Encoder[BandDataType] =
+    Encoder.encodeString.contramap[BandDataType](_.toString)
+
+  implicit val bandDataTypeDecoder: Decoder[BandDataType] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(fromString(str)).leftMap(t => "BandDataType")
+    }
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorCorrect.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorCorrect.scala
@@ -1,0 +1,332 @@
+package com.rasterfoundry.backsplash.color
+
+import io.circe.generic.JsonCodec
+import geotrellis.raster._
+import geotrellis.raster.equalization.HistogramEqualization
+import geotrellis.raster.histogram.Histogram
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.commons.math3.util.FastMath
+import spire.syntax.cfor._
+
+/**
+  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
+  * We can consider these functions usages in case of real performance issues caused by a long color correction.
+  */
+object ColorCorrect extends LazyLogging {
+  import functions.SaturationAdjust._
+  import functions.SigmoidalContrast._
+
+  final case class LayerClipping(redMin: Int,
+                                 redMax: Int,
+                                 greenMin: Int,
+                                 greenMax: Int,
+                                 blueMin: Int,
+                                 blueMax: Int)
+  sealed trait ClipValue
+  final case class ClipBounds(min: Int, max: Int) extends ClipValue
+  final case class MaybeClipBounds(maybeMin: Option[Int], maybeMax: Option[Int])
+      extends ClipValue
+  final case class ClippingParams(band: Int, bounds: ClipValue)
+
+  @JsonCodec
+  final case class Params(redBand: Int,
+                          greenBand: Int,
+                          blueBand: Int,
+                          gamma: BandGamma,
+                          bandClipping: PerBandClipping,
+                          tileClipping: MultiBandClipping,
+                          sigmoidalContrast: SigmoidalContrast,
+                          saturation: Saturation) {
+    def getGamma: Map[Int, Option[Double]] = Map(
+      0 -> (if (gamma.enabled) gamma.redGamma else None),
+      1 -> (if (gamma.enabled) gamma.greenGamma else None),
+      2 -> (if (gamma.enabled) gamma.blueGamma else None)
+    )
+
+    @SuppressWarnings(Array("CollectionIndexOnNonIndexedSeq"))
+    def reorderBands(
+        tile: MultibandTile,
+        hist: Seq[Histogram[Double]]
+    ): (MultibandTile, Array[Histogram[Double]]) = {
+      logger.info(
+        s"RedBand: ${redBand}, GreenBand: ${greenBand}, BlueBand: ${blueBand}")
+      logger.debug(s"RedHist: ${hist(redBand).statistics()}\n GreenHist: ${hist(
+        greenBand).statistics()}\n BlueHist: ${hist(blueBand).statistics()}")
+      (tile.subsetBands(redBand, greenBand, blueBand),
+       Array(hist(redBand), hist(greenBand), hist(blueBand)))
+    }
+
+    def colorCorrect(tile: MultibandTile,
+                     hist: Seq[Histogram[Double]],
+                     nodataValue: Option[Double]): MultibandTile = {
+      val (rgbTile, rgbHist) = reorderBands(tile, hist)
+      ColorCorrect(rgbTile, rgbHist, this, nodataValue)
+    }
+
+    def withBands(red: Int, green: Int, blue: Int) =
+      this.copy(redBand = red, greenBand = green, blueBand = blue)
+  }
+
+  @inline def normalizeAndClampAndGammaCorrectPerPixel(
+      z: Int,
+      oldMin: Int,
+      oldMax: Int,
+      newMin: Int,
+      newMax: Int,
+      gammaOpt: Option[Double]
+  ): Int = {
+    if (isData(z)) {
+      val dNew = newMax - newMin
+      val dOld = oldMax - oldMin
+
+      // When dOld is nothing (normalization is meaningless in this context), we still need to clamp
+      if (dOld == 0) {
+        val v = {
+          if (z > newMax) newMax
+          else if (z < newMin) newMin
+          else z
+        }
+
+        gammaOpt match {
+          case None => v
+          case Some(gamma) =>
+            clampColor {
+              val gammaCorrection = 1 / gamma
+              (255 * FastMath.pow(v / 255.0, gammaCorrection)).toInt
+            }
+        }
+      } else {
+        val v = {
+          val scaled = (((z - oldMin) * dNew) / dOld) + newMin
+
+          if (scaled > newMax) newMax
+          else if (scaled < newMin) newMin
+          else scaled
+        }
+
+        gammaOpt match {
+          case None => v
+          case Some(gamma) =>
+            clampColor {
+              val gammaCorrection = 1 / gamma
+              (255 * FastMath.pow(v / 255.0, gammaCorrection)).toInt
+            }
+        }
+      }
+    } else z
+  }
+
+  val rgbBand: (Option[Int], Option[Int], Int) => Some[Int] =
+    (specificBand: Option[Int], allBands: Option[Int], tileDefault: Int) =>
+      specificBand.fold(allBands)(Some(_)).fold(Some(tileDefault))(x => Some(x))
+
+  def complexColorCorrect(rgbTile: MultibandTile, saturation: Saturation)(
+      layerNormalizeArgs: Map[Int, ClipBounds],
+      gammas: Map[Int, Option[Double]]
+  )(sigmoidalContrast: SigmoidalContrast)(
+      colorCorrectArgs: Map[Int, MaybeClipBounds],
+      tileClipping: MultiBandClipping,
+      nodataValue: Option[Double]
+  ): MultibandTile = {
+    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
+    val (gr, gg, gb) = (gammas(0), gammas(1), gammas(2))
+    val (nred, ngreen, nblue) = (
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
+    )
+
+    val ClipBounds(rmin, rmax) = layerNormalizeArgs(0)
+    val ClipBounds(gmin, gmax) = layerNormalizeArgs(1)
+    val ClipBounds(bmin, bmax) = layerNormalizeArgs(2)
+
+    val tileMin = nodataValue match {
+      case Some(0) => 1
+      case _       => 0
+    }
+    val (rclipMin, rclipMax, rnewMin, rnewMax) = (rmin, rmax, tileMin, 255)
+    val (gclipMin, gclipMax, gnewMin, gnewMax) = (gmin, gmax, tileMin, 255)
+    val (bclipMin, bclipMax, bnewMin, bnewMax) = (bmin, bmax, tileMin, 255)
+
+    val sigmoidal: Double => Double =
+      (
+        sigmoidalContrast.enabled,
+        sigmoidalContrast.alpha,
+        sigmoidalContrast.beta
+      ) match {
+        case (true, Some(a), Some(b)) => localTransform(rgbTile.cellType, a, b)
+        case _                        => identity
+      }
+
+    val (clipr, clipg, clipb): (Int => Int, Int => Int, Int => Int) = {
+      val MaybeClipBounds(mrmin, mrmax) = colorCorrectArgs(0)
+      val MaybeClipBounds(mgmin, mgmax) = colorCorrectArgs(1)
+      val MaybeClipBounds(mbmin, mbmax) = colorCorrectArgs(2)
+
+      val (mrclipMin, mrclipMax) = (
+        rgbBand(mrmin, tileClipping.min, 0).get,
+        rgbBand(mrmax, tileClipping.max, 255).get
+      )
+      val (mgclipMin, mgclipMax) = (
+        rgbBand(mgmin, tileClipping.min, 0).get,
+        rgbBand(mgmax, tileClipping.max, 255).get
+      )
+      val (mbclipMin, mbclipMax) = (
+        rgbBand(mbmin, tileClipping.min, 0).get,
+        rgbBand(mbmax, tileClipping.max, 255).get
+      )
+
+      @inline def clipBands(z: Int, min: Int, max: Int): Int = {
+        if (isData(z) && z > max) 255
+        else if (isData(z) && z < min) 0
+        else z
+      }
+
+      (
+        clipBands(_, mrclipMin, mrclipMax),
+        clipBands(_, mgclipMin, mgclipMax),
+        clipBands(_, mbclipMin, mbclipMax)
+      )
+    }
+
+    logger.debug(
+      s"Red (Clip Min: ${rclipMin}, Max: ${rclipMax}) (New Min: ${rnewMin}, ${rnewMax})")
+
+    /** In this case for some reason with this func wrap it works faster ¯\_(ツ)_/¯ (it was micro benchmarked) */
+    lazyWrapper {
+      cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
+        cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
+          val (r, g, b) =
+            (
+              ColorCorrect.normalizeAndClampAndGammaCorrectPerPixel(
+                red.get(col, row),
+                rclipMin,
+                rclipMax,
+                rnewMin,
+                rnewMax,
+                gr
+              ),
+              ColorCorrect.normalizeAndClampAndGammaCorrectPerPixel(
+                green.get(col, row),
+                gclipMin,
+                gclipMax,
+                gnewMin,
+                gnewMax,
+                gg
+              ),
+              ColorCorrect.normalizeAndClampAndGammaCorrectPerPixel(
+                blue.get(col, row),
+                bclipMin,
+                bclipMax,
+                bnewMin,
+                bnewMax,
+                gb
+              )
+            )
+
+          val (nr, ng, nb) = (saturation.enabled, saturation.saturation) match {
+            case (true, Some(cf)) =>
+              val (hue, chroma, luma) = rgbToHcluma(r, g, b)
+              val newChroma = scaleChroma(chroma, cf)
+              val (nr, ng, nb) = hclumaToRgb(hue, newChroma, luma)
+              (nr, ng, nb)
+
+            case _ => (r, g, b)
+          }
+
+          nred.set(col, row, clipr(sigmoidal(nr).toInt))
+          ngreen.set(col, row, clipg(sigmoidal(ng).toInt))
+          nblue.set(col, row, clipb(sigmoidal(nb).toInt))
+        }
+      }
+    }
+
+    MultibandTile(nred, ngreen, nblue)
+  }
+
+  def apply(rgbTile: MultibandTile,
+            rgbHist: Array[Histogram[Double]],
+            params: Params,
+            nodataValue: Option[Double]): MultibandTile = {
+    var _rgbTile = rgbTile
+    var _rgbHist = rgbHist
+    val gammas = params.getGamma
+
+    val layerRgbClipping = {
+      val range = 1 until 255
+      var isCorrected = true
+      val iMaxMin: Array[(Int, Int)] = Array.ofDim(3)
+      cfor(0)(_ < _rgbHist.length, _ + 1) { index =>
+        val hst = _rgbHist(index)
+        val imin = hst.minValue().map(_.toInt).getOrElse(0)
+        val imax = hst.maxValue().map(_.toInt).getOrElse(255)
+        logger.debug(s"Histogram Min/Max: ${imin}/${imax}")
+        iMaxMin(index) = (imin, imax)
+        isCorrected = {
+          if (range.contains(imin) && range.contains(imax)) true
+          else false
+        }
+      }
+
+      if (!isCorrected) {
+        val (rmin, rmax) = iMaxMin(0)
+        val (gmin, gmax) = iMaxMin(1)
+        val (bmin, bmax) = iMaxMin(2)
+        LayerClipping(rmin, rmax, gmin, gmax, bmin, bmax)
+      } else LayerClipping(0, 255, 0, 255, 0, 255)
+    }
+
+    val layerNormalizeArgs: Map[Int, ClipBounds] = Map(
+      0 -> ClipBounds(layerRgbClipping.redMin, layerRgbClipping.redMax),
+      1 -> ClipBounds(layerRgbClipping.greenMin, layerRgbClipping.greenMax),
+      2 -> ClipBounds(layerRgbClipping.blueMin, layerRgbClipping.blueMax)
+    )
+
+    val colorCorrectArgs: Map[Int, MaybeClipBounds] = Map(
+      0 -> MaybeClipBounds(
+        params.bandClipping.redMin,
+        params.bandClipping.redMax
+      ),
+      1 -> MaybeClipBounds(
+        params.bandClipping.greenMin,
+        params.bandClipping.greenMax
+      ),
+      2 -> MaybeClipBounds(
+        params.bandClipping.blueMin,
+        params.bandClipping.blueMax
+      )
+    )
+
+    logger.debug(s"ColorCorrectArgs: ${colorCorrectArgs}")
+    logger.debug(s"Layer Normalize Args: ${layerNormalizeArgs}")
+    complexColorCorrect(_rgbTile, params.saturation)(
+      layerNormalizeArgs,
+      gammas
+    )(params.sigmoidalContrast)(colorCorrectArgs,
+                                params.tileClipping,
+                                nodataValue)
+  }
+
+  @inline def clampColor(z: Int): Int = {
+    if (z < 0) 0
+    else if (z > 255) 255
+    else z
+  }
+
+  private def lazyWrapper[T](f: => T): T = f
+
+  def paramsFromBandSpecOnly(
+      redBand: Int,
+      greenBand: Int,
+      blueBand: Int
+  ): Params = Params(
+    redBand,
+    greenBand,
+    blueBand,
+    BandGamma(false, None, None, None),
+    PerBandClipping(false, None, None, None, None, None, None),
+    MultiBandClipping(false, None, None),
+    SigmoidalContrast(false, None, None),
+    Saturation(false, None)
+  )
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
@@ -1,0 +1,140 @@
+package com.rasterfoundry.backsplash.color
+
+import com.rasterfoundry.backsplash.error._
+
+import com.typesafe.scalalogging.LazyLogging
+import geotrellis.raster._
+import geotrellis.raster.histogram._
+import geotrellis.raster.render.{ColorMap, ColorRamp, _}
+
+object ColorRampMosaic extends LazyLogging {
+
+  def parseColor(color: String): Int = {
+    Integer.parseUnsignedInt(
+      color
+        .replaceFirst("#", "")
+        .replaceAll("\"", "")
+        .reverse
+        .padTo(6, "0")
+        .reverse
+        .padTo(8, "f")
+        .mkString,
+      16
+    )
+  }
+
+  @SuppressWarnings(Array("CatchThrowable", "TraversableLast"))
+  def colorMapFromMap(colorMap: Map[String, String]): ColorMap = {
+    var fallbackColor: Option[Int] = None
+    var noDataColor: Option[Int] = None
+    val (breaks, colors) = colorMap.toVector
+      .flatMap {
+        case (break, color) =>
+          try {
+            break match {
+              case "NODATA" =>
+                noDataColor = Some(parseColor(color))
+                None
+              case "FALLBACK" =>
+                fallbackColor = Some(parseColor(color))
+                None
+              case _ =>
+                Some((break.toDouble, parseColor(color)))
+            }
+          } catch {
+            case e: Throwable =>
+              val message = "Error parsing color map"
+              logger.error(message)
+              throw new IllegalArgumentException(message).initCause(e)
+          }
+      }
+      .sortWith({ case ((b1: Double, _), (b2: Double, _)) => b1 < b2 })
+      .unzip
+
+    val colorRamp = ColorRamp(colors)
+    ColorMap(breaks, colorRamp)
+      .withNoDataColor(noDataColor.getOrElse(0))
+      .withFallbackColor(fallbackColor match {
+        case Some(color) =>
+          color
+        case _ => colors.last
+      })
+  }
+
+  @SuppressWarnings(Array("CatchThrowable", "TraversableLast"))
+  def colorMapFromVector(colors: Vector[String],
+                         options: SingleBandOptions.Params,
+                         hist: Histogram[Double]): ColorMap = {
+    val cleanedColors = colors map { color =>
+      try {
+        parseColor(color)
+      } catch {
+        case e: Throwable =>
+          val message =
+            s"Color in color scheme could not be parsed: $color ; ${e.getLocalizedMessage}"
+          logger.error(message)
+          throw new IllegalArgumentException(message)
+      }
+    }
+    val lastColor = cleanedColors.last
+    val colorRamp = ColorRamp(cleanedColors)
+
+    // TODO allow setting min / max through options
+    // this would also include optionally masking values outside the specified range
+    val (min, max) = hist.minMaxValues match {
+      case Some((min, max)) =>
+        (min, max)
+      case _ =>
+        val message = "Unable to get histogram min / max"
+        logger.error(message)
+        throw new IllegalArgumentException(message)
+    }
+
+    val steps = options.colorBins match {
+      case 0    => 255
+      case bins => bins
+    }
+
+    val step = (max - min) / steps
+    val breaks = for (j <- 0 until steps) yield min + j * step
+
+    // as an optimization, we could cache the color maps, but I'm not sure it's worth it
+    ColorMap(breaks.toArray, colorRamp.stops(steps))
+      .withFallbackColor(lastColor)
+  }
+
+  def colorTile(tile: MultibandTile,
+                histogram: List[Histogram[Double]],
+                options: SingleBandOptions.Params): MultibandTile = {
+    val singleBandTile = tile.band(0)
+
+    val hist: Histogram[Double] = histogram match {
+      case Nil =>
+        throw MetadataException(
+          "Received an empty list of histograms for single band color correction")
+      case hist +: Nil => hist
+      case _ =>
+        throw MetadataException(
+          "Received too many histograms for single band color correction")
+    }
+    val cmap =
+      (options.colorScheme.asArray, options.colorScheme.asObject) match {
+        case (Some(a), None) =>
+          colorMapFromVector(a.map(e => e.noSpaces), options, hist)
+        case (None, Some(o)) =>
+          colorMapFromMap(o.toMap map { case (k, v) => (k, v.noSpaces) })
+        case _ =>
+          val message =
+            "Invalid color scheme format. Color schemes must be defined as an array of hex colors or a mapping of raster values to hex colors."
+          logger.error(message)
+          throw new IllegalArgumentException(message)
+      }
+
+    val renderedTile = cmap.render(singleBandTile)
+    val r = renderedTile.map(_.red).interpretAs(UByteCellType)
+    val g = renderedTile.map(_.green).interpretAs(UByteCellType)
+    val b = renderedTile.map(_.blue).interpretAs(UByteCellType)
+    val a = renderedTile.map(_.alpha).interpretAs(UByteCellType)
+    MultibandTile(r, g, b, a)
+  }
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Corrections.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Corrections.scala
@@ -1,0 +1,40 @@
+package com.rasterfoundry.backsplash.color
+
+import io.circe.generic.JsonCodec
+
+sealed trait ColorCorrection {
+  val enabled: Boolean
+}
+
+@JsonCodec
+final case class BandGamma(enabled: Boolean,
+                           redGamma: Option[Double],
+                           greenGamma: Option[Double],
+                           blueGamma: Option[Double])
+    extends ColorCorrection
+
+@JsonCodec
+final case class PerBandClipping(enabled: Boolean,
+                                 redMax: Option[Int],
+                                 greenMax: Option[Int],
+                                 blueMax: Option[Int],
+                                 redMin: Option[Int],
+                                 greenMin: Option[Int],
+                                 blueMin: Option[Int])
+    extends ColorCorrection
+
+@JsonCodec
+final case class MultiBandClipping(enabled: Boolean,
+                                   min: Option[Int],
+                                   max: Option[Int])
+    extends ColorCorrection
+
+@JsonCodec
+final case class SigmoidalContrast(enabled: Boolean,
+                                   alpha: Option[Double],
+                                   beta: Option[Double])
+    extends ColorCorrection
+
+@JsonCodec
+final case class Saturation(enabled: Boolean, saturation: Option[Double])
+    extends ColorCorrection

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
@@ -1,0 +1,157 @@
+package com.rasterfoundry.backsplash.color
+
+import geotrellis.raster.{io => _, Tile}
+import geotrellis.raster.render._
+import geotrellis.raster.render.png._
+import io.circe.{Decoder, Encoder, KeyEncoder, KeyDecoder}
+import io.circe.generic.semiauto._
+
+import scala.math.abs
+import scala.util.Try
+
+import java.util.Arrays.binarySearch
+
+trait Implicits {
+
+  // Without this keyencoder/keydecoder we can't derive serialization for render defs
+  implicit val decodeKeyDouble: KeyDecoder[Double] = new KeyDecoder[Double] {
+    final def apply(key: String): Option[Double] = Try(key.toDouble).toOption
+  }
+  implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
+    final def apply(key: Double): String = key.toString
+  }
+
+  // necessary for fallbacks in RenderDefinition
+  implicit val decodeHexRGBA: Decoder[RGBA] = Decoder.decodeString.emap { str =>
+    str.stripPrefix("#").stripPrefix("0x") match {
+      case hex if (hex.size == 8) =>
+        val bytes = hex
+          .sliding(2, 2)
+          .map({ hexByte =>
+            Integer.parseInt(hexByte, 16)
+          })
+          .toList
+        Right(RGBA(bytes(0), bytes(1), bytes(2), bytes(3)))
+      case hex if (hex.size == 6) =>
+        val bytes = hex
+          .sliding(2, 2)
+          .map({ hexByte =>
+            Integer.parseInt(hexByte, 16)
+          })
+          .toList
+        Right(RGB(bytes(0), bytes(1), bytes(2)))
+      case hex => Left(s"Unable to parse $hex as an RGBA")
+    }
+  }
+
+  implicit val encodeRgbaAsHex: Encoder[RGBA] =
+    Encoder.encodeString.contramap[RGBA] { rgba =>
+      "#" + rgba.red.toHexString + rgba.blue.toHexString + rgba.green.toHexString + rgba.alpha.toHexString
+    }
+
+  implicit class renderTileWithDefinition(tile: Tile) {
+
+    /** This function produces a function from cell value to color appropriate to the color
+      * space defined by the provided [[RenderDefinition]]
+      */
+    private def buildFn(definition: RenderDefinition): Double => RGBA =
+      definition.scale match {
+        case Continuous | Sequential | Diverging => continuous(definition)
+        case Qualitative(fallback)               => qual(definition, fallback)
+      }
+
+    /** RGB color interpolation logic */
+    private def RgbLerp(color1: RGBA, color2: RGBA, proportion: Double): Int = {
+      val r = (color1.red + (color2.red - color1.red) * proportion).toInt
+      val g = (color1.green + (color2.green - color1.green) * proportion).toInt
+      val b = (color1.blue + (color2.blue - color1.blue) * proportion).toInt
+      val a
+        : Double = (color1.alpha + (color2.alpha - color1.alpha) * proportion).toDouble / 2.55
+      RGBA(r, g, b, a)
+    }
+
+    /** For production of colors along a continuum */
+    private def continuous(definition: RenderDefinition): Double => RGBA = {
+      dbl: Double =>
+        val decomposed = definition.breakpoints.toArray.sortBy(_._1).unzip
+        val breaks: Array[Double] = decomposed._1
+        val colors: Array[RGBA] = decomposed._2
+
+        val insertionPoint: Int = binarySearch(breaks, dbl)
+        if (insertionPoint == -1) {
+          // MIN VALUE
+          definition.clip match {
+            case ClipNone | ClipRight => colors(0)
+            case ClipLeft | ClipBoth  => 0x00000000
+          }
+        } else if (abs(insertionPoint) - 1 == breaks.size) {
+          // MAX VALUE
+          definition.clip match {
+            case ClipNone | ClipLeft  => colors.last
+            case ClipRight | ClipBoth => 0x00000000
+          }
+        } else if (insertionPoint < 0) {
+          // MUST INTERPOLATE
+          val lowerIdx = abs(insertionPoint) - 2
+          val higherIdx = abs(insertionPoint) - 1
+          val lower = breaks(lowerIdx)
+          val higher = breaks(higherIdx)
+          val proportion = (dbl - lower) / (higher - lower)
+
+          RgbLerp(colors(lowerIdx), colors(higherIdx), proportion)
+        } else {
+          // Direct hit
+          colors(insertionPoint)
+        }
+    }
+
+    /** For production of colors according to discrete breaks */
+    private def qual(definition: RenderDefinition,
+                     fallback: RGBA): Double => RGBA = { dbl: Double =>
+      val decomposed = definition.breakpoints.toArray.sortBy(_._1).unzip
+      val breaks: Array[Double] = decomposed._1
+      val colors: Array[RGBA] = decomposed._2
+
+      val insertionPoint: Int = binarySearch(breaks, dbl)
+      if (insertionPoint == -1) {
+        // MIN VALUE
+        definition.clip match {
+          case ClipNone | ClipRight => fallback
+          case ClipLeft | ClipBoth  => 0x00000000
+        }
+      } else if (abs(insertionPoint) - 1 == breaks.size) {
+        // MAX VALUE
+        definition.clip match {
+          case ClipNone | ClipLeft  => fallback
+          case ClipRight | ClipBoth => 0x00000000
+        }
+      } else if (insertionPoint < 0) {
+        // GRAB LOWER VALUE
+        colors(abs(insertionPoint) - 2)
+      } else {
+        // Direct hit
+        if (insertionPoint == colors.size - 1) colors(insertionPoint - 1)
+        else colors(insertionPoint)
+      }
+    }
+
+    /** This method extension provides sugar to match GeoTrellis' renderPng method */
+    def renderPng(definition: RenderDefinition): Png = {
+      val toWrite =
+        if (tile.cellType.isFloatingPoint) {
+          tile.mapDouble({ cellValue: Double =>
+            buildFn(definition)(cellValue).int
+          })
+        } else {
+          tile.map({ cellValue: Int =>
+            buildFn(definition)(cellValue).int
+          })
+        }
+
+      new PngEncoder(Settings(RgbaPngEncoding, PaethFilter))
+        .writeByteArray(toWrite)
+    }
+  }
+}
+
+object Implicits extends Implicits

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/RenderDefinition.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/RenderDefinition.scala
@@ -1,0 +1,77 @@
+package com.rasterfoundry.backsplash.color
+
+import com.rasterfoundry.backsplash._
+import cats.syntax.either._
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+import io.circe.parser.decode
+import geotrellis.raster.render._
+
+import Implicits._
+
+final case class RenderDefinition(
+    breakpoints: Map[Double, RGBA],
+    scale: ScaleOpt,
+    clip: ClippingOpt
+)
+
+trait ScaleOpt { def repr: String }
+case object Continuous extends ScaleOpt { def repr = "Continuous" }
+case object Sequential extends ScaleOpt { def repr = "Sequential" }
+case object Diverging extends ScaleOpt { def repr = "Diverging" }
+final case class Qualitative(fallback: RGBA = RGBA(0, 0, 0, 0))
+    extends ScaleOpt {
+  def repr = {
+    val hex = fallback.asJson.noSpaces.stripPrefix("\"").stripSuffix("\"")
+    s"Qualitative[$hex]"
+  }
+}
+
+trait ClippingOpt { def repr: String }
+case object ClipNone extends ClippingOpt { def repr = "none" }
+case object ClipLeft extends ClippingOpt { def repr = "left" }
+case object ClipRight extends ClippingOpt { def repr = "right" }
+case object ClipBoth extends ClippingOpt { def repr = "both" }
+
+object RenderDefinition extends Implicits {
+  implicit val renderDefinitionDecoder: Decoder[RenderDefinition] =
+    deriveDecoder[RenderDefinition]
+  implicit val renderDefinitionEncoder: Encoder[RenderDefinition] =
+    deriveEncoder[RenderDefinition]
+}
+
+object ScaleOpt {
+  implicit val scaleOptEncoder: Encoder[ScaleOpt] =
+    Encoder.encodeString.contramap[ScaleOpt](_.repr)
+  implicit val scaleOptDecoder: Decoder[ScaleOpt] = Decoder.decodeString.emap {
+    str =>
+      str.toLowerCase match {
+        case "sequential" => Right(Sequential)
+        case "diverging"  => Right(Diverging)
+        case "continuous" => Right(Continuous)
+        case qual if qual.startsWith("qualitative[") =>
+          val colorString = qual.stripPrefix("qualitative[").stripSuffix("]")
+          decode[RGBA](colorString) match {
+            case Right(rgba) => Right(Qualitative(rgba))
+            case Left(_)     => Left(s"Unable to parse $colorString as RGBA")
+          }
+        case x => Left(s"Unable to decode $x as a ClippingOption")
+      }
+  }
+}
+
+object ClippingOpt {
+  implicit val clipOptEncoder: Encoder[ClippingOpt] =
+    Encoder.encodeString.contramap[ClippingOpt](_.repr)
+  implicit val clipOptDecoder: Decoder[ClippingOpt] =
+    Decoder.decodeString.emap { str =>
+      str.toLowerCase match {
+        case "none"  => Right(ClipNone)
+        case "left"  => Right(ClipLeft)
+        case "right" => Right(ClipRight)
+        case "both"  => Right(ClipBoth)
+        case x       => Left(s"Unable to decode $x as a ClippingOption")
+      }
+    }
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/SingleBandOptions.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/SingleBandOptions.scala
@@ -1,0 +1,15 @@
+package com.rasterfoundry.backsplash.color
+
+import io.circe.Json
+import io.circe.generic.JsonCodec
+
+object SingleBandOptions {
+
+  @JsonCodec
+  final case class Params(band: Int,
+                          dataType: BandDataType,
+                          colorBins: Int,
+                          colorScheme: Json,
+                          legendOrientation: String,
+                          extraNoData: Seq[Int] = Seq.empty[Int])
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/Approximations.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/Approximations.scala
@@ -1,0 +1,48 @@
+package com.rasterfoundry.backsplash.color.functions
+
+/**
+  * Not very good pow and exponent approximations
+  * consider org.apache.commons.math{3|4}.util.FastMath usage
+  * in cases where these functions can't be applied.
+  *
+  * ApproximationsSpec demonstrates max deviation on SaturationAdjust and SigmoidalContrast domains
+  */
+object Approximations {
+
+  /**
+    * For clarifications
+    * see https://www.reddit.com/r/gamedev/comments/n7na0/fast_approximation_to_mathpow/
+    * and https://martin.ankerl.com/2007/10/04/optimized-pow-approximation-for-java-and-c-c/
+    *
+    */
+  def pow(a: Double, b: Double): Double = { // exponentiation by squaring
+    if (a < 1 && java.lang.Double.isInfinite(b)) return 0d
+    if (a >= 1 && java.lang.Double.isInfinite(b)) return Double.NaN
+    if (java.lang.Double.isNaN(a) || java.lang.Double.isNaN(b))
+      return Double.NaN
+
+    var r = 1d
+    var exp = b.toInt
+    var base = a
+    while (exp != 0) {
+      if ((exp & 1) != 0) r *= base
+      base *= base
+      exp >>= 1
+    }
+    // use the IEEE 754 trick for the fraction of the exponent
+    val b_faction = b - b.toInt
+    val tmp = java.lang.Double.doubleToLongBits(a)
+    val tmp2 = (b_faction * (tmp - 4606921280493453312L)).toLong + 4606921280493453312L
+    r * java.lang.Double.longBitsToDouble(tmp2)
+  }
+
+  /**
+    * For clarifications
+    * see http://martin.ankerl.com/2007/02/11/optimized-exponential-functions-for-java/
+    *
+    */
+  def exp(value: Double): Double = {
+    val tmp = (1512775 * value + (1072693248 - 60801)).toLong
+    java.lang.Double.longBitsToDouble(tmp << 32)
+  }
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SaturationAdjust.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SaturationAdjust.scala
@@ -1,0 +1,121 @@
+package com.rasterfoundry.backsplash.color.functions
+
+import geotrellis.raster.{ArrayTile, MultibandTile}
+import org.apache.commons.math3.util.FastMath
+import spire.syntax.cfor.cfor
+
+/**
+  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
+  * We can consider these functions usages in case of real performance issues caused by a long saturation adjust.
+  */
+object SaturationAdjust {
+  def apply(rgbTile: MultibandTile, chromaFactor: Double): MultibandTile = {
+    scaleTileChroma(rgbTile, chromaFactor)
+  }
+
+  /* Convert RGB to Hue, Chroma, Luma https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness */
+  def scaleTileChroma(rgbTile: MultibandTile,
+                      chromaFactor: Double): MultibandTile = {
+    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
+    val (nred, ngreen, nblue) = (
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
+    )
+    cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
+      cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
+        val (r, g, b) =
+          (red.get(col, row), green.get(col, row), blue.get(col, row))
+        val (hue, chroma, luma) = rgbToHcluma(r, g, b)
+        val newChroma = scaleChroma(chroma, chromaFactor)
+        val (nr, ng, nb) = hclumaToRgb(hue, newChroma, luma)
+        nred.set(col, row, nr)
+        ngreen.set(col, row, ng)
+        nblue.set(col, row, nb)
+      }
+    }
+    MultibandTile(nred, ngreen, nblue)
+  }
+
+  def ~=(x: Double, y: Double, precision: Double): Boolean = {
+    (x - y).abs < precision
+  }
+
+  // See link for a detailed explanation of what is happening. Basically we are taking the
+  // RGB cube and tilting it on its side so that the black -> white line runs vertically
+  // up the center of the HCL cylinder, then flattening the cube down into a hexagon and then
+  // pretending that that hexagon is actually a cylinder.
+  // https://en.wikipedia.org/wiki/HSL_and_HSV#Lightness
+  def rgbToHcluma(rByte: Int,
+                  gByte: Int,
+                  bByte: Int): (Double, Double, Double) = {
+    // RGB come in as unsigned Bytes, but the transformation requires Doubles [0,1]
+    val (r, g, b) = (rByte / 255d, gByte / 255d, bByte / 255d)
+    val colors = List(r, g, b)
+    val max = colors.max
+    val min = colors.min
+    val chroma = max - min
+    val hueSextant = (chroma, max) match {
+      case (0, _) =>
+        0 // Technically, undefined, but we'll ignore this value in this case.
+      case (_, x) if ~=(x, r, precision = 0.0001) =>
+        ((g - b) / chroma.toDouble) % 6
+      case (_, x) if ~=(x, g, precision = 0.0001) =>
+        ((b - r) / chroma.toDouble) + 2
+      case (_, x) if ~=(x, b, precision = 0.0001) =>
+        ((r - g) / chroma.toDouble) + 4
+    }
+    // Wrap degrees
+    val hue = (hueSextant * 60d) % 360 match {
+      case h if h < 0  => h + 360
+      case h if h >= 0 => h
+    }
+    // Perceptually weighted average of "lightness" contribution of sRGB primaries (it's
+    // not clear that we're in sRGB here, but that's the default for most images intended for
+    // display so it's a good guess in the absence of explicit information).
+    val luma = 0.21 * r + 0.72 * g + 0.07 * b
+    (hue, chroma, luma)
+  }
+
+  // Reverse the process above
+  def hclumaToRgb(hue: Double,
+                  chroma: Double,
+                  luma: Double): (Int, Int, Int) = {
+    val sextant = hue / 60d
+    val X = chroma * (1 - math.abs((sextant % 2) - 1))
+    // Projected color values, i.e., on the flat projection of the RGB cube
+    val (rFlat: Double, gFlat: Double, bFlat: Double) =
+      (chroma, sextant) match {
+        case (0.0, _)                  => (0.0, 0.0, 0.0) // Gray (or black / white)
+        case (_, s) if 0 <= s && s < 1 => (chroma, X, 0.0)
+        case (_, s) if 1 <= s && s < 2 => (X, chroma, 0.0)
+        case (_, s) if 2 <= s && s < 3 => (0.0, chroma, X)
+        case (_, s) if 3 <= s && s < 4 => (0.0, X, chroma)
+        case (_, s) if 4 <= s && s < 5 => (X, 0.0, chroma)
+        case (_, s) if 5 <= s && s < 6 => (chroma, 0.0, X)
+      }
+
+    // We can add the same value to each component to move straight up the cylinder from the projected
+    // plane, back to the correct lightness value.
+    val lumaCorrection = luma - (0.21 * rFlat + 0.72 * gFlat + 0.07 * bFlat)
+    val r = clamp8Bit((255 * (rFlat + lumaCorrection)).toInt)
+    val g = clamp8Bit((255 * (gFlat + lumaCorrection)).toInt)
+    val b = clamp8Bit((255 * (bFlat + lumaCorrection)).toInt)
+    (r, g, b)
+  }
+
+  def scaleChroma(chroma: Double, scaleFactor: Double): Double = {
+    // Chroma is a Double in the range [0.0, 1.0]. Scale factor is the same as our other gamma corrections:
+    // a Double in the range [0.0, 2.0].
+    val scaled = FastMath.pow(chroma, 1.0 / scaleFactor)
+    if (scaled < 0.0) 0.0
+    else if (scaled > 1.0) 1.0
+    else scaled
+  }
+
+  @inline def clamp8Bit(z: Int): Int = {
+    if (z < 0) 0
+    else if (z > 255) 255
+    else z
+  }
+}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SigmoidalContrast.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SigmoidalContrast.scala
@@ -1,0 +1,90 @@
+package com.rasterfoundry.backsplash.color.functions
+
+import geotrellis.raster._
+import org.apache.commons.math3.util.FastMath
+
+/**
+  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
+  * We can consider these functions usages in case of real performance issues caused by a long sigmoidal contrast.
+  */
+object SigmoidalContrast {
+
+  /**
+    * @param  cellType   The cell type on which the transform is to act
+    * @param  alpha      The center around-which the stretch is performed (given as a fraction)
+    * @param  beta       The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @param  intensity  The raw intensity value to be mapped-from
+    * @return            The intensity value produced by the sigmoidal contrast transformation
+    */
+  def transform(cellType: CellType, alpha: Double, beta: Double)(
+      intensity: Double): Double = {
+    val bits = cellType.bits
+
+    val u = cellType match {
+      case _: FloatCells =>
+        (intensity - Float.MinValue) / (Float.MaxValue - Float.MinValue)
+      case _: DoubleCells =>
+        (intensity / 2 - Double.MinValue / 2) / (Double.MaxValue / 2 - Double.MinValue / 2)
+      case _: BitCells | _: UByteCells | _: UShortCells =>
+        intensity / ((1 << bits) - 1)
+      case _: ByteCells | _: ShortCells | _: IntCells =>
+        (intensity + (1 << (bits - 1))) / ((1 << bits) - 1)
+    }
+
+    val numer = 1 / (1 + FastMath.exp(beta * (alpha - u))) - 1 / (1 + FastMath
+      .exp(beta))
+    val denom = 1 / (1 + FastMath.exp(beta * (alpha - 1))) - 1 / (1 + FastMath
+      .exp(beta * alpha))
+    val gu = math.max(0.0, math.min(1.0, numer / denom))
+
+    cellType match {
+      case _: FloatCells =>
+        Float.MaxValue * (2 * gu - 1d)
+      case _: DoubleCells =>
+        Double.MaxValue * (2 * gu - 1d)
+      case _: BitCells | _: UByteCells | _: UShortCells =>
+        ((1 << bits) - 1) * gu
+      case _: ByteCells | _: ShortCells | _: IntCells =>
+        (((1 << bits) - 1) * gu) - (1 << (bits - 1))
+    }
+  }
+
+  /**
+    * Given a singleband [[Tile]] object and the parameters alpha and
+    * beta, perform the sigmoidal contrast computation and return the
+    * result as a tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  tile   The input tile
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        The output tile
+    */
+  def apply(tile: Tile, alpha: Double, beta: Double): Tile = {
+    val localTransform = transform(tile.cellType, alpha, beta) _
+    tile.mapDouble(localTransform)
+  }
+
+  def localTransform(cellType: CellType, alpha: Double, beta: Double) =
+    transform(cellType, alpha, beta) _
+
+  /**
+    * Given a [[MultibandTile]] object and the parameters alpha and
+    * beta, perform the sigmoidal contrast computation on each band
+    * and return the result as a multiband tile.
+    *
+    * The approach used is described here:
+    * https://www.imagemagick.org/Usage/color_mods/#sigmoidal
+    *
+    * @param  tile   The input multibandtile
+    * @param  alpha  The center around-which the stretch is performed (given as a fraction)
+    * @param  beta   The standard deviation in the computation, used to avoid saturating the upper and lower parts of the gamut
+    * @return        The output tile
+    */
+  def apply(tile: MultibandTile, alpha: Double, beta: Double): MultibandTile = {
+    val localTransform = transform(tile.cellType, alpha, beta) _
+    MultibandTile(tile.bands.map(_.mapDouble(localTransform)))
+  }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -40,7 +40,6 @@ class MosaicService[ProjStore: ProjectStore](
         LayerTms.identity(projects.read(projId, None, bandOverride, None))
       eval(z, x, y) flatMap {
         case Valid(tile) =>
-          println(s"Number of bands in tile: ${tile.bands.length}")
           Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
         case Invalid(e) =>
           BadRequest(s"Could not produce tile: $e")

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -1,8 +1,10 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.database.ToolRunDao
 import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.tool
 
 import doobie._
 import doobie.implicits._
@@ -13,6 +15,24 @@ import java.util.UUID
 class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
   import mosaicImplicits._
   val mamlAdapter = new BacksplashMamlAdapter(mosaicImplicits)
+
+  private def toolToColorRd(toolRd: tool.RenderDefinition): RenderDefinition = {
+    val scaleOpt = toolRd.scale match {
+      case tool.Continuous      => Continuous
+      case tool.Sequential      => Sequential
+      case tool.Diverging       => Diverging
+      case tool.Qualitative(fb) => Qualitative(fb)
+    }
+
+    val clipOpt = toolRd.clip match {
+      case tool.ClipNone  => ClipNone
+      case tool.ClipLeft  => ClipLeft
+      case tool.ClipRight => ClipRight
+      case tool.ClipBoth  => ClipBoth
+    }
+
+    RenderDefinition(toolRd.breakpoints, scaleOpt, clipOpt)
+  }
 
   implicit val toolRunDaoStore: ToolStore[ToolRunDao] =
     new ToolStore[ToolRunDao] {
@@ -26,7 +46,9 @@ class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
             mamlAdapter.asMaml _
           }
         } yield {
-          PaintableTool(expr, identity, params)
+          PaintableTool(expr, params, mdOption flatMap {
+            _.renderDef map { toolToColorRd(_) }
+          })
         }
     }
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -5,8 +5,11 @@ import com.rasterfoundry.database.util.RFTransactor
 
 import cats.effect.IO
 import doobie.implicits._
+import geotrellis.raster.{io => _, Tile}
 import geotrellis.raster.io._
 import geotrellis.raster.histogram._
+import geotrellis.raster.render._
+import geotrellis.raster.render.png._
 import io.circe.{Encoder, Json, KeyEncoder}
 import io.circe.parser._
 import io.circe.syntax._

--- a/app-backend/batch/src/main/scala/ast/RfmlRddResolver.scala
+++ b/app-backend/batch/src/main/scala/ast/RfmlRddResolver.scala
@@ -58,6 +58,8 @@ object RfmlRddResolver extends LazyLogging {
                                   _,
                                   Some(SceneType.COG),
                                   Some(s),
+                                  _,
+                                  _,
                                   _) =>
               (cellTypeO: Option[CellType], band: Int) =>
                 CogRaster(sceneId, Some(band), cellTypeO, s)
@@ -65,6 +67,8 @@ object RfmlRddResolver extends LazyLogging {
                                   _,
                                   Some(SceneType.Avro),
                                   Some(s),
+                                  _,
+                                  _,
                                   _) =>
               (cellTypeO: Option[CellType], band: Int) =>
                 SceneRaster(sceneId, Some(band), cellTypeO, s)

--- a/app-backend/batch/src/test/resources/export/localJob.json
+++ b/app-backend/batch/src/test/resources/export/localJob.json
@@ -77,7 +77,9 @@
                 ]
               ]
             ]
-          }
+          },
+          "singleBandOptions": {},
+          "isSingleBand": false
         }
       ],
       "mask": {

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -115,7 +115,9 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
               ingestLocation = Some("s3://test/"),
               colorCorrections = cc,
               sceneType = Some(SceneType.Avro),
-              footprint = Some(mask)
+              footprint = Some(mask),
+              isSingleBand = false,
+              singleBandOptions = ().asJson
             )),
           mask = Some(mask)
         )

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -32,6 +32,8 @@ lazy val commonSettings = Seq(
     "-language:experimental.macros",
     "-Xmax-classfile-name",
     "100",
+    "-Ywarn-value-discard",
+    "-Ywarn-unused",
     "-Ypartial-unification",
     "-Ypatmat-exhaust-depth",
     "100"

--- a/app-backend/datamodel/src/main/scala/MosaicDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/MosaicDefinition.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.datamodel
 
 import com.rasterfoundry.bridge._
 import geotrellis.vector.{MultiPolygon, Projected}
+import io.circe.Json
 import io.circe.generic.JsonCodec
 
 import java.util.UUID
@@ -11,7 +12,9 @@ final case class MosaicDefinition(sceneId: UUID,
                                   colorCorrections: ColorCorrect.Params,
                                   sceneType: Option[SceneType] = None,
                                   ingestLocation: Option[String],
-                                  footprint: Option[MultiPolygon])
+                                  footprint: Option[MultiPolygon],
+                                  isSingleBand: Boolean,
+                                  singleBandOptions: Json)
 
 object MosaicDefinition {
   def fromScenesToProjects(
@@ -26,13 +29,17 @@ object MosaicDefinition {
           colorCorrection,
           sceneType,
           ingestLocation,
-          footprint
+          footprint,
+          isSingleBand,
+          singleBandOptions
           ) =>
         MosaicDefinition(sceneId,
                          colorCorrection,
                          sceneType,
                          ingestLocation,
-                         footprint flatMap { _.geom.as[MultiPolygon] })
+                         footprint flatMap { _.geom.as[MultiPolygon] },
+                         isSingleBand,
+                         singleBandOptions)
     }
   }
 
@@ -49,7 +56,9 @@ object MosaicDefinition {
           colorCorrection,
           sceneType,
           ingestLocation,
-          footprint
+          footprint,
+          isSingleBand,
+          singleBandOptions
           ) => {
         val ccp = colorCorrection.copy(
           redBand = redBand,
@@ -60,7 +69,9 @@ object MosaicDefinition {
                          ccp,
                          sceneType,
                          ingestLocation,
-                         footprint flatMap { _.geom.as[MultiPolygon] })
+                         footprint flatMap { _.geom.as[MultiPolygon] },
+                         isSingleBand,
+                         singleBandOptions)
       }
     }
   }

--- a/app-backend/datamodel/src/main/scala/SceneToProject.scala
+++ b/app-backend/datamodel/src/main/scala/SceneToProject.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.datamodel
 
 import geotrellis.vector.{Geometry, Projected}
 import io.circe.generic.JsonCodec
+import io.circe.Json
 
 import java.util.UUID
 
@@ -27,7 +28,9 @@ final case class SceneToProjectwithSceneType(
     colorCorrectParams: ColorCorrect.Params,
     sceneType: Option[SceneType] = None,
     ingestLocation: Option[String],
-    dataFootprint: Option[Projected[Geometry]]
+    dataFootprint: Option[Projected[Geometry]],
+    isSingleBand: Boolean,
+    singleBandOptions: Json
 )
 
 @JsonCodec

--- a/app-backend/db/src/main/scala/ImageDao.scala
+++ b/app-backend/db/src/main/scala/ImageDao.scala
@@ -23,8 +23,6 @@ object ImageDao extends Dao[Image] {
       image_metadata, resolution_meters, metadata_files FROM """ ++ tableF
 
   def create(image: Image, user: User): ConnectionIO[Image] = {
-    val id = UUID.randomUUID
-    val now = new Timestamp(new java.util.Date().getTime)
     val ownerId = util.Ownership.checkOwner(user, Some(image.owner))
     (fr"INSERT INTO" ++ tableF ++ fr"""
         (id, created_at, modified_at, created_by, modified_by,

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -132,8 +132,6 @@ object MapTokenDao extends Dao[MapToken] {
       project: Option[UUID],
       toolRun: Option[UUID]
   ): ConnectionIO[MapToken] = {
-    val id = UUID.randomUUID
-    val now = new Timestamp((new java.util.Date()).getTime())
     val ownerId = util.Ownership.checkOwner(user, owner)
     val newMapToken = MapToken.Create(name, project, toolRun, Some(ownerId))
     insert(newMapToken, user)

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -15,6 +15,7 @@ import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import geotrellis.vector.{Polygon, Projected}
+import io.circe.syntax._
 
 import scala.concurrent.duration._
 
@@ -272,7 +273,9 @@ object SceneDao
               ),
               scene.sceneType,
               scene.ingestLocation,
-              scene.dataFootprint map { _.geom }
+              scene.dataFootprint map { _.geom },
+              false,
+              ().asJson
             ))
         case _ => Seq.empty
       }

--- a/app-backend/db/src/main/scala/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/SceneToProjectDao.scala
@@ -9,26 +9,39 @@ import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.datamodel.{
   BatchParams,
-  ColorCorrect,
+  ColorCorrect => RFColorCorrect,
   MosaicDefinition,
   SceneToProject,
   SceneToProjectwithSceneType
+}
+import com.rasterfoundry.datamodel.color.{
+  BandGamma => RFBandGamma,
+  PerBandClipping => RFPerBandClipping,
+  MultiBandClipping => RFMultiBandClipping,
+  SigmoidalContrast => RFSigmoidalContrast,
+  Saturation => RFSaturation
 }
 import com.rasterfoundry.backsplash.{
   ProjectStore,
   BandOverride,
   BacksplashImage
 }
+import com.rasterfoundry.backsplash.color.{
+  ColorCorrect => BSColorCorrect,
+  SingleBandOptions => BSSingleBandOptions,
+  _
+}
 import com.rasterfoundry.backsplash.error._
 import com.typesafe.scalalogging.LazyLogging
-import doobie.Fragments._
 import com.rasterfoundry.datamodel._
 import doobie._
+import doobie.Fragments._
 import doobie.implicits._
 import doobie.postgres._
 import doobie.postgres.implicits._
 import fs2.Stream
 import geotrellis.vector.{MultiPolygon, Polygon, Projected}
+import io.circe.syntax._
 
 case class SceneToProjectDao()
 
@@ -36,6 +49,9 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
 
   implicit val projectStore: ProjectStore[SceneToProjectDao] =
     new ProjectStore[SceneToProjectDao] {
+      // safe to get here, since we're just unapplying from a value that we already know
+      // was constructed correctly
+      @SuppressWarnings(Array("OptionGet"))
       def read(self: SceneToProjectDao,
                projId: UUID,
                window: Option[Projected[Polygon]],
@@ -48,6 +64,8 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
           bandOverride map { _.green },
           bandOverride map { _.blue },
           imageSubset map { _.toList } getOrElse List.empty) map { md =>
+          val singleBandOptions =
+            md.singleBandOptions.as[BSSingleBandOptions.Params].toOption
           BacksplashImage(
             md.ingestLocation getOrElse {
               throw UningestedScenesException(
@@ -57,13 +75,50 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
               throw MetadataException(
                 s"Scene ${md.sceneId} does not have a footprint")
             },
-            bandOverride map { ovr =>
-              List(ovr.red, ovr.green, ovr.blue)
-            } getOrElse {
-              List(md.colorCorrections.redBand,
-                   md.colorCorrections.greenBand,
-                   md.colorCorrections.blueBand)
-            }
+            if (md.isSingleBand) {
+              singleBandOptions map { sbo =>
+                List(sbo.band)
+              } getOrElse {
+                throw SingleBandOptionsException(
+                  "Single band options must be specified for single band projects")
+              }
+            } else {
+              bandOverride map { ovr =>
+                List(ovr.red, ovr.green, ovr.blue)
+              } getOrElse {
+                List(md.colorCorrections.redBand,
+                     md.colorCorrections.greenBand,
+                     md.colorCorrections.blueBand)
+              }
+            },
+            // why is all this necessary? because we're obligated to keep the existing tile
+            // server functioning, and in pursuit of that i want to make as few changes to
+            // functions it calls as possible
+            BSColorCorrect.Params(
+              0, // red
+              1, // green
+              2, // blue
+              (BandGamma.apply _)
+                .tupled(RFBandGamma.unapply(md.colorCorrections.gamma).get),
+              (PerBandClipping.apply _).tupled(
+                RFPerBandClipping
+                  .unapply(md.colorCorrections.bandClipping)
+                  .get),
+              (MultiBandClipping.apply _).tupled(
+                RFMultiBandClipping
+                  .unapply(md.colorCorrections.tileClipping)
+                  .get),
+              (SigmoidalContrast.apply _)
+                .tupled(
+                  RFSigmoidalContrast
+                    .unapply(md.colorCorrections.sigmoidalContrast)
+                    .get),
+              (Saturation.apply _).tupled(
+                RFSaturation
+                  .unapply(md.colorCorrections.saturation)
+                  .get)
+            ),
+            singleBandOptions
           )
         } transact (RFTransactor.xa)
       }
@@ -145,13 +200,12 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
                           blueBand: Option[Int] = None,
                           sceneIdSubset: List[UUID] = List.empty)
     : Stream[ConnectionIO, MosaicDefinition] = {
-
     val filters = List(
       polygonOption.map(polygon =>
-        fr"ST_Intersects(scenes.tile_footprint, ${polygon})"),
-      Some(fr"scenes_to_projects.project_id = ${projectId}"),
-      Some(fr"scenes_to_projects.accepted = true"),
-      Some(fr"scenes.ingest_status = 'INGESTED'"),
+        fr"ST_Intersects(scenes_stp.tile_footprint, ${polygon})"),
+      Some(fr"scenes_stp.project_id = ${projectId}"),
+      Some(fr"scenes_stp.accepted = true"),
+      Some(fr"scenes_stp.ingest_status = 'INGESTED'"),
       sceneIdSubset.toNel map {
         Fragments.in(fr"scene_id", _)
       }
@@ -159,14 +213,19 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
     val select = fr"""
     SELECT
       scene_id, project_id, accepted, scene_order, mosaic_definition, scene_type, ingest_location,
-      data_footprint
-    FROM
+      data_footprint, is_single_band, single_band_options
+    FROM (
       scenes_to_projects
     LEFT JOIN
       scenes
     ON scenes.id = scenes_to_projects.scene_id
+    ) scenes_stp
+    LEFT JOIN
+      projects
+    ON
+      scenes_stp.project_id = projects.id
       """
-    (select ++ whereAndOpt(filters: _*) ++ fr"ORDER BY scenes_to_projects.scene_order ASC")
+    (select ++ whereAndOpt(filters: _*) ++ fr"ORDER BY scenes_stp.scene_order ASC")
       .query[SceneToProjectwithSceneType]
       .stream map { stp =>
       {
@@ -181,7 +240,9 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
               ),
               stp.sceneType,
               stp.ingestLocation,
-              stp.dataFootprint flatMap { _.geom.as[MultiPolygon] }
+              stp.dataFootprint flatMap { _.geom.as[MultiPolygon] },
+              stp.isSingleBand,
+              stp.singleBandOptions
             )
         } getOrElse {
           MosaicDefinition(
@@ -189,7 +250,10 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
             stp.colorCorrectParams,
             stp.sceneType,
             stp.ingestLocation,
-            stp.dataFootprint flatMap { _.geom.as[MultiPolygon] })
+            stp.dataFootprint flatMap { _.geom.as[MultiPolygon] },
+            stp.isSingleBand,
+            stp.singleBandOptions
+          )
         }
       }
     }

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -57,4 +57,7 @@ trait CirceJsonbMeta {
 
   implicit val singleBandOptionsMeta: Meta[SingleBandOptions.Params] =
     CirceJsonbMeta[SingleBandOptions.Params]
+
+  implicit val jsonMeta: Meta[Json] =
+    CirceJsonbMeta[Json]
 }

--- a/app-backend/project/development/repositories
+++ b/app-backend/project/development/repositories
@@ -2,3 +2,5 @@
   local
   ivy-proxy-releases: http://nexus.internal.azavea.com/repository/ivy-public/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
   maven-proxy-releases: http://nexus.internal.azavea.com/repository/maven-public/
+  locationtech-releases: http://nexus.internal.azavea.com/repository/locationtech-releases/
+  locationtech-snapshots: http://nexus.internal.azavea.com/repository/locationtech-snapshots/

--- a/app-backend/tile/src/main/scala/image/GlobalSummary.scala
+++ b/app-backend/tile/src/main/scala/image/GlobalSummary.scala
@@ -111,6 +111,8 @@ object GlobalSummary extends LazyLogging {
                                   _,
                                   maybeSceneType,
                                   Some(ingestLocation),
+                                  _,
+                                  _,
                                   _) =>
               maybeSceneType match {
                 case Some(SceneType.COG) =>

--- a/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/MultiBandMosaic.scala
@@ -198,7 +198,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
       implicit xa: Transactor[IO]): OptionT[Future, MultibandTile] = {
     OptionT(mosaicDefinition(projectId).flatMap { mosaic =>
       val sceneIds = mosaic.map {
-        case MosaicDefinition(sceneId, _, _, _, _) => sceneId
+        case MosaicDefinition(sceneId, _, _, _, _, _, _) => sceneId
       }.toSet
 
       val mayhapTiles: Future[Seq[MultibandTile]] =
@@ -399,7 +399,7 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
     mds.flatMap { mosaic: List[MosaicDefinition] =>
       {
         val sceneIds = mosaic.map {
-          case MosaicDefinition(sceneId, _, _, _, _) => sceneId
+          case MosaicDefinition(sceneId, _, _, _, _, _, _) => sceneId
         }.toSet
 
         val tiles = mosaic.map {
@@ -407,6 +407,8 @@ object MultiBandMosaic extends LazyLogging with KamonTrace {
                                 colorCorrectParams,
                                 sceneType,
                                 maybeIngestLocation,
+                                _,
+                                _,
                                 _) => {
             val tile = (maybeIngestLocation, sceneType) match {
               case (Some(ingestLocation), Some(SceneType.COG)) =>

--- a/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
+++ b/app-backend/tile/src/main/scala/image/SingleBandMosaic.scala
@@ -121,7 +121,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
               .unsafeToFuture
               .map { mds =>
                 val sceneIds = mds.map {
-                  case MosaicDefinition(sceneId, _, _, _, _) => sceneId
+                  case MosaicDefinition(sceneId, _, _, _, _, _, _) => sceneId
                 }.toSet
 
                 Future
@@ -198,7 +198,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
               .unsafeToFuture
               .map { mds =>
                 val sceneIds = mds.map {
-                  case MosaicDefinition(sceneId, _, _, _, _) => sceneId
+                  case MosaicDefinition(sceneId, _, _, _, _, _, _) => sceneId
                 }.toSet
 
                 Future
@@ -278,7 +278,7 @@ object SingleBandMosaic extends LazyLogging with KamonTrace {
           .unsafeToFuture
           .map { mds =>
             val sceneIds = mds.map {
-              case MosaicDefinition(sceneId, _, _, _, _) => sceneId
+              case MosaicDefinition(sceneId, _, _, _, _, _, _) => sceneId
             }.toSet
 
             Future

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,11 +174,11 @@ services:
       - postgres:database.service.rasterfoundry.internal
     env_file: .env
     environment:
-      - RF_LOG_LEVEL=INFO
+      - RF_LOG_LEVEL=DEBUG
       - COURSIER_CACHE=/root/.coursier
     ports:
       - "8080:8080"
-      - "9030:9020"
+      - "9030:9030"
     volumes:
       - $HOME/.sbt:/root/.sbt
       - ./app-backend/:/opt/raster-foundry/app-backend/
@@ -190,10 +190,11 @@ services:
     entrypoint: sbt
     command:
       - "backsplash-server/run"
-      - "-Dcom.sun.management.jmxremote.rmi.port=9020"
-      - "-Dcom.sun.management.jmxremote=true"
-      - "-Dcom.sun.management.jmxremote.port=9020"
-      - "-Dcom.sun.management.jmxremote.ssl=false"
-      - "-Dcom.sun.management.jmxremote.authenticate=false"
-      - "-Dcom.sun.management.jmxremote.local.only=false"
+      - "-J-Dcom.sun.management.jmxremote.rmi.port=9030"
+      - "-J-Dcom.sun.management.jmxremote=true"
+      - "-J-Dcom.sun.management.jmxremote.port=9030"
+      - "-J-Dcom.sun.management.jmxremote.ssl=false"
+      - "-J-Dcom.sun.management.jmxremote.authenticate=false"
+      - "-J-Dcom.sun.management.jmxremote.local.only=false"
+      - "-J-DXmx3G"
       - "-Djava.rmi.server.hostname=localhost"


### PR DESCRIPTION
## Overview

This PR restores color correction to analyses and projects.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

 * put a cog in a project
 * set it to single band
 * try some single band options
 * load your cog into an analysis
 * view the map
 * take down backsplash
 * set the project to a multiband color mode
 * bring up backsplash
 * make one of the tms requests with data again
 * it should all work