### PR TITLE
Add script to re-ingest a list of landsat 8 / sentinel 2 / planet / user uploaded scenes as cogs

### DIFF
--- a/app-tasks/completion.bash
+++ b/app-tasks/completion.bash
@@ -1,5 +1,5 @@
 
 # Completion for rf cli
 complete -W \
-         "export find-aoi-projects ingest-scene process-upload update-aoi-project reprocess-landsat-h reprocess-sentinel" \
+         "export find-aoi-projects ingest-scene process-upload update-aoi-project reprocess-landsat-h reprocess-sentinel reprocess-geotiff-to-cog" \
          rf

--- a/app-tasks/rf/src/rf/cli.py
+++ b/app-tasks/rf/src/rf/cli.py
@@ -13,6 +13,7 @@ from .commands import (
     process_upload,
     reprocess_landsat_h,
     reprocess_sentinel,
+    reprocess_geotiff_to_cog,
     update_aoi_project,
 )
 
@@ -36,4 +37,5 @@ run.add_command(ingest_scene)
 run.add_command(find_aoi_projects)
 run.add_command(reprocess_landsat_h)
 run.add_command(reprocess_sentinel)
+run.add_command(reprocess_geotiff_to_cog)
 run.add_command(update_aoi_project)

--- a/app-tasks/rf/src/rf/commands/__init__.py
+++ b/app-tasks/rf/src/rf/commands/__init__.py
@@ -5,3 +5,4 @@ from .process_upload import process_upload
 from .reprocess_landsat_h import reprocess_landsat_h
 from .update_aoi_project import update_aoi_project
 from .reprocess_sentinel import reprocess_sentinel
