### PR TITLE
Ignore errors from integration test failing

### DIFF
--- a/scripts/cigatling
+++ b/scripts/cigatling
@@ -37,7 +37,7 @@ then
           -e MIN_ZOOM \
           -e MAX_ZOOM \
           openjdk:8-jre \
-          ./sbt gatling:test
+          ./sbt gatling:test || true
 
         echo "Uploading results to '$RESULTS_BUCKET'..."
         aws s3 sync gatling/results "$RESULTS_BUCKET/$GIT_COMMIT"


### PR DESCRIPTION
## Overview

If we don't meet the percentile assertion in the gatling test, that step returns
an exit code of 1. That's good! But it also prevents us from sending the results
to s3. That's bad. Since this isn't part of the success or failure of ci in
general, it makes sense that it should report success if it completes the test.
This PR makes it so that we don't have to have successful results to upload them
to s3.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * observe that we didn't try to upload results to s3 here: http://jenkins.staging.rasterfoundry.com/job/GatlingTMS/30/console
 * and also note that `set -e` is on in the `cigatling` test script
 * and think through those implications