### PR TITLE
Add relationship between project layers and scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added ProjectLayer datamodel, dao, and migration [\#4460]https://github.com/raster-foundry/raster-foundry/pull/4460()\
 - Added lambda function for reactively processing new Landsat 8 imagery [\#4471](https://github.com/raster-foundry/raster-foundry/pull/4471)
 - Added lambda function for reactively processing new Sentinel-2 imagery [\#4491](https://github.com/raster-foundry/raster-foundry/pull/4491)
+- Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s. [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 
 ### Changed
 - Only analyses owned by the current user are displayed in the analysis browsing UI [\#4357](https://github.com/raster-foundry/raster-foundry/pull/4357)

--- a/app-backend/datamodel/src/main/scala/Project.scala
+++ b/app-backend/datamodel/src/main/scala/Project.scala
@@ -35,7 +35,7 @@ final case class Project(id: UUID,
                          singleBandOptions: Option[SingleBandOptions.Params],
                          defaultAnnotationGroup: Option[UUID],
                          extras: Option[Json],
-                         defaultLayer: Option[UUID])
+                         defaultLayerId: Option[UUID])
 
 /** Case class for project creation */
 object Project extends GeoJsonSupport {
@@ -190,7 +190,7 @@ object Project extends GeoJsonSupport {
                             isSingleBand: Boolean,
                             singleBandOptions: Option[SingleBandOptions.Params],
                             extras: Option[Json] = Some("{}".asJson),
-                            defaultLayer: Option[UUID] = None)
+                            defaultLayerId: Option[UUID] = None)
 
   object WithUser {
     def apply(project: Project, user: User): WithUser = {
@@ -215,7 +215,7 @@ object Project extends GeoJsonSupport {
         project.isSingleBand,
         project.singleBandOptions,
         project.extras,
-        project.defaultLayer
+        project.defaultLayerId
       )
     }
 

--- a/app-backend/datamodel/src/main/scala/Project.scala
+++ b/app-backend/datamodel/src/main/scala/Project.scala
@@ -35,7 +35,7 @@ final case class Project(id: UUID,
                          singleBandOptions: Option[SingleBandOptions.Params],
                          defaultAnnotationGroup: Option[UUID],
                          extras: Option[Json],
-                         defaultLayer: UUID)
+                         defaultLayer: Option[UUID])
 
 /** Case class for project creation */
 object Project extends GeoJsonSupport {
@@ -80,8 +80,7 @@ object Project extends GeoJsonSupport {
                           tags: List[String],
                           isSingleBand: Boolean,
                           singleBandOptions: Option[SingleBandOptions.Params],
-                          extras: Option[Json] = Some("{}".asJson),
-                          defaultLayer: UUID = UUID.randomUUID())
+                          extras: Option[Json] = Some("{}".asJson))
       extends OwnerCheck {
     def toProject(user: User): Project = {
       val now = new Timestamp(new java.util.Date().getTime)
@@ -110,7 +109,7 @@ object Project extends GeoJsonSupport {
         singleBandOptions,
         None,
         extras,
-        defaultLayer
+        None
       )
     }
   }
@@ -137,8 +136,7 @@ object Project extends GeoJsonSupport {
             .as[Option[Boolean]]
             .map(_.getOrElse(false)),
           c.downField("singleBandOptions").as[Option[SingleBandOptions.Params]],
-          c.downField("extras").as[Option[Json]],
-          c.downField("defaultLayer").as[UUID]
+          c.downField("extras").as[Option[Json]]
         ).mapN(Create.apply)
     )
 
@@ -163,8 +161,7 @@ object Project extends GeoJsonSupport {
             .as[Option[Boolean]]
             .map(_.getOrElse(false)),
           c.downField("singleBandOptions").as[Option[SingleBandOptions.Params]],
-          c.downField("extras").as[Option[Json]],
-          c.downField("defaultLayer").as[UUID]
+          c.downField("extras").as[Option[Json]]
         ).mapN(Create.apply)
     )
 
@@ -193,7 +190,7 @@ object Project extends GeoJsonSupport {
                             isSingleBand: Boolean,
                             singleBandOptions: Option[SingleBandOptions.Params],
                             extras: Option[Json] = Some("{}".asJson),
-                            defaultLayer: UUID = UUID.randomUUID())
+                            defaultLayer: Option[UUID] = None)
 
   object WithUser {
     def apply(project: Project, user: User): WithUser = {

--- a/app-backend/datamodel/src/main/scala/Project.scala
+++ b/app-backend/datamodel/src/main/scala/Project.scala
@@ -34,7 +34,8 @@ final case class Project(id: UUID,
                          isSingleBand: Boolean = false,
                          singleBandOptions: Option[SingleBandOptions.Params],
                          defaultAnnotationGroup: Option[UUID],
-                         extras: Option[Json])
+                         extras: Option[Json],
+                         defaultLayer: UUID)
 
 /** Case class for project creation */
 object Project extends GeoJsonSupport {
@@ -79,7 +80,8 @@ object Project extends GeoJsonSupport {
                           tags: List[String],
                           isSingleBand: Boolean,
                           singleBandOptions: Option[SingleBandOptions.Params],
-                          extras: Option[Json] = Some("{}".asJson))
+                          extras: Option[Json] = Some("{}".asJson),
+                          defaultLayer: UUID = UUID.randomUUID())
       extends OwnerCheck {
     def toProject(user: User): Project = {
       val now = new Timestamp(new java.util.Date().getTime)
@@ -107,7 +109,8 @@ object Project extends GeoJsonSupport {
         isSingleBand = isSingleBand,
         singleBandOptions,
         None,
-        extras
+        extras,
+        defaultLayer
       )
     }
   }
@@ -134,7 +137,8 @@ object Project extends GeoJsonSupport {
             .as[Option[Boolean]]
             .map(_.getOrElse(false)),
           c.downField("singleBandOptions").as[Option[SingleBandOptions.Params]],
-          c.downField("extras").as[Option[Json]]
+          c.downField("extras").as[Option[Json]],
+          c.downField("defaultLayer").as[UUID]
         ).mapN(Create.apply)
     )
 
@@ -159,7 +163,8 @@ object Project extends GeoJsonSupport {
             .as[Option[Boolean]]
             .map(_.getOrElse(false)),
           c.downField("singleBandOptions").as[Option[SingleBandOptions.Params]],
-          c.downField("extras").as[Option[Json]]
+          c.downField("extras").as[Option[Json]],
+          c.downField("defaultLayer").as[UUID]
         ).mapN(Create.apply)
     )
 
