### PR TITLE
Repair quick export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Added back the scenes mosaic endpoint [\#4439](https://github.com/raster-foundry/raster-foundry/pull/4439)
+- Fixed quick export of projects and analyses [\#4459](https://github.com/raster-foundry/raster-foundry/pull/4459)
 
 ### Security
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -48,6 +48,8 @@ case class BacksplashImage(
   implicit val tileCache = Cache.tileCache
   implicit val flags = Cache.tileCacheFlags
 
+  lazy val rasterSource = BacksplashImage.getRasterSource(uri)
+
   /** Read ZXY tile - defers to a private method to enable disable/enabling of cache **/
   def read(z: Int, x: Int, y: Int): Option[MultibandTile] = {
     readWithCache(z, x, y)
@@ -105,5 +107,4 @@ object BacksplashImage extends RasterSourceUtils with LazyLogging {
     rs.resolutions
     rs
   }
-
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -35,13 +35,14 @@ import scalacache.modes.sync._
   * @param corrections description + operations for how to correct image
   * @param singleBandOptions band + options of how to color a single band
   */
-case class BacksplashImage(imageId: UUID,
-                           projectId: UUID,
-                           uri: String,
-                           @cacheKeyExclude footprint: MultiPolygon,
-                           subsetBands: List[Int],
-                           @cacheKeyExclude corrections: ColorCorrect.Params,
-                           singleBandOptions: Option[SingleBandOptions.Params])
+case class BacksplashImage(
+    imageId: UUID,
+    @cacheKeyExclude projectId: UUID,
+    @cacheKeyExclude uri: String,
+    @cacheKeyExclude footprint: MultiPolygon,
+    subsetBands: List[Int],
+    @cacheKeyExclude corrections: ColorCorrect.Params,
+    @cacheKeyExclude singleBandOptions: Option[SingleBandOptions.Params])
     extends LazyLogging {
 
   implicit val tileCache = Cache.tileCache

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -82,10 +82,9 @@ case class BacksplashImage(imageId: UUID,
         s"Reading Extent ${extent} with CellSize ${cs} - Image: ${imageId} at ${uri}"
       )
       val rs = BacksplashImage.getRasterSource(uri)
-      val destinationExtent = extent.reproject(rs.crs, WebMercator)
       rs.reproject(WebMercator, NearestNeighbor)
         .resampleToGrid(RasterExtent(extent, cs), NearestNeighbor)
-        .read(destinationExtent, subsetBands.toSeq)
+        .read(extent, subsetBands.toSeq)
         .map(_.tile)
     }
   }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -325,7 +325,7 @@ class MosaicImplicits[HistStore: HistogramStore](mtr: MetricsRegistrator,
                 })
                 .map(Raster(_, extent))
             } else {
-              BacksplashMosaic.getStoreHistogram(filtered, histStore) map {
+              BacksplashMosaic.getStoreHistogram(filtered, histStore) flatMap {
                 layerHist =>
                   filtered
                     .map({ relevant =>

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -314,15 +314,15 @@ class MosaicImplicits[HistStore: HistogramStore](mtr: MetricsRegistrator,
                     }
                   }
                 })
-                .collect({ case Some(mbTile) => mbTile })
+                .collect({
+                  case Some(mbTile) =>
+                    Raster(mbTile.interpretAs(invisiCellType), extent)
+                })
                 .compile
                 .toList
-                .map(_.reduceOption({ (mbt1, mbt2) =>
-                  mbt1.interpretAs(invisiCellType) merge mbt2.interpretAs(
-                    invisiCellType)
-                }))
+                .map(_.reduceOption(_ merge _))
                 .map({
-                  case Some(t) => Raster(t, extent)
+                  case Some(r) => r
                   case _       => Raster(invisiTile, extent)
                 })
             } else {
@@ -354,14 +354,14 @@ class MosaicImplicits[HistStore: HistogramStore](mtr: MetricsRegistrator,
                       time.stop()
                       img
                     })
-                    .collect({ case Some(mbtile) => mbtile })
+                    .collect({
+                      case Some(mbtile) => Raster(mbtile, extent)
+                    })
                     .compile
                     .toList
-                    .map(_.reduceOption((mbt1, mbt2) =>
-                      mbt1.interpretAs(invisiCellType) merge mbt2.interpretAs(
-                        invisiCellType)))
+                    .map(_.reduceOption(_ merge _))
                     .map({
-                      case Some(t) => Raster(t, extent)
+                      case Some(r) => r
                       case _       => Raster(invisiTile, extent)
                     })
                 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
@@ -129,7 +129,8 @@ object ColorRampMosaic extends LazyLogging {
           throw new IllegalArgumentException(message)
       }
 
-    val renderedTile = cmap.render(singleBandTile)
+    val renderedTile =
+      cmap.render(singleBandTile.interpretAs(IntUserDefinedNoDataCellType(0)))
     val r = renderedTile.map(_.red).interpretAs(UByteCellType)
     val g = renderedTile.map(_.green).interpretAs(UByteCellType)
     val b = renderedTile.map(_.blue).interpretAs(UByteCellType)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -139,7 +139,13 @@ class AnalysisService[Param: ToolStore, HistStore: HistogramStore](
                                        WebMercator).toByteArray,
                      tiffType)
                 } else {
-                  Ok(tile.band(0).renderPng(ColorRamps.Viridis).bytes, pngType)
+                  val rendered = paintableTool.renderDefinition match {
+                    case Some(renderDef) =>
+                      tile.band(0).renderPng(renderDef)
+                    case _ =>
+                      tile.band(0).renderPng(ColorRamps.Viridis)
+                  }
+                  Ok(rendered.bytes, pngType)
                 }
               case Invalid(e) => BadRequest(s"Could not produce extent: $e")
             }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -139,8 +139,6 @@ class MosaicService[ProjStore: ProjectStore, HistStore: HistogramStore](
                                        greenOverride,
                                        blueOverride)(BandOverride.apply)
             val projectedExtent = extent.reproject(LatLng, WebMercator)
