### PR TITLE
Add scene to layer dao project store evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 - CRUDL endpoints for project layers [\#4512](https://github.com/raster-foundry/raster-foundry/pull/4512)
 - Added `SceneToLayer` data model and `SceneToLayerDao`; updated related function calls in `ProjectDao` and project api [\#4513](https://github.com/raster-foundry/raster-foundry/pull/4513)
+- Added TMS route for project layers [\#4523](https://github.com/raster-foundry/raster-foundry/pull/4523)
 
 ### Changed
 - Only analyses owned by the current user are displayed in the analysis browsing UI [\#4357](https://github.com/raster-foundry/raster-foundry/pull/4357)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -751,14 +751,9 @@ trait ProjectRoutes
         complete {
           val acceptSceneIO = for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            projectLayerId = project.defaultLayerId match {
-              case Some(defaultLayerId) => defaultLayerId
-              case _ =>
-                throw new Exception(
-                  s"Project ${projectId} does not have a default layer")
-            }
             _ <- SceneToProjectDao.acceptScene(projectId, sceneId)
-            rowsAffected <- SceneToLayerDao.acceptScene(projectLayerId, sceneId)
+            rowsAffected <- SceneToLayerDao.acceptScene(project.defaultLayerId,
+                                                        sceneId)
           } yield { rowsAffected }
 
           acceptSceneIO.transact(xa).unsafeToFuture
@@ -780,14 +775,9 @@ trait ProjectRoutes
 
         val acceptScenesIO = for {
           project <- ProjectDao.unsafeGetProjectById(projectId)
-          projectLayerId = project.defaultLayerId match {
-            case Some(defaultLayerId) => defaultLayerId
-            case _ =>
-              throw new Exception(
-                s"Project ${projectId} does not have a default layer")
-          }
           _ <- SceneToProjectDao.acceptScenes(projectId, sceneIds)
-          rowsAffected <- SceneToLayerDao.acceptScenes(projectLayerId, sceneIds)
+          rowsAffected <- SceneToLayerDao.acceptScenes(project.defaultLayerId,
+                                                       sceneIds)
         } yield { rowsAffected }
 
         onSuccess(acceptScenesIO.transact(xa).unsafeToFuture) { updatedOrder =>
@@ -857,14 +847,8 @@ trait ProjectRoutes
 
         val setOrderIO = for {
           project <- ProjectDao.unsafeGetProjectById(projectId)
-          projectLayerId = project.defaultLayerId match {
-            case Some(defaultLayerId) => defaultLayerId
-            case _ =>
-              throw new Exception(
-                s"Project ${projectId} does not have a default layer")
-          }
           _ <- SceneToProjectDao.setManualOrder(projectId, sceneIds)
-          updatedOrder <- SceneToLayerDao.setManualOrder(projectLayerId,
+          updatedOrder <- SceneToLayerDao.setManualOrder(project.defaultLayerId,
                                                          sceneIds)
         } yield { updatedOrder }
 
@@ -887,15 +871,10 @@ trait ProjectRoutes
         complete {
           val getColorCorrectParamsIO = for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            projectLayerId = project.defaultLayerId match {
-              case Some(defaultLayerId) => defaultLayerId
-              case _ =>
-                throw new Exception(
-                  s"Project ${projectId} does not have a default layer")
-            }
             _ <- SceneToProjectDao.getColorCorrectParams(projectId, sceneId)
-            params <- SceneToLayerDao.getColorCorrectParams(projectLayerId,
-                                                            sceneId)
+            params <- SceneToLayerDao.getColorCorrectParams(
+              project.defaultLayerId,
+              sceneId)
           } yield { params }
 
           getColorCorrectParamsIO.transact(xa).unsafeToFuture
@@ -915,16 +894,10 @@ trait ProjectRoutes
         entity(as[ColorCorrect.Params]) { ccParams =>
           val setColorCorrectParamsIO = for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            projectLayerId = project.defaultLayerId match {
-              case Some(defaultLayerId) => defaultLayerId
-              case _ =>
-                throw new Exception(
-                  s"Project ${projectId} does not have a default layer")
-            }
             _ <- SceneToProjectDao.setColorCorrectParams(projectId,
                                                          sceneId,
                                                          ccParams)
-            stl <- SceneToLayerDao.setColorCorrectParams(projectLayerId,
+            stl <- SceneToLayerDao.setColorCorrectParams(project.defaultLayerId,
                                                          sceneId,
                                                          ccParams)
           } yield { stl }
@@ -947,15 +920,9 @@ trait ProjectRoutes
       entity(as[ProjectColorModeParams]) { colorBands =>
         val setProjectColorBandsIO = for {
           project <- ProjectDao.unsafeGetProjectById(projectId)
-          projectLayerId = project.defaultLayerId match {
-            case Some(defaultLayerId) => defaultLayerId
-            case _ =>
-              throw new Exception(
-                s"Project ${projectId} does not have a default layer")
-          }
           _ <- SceneToProjectDao.setProjectColorBands(projectId, colorBands)
           rowsAffected <- SceneToLayerDao
-            .setProjectLayerColorBands(projectLayerId, colorBands)
+            .setProjectLayerColorBands(project.defaultLayerId, colorBands)
         } yield { rowsAffected }
 
         onSuccess(setProjectColorBandsIO.transact(xa).unsafeToFuture) { _ =>
@@ -977,15 +944,9 @@ trait ProjectRoutes
         entity(as[BatchParams]) { params =>
           val setColorCorrectParamsBatchIO = for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            projectLayerId = project.defaultLayerId match {
-              case Some(defaultLayerId) => defaultLayerId
-              case _ =>
-                throw new Exception(
-                  s"Project ${projectId} does not have a default layer")
-            }
             _ <- SceneToProjectDao.setColorCorrectParamsBatch(projectId, params)
-            stl <- SceneToLayerDao.setColorCorrectParamsBatch(projectLayerId,
-                                                              params)
+            stl <- SceneToLayerDao
+              .setColorCorrectParamsBatch(project.defaultLayerId, params)
           } yield { stl }
 
           onSuccess(setColorCorrectParamsBatchIO.transact(xa).unsafeToFuture) {
@@ -1008,18 +969,12 @@ trait ProjectRoutes
         complete {
           val getMosaicDefinitionIO = for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            projectLayerId = project.defaultLayerId match {
-              case Some(defaultLayerId) => defaultLayerId
-              case _ =>
-                throw new Exception(
-                  s"Project ${projectId} does not have a default layer")
-            }
             _ <- SceneToProjectDao
               .getMosaicDefinition(projectId)
               .compile
               .to[List]
             result <- SceneToLayerDao
-              .getMosaicDefinition(projectLayerId)
+              .getMosaicDefinition(project.defaultLayerId)
               .compile
               .to[List]
           } yield { result }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -32,7 +32,7 @@ import scalacache.modes.sync._
   * need to be flagged with the @cacheKeyExclude decorator to avoid unecessarily namespacing values in the keys
   *
   * @param imageId UUID of the image (scene) in the database
-  * @param projectId UUID of the layer this image is a part of
+  * @param projectLayerId UUID of the layer this image is a part of
   * @param uri location of the source data
   * @param footprint extent of data the image covers
   * @param subsetBands subset of bands to be read from source
@@ -41,7 +41,7 @@ import scalacache.modes.sync._
   */
 case class BacksplashImage(
     imageId: UUID,
-    @cacheKeyExclude projectId: UUID,
+    @cacheKeyExclude projectLayerId: UUID,
     @cacheKeyExclude uri: String,
     @cacheKeyExclude footprint: MultiPolygon,
     subsetBands: List[Int],

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/HistogramStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/HistogramStore.scala
@@ -13,9 +13,9 @@ import java.util.UUID
       subsetBands: List[Int]
   ): IO[Array[Histogram[Double]]]
 
-  @op("projectHistogram") def projectHistogram(
+  @op("projectLayerHistogram") def projectLayerHistogram(
       self: A,
-      projectId: UUID,
+      projectLayerId: UUID,
       subsetBands: List[Int]
   ): IO[Array[Histogram[Double]]]
 }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -70,8 +70,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
       val mosaic = {
         val mbtIO = (BacksplashMosaic.filterRelevant(self) map { relevant =>
           logger.debug(s"Band Subset Required: ${relevant.subsetBands}")
-          val img = relevant.read(z, x, y)
-          img
+          relevant.read(z, x, y)
         }).collect({ case Some(mbtile) => mbtile }).compile.toList
         mbtIO.map(_.reduceOption(_ merge _) match {
           case Some(t) => Raster(t, extent)
@@ -179,9 +178,9 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
               firstImOption <- BacksplashMosaic.first(
                 BacksplashMosaic.filterRelevant(self))
               histograms <- {
-                histStore.projectHistogram(
+                histStore.projectLayerHistogram(
                   firstImOption map {
-                    _.projectId
+                    _.projectLayerId
                   } getOrElse {
                     throw MetadataException(
                       "Cannot produce tiles from empty mosaics")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
@@ -1,5 +1,6 @@
 package com.rasterfoundry.backsplash
 
+import cats.implicits._
 import geotrellis.vector.Extent
 import org.http4s._
 import org.http4s.dsl.io._
@@ -16,17 +17,32 @@ object Parameters {
   implicit val uuidQueryParamDecoder: QueryParamDecoder[UUID] =
     QueryParamDecoder[String].map(UUID.fromString)
 
+  object BandOverrideQueryParamDecoder {
+    def unapply(
+        params: Map[String, Seq[String]]): Option[Option[BandOverride]] = {
+      (
+        params.get("redBand") flatMap { _.headOption } map {
+          Integer.parseInt(_)
+        },
+        params.get("greenBand") flatMap { _.headOption } map {
+          Integer.parseInt(_)
+        },
+        params.get("blueBand") flatMap { _.headOption } map {
+          Integer.parseInt(_)
+        }
+      ).tupled map {
+        // We have to wrap the option in another option to get the query param matcher
+        // to emit the correct type
+        case (r, g, b) => Some(BandOverride(r, g, b))
+      }
+    }
+  }
+
   /** Query string query parameters */
   object TokenQueryParamMatcher
       extends OptionalQueryParamDecoderMatcher[String]("token")
   object MapTokenQueryParamMatcher
       extends OptionalQueryParamDecoderMatcher[UUID]("mapToken")
-  object RedBandOptionalQueryParamMatcher
-      extends OptionalQueryParamDecoderMatcher[Int]("redBand")
-  object GreenBandOptionalQueryParamMatcher
-      extends OptionalQueryParamDecoderMatcher[Int]("greenBand")
-  object BlueBandOptionalQueryParamMatcher
-      extends OptionalQueryParamDecoderMatcher[Int]("blueBand")
   object ExtentQueryParamMatcher
       extends QueryParamDecoderMatcher[Extent]("bbox")
   object NodeQueryParamMatcher

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
@@ -18,22 +18,28 @@ object Parameters {
     QueryParamDecoder[String].map(UUID.fromString)
 
   object BandOverrideQueryParamDecoder {
+
+    /** This returns a "Some[Option[]] so that it will "always match".
+      * See Path.scala in http4s
+      */
     def unapply(
-        params: Map[String, Seq[String]]): Option[Option[BandOverride]] = {
-      (
-        params.get("redBand") flatMap { _.headOption } map {
-          Integer.parseInt(_)
-        },
-        params.get("greenBand") flatMap { _.headOption } map {
-          Integer.parseInt(_)
-        },
-        params.get("blueBand") flatMap { _.headOption } map {
-          Integer.parseInt(_)
+        params: Map[String, Seq[String]]): Some[Option[BandOverride]] = {
+      Some {
+        (
+          params.get("redBand") flatMap { _.headOption } map {
+            Integer.parseInt(_)
+          },
+          params.get("greenBand") flatMap { _.headOption } map {
+            Integer.parseInt(_)
+          },
+          params.get("blueBand") flatMap { _.headOption } map {
+            Integer.parseInt(_)
+          }
+        ).tupled map {
+          // We have to wrap the option in another option to get the query param matcher
+          // to emit the correct type
+          case (r, g, b) => BandOverride(r, g, b)
         }
-      ).tupled map {
-        // We have to wrap the option in another option to get the query param matcher
-        // to emit the correct type
-        case (r, g, b) => Some(BandOverride(r, g, b))
       }
     }
   }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -18,7 +18,6 @@ object AuthedAutoSlash {
       implicit F: MonoidK[OptionT[F, ?]],
       ev: Functor[F]): AuthedService[T, F] = Kleisli { authedReq =>
     {
-      // TODO: this doesn't compile anymore :(
       http(authedReq) <+> {
         val pathInfo = authedReq.req.pathInfo
         val scriptName = authedReq.req.scriptName

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HistogramStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HistogramStoreImplicits.scala
@@ -20,6 +20,7 @@ trait HistogramStoreImplicits
 
   val xa: Transactor[IO]
 
+  @SuppressWarnings(Array("TraversableHead"))
   private def mergeHistsForBands(
       bands: List[Int],
       hists: List[Array[Histogram[Double]]]): Array[Histogram[Double]] = {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HistogramStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HistogramStoreImplicits.scala
@@ -20,38 +20,43 @@ trait HistogramStoreImplicits
 
   val xa: Transactor[IO]
 
+  private def mergeHistsForBands(
+      bands: List[Int],
+      hists: List[Array[Histogram[Double]]]): Array[Histogram[Double]] = {
+    val combinedHistogram = hists.foldLeft(
+      Array.fill(hists.head.length)(
+        StreamingHistogram(255): Histogram[Double]))(
+      (histArr1: Array[Histogram[Double]],
+       histArr2: Array[Histogram[Double]]) => {
+        histArr1 zip histArr2 map {
+          case (h1, h2) => h1 merge h2
+        }
+      }
+    )
+    bands.toArray map { band =>
+      combinedHistogram(band)
+    }
+  }
+
   implicit val layerAttributeHistogramStore: HistogramStore[LayerAttributeDao] =
     new HistogramStore[LayerAttributeDao] {
       def layerHistogram(self: LayerAttributeDao,
                          layerId: UUID,
                          subsetBands: List[Int]) = {
-        self.getHistogram[Array[Histogram[Double]]](layerId, xa) map { hists =>
+        self.getHistogram(layerId, xa) map { hists =>
           subsetBands.toArray map { band =>
             hists(band)
           }
         }
       }
 
-      @SuppressWarnings(Array("TraversableHead"))
-      def projectHistogram(
+      def projectLayerHistogram(
           self: LayerAttributeDao,
-          projectId: UUID,
-          subsetBands: List[Int]): IO[Array[Histogram[Double]]] = {
-        self.getProjectHistogram[Array[Histogram[Double]]](projectId, xa) map {
-          hists =>
-            val combinedHistogram = hists.foldLeft(
-              Array.fill(hists.head.length)(
-                StreamingHistogram(255): Histogram[Double]))(
-              (histArr1: Array[Histogram[Double]],
-               histArr2: Array[Histogram[Double]]) => {
-                histArr1 zip histArr2 map {
-                  case (h1, h2) => h1 merge h2
-                }
-              }
-            )
-            subsetBands.toArray map { band =>
-              combinedHistogram(band)
-            }
+          projectLayerId: UUID,
+          subsetBands: List[Int]
+      ): IO[Array[Histogram[Double]]] = {
+        self.getProjectLayerHistogram(projectLayerId, xa) map { hists =>
+          mergeHistsForBands(subsetBands, hists)
         }
       }
     }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -136,7 +136,9 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
 
   val httpApp =
     Router(
-      "/" -> withCORS(withTimeout(mosaicService)),
+      "/" -> ProjectToProjectLayerMiddleware(
+        withCORS(withTimeout(mosaicService)),
+        xa),
       "/scenes" -> withCORS(withTimeout(sceneMosaicService)),
       "/tools" -> withCORS(withTimeout(analysisService)),
       "/healthcheck" -> AutoSlash(new HealthcheckService[IO]().routes)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.backsplash.server
 import com.rasterfoundry.database.{
   LayerAttributeDao,
   SceneDao,
+  SceneToLayerDao,
   SceneToProjectDao,
   ToolRunDao
 }
@@ -113,7 +114,10 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
   val mosaicService: HttpRoutes[IO] =
     authenticators.tokensAuthMiddleware(
       AuthedAutoSlash(
-        new MosaicService(SceneToProjectDao(), mosaicImplicits, xa).routes))
+        new MosaicService(SceneToProjectDao(),
+                          SceneToLayerDao(),
+                          mosaicImplicits,
+                          xa).routes))
 
   val analysisService: HttpRoutes[IO] =
     authenticators.tokensAuthMiddleware(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -76,7 +76,9 @@ class MosaicService[ProjStore: ProjectStore,
             val polygonBbox: Projected[Polygon] =
               TileUtils.getTileBounds(z, x, y)
             val eval = LayerTms.identity(
-              layers.read(layerId, Some(polygonBbox), bandOverride, None)
+              layers.read(layerId, Some(polygonBbox), bandOverride, None) map {
+                _.copy(projectId = projectId)
+              }
             )
 
             for {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -70,7 +70,7 @@ class MosaicService[ProjStore: ProjectStore,
               }
             } yield resp
 
-          case GET -> Root / UUIDWrapper(projectId) / "layer" / UUIDWrapper(
+          case GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
                 layerId) / IntVar(z) / IntVar(x) / IntVar(y) :? BandOverrideQueryParamDecoder(
                 bandOverride) as user =>
             val polygonBbox: Projected[Polygon] =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -4,8 +4,9 @@ import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.error._
-import com.rasterfoundry.database.{SceneDao, SceneToProjectDao}
+import com.rasterfoundry.database.{SceneDao, SceneToLayerDao, SceneToProjectDao}
 import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.datamodel.MosaicDefinition
 import com.rasterfoundry.datamodel.color.{
   BandGamma => RFBandGamma,
   PerBandClipping => RFPerBandClipping,
@@ -33,6 +34,85 @@ import geotrellis.vector.{Polygon, Projected}
 import java.util.UUID
 
 class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
+
+  private def mosaicDefinitionToImage(mosaicDefinition: MosaicDefinition,
+                                      bandOverride: Option[BandOverride],
+                                      projId: UUID): BacksplashImage = {
+    val singleBandOptions =
+      mosaicDefinition.singleBandOptions flatMap {
+        _.as[BSSingleBandOptions.Params].toOption
+      }
+    val sceneId = mosaicDefinition.sceneId
+    val ingestLocation = mosaicDefinition.ingestLocation getOrElse {
+      throw UningestedScenesException(
+        s"Scene ${sceneId} does not have an ingest location"
+      )
+    }
+    val footprint = mosaicDefinition.footprint getOrElse {
+      throw MetadataException(s"Scene ${sceneId} does not have a footprint")
+    }
+
+    val subsetBands = if (mosaicDefinition.isSingleBand) {
+      singleBandOptions map { sbo =>
+        List(sbo.band)
+      } getOrElse {
+        throw SingleBandOptionsException(
+          "Single band options must be specified for single band projects"
+        )
+      }
+    } else {
+      bandOverride map { ovr =>
+        List(ovr.red, ovr.green, ovr.blue)
+      } getOrElse {
+        List(
+          mosaicDefinition.colorCorrections.redBand,
+          mosaicDefinition.colorCorrections.greenBand,
+          mosaicDefinition.colorCorrections.blueBand
+        )
+      }
+    }
+
+    val colorCorrectParameters = BSColorCorrect.Params(
+      0, // red
+      1, // green
+      2, // blue
+      (BandGamma.apply _)
+        .tupled(
+          RFBandGamma.unapply(mosaicDefinition.colorCorrections.gamma).get),
+      (PerBandClipping.apply _).tupled(
+        RFPerBandClipping
+          .unapply(mosaicDefinition.colorCorrections.bandClipping)
+          .get
+      ),
+      (MultiBandClipping.apply _).tupled(
+        RFMultiBandClipping
+          .unapply(mosaicDefinition.colorCorrections.tileClipping)
+          .get
+      ),
+      (SigmoidalContrast.apply _)
+        .tupled(
+          RFSigmoidalContrast
+            .unapply(mosaicDefinition.colorCorrections.sigmoidalContrast)
+            .get
+        ),
+      (Saturation.apply _).tupled(
+        RFSaturation
+          .unapply(mosaicDefinition.colorCorrections.saturation)
+          .get
+      )
+    )
+
+    BacksplashImage(
+      sceneId,
+      projId,
+      ingestLocation,
+      footprint,
+      subsetBands,
+      colorCorrectParameters,
+      singleBandOptions
+    )
+  }
+
   implicit val sceneStore: ProjectStore[SceneDao] = new ProjectStore[SceneDao] {
     def read(
         self: SceneDao,
@@ -71,9 +151,6 @@ class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
 
   implicit val projectStore: ProjectStore[SceneToProjectDao] =
     new ProjectStore[SceneToProjectDao] {
-      // safe to get here, since we're just unapplying from a value that we already know
-      // was constructed correctly
-      @SuppressWarnings(Array("OptionGet"))
       def read(
           self: SceneToProjectDao,
           projId: UUID,
@@ -86,80 +163,30 @@ class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
           bandOverride map { _.red },
           bandOverride map { _.green },
           bandOverride map { _.blue },
-          imageSubset map { _.toList } getOrElse List.empty) map { md =>
-          val singleBandOptions =
-            md.singleBandOptions flatMap {
-              _.as[BSSingleBandOptions.Params].toOption
-            }
-          val sceneId = md.sceneId
-          val ingestLocation = md.ingestLocation getOrElse {
-            throw UningestedScenesException(
-              s"Scene ${sceneId} does not have an ingest location"
-            )
-          }
-          val footprint = md.footprint getOrElse {
-            throw MetadataException(
-              s"Scene ${sceneId} does not have a footprint")
-          }
+          imageSubset map { _.toList } getOrElse List.empty) map {
+          mosaicDefinitionToImage(_, bandOverride, projId)
+        } transact (xa)
+      }
+    }
 
-          val subsetBands = if (md.isSingleBand) {
-            singleBandOptions map { sbo =>
-              List(sbo.band)
-            } getOrElse {
-              throw SingleBandOptionsException(
-                "Single band options must be specified for single band projects"
-              )
-            }
-          } else {
-            bandOverride map { ovr =>
-              List(ovr.red, ovr.green, ovr.blue)
-            } getOrElse {
-              List(
-                md.colorCorrections.redBand,
-                md.colorCorrections.greenBand,
-                md.colorCorrections.blueBand
-              )
-            }
-          }
-
-          val colorCorrectParameters = BSColorCorrect.Params(
-            0, // red
-            1, // green
-            2, // blue
-            (BandGamma.apply _)
-              .tupled(RFBandGamma.unapply(md.colorCorrections.gamma).get),
-            (PerBandClipping.apply _).tupled(
-              RFPerBandClipping
-                .unapply(md.colorCorrections.bandClipping)
-                .get
-            ),
-            (MultiBandClipping.apply _).tupled(
-              RFMultiBandClipping
-                .unapply(md.colorCorrections.tileClipping)
-                .get
-            ),
-            (SigmoidalContrast.apply _)
-              .tupled(
-                RFSigmoidalContrast
-                  .unapply(md.colorCorrections.sigmoidalContrast)
-                  .get
-              ),
-            (Saturation.apply _).tupled(
-              RFSaturation
-                .unapply(md.colorCorrections.saturation)
-                .get
-            )
-          )
-
-          BacksplashImage(
-            sceneId,
-            projId,
-            ingestLocation,
-            footprint,
-            subsetBands,
-            colorCorrectParameters,
-            singleBandOptions
-          )
+  implicit val layerStore: ProjectStore[SceneToLayerDao] =
+    new ProjectStore[SceneToLayerDao] {
+      // projId here actually refers to a layer -- but the argument names have to
+      // match the typeclass we're providing evidence for
+      def read(
+          self: SceneToLayerDao,
+          projId: UUID,
+          window: Option[Projected[Polygon]],
+          bandOverride: Option[BandOverride],
+          imageSubset: Option[NEL[UUID]]): fs2.Stream[IO, BacksplashImage] = {
+        SceneToLayerDao.getMosaicDefinition(
+          projId,
+          window,
+          bandOverride map { _.red },
+          bandOverride map { _.green },
+          bandOverride map { _.blue },
+          imageSubset map { _.toList } getOrElse List.empty) map {
+          mosaicDefinitionToImage(_, bandOverride, projId)
         } transact (xa)
       }
     }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -35,6 +35,7 @@ import java.util.UUID
 
 class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
 
+  @SuppressWarnings(Array("OptionGet"))
   private def mosaicDefinitionToImage(mosaicDefinition: MosaicDefinition,
                                       bandOverride: Option[BandOverride],
                                       projId: UUID): BacksplashImage = {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectToProjectLayerMiddleware.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectToProjectLayerMiddleware.scala
@@ -38,19 +38,9 @@ object ProjectToProjectLayerMiddleware {
                     .getProjectById(projectId)
                     .transact(xa)
                 } map { _.defaultLayerId }
-                resp <- defaultLayerId match {
-                  case Some(defaultId) =>
-                    val newRequest =
-                      req.withPathInfo(
-                        s"/${projectId}/layers/${defaultId}/${z}/${x}/${y}")
-                    service(newRequest)
-                  case _ =>
-                    OptionT.liftF {
-                      Forbidden(
-                        "Resource does not exist or user is not authorized to access this resource"
-                      )
-                    }
-                }
+                resp <- service(
+                  req.withPathInfo(
+                    s"/${projectId}/layers/${defaultLayerId}/${z}/${x}/${y}"))
               } yield resp
             case _ =>
               service(req)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectToProjectLayerMiddleware.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectToProjectLayerMiddleware.scala
@@ -1,0 +1,63 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.backsplash.Parameters.{
+  BandOverrideQueryParamDecoder,
+  UUIDWrapper
+}
+import com.rasterfoundry.database.ProjectDao
+
+import cats.data._
+import cats.effect.IO
+import doobie.Transactor
+import doobie.implicits._
+
+import org.http4s._
+import org.http4s.dsl.io._
+
+object ProjectToProjectLayerMiddleware {
+  def apply(
+      service: HttpRoutes[IO],
+      xa: Transactor[IO]): Kleisli[OptionT[IO, ?], Request[IO], Response[IO]] =
+    Kleisli { req: Request[IO] =>
+      {
+        // match on the request here and route to the service if it matches the deprecated route
+        val scriptName = req.scriptName
+        // Due to middleware application order, we have to strip a trailing slash here
+        if (scriptName.isEmpty && req.pathInfo.charAt(req.pathInfo.length - 1) == '/') {
+          apply(service, xa)(
+            req.withPathInfo(
+              req.pathInfo.substring(0, req.pathInfo.length - 1)))
+        } else if (scriptName.isEmpty) {
+          req match {
+            case GET -> Root / UUIDWrapper(projectId) / IntVar(z) / IntVar(x) / IntVar(
+                  y)
+                  :? BandOverrideQueryParamDecoder(bandOverride) =>
+              for {
+                defaultLayerId <- OptionT {
+                  ProjectDao
+                    .getProjectById(projectId)
+                    .transact(xa)
+                } map { _.defaultLayerId }
+                resp <- defaultLayerId match {
+                  case Some(defaultId) =>
+                    val newRequest =
+                      req.withPathInfo(
+                        s"/${projectId}/layers/${defaultId}/${z}/${x}/${y}")
+                    service(newRequest)
+                  case _ =>
+                    OptionT.liftF {
+                      Forbidden(
+                        "Resource does not exist or user is not authorized to access this resource"
+                      )
+                    }
+                }
+              } yield resp
+            case _ =>
+              service(req)
+          }
+        } else {
+          service(req)
+        }
+      }
+    }
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
@@ -40,13 +40,7 @@ class SceneService[ProjStore: ProjectStore, HistStore: HistogramStore](
         AuthedService {
           case GET -> Root / UUIDWrapper(sceneId) / IntVar(z) / IntVar(x) / IntVar(
                 y)
-                :? RedBandOptionalQueryParamMatcher(redOverride)
-                :? GreenBandOptionalQueryParamMatcher(greenOverride)
-                :? BlueBandOptionalQueryParamMatcher(blueOverride) as user =>
-            val bandOverride =
-              Applicative[Option].map3(redOverride,
-                                       greenOverride,
-                                       blueOverride)(BandOverride.apply)
+                :? BandOverrideQueryParamDecoder(bandOverride) as user =>
             val eval =
               LayerTms.identity(scenes.read(sceneId, None, bandOverride, None))
             for {

--- a/app-backend/datamodel/src/main/scala/Project.scala
+++ b/app-backend/datamodel/src/main/scala/Project.scala
@@ -35,7 +35,7 @@ final case class Project(id: UUID,
                          singleBandOptions: Option[SingleBandOptions.Params],
                          defaultAnnotationGroup: Option[UUID],
                          extras: Option[Json],
-                         defaultLayerId: Option[UUID])
+                         defaultLayerId: UUID)
 
 /** Case class for project creation */
 object Project extends GeoJsonSupport {
@@ -82,7 +82,7 @@ object Project extends GeoJsonSupport {
                           singleBandOptions: Option[SingleBandOptions.Params],
                           extras: Option[Json] = Some("{}".asJson))
       extends OwnerCheck {
-    def toProject(user: User): Project = {
+    def toProject(user: User, defaultLayerId: UUID): Project = {
       val now = new Timestamp(new java.util.Date().getTime)
 
       val ownerId = checkOwner(user, this.owner)
@@ -109,7 +109,7 @@ object Project extends GeoJsonSupport {
         singleBandOptions,
         None,
         extras,
-        None
+        defaultLayerId
       )
     }
   }
@@ -190,7 +190,7 @@ object Project extends GeoJsonSupport {
                             isSingleBand: Boolean,
                             singleBandOptions: Option[SingleBandOptions.Params],
                             extras: Option[Json] = Some("{}".asJson),
-                            defaultLayerId: Option[UUID] = None)
+                            defaultLayerId: UUID)
 
   object WithUser {
     def apply(project: Project, user: User): WithUser = {

--- a/app-backend/datamodel/src/main/scala/ProjectLayer.scala
+++ b/app-backend/datamodel/src/main/scala/ProjectLayer.scala
@@ -18,7 +18,7 @@ final case class ProjectLayer(id: UUID,
                               createdAt: Timestamp,
                               modifiedAt: Timestamp,
                               name: String,
-                              projectId: UUID,
+                              projectId: Option[UUID],
                               colorGroupHex: String,
                               smartLayerId: Option[UUID],
                               rangeStart: Option[Timestamp],
@@ -42,7 +42,7 @@ final case class ProjectLayer(id: UUID,
 }
 
 @JsonCodec
-final case class ProjectLayerProperties(projectId: UUID,
+final case class ProjectLayerProperties(projectId: Option[UUID],
                                         createdAt: Timestamp,
                                         modifiedAt: Timestamp,
                                         name: String,
@@ -56,7 +56,7 @@ object ProjectLayer extends LazyLogging {
 
   @JsonCodec
   final case class Create(name: String,
-                          projectId: UUID,
+                          projectId: Option[UUID],
                           colorGroupHex: String,
                           smartLayerId: Option[UUID],
                           rangeStart: Option[Timestamp],

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -158,9 +158,6 @@ object Generators extends ArbitraryInstances {
   private def fileTypeGen: Gen[FileType] =
     Gen.oneOf(FileType.Geotiff, FileType.GeotiffWithMetadata)
 
-  private def userVisibility: Gen[UserVisibility] =
-    Gen.oneOf(UserVisibility.Public, UserVisibility.Private)
-
   private def timestampIn2016Gen: Gen[Timestamp] =
     for {
       year <- Gen.const(2016)
@@ -402,8 +399,11 @@ object Generators extends ArbitraryInstances {
   private def projectGen: Gen[Project] =
     for {
       projCreate <- projectCreateGen
+      defaultLayerId <- uuidGen
       user <- userGen
-    } yield { projCreate.copy(owner = Some(user.id)).toProject(user) }
+    } yield {
+      projCreate.copy(owner = Some(user.id)).toProject(user, defaultLayerId)
+    }
 
   private def sceneFilterFieldsGen: Gen[SceneFilterFields] =
     for {

--- a/app-backend/db/src/main/scala/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/LayerAttributeDao.scala
@@ -16,26 +16,29 @@ import DefaultJsonProtocol._
 import java.util.UUID
 
 import geotrellis.raster.histogram.{Histogram, StreamingHistogram}
+import geotrellis.raster.io.json._
 import io.circe.{Encoder, Json}
 import io.circe.parser.parse
 
-case class LayerAttributeDao() {
-  def getHistogram[T: JsonFormat](layerId: UUID, xa: Transactor[IO]): IO[T] = {
+case class LayerAttributeDao() extends HistogramJsonFormats {
+  def getHistogram(layerId: UUID,
+                   xa: Transactor[IO]): IO[Array[Histogram[Double]]] = {
     LayerAttributeDao
       .unsafeGetAttribute(LayerId(layerId.toString, 0), "histogram")
       .transact(xa)
       .map({ attr =>
-        attr.value.noSpaces.parseJson.convertTo[T]
+        attr.value.noSpaces.parseJson.convertTo[Array[Histogram[Double]]]
       })
   }
 
-  def getProjectHistogram[T: JsonFormat](projectId: UUID,
-                                         xa: Transactor[IO]): IO[List[T]] = {
+  def getProjectLayerHistogram(
+      projectLayerId: UUID,
+      xa: Transactor[IO]): IO[List[Array[Histogram[Double]]]] = {
     LayerAttributeDao
-      .getProjectHistogram(projectId)
+      .getProjectLayerHistogram(projectLayerId)
       .transact(xa)
       .map(_.map({ attr =>
-        attr.value.noSpaces.parseJson.convertTo[T]
+        attr.value.noSpaces.parseJson.convertTo[Array[Histogram[Double]]]
       }))
   }
 }
@@ -57,6 +60,17 @@ object LayerAttributeDao extends Dao[LayerAttribute] {
       .filter(fr"zoom = 0")
       .filter(
         fr"layer_name in (SELECT scene_id :: varchar(255) from scenes_to_projects where project_id = ${projectId})"
+      )
+      .list
+  }
+
+  def getProjectLayerHistogram(
+      projectLayerId: UUID): ConnectionIO[List[LayerAttribute]] = {
+    query
+      .filter(fr"name = 'histogram'")
+      .filter(fr"zoom = 0")
+      .filter(
+        fr"layer_name in (SELECT scene_id :: varchar(255) from scenes_to_layers where project_layer_id = ${projectLayerId})"
       )
       .list
   }

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -41,21 +41,18 @@ object ProjectDao
   type SceneToProject = (UUID, UUID, Boolean, Option[Int], Option[Json])
   type SceneToLayer = (UUID, UUID, Boolean, Option[Int], Option[Json])
 
-  def unsafeGetProjectById(projectId: UUID): ConnectionIO[Project] = {
+  def projectByIdQuery(projectId: UUID): Query0[Project] = {
     val idFilter = Some(fr"id = ${projectId}")
 
     (selectF ++ Fragments.whereAndOpt(idFilter))
       .query[Project]
-      .unique
   }
 
-  def getProjectById(projectId: UUID): ConnectionIO[Option[Project]] = {
-    val idFilter = Some(fr"id = ${projectId}")
+  def unsafeGetProjectById(projectId: UUID): ConnectionIO[Project] =
+    projectByIdQuery(projectId).unique
 
-    (selectF ++ Fragments.whereAndOpt(idFilter))
-      .query[Project]
-      .option
-  }
+  def getProjectById(projectId: UUID): ConnectionIO[Option[Project]] =
+    projectByIdQuery(projectId).option
 
   def listProjects(
       page: PageRequest,

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -83,20 +83,32 @@ object ProjectDao
     val ownerId = util.Ownership.checkOwner(user, newProject.owner)
     val slug = Project.slugify(newProject.name)
     for {
+      defaultProjectLayer <- ProjectLayerDao.insertProjectLayer(
+        ProjectLayer(UUID.randomUUID(),
+                     now,
+                     now,
+                     "Project default layer",
+                     None,
+                     "#FFFFFF",
+                     None,
+                     None,
+                     None,
+                     None)
+      )
       project <- (fr"INSERT INTO" ++ tableF ++ fr"""
           (id, created_at, modified_at, created_by,
           modified_by, owner, name, slug_label, description,
           visibility, tile_visibility, is_aoi_project,
           aoi_cadence_millis, aois_last_checked, tags, extent,
           manual_order, is_single_band, single_band_options, default_annotation_group,
-          extras)
+          extras, default_layer_id)
         VALUES
           ($id, $now, $now, ${user.id},
           ${user.id}, $ownerId, ${newProject.name}, $slug, ${newProject.description},
           ${newProject.visibility}, ${newProject.tileVisibility}, ${newProject.isAOIProject},
           ${newProject.aoiCadenceMillis}, $now, ${newProject.tags}, null,
           TRUE, ${newProject.isSingleBand}, ${newProject.singleBandOptions}, null,
-          ${newProject.extras}
+          ${newProject.extras}, ${defaultProjectLayer.id}
         )
       """).update.withUniqueGeneratedKeys[Project](
         "id",
@@ -122,22 +134,9 @@ object ProjectDao
         "extras",
         "default_layer_id"
       )
-      defaultProjectLayer <- ProjectLayerDao.insertProjectLayer(
-        ProjectLayer(UUID.randomUUID(),
-                     now,
-                     now,
-                     "Project default layer",
-                     id,
-                     "#FFFFFF",
-                     None,
-                     None,
-                     None,
-                     None)
-      )
-      updatedProject = project.copy(
-        defaultLayerId = Some(defaultProjectLayer.id))
-      _ <- this.updateProject(updatedProject, id, user)
-    } yield updatedProject
+      updatedLayer = defaultProjectLayer.copy(projectId = Some(project.id))
+      _ <- ProjectLayerDao.updateProjectLayer(updatedLayer, updatedLayer.id)
+    } yield project
   }
 
   def updateProjectQ(project: Project, id: UUID, user: User): Update0 = {
@@ -266,9 +265,9 @@ object ProjectDao
   def getProjectLayerId(projectLayerIdO: Option[UUID], project: Project): UUID =
     (projectLayerIdO, project.defaultLayerId) match {
       case (Some(projectLayerId), _) => projectLayerId
-      case (_, Some(defaultLayerId)) => defaultLayerId
+      case (_, defaultLayerId)       => defaultLayerId
       case _ =>
-        throw new Exception(s"Project ${project.id} does not have any layer")
+        throw new Exception(s"Project ${project.id} does not have any layers")
     }
 
   def addScenesToProject(sceneIds: NonEmptyList[UUID],

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -94,7 +94,7 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
   def layerIsInProject(layerId: UUID,
                        projectID: UUID): ConnectionIO[Boolean] = {
     query.filter(layerId).selectOption map {
-      case Some(projectLayer) => projectLayer.projectId == projectID
+      case Some(projectLayer) => projectLayer.projectId == Option(projectID)
       case _                  => false
     }
   }

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -90,4 +90,12 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
   def updateProjectLayer(pl: ProjectLayer, plId: UUID): ConnectionIO[Int] = {
     updateProjectLayerQ(pl, plId).run
   }
+
+  def layerIsInProject(layerId: UUID,
+                       projectID: UUID): ConnectionIO[Boolean] = {
+    query.filter(layerId).selectOption map {
+      case Some(projectLayer) => projectLayer.projectId == projectID
+      case _                  => false
+    }
+  }
 }

--- a/app-backend/db/src/main/scala/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/SceneToProjectDao.scala
@@ -102,16 +102,12 @@ object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
       layerId <- ProjectDao.projectByIdQuery(projectId).stream map { project =>
         project.defaultLayerId
       }
-      scenes <- layerId map {
-        SceneToLayerDao.getMosaicDefinition(_,
-                                            polygonOption,
-                                            redBand,
-                                            greenBand,
-                                            blueBand,
-                                            sceneIdSubset)
-      } getOrElse {
-        Stream.empty
-      }
+      scenes <- SceneToLayerDao.getMosaicDefinition(layerId,
+                                                    polygonOption,
+                                                    redBand,
+                                                    greenBand,
+                                                    blueBand,
+                                                    sceneIdSubset)
     } yield scenes
   }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -82,7 +82,8 @@ class ProjectDaoSpec
             val updateProjectWithUpdatedIO = projInsertWithUserAndOrgIO flatMap {
               case (dbProject: Project, dbUser: User, dbOrg: Organization) => {
                 val fixedUpUpdateProject =
-                  fixupProjectCreate(dbUser, updateProject).toProject(dbUser)
+                  fixupProjectCreate(dbUser, updateProject)
+                    .toProject(dbUser, dbProject.defaultLayerId)
                 ProjectDao.updateProject(fixedUpUpdateProject,
                                          dbProject.id,
                                          dbUser) flatMap {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToLayerDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToLayerDaoSpec.scala
@@ -48,17 +48,11 @@ class SceneToLayerDaoSpec
               _ <- ProjectDao.addScenesToProject(scenesInsert map { _.id },
                                                  dbProject.id,
                                                  false)
-              projectLayerId = dbProject.defaultLayerId match {
-                case Some(defaultLayerId) => defaultLayerId
-                case _ =>
-                  throw new Exception(
-                    s"Project ${dbProject.id} does not have a default layer")
-              }
               acceptedSceneCount <- SceneToLayerDao.acceptScenes(
-                projectLayerId,
+                dbProject.defaultLayerId,
                 scenesInsert map { _.id })
               stls <- SceneToLayerDao.query
-                .filter(fr"project_layer_id = ${projectLayerId}")
+                .filter(fr"project_layer_id = ${dbProject.defaultLayerId}")
                 .list
             } yield (acceptedSceneCount, stls)
 
@@ -98,22 +92,16 @@ class SceneToLayerDaoSpec
               _ <- ProjectDao.addScenesToProject(scenesInsert map { _.id },
                                                  dbProject.id,
                                                  false)
-              projectLayerId = dbProject.defaultLayerId match {
-                case Some(defaultLayerId) => defaultLayerId
-                case _ =>
-                  throw new Exception(
-                    s"Project ${dbProject.id} does not have a default layer")
-              }
-              _ <- SceneToLayerDao.setManualOrder(projectLayerId,
+              _ <- SceneToLayerDao.setManualOrder(dbProject.defaultLayerId,
                                                   scenesInsert map { _.id })
               mds <- SceneToLayerDao
-                .getMosaicDefinition(projectLayerId,
+                .getMosaicDefinition(dbProject.defaultLayerId,
                                      None,
                                      sceneIdSubset = selectedSceneIds)
                 .compile
                 .to[List]
               stls <- SceneToLayerDao.query
-                .filter(fr"project_layer_id = ${projectLayerId}")
+                .filter(fr"project_layer_id = ${dbProject.defaultLayerId}")
                 .filter(selectedSceneIds.toNel map {
                   Fragments.in(fr"scene_id", _)
                 })

--- a/app-backend/migrations/src/main/scala/migrations/160.scala
+++ b/app-backend/migrations/src/main/scala/migrations/160.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/160.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -157,4 +157,5 @@ object MigrationSummary {
   M156
   M157
   M158
+  M160
 }

--- a/app-backend/migrations/src_migrations/main/scala/160.scala
+++ b/app-backend/migrations/src_migrations/main/scala/160.scala
@@ -1,0 +1,33 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M160 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(160)(
+    List(
+      sqlu"""
+-- make default layers for all projects that don't have them
+INSERT INTO project_layers
+  (id, created_at, modified_at, name, project_id, color_group_hex)
+(
+  SELECT uuid_generate_v4(), now(), now(), 'Project default layer', projects.id, '#FFFFFF'
+  FROM projects LEFT JOIN project_layers
+  ON
+    projects.id = project_layers.project_id
+  WHERE
+    project_layers.project_id IS NULL
+);
+
+-- fill in null default layer ids
+UPDATE projects
+SET default_layer_id =
+(SELECT project_layers.id FROM project_layers
+ JOIN projects ON project_layers.project_id = projects.id
+ WHERE project_layers.name = 'Project default layer')
+WHERE
+  projects.default_layer_id IS NULL;
+
+ALTER TABLE project_layers ALTER COLUMN project_id DROP NOT NULL;
+ALTER TABLE projects ALTER COLUMN default_layer_id SET NOT NULL;
+"""
+    ))
+}


### PR DESCRIPTION
This just reopens #4523 for Jenkins reasons.

## Overview

This PR adds projectstore evidence to the SceneToLayerDao, moves mosaic fetches for projects from projects to layers, and implements the mosaic TMS endpoint for layers so that testing instructions have anything useful to say.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Notes

~[wip] until I figure out what to do about histograms and depends on #4533~ Figured it out! There are only layers -- the defualt `/project id/z/x/y` match has actually been removed from the mosaic service, and requests to it get rewritten in [a new middleware](https://github.com/raster-foundry/raster-foundry/blob/feature/js/add-scenetolayerdao-project-store/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectToProjectLayerMiddleware.scala).

## Testing Instructions

 * **run migrations** or you might spend a few minutes confused about why you don't get any imagery for anything :man_facepalming: 
 * assemble your servers
 * start your servers
 * view a project
 * copy the tms request for one of the requests that returned some data (use response sizes to pick one)
 * find the default layer id for that project
 * make the same tms request with `/layers/layerID` before the z/x/y part
 * confirm that they match

Closes #4517 

Closes #4533 

Helps with #4518 
