### PR TITLE
Bump app-frontend NodeJS image version from 6 to 10

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -13,7 +13,7 @@ services:
       dockerfile: Dockerfile.backsplash
 
   app-frontend:
-    image: node:6
+    image: node:10
     working_dir: /opt/raster-foundry/app-frontend/
     volumes:
       - ./app-frontend/.babelrc:/opt/raster-foundry/app-frontend/.babelrc


### PR DESCRIPTION
## Overview

Bump app-frontend NodeJS image version from 6 to 10.

Connects #4431 

## Testing Instructions

See CI checks below.