### PR TITLE
Add filter fields to tool runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s. [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 - Allow sharing most objects when you have edit permissions granted to you [\#4514](https://github.com/raster-foundry/raster-foundry/pull/4514)
 - Added TMS route for project layers [\#4523](https://github.com/raster-foundry/raster-foundry/pull/4523)
+- Added project, project layer, and template ID fields to tool runs for later filtering [\#4546](https://github.com/raster-foundry/raster-foundry/pull/4546)
 
 ### Changed
 - Only analyses owned by the current user are displayed in the analysis browsing UI [\#4357](https://github.com/raster-foundry/raster-foundry/pull/4357)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -243,6 +243,9 @@ lazy val db = Project("db", file("db"))
       "com.lonelyplanet" %% "akka-http-extensions" % "0.4.15"
     )
   })
+  .settings(
+    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4")
+  )
 
 lazy val migrations = Project("migrations", file("migrations"))
   .settings(commonSettings: _*)

--- a/app-backend/datamodel/src/main/scala/ToolRun.scala
+++ b/app-backend/datamodel/src/main/scala/ToolRun.scala
@@ -15,6 +15,9 @@ final case class ToolRun(id: UUID,
                          modifiedBy: String,
                          owner: String,
                          visibility: Visibility,
+                         projectId: Option[UUID],
+                         projectLayerId: Option[UUID],
+                         templateId: Option[UUID],
                          executionParameters: Json)
 
 object ToolRun {
@@ -24,6 +27,9 @@ object ToolRun {
   @JsonCodec
   final case class Create(name: Option[String],
                           visibility: Visibility,
+                          projectId: Option[UUID],
+                          projectLayerId: Option[UUID],
+                          templateId: Option[UUID],
                           executionParameters: Json,
                           owner: Option[String])
       extends OwnerCheck {
@@ -42,6 +48,9 @@ object ToolRun {
         user.id,
         ownerId,
         visibility,
+        projectId,
+        projectLayerId,
+        templateId,
         executionParameters
       )
     }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -709,6 +709,34 @@ object Generators extends ArbitraryInstances {
       }, actionType)
     }
 
+  private def toolCreateGen: Gen[Tool.Create] =
+    for {
+      title <- nonEmptyStringGen
+      description <- nonEmptyStringGen
+      requirements <- nonEmptyStringGen
+      license <- Gen.const("BSD-3")
+      visibility <- visibilityGen
+      compatibleDataSources <- Gen.const(List.empty)
+      owner <- Gen.const(None)
+      stars <- Gen.const(9999.9f) // good tools only :sunglasses:
+      definition <- Gen.const(().asJson)
+      // not super into dealing with tags or categories in testing-land right now
+      tags <- Gen.const(Seq.empty)
+      categories <- Gen.const(Seq.empty)
+    } yield {
+      Tool.Create(title,
+                  description,
+                  requirements,
+                  license,
+                  visibility,
+                  compatibleDataSources,
+                  owner,
+                  stars,
+                  definition,
+                  tags,
+                  categories)
+    }
+
   private def toolRunCreateGen: Gen[ToolRun.Create] =
     for {
       name <- Gen.option(nonEmptyStringGen)
@@ -872,6 +900,9 @@ object Generators extends ArbitraryInstances {
         Gen.nonEmptyListOf[ObjectAccessControlRule](
           arbitrary[ObjectAccessControlRule])
       }
+
+    implicit def arbToolCreate: Arbitrary[Tool.Create] =
+      Arbitrary { toolCreateGen }
 
     implicit def arbToolRunCreate: Arbitrary[ToolRun.Create] =
       Arbitrary { toolRunCreateGen }

--- a/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/datamodel/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -715,7 +715,15 @@ object Generators extends ArbitraryInstances {
       visibility <- visibilityGen
       executionParameters <- Gen.const(().asJson)
       owner <- Gen.const(None)
-    } yield { ToolRun.Create(name, visibility, executionParameters, owner) }
+    } yield {
+      ToolRun.Create(name,
+                     visibility,
+                     None,
+                     None,
+                     None,
+                     executionParameters,
+                     owner)
+    }
 
   private def mapTokenCreateGen: Gen[MapToken.Create] =
     nonEmptyStringGen map { name =>

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -40,6 +40,9 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
     FROM
   """ ++ tableF
 
+  def unsafeGetToolRunById(toolRunId: UUID): ConnectionIO[ToolRun] =
+    query.filter(toolRunId).select
+
   def insertToolRun(newRun: ToolRun.Create,
                     user: User): ConnectionIO[ToolRun] = {
     val now = new Timestamp(new java.util.Date().getTime())

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -36,7 +36,7 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
   val selectF = sql"""
     SELECT
       distinct(id), name, created_at, created_by, modified_at, modified_by, owner, visibility,
-      execution_parameters
+      project_id, project_layer_id, template_id, execution_parameters
     FROM
   """ ++ tableF
 
@@ -48,10 +48,11 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
     sql"""
           INSERT INTO tool_runs
             (id, name, created_at, created_by, modified_at, modified_by, owner, visibility,
-             execution_parameters)
+             execution_parameters, project_id, project_layer_id, template_id)
           VALUES
             (${id}, ${newRun.name}, ${now}, ${user.id}, ${now}, ${user.id}, ${newRun.owner
-      .getOrElse(user.id)}, ${newRun.visibility}, ${newRun.executionParameters})
+      .getOrElse(user.id)}, ${newRun.visibility}, ${newRun.executionParameters},
+             ${newRun.projectId}, ${newRun.projectLayerId}, ${newRun.templateId})
        """.update.withUniqueGeneratedKeys[ToolRun](
       "id",
       "name",
@@ -61,6 +62,9 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
       "modified_by",
       "owner",
       "visibility",
+      "project_id",
+      "project_layer_id",
+      "template_id",
       "execution_parameters"
     )
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolRunDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolRunDaoSpec.scala
@@ -1,0 +1,131 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.datamodel.Generators.Implicits._
+import com.rasterfoundry.database.Implicits._
+
+import doobie._
+import doobie.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+class ToolRunDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+  test("create a tool run with a project id") {
+    check {
+      forAll {
+        (user: User.Create,
+         org: Organization.Create,
+         projCreate: Project.Create,
+         toolRunCreate: ToolRun.Create) =>
+          {
+            val toolRunInsertIO = for {
+              (_, dbUser, dbProject) <- insertUserOrgProject(user,
+                                                             org,
+                                                             projCreate)
+              withProjectId = toolRunCreate.copy(projectId = Some(dbProject.id))
+              inserted <- ToolRunDao.insertToolRun(withProjectId, dbUser)
+            } yield (withProjectId.projectId, inserted)
+
+            val (projectIdCheck, insertedToolRun) =
+              xa.use(t => toolRunInsertIO.transact(t)).unsafeRunSync
+
+            assert(
+              insertedToolRun.name == toolRunCreate.name,
+              "Names should match after db"
+            )
+            assert(
+              insertedToolRun.visibility == toolRunCreate.visibility,
+              "Visibility should match after db"
+            )
+            assert(
+              insertedToolRun.projectId == projectIdCheck,
+              "ProjectIds should match after db"
+            )
+            assert(
+              insertedToolRun.projectLayerId == toolRunCreate.projectLayerId,
+              "ProjectLayerIds should match after db"
+            )
+            assert(
+              insertedToolRun.templateId == toolRunCreate.templateId,
+              "TemplateIds should match after db"
+            )
+            assert(
+              insertedToolRun.executionParameters == toolRunCreate.executionParameters,
+              "ExecutionParameters should match after db"
+            )
+            true
+          }
+      }
+    }
+  }
+
+  test("create a tool run with a project layer id") {
+    check {
+      forAll {
+        (user: User.Create,
+         org: Organization.Create,
+         projCreate: Project.Create,
+         toolRunCreate: ToolRun.Create) =>
+          {
+            val toolRunInsertIO = for {
+              (_, dbUser, dbProject) <- insertUserOrgProject(user,
+                                                             org,
+                                                             projCreate)
+              withProjectLayerId = toolRunCreate.copy(
+                projectLayerId = Some(dbProject.defaultLayerId))
+              inserted <- ToolRunDao.insertToolRun(withProjectLayerId, dbUser)
+            } yield (withProjectLayerId.projectLayerId, inserted)
+
+            val (projectLayerIdCheck, insertedToolRun) =
+              xa.use(t => toolRunInsertIO.transact(t)).unsafeRunSync
+
+            assert(
+              insertedToolRun.name == toolRunCreate.name,
+              "Names should match after db"
+            )
+            assert(
+              insertedToolRun.visibility == toolRunCreate.visibility,
+              "Visibility should match after db"
+            )
+            assert(
+              insertedToolRun.projectId == toolRunCreate.projectId,
+              "ProjectIds should match after db"
+            )
+            assert(
+              insertedToolRun.projectLayerId == projectLayerIdCheck,
+              "ProjectLayerIds should match after db"
+            )
+            assert(
+              insertedToolRun.templateId == toolRunCreate.templateId,
+              "TemplateIds should match after db"
+            )
+            assert(
+              insertedToolRun.executionParameters == toolRunCreate.executionParameters,
+              "ExecutionParameters should match after db"
+            )
+            true
+          }
+      }
+    }
+  }
+
+  test("create a tool run with a template id") {
+    check {
+      forAll {
+        (user: User.Create,
+         org: Organization.Create,
+         projCreate: Project.Create,
+         toolRunCreate: ToolRun.Create) =>
+          {
+            true
+          }
+      }
+    }
+  }
+}

--- a/app-backend/migrations/src/main/scala/migrations/161.scala
+++ b/app-backend/migrations/src/main/scala/migrations/161.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/161.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -158,4 +158,5 @@ object MigrationSummary {
   M157
   M158
   M160
+  M161
 }

--- a/app-backend/migrations/src_migrations/main/scala/161.scala
+++ b/app-backend/migrations/src_migrations/main/scala/161.scala
@@ -1,0 +1,14 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M161 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(161)(
+    List(
+      sqlu"""
+ALTER TABLE tool_runs
+ADD COLUMN project_id uuid REFERENCES projects(id),
+ADD COLUMN project_layer_id uuid REFERENCES project_layers(id),
+ADD COLUMN template_id uuid REFERENCES tools(id)
+"""
+    ))
+}

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -330,7 +330,7 @@ export default (app) => {
             // 'executionParameters' instead.
             return {
                 visibility: 'PRIVATE',
-                template: template.id,
+                templateId: template.id,
                 executionParameters: angular.copy(template.definition)
             };
         }


### PR DESCRIPTION
## Overview

This PR adds tempate, project, and project layer IDs to tool runs to make some filtering possible that isn't currently.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Symlinks from new migrations present or corrected for any new migrations
- [x] Any new SQL strings have tests (and some old ones!)

### Notes

~Still working on template ID tests because templates don't even have an arbitrary instance omg but backend reviewable as is~

## Testing Instructions

 * run migrations
 * assemble the api server
 * bring up ur servers
 * create a new analysis from a template in the frontend
 * confirm that the new analysis has the template id filled in in the db

Closes #4530 
