### PR TITLE
fixes the alignment of search and owner filter on dashboard pages

### DIFF
--- a/app-frontend/src/app/pages/imports/datasources/list/list.html
+++ b/app-frontend/src/app/pages/imports/datasources/list/list.html
@@ -1,10 +1,8 @@
 <div class="container dashboard">
   <div class="row content stack-sm">
     <div class="column-8">
-
-      <!-- Dashboard Header -->
       <div class="dashboard-header">
-        <h1 class="h3">Datasources</h1>
+        <h3>Datasources</h3>
         <div class="flex-fill"></div>
         <rf-search on-search="$ctrl.fetchPage(1, value)"
                    value="$ctrl.search"

--- a/app-frontend/src/app/pages/imports/raster/raster.html
+++ b/app-frontend/src/app/pages/imports/raster/raster.html
@@ -1,16 +1,15 @@
 <div class="container dashboard">
   <div class="row content stack-sm">
     <div class="column-8">
-      <!-- Dashboard Header -->
-      <h3>Imports</h3>
       <div class="dashboard-header">
+        <h3>Imports</h3>
+        <div class="flex-fill"></div>
         <select class="form-control"
                 ng-model="$ctrl.currentOwnershipFilter"
         >
           <option value="owned">Owned by me</option>
           <option value="shared">Shared with me</option>
         </select>
-        <div class="flex-fill"></div>
         <a class="btn btn-primary" ng-click="$ctrl.importModal()">
           Import scenes
         </a>

--- a/app-frontend/src/assets/styles/sass/pages/_dashboard.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_dashboard.scss
@@ -23,6 +23,11 @@
   & > .form-control {
     width: auto;
   }
+
+  rf-search + .btn,
+  .form-control + .btn, {
+    margin-left: 1rem;
+  }
 }
 
 .dashboard-header-reveal {


### PR DESCRIPTION
## Overview

Align the search box and owner filters of the various dashboard pages

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
<img width="787" alt="screen shot 2019-01-21 at 4 21 20 pm" src="https://user-images.githubusercontent.com/1928955/51499569-ce9ad980-1d98-11e9-990f-15d08201c8f6.png">
<img width="796" alt="screen shot 2019-01-21 at 4 21 24 pm" src="https://user-images.githubusercontent.com/1928955/51499570-ce9ad980-1d98-11e9-98ef-9ac64391959f.png">
<img width="796" alt="screen shot 2019-01-21 at 4 21 26 pm" src="https://user-images.githubusercontent.com/1928955/51499571-ce9ad980-1d98-11e9-8b88-9ac15c0ef5cc.png">
<img width="795" alt="screen shot 2019-01-21 at 4 21 30 pm" src="https://user-images.githubusercontent.com/1928955/51499572-ce9ad980-1d98-11e9-989f-76ee12d96c79.png">

## Testing Instructions
- view the following pages:
  - Projects
  - Data: Rasters
  - Data: Vectors
  - Data: Datasources

Closes #4507 4188
