### PR TITLE
Fix permission checks on project and datasource for lab analyses 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added back the scenes mosaic endpoint [\#4439](https://github.com/raster-foundry/raster-foundry/pull/4439)
 - Fixed quick export of projects and analyses [\#4459](https://github.com/raster-foundry/raster-foundry/pull/4459)
 - Fixed route matching for map token authorization for analyses [\#4463](https://github.com/raster-foundry/raster-foundry/pull/4463)
+- Fixed permission checks for project and project datasource in lab analyses [\#4466](https://github.com/raster-foundry/raster-foundry/pull/4466)
 
 ### Security
 

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -432,9 +432,9 @@ trait ProjectRoutes
             authorizeAsync {
               val authorized = for {
                 authProject <- ProjectDao.authorized(user,
-                  ObjectType.Project,
-                  projectId,
-                  ActionType.View)
+                                                     ObjectType.Project,
+                                                     projectId,
+                                                     ActionType.View)
                 authResult <- (authProject, projectQueryParams.analysisId) match {
                   case (false, Some(analysisId: UUID)) =>
                     ToolRunDao
@@ -872,9 +872,9 @@ trait ProjectRoutes
       authorizeAsync {
         val authorized = for {
           authProject <- ProjectDao.authorized(user,
-            ObjectType.Project,
-            projectId,
-            ActionType.View)
+                                               ObjectType.Project,
+                                               projectId,
+                                               ActionType.View)
           authResult <- (authProject, projectQueryParams.analysisId) match {
             case (false, Some(analysisId: UUID)) =>
               ToolRunDao

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -430,23 +430,19 @@ trait ProjectRoutes
         authenticate { user =>
           (projectQueryParameters) { projectQueryParams =>
             authorizeAsync {
-              projectQueryParams.analysisId match {
-                // If an analysisId is provided, the authorization is based on the analysis
-                case Some(analysisId: UUID) =>
-                  ToolRunDao
-                    .authorizeReferencedProject(user, analysisId, projectId)
-                    .transact(xa)
-                    .unsafeToFuture
-
-                case _ =>
-                  ProjectDao
-                    .authorized(user,
-                                ObjectType.Project,
-                                projectId,
-                                ActionType.View)
-                    .transact(xa)
-                    .unsafeToFuture
-              }
+              val authorized = for {
+                authProject <- ProjectDao.authorized(user,
+                  ObjectType.Project,
+                  projectId,
+                  ActionType.View)
+                authResult <- (authProject, projectQueryParams.analysisId) match {
+                  case (false, Some(analysisId: UUID)) =>
+                    ToolRunDao
+                      .authorizeReferencedProject(user, analysisId, projectId)
+                  case (_, _) => authProject.pure[ConnectionIO]
+                }
+              } yield authResult
+              authorized.transact(xa).unsafeToFuture
             } {
               rejectEmptyResponse {
                 complete {
@@ -874,20 +870,19 @@ trait ProjectRoutes
   def listProjectDatasources(projectId: UUID): Route = authenticate { user =>
     (projectQueryParameters) { projectQueryParams =>
       authorizeAsync {
-        projectQueryParams.analysisId match {
-          // If an analysisId is provided, the authorization is based on the analysis
-          case Some(analysisId: UUID) =>
-            ToolRunDao
-              .authorizeReferencedProject(user, analysisId, projectId)
-              .transact(xa)
-              .unsafeToFuture
-
-          case _ =>
-            ProjectDao
-              .authorized(user, ObjectType.Project, projectId, ActionType.View)
-              .transact(xa)
-              .unsafeToFuture
-        }
+        val authorized = for {
+          authProject <- ProjectDao.authorized(user,
+            ObjectType.Project,
+            projectId,
+            ActionType.View)
+          authResult <- (authProject, projectQueryParams.analysisId) match {
+            case (false, Some(analysisId: UUID)) =>
+              ToolRunDao
+                .authorizeReferencedProject(user, analysisId, projectId)
+            case (_, _) => authProject.pure[ConnectionIO]
+          }
+        } yield authResult
+        authorized.transact(xa).unsafeToFuture
       } {
         complete {
           ProjectDatasourcesDao


### PR DESCRIPTION
## Overview

This PR fixes permission checks for project and project datasource in lab analyses.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions

 * Go to lab, create an analysis from a template
 * Select projects and bands for this analysis and make sure it works as expected
 * Share the analysis with account B
 * Log in with account B and check the analysis being shared

Closes #4448 
