### PR TITLE
Read tile as an ArrayTile

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -52,7 +52,9 @@ case class BacksplashImage(imageId: UUID,
     val layoutDefinition = BacksplashImage.tmsLevels(z)
     rs.reproject(WebMercator)
       .tileToLayout(layoutDefinition, NearestNeighbor)
-      .read(SpatialKey(x, y), subsetBands)
+      .read(SpatialKey(x, y), subsetBands) map { tile =>
+      tile.mapBands((n: Int, t: Tile) => t.toArrayTile)
+    }
   }
 
   def colorCorrect(z: Int,
@@ -77,27 +79,6 @@ import scala.collection.mutable.HashMap
 
 object BacksplashImage extends RasterSourceUtils with LazyLogging {
 
-//  def getRasterSource(uri: String): GDALRasterSource = blocking {
-//    GDALRasterSource(URLDecoder.decode(uri, "UTF-8"))
-//  }
-
-  def getRasterSource(uri: String): GeoTiffRasterSource = {
+  def getRasterSource(uri: String): GeoTiffRasterSource =
     new GeoTiffRasterSource(uri)
-  }
-
-//  def fromWkt(imageId: UUID,
-//              uri: String,
-//              wkt: String,
-//              subsetBands: List[Int]): BacksplashImage =
-//    readWktOrWkb(wkt)
-//      .as[Polygon]
-//      .map { poly =>
-//        BacksplashImage(imageId,
-//                        uri,
-//                        MultiPolygon(poly),
-//                        subsetBands,
-//                        ColorCorrect.paramsFromBandSpecOnly(0, 1, 2),
-//                        None)
-//      }
-//      .getOrElse(throw new Exception("Provided WKT/WKB must be a multipolygon"))
 }


### PR DESCRIPTION
## Overview

This PR makes it so that when we read tiles from a `BacksplashImage` we get an `ArrayTile` out instead of a normal `Tile`. The reason this helps is that `Tile`s and `ArrayTile`s have different `forEach` implementations that affect how `PaddedTile`s in geotrellis-contrib fill space. Thanks @moradology and @echeipesh for patience and optimism while debugging this and for eventually figuring it out.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/5702984/50496394-7d97ff80-09fd-11e9-84e8-611784cef824.png)

### Notes

https://github.com/locationtech/geotrellis/issues/2856

## Testing Instructions

 * set a project to single band mode
 * you should be able to render it without weird stripes
