### PR TITLE
Add graphite reporting to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Supported team creation on user's team list page [\#4345](https://github.com/raster-foundry/raster-foundry/pull/4345)
 - Use java's gdal bindings for tile IO in backsplash and better separate concerns between fetching imagery and talking to the database / users [\#4339](https://github.com/raster-foundry/raster-foundry/pull/4339)
 - Added dropwizard metrics instrumentation to backsplash methods and endpoints [\#4381](https://github.com/raster-foundry/raster-foundry/pull/4381)
+- Added graphite reporter to dropwizard metrics [\#4398](https://github.com/raster-foundry/raster-foundry/pull/4398)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 - Address a number of unhandled promise chains on the frontend [\#4380](https://github.com/raster-foundry/raster-foundry/pull/4380)
 - Restored routes missing from backsplash after reintegration into RF main [\#4382](https://github.com/raster-foundry/raster-foundry/pull/4382)
 - Restored color correction [\#4387](https://github.com/raster-foundry/raster-foundry/pull/4387)
+- Fix logo on project share page and add error handling [/#4377](https://github.com/raster-foundry/raster-foundry/pull/4377)
+- Address a number of unhandled promise chains on the frontend [\#4380](https://github.com/raster-foundry/raster-foundry/pull/4380)
+- Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 - Aligned backsplash dockerfile with existing services [\#4394](https://github.com/raster-foundry/raster-foundry/pull/4394)
 
 ### Removed

--- a/app-backend/.dockerignore
+++ b/app-backend/.dockerignore
@@ -1,14 +1,2 @@
-api/target/*
-authentication/target/*
-batch/target/*
-common/target/*
-db/target/*
-datamodel/target/*
-ingest/target/*
-migrations/target/*
-project/target/*
-target/*
-tile/target/*
-tool/target/*
-backsplash/target/*
+*/target/*
 .idea/*

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -17,6 +17,7 @@ import cats.data.{NonEmptyList => NEL}
 import cats.effect.IO
 import io.circe.syntax._
 
+import java.net.URLDecoder
 import java.util.UUID
 
 case class BacksplashImage(
@@ -63,7 +64,8 @@ case class BacksplashImage(
 
 object BacksplashImage extends RasterSourceUtils {
 
-  def getRasterSource(uri: String): GDALRasterSource = GDALRasterSource(uri)
+  def getRasterSource(uri: String): GDALRasterSource =
+    GDALRasterSource(URLDecoder.decode(uri, "UTF-8"))
 
   def fromWkt(uri: String,
               wkt: String,

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MetricsRegistrator.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MetricsRegistrator.scala
@@ -50,9 +50,9 @@ class MetricsRegistrator(implicit clock: Clock[IO]) {
     reporter.start(1, TimeUnit.MINUTES)
   }
 
-  def reportToGraphite = {
+  def reportToGraphite(graphiteUrl: String) = {
     val addr =
-      new InetSocketAddress("graphite.service.rasterfoundry.internal", 2003)
+      new InetSocketAddress(graphiteUrl, 2003)
     val graphite = new Graphite(addr)
     val reporter = GraphiteReporter
       .forRegistry(registry)

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MetricsRegistrator.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MetricsRegistrator.scala
@@ -3,8 +3,10 @@ package com.rasterfoundry.backsplash
 import org.http4s.server.middleware.Metrics
 import org.http4s.metrics.dropwizard.Dropwizard
 import com.codahale.metrics.{Timer => MetricsTimer, _}
+import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import cats.effect.{IO, Clock}
 
+import java.net.InetSocketAddress
 import java.util.concurrent.TimeUnit
 import java.util.Locale
 import java.io.File
@@ -45,6 +47,18 @@ class MetricsRegistrator(implicit clock: Clock[IO]) {
       .convertRatesTo(TimeUnit.SECONDS)
       .convertDurationsTo(TimeUnit.MILLISECONDS)
       .build(f)
-    reporter.start(1, TimeUnit.SECONDS)
+    reporter.start(1, TimeUnit.MINUTES)
+  }
+
+  def reportToGraphite = {
+    val addr =
+      new InetSocketAddress("graphite.service.rasterfoundry.internal", 2003)
+    val graphite = new Graphite(addr)
+    val reporter = GraphiteReporter
+      .forRegistry(registry)
+      .convertRatesTo(TimeUnit.SECONDS)
+      .convertDurationsTo(TimeUnit.MILLISECONDS)
+      .build(graphite)
+    reporter.start(1, TimeUnit.MINUTES)
   }
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -4,9 +4,7 @@ import cats._
 import cats.data._
 import cats.effect._
 import cats.implicits._
-// import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.typesafe.scalalogging.LazyLogging
-// import doobie.util.invariant.InvariantViolation
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.dsl.io._
@@ -42,29 +40,8 @@ final case class WrappedDoobieException(message: String)
 final case class WrappedS3Exception(message: String) extends BacksplashException
 // Private so no one can deliberately throw an UnknownException elsewhere --
 // only exists to catch the fall-through case in the foreign error handler
-private[error] final case class UnknownException(message: String)
+private[backsplash] final case class UnknownException(message: String)
     extends BacksplashException
-
-// class ForeignErrorHandler[F[_], E <: Throwable](implicit M: MonadError[F, E])
-//     extends LazyLogging
-//     with HttpErrorHandler[F, E]
-//     with Http4sDsl[F] {
-//   private def wrapError(t: E): F[Response[F]] = t match {
-//     case (err: InvariantViolation) =>
-//       logger.error(err.getMessage, err.printStackTrace)
-//       throw WrappedDoobieException(err.getMessage)
-//     case (err: AmazonS3Exception) =>
-//       logger.error(err.getMessage, err.printStackTrace)
-//       throw WrappedS3Exception(err.getMessage)
-//     case (err: IllegalArgumentException) =>
-//       throw RequirementFailedException(err.getMessage)
-//     case (err: BacksplashException) => throw err
-//     case t                          => throw UnknownException(t.getMessage)
-//   }
-
-//   override def handle(service: AuthedService[U, F]): AuthedService[U, F] =
-//     ServiceHttpErrorHandler(service)(wrapError)
-// }
 
 class BacksplashHttpErrorHandler[F[_], U](
     implicit M: MonadError[F, BacksplashException])

--- a/app-backend/backsplash-server/src/main/resources/reference.conf
+++ b/app-backend/backsplash-server/src/main/resources/reference.conf
@@ -6,4 +6,7 @@ parallelism {
 server {
   timeoutSeconds = 15
   timeoutSeconds = ${?BACKSPLASH_SERVER_TIMEOUT}
+
+  graphiteUrl = "graphite.service.rasterfoundry.internal"
+  graphiteUrl = ${?GRAPHITE_URL}
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
-import com.rasterfoundry.backsplash.Parameters._
+import com.rasterfoundry.datamodel.User
 
 import cats.data.Validated._
 import cats.effect.{ContextShift, IO}
@@ -16,85 +16,100 @@ import org.http4s.circe._
 import org.http4s.util.CaseInsensitiveString
 
 import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.MetricsRegistrator
+import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.backsplash.color.{Implicits => ColorImplicits}
 
 @SuppressWarnings(Array("TraversableHead"))
-class AnalysisService[Param: ToolStore](
-    analyses: Param,
-    mtr: MetricsRegistrator,
-    mosaicImplicits: MosaicImplicits,
-    toolstoreImplicits: ToolStoreImplicits)(implicit cs: ContextShift[IO])
+class AnalysisService[Param: ToolStore](analyses: Param,
+                                        mtr: MetricsRegistrator,
+                                        mosaicImplicits: MosaicImplicits,
+                                        toolstoreImplicits: ToolStoreImplicits)(
+    implicit cs: ContextShift[IO],
+    H: HttpErrorHandler[IO, BacksplashException, User],
+    ForeignError: HttpErrorHandler[IO, Throwable, User])
     extends ColorImplicits {
   import mosaicImplicits._
   import toolstoreImplicits._
 
-  val routes: HttpRoutes[IO] = HttpRoutes.of {
+  val routes: AuthedService[User, IO] = H.handle {
+    ForeignError.handle {
+      AuthedService {
 
-    case GET -> Root / UUIDWrapper(analysisId) / "histogram"
-          :? NodeQueryParamMatcher(node)
-          :? VoidCacheQueryParamMatcher(void) =>
-      for {
-        paintable <- analyses.read(analysisId, node)
-        histsValidated <- paintable.histogram(4000)
-        resp <- histsValidated match {
-          case Valid(hists) =>
-            Ok(hists.head asJson)
-          case Invalid(e) =>
-            BadRequest(s"Unable to produce histogram for $analysisId: $e")
-        }
-      } yield resp
-
-    case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
-          y)
-          :? NodeQueryParamMatcher(node) =>
-      for {
-        paintable <- analyses.read(analysisId, node)
-        tileValidated <- paintable.tms(z, x, y)
-        resp <- tileValidated match {
-          case Valid(tile) =>
-            Ok(
-              paintable.renderDefinition map { renderDef =>
-                tile.band(0).renderPng(renderDef).bytes
-              } getOrElse { tile.band(0).renderPng(ColorRamps.Viridis).bytes }
-            )
-          case Invalid(e) =>
-            BadRequest(s"Unable to produce tile for $analysisId: $e")
-        }
-      } yield resp
-
-    case req @ GET -> Root / UUIDWrapper(analysisId) / "raw"
-          :? ExtentQueryParamMatcher(extent)
-          :? ZoomQueryParamMatcher(zoom)
-          :? NodeQueryParamMatcher(node) =>
-      val projectedExtent = extent.reproject(LatLng, WebMercator)
-      val respType =
-        req.headers
-          .get(CaseInsensitiveString("Accept")) match {
-          case Some(Header(_, "image/tiff")) =>
-            `Content-Type`(MediaType.image.tiff)
-          case _ => `Content-Type`(MediaType.image.png)
-        }
-      val pngType = `Content-Type`(MediaType.image.png)
-      val tiffType = `Content-Type`(MediaType.image.tiff)
-      for {
-        paintableTool <- analyses.read(analysisId, node)
-        tileValidated <- paintableTool.extent(
-          projectedExtent,
-          BacksplashImage.tmsLevels(zoom).cellSize)
-        // TODO: restore render def coloring
-        resp <- tileValidated match {
-          case Valid(tile) =>
-            if (respType == tiffType) {
-              Ok(
-                SinglebandGeoTiff(tile.band(0), projectedExtent, WebMercator).toByteArray,
-                tiffType)
-            } else {
-              Ok(tile.band(0).renderPng(ColorRamps.Viridis).bytes,
-                 `Content-Type`(MediaType.image.png))
+        case GET -> Root / UUIDWrapper(analysisId) / "histogram" / _
+              :? NodeQueryParamMatcher(node)
+              :? VoidCacheQueryParamMatcher(void) as user =>
+          for {
+            authorized <- Authorizers.authToolRun(user, analysisId)
+            paintable <- analyses.read(analysisId, node)
+            histsValidated <- paintable.histogram(4000)
+            resp <- histsValidated match {
+              case Valid(hists) =>
+                Ok(hists.head asJson)
+              case Invalid(e) =>
+                BadRequest(s"Unable to produce histogram for $analysisId: $e")
             }
-          case Invalid(e) => BadRequest(s"Could not produce extent: $e")
-        }
-      } yield resp
+          } yield resp
+
+        case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
+              y) / _
+              :? NodeQueryParamMatcher(node) as user =>
+          for {
+            authorized <- Authorizers.authToolRun(user, analysisId)
+            paintable <- analyses.read(analysisId, node)
+            tileValidated <- paintable.tms(z, x, y)
+            resp <- tileValidated match {
+              case Valid(tile) =>
+                Ok(
+                  paintable.renderDefinition map { renderDef =>
+                    tile.band(0).renderPng(renderDef).bytes
+                  } getOrElse {
+                    tile.band(0).renderPng(ColorRamps.Viridis).bytes
+                  }
+                )
+              case Invalid(e) =>
+                BadRequest(s"Unable to produce tile for $analysisId: $e")
+            }
+          } yield resp
+
+        case authedReq @ GET -> Root / UUIDWrapper(analysisId) / "raw" / _
+              :? ExtentQueryParamMatcher(extent)
+              :? ZoomQueryParamMatcher(zoom)
+              :? NodeQueryParamMatcher(node) as user =>
+          val projectedExtent = extent.reproject(LatLng, WebMercator)
+          val respType =
+            authedReq.req.headers
+              .get(CaseInsensitiveString("Accept")) match {
+              case Some(Header(_, "image/tiff")) =>
+                `Content-Type`(MediaType.image.tiff)
+              case _ => `Content-Type`(MediaType.image.png)
+            }
+          val pngType = `Content-Type`(MediaType.image.png)
+          val tiffType = `Content-Type`(MediaType.image.tiff)
+          for {
+            authorized <- Authorizers.authToolRun(user, analysisId)
+            paintableTool <- analyses.read(analysisId, node)
+            tileValidated <- paintableTool.extent(
+              projectedExtent,
+              BacksplashImage.tmsLevels(zoom).cellSize)
+            // TODO: restore render def coloring
+            resp <- tileValidated match {
+              case Valid(tile) =>
+                if (respType == tiffType) {
+                  Ok(SinglebandGeoTiff(tile.band(0),
+                                       projectedExtent,
+                                       WebMercator).toByteArray,
+                     tiffType)
+                } else {
+                  Ok(tile.band(0).renderPng(ColorRamps.Viridis).bytes,
+                     `Content-Type`(MediaType.image.png))
+                }
+              case Invalid(e) => BadRequest(s"Could not produce extent: $e")
+            }
+          } yield resp
+      }
+    }
   }
+
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -1,0 +1,37 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.datamodel.{ActionType, ObjectType, User}
+import com.rasterfoundry.database.{ProjectDao, ToolRunDao}
+import com.rasterfoundry.database.util.RFTransactor
+
+import cats.effect._
+
+import doobie.Transactor
+import doobie.implicits._
+
+import java.util.UUID
+
+object Authorizers {
+  val xa = RFTransactor.xa
+
+  def authToolRun(user: User, toolRunId: UUID): IO[Unit] =
+    ToolRunDao
+      .authorized(user, ObjectType.Analysis, toolRunId, ActionType.View)
+      .transact(xa) map {
+      case false =>
+        throw NotAuthorizedException(
+          s"User ${user.id} is not authorized to view analysis $toolRunId")
+      case _ => ()
+    }
+
+  def authProject(user: User, projectId: UUID): IO[Unit] =
+    ProjectDao
+      .authorized(user, ObjectType.Project, projectId, ActionType.View)
+      .transact(xa) map {
+      case false =>
+        throw NotAuthorizedException(
+          s"User ${user.id} is not authorized to view project $projectId")
+      case _ => ()
+    }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -13,5 +13,7 @@ object Config {
   object server {
     private val serverConfig = config.getConfig("server")
     val timeoutSeconds = serverConfig.getInt("timeoutSeconds")
+    val graphiteUrl = serverConfig.getString("graphiteUrl")
+    val environment = serverConfig.getString("environment")
   }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -14,6 +14,5 @@ object Config {
     private val serverConfig = config.getConfig("server")
     val timeoutSeconds = serverConfig.getInt("timeoutSeconds")
     val graphiteUrl = serverConfig.getString("graphiteUrl")
-    val environment = serverConfig.getString("environment")
   }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -1,0 +1,33 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash.error._
+
+import cats._
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import com.typesafe.scalalogging.LazyLogging
+import doobie.util.invariant.InvariantViolation
+import org.http4s._
+import org.http4s.dsl._
+import org.http4s.dsl.io._
+import java.lang.IllegalArgumentException
+
+class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
+    extends LazyLogging
+    with HttpErrorHandler[F, E, U]
+    with Http4sDsl[F] {
+  private def wrapError(t: E): F[Response[F]] = t match {
+    case (err: InvariantViolation) =>
+      logger.error(err.getMessage, err.printStackTrace)
+      throw WrappedDoobieException(err.getMessage)
+    case (err: AmazonS3Exception) =>
+      logger.error(err.getMessage, err.printStackTrace)
+      throw WrappedS3Exception(err.getMessage)
+    case (err: IllegalArgumentException) =>
+      throw RequirementFailedException(err.getMessage)
+    case (err: BacksplashException) => throw err
+    case t                          => throw UnknownException(t.getMessage)
+  }
+
+  override def handle(service: AuthedService[U, F]): AuthedService[U, F] =
+    ServiceHttpErrorHandler(service)(wrapError)
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -92,7 +92,7 @@ object Main extends IOApp {
 
   def run(args: List[String]): IO[ExitCode] =
     for {
-      _ <- IO { mtr.reportToGraphite }
+      _ <- IO { mtr.reportToGraphite(Config.server.graphiteUrl) }
       exit <- stream.compile.drain.map(_ => ExitCode.Success)
     } yield exit
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -92,7 +92,7 @@ object Main extends IOApp {
 
   def run(args: List[String]): IO[ExitCode] =
     for {
-      _ <- IO { mtr.reportToConsole }
+      _ <- IO { mtr.reportToGraphite }
       exit <- stream.compile.drain.map(_ => ExitCode.Success)
     } yield exit
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -6,7 +6,6 @@ import com.azavea.maml.ast._
 import com.azavea.maml.util.{NeighborhoodConversion, ClassMap => MamlClassMap}
 import geotrellis.vector.io._
 import cats._
-import cats.data._
 import cats.implicits._
 import doobie.implicits._
 
@@ -17,7 +16,8 @@ import com.rasterfoundry.datamodel.{BandDataType, SingleBandOptions}
 import com.rasterfoundry.tool.ast.MapAlgebraAST.{CogRaster, SceneRaster}
 import io.circe.Json
 
-class BacksplashMamlAdapter(mosaicImplicits: MosaicImplicits) {
+class BacksplashMamlAdapter(mosaicImplicits: MosaicImplicits)
+    extends ProjectStoreImplicits {
   import mosaicImplicits._
 
   def asMaml(ast: MapAlgebraAST)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -1,11 +1,17 @@
 package com.rasterfoundry.backsplash.server
 
+import com.rasterfoundry.datamodel.User
+
+import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.backsplash.MetricsRegistrator
+import com.rasterfoundry.backsplash.Parameters._
+
 import cats.Applicative
 import cats.data.{NonEmptyList => NEL}
 import cats.data.Validated._
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
-import com.rasterfoundry.backsplash.Parameters._
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.server._
@@ -17,111 +23,133 @@ import org.http4s.dsl.io._
 import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString
 
-import com.rasterfoundry.backsplash._
-import com.rasterfoundry.backsplash.MetricsRegistrator
-
 import java.util.UUID
 
-class MosaicService[ProjStore: ProjectStore](
-    projects: ProjStore,
-    mtr: MetricsRegistrator,
-    mosaicImplicits: MosaicImplicits)(implicit cs: ContextShift[IO]) {
+class MosaicService[ProjStore: ProjectStore](projects: ProjStore,
+                                             mtr: MetricsRegistrator,
+                                             mosaicImplicits: MosaicImplicits)(
+    implicit cs: ContextShift[IO],
+    H: HttpErrorHandler[IO, BacksplashException, User],
+    ForeignError: HttpErrorHandler[IO, Throwable, User]) {
+
   import mosaicImplicits._
 
-  val routes: HttpRoutes[IO] = HttpRoutes.of {
-    case GET -> Root / UUIDWrapper(projId) / IntVar(z) / IntVar(x) / IntVar(y)
-          :? RedBandOptionalQueryParamMatcher(redOverride)
-          :? GreenBandOptionalQueryParamMatcher(greenOverride)
-          :? BlueBandOptionalQueryParamMatcher(blueOverride) =>
-      val bandOverride =
-        Applicative[Option].map3(redOverride, greenOverride, blueOverride)(
-          BandOverride.apply)
-      val eval =
-        LayerTms.identity(projects.read(projId, None, bandOverride, None))
-      eval(z, x, y) flatMap {
-        case Valid(tile) =>
-          Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
-        case Invalid(e) =>
-          BadRequest(s"Could not produce tile: $e")
-      }
-
-    case GET -> Root / UUIDWrapper(projId) / "histogram" =>
-      val mosaic: BacksplashMosaic = projects.read(projId, None, None, None)
-      LayerHistogram.identity(mosaic, 4000) flatMap {
-        case Valid(hists) =>
-          Ok(hists map { hist =>
-            Map(hist.binCounts: _*)
-          } asJson)
-        case Invalid(e) => BadRequest(s"Histograms could not be produced: $e")
-      }
-
-    case req @ POST -> Root / UUIDWrapper(projectId) / "histogram" / _
-          :? RedBandOptionalQueryParamMatcher(redOverride)
-          :? GreenBandOptionalQueryParamMatcher(greenOverride)
-          :? BlueBandOptionalQueryParamMatcher(blueOverride) =>
-      // Compile to a byte array, decode that as a string, and do something with the results
-      req.body.compile.to[Array] flatMap { uuids =>
-        decode[List[UUID]](
-          uuids map { _.toChar } mkString
-        ) match {
-          case Right(uuids) =>
-            val overrides = (redOverride, greenOverride, blueOverride).mapN {
-              case (r, g, b) => BandOverride(r, g, b)
-            }
+  val routes: AuthedService[User, IO] =
+    H.handle {
+      ForeignError.handle {
+        AuthedService {
+          case GET -> Root / UUIDWrapper(projectId) / IntVar(z) / IntVar(x) / IntVar(
+                y) / _
+                :? RedBandOptionalQueryParamMatcher(redOverride)
+                :? GreenBandOptionalQueryParamMatcher(greenOverride)
+                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+            val bandOverride =
+              Applicative[Option].map3(redOverride,
+                                       greenOverride,
+                                       blueOverride)(BandOverride.apply)
+            val eval =
+              LayerTms.identity(
+                projects.read(projectId, None, bandOverride, None))
             for {
-              mosaic <- IO {
-                projects.read(projectId, None, overrides, uuids.toNel)
-              }
-              histsValidated <- LayerHistogram.identity(mosaic, 4000)
-              resp <- histsValidated match {
-                case Valid(hists) => Ok(hists asJson)
+              _ <- Authorizers.authProject(user, projectId)
+              resp <- eval(z, x, y) flatMap {
+                case Valid(tile) =>
+                  Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
                 case Invalid(e) =>
-                  BadRequest(s"Unable to produce histograms: $e")
+                  BadRequest(s"Could not produce tile: $e")
               }
             } yield resp
-          case _ =>
-            BadRequest("Could not decode body as sequence of UUIDs")
-        }
-      }
 
-    case req @ GET -> Root / UUIDWrapper(projectId) / "export"
-          :? ExtentQueryParamMatcher(extent)
-          :? ZoomQueryParamMatcher(zoom)
-          :? RedBandOptionalQueryParamMatcher(redOverride)
-          :? GreenBandOptionalQueryParamMatcher(greenOverride)
-          :? BlueBandOptionalQueryParamMatcher(blueOverride) =>
-      val bandOverride =
-        Applicative[Option].map3(redOverride, greenOverride, blueOverride)(
-          BandOverride.apply)
-      val projectedExtent = extent.reproject(LatLng, WebMercator)
-      val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
-      // TODO: this will come from the project once we're fetching the project for authorization reasons
-      val toPaint: Boolean = true
-      val eval =
-        if (toPaint) {
-          LayerExtent.identity(
-            projects.read(projectId, None, bandOverride, None))(
-            paintedMosaicExtentReification,
-            cs)
-        } else {
-          LayerExtent.identity(
-            projects.read(projectId, None, bandOverride, None))(
-            rawMosaicExtentReification,
-            cs)
+          case GET -> Root / UUIDWrapper(projectId) / "histogram" / _ as user =>
+            for {
+              _ <- Authorizers.authProject(user, projectId)
+              mosaic = projects.read(projectId, None, None, None)
+              resp <- LayerHistogram.identity(mosaic, 4000) flatMap {
+                case Valid(hists) =>
+                  Ok(hists map { hist =>
+                    Map(hist.binCounts: _*)
+                  } asJson)
+                case Invalid(e) =>
+                  BadRequest(s"Histograms could not be produced: $e")
+              }
+            } yield resp
+
+          case authedReq @ POST -> Root / UUIDWrapper(projectId) / "histogram" / _
+                :? RedBandOptionalQueryParamMatcher(redOverride)
+                :? GreenBandOptionalQueryParamMatcher(greenOverride)
+                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+            // Compile to a byte array, decode that as a string, and do something with the results
+            authedReq.req.body.compile.to[Array] flatMap { uuids =>
+              decode[List[UUID]](
+                uuids map { _.toChar } mkString
+              ) match {
+                case Right(uuids) =>
+                  val overrides =
+                    (redOverride, greenOverride, blueOverride).mapN {
+                      case (r, g, b) => BandOverride(r, g, b)
+                    }
+                  for {
+                    _ <- Authorizers.authProject(user, projectId)
+                    mosaic <- IO {
+                      projects.read(projectId, None, overrides, uuids.toNel)
+                    }
+                    histsValidated <- LayerHistogram.identity(mosaic, 4000)
+                    resp <- histsValidated match {
+                      case Valid(hists) => Ok(hists asJson)
+                      case Invalid(e) =>
+                        BadRequest(s"Unable to produce histograms: $e")
+                    }
+                  } yield resp
+                case _ =>
+                  BadRequest("Could not decode body as sequence of UUIDs")
+              }
+            }
+
+          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "export" / _
+                :? ExtentQueryParamMatcher(extent)
+                :? ZoomQueryParamMatcher(zoom)
+                :? RedBandOptionalQueryParamMatcher(redOverride)
+                :? GreenBandOptionalQueryParamMatcher(greenOverride)
+                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
+            val bandOverride =
+              Applicative[Option].map3(redOverride,
+                                       greenOverride,
+                                       blueOverride)(BandOverride.apply)
+            val projectedExtent = extent.reproject(LatLng, WebMercator)
+            val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
+            // TODO: this will come from the project once we're fetching the project for authorization reasons
+            val toPaint: Boolean = true
+            val eval =
+              if (toPaint) {
+                LayerExtent.identity(
+                  projects.read(projectId, None, bandOverride, None))(
+                  paintedMosaicExtentReification,
+                  cs)
+              } else {
+                LayerExtent.identity(
+                  projects.read(projectId, None, bandOverride, None))(
+                  rawMosaicExtentReification,
+                  cs)
+              }
+            for {
+              _ <- Authorizers.authProject(user, projectId)
+              resp <- eval(extent, cellSize) flatMap {
+                case Valid(tile) =>
+                  authedReq.req.headers
+                    .get(CaseInsensitiveString("Accept")) match {
+                    case Some(Header(_, "image/tiff")) =>
+                      Ok(
+                        MultibandGeoTiff(tile, projectedExtent, WebMercator).toByteArray,
+                        `Content-Type`(MediaType.image.tiff)
+                      )
+                    case _ =>
+                      Ok(tile.renderPng.bytes,
+                         `Content-Type`(MediaType.image.png))
+                  }
+                case Invalid(e) => BadRequest(s"Could not produce extent: $e")
+              }
+            } yield resp
         }
-      eval(extent, cellSize) flatMap {
-        case Valid(tile) =>
-          req.headers
-            .get(CaseInsensitiveString("Accept")) match {
-            case Some(Header(_, "image/tiff")) =>
-              Ok(
-                MultibandGeoTiff(tile, projectedExtent, WebMercator).toByteArray,
-                `Content-Type`(MediaType.image.tiff)
-              )
-            case _ =>
-              Ok(tile.renderPng.bytes, `Content-Type`(MediaType.image.png))
-          }
-        case Invalid(e) => BadRequest(s"Could not produce extent: $e")
       }
-  }
+    }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -1,0 +1,110 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.database.SceneToProjectDao
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.datamodel.color.{
+  BandGamma => RFBandGamma,
+  PerBandClipping => RFPerBandClipping,
+  MultiBandClipping => RFMultiBandClipping,
+  SigmoidalContrast => RFSigmoidalContrast,
+  Saturation => RFSaturation
+}
+import com.rasterfoundry.backsplash.{
+  ProjectStore,
+  BandOverride,
+  BacksplashImage
+}
+import com.rasterfoundry.backsplash.color.{
+  ColorCorrect => BSColorCorrect,
+  SingleBandOptions => BSSingleBandOptions,
+  _
+}
+import cats.data.{NonEmptyList => NEL}
+import cats.effect.IO
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import geotrellis.vector.{Polygon, Projected}
+
+import java.util.UUID
+
+trait ProjectStoreImplicits extends ToProjectStoreOps {
+  implicit val projectStore: ProjectStore[SceneToProjectDao] =
+    new ProjectStore[SceneToProjectDao] {
+      // safe to get here, since we're just unapplying from a value that we already know
+      // was constructed correctly
+      @SuppressWarnings(Array("OptionGet"))
+      def read(self: SceneToProjectDao,
+               projId: UUID,
+               window: Option[Projected[Polygon]],
+               bandOverride: Option[BandOverride],
+               imageSubset: Option[NEL[UUID]]) = {
+        SceneToProjectDao.getMosaicDefinition(
+          projId,
+          window,
+          bandOverride map { _.red },
+          bandOverride map { _.green },
+          bandOverride map { _.blue },
+          imageSubset map { _.toList } getOrElse List.empty) map { md =>
+          val singleBandOptions =
+            md.singleBandOptions flatMap {
+              _.as[BSSingleBandOptions.Params].toOption
+            }
+          BacksplashImage(
+            md.ingestLocation getOrElse {
+              throw UningestedScenesException(
+                s"Scene ${md.sceneId} does not have an ingest location")
+            },
+            md.footprint getOrElse {
+              throw MetadataException(
+                s"Scene ${md.sceneId} does not have a footprint")
+            },
+            if (md.isSingleBand) {
+              singleBandOptions map { sbo =>
+                List(sbo.band)
+              } getOrElse {
+                throw SingleBandOptionsException(
+                  "Single band options must be specified for single band projects")
+              }
+            } else {
+              bandOverride map { ovr =>
+                List(ovr.red, ovr.green, ovr.blue)
+              } getOrElse {
+                List(md.colorCorrections.redBand,
+                     md.colorCorrections.greenBand,
+                     md.colorCorrections.blueBand)
+              }
+            },
+            BSColorCorrect.Params(
+              0, // red
+              1, // green
+              2, // blue
+              (BandGamma.apply _)
+                .tupled(RFBandGamma.unapply(md.colorCorrections.gamma).get),
+              (PerBandClipping.apply _).tupled(
+                RFPerBandClipping
+                  .unapply(md.colorCorrections.bandClipping)
+                  .get),
+              (MultiBandClipping.apply _).tupled(
+                RFMultiBandClipping
+                  .unapply(md.colorCorrections.tileClipping)
+                  .get),
+              (SigmoidalContrast.apply _)
+                .tupled(
+                  RFSigmoidalContrast
+                    .unapply(md.colorCorrections.sigmoidalContrast)
+                    .get),
+              (Saturation.apply _).tupled(
+                RFSaturation
+                  .unapply(md.colorCorrections.saturation)
+                  .get)
+            ),
+            singleBandOptions
+          )
+        } transact (RFTransactor.xa)
+      }
+    }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -1,18 +1,24 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash._
+import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.color._
+import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.ToolRunDao
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.tool
+import com.rasterfoundry.tool.ast.MapAlgebraAST
 
+import cats.effect.IO
+import cats.implicits._
 import doobie._
 import doobie.implicits._
-import cats.effect.IO
 
 import java.util.UUID
 
-class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
+class ToolStoreImplicits(mosaicImplicits: MosaicImplicits)
+    extends ProjectStoreImplicits {
   import mosaicImplicits._
   val mamlAdapter = new BacksplashMamlAdapter(mosaicImplicits)
 
@@ -34,15 +40,33 @@ class ToolStoreImplicits(mosaicImplicits: MosaicImplicits) {
     RenderDefinition(toolRd.breakpoints, scaleOpt, clipOpt)
   }
 
+  private def unsafeGetAST(analysisId: UUID,
+                           nodeId: Option[UUID]): IO[MapAlgebraAST] =
+    (for {
+      executionParams <- ToolRunDao.query.filter(analysisId).select map {
+        _.executionParameters
+      }
+    } yield {
+      val decoded = executionParams.as[MapAlgebraAST].toOption getOrElse {
+        throw MetadataException(s"Could not decode AST for $analysisId")
+      }
+      nodeId map {
+        decoded
+          .find(_)
+          .getOrElse {
+            throw MetadataException(
+              s"Node $nodeId missing from AST $analysisId")
+          }
+      } getOrElse { decoded }
+    }).transact(RFTransactor.xa)
+
   implicit val toolRunDaoStore: ToolStore[ToolRunDao] =
     new ToolStore[ToolRunDao] {
       def read(self: ToolRunDao,
                analysisId: UUID,
                nodeId: Option[UUID]): IO[PaintableTool] =
         for {
-          (expr, mdOption, params) <- ToolRunDao
-            .unsafeGetAST(analysisId, nodeId)
-            .transact(RFTransactor.xa) map {
+          (expr, mdOption, params) <- unsafeGetAST(analysisId, nodeId) map {
             mamlAdapter.asMaml _
           }
         } yield {

--- a/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
+++ b/app-backend/batch/src/test/scala/com/azavea/rf/batch/export/model/ExportDefinitionSpec.scala
@@ -117,7 +117,7 @@ class ExportDefinitionSpec extends FunSpec with Matchers with BatchSpec {
               sceneType = Some(SceneType.Avro),
               footprint = Some(mask),
               isSingleBand = false,
-              singleBandOptions = ().asJson
+              singleBandOptions = Some(().asJson)
             )),
           mask = Some(mask)
         )

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -271,7 +271,7 @@ lazy val common = Project("common", file("common"))
   })
 
 lazy val db = Project("db", file("db"))
-  .dependsOn(datamodel % "compile->compile;test->test", common, backsplashCore)
+  .dependsOn(datamodel % "compile->compile;test->test", common)
   .settings(commonSettings: _*)
   .settings({
     libraryDependencies ++= dbDependencies ++ loggingDependencies ++ Seq(
@@ -475,7 +475,8 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
       "org.scalatest" %% "scalatest" % Version.scalaTest,
       "com.azavea" %% "geotrellis-server-core" % Version.geotrellisServer,
       "org.scalacheck" %% "scalacheck" % Version.scalaCheck,
-      "org.apache.spark" %% "spark-core" % "2.4.0" % Provided
+      "org.apache.spark" %% "spark-core" % "2.4.0" % Provided,
+      Dependencies.catsMeow
     ),
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -467,6 +467,7 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
   .settings(
     fork in run := true,
     libraryDependencies ++= Seq(
+      "io.dropwizard.metrics" % "metrics-graphite" % "4.0.3",
       "org.http4s" %% "http4s-blaze-server" % Version.http4s,
       "org.http4s" %% "http4s-circe" % Version.http4s,
       "org.http4s" %% "http4s-dsl" % Version.http4s,

--- a/app-backend/datamodel/src/main/scala/MosaicDefinition.scala
+++ b/app-backend/datamodel/src/main/scala/MosaicDefinition.scala
@@ -14,7 +14,7 @@ final case class MosaicDefinition(sceneId: UUID,
                                   ingestLocation: Option[String],
                                   footprint: Option[MultiPolygon],
                                   isSingleBand: Boolean,
-                                  singleBandOptions: Json)
+                                  singleBandOptions: Option[Json])
 
 object MosaicDefinition {
   def fromScenesToProjects(

--- a/app-backend/datamodel/src/main/scala/SceneToProject.scala
+++ b/app-backend/datamodel/src/main/scala/SceneToProject.scala
@@ -30,7 +30,7 @@ final case class SceneToProjectwithSceneType(
     ingestLocation: Option[String],
     dataFootprint: Option[Projected[Geometry]],
     isSingleBand: Boolean,
-    singleBandOptions: Json
+    singleBandOptions: Option[Json]
 )
 
 @JsonCodec

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -275,7 +275,7 @@ object SceneDao
               scene.ingestLocation,
               scene.dataFootprint map { _.geom },
               false,
-              ().asJson
+              Some(().asJson)
             ))
         case _ => Seq.empty
       }

--- a/app-backend/db/src/main/scala/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/SceneToProjectDao.scala
@@ -14,24 +14,6 @@ import com.rasterfoundry.datamodel.{
   SceneToProject,
   SceneToProjectwithSceneType
 }
-import com.rasterfoundry.datamodel.color.{
-  BandGamma => RFBandGamma,
-  PerBandClipping => RFPerBandClipping,
-  MultiBandClipping => RFMultiBandClipping,
-  SigmoidalContrast => RFSigmoidalContrast,
-  Saturation => RFSaturation
-}
-import com.rasterfoundry.backsplash.{
-  ProjectStore,
-  BandOverride,
-  BacksplashImage
-}
-import com.rasterfoundry.backsplash.color.{
-  ColorCorrect => BSColorCorrect,
-  SingleBandOptions => BSSingleBandOptions,
-  _
-}
-import com.rasterfoundry.backsplash.error._
 import com.typesafe.scalalogging.LazyLogging
 import com.rasterfoundry.datamodel._
 import doobie._
@@ -46,83 +28,6 @@ import io.circe.syntax._
 case class SceneToProjectDao()
 
 object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
-
-  implicit val projectStore: ProjectStore[SceneToProjectDao] =
-    new ProjectStore[SceneToProjectDao] {
-      // safe to get here, since we're just unapplying from a value that we already know
-      // was constructed correctly
-      @SuppressWarnings(Array("OptionGet"))
-      def read(self: SceneToProjectDao,
-               projId: UUID,
-               window: Option[Projected[Polygon]],
-               bandOverride: Option[BandOverride],
-               imageSubset: Option[NEL[UUID]]) = {
-        getMosaicDefinition(
-          projId,
-          window,
-          bandOverride map { _.red },
-          bandOverride map { _.green },
-          bandOverride map { _.blue },
-          imageSubset map { _.toList } getOrElse List.empty) map { md =>
-          val singleBandOptions =
-            md.singleBandOptions.as[BSSingleBandOptions.Params].toOption
-          BacksplashImage(
-            md.ingestLocation getOrElse {
-              throw UningestedScenesException(
-                s"Scene ${md.sceneId} does not have an ingest location")
-            },
-            md.footprint getOrElse {
-              throw MetadataException(
-                s"Scene ${md.sceneId} does not have a footprint")
-            },
-            if (md.isSingleBand) {
-              singleBandOptions map { sbo =>
-                List(sbo.band)
-              } getOrElse {
-                throw SingleBandOptionsException(
-                  "Single band options must be specified for single band projects")
-              }
-            } else {
-              bandOverride map { ovr =>
-                List(ovr.red, ovr.green, ovr.blue)
-              } getOrElse {
-                List(md.colorCorrections.redBand,
-                     md.colorCorrections.greenBand,
-                     md.colorCorrections.blueBand)
-              }
-            },
-            // why is all this necessary? because we're obligated to keep the existing tile
-            // server functioning, and in pursuit of that i want to make as few changes to
-            // functions it calls as possible
-            BSColorCorrect.Params(
-              0, // red
-              1, // green
-              2, // blue
-              (BandGamma.apply _)
-                .tupled(RFBandGamma.unapply(md.colorCorrections.gamma).get),
-              (PerBandClipping.apply _).tupled(
-                RFPerBandClipping
-                  .unapply(md.colorCorrections.bandClipping)
-                  .get),
-              (MultiBandClipping.apply _).tupled(
-                RFMultiBandClipping
-                  .unapply(md.colorCorrections.tileClipping)
-                  .get),
-              (SigmoidalContrast.apply _)
-                .tupled(
-                  RFSigmoidalContrast
-                    .unapply(md.colorCorrections.sigmoidalContrast)
-                    .get),
-              (Saturation.apply _).tupled(
-                RFSaturation
-                  .unapply(md.colorCorrections.saturation)
-                  .get)
-            ),
-            singleBandOptions
-          )
-        } transact (RFTransactor.xa)
-      }
-    }
 
   val tableName = "scenes_to_projects"
 

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -2,8 +2,6 @@ package com.rasterfoundry.database
 
 import java.sql.Timestamp
 
-import com.rasterfoundry.backsplash.PaintableTool
-import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.datamodel.{
@@ -110,24 +108,4 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
       .filter(authorizedF(user, objectType, actionType))
       .filter(objectId)
       .exists
-
-  def unsafeGetAST(analysisId: UUID,
-                   nodeId: Option[UUID]): ConnectionIO[MapAlgebraAST] =
-    for {
-      executionParams <- query.filter(analysisId).select map {
-        _.executionParameters
-      }
-    } yield {
-      val decoded = executionParams.as[MapAlgebraAST].toOption getOrElse {
-        throw MetadataException(s"Could not decode AST for $analysisId")
-      }
-      nodeId map {
-        decoded
-          .find(_)
-          .getOrElse {
-            throw MetadataException(
-              s"Node $nodeId missing from AST $analysisId")
-          }
-      } getOrElse { decoded }
-    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,6 +172,7 @@ services:
         condition: service_healthy
     links:
       - postgres:database.service.rasterfoundry.internal
+      - graphite:graphite.service.rasterfoundry.internal
     env_file: .env
     environment:
       - RF_LOG_LEVEL=DEBUG
@@ -198,3 +199,12 @@ services:
       - "-J-Dcom.sun.management.jmxremote.local.only=false"
       - "-J-DXmx3G"
       - "-Djava.rmi.server.hostname=localhost"
+
+  graphite:
+    image: graphiteapp/graphite-statsd
+    ports:
+      - 2003-2004:2003-2004
+      - 2023-2024:2023-2024
+      - 8125:8125/udp
+      - 8126:8126
+      - 8090:80


### PR DESCRIPTION
## Overview

This PR points metrics to a graphite server instead of to stdout, since stdout was going to get pretty noisy.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Choice between graphite and ganglia was based on ease of setup -- ganglia deps were mad at me, so I switched to graphite and everything was fine. They both have ugly dashboards we can access and docker containers for easy setup, so :man_shrugging:

## Testing Instructions

 * docker-compose up backsplash
 * navigate to `localhost:8090`
 * check out your sweet dashboard
 * wait a minute (don't make any requests since we're segfaulting like mad right now) and then explore down the `com` / `rasterfoundry` / `backsplash` tree of the metrics browser