### PR TITLE
Prevent serializing null tokens in query parameters

### DIFF
--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -47,10 +47,11 @@ export default class ShareController {
     }
 
     addProjectLayer() {
-        let url = this.projectService.getProjectTileURL(
-            this.project,
-            {token: this.authService.token()}
-        );
+        // Only set query parameters if token is present to prevent serializing a null
+        // token as a string in query parameters
+        let token = this.authService.token();
+        let queryParameters = token ? {token: token} : null;
+        let url = this.projectService.getProjectTileURL(this.project, queryParameters);
         let layer = L.tileLayer(url, {maxZoom: 30});
 
         this.getMap().then(m => {


### PR DESCRIPTION
## Overview

`null` token query parameters were being serialized as `token=null`, which the backend was correctly returning a 401 since `null` is not a valid token. This change fixes that by passing in `null` for query parameters if a token is not present - so no query parameter is sent at all

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/898060/52223586-f5b2da00-2873-11e9-8725-3ac0374b96ef.png)

## Testing Instructions

 * Open a project, go to publish options, make it public
 * Copy "Published Page" URL and open in incognito, tiles should load

Closes #4576
