### PR TITLE
Add improved health check that checks health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 - Shapes drawn within the scene search filter context can now be saved [\#4474](https://github.com/raster-foundry/raster-foundry/pull/4474)
 - Mosaics are again constructed with rasters instead of with IO[rasters] [\#4498](https://github.com/raster-foundry/raster-foundry/pull/4498)
+- Improved healthcheck logic in backsplash healthcheck endpoint [\#4548](https://github.com/raster-foundry/raster-foundry/pull/4548)
 
 ### Security
 - Upgrade webpack-dev-server to address vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2018-14732) [\#4476](https://github.com/raster-foundry/raster-foundry/pull/4476)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
@@ -65,7 +65,8 @@ class HealthcheckService(xa: Transactor[IO])(implicit timer: Timer[IO],
   val routes: HttpRoutes[IO] =
     HttpRoutes.of {
       case GET -> Root =>
-        val healthcheck = HealthReporter.fromChecks(dbHealth, cacheHealth)
+        val healthcheck = (dbHealth |+| cacheHealth)
+          .through(mods.recoverToSick)
         healthcheck.check flatMap { check =>
           if (check.value.reduce.isHealthy) Ok("A-ok")
           else {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
@@ -1,20 +1,62 @@
 package com.rasterfoundry.backsplash.server
 
-import cats.data.OptionT
-import cats.effect.Effect
+import com.rasterfoundry.backsplash.Cache.tileCache
+
+import cats._
+import cats.data._
+import cats.effect._
+import cats.implicits._
+import doobie._
+import doobie.implicits._
 import io.circe.Json
 import org.http4s._
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
+import scalacache.modes.sync._
+import sup._
 
-class HealthcheckService[F[_]: Effect] extends Http4sDsl[F] {
-  val routes: HttpRoutes[F] = {
+import scala.concurrent.duration._
+
+class HealthcheckService(xa: Transactor[IO])(implicit timer: Timer[IO],
+                                             contextShift: ContextShift[IO])
+    extends Http4sDsl[IO] {
+
+  private def dbHealth: HealthCheck[IO, Id] =
+    HealthCheck
+      .liftFBoolean(
+        // select things from the db
+        fr"select name from licenses limit 1;"
+          .query[String]
+          .to[List]
+          .transact(xa)
+          .map(_ => true)
+      )
+      .through(mods.timeoutToSick(3 seconds))
+
+  private def cacheHealth: HealthCheck[IO, Id] =
+    HealthCheck
+      .liftFBoolean(
+        IO { tileCache.get("bogus") } map { _ =>
+          true
+        }
+      )
+      .through(mods.timeoutToSick(3 seconds))
+
+  val routes: HttpRoutes[IO] =
     HttpRoutes.of {
-      case GET -> Root => {
-        Ok(
-          Json.obj("message" -> Json.fromString("Healthy"),
-                   "reason" -> Json.fromString("A-ok")))
-      }
+      case GET -> Root =>
+        // timeout or recover to sick, so that if either the cache / db are reachable but not responding
+        // or unreachable, we still return a 503
+        val healthcheck = (dbHealth |+| cacheHealth)
+          .through(
+            mods.timeoutToSick(7 seconds)
+          )
+          .through(
+            mods.recoverToSick
+          )
+        healthcheck.check flatMap { check =>
+          if (check.value.reduce.isHealthy) Ok("A-ok")
+          else ServiceUnavailable("No good")
+        }
     }
-  }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -141,7 +141,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
         xa),
       "/scenes" -> withCORS(withTimeout(sceneMosaicService)),
       "/tools" -> withCORS(withTimeout(analysisService)),
-      "/healthcheck" -> AutoSlash(new HealthcheckService[IO]().routes)
+      "/healthcheck" -> AutoSlash(new HealthcheckService(xa).routes)
     )
 
   val startupBanner =

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -418,6 +418,7 @@ lazy val backsplashServer = Project("backsplash-server",
       Dependencies.http4sServer,
       Dependencies.mamlJvm,
       Dependencies.nimbusJose,
+      Dependencies.sup,
       "com.github.cb372" %% "scalacache-cats-effect" % "0.27.0",
       "com.github.cb372" %% "scalacache-core" % "0.27.0",
       "com.github.cb372" %% "scalacache-caffeine" % "0.27.0"

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -73,4 +73,5 @@ object Dependencies {
   val slickMigrationAPI = "io.github.nafg" %% "slick-migration-api" % Version.slickMigrationAPI
   val spark = "org.apache.spark" %% "spark-core" % Version.spark % "provided"
   val sparkCore = "org.apache.spark" %% "spark-core" % Version.spark
+  val sup = "com.kubukoz" %% "sup-core" % Version.sup
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -47,5 +47,5 @@ object Version {
   val scopt = "3.5.0"
   val slickMigrationAPI = "0.4.0"
   val spark = "2.2.0"
-  val sup = "0.2.1"
+  val sup = "0.2.0"
 }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -5,6 +5,7 @@ object Version {
   val akkaHttpCors = "0.2.2"
   val akkaHttpExtensions = "0.4.13"
   val akkaSlf4j = "2.4.11"
+  val apacheCommonsEmail = "1.5"
   val auth0 = "1.5.0"
   val awsBatchSdk = "1.11.196"
   val awsStsSdk = "1.11.232"
@@ -46,5 +47,5 @@ object Version {
   val scopt = "3.5.0"
   val slickMigrationAPI = "0.4.0"
   val spark = "2.2.0"
-  val apacheCommonsEmail = "1.5"
+  val sup = "0.2.1"
 }


### PR DESCRIPTION
## Overview

This PR makes the backsplash healthcheck endpoint actually check health.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes
I tried making those improvements again this morning, and I'm having no luck. I keep running into diverging implicit expansion in places where I'm basically copying the code from the docs. Given that this fails in the case where we really want it to fail, I'm going to bail on this for now and move on to other pressing issues.

~There are two improvements that I think could reasonably be made --~

1. run the healthchecks in parallel. This is supposedly possible using `HealthCheck.parTupled`, but I had no success with it. I'll try again tomorrow morning.
2. encode the health check failures, rather than "no good", in the `Sick` case. This is supposedly possible [by magic](https://github.com/kubukoz/sup/blob/master/modules/http4s/src/main/scala/sup/modules/http4s.scala#L41-L43), but I am not a high-enough level mage apparently. I will also try this again tomorrow morning.

## Testing Instructions

 * update deps, assemble your backsplash-server jar
 * drop your postgres_db_pool_size to 2 in docker-compose.java.yml
 * request some tiles
 * observe that you don't see any, so you should expect the healthcheck to say it's sick
 * GET `:8081/healthcheck/`
 * observe that you get a 503
 * kill the server
 * bring the postgres pool back to normal
 * bring the servers back up
 * kill memcached
 * hit the healthcheck endpoint
 * it should be sick

Closes #4527 
