### PR TITLE
Make RasterLits out of Rasters instead of IO[Raster]s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - Shapes drawn within the scene search filter context can now be saved [\#4474](https://github.com/raster-foundry/raster-foundry/pull/4474)
+- Mosaics are again constructed with rasters instead of with IO[rasters] [\#4498](https://github.com/raster-foundry/raster-foundry/pull/4498)
 
 ### Security
 - Upgrade webpack-dev-server to address vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-14732) [\#4476](https://github.com/raster-foundry/raster-foundry/pull/4476)

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -123,7 +123,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
           extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
           // for single band imagery, after color correction we have RGBA, so
           // the empty tile needs to be four band as well
-          mosaic = if (bandCount == 3) {
+          mosaic <- if (bandCount == 3) {
             val ioMBT = filtered
               .parEvalMap(streamConcurrency)({ relevant =>
                 for {
@@ -275,7 +275,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
               .compile
               .toList
               .map(_.flatten)
-            mosaic = if (bands.length == 3) {
+            mosaic <- if (bands.length == 3) {
               BacksplashMosaic
                 .filterRelevant(self)
                 .parEvalMap(streamConcurrency)({ relevant =>


### PR DESCRIPTION
## Overview

This PR binds out of the IOs constructing mosaics in two places, instead of assigning the IO and yielding the IO inside a raster lit. This makes it so that we're constructing a RasterLit out of a Raster[...] instead of an IO[Raster].

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * turn your tile caches off
 * use the app
 * you should get tiles and no warnings about unallowable casts