### PR TITLE
Set project id on new project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Added
 - Templates can now be shared and filtered by ownership [\#4357](https://github.com/raster-foundry/raster-foundry/pull/4357)
-- Added ProjectLayer datamodel, dao, and migration [\#4460]https://github.com/raster-foundry/raster-foundry/pull/4460()\
+- Added ProjectLayer datamodel, dao, and migration [\#4460](https://github.com/raster-foundry/raster-foundry/pull/4460)
 - Added lambda function for reactively processing new Landsat 8 imagery [\#4471](https://github.com/raster-foundry/raster-foundry/pull/4471)
 - Added lambda function for reactively processing new Sentinel-2 imagery [\#4491](https://github.com/raster-foundry/raster-foundry/pull/4491)
 - Added a migration that creates relationship among projects, project layers, and scenes and populates corresponding tables. Updated associated data models and `Dao`s [\#4479](https://github.com/raster-foundry/raster-foundry/pull/4479)

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -64,7 +64,8 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
       modified_at = ${updateTime},
       name = ${projectLayer.name},
       color_group_hex = ${projectLayer.colorGroupHex},
-      geometry = ${projectLayer.geometry}
+      geometry = ${projectLayer.geometry},
+      project_id = ${projectLayer.projectId}
     """ ++ Fragments.whereAndOpt(Some(idFilter))).update
     query
   }


### PR DESCRIPTION
## Overview

This PR allows updating project id on project layers. If you can't update project id, you can't associate a project layer with a project after you make the project. If you can't associate project layers with projects, the join from projects to project layers returns no rows. If the join from projects to project layers returns no rows, the join from the join to scenes to layers returns no rows, so you can't have any imagery served for project layers, which is a drag, because that's where imagery comes from.

:train:
 
### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible (not for this, but not a necessary changelog item, since it it's a fix to something that doesn't exist yet)
- ~Any new SQL strings have tests~ (no currently existing `ProjectLayerDaoSpec`)

## Testing Instructions

 * create a new project
 * add a scene to it (it can be already ingested, it doesn't matter)
 * you should get tiles