### PR TITLE
Refactor so scene ingest can be caleld from reprocess_sentinel

### DIFF
--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -19,6 +19,10 @@ def ingest_scene(scene_id):
     Args:
         scene_id (str): ID of scene to ingest
     """
+    ingest(scene_id)
+
+
+def ingest(scene_id):
     logger.info("Converting scene to COG: %s", scene_id)
     scene = Scene.from_id(scene_id)
     if scene.ingestStatus != 'INGESTED':

--- a/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
@@ -5,7 +5,7 @@ import uuid
 import psycopg2
 import psycopg2.extras
 from ..utils.exception_reporting import wrap_rollbar
-from ingest_scene import ingest_scene
+from ingest_scene import ingest
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +17,12 @@ def reprocess_sentinel(scene_ids):
     """Fix a sentinel 2 scene by replacing scene metadata bands and Images
 
     Args:
-        scene_id (str): Scene id to reprocess
         scene_ids (str): comma separated list of ids to reprocess
     """
+    reprocess(scene_ids)
+
+
+def reprocess(scene_ids):
     conn = psycopg2.connect('host={} dbname={} user={} password={}'.format(
         os.environ.get('POSTGRES_HOST', 'postgres'),
         os.environ['POSTGRES_DB'],
@@ -67,7 +70,7 @@ def reprocess_scene_id(cur, conn, scene_id):
         conn.commit()
         if scene['ingest_status'] == 'INGESTED':
             logger.info('Re-ingesting scene')
-            ingest_scene(scene_id)
+            ingest(scene_id)
     elif scene['datasource'] == '4a50cb75-815d-4fe5-8bc1-144729ce5b42':
         logger.info('Skipping re-import for Scene: %s . Scene is not broken.', scene['id'])
     else:


### PR DESCRIPTION
## Overview
Click functions can't be called like normal functions

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Styleguide updated, if necessary
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/50351073-0e0ea580-050f-11e9-9a8f-3c70aaa5e3f9.png)



## Testing Instructions

 * Reprocess a sentinel scene that needs to be re-ingested
