### PR TITLE
Return sensible error when data have gone missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 - Aligned backsplash dockerfile with existing services [\#4394](https://github.com/raster-foundry/raster-foundry/pull/4394)
 - Upgraded geotrellis-server to handle thread safety issue that was causing SEGFAULTs in backsplash [\#4399](https://github.com/raster-foundry/raster-foundry/pull/4399), [\#4412](https://github.com/raster-foundry/raster-foundry/pull/4412)
+- Made backsplash server's foreign error handler handler the correct "data are missing" error [\#4408](https://github.com/raster-foundry/raster-foundry/pull/4408)
 
 ### Removed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -48,10 +48,6 @@ object BacksplashMosaic {
   def layerHistogram(mosaic: BacksplashMosaic)(
       implicit hasRasterExtents: HasRasterExtents[BacksplashMosaic],
       extentReification: ExtentReification[BacksplashMosaic],
-      cs: ContextShift[IO]) = {
-    LayerHistogram.identity(mosaic, 4000) handleErrorWith { err =>
-      println(s"Class of error was: ${err.getClass}")
-      throw err
-    }
-  }
+      cs: ContextShift[IO]) =
+    LayerHistogram.identity(mosaic, 4000)
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -14,6 +14,8 @@ import cats.implicits._
 import cats.data.{NonEmptyList => NEL}
 import cats.effect._
 
+import scala.util.{Try, Success, Failure}
+
 object BacksplashMosaic {
 
   /** Filter out images that don't need to be included  */
@@ -47,6 +49,9 @@ object BacksplashMosaic {
       implicit hasRasterExtents: HasRasterExtents[BacksplashMosaic],
       extentReification: ExtentReification[BacksplashMosaic],
       cs: ContextShift[IO]) = {
-    LayerHistogram.identity(mosaic, 4000)
+    LayerHistogram.identity(mosaic, 4000) handleErrorWith { err =>
+      println(s"Class of error was: ${err.getClass}")
+      throw err
+    }
   }
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -63,6 +63,7 @@ class MosaicImplicits(mtr: MetricsRegistrator)
             case Invalid(e) =>
               throw MetadataException(s"Could not resolve histograms: $e")
           }
+          _ <- IO { println("Made it past getting histograms") }
           extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
           // for single band imagery, after color correction we have RGBA, so
           // the empty tile needs to be four band as well

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -37,7 +37,8 @@ final case class RequirementFailedException(message: String)
 final case class WrappedDoobieException(message: String)
     extends BacksplashException
 // When we get any S3 error
-final case class WrappedS3Exception(message: String) extends BacksplashException
+final case class MissingSceneDataException(message: String)
+    extends BacksplashException
 // Private so no one can deliberately throw an UnknownException elsewhere --
 // only exists to catch the fall-through case in the foreign error handler
 private[backsplash] final case class UnknownException(message: String)
@@ -61,7 +62,7 @@ class BacksplashHttpErrorHandler[F[_], U](
         "Resource does not exist or user is not authorized to access this resource")
     case WrappedDoobieException(m) =>
       NotFound(m)
-    case WrappedS3Exception(_) =>
+    case MissingSceneDataException(_) =>
       NotFound(
         "Underlying data to produce tiles for this project appears to have moved or is no longer available")
     case t @ UnknownException(m) =>

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -64,7 +64,7 @@ class BacksplashHttpErrorHandler[F[_], U](
       NotFound(m)
     case MissingSceneDataException(_) =>
       NotFound(
-        "Underlying data to produce tiles for this project appears to have moved or is no longer available")
+        "Underlying data to produce tiles for this project appears to have moved or has no data at this spatial key")
     case t @ UnknownException(m) =>
       InternalServerError(m)
   }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -21,7 +21,7 @@ class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
       throw WrappedDoobieException(err.getMessage)
     case (err: AmazonS3Exception) =>
       logger.error(err.getMessage, err.printStackTrace)
-      throw WrappedS3Exception(err.getMessage)
+      throw MissingSceneDataException(err.getMessage)
     case (err: IllegalArgumentException) =>
       throw RequirementFailedException(err.getMessage)
     case (err: BacksplashException) => throw err

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -19,7 +19,6 @@ class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
       logger.error(err.getMessage, err.printStackTrace)
       throw WrappedDoobieException(err.getMessage)
     case (err: NullPointerException) =>
-      logger.error(err.getMessage, err.printStackTrace)
       throw MissingSceneDataException(err.getMessage)
     case (err: IllegalArgumentException) =>
       throw RequirementFailedException(err.getMessage)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -3,13 +3,12 @@ package com.rasterfoundry.backsplash.server
 import com.rasterfoundry.backsplash.error._
 
 import cats._
-import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.typesafe.scalalogging.LazyLogging
 import doobie.util.invariant.InvariantViolation
 import org.http4s._
 import org.http4s.dsl._
 import org.http4s.dsl.io._
-import java.lang.IllegalArgumentException
+import java.lang.{IllegalArgumentException, NullPointerException}
 
 class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
     extends LazyLogging
@@ -19,7 +18,7 @@ class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
     case (err: InvariantViolation) =>
       logger.error(err.getMessage, err.printStackTrace)
       throw WrappedDoobieException(err.getMessage)
-    case (err: AmazonS3Exception) =>
+    case (err: NullPointerException) =>
       logger.error(err.getMessage, err.printStackTrace)
       throw MissingSceneDataException(err.getMessage)
     case (err: IllegalArgumentException) =>


### PR DESCRIPTION
## Overview

This PR makes it so that we catch NullPointerExceptions instead of AmazonS3Exceptions in the `ForeignErrorHandler`. After switching to use gdal, the s3 reads are no longer occuring in the aws java sdk,
so the error-handling wasn't catching the right kind of error. Now it is again.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I opted to remove the logging of the error as well, since NPEs are generally not going to have interesting error logs now that we know the cause.

Also, ci is going to fail because this depends on some version upgrades in test/js/set-gdal-options. Just opening the PR for now so I'll have something easy to rebase once that has stabilized.

## Testing Instructions

 * Move the ingest location for a COG you have from its location in s3 to `wherever.it.was.bak`
 * try to view its project
 * see you get 404s with a helpful message, instead of 500s and no useful message 