### PR TITLE
Fix Analysis Rendering and Histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Removed faulty no-data interpretation in single band visualization [\#4433](https://github.com/raster-foundry/raster-foundry/pull/4433)
+- Fixed histogram calcuation + sampling logic and analysis rendering [\#4438](https://github.com/raster-foundry/raster-foundry/pull/4438)
 
 ### Removed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -12,8 +12,9 @@ import geotrellis.vector._
 import geotrellis.server._
 import cats.effect._
 import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
 
-sealed trait PaintableTool extends ColorImplicits {
+sealed trait PaintableTool extends ColorImplicits with LazyLogging {
   def tms(z: Int, x: Int, y: Int)(
       implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]]
   def extent(extent: Extent, cellsize: CellSize)(
@@ -46,11 +47,11 @@ object PaintableTool {
     }
 
     def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO])
-      : IO[Interpreted[List[Histogram[Double]]]] =
-      LayerHistogram(IO.pure(expr),
-                     IO.pure(paramMap),
-                     interpreter,
-                     maxCellsSampled)
+      : IO[Interpreted[List[Histogram[Double]]]] = {
+
+      logger.debug(s"Cells to sample: $maxCellsSampled")
+      LayerHistogram(IO.pure(expr), IO.pure(paramMap), interpreter, 2000000)
+    }
 
     def renderDefinition: Option[RenderDefinition] = renderDef
   }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -33,6 +33,9 @@ class AnalysisService[Param: ToolStore, HistStore: HistogramStore](
     extends ColorImplicits {
 
   import mosaicImplicits._
+
+  implicit val tmsReification = rawMosaicTmsReification
+
   import toolstoreImplicits._
 
   private val pngType = `Content-Type`(MediaType.image.png)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -15,26 +15,28 @@ import org.http4s.server.middleware._
   */
 object AuthedAutoSlash {
   def apply[T, F[_]](http: AuthedService[T, F])(
-      implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] = Kleisli {
-    authedReq =>
-      {
-        // <+> is MonoidK combine
-        // It's used here for consistency with the http4s non-authed autoslash
-        // https://github.com/http4s/http4s/blob/v0.20.0-M4/server/src/main/scala/org/http4s/server/middleware/AutoSlash.scala#L20
-        // what it does here is compose the un-autoslashed service with a copy of itself that strips the
-        // trailing slashes and routes the original request back to the first service
-        http(authedReq) <+> {
-          val pathInfo = authedReq.req.pathInfo
+      implicit F: MonoidK[OptionT[F, ?]],
+      ev: Functor[F]): AuthedService[T, F] = Kleisli { authedReq =>
+    {
+      // TODO: this doesn't compile anymore :(
+      http(authedReq) <+> {
+        val pathInfo = authedReq.req.pathInfo
+        val scriptName = authedReq.req.scriptName
 
-          if (pathInfo.isEmpty || pathInfo.charAt(pathInfo.length - 1) != '/') {
-            F.empty
-          } else {
-            // Request has not been translated already
-            http.apply(
-              authedReq.copy(req = authedReq.req.withPathInfo(
-                pathInfo.substring(0, pathInfo.length - 1))))
-          }
+        if (pathInfo.isEmpty || pathInfo.charAt(pathInfo.length - 1) != '/') {
+          F.empty
+        } else if (scriptName.isEmpty) {
+          // Request has not been translated already
+          http.apply(
+            authedReq.copy(req = authedReq.req.withPathInfo(
+              pathInfo.substring(0, pathInfo.length - 1))))
+        } else {
+          val translated = AuthedTranslateUri(scriptName)(http)
+          translated.apply(
+            authedReq.copy(req = authedReq.req.withPathInfo(
+              pathInfo.substring(0, pathInfo.length - 1))))
         }
       }
+    }
   }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
@@ -1,0 +1,48 @@
+package com.rasterfoundry.backsplash.server
+
+import org.http4s._
+import org.http4s.server._
+import org.http4s.server.middleware._
+
+import cats._
+import cats.data._
+import cats.implicits._
+
+/** Removes the given prefix from the beginning of the path of the [[Request]].
+  */
+object AuthedTranslateUri {
+
+  def apply[F[_], T](prefix: String)(http: AuthedService[T, F])(
+      implicit F: MonoidK[OptionT[F, ?]],
+      ev: Functor[F]): AuthedService[T, F] =
+    if (prefix.isEmpty || prefix == "/") http
+    else {
+      val (slashedPrefix, unslashedPrefix) =
+        if (prefix.startsWith("/")) (prefix, prefix.substring(1))
+        else (s"/$prefix", prefix)
+
+      val newCaret = slashedPrefix.length
+
+      Kleisli { authedReq =>
+        val shouldTranslate =
+          authedReq.req.pathInfo
+            .startsWith(unslashedPrefix) || authedReq.req.pathInfo
+            .startsWith(slashedPrefix)
+
+        if (shouldTranslate)
+          http(
+            AuthedRequest(authedReq.authInfo,
+                          setCaret(authedReq.req, newCaret)))
+        else F.empty
+      }
+
+    }
+
+  private def setCaret[F[_]: Functor](req: Request[F],
+                                      newCaret: Int): Request[F] = {
+    val oldCaret = req.attributes
+      .get(Request.Keys.PathInfoCaret)
+      .getOrElse(0)
+    req.withAttribute(Request.Keys.PathInfoCaret(oldCaret + newCaret))
+  }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -32,7 +32,7 @@ class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])
         err
       }
     case t => {
-      logger.error(t.getStackTraceString)
+      logger.error("An unmapped error occurred", t)
       throw UnknownException(t.getMessage)
     }
   }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -58,7 +58,7 @@ class MosaicService[ProjStore: ProjectStore, HistStore: HistogramStore](
               TileUtils.getTileBounds(z, x, y)
             val eval =
               LayerTms.identity(
-                projects.read(projectId, None, bandOverride, None))
+                projects.read(projectId, Some(polygonBbox), bandOverride, None))
             for {
               fiberAuth <- authorizers.authProject(user, projectId).start
               fiberResp <- eval(z, x, y).start

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -36,6 +36,8 @@ class MosaicService[ProjStore: ProjectStore, HistStore: HistogramStore](
 
   import mosaicImplicits._
 
+  implicit val tmsReification = paintedMosaicTmsReification
+
   private val pngType = `Content-Type`(MediaType.image.png)
   private val tiffType = `Content-Type`(MediaType.image.tiff)
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -22,7 +22,9 @@ class ToolStoreImplicits[HistStore: HistogramStore](
     xa: Transactor[IO],
     mtr: MetricsRegistrator)
     extends ProjectStoreImplicits(xa, mtr) {
+
   import mosaicImplicits._
+  implicit val tmsReification = rawMosaicTmsReification
 
   val mamlAdapter = new BacksplashMamlAdapter(mosaicImplicits, xa, mtr)
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -10,7 +10,9 @@ import geotrellis.raster.io._
 import geotrellis.raster.histogram._
 import geotrellis.raster.render._
 import geotrellis.raster.render.png._
+import geotrellis.raster.summary._
 import io.circe.{Encoder, Json, KeyEncoder}
+import io.circe.generic.semiauto._
 import io.circe.parser._
 import io.circe.syntax._
 
@@ -40,4 +42,6 @@ package object server {
     new Encoder[Histogram[Double]] {
       final def apply(hist: Histogram[Double]): Json = hist.toJson.asJson
     }
+
+  implicit val statsEncoder: Encoder[Statistics[Double]] = deriveEncoder
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -24,7 +24,7 @@ object Version {
   val findbugAnnotations = "3.0.1u2"
   val geotools = "17.1"
   val geotrellis = "3.0.0-SNAPSHOT"
-  val geotrellisServer = "0.0.15"
+  val geotrellisServer = "0.0.17"
   val hadoop = "2.8.4"
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M4"


### PR DESCRIPTION
## Overview

- Fixes histogram generation for analyses
- Fixes rendering tiles for analyses
- Adds missing statistics endpoint to backsplash

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Assemble the backsplash jar
 * Create and open an analysis - histograms and rendering should work