### PR TITLE
Add Image and Local Files to Development Environment Setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Updated permission check logic for lab templates to make ownership filter work as expected [\#4462](https://github.com/raster-foundry/raster-foundry/pull/4462)
 - Unify S3 client interface usage [\#4441](https://github.com/raster-foundry/raster-foundry/pull/4441)
 - Moved common authentication logic to http4s-util subproject [\#4496](https://github.com/raster-foundry/raster-foundry/pull/4496)
+- Added ability to download images as part of development environment setup [\#4509](https://github.com/raster-foundry/raster-foundry/pull/4509)
 
 ### Deprecated
 

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -28,6 +28,14 @@ function download_database_backup() {
     popd
 }
 
+function download_development_images() {
+
+    pushd "${DIR}/.."
+    echo "Downloading images from s3"
+    aws s3 sync "s3://${RF_SETTINGS_BUCKET}/development-images/" "data/"
+    popd
+}
+
 function load_database_backup() {
     echo "Drop rasterfoundry database"
     docker-compose \
@@ -54,6 +62,7 @@ then
         docker-compose up -d api-server
         if [ "${1:-}" = "--download" ] || [ ! -f data/database.pgdump ]; then
             download_database_backup
+            download_development_images
         fi
         load_database_backup
         docker-compose rm -sf api-server


### PR DESCRIPTION
## Overview

Adds download of imagery as part of development environment setup and resets Azavea specific development environment to be COG Only

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/898060/51540369-4104cb80-1e24-11e9-993f-6631d2887526.png)

![image](https://user-images.githubusercontent.com/898060/51540400-5974e600-1e24-11e9-867f-374f49a0b1de.png)

### Notes

I kept existing admin and organizations set up so that when we work on permissions and sharing those things exist. The main thrust of changes was creating a variety of projects, some of which are tied to local files, for easier development and testing.

## Testing Instructions

 * Run `./scripts/load-development-data --download`
 * Start servers and browse projects and analyses

Closes https://github.com/azavea/raster-foundry-platform/issues/592
