### PR TITLE
Add AuthedAutoSlash middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added graphite reporter to dropwizard metrics [\#4398](https://github.com/raster-foundry/raster-foundry/pull/4398)
 - Added alternative development runner/setup for testing API server and backsplash [\#4402](https://github.com/raster-foundry/raster-foundry/pull/4402)
 - Added configuration and helper script for gatling integration test results [\#4410](https://github.com/raster-foundry/raster-foundry/pull/4410)
+- Created AuthedAutoSlash middleware to make authentication and route matching cooperate [\#4425](https://github.com/raster-foundry/raster-foundry/pull/4425)
 
 ### Changed
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -18,6 +18,9 @@ object AuthedAutoSlash {
       implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] = Kleisli {
     authedReq =>
       {
+        // <+> is MonoidK combine
+        // It's used here for consistency with the http4s non-authed autoslash
+        // https://github.com/http4s/http4s/blob/master/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala#L20
         http(authedReq) <+> {
           val pathInfo = authedReq.req.pathInfo
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -20,7 +20,7 @@ object AuthedAutoSlash {
       {
         // <+> is MonoidK combine
         // It's used here for consistency with the http4s non-authed autoslash
-        // https://github.com/http4s/http4s/blob/master/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala#L20
+        // https://github.com/http4s/http4s/blob/v0.20.0-M4/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala#L20
         // what it does here is compose the un-autoslashed service with a copy of itself that strips the
         // trailing slashes and routes the original request back to the first service
         http(authedReq) <+> {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -1,0 +1,35 @@
+package com.rasterfoundry.backsplash.server
+
+import cats._
+import cats.data._
+import cats.implicits._
+import org.http4s._
+import org.http4s.server._
+import org.http4s.server.middleware._
+
+/** Removes a trailing slash from [[Request]] path
+  *
+  * If a route exists with a file style [[Uri]], eg "/foo",
+  * this middleware will cause [[Request]]s with uri = "/foo" and
+  * uri = "/foo/" to match the route.
+  */
+object AuthedAutoSlash {
+  def apply[T, F[_]](http: AuthedService[T, F])(
+      implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] = Kleisli {
+    authedReq =>
+      {
+        http(authedReq) <+> {
+          val pathInfo = authedReq.req.pathInfo
+
+          if (pathInfo.isEmpty || pathInfo.charAt(pathInfo.length - 1) != '/') {
+            F.empty
+          } else {
+            // Request has not been translated already
+            http.apply(
+              authedReq.copy(req = authedReq.req.withPathInfo(
+                pathInfo.substring(0, pathInfo.length - 1))))
+          }
+        }
+      }
+  }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -21,6 +21,8 @@ object AuthedAutoSlash {
         // <+> is MonoidK combine
         // It's used here for consistency with the http4s non-authed autoslash
         // https://github.com/http4s/http4s/blob/master/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala#L20
+        // what it does here is compose the un-autoslashed service with a copy of itself that strips the
+        // trailing slashes and routes the original request back to the first service
         http(authedReq) <+> {
           val pathInfo = authedReq.req.pathInfo
 


### PR DESCRIPTION
## Overview

This PR adds an AuthedAutoSlash middleware that we can apply to `AuthedService`s.

The first commit removes all of the trailing `/ _` matchers from routes to make sure that without an appropriate autoslash, all the requests for tiles from the frontend will fail. The second commit adds an `AuthedAutoSlash` middleware that fires _before_ the authed service has a chance to complain that it can't find a route with a trailing slash.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

You may have noticed that the default AutoSlash has a branch for something about a `scriptName`. I don't know what that is, and when I was logging the values that the middleware was working with ours was always empty, so I don't think it's important to us.

## Testing Instructions

 * use the lab
 * it should be fine