### PR TITLE
Check for NODATA before rendering

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
@@ -135,16 +135,20 @@ trait Implicits {
       }
     }
 
-    /** This method extension provides sugar to match GeoTrellis' renderPng method */
+    /** This method extension provides sugar to match GeoTrellis' renderPng method
+     *  Note the return of 0: this ensure transparency for NODATA values
+     */
     def renderPng(definition: RenderDefinition): Png = {
       val toWrite =
         if (tile.cellType.isFloatingPoint) {
           tile.mapDouble({ cellValue: Double =>
-            buildFn(definition)(cellValue).int
+            if (isData(cellValue)) buildFn(definition)(cellValue).int
+            else 0
           })
         } else {
           tile.map({ cellValue: Int =>
-            buildFn(definition)(cellValue).int
+            if (isData(cellValue)) buildFn(definition)(cellValue).int
+            else 0
           })
         }
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.backsplash.color
 
-import geotrellis.raster.{io => _, Tile}
+import geotrellis.raster.{io => _, _}
 import geotrellis.raster.render._
 import geotrellis.raster.render.png._
 import io.circe.{Decoder, Encoder, KeyEncoder, KeyDecoder}


### PR DESCRIPTION
## Overview

`NODATA` values are not precluded from GT `map` and `mapDouble` calls. These happen within analysis color correction and we don't compensate by explicitly guarding against such values. As a result, we map `ND` values to one of the colors provided via `RenderDefinition`. This PR guards against ND

## Testing Instructions

1. Run an analysis (make sure not to shoot yourself in the foot with caching)
2. Make sure regions outside of the data aren't colored