### PR TITLE
Add docker-compose file to start services with java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Use java's gdal bindings for tile IO in backsplash and better separate concerns between fetching imagery and talking to the database / users [\#4339](https://github.com/raster-foundry/raster-foundry/pull/4339)
 - Added dropwizard metrics instrumentation to backsplash methods and endpoints [\#4381](https://github.com/raster-foundry/raster-foundry/pull/4381)
 - Added graphite reporter to dropwizard metrics [\#4398](https://github.com/raster-foundry/raster-foundry/pull/4398)
+- Added alternative development runner/setup for testing API server and backsplash [\#4402](https://github.com/raster-foundry/raster-foundry/pull/4402)
 
 ### Changed
 

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -86,7 +86,7 @@ services:
     env_file: .env
     environment:
       - RF_LOG_LEVEL=INFO
-      - TILE_SERVER_LOCATION=http://localhost:8080
+      - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
     ports:
       - "9000:9000"

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -1,0 +1,163 @@
+version: '2.3'
+services:
+  postgres:
+    image: quay.io/azavea/postgis:2.3-postgres9.6-slim
+    volumes:
+      - ./data/:/tmp/data/
+    env_file: .env
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  sbt:
+    image: openjdk:8-jre
+    links:
+      - postgres:database.service.rasterfoundry.internal
+      - memcached:tile-cache.service.rasterfoundry.internal
+    external_links:
+      - statsd
+    env_file: .env
+    environment:
+      - RF_LOG_LEVEL=INFO
+      - COURSIER_CACHE=/root/.coursier
+    volumes:
+      - ./app-backend/:/opt/raster-foundry/app-backend/
+      - $HOME/.coursier:/root/.coursier
+      - ./.sbt:/root/.sbt
+      - ./.bintray:/root/.bintray
+      - $HOME/.aws:/root/.aws:ro
+      - $HOME/.ivy2:/root/.ivy2
+    working_dir: /opt/raster-foundry/app-backend/
+    entrypoint: ./sbt
+
+  memcached:
+    image: memcached:1.4-alpine
+    command: -m 4096 -c 8192 -I 5242880b
+
+  nginx-api:
+    image: raster-foundry-nginx-api
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile.api
+    ports:
+      - "9100:443"
+    extra_hosts:
+      - "tile-server:127.0.0.1"
+    links:
+      - api-server
+    volumes:
+      - ./nginx/srv/dist/:/srv/dist/
+      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
+      - ./nginx/etc/nginx/conf.d/api.conf:/etc/nginx/conf.d/default.conf
+
+  nginx-backsplash:
+    image: raster-foundry-nginx-backsplash
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile.backsplash
+    ports:
+      - "8081:443"
+    extra_hosts:
+      - "api-server:127.0.0.1"
+    links:
+      - backsplash
+    volumes:
+      - ./nginx/srv/dist/:/srv/dist/
+      - ./nginx/etc/nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/etc/nginx/includes/:/etc/nginx/includes/
+      - ./nginx/etc/nginx/conf.d/backsplash.conf:/etc/nginx/conf.d/default.conf
+
+  api-server:
+    image: openjdk:8-jre
+    links:
+      - postgres:database.service.rasterfoundry.internal
+      - memcached:tile-cache.service.rasterfoundry.internal
+    external_links:
+      - statsd
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file: .env
+    environment:
+      - RF_LOG_LEVEL=INFO
+      - TILE_SERVER_LOCATION=http://localhost:8080
+      - COURSIER_CACHE=/root/.coursier
+    ports:
+      - "9000:9000"
+      - "9010:9010"
+    volumes:
+      - ./app-backend/:/opt/raster-foundry/app-backend/
+      - $HOME/.aws:/root/.aws:ro
+    working_dir: /opt/raster-foundry/app-backend/api/target/scala-2.11/
+    entrypoint: java
+    command:
+      - "-jar"
+      - "api-assembly.jar"
+      - "-Dcom.sun.management.jmxremote.rmi.port=9010"
+      - "-Dcom.sun.management.jmxremote=true"
+      - "-Dcom.sun.management.jmxremote.port=9010"
+      - "-Dcom.sun.management.jmxremote.ssl=false"
+      - "-Dcom.sun.management.jmxremote.authenticate=false"
+      - "-Dcom.sun.management.jmxremote.local.only=false"
+      - "-Djava.rmi.server.hostname=localhost"
+
+  backsplash:
+    image: daunnc/openjdk-gdal:2.3.2
+    build:
+      context: app-backend
+      dockerfile: Dockerfile.backsplash
+    depends_on:
+      postgres:
+        condition: service_healthy
+    links:
+      - postgres:database.service.rasterfoundry.internal
+      - graphite:graphite.service.rasterfoundry.internal
+    env_file: .env
+    environment:
+      - RF_LOG_LEVEL=DEBUG
+      - COURSIER_CACHE=/root/.coursier
+      - VSI_CACHE=TRUE
+      - GDAL_CACHEMAX=1000
+    ports:
+      - "8080:8080"
+      - "9030:9030"
+    volumes:
+      - ./app-backend/:/opt/raster-foundry/app-backend/
+      - $HOME/.aws:/root/.aws:ro
+    working_dir: /opt/raster-foundry/app-backend/backsplash-server/target/scala-2.11/
+    entrypoint: java
+    command:
+      - "-Dcom.sun.management.jmxremote.rmi.port=9030"
+      - "-Dcom.sun.management.jmxremote=true"
+      - "-Dcom.sun.management.jmxremote.port=9030"
+      - "-Dcom.sun.management.jmxremote.ssl=false"
+      - "-Dcom.sun.management.jmxremote.authenticate=false"
+      - "-Dcom.sun.management.jmxremote.local.only=false"
+      - "-Djava.rmi.server.hostname=localhost"
+      - "-jar"
+      - "backsplash-assembly.jar"
+
+  graphite:
+    image: graphiteapp/graphite-statsd
+    ports:
+      - 2003-2004:2003-2004
+      - 2023-2024:2023-2024
+      - 8125:8125/udp
+      - 8126:8126
+      - 8090:80
+
+  grafana:
+    image: grafana/grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    links:
+      - graphite
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=password

--- a/scripts/console
+++ b/scripts/console
@@ -18,8 +18,12 @@ then
     if [ "${1:-}" = "--help" ]
     then
         usage
+    elif [ "${1:-}" = "sbt" ]
+    then
+        docker-compose -f "${DIR}/../docker-compose.java.yml" \
+                       run sbt
     else
-        docker-compose -f "${DIR}/../docker-compose.yml" \
+        docker-compose -f "${DIR}/../docker-compose.java.yml" \
                        run --rm --service-ports --entrypoint \
                        "/bin/bash -c" "$1" "${@:2}"
     fi

--- a/scripts/server
+++ b/scripts/server
@@ -28,8 +28,7 @@ then
             docker-compose logs -f --tail 20 api-server "$@"
     elif [ "${1:-}" = "--backsplash" ]
     then
-        TILE_SERVER_LOCATION="http://localhost:8081" \
-        docker-compose up nginx-backsplash nginx-api memcached api-server backsplash
+        TILE_SERVER_LOCATION="http://localhost:8081" docker-compose -f docker-compose.java.yml up nginx-backsplash backsplash api-server nginx-api
     else
         TILE_SERVER_LOCATION="http://localhost:9101" \
         docker-compose up nginx-tiler nginx-api memcached api-server tile-server


### PR DESCRIPTION
## Overview

Adds some alternative development for working with the API and backsplash servers so we can avoid recompiling projects accidentally when it is unnecessary.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Run `./scripts/console sbt`
 * Assembly fat jars for both API server and backsplash:
```
project backsplash-server
assembly
project api
assembly
```
 * Start server: `./scripts/server --backsplash` and make some requests