### PR TITLE
Add project layer creation workflow on UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Added project, project layer, and template ID fields to tool runs for later filtering [\#4546](https://github.com/raster-foundry/raster-foundry/pull/4546) and to API routes as filter fields [\#4551](https://github.com/raster-foundry/raster-foundry/pull/4551)
 - Added project layer mosaic and scene order endpoint [\#4547](https://github.com/raster-foundry/raster-foundry/pull/4547)
 - Add Layer ID to Annotations and Annotation Groups [\#4558](https://github.com/raster-foundry/raster-foundry/pull/4558)
+- Added project layer creation workflow's modal on UI [\#4575](https://github.com/raster-foundry/raster-foundry/pull/4575)
 
 ### Changed
 - Reorganized project structure to simplify dependency graph (`tool` was mostly removed; `tool`s still-relevant pieces, `bridge`, and `datamodel` moved into the project `common`) [\#4564](https://github.com/raster-foundry/raster-foundry/pull/4564)

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -1,5 +1,5 @@
 <div class="sidebar-actions-group">
-  <button class="btn btn-small btn-transparent">
+  <button class="btn btn-small btn-transparent" ng-click="$ctrl.showNewLayerModal()">
     <i class="icon-plus"></i> New Layer
   </button>
   <div style="flex: 1;"></div>

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -230,6 +230,19 @@ class ProjectLayersPageController {
             map.setLayer('Project Layers', mapLayers, true);
         });
     }
+
+    showNewLayerModal() {
+        const modal = this.modalService.open({
+            component: 'rfProjectLayerCreateModal',
+            resolve: {
+                projectId: () => this.project.id
+            }
+        });
+
+        modal.result
+            .then(() => this.fetchPage())
+            .catch(() => {});
+    }
 }
 
 const component = {

--- a/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.html
+++ b/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.html
@@ -1,1 +1,77 @@
-modal goes here
+<div class="modal-scrollable-body modal-sidebar-header">
+  <div class="modal-header">
+    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.close()">
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title">
+      New Layer
+    </h4>
+    <p>Group imagery together</p>
+  </div>
+
+  <div class="modal-body">
+    <div class="modal-inner-container small">
+      <div class="content">
+        <div ng-if="$ctrl.isCreatingLayerError">
+          <h5 class="error color-danger">There was an error creating this project layer.</h5>
+          <button type="button"
+                  class="btn btn-primary"
+                  ng-click="$ctrl.resetModal()">
+            Try again
+          </button>
+        </div>
+        <form name="projectLayerCreate" autocomplete="off" ng-if="!$ctrl.isCreatingLayerError">
+          <h5 class="modal-content-header-thin">
+            Layer name
+            <span class="error color-danger" ng-show="projectLayerCreate.layerName.$error.required">
+              (required)
+            </span>
+          </h5>
+          <div class="form-group all-in-one">
+            <input class="form-control"
+                   id="layerName"
+                   name="layerName"
+                   type="text"
+                   placeholder="My custom layer name"
+                   ng-model="$ctrl.projectLayerCreateBuffer.name"
+                   required>
+          </div>
+          <h5 class="modal-content-header-thin">Color</h5>
+          <div class="form-group all-in-one">
+            <input class="form-control color-picker"
+                   type="color"
+                   id="color"
+                   ng-init="$ctrl.projectLayerCreateBuffer.colorGroupHex"
+                   ng-model="$ctrl.projectLayerCreateBuffer.colorGroupHex">
+          </div>
+          <h5 class="modal-content-header-thin">Layer type</h5>
+          <div class="form-group all-in-one">
+            <select class="form-control">
+              <option value="standard">Standard layer</option>
+              <option value="smart" ng-if="$ctrl.showSmartLayerOption">Smart layer</option>
+            </select>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal-footer">
+    <div class="footer-section left">
+      <button type="button"
+              class="btn"
+              ng-disabled="$ctrl.isCreatingLayer"
+              ng-click="$ctrl.dismiss()">
+        Close
+      </button>
+    </div>
+    <div class="footer-section right">
+      <button type="button"
+              class="btn btn-primary"
+              ng-click="$ctrl.createProjectLayer()"
+              ng-disabled="$ctrl.isCreateDisabled()">
+        Create
+      </button>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.js
+++ b/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.js
@@ -14,11 +14,61 @@ const ProjectLayerCreateModalComponent = {
 
 class ProjectLayerCreateModalController {
     constructor(
+        $rootScope, $log,
+        projectService
     ) {
         'ngInject';
+        $rootScope.autoInject(this, arguments);
     }
 
     $onInit() {
+        this.showSmartLayerOption = false;
+        this.setProjectLayerCreate();
+    }
+
+    setProjectLayerCreate() {
+        this.projectLayerCreate = {
+            name: '',
+            projectId: this.resolve.projectId,
+            colorGroupHex: '#4da687'
+        };
+        this.projectLayerCreateBuffer = Object.assign({}, this.projectLayerCreate);
+    }
+
+    resetModal() {
+        this.isCreatingLayer = false;
+        this.isCreatingLayerError = false;
+        this.projectLayerCreateBuffer = Object.assign({}, this.projectLayerCreate);
+    }
+
+    isCreateDisabled() {
+        return !(this.projectLayerCreateBuffer.name &&
+            this.projectLayerCreateBuffer.name.length) ||
+            this.isCreatingLayer ||
+            this.isCreatingLayerError;
+    }
+
+    createProjectLayer() {
+        this.isCreatingLayer = true;
+        this.isCreatingLayerError = false;
+
+        this.projectService
+            .createProjectLayer(this.resolve.projectId, this.projectLayerCreateBuffer)
+            .then(createdProjectLayer => {
+                this.isCreatingLayerError = false;
+                this.projectLayerCreate = Object.assign(
+                    this.projectLayerCreate,
+                    this.projectLayerCreateBuffer
+                );
+                this.close({$value: createdProjectLayer});
+            })
+            .catch(err => {
+                this.isCreatingLayerError = true;
+                this.$log.error(err);
+            })
+            .finally(() => {
+                this.isCreatingLayer = false;
+            });
     }
 }
 

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -178,6 +178,13 @@ export default (app) => {
                             projectId: '@projectId'
                         }
                     },
+                    createLayer: {
+                        method: 'POST',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/layers`,
+                        params: {
+                            projectId: '@projectId'
+                        }
+                    },
                     deleteLayer: {
                         method: 'DELETE',
                         url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/layers/:layerId`,
@@ -599,6 +606,10 @@ export default (app) => {
 
         getProjectLayers(projectId, params = {}) {
             return this.Project.listLayers({...params, projectId}).$promise;
+        }
+
+        createProjectLayer(projectId, params = {}) {
+            return this.Project.createLayer({projectId}, params).$promise;
         }
 
         deleteProjectLayer(projectId, layerId) {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -727,6 +727,10 @@ rf-box-select-item{
   margin: 0 0 2rem 0;
 }
 
+.modal-content-header-thin {
+  margin: 0 0 1rem 0;
+}
+
 .list-group-item.no-flex {
   display: block;
 }
@@ -3270,4 +3274,8 @@ rf-project-layers-page {
         border-radius: 3px;
         margin: .25em;
     }
+}
+
+.form-control.color-picker {
+  cursor: pointer;
 }


### PR DESCRIPTION
## Overview

This PR adds project layer creation workflow (the modal part) for UI of the project layers list page.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

<img width="1406" alt="screen shot 2019-02-01 at 5 02 54 pm" src="https://user-images.githubusercontent.com/16109558/52152269-d0d82000-2643-11e9-8375-7ca1a694a049.png">

<img width="1519" alt="screen shot 2019-02-01 at 5 05 01 pm" src="https://user-images.githubusercontent.com/16109558/52152272-d59cd400-2643-11e9-886b-4c1c8d9de5f7.png">


### Notes

The second UI in the original issue #4541 is moved to another one, which is reflected in the issue comment.


## Testing Instructions

 * Go to `http://localhost:9091/v2/project/<project ID>/layers`
 * Click on `+ New Layer` and use the modal to create a new project layer. Make sure it works.
 * Click on `+ New Layer`, fill in the form in the modal, stop the dev server, click on create, make sure that it shows the second screenshot in the demo section. Click on `Try again` will bring you to the modal with a clean state.

Closes #4541 