### PR TITLE
Project layer CRUDL endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added lambda function for reactively processing new Landsat 8 imagery [\#4471](https://github.com/raster-foundry/raster-foundry/pull/4471)
 - Added lambda function for reactively processing new Sentinel-2 imagery [\#4491](https://github.com/raster-foundry/raster-foundry/pull/4491)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s. [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
+- CRUDL endpoints for project layers [\#4512](https://github.com/raster-foundry/raster-foundry/pull/4512)
 
 ### Changed
 - Only analyses owned by the current user are displayed in the analysis browsing UI [\#4357](https://github.com/raster-foundry/raster-foundry/pull/4357)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -87,9 +87,9 @@ trait ProjectRoutes
               post {
                 createProjectLayer(projectId)
               } ~
-              get {
-                listProjectLayers(projectId)
-              }
+                get {
+                  listProjectLayers(projectId)
+                }
             } ~
               pathPrefix(JavaUUID) { layerId =>
                 get {

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -86,7 +86,7 @@ trait ProjectRoutes
             pathEndOrSingleSlash {
               post {
                 createProjectLayer(projectId)
-              }
+              } ~
               get {
                 listProjectLayers(projectId)
               }

--- a/app-backend/datamodel/src/main/scala/ProjectLayer.scala
+++ b/app-backend/datamodel/src/main/scala/ProjectLayer.scala
@@ -52,6 +52,32 @@ final case class ProjectLayerProperties(projectId: UUID,
                                         rangeEnd: Option[Timestamp])
 
 object ProjectLayer extends LazyLogging {
+  def create = Create.apply _
+
+  @JsonCodec
+  final case class Create(name: String,
+                          projectId: UUID,
+                          colorGroupHex: String,
+                          smartLayerId: Option[UUID],
+                          rangeStart: Option[Timestamp],
+                          rangeEnd: Option[Timestamp],
+                          geometry: Option[Projected[Geometry]]) {
+    def toProjectLayer: ProjectLayer = {
+      val now = new Timestamp(new java.util.Date().getTime)
+      ProjectLayer(
+        UUID.randomUUID,
+        now,
+        now,
+        this.name,
+        this.projectId,
+        this.colorGroupHex,
+        this.smartLayerId,
+        this.rangeStart,
+        this.rangeEnd,
+        this.geometry
+      )
+    }
+  }
   final case class GeoJSON(id: UUID,
                            geometry: Option[Projected[Geometry]],
                            properties: ProjectLayerProperties,

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -17,7 +17,7 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
   val tableName = "project_layers"
 
   val selectF: Fragment =
-    fr"SELECT id, created_at, modified_at, name, project_id, color_group_hex, smart_layer_id, range_start, range_end, geometry" ++ tableF
+    fr"SELECT id, created_at, modified_at, name, project_id, color_group_hex, smart_layer_id, range_start, range_end, geometry from" ++ tableF
 
   def unsafeGetProjectLayerById(
       projectLayerId: UUID): ConnectionIO[ProjectLayer] = {
@@ -63,7 +63,7 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
     val query = (fr"UPDATE" ++ tableF ++ fr"""SET
       modified_at = ${updateTime},
       name = ${projectLayer.name},
-      colorGroupHex = ${projectLayer.colorGroupHex},
+      color_group_hex = ${projectLayer.colorGroupHex},
       geometry = ${projectLayer.geometry}
     """ ++ Fragments.whereAndOpt(Some(idFilter))).update
     query
@@ -80,7 +80,7 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
       layerId: UUID,
       user: User
   ): ConnectionIO[Option[ProjectLayer]] =
-    query.filter(fr"project = ${projectId}").filter(layerId).selectOption
+    query.filter(fr"project_id = ${projectId}").filter(layerId).selectOption
 
   def deleteProjectLayer(layerId: UUID): ConnectionIO[Int] =
     for {


### PR DESCRIPTION
## Overview

This PR adds endpoints for each CRUDL operation.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

It is currently not possible to delete a default layer due to the FK constraint from projects. If we want to allow this or not is probably worth a discussion.


## Testing Instructions

 * `GET /api/projects/{someProjectId}/layers` -- it should work and you can grab the layer id from here to further test endpoints
* `GET /api/projects/{someProjectId}/layers/{someLayerId}` -- use the above id if you want
* copy the response and update some fields (name, colorGroupHex, or geometry) and then PUT it back, then GET it again to confirm the changes
* create a project layer with a `POST /api/projects/{someProjectId}/layers`
* `GET` it back to confirm it was successful
* `DELETE` it

Closes #4452 