-            println(
-              s"Projected extent (what I'm expecting to read): ${projectedExtent}")
             val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
             val eval = authedReq.req.headers
               .get(CaseInsensitiveString("Accept")) match {
@@ -173,8 +171,6 @@ class MosaicService[ProjStore: ProjectStore, HistStore: HistogramStore](
                         tiffType
                       )
                     case _ =>
-                      println(
-                        s"How many bands does it have: ${tile.bands.length}")
                       Ok(tile.renderPng.bytes, pngType)
                   }
                 case Invalid(e) => BadRequest(s"Could not produce extent: $e")


### PR DESCRIPTION
## Overview

This PR fixes quick export of all kinds. More specifically, it fixes:

- a cache key bug that caused multiband tiles to fail to render if the single band was cached and also caused different images to be stored under the same cache key
- merger of tiles from different tiffs causing ArrayIndexOutOfBoundsExceptions because they weren't the same size when combined in arbitrary bboxes
- overwrite of later tiles in a stream by earlier tiles due to bad cell types in single band renders

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![zoom09sb6](https://user-images.githubusercontent.com/5702984/50986754-acba7080-14d5-11e9-98bf-df2ecc6e6a51.png)

![img](https://user-images.githubusercontent.com/5702984/50986763-b2b05180-14d5-11e9-8ad7-c0344b0e94fd.png)

## Testing Instructions

 * Find a project with two overlapping but not coextensive scenes (like the demo)
 * Browse in it to find a bbox where you have data from both scenes and each should contribute
 * save that bbox
 * get a token
 * set viz to single band
 * export the project as a png (`http :8081/<project id>/export token==$token bbox==$bbox zoom==11 Accept:image/png > projsb.png`)
 * export the project as a tiff ((`http :8081/<project id>/export token==$token bbox==$bbox zoom==11 Accept:image/tiff > projsb.tiff`)
 * set it to multiband and export as a png and a tiff -- `http :8081/<project id>/export token==$token bbox==$bbox zoom==11 Accept:image/png > projmb.png`, `http :8081/<project id>/export token==$token bbox==$bbox zoom==11 Accept:image/tiff > projmb.tiff`
 * put the project in an analysis
 * export the analysis as a png -- `http :8081/tools/<analysis id>/raw token==$token  bbox==$bbox zoom==11 > Accept:image/png > analysissb.png`
 *  * export the analysis as a tiff -- `http :8081/tools/<analysis id>/raw token==$token  bbox==$bbox zoom==11 > Accept:image/tiff > analysissb.tiff`
 * everything should succeed

Closes #4444 
