### PR TITLE
Use gt instead of gdal for raster sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 - Aligned backsplash dockerfile with existing services [\#4394](https://github.com/raster-foundry/raster-foundry/pull/4394)
 - Upgraded geotrellis-server to handle thread safety issue that was causing SEGFAULTs in backsplash [\#4399](https://github.com/raster-foundry/raster-foundry/pull/4399), [\#4412](https://github.com/raster-foundry/raster-foundry/pull/4412)
-- Swithced back to geotrellis for IO to shrink the space of failure conditions [\#4414](https://github.com/raster-foundry/raster-foundry/pull/4414)
+- Switched back to geotrellis for IO to shrink the space of failure conditions [\#4414](https://github.com/raster-foundry/raster-foundry/pull/4414)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Restored auth and error-handling [\#4390](https://github.com/raster-foundry/raster-foundry/pull/4390)
 - Aligned backsplash dockerfile with existing services [\#4394](https://github.com/raster-foundry/raster-foundry/pull/4394)
 - Upgraded geotrellis-server to handle thread safety issue that was causing SEGFAULTs in backsplash [\#4399](https://github.com/raster-foundry/raster-foundry/pull/4399), [\#4412](https://github.com/raster-foundry/raster-foundry/pull/4412)
+- Swithced back to geotrellis for IO to shrink the space of failure conditions [\#4414](https://github.com/raster-foundry/raster-foundry/pull/4414)
 
 ### Removed
 

--- a/app-backend/Dockerfile.backsplash
+++ b/app-backend/Dockerfile.backsplash
@@ -1,6 +1,7 @@
-FROM daunnc/openjdk-gdal:2.3.2
+FROM openjdk:8-jre
 
-RUN apt-get install apt-transport-https && \
+RUN apt-get update && \
+  apt-get install -yq apt-transport-https && \
   echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
   apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \
   apt-get update && \

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -11,7 +11,6 @@ import geotrellis.spark.SpatialKey
 import geotrellis.proj4.{WebMercator, LatLng}
 
 import geotrellis.server.vlm.RasterSourceUtils
-import geotrellis.contrib.vlm.TargetRegion
 import geotrellis.contrib.vlm.geotiff.GeoTiffRasterSource
 
 import cats.data.{NonEmptyList => NEL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
       - "-Djava.rmi.server.hostname=localhost"
 
   backsplash:
-    image: raster-foundry-backsplash
+    image: openjdk:8-jre
     build:
       context: app-backend
       dockerfile: Dockerfile.backsplash

--- a/scripts/console
+++ b/scripts/console
@@ -23,8 +23,7 @@ then
         docker-compose -f "${DIR}/../docker-compose.java.yml" \
                        run sbt
     else
-        docker-compose -f "${DIR}/../docker-compose.java.yml" \
-                       run --rm --service-ports --entrypoint \
+        docker-compose run --rm --service-ports --entrypoint \
                        "/bin/bash -c" "$1" "${@:2}"
     fi
     exit


### PR DESCRIPTION
## Overview

This PR takes us from the universe of a large terrifying unknown space for bugs into a universe of a smaller less terrifying unknown space for bugs by going back to gt for tile IO.
 
### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Ideally this will be a temporary fix and eventually we'll be able to go back to the features that reading with gdal will get us. Ideally.

## Testing Instructions

 * try to view tiles for a project
 * it should work
