### PR TITLE
Set gdal options and upgrade gt-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Address a number of unhandled promise chains on the frontend [\#4380](https://github.com/raster-foundry/raster-foundry/pull/4380)
 - Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 - Aligned backsplash dockerfile with existing services [\#4394](https://github.com/raster-foundry/raster-foundry/pull/4394)
-- Upgraded geotrellis-server to handle thread safety issue that was causing SEGFAULTs in backsplash [\#4399](https://github.com/raster-foundry/raster-foundry/pull/4399)
+- Upgraded geotrellis-server to handle thread safety issue that was causing SEGFAULTs in backsplash [\#4399](https://github.com/raster-foundry/raster-foundry/pull/4399), [\#4412](https://github.com/raster-foundry/raster-foundry/pull/4412)
 
 ### Removed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -83,7 +83,7 @@ object BacksplashImage extends RasterSourceUtils {
       }
       .getOrElse(throw new Exception("Provided WKT/WKB must be a multipolygon"))
 
-  def getRasterExtents(uri: String): IO[NEL[RasterExtent]] = {
+  override def getRasterExtents(uri: String): IO[NEL[RasterExtent]] = {
     val rs = getRasterSource(uri)
     val dataset = rs.dataset
     val band = dataset.getRasterBand(1)

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -82,20 +82,4 @@ object BacksplashImage extends RasterSourceUtils {
                         None)
       }
       .getOrElse(throw new Exception("Provided WKT/WKB must be a multipolygon"))
-
-  override def getRasterExtents(uri: String): IO[NEL[RasterExtent]] = {
-    val rs = getRasterSource(uri)
-    val dataset = rs.dataset
-    val band = dataset.getRasterBand(1)
-
-    IO {
-      NEL(
-        rs.rasterExtent,
-        (0 until band.getOverviewCount).toList.map { idx =>
-          val ovr = band.getOverview(idx)
-          RasterExtent(rs.extent, CellSize(ovr.getXSize, ovr.getYSize))
-        }
-      )
-    }
-  }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -37,6 +37,7 @@ import java.util.UUID
 
 object Main extends IOApp with ProjectStoreImplicits {
 
+  sgdal.setConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "YES")
   sgdal.setConfigOption("GDAL_MAX_DATASET_POOL_SIZE", "1")
   sgdal.setConfigOption("VRT_SHARED_SOURCE", "0")
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -9,6 +9,7 @@ import cats.effect._
 import cats.implicits._
 import com.olegpy.meow.hierarchy._
 import fs2.Stream
+import geotrellis.gdal.sgdal
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.io.geotiff.MultibandGeoTiff
 import geotrellis.server._
@@ -35,6 +36,9 @@ import com.rasterfoundry.backsplash.MetricsRegistrator
 import java.util.UUID
 
 object Main extends IOApp with ProjectStoreImplicits {
+
+  sgdal.setConfigOption("GDAL_MAX_DATASET_POOL_SIZE", "1")
+  sgdal.setConfigOption("VRT_SHARED_SOURCE", "0")
 
   override protected implicit def contextShift: ContextShift[IO] =
     IO.contextShift(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -38,8 +38,6 @@ import java.util.UUID
 object Main extends IOApp with ProjectStoreImplicits {
 
   sgdal.setConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "YES")
-  sgdal.setConfigOption("GDAL_MAX_DATASET_POOL_SIZE", "1")
-  sgdal.setConfigOption("VRT_SHARED_SOURCE", "0")
 
   override protected implicit def contextShift: ContextShift[IO] =
     IO.contextShift(

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -24,7 +24,7 @@ object Version {
   val findbugAnnotations = "3.0.1u2"
   val geotools = "17.1"
   val geotrellis = "3.0.0-SNAPSHOT"
-  val geotrellisServer = "0.0.14-RC1"
+  val geotrellisServer = "0.0.14-RC2"
   val hadoop = "2.8.4"
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M4"


### PR DESCRIPTION
## Overview

With some experimentation, @pomadchin figured out that our threading issues live in gdal C code, and that java synchronization isn't getting us anything (and based on gatling tests is probably just making performance work). Some options around vrt reads and max open datasets are in an upgraded gt-server release, and another option is set in `Main.scala`, to alleviate a lot of our unsafe thread problems.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

This PR captures changes from `test/js/set-gdal-options` in a feature branch.

## Testing Instructions

Testing was done with the test branch to determine prevalence of seg faults on initial reads and resulting performance of a few different configurations. No further testing is required.