@@ -187,7 +192,8 @@ object Project extends GeoJsonSupport {
                             manualOrder: Boolean,
                             isSingleBand: Boolean,
                             singleBandOptions: Option[SingleBandOptions.Params],
-                            extras: Option[Json] = Some("{}".asJson))
+                            extras: Option[Json] = Some("{}".asJson),
+                            defaultLayer: UUID = UUID.randomUUID())
 
   object WithUser {
     def apply(project: Project, user: User): WithUser = {
@@ -211,7 +217,8 @@ object Project extends GeoJsonSupport {
         project.manualOrder,
         project.isSingleBand,
         project.singleBandOptions,
-        project.extras
+        project.extras,
+        project.defaultLayer
       )
     }
 

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -382,7 +382,8 @@ object Generators extends ArbitraryInstances {
       tags <- stringListGen
       isSingleBand <- arbitrary[Boolean]
       singleBandOptions <- singleBandOptionsParamsGen map { Some(_) }
-      extras <- Gen.const(().asJson)
+      extras <- Gen.const(().asJson),
+      defaultLayer <- uuidGen
     } yield {
       Project.Create(
         name,
@@ -395,7 +396,8 @@ object Generators extends ArbitraryInstances {
         tags,
         isSingleBand,
         singleBandOptions,
-        Some(extras)
+        Some(extras),
+        defaultLayer
       )
     }
 

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -382,8 +382,7 @@ object Generators extends ArbitraryInstances {
       tags <- stringListGen
       isSingleBand <- arbitrary[Boolean]
       singleBandOptions <- singleBandOptionsParamsGen map { Some(_) }
-      extras <- Gen.const(().asJson),
-      defaultLayer <- uuidGen
+      extras <- Gen.const(().asJson)
     } yield {
       Project.Create(
         name,
@@ -396,8 +395,7 @@ object Generators extends ArbitraryInstances {
         tags,
         isSingleBand,
         singleBandOptions,
-        Some(extras),
-        defaultLayer
+        Some(extras)
       )
     }
 

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -136,7 +136,8 @@ object ProjectDao
                      None,
                      None)
       )
-      updatedProject = project.copy(defaultLayerId = Some(defaultProjectLayer.id))
+      updatedProject = project.copy(
+        defaultLayerId = Some(defaultProjectLayer.id))
       _ <- this.updateProject(updatedProject, id, user)
     } yield updatedProject
   }

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -36,14 +36,14 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
   def insertProjectLayer(
       pl: ProjectLayer
   ): ConnectionIO[ProjectLayer] = {
-    fr"""
-    INSERT INTO project_layers (
-    id, created_at, modified_at, name, project_id, color_group_hex, smart_layer_id, range_start, range_end, geometry"
-    )
+    (fr"INSERT INTO" ++ tableF ++ fr"""
+    (id, created_at, modified_at, name, project_id, color_group_hex,
+    smart_layer_id, range_start, range_end, geometry)
     VALUES
-    (${pl.id}, ${pl.createdAt}, ${pl.modifiedAt}, ${pl.name}, ${pl.projectId}, ${pl.colorGroupHex}, ${pl.smartLayerId},
-     ${pl.rangeStart}, ${pl.rangeEnd}, ${pl.geometry})
-    """.update.withUniqueGeneratedKeys[ProjectLayer](
+      (${pl.id}, ${pl.createdAt}, ${pl.modifiedAt}, ${pl.name}, ${pl.projectId},
+      ${pl.colorGroupHex}, ${pl.smartLayerId}, ${pl.rangeStart}, ${pl.rangeEnd},
+      ${pl.geometry})
+    """).update.withUniqueGeneratedKeys[ProjectLayer](
       "id",
       "created_at",
       "modified_at",

--- a/app-backend/migrations/src/main/scala/migrations/157.scala
+++ b/app-backend/migrations/src/main/scala/migrations/157.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/157.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -155,4 +155,5 @@ object MigrationSummary {
   M154
   M155
   M156
+  M157
 }

--- a/app-backend/migrations/src_migrations/main/scala/157.scala
+++ b/app-backend/migrations/src_migrations/main/scala/157.scala
@@ -15,24 +15,24 @@ object M157 {
     DROP COLUMN smart_layer_id,
     ADD COLUMN smart_layer_id UUID;
 
-    -- Add a default_layer column to projects table and populate with uuid
+    -- Add a default_layer_id column to projects table and populate with uuid
     -- these default uuid values are temporary
     -- this field is nullable due to similiar reason as default_annotation_group
     ALTER TABLE projects
-    ADD COLUMN default_layer UUID DEFAULT uuid_generate_v4();
+    ADD COLUMN default_layer_id UUID DEFAULT uuid_generate_v4();
 
     -- Insert default project layers based on project id and project default layer from projects table
     INSERT INTO project_layers (
       SELECT
-        default_layer AS id, now() AS created_at, now() AS modified_at, 'default_layer' AS name, id AS project_id
+        default_layer_id AS id, now() AS created_at, now() AS modified_at, 'Project default layer' AS name, id AS project_id
       FROM projects
     );
 
-    -- default_layer of projects table should refer to id of project_layers
-    -- remove the default value constraint on default_layer
+    -- default_layer_id of projects table should refer to id of project_layers
+    -- remove the default value constraint on default_layer_id
     ALTER TABLE projects
-    ADD CONSTRAINT projects_default_project_layer_id_fkey FOREIGN KEY (default_layer) REFERENCES project_layers(id),
-    ALTER COLUMN default_layer DROP DEFAULT;
+    ADD CONSTRAINT projects_default_project_layer_id_fkey FOREIGN KEY (default_layer_id) REFERENCES project_layers(id),
+    ALTER COLUMN default_layer_id DROP DEFAULT;
 
     -- Create a scenes_to_layers table similar to scenes_to_projects table
     CREATE TABLE scenes_to_layers (
@@ -42,14 +42,6 @@ object M157 {
       mosaic_definition     JSONB NOT NULL DEFAULT '{}'::json,
       accepted              BOOLEAN NOT NULL DEFAULT true,
       CONSTRAINT scenes_to_layers_pkey PRIMARY KEY (scene_id, project_layer_id)
-    );
-
-    -- Populate scenes_to_layers table based on the joined result of scenes_to_projects and projects tables
-    INSERT INTO scenes_to_layers (
-      SELECT
-        stp.scene_id, p.default_layer AS project_layer_id, stp.scene_order, stp.mosaic_definition, stp.accepted
-      FROM scenes_to_projects AS stp
-      JOIN projects p ON stp.project_id = p.id
     );
     """
     ))

--- a/app-backend/migrations/src_migrations/main/scala/157.scala
+++ b/app-backend/migrations/src_migrations/main/scala/157.scala
@@ -13,7 +13,8 @@ object M157 {
     -- Change smart_layer_id column type to nullable uuid
     ALTER TABLE project_layers
     DROP COLUMN smart_layer_id,
-    ADD COLUMN smart_layer_id UUID;
+    ADD COLUMN smart_layer_id UUID,
+    ALTER COLUMN color_group_hex DROP DEFAULT;
 
     -- Add a default_layer_id column to projects table and populate with uuid
     -- these default uuid values are temporary
@@ -24,7 +25,8 @@ object M157 {
     -- Insert default project layers based on project id and project default layer from projects table
     INSERT INTO project_layers (
       SELECT
-        default_layer_id AS id, now() AS created_at, now() AS modified_at, 'Project default layer' AS name, id AS project_id
+        default_layer_id AS id, now() AS created_at, now() AS modified_at,
+        'Project default layer' AS name, id AS project_id, '#FFFFFF' as color_group_hex
       FROM projects
     );
 

--- a/app-backend/migrations/src_migrations/main/scala/157.scala
+++ b/app-backend/migrations/src_migrations/main/scala/157.scala
@@ -1,0 +1,56 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M157 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(157)(
+    List(
+      sqlu"""
+    -- Cascade the deletion of projects so that project layers are also deleted
+    ALTER TABLE project_layers
+    DROP CONSTRAINT project_layers_project_id_fkey,
+    ADD CONSTRAINT project_layers_project_id_fkey FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE;
+
+    -- Change smart_layer_id column type to nullable uuid
+    ALTER TABLE project_layers
+    DROP COLUMN smart_layer_id,
+    ADD COLUMN smart_layer_id UUID;
+
+    -- Add a default_layer column to projects table and populate with uuid
+    -- these default uuid values are temporary
+    -- this field is nullable due to similiar reason as default_annotation_group
+    ALTER TABLE projects
+    ADD COLUMN default_layer UUID DEFAULT uuid_generate_v4();
+
+    -- Insert default project layers based on project id and project default layer from projects table
+    INSERT INTO project_layers (
+      SELECT
+        default_layer AS id, now() AS created_at, now() AS modified_at, 'default_layer' AS name, id AS project_id
+      FROM projects
+    );
+
+    -- default_layer of projects table should refer to id of project_layers
+    -- remove the default value constraint on default_layer
+    ALTER TABLE projects
+    ADD CONSTRAINT projects_default_project_layer_id_fkey FOREIGN KEY (default_layer) REFERENCES project_layers(id),
+    ALTER COLUMN default_layer DROP DEFAULT;
+
+    -- Create a scenes_to_layers table similar to scenes_to_projects table
+    CREATE TABLE scenes_to_layers (
+      scene_id              UUID NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+      project_layer_id      UUID NOT NULL REFERENCES project_layers(id) ON DELETE CASCADE,
+      scene_order           INTEGER,
+      mosaic_definition     JSONB NOT NULL DEFAULT '{}'::json,
+      accepted              BOOLEAN NOT NULL DEFAULT true,
+      CONSTRAINT scenes_to_layers_pkey PRIMARY KEY (scene_id, project_layer_id)
+    );
+
+    -- Populate scenes_to_layers table based on the joined result of scenes_to_projects and projects tables
+    INSERT INTO scenes_to_layers (
+      SELECT
+        stp.scene_id, p.default_layer AS project_layer_id, stp.scene_order, stp.mosaic_definition, stp.accepted
+      FROM scenes_to_projects AS stp
+      JOIN projects p ON stp.project_id = p.id
+    );
+    """
+    ))
+}


### PR DESCRIPTION
## Overview

This PR:
* adds a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables
* fixes a bug in the schema of `project_layers` table
* fixes a bug in `ProjectLayerDao`
* updates `Project` data model
* updates `insertProject` method of `ProjectDao` so that a default project layer is inserted along with it

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- [X] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Check if the migration makes sense, and make sure it runs successfully
 * Make sure that the property tests pass

**Updated 01/17/2019**:
 * From within the DB: check that `project_layers` table is populated -- these are the default project layers for existing projects
 * From within the DB: check that for existing projects, the `default_layer_id` field is populated with layer ids that refer to the `project_layers` table
 * Spin up the server and frontend, create a new project, go into DB and check that a new record is added in `project_layers` table which is for the project's default layer, and that the `default_layer_id` field is also populated for this newly created project
 * Make sure the spec change in here: https://github.com/raster-foundry/raster-foundry-api-spec/pull/78 makes sense

Closes https://github.com/raster-foundry/raster-foundry/issues/4453
