### PR TITLE
Remove geotrellis-raster-testkit dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Deprecated
 
 ### Removed
+- Removed unused dependency `geotrellis-raster-testkit`[\#4482](https://github.com/raster-foundry/raster-foundry/pull/4482)
 
 ### Fixed
 - Shapes drawn within the scene search filter context can now be saved [\#4474](https://github.com/raster-foundry/raster-foundry/pull/4474)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -204,7 +204,6 @@ lazy val migrationsDependencies =
 
 lazy val testDependencies = List(
   Dependencies.scalatest,
-  Dependencies.geotrellisRasterTestkit,
   Dependencies.akkatestkit
 )
 
@@ -409,7 +408,6 @@ lazy val tool = Project("tool", file("tool"))
       Dependencies.sparkCore,
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisRaster,
-      Dependencies.geotrellisRasterTestkit % "test",
       Dependencies.scalatest,
       Dependencies.circeCore,
       Dependencies.circeGeneric,

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -42,7 +42,6 @@ object Dependencies {
   val geotools = "org.geotools" % "gt-shapefile" % Version.geotools
   val geotrellisGeotools = "org.locationtech.geotrellis" %% "geotrellis-geotools" % Version.geotrellis
   val geotrellisRaster = "org.locationtech.geotrellis" %% "geotrellis-raster" % Version.geotrellis
-  val geotrellisRasterTestkit = "org.locationtech.geotrellis" %% "geotrellis-raster-testkit" % Version.geotrellis
   val geotrellisS3 = "org.locationtech.geotrellis" %% "geotrellis-s3" % Version.geotrellis
   val geotrellisServer = "com.azavea" %% "geotrellis-server-core" % Version.geotrellisServer
   val geotrellisShapefile = "org.locationtech.geotrellis" %% "geotrellis-shapefile" % Version.geotrellis


### PR DESCRIPTION
## Overview

This PR removes `geotrellis-raster-testkit`dependency since:
* it is not being used
* `http://maven.geotoolkit.org/org/locationtech/geotrellis/geotrellis-raster-testkit_2.11/2.2.0/geotrellis-raster-testkit_2.11-2.2.0.pom` gives 404.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


## Testing Instructions

 * CI