### PR TITLE
Fix silly variable naming error in batch reprocess script

### DIFF
--- a/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
+++ b/app-tasks/rf/src/rf/commands/reprocess_sentinel.py
@@ -63,7 +63,7 @@ def reprocess(scene_ids):
 
 def get_latest_def(batch, job_name):
     job_definitions = []
-    response = client.describe_job_definitions(
+    response = batch.describe_job_definitions(
         status='ACTIVE',
         jobDefinitionName=job_name
     )
@@ -72,7 +72,7 @@ def get_latest_def(batch, job_name):
     counter = 0
     while next_token:
         counter += 1
-        response = client.describe_job_definitions(
+        response = batch.describe_job_definitions(
             status='active',
             jobDefinitionName=job_name,
             nextToken=next_token


### PR DESCRIPTION
## Overview
^

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

Merging, trivial
