### PR TITLE
Update object permission check for lab templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - Only analyses owned by the current user are displayed in the analysis browsing UI [\#4357](https://github.com/raster-foundry/raster-foundry/pull/4357)
+- Updated permission check logic for lab templates to make ownership filter work as expected [\#4462](https://github.com/raster-foundry/raster-foundry/pull/4462)
 
 ### Deprecated
 

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -217,7 +217,7 @@ trait ObjectPermissions[Model] {
         Some(ownedF)
       // shared to the requesting user directly, across platform, or due to group membership
       case Some(ownershipType) if ownershipType == "shared" =>
-        if (objectType == ObjectType.Shape) {
+        if (objectType == ObjectType.Shape || objectType == ObjectType.Template) {
           Some(fr"(" ++ acrFilterF ++ fr") AND owner <> ${user.id}")
         } else {
           Some(


### PR DESCRIPTION
## Overview

This PR updates object permission check for lab templates.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Check all SQL in the comment area of https://github.com/azavea/raster-foundry-platform/issues/593 and make sure they make sense
 * SQL for staging has already been run. Not for production though -- we will run that manually
 * Run the local development part of SQL against your local DB
 * Go to your lab templates page and apply ownership filters -- make sure it works as you would expect

Closes https://github.com/azavea/raster-foundry-platform/issues/593
