### PR TITLE
Rewrite all project mosaic routes to project layer routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added `SceneToLayer` data model and `SceneToLayerDao`; updated related function calls in `ProjectDao` and project api [\#4513](https://github.com/raster-foundry/raster-foundry/pull/4513)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s. [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)
 - Allow sharing most objects when you have edit permissions granted to you [\#4514](https://github.com/raster-foundry/raster-foundry/pull/4514)
-- Added TMS route for project layers [\#4523](https://github.com/raster-foundry/raster-foundry/pull/4523)
+- Added TMS, quick export, and histogram routes for project layers [\#4523](https://github.com/raster-foundry/raster-foundry/pull/4523), [\#4553](https://github.com/raster-foundry/raster-foundry/pull/4553)
 - Added project, project layer, and template ID fields to tool runs for later filtering [\#4546](https://github.com/raster-foundry/raster-foundry/pull/4546)
 - Added project layer mosaic and scene order endpoint [\#4547](https://github.com/raster-foundry/raster-foundry/pull/4547)
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -114,10 +114,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
   val mosaicService: HttpRoutes[IO] =
     authenticators.tokensAuthMiddleware(
       AuthedAutoSlash(
-        new MosaicService(SceneToProjectDao(),
-                          SceneToLayerDao(),
-                          mosaicImplicits,
-                          xa).routes))
+        new MosaicService(SceneToLayerDao(), mosaicImplicits, xa).routes))
 
   val analysisService: HttpRoutes[IO] =
     authenticators.tokensAuthMiddleware(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -25,10 +25,7 @@ import com.rasterfoundry.common.utils.TileUtils
 import doobie.util.transactor.Transactor
 import geotrellis.vector.{Polygon, Projected}
 
-class MosaicService[ProjStore: ProjectStore,
-                    LayerStore: ProjectStore,
-                    HistStore: HistogramStore](
-    projects: ProjStore,
+class MosaicService[LayerStore: ProjectStore, HistStore: HistogramStore](
     layers: LayerStore,
     mosaicImplicits: MosaicImplicits[HistStore],
     xa: Transactor[IO])(implicit cs: ContextShift[IO],
@@ -75,10 +72,12 @@ class MosaicService[ProjStore: ProjectStore,
               }
             } yield resp
 
-          case GET -> Root / UUIDWrapper(projectId) / "histogram" as user =>
+          case GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+                layerId) / "histogram" :? BandOverrideQueryParamDecoder(
+                overrides) as user =>
             for {
               authFiber <- authorizers.authProject(user, projectId).start
-              mosaic = projects.read(projectId, None, None, None)
+              mosaic = layers.read(layerId, None, overrides, None)
               histFiber <- LayerHistogram.identity(mosaic, 4000).start
               _ <- authFiber.join.handleErrorWith { error =>
                 histFiber.cancel *> IO.raiseError(error)
@@ -93,7 +92,8 @@ class MosaicService[ProjStore: ProjectStore,
               }
             } yield resp
 
-          case authedReq @ POST -> Root / UUIDWrapper(projectId) / "histogram"
+          case authedReq @ POST -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+                layerId) / "histogram"
                 :? BandOverrideQueryParamDecoder(overrides) as user =>
             // Compile to a byte array, decode that as a string, and do something with the results
             authedReq.req.body.compile.to[Array] flatMap { uuids =>
@@ -103,10 +103,7 @@ class MosaicService[ProjStore: ProjectStore,
                 case Right(uuids) =>
                   for {
                     authFiber <- authorizers.authProject(user, projectId).start
-                    mosaic = projects.read(projectId,
-                                           None,
-                                           overrides,
-                                           uuids.toNel)
+                    mosaic = layers.read(layerId, None, overrides, uuids.toNel)
                     histFiber <- LayerHistogram.identity(mosaic, 4000).start
                     _ <- authFiber.join.handleErrorWith { error =>
                       histFiber.cancel *> IO.raiseError(error)
@@ -118,11 +115,17 @@ class MosaicService[ProjStore: ProjectStore,
                     }
                   } yield resp
                 case _ =>
-                  BadRequest("Could not decode body as sequence of UUIDs")
+                  BadRequest(
+                    """
+                    | Could not decode body as sequence of UUIDs.
+                    | Format should be, e.g.,
+                    | ["342a82e2-a5c1-4b35-bb6b-0b9dd6a52fa7", "8f3bb3fc-4bd6-49e8-9b25-6fa075cc0c77
+"]""".trim.stripMargin)
               }
             }
 
-          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "export"
+          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+                layerId) / "export"
                 :? ExtentQueryParamMatcher(extent)
                 :? ZoomQueryParamMatcher(zoom)
                 :? BandOverrideQueryParamDecoder(bandOverride) as user =>
@@ -132,16 +135,16 @@ class MosaicService[ProjStore: ProjectStore,
               .get(CaseInsensitiveString("Accept")) match {
               case Some(Header(_, "image/tiff")) =>
                 LayerExtent.identity(
-                  projects.read(projectId,
-                                Some(Projected(projectedExtent, 3857)),
-                                bandOverride,
-                                None))(rawMosaicExtentReification, cs)
+                  layers.read(layerId,
+                              Some(Projected(projectedExtent, 3857)),
+                              bandOverride,
+                              None))(rawMosaicExtentReification, cs)
               case _ =>
                 LayerExtent.identity(
-                  projects.read(projectId,
-                                Some(Projected(projectedExtent, 3857)),
-                                bandOverride,
-                                None))(paintedMosaicExtentReification, cs)
+                  layers.read(layerId,
+                              Some(Projected(projectedExtent, 3857)),
+                              bandOverride,
+                              None))(paintedMosaicExtentReification, cs)
             }
             for {
               authFiber <- authorizers.authProject(user, projectId).start


### PR DESCRIPTION
## Overview

This PR rewrites the rest of the mosaic routes to use layers instead of projects.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

This will also include some work on getting the project histograms visualizing in the frontend again, since that's been broken for a while and is a really easy way to confirm that the endpoint still "works" in a backwards compatible way (I think it's been broken since backsplash, but possibly longer, since COG histograms didn't exist in the previous tile server).

## Testing Instructions

 * `backsplash-server/assembly` in sbt
 * browse scenes in a project to get a nice bounding box inside its bounds
 * get a token
 * `http :8081/<project id>/export zoom==9 bbox==<your bbox> token==<your token without Bearer> > img.png`
 * `http :8081/<project id>/export zoom==9 bbox==<your bbox> token==<your token without Bearer> Accept:image/tiff > img.tiff`
 * view your png and tiff and confirm they look ok
 * go to advanced color correction and mess with the histogram

Closes #4518 