### PR TITLE
Encode smaller subset of user fields in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Security
 - Upgrade webpack-dev-server to address vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-14732) [\#4476](https://github.com/raster-foundry/raster-foundry/pull/4476)
+- Sanitized more user fields in search endpoint [\#4505](https://github.com/raster-foundry/raster-foundry/pull/4505)
 
 ## [1.16.3](https://github.com/raster-foundry/raster-foundry/tree/1.16.2) (2019-01-17)
 

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -84,7 +84,7 @@ trait UserRoutes
   }
 
   def getDbOwnUser: Route = authenticate { user =>
-    complete(UserDao.unsafeGetUserById(user.id).transact(xa).unsafeToFuture())
+    complete(UserDao.unsafeGetUserById(user.id, Some(true)).transact(xa).unsafeToFuture())
   }
 
   def updateAuth0User: Route = authenticate { user =>

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -84,7 +84,11 @@ trait UserRoutes
   }
 
   def getDbOwnUser: Route = authenticate { user =>
-    complete(UserDao.unsafeGetUserById(user.id, Some(true)).transact(xa).unsafeToFuture())
+    complete(
+      UserDao
+        .unsafeGetUserById(user.id, Some(true))
+        .transact(xa)
+        .unsafeToFuture())
   }
 
   def updateAuth0User: Route = authenticate { user =>

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -138,6 +138,7 @@ final case class User(id: String,
       }
     this.copy(name = scrubbedName)
   }
+
 }
 
 object User {


### PR DESCRIPTION
## Overview

This PR more carefully selects the subset of user fields to return to clients when doing user searches.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * demo

azavea/raster-foundry-platform#609