### PR TITLE
Remove references to RF_ARTIFACTS_BUCKET

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,6 @@ node {
     }
 
     env.AWS_DEFAULT_REGION = 'us-east-1'
-    env.RF_ARTIFACTS_BUCKET = 'rasterfoundry-global-artifacts-us-east-1'
 
     // Execute `cibuild` wrapped within a plugin that translates
     // ANSI color codes to something that renders inside the Jenkins

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Vagrant is used to manage VirtualBox provisioning and configuration. Raster Foun
 ```bash
 export RF_AWS_PROFILE=raster-foundry
 export RF_SETTINGS_BUCKET=rasterfoundry-development-config-us-east-1
-export RF_ARTIFACTS_BUCKET=rasterfoundry-global-artifacts-us-east-1
 ```
 
 After exporting your environment settings, you are ready to get started:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,8 +57,6 @@ Vagrant.configure(2) do |config|
   aws_profile = ENV.fetch("RF_AWS_PROFILE", "raster-foundry")
   rf_settings_bucket = ENV.fetch("RF_SETTINGS_BUCKET",
                                 "rasterfoundry-development-config-us-east-1")
-  rf_artifacts_bucket = ENV.fetch("RF_ARTIFACTS_BUCKET",
-                                   "rasterfoundry-global-artifacts-us-east-1")
 
   config.vm.provision "shell", inline: "mkdir -p /vagrant"
   config.vm.provision "ansible_local" do |ansible|
@@ -72,8 +70,7 @@ Vagrant.configure(2) do |config|
     ansible.extra_vars = {
       host_user: host_user,
       aws_profile: aws_profile,
-      rf_settings_bucket: rf_settings_bucket,
-      rf_artifacts_bucket: rf_artifacts_bucket
+      rf_settings_bucket: rf_settings_bucket
     }
   end
 
@@ -82,7 +79,6 @@ Vagrant.configure(2) do |config|
       cd /opt/raster-foundry
       export AWS_PROFILE=#{aws_profile}
       export RF_SETTINGS_BUCKET=#{rf_settings_bucket}
-      export RF_ARTIFACTS_BUCKET=#{rf_artifacts_bucket}
       su vagrant ./scripts/bootstrap
       su vagrant ./scripts/update
     SHELL

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -23,11 +23,6 @@
       lineinfile: dest=/etc/environment regexp=^RF_SETTINGS_BUCKET line="RF_SETTINGS_BUCKET={{ rf_settings_bucket }}"
       when: rf_settings_bucket is defined
 
-    - name: Set Environment variable for Raster Foundry AWS Artifacts Bucket
-      lineinfile: dest=/etc/environment regexp=^RF_ARTIFACTS_BUCKET
-                  line="RF_ARTIFACTS_BUCKET={{ rf_artifacts_bucket }}"
-      when: rf_artifacts_bucket is defined
-
     - name: Set Environment variable for host user (used to namespace jars and other artifacts in development)
       lineinfile: dest=/etc/environment regexp=^RF_HOST_USER line="RF_HOST_USER={{ host_user }}"
       when: host_user is defined


### PR DESCRIPTION
It doesn't look like we're using this anymore. The `publish_jars` script was removed in completing https://github.com/azavea/raster-foundry-platform/issues/549/.