### PR TITLE
Gatling Simulation Update

### DIFF
--- a/gatling/.sbtopts
+++ b/gatling/.sbtopts
@@ -1,5 +1,0 @@
--Dsbt.boot.directory=project/.boot
--Dsbt.global.base=project/.sbtboot
--Dsbt.ivy.home=project/.ivy
--Dsbt.override.build.repos=true
--Dsbt.repository.config=project/ci/repositories

--- a/gatling/.sbtopts
+++ b/gatling/.sbtopts
@@ -1,0 +1,5 @@
+-Dsbt.boot.directory=project/.boot
+-Dsbt.global.base=project/.sbtboot
+-Dsbt.ivy.home=project/.ivy
+-Dsbt.override.build.repos=true
+-Dsbt.repository.config=project/ci/repositories

--- a/gatling/project/ci/repositories
+++ b/gatling/project/ci/repositories
@@ -1,0 +1,6 @@
+[repositories]
+  local
+  ivy-proxy-releases: http://nexus.rasterfoundry.internal/repository/ivy-public/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  maven-proxy-releases: http://nexus.rasterfoundry.internal/repository/maven-public/
+  locationtech-proxy-releases: http://nexus.rasterfoundry.internal/repository/locationtech-releases/
+  locationtech-proxy-snapshots: http://nexus.rasterfoundry.internal/repository/locationtech-snapshots/

--- a/gatling/src/test/resources/application.conf
+++ b/gatling/src/test/resources/application.conf
@@ -3,8 +3,11 @@ gatling {
     refreshToken = ""
     refreshToken = ${?REFRESH_TOKEN}
 
-    apiHost = "http://api-server:9000"
+    apiHost = "https://app.staging.rasterfoundry.com"
     apiHost = ${?RF_API_HOST}
+
+    tileHost = "https://backsplash.staging.rasterfoundry.com"
+    tileHost = ${?RF_TILE_HOST}
 
     projectIds = ""
     projectIds = ${?RF_PROJECT_IDS}
@@ -16,21 +19,21 @@ gatling {
   }
 
   users {
-    count = 10
+    count = 120
     count = ${?USER_COUNT}
-    rampupTime = 30
+  }
+
+  load {
+    rampupTime = 60
     rampupTime = ${?RAMPUP_TIME}
   }
 
   tms {
-    template = "https://backsplash.staging.rasterfoundry.com/${projectId}/${z}/${x}/${y}/"
-    template = ${?BACKSPLASH_TMS_URL_TEMPLATE}
-    minZoom = 1
+    minZoom = 18
     minZoom = ${?MIN_ZOOM}
-    maxZoom = 20
+    maxZoom = 21
     maxZoom = ${?MAX_ZOOM}
     randomSeed = 42
     randomSeed = ${?RANDOM_SEED}
   }
 }
-

