### PR TITLE
Add persistent modal option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Removed
 
 ### Fixed
+- Shapes drawn within the scene search filter context can now be saved [\#4474](https://github.com/raster-foundry/raster-foundry/pull/4474)
 
 ### Security
 - Upgrade webpack-dev-server to address vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-14732) [\#4476](https://github.com/raster-foundry/raster-foundry/pull/4476)

--- a/app-frontend/src/app/components/filters/shapeFilter/shapeFilter.module.js
+++ b/app-frontend/src/app/components/filters/shapeFilter/shapeFilter.module.js
@@ -210,7 +210,7 @@ class ShapeFilterController {
                 resolve: {
                     shape: geojson
                 }
-            });
+            }, true, true);
             return modal.result.then((shapes) => {
                 this.shapes = this.shapes.concat(shapes);
                 this.onSearchChange();

--- a/app-frontend/src/app/services/common/modal.service.js
+++ b/app-frontend/src/app/services/common/modal.service.js
@@ -3,11 +3,14 @@ export default (app) => {
         constructor($uibModal) {
             this.$uibModal = $uibModal;
             this.activeModal = false;
+            this.persistentModal = false;
         }
 
-        open(modalConfig, closeActive = true) {
+        open(modalConfig, closeActive = true, persist = false) {
+            this.persistentModal = persist;
+
             if (closeActive) {
-                this.closeActiveModal();
+                this.closeActiveModal(true);
             }
 
             this.activeModal = this.$uibModal.open(modalConfig);
@@ -17,8 +20,8 @@ export default (app) => {
             return this.activeModal;
         }
 
-        closeActiveModal() {
-            if (this.activeModal) {
+        closeActiveModal(force = false) {
+            if (this.activeModal && (force || !this.persistentModal)) {
                 this.activeModal.dismiss();
             }
         }


### PR DESCRIPTION
## Overview

This PR fixes a bug that resulted from a map size invalidation that triggered a re-render with a new bbox which updated the url which caused a transition which closed the modal before the user could interact with it. This PR solves the issue by allowing the drawing mode change to initiate the full-screen change but requiring an explicit call to toggle the full-screen mode off. It's not the cleanest solution and it may be wise to make the full-screen mode initiation more explicit as well, but I didn't do that in this PR.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible


## Testing Instructions

 * Within the scene browser, draw a new AOI to use as a search filter
 * Notice that when you finish drawing the shape, you are able to interact with the modal to save or cancel the drawing

Closes #4467 
