### PR TITLE
Restore authentication, authorization, and fancy error-handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Restored color correction [\#4387](https://github.com/raster-foundry/raster-foundry/pull/4387)
 - Address a number of unhandled promise chains on the frontend [\#4380](https://github.com/raster-foundry/raster-foundry/pull/4380)
 - Fix logo on project share page and add error handling [/#4377](https://github.com/raster-foundry/raster-foundry/pull/4377)
+- Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 
 ### Removed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -4,9 +4,7 @@ import cats._
 import cats.data._
 import cats.effect._
 import cats.implicits._
-// import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.typesafe.scalalogging.LazyLogging
-// import doobie.util.invariant.InvariantViolation
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.dsl.io._
@@ -42,29 +40,8 @@ final case class WrappedDoobieException(message: String)
 final case class WrappedS3Exception(message: String) extends BacksplashException
 // Private so no one can deliberately throw an UnknownException elsewhere --
 // only exists to catch the fall-through case in the foreign error handler
-private[error] final case class UnknownException(message: String)
+private[backsplash] final case class UnknownException(message: String)
     extends BacksplashException
-
-// class ForeignErrorHandler[F[_], E <: Throwable](implicit M: MonadError[F, E])
-//     extends LazyLogging
-//     with HttpErrorHandler[F, E]
-//     with Http4sDsl[F] {
-//   private def wrapError(t: E): F[Response[F]] = t match {
-//     case (err: InvariantViolation) =>
-//       logger.error(err.getMessage, err.printStackTrace)
-//       throw WrappedDoobieException(err.getMessage)
-//     case (err: AmazonS3Exception) =>
-//       logger.error(err.getMessage, err.printStackTrace)
-//       throw WrappedS3Exception(err.getMessage)
-//     case (err: IllegalArgumentException) =>
-//       throw RequirementFailedException(err.getMessage)
-//     case (err: BacksplashException) => throw err
-//     case t                          => throw UnknownException(t.getMessage)
-//   }
-
-//   override def handle(service: AuthedService[U, F]): AuthedService[U, F] =
-//     ServiceHttpErrorHandler(service)(wrapError)
-// }
 
 class BacksplashHttpErrorHandler[F[_], U](
     implicit M: MonadError[F, BacksplashException])

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -37,7 +37,7 @@ class AnalysisService[Param: ToolStore](analyses: Param,
     ForeignError.handle {
       AuthedService {
 
-        case GET -> Root / UUIDWrapper(analysisId) / "histogram"
+        case GET -> Root / UUIDWrapper(analysisId) / "histogram" / _
               :? NodeQueryParamMatcher(node)
               :? VoidCacheQueryParamMatcher(void) as user =>
           for {
@@ -53,7 +53,7 @@ class AnalysisService[Param: ToolStore](analyses: Param,
           } yield resp
 
         case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
-              y)
+              y) / _
               :? NodeQueryParamMatcher(node) as user =>
           for {
             authorized <- Authorizers.authToolRun(user, analysisId)
@@ -73,7 +73,7 @@ class AnalysisService[Param: ToolStore](analyses: Param,
             }
           } yield resp
 
-        case authedReq @ GET -> Root / UUIDWrapper(analysisId) / "raw"
+        case authedReq @ GET -> Root / UUIDWrapper(analysisId) / "raw" / _
               :? ExtentQueryParamMatcher(extent)
               :? ZoomQueryParamMatcher(zoom)
               :? NodeQueryParamMatcher(node) as user =>

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
-import com.rasterfoundry.backsplash.Parameters._
+import com.rasterfoundry.datamodel.User
 
 import cats.data.Validated._
 import cats.effect.{ContextShift, IO}
@@ -16,85 +16,100 @@ import org.http4s.circe._
 import org.http4s.util.CaseInsensitiveString
 
 import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.MetricsRegistrator
+import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.backsplash.color.{Implicits => ColorImplicits}
 
 @SuppressWarnings(Array("TraversableHead"))
-class AnalysisService[Param: ToolStore](
-    analyses: Param,
-    mtr: MetricsRegistrator,
-    mosaicImplicits: MosaicImplicits,
-    toolstoreImplicits: ToolStoreImplicits)(implicit cs: ContextShift[IO])
+class AnalysisService[Param: ToolStore](analyses: Param,
+                                        mtr: MetricsRegistrator,
+                                        mosaicImplicits: MosaicImplicits,
+                                        toolstoreImplicits: ToolStoreImplicits)(
+    implicit cs: ContextShift[IO],
+    H: HttpErrorHandler[IO, BacksplashException, User],
+    ForeignError: HttpErrorHandler[IO, Throwable, User])
     extends ColorImplicits {
   import mosaicImplicits._
   import toolstoreImplicits._
 
-  val routes: HttpRoutes[IO] = HttpRoutes.of {
+  val routes: AuthedService[User, IO] = H.handle {
+    ForeignError.handle {
+      AuthedService {
 
-    case GET -> Root / UUIDWrapper(analysisId) / "histogram"
-          :? NodeQueryParamMatcher(node)
-          :? VoidCacheQueryParamMatcher(void) =>
-      for {
-        paintable <- analyses.read(analysisId, node)
-        histsValidated <- paintable.histogram(4000)
-        resp <- histsValidated match {
-          case Valid(hists) =>
-            Ok(hists.head asJson)
-          case Invalid(e) =>
-            BadRequest(s"Unable to produce histogram for $analysisId: $e")
-        }
-      } yield resp
-
-    case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
-          y)
-          :? NodeQueryParamMatcher(node) =>
-      for {
-        paintable <- analyses.read(analysisId, node)
-        tileValidated <- paintable.tms(z, x, y)
-        resp <- tileValidated match {
-          case Valid(tile) =>
-            Ok(
-              paintable.renderDefinition map { renderDef =>
-                tile.band(0).renderPng(renderDef).bytes
-              } getOrElse { tile.band(0).renderPng(ColorRamps.Viridis).bytes }
-            )
-          case Invalid(e) =>
-            BadRequest(s"Unable to produce tile for $analysisId: $e")
-        }
-      } yield resp
-
-    case req @ GET -> Root / UUIDWrapper(analysisId) / "raw"
-          :? ExtentQueryParamMatcher(extent)
-          :? ZoomQueryParamMatcher(zoom)
-          :? NodeQueryParamMatcher(node) =>
-      val projectedExtent = extent.reproject(LatLng, WebMercator)
-      val respType =
-        req.headers
-          .get(CaseInsensitiveString("Accept")) match {
-          case Some(Header(_, "image/tiff")) =>
-            `Content-Type`(MediaType.image.tiff)
-          case _ => `Content-Type`(MediaType.image.png)
-        }
-      val pngType = `Content-Type`(MediaType.image.png)
-      val tiffType = `Content-Type`(MediaType.image.tiff)
-      for {
-        paintableTool <- analyses.read(analysisId, node)
-        tileValidated <- paintableTool.extent(
-          projectedExtent,
-          BacksplashImage.tmsLevels(zoom).cellSize)
-        // TODO: restore render def coloring
-        resp <- tileValidated match {
-          case Valid(tile) =>
-            if (respType == tiffType) {
-              Ok(
-                SinglebandGeoTiff(tile.band(0), projectedExtent, WebMercator).toByteArray,
-                tiffType)
-            } else {
-              Ok(tile.band(0).renderPng(ColorRamps.Viridis).bytes,
-                 `Content-Type`(MediaType.image.png))
+        case GET -> Root / UUIDWrapper(analysisId) / "histogram"
+              :? NodeQueryParamMatcher(node)
+              :? VoidCacheQueryParamMatcher(void) as user =>
+          for {
+            authorized <- Authorizers.authToolRun(user, analysisId)
+            paintable <- analyses.read(analysisId, node)
+            histsValidated <- paintable.histogram(4000)
+            resp <- histsValidated match {
+              case Valid(hists) =>
+                Ok(hists.head asJson)
+              case Invalid(e) =>
+                BadRequest(s"Unable to produce histogram for $analysisId: $e")
             }
-          case Invalid(e) => BadRequest(s"Could not produce extent: $e")
-        }
-      } yield resp
+          } yield resp
+
+        case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
+              y)
+              :? NodeQueryParamMatcher(node) as user =>
+          for {
+            authorized <- Authorizers.authToolRun(user, analysisId)
+            paintable <- analyses.read(analysisId, node)
+            tileValidated <- paintable.tms(z, x, y)
+            resp <- tileValidated match {
+              case Valid(tile) =>
+                Ok(
+                  paintable.renderDefinition map { renderDef =>
+                    tile.band(0).renderPng(renderDef).bytes
+                  } getOrElse {
+                    tile.band(0).renderPng(ColorRamps.Viridis).bytes
+                  }
+                )
+              case Invalid(e) =>
+                BadRequest(s"Unable to produce tile for $analysisId: $e")
+            }
+          } yield resp
+
+        case authedReq @ GET -> Root / UUIDWrapper(analysisId) / "raw"
+              :? ExtentQueryParamMatcher(extent)
+              :? ZoomQueryParamMatcher(zoom)
+              :? NodeQueryParamMatcher(node) as user =>
+          val projectedExtent = extent.reproject(LatLng, WebMercator)
+          val respType =
+            authedReq.req.headers
+              .get(CaseInsensitiveString("Accept")) match {
+              case Some(Header(_, "image/tiff")) =>
+                `Content-Type`(MediaType.image.tiff)
+              case _ => `Content-Type`(MediaType.image.png)
+            }
+          val pngType = `Content-Type`(MediaType.image.png)
+          val tiffType = `Content-Type`(MediaType.image.tiff)
+          for {
+            authorized <- Authorizers.authToolRun(user, analysisId)
+            paintableTool <- analyses.read(analysisId, node)
+            tileValidated <- paintableTool.extent(
+              projectedExtent,
+              BacksplashImage.tmsLevels(zoom).cellSize)
+            // TODO: restore render def coloring
+            resp <- tileValidated match {
+              case Valid(tile) =>
+                if (respType == tiffType) {
+                  Ok(SinglebandGeoTiff(tile.band(0),
+                                       projectedExtent,
+                                       WebMercator).toByteArray,
+                     tiffType)
+                } else {
+                  Ok(tile.band(0).renderPng(ColorRamps.Viridis).bytes,
+                     `Content-Type`(MediaType.image.png))
+                }
+              case Invalid(e) => BadRequest(s"Could not produce extent: $e")
+            }
+          } yield resp
+      }
+    }
   }
+
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -1,0 +1,37 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.datamodel.{ActionType, ObjectType, User}
+import com.rasterfoundry.database.{ProjectDao, ToolRunDao}
+import com.rasterfoundry.database.util.RFTransactor
+
+import cats.effect._
+
+import doobie.Transactor
+import doobie.implicits._
+
+import java.util.UUID
+
+object Authorizers {
+  val xa = RFTransactor.xa
+
+  def authToolRun(user: User, toolRunId: UUID): IO[Unit] =
+    ToolRunDao
+      .authorized(user, ObjectType.Analysis, toolRunId, ActionType.View)
+      .transact(xa) map {
+      case false =>
+        throw NotAuthorizedException(
+          s"User ${user.id} is not authorized to view analysis $toolRunId")
+      case _ => ()
+    }
+
+  def authProject(user: User, projectId: UUID): IO[Unit] =
+    ProjectDao
+      .authorized(user, ObjectType.Project, projectId, ActionType.View)
+      .transact(xa) map {
+      case false =>
+        throw NotAuthorizedException(
+          s"User ${user.id} is not authorized to view project $projectId")
+      case _ => ()
+    }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -1,0 +1,33 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash.error._
+
+import cats._
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import com.typesafe.scalalogging.LazyLogging
+import doobie.util.invariant.InvariantViolation
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.dsl.io._
+import java.lang.IllegalArgumentException
+
+class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
+    extends LazyLogging
+    with HttpErrorHandler[F, E, U]
+    with Http4sDsl[F] {
+  private def wrapError(t: E): F[Response[F]] = t match {
+    case (err: InvariantViolation) =>
+      logger.error(err.getMessage, err.printStackTrace)
+      throw WrappedDoobieException(err.getMessage)
+    case (err: AmazonS3Exception) =>
+      logger.error(err.getMessage, err.printStackTrace)
+      throw WrappedS3Exception(err.getMessage)
+    case (err: IllegalArgumentException) =>
+      throw RequirementFailedException(err.getMessage)
+    case (err: BacksplashException) => throw err
+    case t                          => throw UnknownException(t.getMessage)
+  }
+
+  override def handle(service: AuthedService[U, F]): AuthedService[U, F] =
+    ServiceHttpErrorHandler(service)(wrapError)
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -34,7 +34,7 @@ import com.rasterfoundry.backsplash.MetricsRegistrator
 
 import java.util.UUID
 
-object Main extends IOApp {
+object Main extends IOApp with ProjectStoreImplicits {
 
   override protected implicit def contextShift: ContextShift[IO] =
     IO.contextShift(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -1,11 +1,13 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.database.{SceneToProjectDao, ToolRunDao}
+import com.rasterfoundry.datamodel.User
 import cats.Applicative
 import cats.data.OptionT
 import cats.data.Validated._
 import cats.effect._
 import cats.implicits._
+import com.olegpy.meow.hierarchy._
 import fs2.Stream
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
@@ -25,6 +27,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.{TimeUnit, Executors}
 
+import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.MosaicImplicits
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.backsplash.MetricsRegistrator
@@ -42,6 +45,13 @@ object Main extends IOApp {
 
   val timeout: FiniteDuration =
     new FiniteDuration(Config.server.timeoutSeconds, TimeUnit.SECONDS)
+
+  implicit val backsplashErrorHandler
+    : HttpErrorHandler[IO, BacksplashException, User] =
+    new BacksplashHttpErrorHandler[IO, User]
+
+  implicit val foreignErrorHandler: HttpErrorHandler[IO, Throwable, User] =
+    new ForeignErrorHandler[IO, Throwable, User]
 
   def withCORS(svc: HttpRoutes[IO]): HttpRoutes[IO] =
     CORS(
@@ -69,10 +79,15 @@ object Main extends IOApp {
   import toolStoreImplicits._
 
   val mosaicService: HttpRoutes[IO] =
-    new MosaicService(SceneToProjectDao(), mtr, mosaicImplicits).routes
+    Authenticators.tokensAuthMiddleware(
+     new MosaicService(SceneToProjectDao(), mtr, mosaicImplicits).routes)
 
   val analysisService: HttpRoutes[IO] =
-    new AnalysisService(ToolRunDao(), mtr, mosaicImplicits, toolStoreImplicits).routes
+    Authenticators.tokensAuthMiddleware(
+      new AnalysisService(ToolRunDao(),
+                          mtr,
+                          mosaicImplicits,
+                          toolStoreImplicits).routes)
 
   val httpApp =
     Router(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -80,7 +80,7 @@ object Main extends IOApp {
 
   val mosaicService: HttpRoutes[IO] =
     Authenticators.tokensAuthMiddleware(
-     new MosaicService(SceneToProjectDao(), mtr, mosaicImplicits).routes)
+      new MosaicService(SceneToProjectDao(), mtr, mosaicImplicits).routes)
 
   val analysisService: HttpRoutes[IO] =
     Authenticators.tokensAuthMiddleware(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -6,7 +6,6 @@ import com.azavea.maml.ast._
 import com.azavea.maml.util.{NeighborhoodConversion, ClassMap => MamlClassMap}
 import geotrellis.vector.io._
 import cats._
-import cats.data._
 import cats.implicits._
 import doobie.implicits._
 
@@ -17,7 +16,8 @@ import com.rasterfoundry.datamodel.{BandDataType, SingleBandOptions}
 import com.rasterfoundry.tool.ast.MapAlgebraAST.{CogRaster, SceneRaster}
 import io.circe.Json
 
-class BacksplashMamlAdapter(mosaicImplicits: MosaicImplicits) {
+class BacksplashMamlAdapter(mosaicImplicits: MosaicImplicits)
+    extends ProjectStoreImplicits {
   import mosaicImplicits._
 
   def asMaml(ast: MapAlgebraAST)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -39,7 +39,7 @@ class MosaicService[ProjStore: ProjectStore](projects: ProjStore,
       ForeignError.handle {
         AuthedService {
           case GET -> Root / UUIDWrapper(projectId) / IntVar(z) / IntVar(x) / IntVar(
-                y)
+                y) / _
                 :? RedBandOptionalQueryParamMatcher(redOverride)
                 :? GreenBandOptionalQueryParamMatcher(greenOverride)
                 :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
@@ -60,7 +60,7 @@ class MosaicService[ProjStore: ProjectStore](projects: ProjStore,
               }
             } yield resp
 
-          case GET -> Root / UUIDWrapper(projectId) / "histogram" as user =>
+          case GET -> Root / UUIDWrapper(projectId) / "histogram" / _ as user =>
             for {
               _ <- Authorizers.authProject(user, projectId)
               mosaic = projects.read(projectId, None, None, None)
@@ -105,7 +105,7 @@ class MosaicService[ProjStore: ProjectStore](projects: ProjStore,
               }
             }
 
-          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "export"
+          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "export" / _
                 :? ExtentQueryParamMatcher(extent)
                 :? ZoomQueryParamMatcher(zoom)
                 :? RedBandOptionalQueryParamMatcher(redOverride)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -1,11 +1,17 @@
 package com.rasterfoundry.backsplash.server
 
+import com.rasterfoundry.datamodel.User
+
+import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.backsplash.MetricsRegistrator
+import com.rasterfoundry.backsplash.Parameters._
+
 import cats.Applicative
 import cats.data.{NonEmptyList => NEL}
 import cats.data.Validated._
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
-import com.rasterfoundry.backsplash.Parameters._
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.server._
@@ -17,111 +23,133 @@ import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString
 
-import com.rasterfoundry.backsplash._
-import com.rasterfoundry.backsplash.MetricsRegistrator
-
 import java.util.UUID
 
-class MosaicService[ProjStore: ProjectStore](
-    projects: ProjStore,
-    mtr: MetricsRegistrator,
-    mosaicImplicits: MosaicImplicits)(implicit cs: ContextShift[IO]) {
+class MosaicService[ProjStore: ProjectStore](projects: ProjStore,
+                                             mtr: MetricsRegistrator,
+                                             mosaicImplicits: MosaicImplicits)(
+    implicit cs: ContextShift[IO],
+    H: HttpErrorHandler[IO, BacksplashException, User],
+    ForeignError: HttpErrorHandler[IO, Throwable, User]) {
+
   import mosaicImplicits._
 
-  val routes: HttpRoutes[IO] = HttpRoutes.of {
-    case GET -> Root / UUIDWrapper(projId) / IntVar(z) / IntVar(x) / IntVar(y)
-          :? RedBandOptionalQueryParamMatcher(redOverride)
-          :? GreenBandOptionalQueryParamMatcher(greenOverride)
-          :? BlueBandOptionalQueryParamMatcher(blueOverride) =>
-      val bandOverride =
-        Applicative[Option].map3(redOverride, greenOverride, blueOverride)(
-          BandOverride.apply)
-      val eval =
-        LayerTms.identity(projects.read(projId, None, bandOverride, None))
-      eval(z, x, y) flatMap {
-        case Valid(tile) =>
-          Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
-        case Invalid(e) =>
-          BadRequest(s"Could not produce tile: $e")
-      }
-
-    case GET -> Root / UUIDWrapper(projId) / "histogram" =>
-      val mosaic: BacksplashMosaic = projects.read(projId, None, None, None)
-      LayerHistogram.identity(mosaic, 4000) flatMap {
-        case Valid(hists) =>
-          Ok(hists map { hist =>
-            Map(hist.binCounts: _*)
-          } asJson)
-        case Invalid(e) => BadRequest(s"Histograms could not be produced: $e")
-      }
-
-    case req @ POST -> Root / UUIDWrapper(projectId) / "histogram" / _
-          :? RedBandOptionalQueryParamMatcher(redOverride)
-          :? GreenBandOptionalQueryParamMatcher(greenOverride)
-          :? BlueBandOptionalQueryParamMatcher(blueOverride) =>
-      // Compile to a byte array, decode that as a string, and do something with the results
-      req.body.compile.to[Array] flatMap { uuids =>
-        decode[List[UUID]](
-          uuids map { _.toChar } mkString
-        ) match {
-          case Right(uuids) =>
-            val overrides = (redOverride, greenOverride, blueOverride).mapN {
-              case (r, g, b) => BandOverride(r, g, b)
-            }
+  val routes: AuthedService[User, IO] =
+    H.handle {
+      ForeignError.handle {
+        AuthedService {
+          case GET -> Root / UUIDWrapper(projectId) / IntVar(z) / IntVar(x) / IntVar(
+                y)
+                :? RedBandOptionalQueryParamMatcher(redOverride)
+                :? GreenBandOptionalQueryParamMatcher(greenOverride)
+                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+            val bandOverride =
+              Applicative[Option].map3(redOverride,
+                                       greenOverride,
+                                       blueOverride)(BandOverride.apply)
+            val eval =
+              LayerTms.identity(
+                projects.read(projectId, None, bandOverride, None))
             for {
-              mosaic <- IO {
-                projects.read(projectId, None, overrides, uuids.toNel)
-              }
-              histsValidated <- LayerHistogram.identity(mosaic, 4000)
-              resp <- histsValidated match {
-                case Valid(hists) => Ok(hists asJson)
+              _ <- Authorizers.authProject(user, projectId)
+              resp <- eval(z, x, y) flatMap {
+                case Valid(tile) =>
+                  Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
                 case Invalid(e) =>
-                  BadRequest(s"Unable to produce histograms: $e")
+                  BadRequest(s"Could not produce tile: $e")
               }
             } yield resp
-          case _ =>
-            BadRequest("Could not decode body as sequence of UUIDs")
-        }
-      }
 
-    case req @ GET -> Root / UUIDWrapper(projectId) / "export"
-          :? ExtentQueryParamMatcher(extent)
-          :? ZoomQueryParamMatcher(zoom)
-          :? RedBandOptionalQueryParamMatcher(redOverride)
-          :? GreenBandOptionalQueryParamMatcher(greenOverride)
-          :? BlueBandOptionalQueryParamMatcher(blueOverride) =>
-      val bandOverride =
-        Applicative[Option].map3(redOverride, greenOverride, blueOverride)(
-          BandOverride.apply)
-      val projectedExtent = extent.reproject(LatLng, WebMercator)
-      val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
-      // TODO: this will come from the project once we're fetching the project for authorization reasons
-      val toPaint: Boolean = true
-      val eval =
-        if (toPaint) {
-          LayerExtent.identity(
-            projects.read(projectId, None, bandOverride, None))(
-            paintedMosaicExtentReification,
-            cs)
-        } else {
-          LayerExtent.identity(
-            projects.read(projectId, None, bandOverride, None))(
-            rawMosaicExtentReification,
-            cs)
+          case GET -> Root / UUIDWrapper(projectId) / "histogram" as user =>
+            for {
+              _ <- Authorizers.authProject(user, projectId)
+              mosaic = projects.read(projectId, None, None, None)
+              resp <- LayerHistogram.identity(mosaic, 4000) flatMap {
+                case Valid(hists) =>
+                  Ok(hists map { hist =>
+                    Map(hist.binCounts: _*)
+                  } asJson)
+                case Invalid(e) =>
+                  BadRequest(s"Histograms could not be produced: $e")
+              }
+            } yield resp
+
+          case authedReq @ POST -> Root / UUIDWrapper(projectId) / "histogram" / _
+                :? RedBandOptionalQueryParamMatcher(redOverride)
+                :? GreenBandOptionalQueryParamMatcher(greenOverride)
+                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+            // Compile to a byte array, decode that as a string, and do something with the results
+            authedReq.req.body.compile.to[Array] flatMap { uuids =>
+              decode[List[UUID]](
+                uuids map { _.toChar } mkString
+              ) match {
+                case Right(uuids) =>
+                  val overrides =
+                    (redOverride, greenOverride, blueOverride).mapN {
+                      case (r, g, b) => BandOverride(r, g, b)
+                    }
+                  for {
+                    _ <- Authorizers.authProject(user, projectId)
+                    mosaic <- IO {
+                      projects.read(projectId, None, overrides, uuids.toNel)
+                    }
+                    histsValidated <- LayerHistogram.identity(mosaic, 4000)
+                    resp <- histsValidated match {
+                      case Valid(hists) => Ok(hists asJson)
+                      case Invalid(e) =>
+                        BadRequest(s"Unable to produce histograms: $e")
+                    }
+                  } yield resp
+                case _ =>
+                  BadRequest("Could not decode body as sequence of UUIDs")
+              }
+            }
+
+          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "export"
+                :? ExtentQueryParamMatcher(extent)
+                :? ZoomQueryParamMatcher(zoom)
+                :? RedBandOptionalQueryParamMatcher(redOverride)
+                :? GreenBandOptionalQueryParamMatcher(greenOverride)
+                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+            val bandOverride =
+              Applicative[Option].map3(redOverride,
+                                       greenOverride,
+                                       blueOverride)(BandOverride.apply)
+            val projectedExtent = extent.reproject(LatLng, WebMercator)
+            val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
+            // TODO: this will come from the project once we're fetching the project for authorization reasons
+            val toPaint: Boolean = true
+            val eval =
+              if (toPaint) {
+                LayerExtent.identity(
+                  projects.read(projectId, None, bandOverride, None))(
+                  paintedMosaicExtentReification,
+                  cs)
+              } else {
+                LayerExtent.identity(
+                  projects.read(projectId, None, bandOverride, None))(
+                  rawMosaicExtentReification,
+                  cs)
+              }
+            for {
+              _ <- Authorizers.authProject(user, projectId)
+              resp <- eval(extent, cellSize) flatMap {
+                case Valid(tile) =>
+                  authedReq.req.headers
+                    .get(CaseInsensitiveString("Accept")) match {
+                    case Some(Header(_, "image/tiff")) =>
+                      Ok(
+                        MultibandGeoTiff(tile, projectedExtent, WebMercator).toByteArray,
+                        `Content-Type`(MediaType.image.tiff)
+                      )
+                    case _ =>
+                      Ok(tile.renderPng.bytes,
+                         `Content-Type`(MediaType.image.png))
+                  }
+                case Invalid(e) => BadRequest(s"Could not produce extent: $e")
+              }
+            } yield resp
         }
-      eval(extent, cellSize) flatMap {
-        case Valid(tile) =>
-          req.headers
-            .get(CaseInsensitiveString("Accept")) match {
-            case Some(Header(_, "image/tiff")) =>
-              Ok(
-                MultibandGeoTiff(tile, projectedExtent, WebMercator).toByteArray,
-                `Content-Type`(MediaType.image.tiff)
-              )
-            case _ =>
-              Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
-          }
-        case Invalid(e) => BadRequest(s"Could not produce extent: $e")
       }
-  }
+    }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -1,0 +1,108 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.database.SceneToProjectDao
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.datamodel.color.{
+  BandGamma => RFBandGamma,
+  PerBandClipping => RFPerBandClipping,
+  MultiBandClipping => RFMultiBandClipping,
+  SigmoidalContrast => RFSigmoidalContrast,
+  Saturation => RFSaturation
+}
+import com.rasterfoundry.backsplash.{
+  ProjectStore,
+  BandOverride,
+  BacksplashImage
+}
+import com.rasterfoundry.backsplash.color.{
+  ColorCorrect => BSColorCorrect,
+  SingleBandOptions => BSSingleBandOptions,
+  _
+}
+import cats.data.{NonEmptyList => NEL}
+import cats.effect.IO
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import geotrellis.vector.{Polygon, Projected}
+
+import java.util.UUID
+
+trait ProjectStoreImplicits extends ToProjectStoreOps {
+  implicit val projectStore: ProjectStore[SceneToProjectDao] =
+    new ProjectStore[SceneToProjectDao] {
+      // safe to get here, since we're just unapplying from a value that we already know
+      // was constructed correctly
+      @SuppressWarnings(Array("OptionGet"))
+      def read(self: SceneToProjectDao,
+               projId: UUID,
+               window: Option[Projected[Polygon]],
+               bandOverride: Option[BandOverride],
+               imageSubset: Option[NEL[UUID]]) = {
+        SceneToProjectDao.getMosaicDefinition(
+          projId,
+          window,
+          bandOverride map { _.red },
+          bandOverride map { _.green },
+          bandOverride map { _.blue },
+          imageSubset map { _.toList } getOrElse List.empty) map { md =>
+          val singleBandOptions =
+            md.singleBandOptions.as[BSSingleBandOptions.Params].toOption
+          BacksplashImage(
+            md.ingestLocation getOrElse {
+              throw UningestedScenesException(
+                s"Scene ${md.sceneId} does not have an ingest location")
+            },
+            md.footprint getOrElse {
+              throw MetadataException(
+                s"Scene ${md.sceneId} does not have a footprint")
+            },
+            if (md.isSingleBand) {
+              singleBandOptions map { sbo =>
+                List(sbo.band)
+              } getOrElse {
+                throw SingleBandOptionsException(
+                  "Single band options must be specified for single band projects")
+              }
+            } else {
+              bandOverride map { ovr =>
+                List(ovr.red, ovr.green, ovr.blue)
+              } getOrElse {
+                List(md.colorCorrections.redBand,
+                     md.colorCorrections.greenBand,
+                     md.colorCorrections.blueBand)
+              }
+            },
+            BSColorCorrect.Params(
+              0, // red
+              1, // green
+              2, // blue
+              (BandGamma.apply _)
+                .tupled(RFBandGamma.unapply(md.colorCorrections.gamma).get),
+              (PerBandClipping.apply _).tupled(
+                RFPerBandClipping
+                  .unapply(md.colorCorrections.bandClipping)
+                  .get),
+              (MultiBandClipping.apply _).tupled(
+                RFMultiBandClipping
+                  .unapply(md.colorCorrections.tileClipping)
+                  .get),
+              (SigmoidalContrast.apply _)
+                .tupled(
+                  RFSigmoidalContrast
+                    .unapply(md.colorCorrections.sigmoidalContrast)
+                    .get),
+              (Saturation.apply _).tupled(
+                RFSaturation
+                  .unapply(md.colorCorrections.saturation)
+                  .get)
+            ),
+            singleBandOptions
+          )
+        } transact (RFTransactor.xa)
+      }
+    }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -1,19 +1,24 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.ToolRunDao
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.tool
+import com.rasterfoundry.tool.ast.MapAlgebraAST
 
+import cats.effect.IO
+import cats.implicits._
 import doobie._
 import doobie.implicits._
-import cats.effect.IO
 
 import java.util.UUID
 
-class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
+class ToolStoreImplicits(mosaicImplicits: MosaicImplicits)
+    extends ProjectStoreImplicits {
   import mosaicImplicits._
   val mamlAdapter = new BacksplashMamlAdapter(mosaicImplicits)
 
@@ -35,8 +40,9 @@ class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
     RenderDefinition(toolRd.breakpoints, scaleOpt, clipOpt)
   }
 
-  private def unsafeGetAST(anslysisId: UUID, nodeId: Option[UUID]): IO[MapAlgebraAST] =
-    for {
+  private def unsafeGetAST(analysisId: UUID,
+                           nodeId: Option[UUID]): IO[MapAlgebraAST] =
+    (for {
       executionParams <- ToolRunDao.query.filter(analysisId).select map {
         _.executionParameters
       }
@@ -52,7 +58,7 @@ class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
               s"Node $nodeId missing from AST $analysisId")
           }
       } getOrElse { decoded }
-    } transact { RFTransactor.xa }
+    }).transact(RFTransactor.xa)
 
   implicit val toolRunDaoStore: ToolStore[ToolRunDao] =
     new ToolStore[ToolRunDao] {

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -271,7 +271,7 @@ lazy val common = Project("common", file("common"))
   })
 
 lazy val db = Project("db", file("db"))
-  .dependsOn(datamodel % "compile->compile;test->test", common, backsplashCore)
+  .dependsOn(datamodel % "compile->compile;test->test", common)
   .settings(commonSettings: _*)
   .settings({
     libraryDependencies ++= dbDependencies ++ loggingDependencies ++ Seq(

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -31,7 +31,7 @@ lazy val commonSettings = Seq(
     "-language:existentials",
     "-language:experimental.macros",
     "-Xmax-classfile-name",
-    "70",
+    "72",
     "-Ywarn-value-discard",
     "-Ywarn-unused",
     "-Ypartial-unification",
@@ -474,7 +474,8 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
       "org.scalatest" %% "scalatest" % Version.scalaTest,
       "com.azavea" %% "geotrellis-server-core" % Version.geotrellisServer,
       "org.scalacheck" %% "scalacheck" % Version.scalaCheck,
-      "org.apache.spark" %% "spark-core" % "2.4.0" % Provided
+      "org.apache.spark" %% "spark-core" % "2.4.0" % Provided,
+      Dependencies.catsMeow
     ),
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),

--- a/app-backend/db/src/main/scala/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/SceneToProjectDao.scala
@@ -14,24 +14,6 @@ import com.rasterfoundry.datamodel.{
   SceneToProject,
   SceneToProjectwithSceneType
 }
-import com.rasterfoundry.datamodel.color.{
-  BandGamma => RFBandGamma,
-  PerBandClipping => RFPerBandClipping,
-  MultiBandClipping => RFMultiBandClipping,
-  SigmoidalContrast => RFSigmoidalContrast,
-  Saturation => RFSaturation
-}
-import com.rasterfoundry.backsplash.{
-  ProjectStore,
-  BandOverride,
-  BacksplashImage
-}
-import com.rasterfoundry.backsplash.color.{
-  ColorCorrect => BSColorCorrect,
-  SingleBandOptions => BSSingleBandOptions,
-  _
-}
-import com.rasterfoundry.backsplash.error._
 import com.typesafe.scalalogging.LazyLogging
 import com.rasterfoundry.datamodel._
 import doobie._
@@ -46,83 +28,6 @@ import io.circe.syntax._
 case class SceneToProjectDao()
 
 object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
-
-  implicit val projectStore: ProjectStore[SceneToProjectDao] =
-    new ProjectStore[SceneToProjectDao] {
-      // safe to get here, since we're just unapplying from a value that we already know
-      // was constructed correctly
-      @SuppressWarnings(Array("OptionGet"))
-      def read(self: SceneToProjectDao,
-               projId: UUID,
-               window: Option[Projected[Polygon]],
-               bandOverride: Option[BandOverride],
-               imageSubset: Option[NEL[UUID]]) = {
-        getMosaicDefinition(
-          projId,
-          window,
-          bandOverride map { _.red },
-          bandOverride map { _.green },
-          bandOverride map { _.blue },
-          imageSubset map { _.toList } getOrElse List.empty) map { md =>
-          val singleBandOptions =
-            md.singleBandOptions.as[BSSingleBandOptions.Params].toOption
-          BacksplashImage(
-            md.ingestLocation getOrElse {
-              throw UningestedScenesException(
-                s"Scene ${md.sceneId} does not have an ingest location")
-            },
-            md.footprint getOrElse {
-              throw MetadataException(
-                s"Scene ${md.sceneId} does not have a footprint")
-            },
-            if (md.isSingleBand) {
-              singleBandOptions map { sbo =>
-                List(sbo.band)
-              } getOrElse {
-                throw SingleBandOptionsException(
-                  "Single band options must be specified for single band projects")
-              }
-            } else {
-              bandOverride map { ovr =>
-                List(ovr.red, ovr.green, ovr.blue)
-              } getOrElse {
-                List(md.colorCorrections.redBand,
-                     md.colorCorrections.greenBand,
-                     md.colorCorrections.blueBand)
-              }
-            },
-            // why is all this necessary? because we're obligated to keep the existing tile
-            // server functioning, and in pursuit of that i want to make as few changes to
-            // functions it calls as possible
-            BSColorCorrect.Params(
-              0, // red
-              1, // green
-              2, // blue
-              (BandGamma.apply _)
-                .tupled(RFBandGamma.unapply(md.colorCorrections.gamma).get),
-              (PerBandClipping.apply _).tupled(
-                RFPerBandClipping
-                  .unapply(md.colorCorrections.bandClipping)
-                  .get),
-              (MultiBandClipping.apply _).tupled(
-                RFMultiBandClipping
-                  .unapply(md.colorCorrections.tileClipping)
-                  .get),
-              (SigmoidalContrast.apply _)
-                .tupled(
-                  RFSigmoidalContrast
-                    .unapply(md.colorCorrections.sigmoidalContrast)
-                    .get),
-              (Saturation.apply _).tupled(
-                RFSaturation
-                  .unapply(md.colorCorrections.saturation)
-                  .get)
-            ),
-            singleBandOptions
-          )
-        } transact (RFTransactor.xa)
-      }
-    }
 
   val tableName = "scenes_to_projects"
 

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -2,8 +2,6 @@ package com.rasterfoundry.database
 
 import java.sql.Timestamp
 
-import com.rasterfoundry.backsplash.PaintableTool
-import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.datamodel.{
@@ -110,24 +108,4 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
       .filter(authorizedF(user, objectType, actionType))
       .filter(objectId)
       .exists
-
-  def unsafeGetAST(analysisId: UUID,
-                   nodeId: Option[UUID]): ConnectionIO[MapAlgebraAST] =
-    for {
-      executionParams <- query.filter(analysisId).select map {
-        _.executionParameters
-      }
-    } yield {
-      val decoded = executionParams.as[MapAlgebraAST].toOption getOrElse {
-        throw MetadataException(s"Could not decode AST for $analysisId")
-      }
-      nodeId map {
-        decoded
-          .find(_)
-          .getOrElse {
-            throw MetadataException(
-              s"Node $nodeId missing from AST $analysisId")
-          }
-      } getOrElse { decoded }
-    }
 }


### PR DESCRIPTION
## Overview

This PR brings backsplash to slightly more than parity with what it used to be (since the lab + histograms works now). It's the last restoration task.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * make some requests without tokens and with tokens for projects that don't exist
 * they should return the expected statuses