### PR TITLE
Remove references to `it` stage of tile subproject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Supported team creation on user's team list page [\#4345](https://github.com/raster-foundry/raster-foundry/pull/4345)
 - Use java's gdal bindings for tile IO in backsplash and better separate concerns between fetching imagery and talking to the database / users [\#4339](https://github.com/raster-foundry/raster-foundry/pull/4339)
 - Added dropwizard metrics instrumentation to backsplash methods and endpoints [\#4381](https://github.com/raster-foundry/raster-foundry/pull/4381)
-- Added script for ad hoc tile server load testing [\#4395](https://github.com/raster-foundry/raster-foundry/pull/4395)
+- Added script for ad hoc tile server load testing [\#4395](https://github.com/raster-foundry/raster-foundry/pull/4395), [\#4404](https://github.com/raster-foundry/raster-foundry/pull/4404)
 - Added graphite reporter to dropwizard metrics [\#4398](https://github.com/raster-foundry/raster-foundry/pull/4398)
 
 ### Changed

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -381,11 +381,11 @@ lazy val tile = Project("tile", file("tile"))
       Dependencies.akkaHttpCors,
       Dependencies.akkastream,
       Dependencies.akkaSlf4j,
-      Dependencies.circeCore % "it,test",
-      Dependencies.circeGeneric % "it,test",
-      Dependencies.circeParser % "it,test",
-      Dependencies.circeOptics % "it,test",
-      Dependencies.scalajHttp % "it,test"
+      Dependencies.circeCore % "test",
+      Dependencies.circeGeneric % "test",
+      Dependencies.circeParser % "test",
+      Dependencies.circeOptics % "test",
+      Dependencies.scalajHttp % "test"
     )
   })
   .settings(assemblyMergeStrategy in assembly := {


### PR DESCRIPTION
## Overview

#4395 removed the `it` stage from the `tile` subproject so that integration testing (which doesn't depend on any other part of the project) could live on its own. It didn't remove references to it from `build.sbt` though, which we discovered only when trying to assemble the tile server jar in CI. This PR removes `it` references from the `tile` subproject dependency list so that assembly can run again and we can succeed in CI.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * run `tile/assembly`
 * it should succeed