### PR TITLE
 Allow users with edit permissions on objects to share them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Unify S3 client interface usage [\#4441](https://github.com/raster-foundry/raster-foundry/pull/4441)
 - Moved common authentication logic to http4s-util subproject [\#4496](https://github.com/raster-foundry/raster-foundry/pull/4496)
 - Added ability to download images as part of development environment setup [\#4509](https://github.com/raster-foundry/raster-foundry/pull/4509)
+- Allow users with edit permissions to edit the permissions of objects [\#4490](https://github.com/raster-foundry/raster-foundry/pull/4490)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -240,7 +240,10 @@ trait ShapeRoutes
 
   def listShapePermissions(shapeId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ShapeDao.query.ownedBy(user, shapeId).exists.transact(xa).unsafeToFuture
+      ShapeDao
+        .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
+        .transact(xa)
+        .unsafeToFuture
     } {
       complete {
         ShapeDao
@@ -254,9 +257,10 @@ trait ShapeRoutes
   def replaceShapePermissions(shapeId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (ShapeDao.query.ownedBy(user, shapeId).exists, acrList traverse { acr =>
-          ShapeDao.isValidPermission(acr, user)
-        } map { _.foldLeft(true)(_ && _) }).tupled
+        (ShapeDao.authorized(user, ObjectType.Shape, shapeId, ActionType.Edit),
+         acrList traverse { acr =>
+           ShapeDao.isValidPermission(acr, user)
+         } map { _.foldLeft(true)(_ && _) }).tupled
           .map({ authTup =>
             authTup._1 && authTup._2
           })
@@ -276,7 +280,7 @@ trait ShapeRoutes
   def addShapePermission(shapeId: UUID): Route = authenticate { user =>
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
-        (ShapeDao.query.ownedBy(user, shapeId).exists,
+        (ShapeDao.authorized(user, ObjectType.Shape, shapeId, ActionType.Edit),
          ShapeDao.isValidPermission(acr, user)).tupled
           .map({ authTup =>
             authTup._1 && authTup._2
@@ -301,30 +305,29 @@ trait ShapeRoutes
         .transact(xa)
         .unsafeToFuture
     } {
-      user.isSuperuser match {
-        case true => complete(List("*"))
-        case false =>
-          onSuccess(
-            ShapeDao.unsafeGetShapeById(shapeId).transact(xa).unsafeToFuture
-          ) { shape =>
-            shape.owner == user.id match {
-              case true => complete(List("*"))
-              case false =>
-                complete {
-                  ShapeDao
-                    .listUserActions(user, shapeId)
-                    .transact(xa)
-                    .unsafeToFuture
-                }
+      onSuccess(
+        ShapeDao.unsafeGetShapeById(shapeId).transact(xa).unsafeToFuture
+      ) { shape =>
+        shape.owner == user.id match {
+          case true => complete(List("*"))
+          case false =>
+            complete {
+              ShapeDao
+                .listUserActions(user, shapeId)
+                .transact(xa)
+                .unsafeToFuture
             }
-          }
+        }
       }
     }
   }
 
   def deleteShapePermissions(shapeId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ShapeDao.query.ownedBy(user, shapeId).exists.transact(xa).unsafeToFuture
+      ShapeDao
+        .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
+        .transact(xa)
+        .unsafeToFuture
     } {
       complete {
         ShapeDao

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -156,9 +156,8 @@ trait ToolRunRoutes
 
   def listToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ToolRunDao.query
-        .ownedBy(user, toolRunId)
-        .exists
+      ToolRunDao
+        .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit)
         .transact(xa)
         .unsafeToFuture
     } {
@@ -174,9 +173,10 @@ trait ToolRunRoutes
   def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (ToolRunDao.query
-           .ownedBy(user, toolRunId)
-           .exists,
+        (ToolRunDao.authorized(user,
+                               ObjectType.Analysis,
+                               toolRunId,
+                               ActionType.Edit),
          acrList traverse { acr =>
            ToolRunDao.isValidPermission(acr, user)
          } map { _.foldLeft(true)(_ && _) }).tupled
@@ -199,9 +199,8 @@ trait ToolRunRoutes
   def addToolRunPermission(toolRunId: UUID): Route = authenticate { user =>
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
-        (ToolRunDao.query
-           .ownedBy(user, toolRunId)
-           .exists,
+        (ToolRunDao
+           .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit),
          ToolRunDao.isValidPermission(acr, user)).tupled
           .map({ authTup =>
             authTup._1 && authTup._2
@@ -222,7 +221,7 @@ trait ToolRunRoutes
   def listUserAnalysisActions(analysisId: UUID): Route = authenticate { user =>
     authorizeAsync {
       ToolRunDao
-        .authorized(user, ObjectType.Analysis, analysisId, ActionType.View)
+        .authorized(user, ObjectType.Analysis, analysisId, ActionType.Edit)
         .transact(xa)
         .unsafeToFuture
     } {
@@ -253,9 +252,8 @@ trait ToolRunRoutes
 
   def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ToolRunDao.query
-        .ownedBy(user, toolRunId)
-        .exists
+      ToolRunDao
+        .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit)
         .transact(xa)
         .unsafeToFuture
     } {

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -206,7 +206,10 @@ trait ToolRoutes
 
   def listToolPermissions(toolId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ToolDao.query.ownedBy(user, toolId).exists.transact(xa).unsafeToFuture
+      ToolDao
+        .authorized(user, ObjectType.Template, toolId, ActionType.Edit)
+        .transact(xa)
+        .unsafeToFuture
     } {
       complete {
         ToolDao
@@ -220,9 +223,10 @@ trait ToolRoutes
   def replaceToolPermissions(toolId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (ToolDao.query.ownedBy(user, toolId).exists, acrList traverse { acr =>
-          ToolDao.isValidPermission(acr, user)
-        } map { _.foldLeft(true)(_ && _) }).tupled
+        (ToolDao.authorized(user, ObjectType.Template, toolId, ActionType.Edit),
+         acrList traverse { acr =>
+           ToolDao.isValidPermission(acr, user)
+         } map { _.foldLeft(true)(_ && _) }).tupled
           .map({ authTup =>
             authTup._1 && authTup._2
           })
@@ -242,7 +246,7 @@ trait ToolRoutes
   def addToolPermission(toolId: UUID): Route = authenticate { user =>
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
-        (ToolDao.query.ownedBy(user, toolId).exists,
+        (ToolDao.authorized(user, ObjectType.Template, toolId, ActionType.Edit),
          ToolDao.isValidPermission(acr, user)).tupled
           .map({ authTup =>
             authTup._1 && authTup._2
@@ -290,7 +294,10 @@ trait ToolRoutes
 
   def deleteToolPermissions(toolId: UUID): Route = authenticate { user =>
     authorizeAsync {
-      ToolDao.query.ownedBy(user, toolId).exists.transact(xa).unsafeToFuture
+      ToolDao
+        .authorized(user, ObjectType.Template, toolId, ActionType.Edit)
+        .transact(xa)
+        .unsafeToFuture
     } {
       complete {
         ToolDao

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -92,6 +92,7 @@ trait ObjectPermissions[Model] {
   def getPermissions(
       id: UUID): ConnectionIO[List[Option[ObjectAccessControlRule]]] =
     for {
+      // TODO restrict to the user's permissions if the user does not have edit permissions
       isValidObject <- isValidObject(id)
       getPermissions <- isValidObject match {
         case false => throw new Exception(s"Invalid ${tableName} object ${id}")


### PR DESCRIPTION
## Overview
Switch from using ownership to permissions when viewing, adding, and removing permissions

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

### Notes
* Frontend changes are being worked on for a separate pr

## Testing Instructions
* Verify that users with edit permissions are now authorized to make requests to the permissions endpoints on datasources, projects, scenes, shapes, tools, and tool-runs

Closes #4455

