### PR TITLE
Support a list of projects in cigatling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Used a fixed number of threadPool for Backsplash [\#4389](https://github.com/raster-foundry/raster-foundry/pull/4389)
 - Made timeout length and number of threadPool configurable [\#4389](https://github.com/raster-foundry/raster-foundry/pull/4389)
 - Ignored errors from integration tests so that reports will always be written to s3 [\#4406](https://github.com/raster-foundry/raster-foundry/pull/4406)
+- Added ability to test against several projects in gatling integration tests [\#4416](https://github.com/raster-foundry/raster-foundry/pull/4416)
 
 ### Fixed
 

--- a/gatling/src/test/resources/application.conf
+++ b/gatling/src/test/resources/application.conf
@@ -23,9 +23,7 @@ gatling {
   }
 
   tms {
-    server = "backsplash"
-    server = ${?BACKSPLASH_TMS_SERVER}
-    template = "https://${server}.staging.rasterfoundry.com/${projectId}/${z}/${x}/${y}/"
+    template = "https://backsplash.staging.rasterfoundry.com/${projectId}/${z}/${x}/${y}/"
     template = ${?BACKSPLASH_TMS_URL_TEMPLATE}
     minZoom = 1
     minZoom = ${?MIN_ZOOM}

--- a/gatling/src/test/resources/application.conf
+++ b/gatling/src/test/resources/application.conf
@@ -6,8 +6,8 @@ gatling {
     apiHost = "http://api-server:9000"
     apiHost = ${?RF_API_HOST}
 
-    projectId = ""
-    projectId = ${?RF_PROJECT_ID}
+    projectIds = ""
+    projectIds = ${?RF_PROJECT_IDS}
 
     tokenRoute = "/api/tokens/"
     tokenRoute = ${?TOKEN_ROUTE}
@@ -23,7 +23,9 @@ gatling {
   }
 
   tms {
-    template = "http://backsplash:8080/${projectId}/${z}/${x}/${y}/?token=${authToken}"
+    server = "backsplash"
+    server = ${?BACKSPLASH_TMS_SERVER}
+    template = "https://${server}.staging.rasterfoundry.com/${projectId}/${z}/${x}/${y}/"
     template = ${?BACKSPLASH_TMS_URL_TEMPLATE}
     minZoom = 1
     minZoom = ${?MIN_ZOOM}

--- a/gatling/src/test/scala/Config.scala
+++ b/gatling/src/test/scala/Config.scala
@@ -10,16 +10,18 @@ object Config {
     val tokenEndpoint = apiHost + config.getString("gatling.rf.tokenRoute")
     val projectEndpoint = apiHost + config.getString("gatling.rf.projectRoute")
 
-    val projectId = config.getString("gatling.rf.projectId")
+    val projectIds = config.getString("gatling.rf.projectIds")
     val refreshToken = config.getString("gatling.rf.refreshToken")
   }
 
   object TMS {
+    val server = config.getString("gatling.tms.server")
     val template = config.getString("gatling.tms.template")
     val minZoom = config.getInt("gatling.tms.minZoom")
     val maxZoom = config.getInt("gatling.tms.maxZoom")
     val randomSeed = config.getInt("gatling.tms.randomSeed")
   }
+
   object Users {
     val count = config.getInt("gatling.users.count")
     val rampupTime = config.getInt("gatling.users.rampupTime")

--- a/gatling/src/test/scala/Config.scala
+++ b/gatling/src/test/scala/Config.scala
@@ -15,7 +15,6 @@ object Config {
   }
 
   object TMS {
-    val server = config.getString("gatling.tms.server")
     val template = config.getString("gatling.tms.template")
     val minZoom = config.getInt("gatling.tms.minZoom")
     val maxZoom = config.getInt("gatling.tms.maxZoom")

--- a/gatling/src/test/scala/MosaicTmsSimulation.scala
+++ b/gatling/src/test/scala/MosaicTmsSimulation.scala
@@ -22,27 +22,39 @@ class MosaicTmsSimulation extends Simulation {
     .userAgentHeader(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:16.0) Gecko/20100101 Firefox/16.0")
 
-  val bbox = {
-    val uuid = UUID.fromString(Config.RF.projectId)
-    ApiUtils.getProjectBBox(uuid).getOrElse(LatLng.worldExtent)
-  }
+  val projectIds = Config.RF.projectIds.split(",") map { UUID.fromString _ }
+  val bboxes = Map(
+    (projectIds map { projectId =>
+      (projectId,
+       ApiUtils.getProjectBBox(projectId).getOrElse(LatLng.worldExtent))
+    }): _*
+  )
 
   val tmsScenario =
     scenario("Mosaic TMS")
-      .exec(feed(TmsUtils
-        .randomTileFeeder(bbox, Config.TMS.minZoom, Config.TMS.maxZoom)))
+      .exec(
+        feed(
+          TmsUtils
+            .randomTileFeeder(projectIds,
+                              bboxes,
+                              Config.TMS.minZoom,
+                              Config.TMS.maxZoom)
+            .random))
       .exec(_.set("authToken", ApiUtils.getAuthToken))
-      .exec(_.set("projectId", Config.RF.projectId))
       .exec(foreach("${tiles}", "tile") {
         exec({ session =>
-          val tile = session("tile").as[(Int, Int, Int)]
-          session.set("z", tile._1).set("x", tile._2).set("y", tile._3)
+          val tile = session("tile").as[(UUID, Int, Int, Int)]
+          session
+            .set("projectId", tile._1)
+            .set("z", tile._2)
+            .set("x", tile._3)
+            .set("y", tile._4)
         }).exec {
-            http("tiles at ${tile._1}/${tile._2}/${tile._3}")
-              .get(Config.TMS.template)
-              .header("authorization", "Bearer ${authToken}")
-              .check(status.is(200))
-          }
+          http("tiles at ${projectId}/${z}/${x}/${y}")
+            .get(Config.TMS.template)
+            .header("authorization", "Bearer ${authToken}")
+            .check(status.is(200))
+        }
       })
       .pause(4)
 

--- a/scripts/cigatling
+++ b/scripts/cigatling
@@ -33,7 +33,6 @@ then
           -e PROJECT_ROUTE \
           -e USER_COUNT \
           -e RAMPUP_TIME \
-          -e BACKSPLASH_TMS_SERVER \
           -e BACKSPLASH_TMS_URL_TEMPLATE \
           -e MIN_ZOOM \
           -e MAX_ZOOM \

--- a/scripts/cigatling
+++ b/scripts/cigatling
@@ -26,13 +26,14 @@ then
           -v "$HOME/.ivy2:/root/.ivy2" \
           -w /opt/gatling/ \
           -e RF_API_HOST \
-          -e RF_PROJECT_ID \
+          -e RF_PROJECT_IDS \
           -e TOKEN_ROUTE \
           -e REFRESH_TOKEN \
           -e RANDOM_SEED \
           -e PROJECT_ROUTE \
           -e USER_COUNT \
           -e RAMPUP_TIME \
+          -e BACKSPLASH_TMS_SERVER \
           -e BACKSPLASH_TMS_URL_TEMPLATE \
           -e MIN_ZOOM \
           -e MAX_ZOOM \


### PR DESCRIPTION
## Overview

This PR makes it so that we can specify a list of project IDs instead of a single project ID for load testing
purposes.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * create a `jenkins.env` file to use for the load test (I can send you a template)
 * `source jenkins.env`
 * `./scripts/cigatling`
 * you should run a load test without configuration errors
 * you should see more than one project in the list of URLs tested against