### PR TITLE
Use blessed openjdk gdal container + upgrade requests

### DIFF
--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-slim
+FROM quay.io/azavea/openjdk-gdal:2.3-jdk8-slim
 
 ENV SPARK_VERSION 2.1.0
 ENV HADOOP_VERSION 2.7
@@ -7,8 +7,6 @@ ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
 COPY rf/requirements.txt /tmp/
 RUN set -ex \
     && gdalDeps=' \
-       gdal-bin/sid \
-       python-gdal/sid \
        python-pip \
        python-setuptools \
        python-dev \
@@ -16,7 +14,7 @@ RUN set -ex \
        build-essential \
        imagemagick \
     ' \
-    && echo 'deb http://http.us.debian.org/debian sid main non-free contrib' > /etc/apt/sources.list.d/sid.list \
+    && echo 'deb http://http.us.debian.org/debian main non-free contrib' > /etc/apt/sources.list.d/sid.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends ${gdalDeps} wget \
     && pip install --no-cache-dir \

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -14,7 +14,6 @@ RUN set -ex \
        build-essential \
        imagemagick \
     ' \
-    && echo 'deb http://http.us.debian.org/debian main non-free contrib' > /etc/apt/sources.list.d/sid.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends ${gdalDeps} wget \
     && pip install --no-cache-dir \

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -14,3 +14,4 @@ click==6.7
 dropbox==9.0.0
 rasterfoundry==0.7.1
 psycopg2-binary==2.7.6
+requests==2.16.2


### PR DESCRIPTION
## Overview

This PR fixes problems with missing `_gdal_array` in gdal 2.4.0, which is what the debian sid repo upgraded to recently. As a result, it fixes some import problems, specifically around MODIS, but possibly in other cases as well.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * rebuild batch container
 * bring up ur servers
 * create a MODIS upload (add a MODIS scene to a project from the CMR)
 * `rf process-upload <that upload id>` from the batch container
 * it should work

Closes #4561 