### PR TITLE
Respect RF_LOG_LEVEL environment variable in backsplash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixed
 - Shapes drawn within the scene search filter context can now be saved [\#4474](https://github.com/raster-foundry/raster-foundry/pull/4474)
+- Made backsplash respect the RF_LOG_LEVEL environment variable [\#4483](https://github.com/raster-foundry/raster-foundry/pull/4483)
 
 ### Security
 - Upgrade webpack-dev-server to address vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-14732) [\#4476](https://github.com/raster-foundry/raster-foundry/pull/4476)

--- a/app-backend/backsplash-server/src/main/resources/logback.xml
+++ b/app-backend/backsplash-server/src/main/resources/logback.xml
@@ -5,7 +5,8 @@
     </encoder>
   </appender>
 
-  <logger name="com.rasterfoundry.backsplash" level="DEBUG"/>
+  <logger name="com.rasterfoundry.backsplash" level="${RF_LOG_LEVEL:-INFO}"/>
+  <logger name="org.http4s.blaze.channel.nio1" level="WARN"/>
   <logger name="geotrellis.server" level="WARN"/>
 
   <root level="INFO">


### PR DESCRIPTION
## Overview

This PR makes backsplash respect the RF_LOG_LEVEL environment variable for its own logs and quiets down the `nio1` logs coming out of blaze server a bit.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * Verify configuration matches api server's logback.xml
 * Bring up your backsplash server with a less noisy log level than debug and confirm you don't get as many boring logs