### PR TITLE
Support uploads to project layers on the api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Added project, project layer, and template ID fields to tool runs for later filtering [\#4546](https://github.com/raster-foundry/raster-foundry/pull/4546) and to API routes as filter fields [\#4551](https://github.com/raster-foundry/raster-foundry/pull/4551)
 - Added project layer mosaic and scene order endpoint [\#4547](https://github.com/raster-foundry/raster-foundry/pull/4547)
 - Add Layer ID to Annotations and Annotation Groups [\#4558](https://github.com/raster-foundry/raster-foundry/pull/4558)
+- Support uploads to project layers on the API [#\4524](https://github.com/raster-foundry/raster-foundry/pull/4524)
 
 ### Changed
 - Reorganized project structure to simplify dependency graph (`tool` was mostly removed; `tool`s still-relevant pieces, `bridge`, and `datamodel` moved into the project `common`) [\#4564](https://github.com/raster-foundry/raster-foundry/pull/4564)

--- a/app-backend/common/src/main/scala/datamodel/Upload.scala
+++ b/app-backend/common/src/main/scala/datamodel/Upload.scala
@@ -21,6 +21,7 @@ final case class Upload(id: UUID,
                         metadata: Json,
                         visibility: Visibility,
                         projectId: Option[UUID],
+                        layerId: Option[UUID],
                         source: Option[String])
 
 object Upload {
@@ -39,6 +40,7 @@ object Upload {
                           owner: Option[String],
                           visibility: Visibility,
                           projectId: Option[UUID],
+                          layerId: Option[UUID],
                           source: Option[String]) {
     def toUpload(user: User,
                  userPlatformAdmin: (UUID, Boolean),
@@ -91,6 +93,7 @@ object Upload {
         this.metadata,
         this.visibility,
         this.projectId,
+        this.layerId,
         this.source
       )
     }

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/UploadSpec.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/UploadSpec.scala
@@ -19,6 +19,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       Some("foo"), // proposed owner
       Visibility.Private,
       None,
+      None,
       None
     )
     // note the id is not "foo"
@@ -43,6 +44,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       Some("foo"), // proposed owner
       Visibility.Private,
       None,
+      None,
       None
     )
     // note the id is not "foo"
@@ -66,6 +68,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       Some("foo"), // proposed owner
       Visibility.Private,
       None,
+      None,
       None
     )
     // note the id is not "foo"
@@ -88,6 +91,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       ().asJson,
       Some("foo"), // proposed owner
       Visibility.Private,
+      None,
       None,
       None
     )

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -571,6 +571,7 @@ object Generators extends ArbitraryInstances {
       owner <- Gen.const(None)
       visibility <- visibilityGen
       projectId <- Gen.const(None)
+      layerId <- Gen.const(None)
       source <- Gen.oneOf(nonEmptyStringGen map { Some(_) }, Gen.const(None))
     } yield {
       Upload.Create(
@@ -583,6 +584,7 @@ object Generators extends ArbitraryInstances {
         owner,
         visibility,
         projectId,
+        layerId,
         source
       )
     }

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -21,7 +21,7 @@ object UploadDao extends Dao[Upload] {
        id, created_at, created_by, modified_at, modified_by,
        owner, upload_status, file_type, upload_type,
        files, datasource, metadata, visibility, project_id,
-       source
+       layer_id, source
     FROM
   """ ++ tableF
 
@@ -47,12 +47,12 @@ object UploadDao extends Dao[Upload] {
          (id, created_at, created_by, modified_at, modified_by,
           owner, upload_status, file_type, upload_type,
           files, datasource, metadata, visibility, project_id,
-          source)
+          layer_id, source)
        VALUES (
          ${upload.id}, ${upload.createdAt}, ${upload.createdBy}, ${upload.modifiedAt}, ${upload.modifiedBy},
          ${upload.owner}, ${upload.uploadStatus}, ${upload.fileType}, ${upload.uploadType},
          ${upload.files}, ${upload.datasource}, ${upload.metadata}, ${upload.visibility}, ${upload.projectId},
-         ${upload.source}
+         ${upload.layerId}, ${upload.source}
        )
       """.update.withUniqueGeneratedKeys[Upload](
           "id",
@@ -69,6 +69,7 @@ object UploadDao extends Dao[Upload] {
           "metadata",
           "visibility",
           "project_id",
+          "layer_id",
           "source"
         )
       )
@@ -90,6 +91,7 @@ object UploadDao extends Dao[Upload] {
           metadata = ${upload.metadata},
           visibility = ${upload.visibility},
           project_id = ${upload.projectId},
+          layer_id = ${upload.layerId},
           source = ${upload.source}
      """ ++ Fragments.whereAndOpt(Some(idFilter))).update.run
     (for {

--- a/app-backend/migrations/src/main/scala/migrations/163.scala
+++ b/app-backend/migrations/src/main/scala/migrations/163.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/163.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -160,4 +160,5 @@ object MigrationSummary {
   M160
   M161
   M162
+  M163
 }

--- a/app-backend/migrations/src_migrations/main/scala/163.scala
+++ b/app-backend/migrations/src_migrations/main/scala/163.scala
@@ -1,0 +1,11 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M163 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(163)(
+    List(
+      sqlu"""
+ALTER TABLE uploads ADD COLUMN layer_id UUID REFERENCES project_layers(id);
+"""
+    ))
+}

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -49,6 +49,7 @@ def process_upload(upload_id):
                 upload.id,
                 client,
                 upload.projectId,
+                upload.layerId,
                 upload.visibility,
                 [],
                 upload.owner
@@ -60,6 +61,7 @@ def process_upload(upload_id):
                 upload.datasource,
                 upload.id,
                 upload.projectId,
+                upload.layerId,
                 upload.visibility,
                 upload.owner
             )
@@ -74,7 +76,15 @@ def process_upload(upload_id):
         created_scenes = [scene.create() for scene in scenes]
         logger.info('Successfully created %s scenes (%s)', len(created_scenes), [s.id for s in created_scenes])
 
-        if upload.projectId:
+        if upload.layerId and upload.projectId:
+            logger.info('Upload specified to a project layer. Linking scenes to layer %s', upload.layerId)
+            scene_ids = [scene.id for scene in created_scenes]
+            batch_scene_to_layer_url = '{HOST}/api/projects/{PROJECT}/layers/{LAYER}/scenes'.format(
+                HOST=HOST, PROJECT=upload.projectId, LAYER=upload.layerId)
+            session = get_session()
+            response = session.post(batch_scene_to_layer_url, json=scene_ids)
+            response.raise_for_status()
+        elif upload.projectId:
             logger.info('Upload specified a project. Linking scenes to project %s', upload.projectId)
             scene_ids = [scene.id for scene in created_scenes]
             batch_scene_to_project_url = '{HOST}/api/projects/{PROJECT}/scenes'.format(HOST=HOST, PROJECT=upload.projectId)

--- a/app-tasks/rf/src/rf/models/upload.py
+++ b/app-tasks/rf/src/rf/models/upload.py
@@ -7,7 +7,7 @@ class Upload(BaseModel):
     def __init__(self, uploadStatus, fileType, uploadType, files,
                  datasource, metadata, visibility, id=None, createdAt=None,
                  createdBy=None, modifiedAt=None, modifiedBy=None, owner=None,
-                 projectId=None):
+                 projectId=None, layerId=None):
         self.id = id
         self.createdAt = createdAt
         self.createdBy = createdBy
@@ -22,6 +22,7 @@ class Upload(BaseModel):
         self.metadata = metadata
         self.visibility = visibility
         self.projectId = projectId
+        self.layerId = layerId
 
     def to_dict(self):
         return dict(
@@ -38,7 +39,8 @@ class Upload(BaseModel):
             metadata=self.metadata,
             visibility=self.visibility,
             owner=self.owner,
-            projectId=self.projectId
+            projectId=self.projectId,
+            layerId=self.layerId
         )
 
     def update_upload_status(self, status):
@@ -61,7 +63,8 @@ class Upload(BaseModel):
             modifiedAt=d.get('modifiedAt'),
             modifiedBy=d.get('modifiedBy'),
             owner=d.get('owner'),
-            projectId=d.get('projectId')
+            projectId=d.get('projectId'),
+            layerId=d.get('layerId')
         )
 
     @classmethod

--- a/app-tasks/rf/src/rf/uploads/modis/factories.py
+++ b/app-tasks/rf/src/rf/uploads/modis/factories.py
@@ -61,7 +61,7 @@ modis_configs = {
 
 
 class MODISSceneFactory(object):
-    def __init__(self, hdf_urls, datasource, upload, project_id=None, visibility=Visibility.PRIVATE, owner=None):
+    def __init__(self, hdf_urls, datasource, upload, project_id=None, layer_id=None, visibility=Visibility.PRIVATE, owner=None):
         """Create factory for generating MODIS scenes
 
         Args:
@@ -69,6 +69,7 @@ class MODISSceneFactory(object):
             datasource (str): ID of MODIS datasource
             upload (str): ID of upload scene creation is associated with
             project_id (str): optional project to associate with uploads
+            layer_id (str): optional layer to associate with uploads
             visibility (str): level of visibility for new scene
             owner (str): optional owner to set for scene
         """
@@ -76,6 +77,7 @@ class MODISSceneFactory(object):
         self.datasource = datasource
         self.upload = upload
         self.project_id = project_id
+        self.layer_id = layer_id
         self.visibility = visibility
         self.owner = owner
 

--- a/app-tasks/rf/src/rf/uploads/planet/factories.py
+++ b/app-tasks/rf/src/rf/uploads/planet/factories.py
@@ -27,10 +27,13 @@ class PlanetSceneFactory(object):
     """
 
     def __init__(self, planet_ids, datasource, upload_id, client,
-                 project_id=None, visibility=Visibility.PRIVATE, tags=[],
+                 project_id=None, layer_id=None, visibility=Visibility.PRIVATE, tags=[],
                  owner=None):
         self.upload_id = upload_id
         self.isProjectUpload = project_id is not None
+        self.project_id = project_id
+        self.isLayerUpload = layer_id is not None
+        self.layer_id = layer_id
         self.datasource = datasource
         self.visibility = visibility
         self.tags = tags


### PR DESCRIPTION
## Overview
Allow specifying a layer ID when creating an upload. Specifying a project and layer ID will cause the upload to use the projects/{}/layers/{}/scenes endpoint to add scenes instead of the projects/{}/scenes endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- [x] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Demo


## Testing Instructions
* Run migrations
* Rebuild your batch container to pull in the updated python scripts
* Upload a small tif to a project
* process the upload using the normal RF script inside the batch container
* Verify that the scene appears in the project
* Upload a second tif to a project
* using psql, set the layer_id to a layer in the project.
* process the upload and verify that it uses the correct url (projects/{id}/layers/{id}/scenes) to create the scenes. This step won't work until #4520 is completed because the endpoints don't exist yet, but they should function identically as far as the data included in the post request goes.

Closes #4485 
Depends on #4520