+from .reprocess_geotiff_to_cog import reprocess_geotiff_to_cog

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -21,8 +21,9 @@ def ingest_scene(scene_id):
     """
     logger.info("Converting scene to COG: %s", scene_id)
     scene = Scene.from_id(scene_id)
-    scene.ingestStatus = 'INGESTING'
-    scene.update()
+    if scene.ingestStatus != 'INGESTED':
+        scene.ingestStatus = 'INGESTING'
+        scene.update()
     image_locations = [(x.sourceUri, x.filename) for x in sorted(
         scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
     io.create_cog(image_locations, scene)

--- a/app-tasks/rf/src/rf/commands/reprocess_geotiff_to_cog.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_geotiff_to_cog.py
@@ -1,0 +1,78 @@
+import click
+import subprocess
+
+from ..models import Scene
+from ..ingest import io
+
+from ..utils.exception_reporting import wrap_rollbar
+from rf.ingest.settings import (landsat8_datasource_id,
+                                sentinel2_datasource_id)
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+@click.command(name='reprocess-geotiff-to-cog')
+@click.argument('scene_ids')
+@wrap_rollbar
+def reprocess_geotiff_to_cog(scene_ids):
+    """ Reprocess user uploaded and planet AVRO scenes to COGs
+
+    Should be fine for anything other than landsat / sentinel scenes
+    Will not re-ingest cogs.
+
+    Accepts a comma separated list of scene ids
+    """
+
+    ids = [scene.strip() for scene in scene_ids.split(',')]
+    logger.info("Processing %d scenes", len(ids))
+
+    for scene_id in ids:
+        try:
+            process_id(scene_id)
+        except Exception as e:
+            logger.exception("Failed to reprocess geotiff for scene: %s; %s", scene_id, e)
+
+
+def process_id(scene_id):
+    """Process a single scene id"""
+    logger.info("Converting AVRO scene to COG: %s", scene_id)
+    scene = Scene.from_id(scene_id)
+    if scene.ingestStatus != 'INGESTED':
+        logger.info("Skipping scene because it is not already ingested")
+        return
+    if scene.sceneType == 'COG':
+        logger.info("Skipping scene because it's already a cog")
+        return
+
+    if scene.datasource == sentinel2_datasource_id or scene.datasource == landsat8_datasource_id:
+        image_locations = [(x.sourceUri, x.filename) for x in sorted(
+            scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
+        io.create_cog(image_locations, scene)
+    else:
+        image_locations = [(x.sourceUri, x.filename) for x in scene.images]
+        io.create_cog(image_locations, scene, True)
+    logger.info('Cog created, writing histogram to attribute store')
+    metadata_to_postgres(scene.id)
+    logger.info('Histogram written to attribute store')
+
+
+def metadata_to_postgres(scene_id):
+    """Save histogram for the generated COG in the database
+
+    Args:
+        scene_id (str): ID of scene to save metadata for
+    """
+
+    bash_cmd = [
+        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
+        'com.rasterfoundry.batch.Main', 'cog-histogram-backfill',
+        scene_id
+    ]
+
+    logger.debug('Bash command to store histogram: %s', ' '.join(bash_cmd))
+    running_cmd = subprocess.Popen(bash_cmd)
+    running_cmd.communicate()
+    logger.info('Successfully completed metadata postgres write for scene %s',
+                scene_id)
+    return True

--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -10,6 +10,7 @@ import boto3
 
 import logging
 import os
+import urllib
 
 DATA_BUCKET = os.getenv('DATA_BUCKET')
 
@@ -17,7 +18,7 @@ s3client = boto3.client('s3')
 logger = logging.getLogger(__name__)
 
 
-def create_cog(image_locations, scene):
+def create_cog(image_locations, scene, same_path=False):
     with get_tempdir() as local_dir:
         dsts = [os.path.join(local_dir, fname) for _, fname in image_locations]
         cog.fetch_imagery(image_locations, local_dir)
@@ -25,12 +26,21 @@ def create_cog(image_locations, scene):
         merged_tif = cog.merge_tifs(warped_paths, local_dir)
         cog.add_overviews(merged_tif)
         cog_path = cog.convert_to_cog(merged_tif, local_dir)
-        updated_scene = upload_tif(cog_path, scene)
+        if same_path:
+            updated_scene = upload_tif(
+                cog_path, scene,
+                os.path.join('user-uploads', urllib.quote_plus(scene.owner), '{}_COG.tif'.format(scene.id))
+            )
+        else:
+            updated_scene = upload_tif(cog_path, scene)
         updated_scene.update()
+        os.remove(cog_path)
 
 
-def upload_tif(tif_path, scene):
-    key = os.path.join('public-cogs', '{}_COG.tif'.format(scene.id))
+def upload_tif(tif_path, scene, key=''):
+    if len(key) == 0:
+        key = os.path.join('public-cogs', '{}_COG.tif'.format(scene.id))
+
     s3uri = 's3://{}/{}'.format(DATA_BUCKET, key)
     logger.info('Uploading tif to S3 at %s', s3uri)
     with open(tif_path, 'r') as inf:

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -51,10 +51,10 @@ def fetch_imagery(image_locations, local_dir):
 
 def fetch_image(location, filename, local_dir):
     bucket, key = s3_bucket_and_key_from_url(location)
-    if bucket.startswith('landsat'):
-        extra_kwargs = {}
-    elif bucket.startswith('sentinel'):
+    if bucket.startswith('sentinel'):
         extra_kwargs = {'RequestPayer': 'requester'}
+    else:
+        extra_kwargs = {}
     # both sentinel and landsat have these uris in bucket.s3.amazonaws.com/...,
     # so bucket and key from url does a bad job splitting correctly. follow up
     # by splitting on '.' and taking the first one


### PR DESCRIPTION
## Overview
Feed the script a list of UUID and it will re-ingest them. Should work for pretty much any avro scene, but we need to test it on staging since I don't want to spend another 6 hours waiting for scenes to ingest locally.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog]~(https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![uuidmuncher](https://user-images.githubusercontent.com/4392704/50185032-aecd4d00-02e4-11e9-80f5-f54336649b15.png)

```
root@6caf249dcbf6:/# rf reprocess-geotiff-to-cog 214db19b-9f29-429b-8da4-41478f4b2b3e
INFO:rf.commands.reprocess_geotiff_to_cog:Processing 1 scenes
INFO:rf.commands.reprocess_geotiff_to_cog:Converting AVRO scene to COG: 214db19b-9f29-429b-8da4-41478f4b2b3e
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B1.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B3.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B2.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B4.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B5.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B6.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B7.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B8.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B9.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B10.TIF
INFO:rf.utils.cog:Fetching image from bucket landsat-pds with key c1/L8/191/034/LC08_L1TP_191034_20170417_20170501_01_T1/LC08_L1TP_191034_20170417_20170501_01_T1_B11.TIF
INFO:rf.utils.cog:Getting metadata for tifs
INFO:rf.utils.cog:Resampling to maximum available resolution
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B1.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B2.TIF
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B3.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B4.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
Creating output file that is 15242P x 15522L.
Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B2.TIF [1/1] : 0Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B3.TIF [1/1] : 0Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B1.TIF [1/1] : 0Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B4.TIF [1/1] : 0............10101010............20202020............30303030..........40..40.4040.........50.50.5050..........6060...6060.........70..70..70.70.....80..80...8080.......90...90....9090....100 - done.
...100 - done.
..100 - done.
100 - done.
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B5.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B6.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B5.TIF [1/1] : 0Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B6.TIF [1/1] : 0....INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B7.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
INFO:rf.utils.cog:No need to reproject for /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B8.TIF, already in target resolution
Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B7.TIF [1/1] : 0Input file size is 15241, 15521
0....10.10....10.......10.2020...20........20.3030.30.......30...4040....40........5050.40.50........60.50...60...60.70.......60...70..7080.......70.80..80.......9080..9090..........90100 - done.
100 - done.
....100 - done.
.100 - done.
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B9.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B9.TIF [1/1] : 0...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B10.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B10.TIF [1/1] : 0..INFO:rf.utils.cog:Resampling LC08_L1TP_191034_20170417_20170501_01_T1_B11.TIF
INFO:rf.utils.cog:Increasing x resolution by 2x, y resolution by 2x
Creating output file that is 15242P x 15522L.
Processing /tmp/tmpGCxP_q/LC08_L1TP_191034_20170417_20170501_01_T1_B11.TIF [1/1] : 0...10...10...20..20.....3030.....40...40..50....50.60.....70...60.80......90.70...100 - done.
..80...90...100 - done.
INFO:rf.utils.cog:Merging 11 tif paths
0...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.utils.cog:Adding overviews to /tmp/tmpGCxP_q/merged.tif
0...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.utils.cog:Converting /tmp/tmpGCxP_q/merged.tif to a cog
Input file size is 15242, 15522
0...10...20...30...40...50...60...70...80...90...100 - done.
INFO:rf.ingest.io:Uploading tif to S3 at s3://rasterfoundry-development-data-us-east-1/public-cogs/214db19b-9f29-429b-8da4-41478f4b2b3e_COG.tif
INFO:rf.ingest.io:Tif uploaded successfully
INFO:rf.commands.reprocess_geotiff_to_cog:Cog created, writing histogram to attribute store
[main] INFO  - Raster-Foundry-Hikari-Pool - Starting...
[main] INFO  - Raster-Foundry-Hikari-Pool - Start completed.
[pool-1-thread-1] INFO  - HikariPool-1 - Starting...
[pool-1-thread-1] INFO  - HikariPool-1 - Start completed.
[ForkJoinPool-1-worker-5] INFO  - Fetching histogram for scene at s3://rasterfoundry-development-data-us-east-1/public-cogs/214db19b-9f29-429b-8da4-41478f4b2b3e_COG.tif
[ForkJoinPool-1-worker-5] INFO  -  Created histograms for 1 scenes.
 Failed to create histograms for 0 scenes.
[ForkJoinPool-1-worker-5] INFO  - Shutting down threadpool
[ForkJoinPool-1-worker-5] INFO  - Thread pool shutdown completed
[ForkJoinPool-1-worker-5] INFO  - HikariPool-1 - Shutdown initiated...
[ForkJoinPool-1-worker-5] INFO  - HikariPool-1 - Shutdown completed.
INFO:rf.commands.reprocess_geotiff_to_cog:Successfully completed metadata postgres write for scene 214db19b-9f29-429b-8da4-41478f4b2b3e
INFO:rf.commands.reprocess_geotiff_to_cog:Histogram written to attribute store
```

## Testing Instructions
* Rebuild your batch container
* In the batch container, run `rf reprocess-geotiff-to-cog 323c20e1-6f63-48d4-bddb-f03a7af808ca` to re-ingest the scene in the default `small flight import` project
* Verify that the scene is ingested as a COG and works. Expect the usual COG weirdness like badly colored thumbnails etc.
* If you have a lot of patience, run it on a landsat and sentinel scene. I tested landsat and it took about 1:15 locally.

Closes https://github.com/azavea/raster-foundry-platform/issues/579
