### PR TITLE
Add API endpoints for project-layer scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - Added lambda function for reactively processing new Sentinel-2 imagery [\#4491](https://github.com/raster-foundry/raster-foundry/pull/4491)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 - CRUDL endpoints for project layers [\#4512](https://github.com/raster-foundry/raster-foundry/pull/4512)
+- CRUDL endpoints for project layer scenes [\#4550](https://github.com/raster-foundry/raster-foundry/pull/4550)
+- Added project layer mosaic and scene order endpoint [\#4547](https://github.com/raster-foundry/raster-foundry/pull/4547)
 - Added `SceneToLayer` data model and `SceneToLayerDao`; updated related function calls in `ProjectDao` and project api [\#4513](https://github.com/raster-foundry/raster-foundry/pull/4513)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s. [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 - Allow sharing most objects when you have edit permissions granted to you [\#4514](https://github.com/raster-foundry/raster-foundry/pull/4514)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Added project layer creation workflow's modal on UI [\#4575](https://github.com/raster-foundry/raster-foundry/pull/4575)
 - Added project layer Annotation related endpoints [\#4569](https://github.com/raster-foundry/raster-foundry/pull/4569)
+- CRUDL endpoints for project layer scenes [\#4550](https://github.com/raster-foundry/raster-foundry/pull/4550)
 
 ### Changed
 
@@ -33,7 +34,6 @@
 - Added lambda function for reactively processing new Sentinel-2 imagery [\#4491](https://github.com/raster-foundry/raster-foundry/pull/4491)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 - CRUDL endpoints for project layers [\#4512](https://github.com/raster-foundry/raster-foundry/pull/4512)
-- CRUDL endpoints for project layer scenes [\#4550](https://github.com/raster-foundry/raster-foundry/pull/4550)
 - Added project layer mosaic and scene order endpoint [\#4547](https://github.com/raster-foundry/raster-foundry/pull/4547)
 - Added `SceneToLayer` data model and `SceneToLayerDao`; updated related function calls in `ProjectDao` and project api [\#4513](https://github.com/raster-foundry/raster-foundry/pull/4513)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s. [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)

--- a/app-backend/api/src/main/scala/project/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/project/QueryParameters.scala
@@ -1,11 +1,9 @@
 package com.rasterfoundry.api.project
 
-import java.util.UUID
-
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
 
-import com.rasterfoundry.datamodel._
+import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.queryparams._
 
 ///** Trait to abstract out query parameters for scenes */

--- a/app-backend/api/src/main/scala/project/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/project/QueryParameters.scala
@@ -1,0 +1,21 @@
+package com.rasterfoundry.api.project
+
+import java.util.UUID
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
+
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.api.utils.queryparams._
+
+///** Trait to abstract out query parameters for scenes */
+trait ProjectSceneQueryParameterDirective extends QueryParametersCommon {
+
+  val projectSceneQueryParameters = parameters(
+    (
+      'ingested.as[Boolean].?,
+      'ingestStatus.as[String].*,
+      'accepted.as[Boolean].?
+    )
+  ).as(ProjectSceneQueryParameters.apply _)
+}

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -47,6 +47,7 @@ trait ProjectRoutes
     with Config
     with QueryParametersCommon
     with SceneQueryParameterDirective
+    with ProjectSceneQueryParameterDirective
     with PaginationDirectives
     with CommonHandlers
     with AWSBatch
@@ -1637,6 +1638,7 @@ trait ProjectRoutes
         }
       }
     }
+
   def listLayerScenes(projectId: UUID, layerId: UUID): Route = authenticate {
     user =>
       authorizeAsync {
@@ -1645,7 +1647,7 @@ trait ProjectRoutes
           .transact(xa)
           .unsafeToFuture
       } {
-        (withPagination & sceneQueryParameters) { (page, sceneParams) =>
+        (withPagination & projectSceneQueryParameters) { (page, sceneParams) =>
           complete {
             ProjectLayerScenesDao
               .listLayerScenes(layerId, page, sceneParams)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -273,7 +273,7 @@ trait ProjectRoutes
                   pathPrefix("datasources") {
                     pathEndOrSingleSlash {
                       get {
-                        listLayerDatsources(projectId, layerId)
+                        listLayerDatasources(projectId, layerId)
                       }
                     }
                   }
@@ -1656,7 +1656,7 @@ trait ProjectRoutes
       }
   }
 
-  def listLayerDatsources(projectId: UUID, layerId: UUID): Route =
+  def listLayerDatasources(projectId: UUID, layerId: UUID): Route =
     authenticate { user =>
       (projectQueryParameters) { projectQueryParams =>
         authorizeAsync {

--- a/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
+++ b/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
@@ -20,11 +20,13 @@ object ThumbnailQueryParameters {
 
 /** Case class for combined params for images */
 /** Query parameters specific to image files */
-final case class ImageQueryParameters(minRawDataBytes: Option[Long] = None,
-                                      maxRawDataBytes: Option[Long] = None,
-                                      minResolution: Option[Float] = None,
-                                      maxResolution: Option[Float] = None,
-                                      scene: Iterable[UUID] = Seq.empty[UUID])
+final case class ImageQueryParameters(
+    minRawDataBytes: Option[Long] = None,
+    maxRawDataBytes: Option[Long] = None,
+    minResolution: Option[Float] = None,
+    maxResolution: Option[Float] = None,
+    scene: Iterable[UUID] = Seq.empty[UUID]
+)
 
 object ImageQueryParameters {
   implicit def encImageQueryParameters: Encoder[ImageQueryParameters] =
@@ -133,6 +135,20 @@ object ProjectQueryParameters {
     deriveDecoder[ProjectQueryParameters]
 }
 
+final case class ProjectSceneQueryParameters(
+    ingested: Option[Boolean] = None,
+    ingestStatus: Iterable[String] = Seq.empty[String],
+    accepted: Option[Boolean] = Some(true)
+)
+
+object ProjectSceneQueryParameters {
+  implicit def encProjectSceneQueryParameters
+    : Encoder[ProjectSceneQueryParameters] =
+    deriveEncoder[ProjectSceneQueryParameters]
+  implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
+    deriveDecoder[ProjectSceneQueryParameters]
+}
+
 final case class AoiQueryParameters(
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
@@ -166,9 +182,11 @@ object CombinedToolQueryParameters {
     deriveDecoder[CombinedToolQueryParameters]
 }
 
-final case class FootprintQueryParameters(x: Option[Double] = None,
-                                          y: Option[Double] = None,
-                                          bbox: Option[String] = None)
+final case class FootprintQueryParameters(
+    x: Option[Double] = None,
+    y: Option[Double] = None,
+    bbox: Option[String] = None
+)
 
 object FootprintQueryParameters {
   implicit def encFootprintQueryParameters: Encoder[FootprintQueryParameters] =
@@ -194,7 +212,8 @@ object CombinedFootprintQueryParams {
 
 /** Common query parameters for models that have organization attributes */
 final case class OrgQueryParameters(
-    organizations: Iterable[UUID] = Seq.empty[UUID])
+    organizations: Iterable[UUID] = Seq.empty[UUID]
+)
 
 object OrgQueryParameters {
   implicit def encOrgQueryParameters: Encoder[OrgQueryParameters] =
@@ -204,8 +223,10 @@ object OrgQueryParameters {
 }
 
 /** Query parameters to filter by only users */
-final case class UserAuditQueryParameters(createdBy: Option[String] = None,
-                                          modifiedBy: Option[String] = None)
+final case class UserAuditQueryParameters(
+    createdBy: Option[String] = None,
+    modifiedBy: Option[String] = None
+)
 
 object UserAuditQueryParameters {
   implicit def encUserAuditQueryParameters: Encoder[UserAuditQueryParameters] =
@@ -244,8 +265,10 @@ object OwnershipTypeQueryParameters {
 }
 
 /** Query parameters to filter by group membership*/
-final case class GroupQueryParameters(groupType: Option[GroupType] = None,
-                                      groupId: Option[UUID] = None)
+final case class GroupQueryParameters(
+    groupType: Option[GroupType] = None,
+    groupId: Option[UUID] = None
+)
 
 object GroupQueryParameters {
   implicit def encGroupQueryParameters: Encoder[GroupQueryParameters] =
@@ -294,10 +317,12 @@ object ToolCategoryQueryParameters {
     deriveDecoder[ToolCategoryQueryParameters]
 }
 
-final case class ToolRunQueryParameters(createdBy: Option[String] = None,
-                                        projectId: Option[UUID] = None,
-                                        templateId: Option[UUID] = None,
-                                        projectLayerId: Option[UUID] = None)
+final case class ToolRunQueryParameters(
+    createdBy: Option[String] = None,
+    projectId: Option[UUID] = None,
+    templateId: Option[UUID] = None,
+    projectLayerId: Option[UUID] = None
+)
 
 object ToolRunQueryParameters {
   implicit def encToolRunQueryParameters: Encoder[ToolRunQueryParameters] =
@@ -357,8 +382,10 @@ object DatasourceQueryParameters {
     deriveDecoder[DatasourceQueryParameters]
 }
 
-final case class MapTokenQueryParameters(name: Option[String] = None,
-                                         projectId: Option[UUID] = None)
+final case class MapTokenQueryParameters(
+    name: Option[String] = None,
+    projectId: Option[UUID] = None
+)
 
 object MapTokenQueryParameters {
   implicit def encMapTokenQueryParameters: Encoder[MapTokenQueryParameters] =
@@ -382,9 +409,11 @@ object CombinedMapTokenQueryParameters {
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
-final case class UploadQueryParameters(datasource: Option[UUID] = None,
-                                       uploadStatus: Option[String] = None,
-                                       projectId: Option[UUID] = None)
+final case class UploadQueryParameters(
+    datasource: Option[UUID] = None,
+    uploadStatus: Option[String] = None,
+    projectId: Option[UUID] = None
+)
 
 object UploadQueryParameters {
   implicit def encUploadQueryParameters: Encoder[UploadQueryParameters] =
@@ -393,11 +422,12 @@ object UploadQueryParameters {
     deriveDecoder[UploadQueryParameters]
 }
 
-final case class ExportQueryParameters(organization: Option[UUID] = None,
-                                       project: Option[UUID] = None,
-                                       analysis: Option[UUID] = None,
-                                       exportStatus: Iterable[String] =
-                                         Seq.empty[String])
+final case class ExportQueryParameters(
+    organization: Option[UUID] = None,
+    project: Option[UUID] = None,
+    analysis: Option[UUID] = None,
+    exportStatus: Iterable[String] = Seq.empty[String]
+)
 
 object ExportQueryParameters {
   implicit def encExportQueryParameters: Encoder[ExportQueryParameters] =
@@ -442,7 +472,8 @@ object AnnotationQueryParameters {
 }
 
 final case class AnnotationExportQueryParameters(
-    exportAll: Option[Boolean] = None)
+    exportAll: Option[Boolean] = None
+)
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
@@ -555,13 +586,15 @@ object OrganizationQueryParameters {
     deriveDecoder[OrganizationQueryParameters]
 }
 
-final case class SceneThumbnailQueryParameters(width: Option[Int],
-                                               height: Option[Int],
-                                               token: String,
-                                               red: Option[Int],
-                                               green: Option[Int],
-                                               blue: Option[Int],
-                                               floor: Option[Int])
+final case class SceneThumbnailQueryParameters(
+    width: Option[Int],
+    height: Option[Int],
+    token: String,
+    red: Option[Int],
+    green: Option[Int],
+    blue: Option[Int],
+    floor: Option[Int]
+)
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters

--- a/app-backend/common/src/main/scala/datamodel/Scene.scala
+++ b/app-backend/common/src/main/scala/datamodel/Scene.scala
@@ -8,11 +8,12 @@ import io.circe._
 import io.circe.generic.JsonCodec
 
 @JsonCodec
-final case class SceneFilterFields(cloudCover: Option[Float] = None,
-                                   acquisitionDate: Option[java.sql.Timestamp] =
-                                     None,
-                                   sunAzimuth: Option[Float] = None,
-                                   sunElevation: Option[Float] = None)
+final case class SceneFilterFields(
+    cloudCover: Option[Float] = None,
+    acquisitionDate: Option[java.sql.Timestamp] = None,
+    sunAzimuth: Option[Float] = None,
+    sunElevation: Option[Float] = None
+)
 
 object SceneFilterFields {
   def tupled = (SceneFilterFields.apply _).tupled
@@ -22,9 +23,11 @@ object SceneFilterFields {
 }
 
 @JsonCodec
-final case class SceneStatusFields(thumbnailStatus: JobStatus,
-                                   boundaryStatus: JobStatus,
-                                   ingestStatus: IngestStatus)
+final case class SceneStatusFields(
+    thumbnailStatus: JobStatus,
+    boundaryStatus: JobStatus,
+    ingestStatus: IngestStatus
+)
 
 object SceneStatusFields {
   def tupled = (SceneStatusFields.apply _).tupled
@@ -55,9 +58,11 @@ final case class Scene(
 ) {
   def toScene: Scene = this
 
-  def withRelatedFromComponents(images: List[Image.WithRelated],
-                                thumbnails: List[Thumbnail],
-                                datasource: Datasource): Scene.WithRelated =
+  def withRelatedFromComponents(
+      images: List[Image.WithRelated],
+      thumbnails: List[Thumbnail],
+      datasource: Datasource
+  ): Scene.WithRelated =
     Scene.WithRelated(
       this.id,
       this.createdAt,
@@ -111,7 +116,7 @@ final case class Scene(
   def projectSceneFromComponents(
       thumbnails: List[Thumbnail],
       datasource: Datasource,
-      sceneToProject: Option[SceneToProject]
+      sceneOrder: Option[Int]
   ): Scene.ProjectScene = Scene.ProjectScene(
     this.id,
     this.createdAt,
@@ -132,7 +137,7 @@ final case class Scene(
     this.filterFields,
     this.statusFields,
     this.sceneType,
-    sceneToProject.map(_.sceneOrder).flatten
+    sceneOrder
   )
 }
 
@@ -140,24 +145,24 @@ object Scene {
 
   /** Case class extracted from a POST request */
   @JsonCodec
-  final case class Create(id: Option[UUID],
-                          visibility: Visibility,
-                          tags: List[String],
-                          datasource: UUID,
-                          sceneMetadata: Json,
-                          name: String,
-                          owner: Option[String],
-                          tileFootprint: Option[Projected[MultiPolygon]],
-                          dataFootprint: Option[Projected[MultiPolygon]],
-                          metadataFiles: List[String],
-                          images: List[Image.Banded],
-                          thumbnails: List[Thumbnail.Identified],
-                          ingestLocation: Option[String],
-                          filterFields: SceneFilterFields =
-                            new SceneFilterFields(),
-                          statusFields: SceneStatusFields,
-                          sceneType: Option[SceneType] = None)
-      extends OwnerCheck {
+  final case class Create(
+      id: Option[UUID],
+      visibility: Visibility,
+      tags: List[String],
+      datasource: UUID,
+      sceneMetadata: Json,
+      name: String,
+      owner: Option[String],
+      tileFootprint: Option[Projected[MultiPolygon]],
+      dataFootprint: Option[Projected[MultiPolygon]],
+      metadataFiles: List[String],
+      images: List[Image.Banded],
+      thumbnails: List[Thumbnail.Identified],
+      ingestLocation: Option[String],
+      filterFields: SceneFilterFields = new SceneFilterFields(),
+      statusFields: SceneStatusFields,
+      sceneType: Option[SceneType] = None
+  ) extends OwnerCheck {
     def toScene(user: User): Scene = {
       val now = new Timestamp(new java.util.Date().getTime)
 
@@ -187,27 +192,28 @@ object Scene {
   }
 
   @JsonCodec
-  final case class WithRelated(id: UUID,
-                               createdAt: Timestamp,
-                               createdBy: String,
-                               modifiedAt: Timestamp,
-                               modifiedBy: String,
-                               owner: String,
-                               visibility: Visibility,
-                               tags: List[String],
-                               datasource: Datasource.Thin,
-                               sceneMetadata: Json,
-                               name: String,
-                               tileFootprint: Option[Projected[MultiPolygon]],
-                               dataFootprint: Option[Projected[MultiPolygon]],
-                               metadataFiles: List[String],
-                               images: List[Image.WithRelated],
-                               thumbnails: List[Thumbnail],
-                               ingestLocation: Option[String],
-                               filterFields: SceneFilterFields =
-                                 new SceneFilterFields(),
-                               statusFields: SceneStatusFields,
-                               sceneType: Option[SceneType] = None) {
+  final case class WithRelated(
+      id: UUID,
+      createdAt: Timestamp,
+      createdBy: String,
+      modifiedAt: Timestamp,
+      modifiedBy: String,
+      owner: String,
+      visibility: Visibility,
+      tags: List[String],
+      datasource: Datasource.Thin,
+      sceneMetadata: Json,
+      name: String,
+      tileFootprint: Option[Projected[MultiPolygon]],
+      dataFootprint: Option[Projected[MultiPolygon]],
+      metadataFiles: List[String],
+      images: List[Image.WithRelated],
+      thumbnails: List[Thumbnail],
+      ingestLocation: Option[String],
+      filterFields: SceneFilterFields = new SceneFilterFields(),
+      statusFields: SceneStatusFields,
+      sceneType: Option[SceneType] = None
+  ) {
     def toScene: Scene =
       Scene(
         id,

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -170,8 +170,8 @@ object Generators extends ArbitraryInstances {
     for {
       width <- Gen.choose(100, 50000)
       height <- Gen.choose(100, 50000)
-      centerX <- Gen.choose(-2E7, 2E7)
-      centerY <- Gen.choose(-2E7, 2E7)
+      centerX <- Gen.choose(-2e7, 2e7)
+      centerY <- Gen.choose(-2e7, 2e7)
     } yield {
       Rectangle()
         .withWidth(width)
@@ -606,6 +606,9 @@ object Generators extends ArbitraryInstances {
   private def combinedSceneQueryParamsGen: Gen[CombinedSceneQueryParams] =
     Gen.const(CombinedSceneQueryParams())
 
+  private def projectSceneQueryParametersGen: Gen[ProjectSceneQueryParameters] =
+    Gen.const(ProjectSceneQueryParameters())
+
   private def teamCreateGen: Gen[Team.Create] =
     for {
       orgId <- uuidGen
@@ -724,17 +727,19 @@ object Generators extends ArbitraryInstances {
       tags <- Gen.const(Seq.empty)
       categories <- Gen.const(Seq.empty)
     } yield {
-      Tool.Create(title,
-                  description,
-                  requirements,
-                  license,
-                  visibility,
-                  compatibleDataSources,
-                  owner,
-                  stars,
-                  definition,
-                  tags,
-                  categories)
+      Tool.Create(
+        title,
+        description,
+        requirements,
+        license,
+        visibility,
+        compatibleDataSources,
+        owner,
+        stars,
+        definition,
+        tags,
+        categories
+      )
     }
 
   private def toolRunCreateGen: Gen[ToolRun.Create] =
@@ -744,13 +749,15 @@ object Generators extends ArbitraryInstances {
       executionParameters <- Gen.const(().asJson)
       owner <- Gen.const(None)
     } yield {
-      ToolRun.Create(name,
-                     visibility,
-                     None,
-                     None,
-                     None,
-                     executionParameters,
-                     owner)
+      ToolRun.Create(
+        name,
+        visibility,
+        None,
+        None,
+        None,
+        executionParameters,
+        owner
+      )
     }
 
   private def mapTokenCreateGen: Gen[MapToken.Create] =
@@ -771,6 +778,10 @@ object Generators extends ArbitraryInstances {
       : Arbitrary[CombinedSceneQueryParams] = Arbitrary {
       combinedSceneQueryParamsGen
     }
+
+    implicit def arbProjectsceneQueryParameters
+      : Arbitrary[ProjectSceneQueryParameters] =
+      Arbitrary { projectSceneQueryParametersGen }
 
     implicit def arbAnnotationCreate: Arbitrary[Annotation.Create] = Arbitrary {
       annotationCreateGen
@@ -898,7 +909,8 @@ object Generators extends ArbitraryInstances {
       : Arbitrary[List[ObjectAccessControlRule]] =
       Arbitrary {
         Gen.nonEmptyListOf[ObjectAccessControlRule](
-          arbitrary[ObjectAccessControlRule])
+          arbitrary[ObjectAccessControlRule]
+        )
       }
 
     implicit def arbToolCreate: Arbitrary[Tool.Create] =

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -421,7 +421,7 @@ object ProjectDao
                               projectLayerIdO)
       scenes <- SceneDao.query
         .filter(
-          fr"scenes.id IN (SELECT scene_id FROM scenes_to_layers WHERE project_layer_id = ${projectLayerId}")
+          fr"scenes.id IN (SELECT scene_id FROM scenes_to_layers WHERE project_layer_id = ${projectLayerId})")
         .list
     } yield scenes
 
@@ -446,19 +446,6 @@ object ProjectDao
         } yield rowsDeleted
       case _ => 0.pure[ConnectionIO]
     }
-  }
-
-  def addScenesToProjectFromQuery(
-      sceneParams: CombinedSceneQueryParams,
-      projectId: UUID,
-      projectLayerIdO: Option[UUID] = None): ConnectionIO[Int] = {
-    for {
-      scenes <- SceneDao.query.filter(sceneParams).list
-      scenesAdded <- addScenesToProject(scenes.map(_.id),
-                                        projectId,
-                                        true,
-                                        projectLayerIdO)
-    } yield scenesAdded
   }
 
   // head is safe here, because we're looking up users from the ids in projects, and the map was

--- a/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
@@ -1,17 +1,11 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.Page
-import com.rasterfoundry.datamodel._
+import com.rasterfoundry.common.datamodel.Datasource
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.implicits._
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
@@ -1,0 +1,33 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.database.util.Page
+import com.rasterfoundry.datamodel._
+import doobie._
+import doobie.implicits._
+import doobie.postgres._
+import doobie.postgres.implicits._
+import doobie.postgres.circe.jsonb.implicits._
+import cats._
+import cats.data._
+import cats.effect.IO
+import cats.implicits._
+
+import java.util.UUID
+
+object ProjectLayerDatasourcesDao extends Dao[Datasource] {
+  val tableName = """scenes_to_layers sl
+                     INNER JOIN scenes s ON sl.scene_id = s.id
+                     INNER JOIN datasources d on s.datasource = d.id"""
+  val selectF = fr"""
+      SELECT
+        distinct(d.id), d.created_at, d.created_by, d.modified_at, d.modified_by, d.owner,
+        d.name, d.visibility, d.composites, d.extras, d.bands, d.license_name
+          FROM""" ++ tableF
+  def listProjectLayerDatasources(
+      projectId: UUID,
+      projectLayerId: UUID
+  ): ConnectionIO[List[Datasource]] = {
+    query.filter(fr"sl.project_layer_id=$projectLayerId").list
+  }
+}

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -32,13 +32,13 @@ object ProjectLayerScenesDao extends Dao[Scene] {
   def listLayerScenes(
       layerId: UUID,
       pageRequest: PageRequest,
-      sceneParams: CombinedSceneQueryParams
+      sceneParams: ProjectSceneQueryParameters
   ): ConnectionIO[PaginatedResponse[Scene.ProjectScene]] = {
 
     val layerQuery = ProjectLayerDao.query.filter(layerId).select
-    val andPendingF: Fragment = sceneParams.sceneParams.pending match {
-      case Some(true) => fr"accepted = false"
-      case _          => fr"accepted = true"
+    val andPendingF: Fragment = sceneParams.accepted match {
+      case Some(true) => fr"accepted = true"
+      case _          => fr"accepted = false"
     }
 
     val manualOrder = Map(

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -1,16 +1,12 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.Page
-import com.rasterfoundry.datamodel._
+import com.rasterfoundry.common.datamodel._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -1,65 +1,62 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.common.datamodel._
-
+import com.rasterfoundry.database.util.Page
+import com.rasterfoundry.datamodel._
 import doobie._
 import doobie.implicits._
+import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import cats._
+import cats.data._
+import cats.effect.IO
 import cats.implicits._
 
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 
 import java.util.UUID
 
-object ProjectScenesDao extends Dao[Scene] {
-  val tableName = "scenes_to_projects INNER JOIN scenes ON scene_id = id"
+object ProjectLayerScenesDao extends Dao[Scene] {
+  val tableName =
+    "scenes_to_layers s2l INNER JOIN scenes s ON s2l.scene_id = s.id"
   val selectF = fr"""
       SELECT
-      id, created_at, created_by, modified_at, modified_by, owner,
-          visibility, tags,
-          datasource, scene_metadata, name, tile_footprint,
-          data_footprint, metadata_files, ingest_location, cloud_cover,
-          acquisition_date, sun_azimuth, sun_elevation, thumbnail_status,
-          boundary_status, ingest_status, scene_type FROM""" ++ tableF
+      s.id, s.created_at, s.created_by, s.modified_at, s.modified_by, s.owner,
+          s.visibility, s.tags,
+          s.datasource, s.scene_metadata, s.name, s.tile_footprint,
+          s.data_footprint, s.metadata_files, s.ingest_location, s.cloud_cover,
+          s.acquisition_date, s.sun_azimuth, s.sun_elevation, s.thumbnail_status,
+          s.boundary_status, s.ingest_status, s.scene_type FROM""" ++ tableF
 
-  def listProjectScenes(
-      projectId: UUID,
+  def listLayerScenes(
+      layerId: UUID,
       pageRequest: PageRequest,
       sceneParams: CombinedSceneQueryParams
   ): ConnectionIO[PaginatedResponse[Scene.ProjectScene]] = {
 
-    val projectQuery = ProjectDao.query.filter(projectId).select
+    val layerQuery = ProjectLayerDao.query.filter(layerId).select
     val andPendingF: Fragment = sceneParams.sceneParams.pending match {
       case Some(true) => fr"accepted = false"
       case _          => fr"accepted = true"
     }
 
-    // we don't need to specify NULLS LAST for scene_order ASC,
-    // since it is the default when sorting ASC,
     val manualOrder = Map(
       "scene_order" -> Order.Asc,
       "acquisition_date" -> Order.Asc,
       "cloud_cover" -> Order.Asc
     )
-    val autoOrder =
-      Map("acquisition_date" -> Order.Asc, "cloud_cover" -> Order.Asc)
     val filterQ = query
-      .filter(fr"project_id = ${projectId}")
+      .filter(fr"project_layer_id = ${layerId}")
       .filter(andPendingF)
       .filter(sceneParams)
 
     val paginatedScenes = for {
-      project <- projectQuery
-      page <- project.manualOrder match {
-        case true => filterQ.page(pageRequest, manualOrder)
-        case _    => filterQ.page(pageRequest, autoOrder)
-      }
+      layer <- layerQuery
+      page <- filterQ.page(pageRequest, manualOrder)
     } yield page
     paginatedScenes.flatMap { (pr: PaginatedResponse[Scene]) =>
-      scenesToProjectScenes(pr.results.toList, projectId).map(
+      scenesToProjectScenes(pr.results.toList, layerId).map(
         projectScenes =>
           PaginatedResponse[Scene.ProjectScene](
             pr.count,
@@ -77,13 +74,13 @@ object ProjectScenesDao extends Dao[Scene] {
   @SuppressWarnings(Array("TraversableHead"))
   def scenesToProjectScenes(
       scenes: List[Scene],
-      projectId: UUID
+      layerId: UUID
   ): ConnectionIO[List[Scene.ProjectScene]] = {
     // "The astute among you will note that we don’t actually need a monad to do this;
     // an applicative functor is all we need here."
     // let's roll, doobie
     val componentsIO: ConnectionIO[
-      (List[Thumbnail], List[Datasource], List[SceneToProject])
+      (List[Thumbnail], List[Datasource], List[SceneToLayer])
     ] = {
       val thumbnails = SceneWithRelatedDao.getScenesThumbnails(scenes map {
         _.id
@@ -91,23 +88,20 @@ object ProjectScenesDao extends Dao[Scene] {
       val datasources = SceneWithRelatedDao.getScenesDatasources(scenes map {
         _.datasource
       })
-      val sceneToProjects = SceneWithRelatedDao.getSceneToProjects(scenes map {
+      val sceneToLayers = SceneWithRelatedDao.getScenesToLayers(scenes map {
         _.id
-      }, projectId)
-      (thumbnails, datasources, sceneToProjects).tupled
+      }, layerId)
+      (thumbnails, datasources, sceneToLayers).tupled
     }
 
     componentsIO map {
-      case (thumbnails, datasources, sceneToProjects) => {
+      case (thumbnails, datasources, sceneToLayers) => {
         val groupedThumbs = thumbnails.groupBy(_.sceneId)
         scenes map { scene: Scene =>
           scene.projectSceneFromComponents(
             groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail]),
             datasources.filter(_.id == scene.datasource).head,
-            sceneToProjects
-              .find(_.sceneId == scene.id)
-              .map(_.sceneOrder)
-              .flatten
+            sceneToLayers.find(_.sceneId == scene.id).map(_.sceneOrder).flatten
           )
         }
       }

--- a/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
@@ -111,6 +111,20 @@ object SceneWithRelatedDao
         List.empty[SceneToProject].pure[ConnectionIO]
     }
 
+  def getScenesToLayers(
+      sceneIds: List[UUID],
+      layerId: UUID
+  ): ConnectionIO[List[SceneToLayer]] =
+    sceneIds.toNel match {
+      case Some(ids) =>
+        SceneToLayerDao.query
+          .filter(Fragments.in(fr"scene_id", ids))
+          .filter(fr"project_layer_id=$layerId")
+          .list
+      case _ =>
+        List.empty[SceneToLayer].pure[ConnectionIO]
+    }
+
   // We know the datasources list head exists because of the foreign key relationship
   @SuppressWarnings(Array("FilterDotHead", "TraversableHead"))
   def scenesToSceneBrowse(

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -200,6 +200,21 @@ trait Filterables extends RFMeta with LazyLogging {
           )
     }
 
+  implicit val projectSceneQueryParameters
+    : Filterable[Any, ProjectSceneQueryParameters] =
+    Filterable[Any, ProjectSceneQueryParameters] { params =>
+      List(
+        params.ingested.map({
+          case true => fr"ingest_status = 'INGESTED'"
+          case _    => fr"ingest_status != 'INGESTED'"
+        }),
+        params.ingestStatus.toList.toNel.map({ statuses =>
+          Fragments.in(fr"ingest_status",
+                       statuses.map(IngestStatus.fromString(_)))
+        })
+      )
+    }
+
   implicit val mapTokenQueryParametersFilter
     : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -1,21 +1,15 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.datamodel._
-import com.rasterfoundry.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.common.datamodel._
+import com.rasterfoundry.common.datamodel.Generators.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import org.scalacheck.Prop.{forAll, exists}
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.sql.Timestamp
-import java.time.LocalDate
 
 class ProjectLayerDatasourceDaoSpec
     extends FunSuite
@@ -32,8 +26,7 @@ class ProjectLayerDatasourceDaoSpec
             project: Project.Create,
             scenes: List[Scene.Create],
             dsCreate: Datasource.Create,
-            page: PageRequest,
-            csq: CombinedSceneQueryParams
+            page: PageRequest
         ) =>
           {
             val scenesInsertWithUserProjectIO = for {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -1,0 +1,91 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.datamodel.Generators.Implicits._
+import com.rasterfoundry.database.Implicits._
+
+import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+
+import doobie._, doobie.implicits._
+import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import org.scalacheck.Prop.{forAll, exists}
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import java.sql.Timestamp
+import java.time.LocalDate
+
+class ProjectLayerDatasourceDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+  test("list datasources for a project layer") {
+    check {
+      forAll {
+        (
+            user: User.Create,
+            org: Organization.Create,
+            project: Project.Create,
+            scenes: List[Scene.Create],
+            dsCreate: Datasource.Create,
+            page: PageRequest,
+            csq: CombinedSceneQueryParams
+        ) =>
+          {
+            val scenesInsertWithUserProjectIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              datasource <- DatasourceDao.create(
+                dsCreate.toDatasource(dbUser),
+                dbUser
+              )
+              scenesInsert <- (scenes map {
+                fixupSceneCreate(dbUser, datasource, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+            } yield (scenesInsert, dbUser, dbProject, datasource)
+
+            val datasourceListIO = scenesInsertWithUserProjectIO flatMap {
+              case (
+                  dbScenes: List[Scene.WithRelated],
+                  dbUser: User,
+                  dbProject: Project,
+                  datasource: Datasource
+                  ) => {
+                ProjectDao.addScenesToProject(
+                  dbScenes map { _.id },
+                  dbProject.id
+                ) flatMap { _ =>
+                  {
+                    ProjectLayerDatasourcesDao.listProjectLayerDatasources(
+                      dbProject.id,
+                      dbProject.defaultLayerId
+                    ) map { datasources: List[Datasource] =>
+                      (List(datasource), datasources)
+                    }
+                  }
+                }
+              }
+            }
+
+            val (insertedDatasources, listedDatasources) =
+              xa.use(t => datasourceListIO.transact(t)).unsafeRunSync
+            val insertedIds = insertedDatasources.toSet map {
+              (datasource: Datasource) =>
+                datasource.id
+            }
+            val listedIds = listedDatasources.toSet map {
+              (datasource: Datasource) =>
+                datasource.id
+            }
+            insertedIds == listedIds
+          }
+      }
+    }
+  }
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -66,7 +66,7 @@ class ProjectLayerDatasourceDaoSpec
                       dbProject.id,
                       dbProject.defaultLayerId
                     ) map { datasources: List[Datasource] =>
-                      (List(datasource), datasources)
+                      (dbScenes.map { _.datasource }, datasources)
                     }
                   }
                 }
@@ -76,13 +76,15 @@ class ProjectLayerDatasourceDaoSpec
             val (insertedDatasources, listedDatasources) =
               xa.use(t => datasourceListIO.transact(t)).unsafeRunSync
             val insertedIds = insertedDatasources.toSet map {
-              (datasource: Datasource) =>
+              (datasource: Datasource.Thin) =>
                 datasource.id
             }
+            // println(insertedDatasources)
             val listedIds = listedDatasources.toSet map {
               (datasource: Datasource) =>
                 datasource.id
             }
+            // println(listedIds)
             insertedIds == listedIds
           }
       }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerScenesDaoSpec.scala
@@ -1,0 +1,94 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.datamodel.Generators.Implicits._
+import com.rasterfoundry.database.Implicits._
+
+import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+
+import doobie._, doobie.implicits._
+import cats._, cats.data._, cats.effect.IO
+import cats.implicits._
+import doobie.postgres._, doobie.postgres.implicits._
+import org.scalacheck.Prop.{forAll, exists}
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import java.sql.Timestamp
+import java.time.LocalDate
+
+class LayerScenesDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+  test("list scenes for a project layer") {
+    check {
+      forAll {
+        (
+            user: User.Create,
+            org: Organization.Create,
+            project: Project.Create,
+            scenes: List[Scene.Create],
+            dsCreate: Datasource.Create,
+            page: PageRequest,
+            csq: CombinedSceneQueryParams
+        ) =>
+          {
+            val scenesInsertWithUserProjectIO = for {
+              orgUserProject <- insertUserOrgProject(user, org, project)
+              (dbOrg, dbUser, dbProject) = orgUserProject
+              datasource <- DatasourceDao.create(
+                dsCreate.toDatasource(dbUser),
+                dbUser
+              )
+              scenesInsert <- (scenes map {
+                fixupSceneCreate(dbUser, datasource, _)
+              }).traverse(
+                (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
+              )
+            } yield (scenesInsert, dbUser, dbProject)
+
+            val scenesListIO = scenesInsertWithUserProjectIO flatMap {
+              case (
+                  dbScenes: List[Scene.WithRelated],
+                  dbUser: User,
+                  dbProject: Project
+                  ) => {
+                ProjectDao.addScenesToProject(
+                  dbScenes map { _.id },
+                  dbProject.id
+                ) flatMap { _ =>
+                  {
+                    ProjectLayerScenesDao.listLayerScenes(
+                      dbProject.defaultLayerId,
+                      page,
+                      csq
+                    ) map {
+                      (paginatedResponse: PaginatedResponse[
+                        Scene.ProjectScene
+                      ]) =>
+                        (dbScenes, paginatedResponse.results)
+                    }
+                  }
+                }
+              }
+            }
+
+            val (insertedScenes, listedScenes) =
+              xa.use(t => scenesListIO.transact(t)).unsafeRunSync
+            val insertedIds = insertedScenes.toSet map {
+              (scene: Scene.WithRelated) =>
+                scene.id
+            }
+            val listedIds = listedScenes.toSet map {
+              (scene: Scene.ProjectScene) =>
+                scene.id
+            }
+            insertedIds == listedIds
+          }
+      }
+    }
+  }
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerScenesDaoSpec.scala
@@ -1,21 +1,15 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.datamodel._
-import com.rasterfoundry.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.common.datamodel._
+import com.rasterfoundry.common.datamodel.Generators.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import org.scalacheck.Prop.{forAll, exists}
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.sql.Timestamp
-import java.time.LocalDate
 
 class LayerScenesDaoSpec
     extends FunSuite
@@ -33,12 +27,12 @@ class LayerScenesDaoSpec
             scenes: List[Scene.Create],
             dsCreate: Datasource.Create,
             page: PageRequest,
-            csq: CombinedSceneQueryParams
+            csq: ProjectSceneQueryParameters
         ) =>
           {
             val scenesInsertWithUserProjectIO = for {
               orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) = orgUserProject
               datasource <- DatasourceDao.create(
                 dsCreate.toDatasource(dbUser),
                 dbUser


### PR DESCRIPTION
## Overview

This PR adds a few endpoints to handle requests for scenes within project layers. They function similarly to their project level analogs.

- `GET /projects/{projectId}/layers/{layerId}/scenes` to get a list of scenes within a layer
- `PUT /projects/{projectId}/layers/{layerId}/scenes` to replace the list of scenes within a layer
- `POST /projects/{projectId}/layers/{layerId}/scenes` to add scenes to a layer
- `DELETE /projects/{projectId}/layers/{layerId}/scenes` to remove scenes from a layer
- `GET /projects/{projectId}/layers/{layerId}/scenes/datasources` to get a list of distinct datasources for the scenes within a layer

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Notes

The spec is being updated in another task that involves ensuring it is correct for all layer routes.

## Testing Instructions

 * Test each of the new routes using something like curl, postman, etc.
 * See tests ran successfully in CI

Closes #4520 