### PR TITLE
Remove Implicit Execution Contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Used a fixed number of threadPool for Backsplash [\#4389](https://github.com/raster-foundry/raster-foundry/pull/4389)
 - Made timeout length and number of threadPool configurable [\#4389](https://github.com/raster-foundry/raster-foundry/pull/4389)
 - Ignored errors from integration tests so that reports will always be written to s3 [\#4406](https://github.com/raster-foundry/raster-foundry/pull/4406)
+- Changed how the database transactor is passed to backsplash and API servers to prevent accidentally passing implicit execution contexts where they are not wanted [\#4415](https://github.com/raster-foundry/raster-foundry/pull/4415)
 
 ### Fixed
 

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -1,9 +1,12 @@
 package com.rasterfoundry.api
 
+import java.util.concurrent.Executors
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.rasterfoundry.akkautil.RFRejectionHandler._
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.database.util.RFTransactor
@@ -17,6 +20,7 @@ import doobie.implicits._
 import doobie.postgres._
 import doobie.postgres.implicits._
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 object AkkaSystem {
@@ -31,7 +35,16 @@ object Main extends App with Config with Router {
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
 
-  val xa = RFTransactor.xa
+  val dbContextShift: ContextShift[IO] = IO.contextShift(
+    ExecutionContext.fromExecutor(
+      Executors.newFixedThreadPool(
+        8,
+        new ThreadFactoryBuilder().setNameFormat("db-client-%d").build()
+      )
+    ))
+
+  val xa = RFTransactor.transactor(dbContextShift)
+
   val canSelect = sql"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync
   println(s"Server Started (${canSelect})")
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authenticators.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authenticators.scala
@@ -24,9 +24,9 @@ import org.http4s.util.CaseInsensitiveString
 
 import java.net.URL
 import java.util.UUID
+import doobie.util.transactor.Transactor
 
-object Authenticators {
-  implicit val xa = RFTransactor.xa
+class Authenticators(val xa: Transactor[IO]) {
 
   val tokensAuthenticator = Kleisli[OptionT[IO, ?], Request[IO], User](
     {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -12,8 +12,7 @@ import doobie.implicits._
 
 import java.util.UUID
 
-object Authorizers {
-  val xa = RFTransactor.xa
+class Authorizers(xa: Transactor[IO]) {
 
   def authToolRun(user: User, toolRunId: UUID): IO[Unit] =
     ToolRunDao

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -24,18 +24,21 @@ import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.Router
 import org.http4s.syntax.kleisli._
 import org.http4s.util.CaseInsensitiveString
+
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
-import java.util.concurrent.{TimeUnit, Executors}
+import java.util.concurrent.{Executors, TimeUnit}
 
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.MosaicImplicits
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.backsplash.MetricsRegistrator
-
 import java.util.UUID
 
-object Main extends IOApp with ProjectStoreImplicits {
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.rasterfoundry.database.util.RFTransactor
+
+object Main extends IOApp {
 
   sgdal.setConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "YES")
 
@@ -43,8 +46,24 @@ object Main extends IOApp with ProjectStoreImplicits {
     IO.contextShift(
       ExecutionContext.fromExecutor(
         Executors.newFixedThreadPool(
-          Config.parallelism.threadPoolSize
-        )))
+          2,
+          new ThreadFactoryBuilder().setNameFormat("main-http4s-%d").build()
+        )
+      )
+    )
+
+  val dbContextShift: ContextShift[IO] = IO.contextShift(
+    ExecutionContext.fromExecutor(
+      Executors.newFixedThreadPool(
+        8,
+        new ThreadFactoryBuilder().setNameFormat("db-client-%d").build()
+      )
+    ))
+
+  val xa = RFTransactor.transactor(dbContextShift)
+
+  val projectStoreImplicits = new ProjectStoreImplicits(xa)
+  import projectStoreImplicits.projectStore
 
   val timeout: FiniteDuration =
     new FiniteDuration(Config.server.timeoutSeconds, TimeUnit.SECONDS)
@@ -76,21 +95,23 @@ object Main extends IOApp with ProjectStoreImplicits {
     )(service)
 
   val mtr = new MetricsRegistrator()
+  val authenticators = new Authenticators(xa)
 
   val mosaicImplicits = new MosaicImplicits(mtr)
-  val toolStoreImplicits = new ToolStoreImplicits(mosaicImplicits)
+  val toolStoreImplicits = new ToolStoreImplicits(mosaicImplicits, xa)
   import toolStoreImplicits._
 
   val mosaicService: HttpRoutes[IO] =
-    Authenticators.tokensAuthMiddleware(
-      new MosaicService(SceneToProjectDao(), mtr, mosaicImplicits).routes)
+    authenticators.tokensAuthMiddleware(
+      new MosaicService(SceneToProjectDao(), mtr, mosaicImplicits, xa).routes)
 
   val analysisService: HttpRoutes[IO] =
-    Authenticators.tokensAuthMiddleware(
+    authenticators.tokensAuthMiddleware(
       new AnalysisService(ToolRunDao(),
                           mtr,
                           mosaicImplicits,
-                          toolStoreImplicits).routes)
+                          toolStoreImplicits,
+                          xa).routes)
 
   val httpApp =
     Router(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -42,16 +42,6 @@ object Main extends IOApp {
 
   sgdal.setConfigOption("GDAL_DISABLE_READDIR_ON_OPEN", "YES")
 
-  override protected implicit def contextShift: ContextShift[IO] =
-    IO.contextShift(
-      ExecutionContext.fromExecutor(
-        Executors.newFixedThreadPool(
-          2,
-          new ThreadFactoryBuilder().setNameFormat("main-http4s-%d").build()
-        )
-      )
-    )
-
   val dbContextShift: ContextShift[IO] = IO.contextShift(
     ExecutionContext.fromExecutor(
       Executors.newFixedThreadPool(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -6,18 +6,20 @@ import com.azavea.maml.ast._
 import com.azavea.maml.util.{NeighborhoodConversion, ClassMap => MamlClassMap}
 import geotrellis.vector.io._
 import cats._
+import cats.effect.IO
 import cats.implicits._
 import doobie.implicits._
-
 import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.datamodel.{BandDataType, SingleBandOptions}
 import com.rasterfoundry.tool.ast.MapAlgebraAST.{CogRaster, SceneRaster}
+import doobie.util.transactor.Transactor
 import io.circe.Json
 
-class BacksplashMamlAdapter(mosaicImplicits: MosaicImplicits)
-    extends ProjectStoreImplicits {
+class BacksplashMamlAdapter(mosaicImplicits: MosaicImplicits,
+                            xa: Transactor[IO])
+    extends ProjectStoreImplicits(xa) {
   import mosaicImplicits._
 
   def asMaml(ast: MapAlgebraAST)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -31,7 +31,7 @@ import geotrellis.vector.{Polygon, Projected}
 
 import java.util.UUID
 
-trait ProjectStoreImplicits extends ToProjectStoreOps {
+class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
   implicit val projectStore: ProjectStore[SceneToProjectDao] =
     new ProjectStore[SceneToProjectDao] {
       // safe to get here, since we're just unapplying from a value that we already know
@@ -104,7 +104,7 @@ trait ProjectStoreImplicits extends ToProjectStoreOps {
             ),
             singleBandOptions
           )
-        } transact (RFTransactor.xa)
+        } transact (xa)
       }
     }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -17,10 +17,11 @@ import doobie.implicits._
 
 import java.util.UUID
 
-class ToolStoreImplicits(mosaicImplicits: MosaicImplicits)
-    extends ProjectStoreImplicits {
+class ToolStoreImplicits(mosaicImplicits: MosaicImplicits, xa: Transactor[IO])
+    extends ProjectStoreImplicits(xa) {
   import mosaicImplicits._
-  val mamlAdapter = new BacksplashMamlAdapter(mosaicImplicits)
+
+  val mamlAdapter = new BacksplashMamlAdapter(mosaicImplicits, xa)
 
   private def toolToColorRd(toolRd: tool.RenderDefinition): RenderDefinition = {
     val scaleOpt = toolRd.scale match {
@@ -58,7 +59,7 @@ class ToolStoreImplicits(mosaicImplicits: MosaicImplicits)
               s"Node $nodeId missing from AST $analysisId")
           }
       } getOrElse { decoded }
-    }).transact(RFTransactor.xa)
+    }).transact(xa)
 
   implicit val toolRunDaoStore: ToolStore[ToolRunDao] =
     new ToolStore[ToolRunDao] {

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -66,6 +66,26 @@ object RFTransactor extends Config {
     HikariTransactor.apply[IO](hikariDS, connectionEC, transactionEC)
   }
 
+  lazy val xaResource: Resource[IO, HikariTransactor[IO]] = {
+
+    implicit val cs: ContextShift[IO] = IO.contextShift(
+      ExecutionContext.fromExecutor(
+        Executors.newFixedThreadPool(
+          8,
+          new ThreadFactoryBuilder().setNameFormat("db-client-%d").build()
+        )
+      ))
+
+    HikariTransactor.newHikariTransactor[IO](
+      jdbcDriver,
+      jdbcNoDBUrl,
+      dbUser,
+      dbPassword,
+      connectionEC,
+      transactionEC
+    )
+  }
+
   // Only use in Tile subproject!!
   lazy val xa: HikariTransactor[IO] = {
 

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -66,4 +66,21 @@ object RFTransactor extends Config {
     HikariTransactor.apply[IO](hikariDS, connectionEC, transactionEC)
   }
 
+  // Only use in Tile subproject!!
+  lazy val xa: HikariTransactor[IO] = {
+
+    implicit val cs: ContextShift[IO] = IO.contextShift(
+      ExecutionContext.fromExecutor(
+        Executors.newFixedThreadPool(
+          8,
+          new ThreadFactoryBuilder().setNameFormat("db-client-%d").build()
+        )
+      ))
+
+    HikariTransactor.apply[IO](
+      hikariDS,
+      connectionEC,
+      transactionEC
+    )
+  }
 }

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -97,8 +97,6 @@ services:
     working_dir: /opt/raster-foundry/app-backend/api/target/scala-2.11/
     entrypoint: java
     command:
-      - "-jar"
-      - "api-assembly.jar"
       - "-Dcom.sun.management.jmxremote.rmi.port=9010"
       - "-Dcom.sun.management.jmxremote=true"
       - "-Dcom.sun.management.jmxremote.port=9010"
@@ -106,6 +104,8 @@ services:
       - "-Dcom.sun.management.jmxremote.authenticate=false"
       - "-Dcom.sun.management.jmxremote.local.only=false"
       - "-Djava.rmi.server.hostname=localhost"
+      - "-jar"
+      - "api-assembly.jar"
 
   backsplash:
     image: daunnc/openjdk-gdal:2.3.2


### PR DESCRIPTION
## Overview

This PR removes some execution context pollution that was happening when importing a transactor from the database and also more explicitly names our generated execution contexts for easier identification later.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/898060/50453843-74316900-0911-11e9-9d66-c6d2775d4675.png)
