### PR TITLE
shows name of node when selecting a project for analysis

### DIFF
--- a/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
+++ b/app-frontend/src/app/components/lab/inputNode/inputNode.module.js
@@ -118,7 +118,10 @@ class InputNodeController {
                 component: 'rfProjectSelectModal',
                 resolve: {
                     project: () => this.selectedProject && this.selectedProject.id || false,
-                    content: () => ({title: 'Select a project'})
+                    content: () => ({
+                        title: 'Select a project',
+                        nodeName: this.node.metadata.label
+                    })
                 }
             }).result.then(project => {
                 this.checkValidity();

--- a/app-frontend/src/app/components/projects/projectSelectModal/projectSelectModal.html
+++ b/app-frontend/src/app/components/projects/projectSelectModal/projectSelectModal.html
@@ -10,6 +10,7 @@
     </i>
   </button>
   <h4 class="modal-title">{{ $ctrl.resolve.content.title }}</h4>
+  <p>for <strong>{{$ctrl.resolve.content.nodeName}}</strong> node</p>
 </div>
 <div class="modal-body">
   <div class="modal-action-bar">


### PR DESCRIPTION
## Overview

Shows the lab node label in the project select modal.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
<img width="443" alt="screen shot 2019-01-21 at 4 25 17 pm" src="https://user-images.githubusercontent.com/1928955/51499768-862feb80-1d99-11e9-8e0f-16afddac673e.png">
<img width="1064" alt="screen shot 2019-01-21 at 4 25 12 pm" src="https://user-images.githubusercontent.com/1928955/51499771-88924580-1d99-11e9-8560-e25fe74585ac.png">

## Testing Instructions

 * Open an analysis
 * Open the modal to select a project for an input

Closes #4346
