### PR TITLE
Be honest about whether reading a raster source is effectful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Ignored errors from integration tests so that reports will always be written to s3 [\#4406](https://github.com/raster-foundry/raster-foundry/pull/4406)
 - Changed how the database transactor is passed to backsplash and API servers to prevent accidentally passing implicit execution contexts where they are not wanted [\#4415](https://github.com/raster-foundry/raster-foundry/pull/4415)
 - Added ability to test against several projects in gatling integration tests [\#4416](https://github.com/raster-foundry/raster-foundry/pull/4416)
+- Used explicit IO when getting raster sources for BacksplashImages [\#4419](https://github.com/raster-foundry/raster-foundry/pull/4419)
 
 ### Fixed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -1,8 +1,10 @@
 package com.rasterfoundry.backsplash
 
 import com.rasterfoundry.backsplash.color._
+import com.rasterfoundry.backsplash.error._
 import geotrellis.vector.{io => _, _}
 import geotrellis.raster.{io => _, _}
+import geotrellis.spark.tiling.{LayoutDefinition, ZoomedLayoutScheme}
 import geotrellis.vector.io.readWktOrWkb
 import geotrellis.raster.histogram._
 import geotrellis.raster.io.geotiff.AutoHigherResolution
@@ -15,6 +17,7 @@ import geotrellis.contrib.vlm.geotiff.GeoTiffRasterSource
 
 import cats.data.{NonEmptyList => NEL}
 import cats.effect.IO
+import cats.implicits._
 import io.circe.syntax._
 
 import java.util.UUID
@@ -26,44 +29,46 @@ case class BacksplashImage(
     subsetBands: List[Int],
     corrections: ColorCorrect.Params,
     singleBandOptions: Option[SingleBandOptions.Params]) {
-  def read(extent: Extent, cs: CellSize): Option[MultibandTile] = {
-    val rs = BacksplashImage.getRasterSource(uri)
-    val destinationExtent = extent.reproject(rs.crs, WebMercator)
-    rs.reproject(WebMercator, NearestNeighbor)
-      .resampleToGrid(RasterExtent(extent, cs), NearestNeighbor)
-      .read(destinationExtent, subsetBands.toSeq)
-      .map(_.tile)
-  }
+  def read(extent: Extent, cs: CellSize): IO[Option[MultibandTile]] =
+    for {
+      rs <- BacksplashImage.getRasterSource(uri)
+      destinationExtent = extent.reproject(rs.crs, WebMercator)
+    } yield {
+      rs.reproject(WebMercator, NearestNeighbor)
+        .resampleToGrid(RasterExtent(extent, cs), NearestNeighbor)
+        .read(destinationExtent, subsetBands.toSeq)
+        .map(_.tile)
+    }
 
-  def read(z: Int, x: Int, y: Int): Option[MultibandTile] = {
-    val rs = BacksplashImage.getRasterSource(uri)
-    val layoutDefinition = BacksplashImage.tmsLevels(z)
-    rs.reproject(WebMercator)
-      .tileToLayout(layoutDefinition, NearestNeighbor)
-      .read(SpatialKey(x, y), subsetBands)
-  }
-
-  def colorCorrect(z: Int,
-                   x: Int,
-                   y: Int,
-                   hists: Seq[Histogram[Double]],
-                   nodataValue: Option[Double]): Option[MultibandTile] =
-    read(z, x, y) map {
-      corrections.colorCorrect(_, hists, nodataValue)
+  def read(z: Int, x: Int, y: Int): IO[Option[MultibandTile]] =
+    for {
+      rs <- BacksplashImage.getRasterSource(uri)
+      layoutDefinition = BacksplashImage.tmsLevels(z)
+    } yield {
+      rs.reproject(WebMercator)
+        .tileToLayout(layoutDefinition, NearestNeighbor)
+        .read(SpatialKey(x, y), subsetBands)
     }
 
   def colorCorrect(extent: Extent,
                    cs: CellSize,
                    hists: Seq[Histogram[Double]],
                    nodataValue: Option[Double]) =
-    read(extent, cs) map {
-      corrections.colorCorrect(_, hists, nodataValue)
+    for {
+      maybeTile <- read(extent, cs)
+    } yield {
+      maybeTile map { corrections.colorCorrect(_, hists, nodataValue) }
     }
 }
 
-object BacksplashImage extends RasterSourceUtils {
+object BacksplashImage {
 
-  def getRasterSource(uri: String): GeoTiffRasterSource = {
+  val tmsLevels: Array[LayoutDefinition] = {
+    val scheme = ZoomedLayoutScheme(WebMercator, 256)
+    for (zoom <- 0 to 64) yield scheme.levelForZoom(zoom).layout
+  }.toArray
+
+  def getRasterSource(uri: String): IO[GeoTiffRasterSource] = IO {
     new GeoTiffRasterSource(uri)
   }
 
@@ -82,4 +87,13 @@ object BacksplashImage extends RasterSourceUtils {
                         None)
       }
       .getOrElse(throw new Exception("Provided WKT/WKB must be a multipolygon"))
+
+  def getRasterExtents(uri: String): IO[NEL[RasterExtent]] =
+    for {
+      rs <- getRasterSource(uri)
+    } yield {
+      rs.resolutions.toNel getOrElse {
+        throw new MetadataException(s"No overviews available at $uri")
+      }
+    }
 }


### PR DESCRIPTION
## Overview

This PR tells the compiler that `getRasterSource` on `BacksplashImage` is effectful, because it is.
Ideally that also means that `getRasterSource` will understand better how to play nicely with anything in an `IO` monad, in case that was causing any sort of problem with threading, which we don't know for sure but we may as well be safe about.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

The cost of doing so is that we can't extend `RasterSourceUtils` from gt-contrib anymore. This has two consequences:

- have to implement `getRasterExtents` again
- have to provide `tmsLevels`

Those are both pretty cheap, so :man_shrugging: 

## Testing Instructions

 * just a types change, compilation = same degree of "success" as before
