### PR TITLE
Only url-encode the url used to update scene, not upload

### DIFF
--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -29,6 +29,7 @@ def create_cog(image_locations, scene, same_path=False):
         if same_path:
             updated_scene = upload_tif(
                 cog_path, scene,
+                os.path.join('user-uploads', scene.owner, '{}_COG.tif'.format(scene.id)),
                 os.path.join('user-uploads', urllib.quote_plus(scene.owner), '{}_COG.tif'.format(scene.id))
             )
         else:
@@ -37,16 +38,17 @@ def create_cog(image_locations, scene, same_path=False):
         os.remove(cog_path)
 
 
-def upload_tif(tif_path, scene, key=''):
+def upload_tif(tif_path, scene, key='', ingest_location=''):
     if len(key) == 0:
         key = os.path.join('public-cogs', '{}_COG.tif'.format(scene.id))
 
     s3uri = 's3://{}/{}'.format(DATA_BUCKET, key)
+    ingestUri = 's3://{}/{}'.format(DATA_BUCKET, ingest_location)
     logger.info('Uploading tif to S3 at %s', s3uri)
-    with open(tif_path, 'r') as inf:
+    with open(tif_path, 'rb') as inf:
         s3client.put_object(Bucket=DATA_BUCKET, Key=key, Body=inf)
     logger.info('Tif uploaded successfully')
-    scene.ingestLocation = s3uri
+    scene.ingestLocation = s3uri if len(ingest_location) == 0 else ingestUri
     scene.sceneType = 'COG'
     scene.ingestStatus = 'INGESTED'
     return scene


### PR DESCRIPTION
## Overview
Urls passed into AWS libraries must not be encoded, but scene.ingestLocation is expected to be encoded.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ reprocess script was added this release
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
```
INFO:rf.ingest.io:Uploading tif to S3 at s3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/323c20e1-6f63-48d4-bddb-f03a7af808ca_COG.tif
INFO:rf.ingest.io:Tif uploaded successfully
INFO:rf.commands.reprocess_geotiff_to_cog:Cog created, writing histogram to attribute store
[main] INFO  - Raster-Foundry-Hikari-Pool - Starting...
[main] INFO  - Raster-Foundry-Hikari-Pool - Start completed.
[ForkJoinPool-1-worker-5] WARN  - Your profile name includes a 'profile ' prefix. This is considered part of the profile name in the Java SDK, so you will need to include this prefix in your profile name when you reference this profile from your Java code.
[ForkJoinPool-1-worker-5] WARN  - Your profile name includes a 'profile ' prefix. This is considered part of the profile name in the Java SDK, so you will need to include this prefix in your profile name when you reference this profile from your Java code.
[ForkJoinPool-1-worker-5] WARN  - Your profile name includes a 'profile ' prefix. This is considered part of the profile name in the Java SDK, so you will need to include this prefix in your profile name when you reference this profile from your Java code.
[ForkJoinPool-1-worker-5] WARN  - Your profile name includes a 'profile ' prefix. This is considered part of the profile name in the Java SDK, so you will need to include this prefix in your profile name when you reference this profile from your Java code.
[pool-1-thread-1] INFO  - HikariPool-1 - Starting...
[pool-1-thread-1] INFO  - HikariPool-1 - Start completed.
[ForkJoinPool-1-worker-5] INFO  - Fetching histogram for scene at s3://rasterfoundry-development-data-us-east-1/user-uploads/auth0%7C59318a9d2fbbca3e16bcfc92/323c20e1-6f63-48d4-bddb-f03a7af808ca_COG.tif
[ForkJoinPool-1-worker-5] INFO  -  Created histograms for 1 scenes.
 Failed to create histograms for 0 scenes.
[ForkJoinPool-1-worker-5] INFO  - Shutting down threadpool
[ForkJoinPool-1-worker-5] INFO  - Thread pool shutdown completed
[ForkJoinPool-1-worker-5] INFO  - HikariPool-1 - Shutdown initiated...
[ForkJoinPool-1-worker-5] INFO  - HikariPool-1 - Shutdown completed.
INFO:rf.commands.reprocess_geotiff_to_cog:Successfully completed metadata postgres write for scene 323c20e1-6f63-48d4-bddb-f03a7af808ca
INFO:rf.commands.reprocess_geotiff_to_cog:Histogram written to attribute store
```

## Testing Instructions
* Rebuild your batch container
 * Reprocess a user uploaded scene. To make a scene reprocessable, set its scene_type to 'AVRO' and ingest_status to 'INGESTED'
* run `rf reprocess-avro-to-cog {id}` for a scene and verify that the histogram is created successfully (no errors)

Fix is for https://github.com/azavea/raster-foundry-platform/issues/581