### PR TITLE
Sync gatling results with s3 and include script for viewing

### DIFF
--- a/gatling/src/test/scala/MosaicTmsSimulation.scala
+++ b/gatling/src/test/scala/MosaicTmsSimulation.scala
@@ -38,11 +38,11 @@ class MosaicTmsSimulation extends Simulation {
           val tile = session("tile").as[(Int, Int, Int)]
           session.set("z", tile._1).set("x", tile._2).set("y", tile._3)
         }).exec {
-            http("tiles at ${tile._1}/${tile._2}/${tile._3}")
-              .get(Config.TMS.template)
-              .header("authorization", "Bearer ${authToken}")
-              .check(status.is(200))
-          }
+          http("tiles at ${tile._1}/${tile._2}/${tile._3}")
+            .get(Config.TMS.template)
+            .header("authorization", "Bearer ${authToken}")
+            .check(status.is(200))
+        }
       })
       .pause(4)
 
@@ -52,6 +52,6 @@ class MosaicTmsSimulation extends Simulation {
         rampUsers(Config.Users.count) during (Config.Users.rampupTime seconds))
       .protocols(httpConf)
   ).assertions(
-    global.responseTime.percentile2.lt(1000)
+    global.responseTime.percentile3.lt(1000)
   )
 }

--- a/scripts/cigatling
+++ b/scripts/cigatling
@@ -40,7 +40,9 @@ then
           ./sbt gatling:test || true
 
         echo "Uploading results to '$RESULTS_BUCKET'..."
-        aws s3 sync gatling/results "$RESULTS_BUCKET/$GIT_COMMIT"
+        # Most recent report will always be last, since they're timestamped
+        reportDir=$(find ./gatling/target/gatling/ -maxdepth 1 -type d | head -n 1)
+        aws s3 sync "${reportDir}" "s3://$RESULTS_BUCKET/$GIT_COMMIT"
     fi
     exit
 fi

--- a/scripts/fetch-it-result
+++ b/scripts/fetch-it-result
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+GIT_COMMIT="${GIT_COMMIT:-latest}"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0") GIT_COMMIT RESULT
+
+Retrieve results for a previously run Gatling integration test
+
+Example: ./scripts/fetchITresult local-test mosaictmssimulation-20181224194546570
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        bucket="${RESULTS_BUCKET:-rasterfoundry-staging-it-us-east-1}"
+        s3path="s3://${bucket}/$1/$2"
+        mkdir -p "./gatling-results/$2"
+        echo "./gatling-results/$2"
+        aws s3 sync "$s3path" "./gatling-results/$2"
+    fi
+fi


### PR DESCRIPTION
## Overview

This PR finds the gatling results correctly and syncs them to s3 under a specific it results bucket. It also
includes a script for downloading the results of a run for local viewing.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * set the env variables necessary to run a gatling it test (check `application.conf` under `gatling/src/test/resources/` to see what you need)
 * set `AWS_PROFILE` so you can actually interact with the bucket
 * set `GIT_COMMIT` and set `RESULTS_BUCKET` to `rasterfoundry-staging-it-us-east-1`  so the cigatling script can figure out where to put the results
 * run `scripts/cigatling`
 * run either the example from `scripts/fetch-it-result` or `scripts/fetch-it-result GIT_COMMIT your-result`
 * open the downloaded `index.html` in your browser of choice