--- a/gatling/src/test/scala/Config.scala
+++ b/gatling/src/test/scala/Config.scala
@@ -7,6 +7,8 @@ object Config {
 
   object RF {
     val apiHost = config.getString("gatling.rf.apiHost")
+    val tileHost = config.getString("gatling.rf.tileHost")
+
     val tokenEndpoint = apiHost + config.getString("gatling.rf.tokenRoute")
     val projectEndpoint = apiHost + config.getString("gatling.rf.projectRoute")
 
@@ -15,7 +17,6 @@ object Config {
   }
 
   object TMS {
-    val template = config.getString("gatling.tms.template")
     val minZoom = config.getInt("gatling.tms.minZoom")
     val maxZoom = config.getInt("gatling.tms.maxZoom")
     val randomSeed = config.getInt("gatling.tms.randomSeed")
@@ -23,6 +24,10 @@ object Config {
 
   object Users {
     val count = config.getInt("gatling.users.count")
-    val rampupTime = config.getInt("gatling.users.rampupTime")
+    val rampupTimeSeconds = config.getInt("gatling.load.rampupTime")
+  }
+
+  object Load {
+    val durationMinutes = config.getInt("gatling.load.durationMinutes")
   }
 }

--- a/gatling/src/test/scala/TmsUtils.scala
+++ b/gatling/src/test/scala/TmsUtils.scala
@@ -3,14 +3,11 @@ package rfgatling
 import _root_.io.gatling.core.Predef._
 import _root_.io.gatling.http.Predef._
 import _root_.io.gatling.http.request.builder.HttpRequestBuilder
-import com.typesafe.config.ConfigFactory
 import geotrellis.proj4._
 import geotrellis.spark._
 import geotrellis.spark.tiling._
 import geotrellis.vector._
 
-import scala.concurrent.duration._
-import scala.collection.JavaConverters._
 import scala.util.Random
 import java.util.UUID
 
@@ -40,16 +37,11 @@ object TmsUtils {
 
     val (_, x, y) = getTileZXY(lat, lon, zoom)
 
-    /** The logic here is that:
-      *  zoom 0: offsetting by 0 makes sense (0, 0)
-      *  zoom 1: offsetting by up to 1 makes sense (0-1, 0-1) i.e. a 'space' of 4 tiles
-      *  zoom 2: offsetting by up to 2 makes sense (0-2, 0-2) i.e. 9 tiles
-      *  zoom 3+: offsetting by up to 3 makes sense (0-3, 0-3) i.e. 16 tiles
-      *  Multiple TMS requests are sent out simultaneously for any given centerpoint. The actual
-      *   number of such requests will depend on the client, but the assumptions here are
-      *   reasonable.
+    /** The logic here is that a single page load of a map is ~36 requests on a 1080p
+      *  screen in chrome at 100 percent zoom - so that's what is being simulated -- a full
+      *  map load
       */
-    val requiredColRows = Math.min(zoom, 3)
+    val requiredColRows = 6
 
     for {
       xOffset <- 0 to requiredColRows
@@ -73,42 +65,43 @@ object TmsUtils {
     (rnd.nextDouble() * range) + minVal
   }
 
-  def randomZoom(min: Int = 1, max: Int = 20) = {
-    val minVal = Math.max(min, 1)
-    val maxVal = Math.max(minVal, Math.min(20, max))
-    val range = maxVal - minVal
-
-    if (range > 0) rnd.nextInt(range) + minVal
-    else minVal
+  def seqToRequest(projectId: UUID,
+                   z: Int,
+                   x: Int,
+                   y: Int,
+                   authToken: String): HttpRequestBuilder = {
+    http(s"${x}-${y}")
+      .get(
+        s"/${projectId}/${z}/${x}/${y}/?token=${authToken}"
+      )
+      .check(status.is(200))
   }
 
-  /** Random TMS indices constrained by a provided bounding box and bounding zoom levels */
-  def randomTileIdxsForBBox(projectId: UUID,
-                            bboxes: Map[UUID, Extent],
-                            minZoom: Int = 1,
-                            maxZoom: Int = 20): Seq[(Int, Int, Int)] = {
-
-    val bbox = bboxes.get(projectId) getOrElse {
-      throw new Exception(
-        s"Project $projectId missing from bbox map for mysterious reasons")
-    }
-    (minZoom until maxZoom + 1).reverse.flatMap { zoom =>
+  /** For a given project, extent, and zoom return an [[HttpRequestBuilder]]
+    *
+    * To better simulate loading a whole zoom level of tiles this constructs the request
+    * by making the first tile request and telling gatling that the rest of the tiles are
+    * "resources" for the initial tile. This means that the rest of the tiles should be requested
+    * in a parallel-ish fashion
+    *
+    * @param projectId
+    * @param bbox
+    * @param zoom
+    * @param authToken
+    * @return
+    */
+  def randomTileRequestSequence(projectId: UUID,
+                                bbox: Extent,
+                                zoom: Int,
+                                authToken: String): HttpRequestBuilder = {
+    val keySeq =
       tileIdxsForScreen(randomLat(bbox.ymin, bbox.ymax),
-        randomLon(bbox.xmin, bbox.xmax), zoom)
+                        randomLon(bbox.xmin, bbox.xmax),
+                        zoom)
+    val allRequests = keySeq.map {
+      case (z, x, y) => seqToRequest(projectId, z, x, y, authToken)
     }
+    allRequests.head.resources(allRequests.tail: _*)
   }
 
-  /** A gatling [[Feeder] instance for generating requests that mimic TMS requests */
-  def randomTileFeeder(projectIds: Array[UUID],
-                       bboxes: Map[UUID, Extent],
-                       minZoom: Int = 1,
-                       maxZoom: Int = 20) = {
-    projectIds map { (projectId: UUID) =>
-      {
-        val keySeq =
-          randomTileIdxsForBBox(projectId, bboxes, minZoom, maxZoom)
-        Map("tiles" -> (keySeq map { case (z, x, y) => (projectId, z, x, y) }))
-      }
-    }
-  }
 }

--- a/gatling/src/test/scala/TmsUtils.scala
+++ b/gatling/src/test/scala/TmsUtils.scala
@@ -92,9 +92,10 @@ object TmsUtils {
       throw new Exception(
         s"Project $projectId missing from bbox map for mysterious reasons")
     }
-    tileIdxsForScreen(randomLat(bbox.ymin, bbox.ymax),
-                      randomLon(bbox.xmin, bbox.xmax),
-                      randomZoom(minZoom, maxZoom))
+    (minZoom until maxZoom + 1).reverse.flatMap { zoom =>
+      tileIdxsForScreen(randomLat(bbox.ymin, bbox.ymax),
+        randomLon(bbox.xmin, bbox.xmax), zoom)
+    }
   }
 
   /** A gatling [[Feeder] instance for generating requests that mimic TMS requests */


### PR DESCRIPTION
## Overview

Updates the simulation so that increasing the number of users increases the number of requests per second being made. This makes it a little easier to reason about changes we make and how it affects performance. Uses gatling's idea about `resources` for a web page - these are requests that are made in parallel (as far as I can tell based on logs and documentation) that would normally be assets on the page (like images, css, js, etc.). This fits our needs pretty good I think.
