### PR TITLE
Fix landsat historical local paths construction

### DIFF
--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -126,7 +126,7 @@ def process_to_cog(prefix, gcs_prefix, landsat_id, config):
         'COG': os.path.join(prefix, cog_fname),
         'STACKED': os.path.join(prefix, stacked_fname)
     }
-    local_paths = sorted(glob.glob('/{}/{}*.TIF'.format(prefix, landsat_id)))
+    local_paths = sorted(glob.glob('{}/{}*.TIF'.format(prefix, landsat_id)))
     warped_paths = cog.warp_tifs(local_paths, prefix)
     merged = cog.merge_tifs(warped_paths, prefix)
     cog.add_overviews(merged)


### PR DESCRIPTION
## Overview

This PR makes it so that we try to read from `/tmp/...` instead of `//tmp/...` for locally downloaded historical landsat imagery.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ no changelog based on this morning's discussion of "bugs that didn't make it to prod"

### Notes

Unclear why this ever worked -- maybe changing the container got us different behavior on repeated `/`es to start a filename?

## Testing Instructions

 * create an upload for a Landsat 7 scene and for a Landsat 4/5 scene
 * process them
 * the process should complete successfully