### PR TITLE
Decrease max classfile name length to 70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - If users are not requesting their own info, the returned other users' personal info are protected [\#4360](https://github.com/raster-foundry/raster-foundry/pull/4360)
 - Changed the data model of the return of `users/me/roles` endpoint [\#4375](https://github.com/raster-foundry/raster-foundry/pull/4375)
 - Added more aggressive timeout to backsplash for improved thread recovery [\#4383](https://github.com/raster-foundry/raster-foundry/pull/4383)
+- Decreased max classfile name length from 100 to 70 for CI reasons [\#4388](https://github.com/raster-foundry/raster-foundry/pull/4388)
 
 ### Fixed
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -31,7 +31,7 @@ lazy val commonSettings = Seq(
     "-language:existentials",
     "-language:experimental.macros",
     "-Xmax-classfile-name",
-    "100",
+    "70",
     "-Ywarn-value-discard",
     "-Ywarn-unused",
     "-Ypartial-unification",


### PR DESCRIPTION
## Overview

This PR decreases the max classfile name length to 70, because docker was mad.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo / Testing Instructions

Observer that #991 cipublish was a disaster:

http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/develop/

While in the test branch with this change it went fine until it reached a dependency on some steps I skipped:

http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/test%252Fjs%252Fdecrease-max-classfile-name-length/