### PR TITLE
Add restart: always to Nexus Docker Compose service

### DIFF
--- a/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.jenkins/tasks/main.yml
@@ -83,10 +83,10 @@
   changed_when: False
 
 - name: Setup weekly Coursier cleanup cron task
-   cron:
-     name: "coursier-cleanup"
-     user: "root"
-     special_time: "weekly"
-     job: find /var/lib/jenkins/workspace/ -path "*/.coursier/*" -delete
-     state: "present"
-   changed_when: False
+  cron:
+    name: "coursier-cleanup"
+    user: "root"
+    special_time: "weekly"
+    job: find /var/lib/jenkins/workspace/ -path "*/.coursier/*" -delete
+    state: "present"
+  changed_when: False

--- a/deployment/ansible/roles/raster-foundry.nexus/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.nexus/tasks/main.yml
@@ -34,7 +34,7 @@
             - "{{ nexus_http_port }}:8081"
           volumes:
             - "/opt/nexus-data:/nexus-data"
-          restart: on-failure
+          restart: always
           logging:
             driver: syslog
             options:


### PR DESCRIPTION
## Overview

Add `restart: always` to Nexus Docker Compose service.

I had already tried this solution before, but it looks like I was running the playbook against the internal Nexus instance by mistake, rather than the Raster Foundry Jenkins instance.

Fixes https://github.com/azavea/raster-foundry-platform/issues/607

## Testing Instructions

Execute the playbook and restart the EC2 instance:

```bash
$ ansible-playbook \
  -i deployment/ansible/inventory \
  -K deployment/ansible/raster-foundry-jenkins.yml \
  --key-file=~/.ssh/raster-foundry-stg.pem
```

```bash
$ ssh rfjenkins
ubuntu@ip-172-31-52-80:~$ sudo reboot now
```

See that the Docker Compose service came back up:

```bash
$ ssh rfjenkins
ubuntu@ip-172-31-52-80:~$ docker ps
CONTAINER ID        IMAGE                    COMMAND                  CREATED             STATUS              PORTS                    NAMES
33112a2ed5dc        sonatype/nexus3:3.13.0   "sh -c ${SONATYPE_DI…"   19 minutes ago      Up 12 minutes       0.0.0.0:8081->8081/tcp   nexus_nexus-server_1
```