### PR TITLE
Upgrade geotrellis-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Address a number of unhandled promise chains on the frontend [\#4380](https://github.com/raster-foundry/raster-foundry/pull/4380)
 - Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 - Aligned backsplash dockerfile with existing services [\#4394](https://github.com/raster-foundry/raster-foundry/pull/4394)
+- Upgraded geotrellis-server to handle thread safety issue that was causing SEGFAULTs in backsplash [\#4399](https://github.com/raster-foundry/raster-foundry/pull/4399)
 
 ### Removed
 

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -25,7 +25,7 @@ object Version {
   val gatling = "2.2.4"
   val geotools = "17.1"
   val geotrellis = "3.0.0-SNAPSHOT"
-  val geotrellisServer = "0.0.13"
+  val geotrellisServer = "0.0.14-RC1"
   val hadoop = "2.8.4"
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M4"


### PR DESCRIPTION
## Overview

This PR upgrades geotrellis-server to 0.14.0-RC1, which includes some work to ensure thread safe gdal usage.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * load up a project page
 * you should render tiles without seg faults killing the tile server