### PR TITLE
Use scalafix to remove a ton of things we don't need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Removed unused imports and assignments [\#4579](https://github.com/raster-foundry/raster-foundry/pull/4579)
 - Included geometry filter in backsplash scene service to prevent erroneous 500s [\#4580](https://github.com/raster-foundry/raster-foundry/pull/4580)
 
 ### Security

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -143,7 +143,7 @@ trait Authentication extends Directives with LazyLogging {
                                            user: User)
         // All users will have a platform role, either added by a migration or created with the user if they are new
         val query = for {
-          (_, roles) <- UserDao.getUserAndActiveRolesById(userId).flatMap {
+          (user, roles) <- UserDao.getUserAndActiveRolesById(userId).flatMap {
             case UserOptionAndRoles(Some(user), roles) =>
               (user, roles).pure[ConnectionIO]
             case UserOptionAndRoles(None, _) =>

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -8,7 +8,6 @@ import akka.http.scaladsl.server.AuthenticationFailedRejection.CredentialsReject
 import akka.http.scaladsl.server._
 import cats.effect.IO
 import cats.implicits._
-import cats.data._
 import com.guizmaii.scalajwt.{ConfigurableJwtValidator, JwtToken}
 import com.nimbusds.jose.jwk.source.{JWKSource, RemoteJWKSet}
 import com.nimbusds.jose.proc.SecurityContext
@@ -18,7 +17,6 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 import scala.concurrent.Future
@@ -145,13 +143,12 @@ trait Authentication extends Directives with LazyLogging {
                                            user: User)
         // All users will have a platform role, either added by a migration or created with the user if they are new
         val query = for {
-          userAndRoles <- UserDao.getUserAndActiveRolesById(userId).flatMap {
+          (_, roles) <- UserDao.getUserAndActiveRolesById(userId).flatMap {
             case UserOptionAndRoles(Some(user), roles) =>
               (user, roles).pure[ConnectionIO]
             case UserOptionAndRoles(None, _) =>
               createUserWithRoles(userId, email, name, picture, jwtClaims)
           }
-          (user, roles) = userAndRoles
           platformRole = roles.find(role =>
             role.groupType == GroupType.Platform)
           plat <- platformRole match {
@@ -264,8 +261,7 @@ trait Authentication extends Directives with LazyLogging {
       newUserWithRoles <- {
         UserDao.createUserWithJWT(systemUser, jwtUser)
       }
-      (newUser, roles) = newUserWithRoles
-    } yield (newUser, roles)
+    } yield newUserWithRoles
   }
 
   /**

--- a/app-backend/akkautil/src/main/scala/CommonHandlers.scala
+++ b/app-backend/akkautil/src/main/scala/CommonHandlers.scala
@@ -3,14 +3,12 @@ package com.rasterfoundry.akkautil
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{RequestContext, RouteResult}
 import akka.http.scaladsl.server.{StandardRoute, ExceptionHandler}
-import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.directives.{
   RouteDirectives,
   FutureDirectives,
   CompleteOrRecoverWithMagnet
 }
 import io.circe._
-import cats.syntax.show
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}

--- a/app-backend/akkautil/src/main/scala/MalformedContentRejectionHandler.scala
+++ b/app-backend/akkautil/src/main/scala/MalformedContentRejectionHandler.scala
@@ -5,8 +5,6 @@ import akka.http.scaladsl.model._
 import StatusCodes._
 import Directives._
 
-import scala.util.matching.Regex
-
 object RFRejectionHandler {
   implicit val rfRejectionHandler: RejectionHandler = RejectionHandler
     .newBuilder()

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -11,16 +11,9 @@ import com.rasterfoundry.akkautil.RFRejectionHandler._
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.database.util.RFTransactor
 
-import scala.util.Try
-import doobie.hikari._
-import doobie.hikari.implicits._
-import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
 
 object AkkaSystem {
   implicit val system = ActorSystem("rf-system")

--- a/app-backend/api/src/main/scala/aoi/Routes.scala
+++ b/app-backend/api/src/main/scala/aoi/Routes.scala
@@ -13,13 +13,9 @@ import akka.http.scaladsl.server.Route
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import cats.effect.IO
-import cats.implicits._
 import com.rasterfoundry.database.filter.Filterables._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 import java.util.UUID
 

--- a/app-backend/api/src/main/scala/categories/Routes.scala
+++ b/app-backend/api/src/main/scala/categories/Routes.scala
@@ -7,18 +7,12 @@ import com.rasterfoundry.database.filter.Filterables._
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import cats.effect.IO
 
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
-
-import scala.util.{Success, Failure}
 
 trait ToolCategoryRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/config/Routes.scala
+++ b/app-backend/api/src/main/scala/config/Routes.scala
@@ -2,17 +2,12 @@ package com.rasterfoundry.api.config
 
 import akka.http.scaladsl.server.Route
 import cats.effect.IO
-import com.rasterfoundry.api.Codec._
 import com.rasterfoundry.akkautil.{Authentication, CommonHandlers}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.util.transactor.Transactor
-import io.circe._
 import io.circe.generic.auto._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 trait ConfigRoutes extends CommonHandlers with Authentication {
   val xa: Transactor[IO]

--- a/app-backend/api/src/main/scala/datasource/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/datasource/QueryParameters.scala
@@ -1,10 +1,5 @@
 package com.rasterfoundry.api.datasource
 
-import java.util.UUID
-
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.queryparams._
 

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -12,18 +12,13 @@ import com.rasterfoundry.database.filter.Filterables._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.{PaginationDirectives, PageRequest}
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import cats.effect.IO
 
 import java.util.UUID
-import scala.util.{Success, Failure}
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 trait DatasourceRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -17,7 +17,6 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe._
 

--- a/app-backend/api/src/main/scala/exports/package.scala
+++ b/app-backend/api/src/main/scala/exports/package.scala
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.sql.Timestamp
 import java.util.Date
 
-import com.amazonaws.services.s3.AmazonS3URI
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.common.S3
 import com.rasterfoundry.common.datamodel.{Export, ExportOptions, User}

--- a/app-backend/api/src/main/scala/featureflags/Routes.scala
+++ b/app-backend/api/src/main/scala/featureflags/Routes.scala
@@ -7,19 +7,13 @@ import com.rasterfoundry.akkautil.{
   UserErrorHandler
 }
 import com.rasterfoundry.database.FeatureFlagDao
-import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import java.util.UUID
 
 import cats.effect.IO
 import doobie.util.transactor.Transactor
-import com.rasterfoundry.database.filter.Filterables._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 /**
   * Routes for FeatureFlag overrides

--- a/app-backend/api/src/main/scala/feed/Routes.scala
+++ b/app-backend/api/src/main/scala/feed/Routes.scala
@@ -3,10 +3,8 @@ package com.rasterfoundry.api.feed
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.unmarshalling._
-import com.lonelyplanet.akka.http.extensions.PageRequest
 import com.typesafe.scalalogging.LazyLogging
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import akka.http.scaladsl.server.Directives._

--- a/app-backend/api/src/main/scala/healthcheck/Routes.scala
+++ b/app-backend/api/src/main/scala/healthcheck/Routes.scala
@@ -4,16 +4,12 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server._
 import cats.effect.IO
 import com.rasterfoundry.akkautil.Authentication
-import com.rasterfoundry.api.Codec._
 import com.rasterfoundry.common.RollbarNotifier
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.util.transactor.Transactor
 import org.postgresql.util.PSQLException
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 /**
   * Routes for healthchecks -- additional routes for individual healthchecks

--- a/app-backend/api/src/main/scala/license/LicenseRoutes.scala
+++ b/app-backend/api/src/main/scala/license/LicenseRoutes.scala
@@ -8,18 +8,13 @@ import com.rasterfoundry.akkautil.{
 import com.rasterfoundry.database.LicenseDao
 import akka.http.scaladsl.server.Route
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 import cats.effect.IO
 import doobie.util.transactor.Transactor
 import com.rasterfoundry.database.filter.Filterables._
-import com.rasterfoundry.common.datamodel._
-import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 trait LicenseRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -12,7 +12,6 @@ import com.rasterfoundry.akkautil.{
   UserErrorHandler
 }
 import com.rasterfoundry.database._
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 import doobie.util.transactor.Transactor
@@ -21,11 +20,6 @@ import com.rasterfoundry.common.datamodel._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments
-import doobie.postgres._
-import doobie.postgres.implicits._
-
-import scala.concurrent.Future
 
 trait MapTokenRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/organization/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/organization/QueryParameters.scala
@@ -1,8 +1,5 @@
 package com.rasterfoundry.api.organization
 
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.queryparams._
 

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -7,24 +7,18 @@ import com.rasterfoundry.akkautil.{
 }
 import com.rasterfoundry.database.OrganizationDao
 import com.rasterfoundry.database.filter.Filterables._
-import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.Config
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import java.util.UUID
 
 import cats.effect.IO
 
 import doobie.util.transactor.Transactor
-import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 trait OrganizationRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/platform/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/platform/QueryParameters.scala
@@ -1,8 +1,5 @@
 package com.rasterfoundry.api.platform
 
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.queryparams._
 

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -9,8 +9,7 @@ import com.rasterfoundry.database.{
   PlatformDao,
   OrganizationDao,
   TeamDao,
-  UserDao,
-  UserGroupRoleDao
+  UserDao
 }
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.filter.Filterables._
@@ -20,17 +19,10 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import cats.effect.IO
 import cats.implicits._
-import cats.syntax._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import io.circe._
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
 
 import java.util.UUID
 

--- a/app-backend/api/src/main/scala/project/AnnotationShapefileService.scala
+++ b/app-backend/api/src/main/scala/project/AnnotationShapefileService.scala
@@ -22,10 +22,9 @@ import org.geotools.feature.simple.{
   SimpleFeatureBuilder,
   SimpleFeatureTypeBuilder
 }
-import org.geotools.referencing.{CRS => geotoolsCRS}
+import org.geotools.referencing.{CRS => _}
 import org.geotools.referencing.crs.DefaultGeographicCRS
 import org.opengis.feature.simple.SimpleFeature
-import org.opengis.referencing.crs.CoordinateReferenceSystem
 import better.files._
 
 import java.util.{HashMap => JHashMap}
@@ -39,7 +38,7 @@ object AnnotationShapefileService extends LazyLogging with Config {
 
     val featureCollection = new DefaultFeatureCollection()
     annotationFeatures.foreach(feature => {
-      val x = featureCollection.add(feature)
+      featureCollection.add(feature)
     })
 
     val zipfile = File.newTemporaryFile("export", ".zip")

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -28,7 +28,6 @@ import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.shapefile.ShapeFileReader
 import io.circe.generic.JsonCodec

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -7,7 +7,6 @@ import akka.http.scaladsl.server.Route
 import cats.data._
 import cats.effect.IO
 import cats.implicits._
-import java.net.URLDecoder
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.common.utils.CogUtils
 import com.rasterfoundry.common.{AWSBatch, S3}
@@ -22,7 +21,6 @@ import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.raster.{IntArrayTile, MultibandTile}
 import geotrellis.raster.histogram.Histogram

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -10,7 +10,6 @@ import cats.effect.IO
 import cats.implicits._
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
 import com.rasterfoundry.akkautil._
-import com.rasterfoundry.common._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.ShapeDao
 import com.rasterfoundry.common.datamodel.GeoJsonCodec._
@@ -19,7 +18,6 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.shapefile.ShapeFileReader

--- a/app-backend/api/src/main/scala/tags/Routes.scala
+++ b/app-backend/api/src/main/scala/tags/Routes.scala
@@ -10,18 +10,14 @@ import com.rasterfoundry.common.datamodel._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
-import scala.util.{Failure, Success}
 import java.util.UUID
 
 import cats.effect.IO
 import com.rasterfoundry.database.filter.Filterables._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 trait ToolTagRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/team/Routes.scala
+++ b/app-backend/api/src/main/scala/team/Routes.scala
@@ -6,12 +6,9 @@ import com.rasterfoundry.akkautil.{
   UserErrorHandler
 }
 import com.rasterfoundry.database._
-import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.common.datamodel._
 import akka.http.scaladsl.server.Route
-import akka.http.scaladsl.model.StatusCodes
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import java.util.UUID
 
@@ -19,12 +16,8 @@ import cats.data.OptionT
 import cats.effect.IO
 
 import doobie.util.transactor.Transactor
-import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 /**
   * Routes for Organizations

--- a/app-backend/api/src/main/scala/thumbnail/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/thumbnail/QueryParameters.scala
@@ -1,11 +1,8 @@
 package com.rasterfoundry.api.thumbnail
 
 import java.util.UUID
-import java.sql.Timestamp
-import java.time.Instant
 
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.{Directive1, Rejection}
 import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
 import com.rasterfoundry.common.datamodel._
 

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -15,7 +15,6 @@ import com.rasterfoundry.akkautil.{
 import com.rasterfoundry.common.S3
 import com.rasterfoundry.common.S3RegionEnum
 import com.lonelyplanet.akka.http.extensions.PaginationDirectives
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 trait ThumbnailRoutes

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.{Authentication, UserErrorHandler}
 import com.rasterfoundry.api.utils.{Auth0ErrorHandler}
 
 import akka.http.scaladsl.server.Route
-import io.circe._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 
 /**

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -1,11 +1,7 @@
 package com.rasterfoundry.api.toolrun
 
 import com.rasterfoundry.akkautil._
-import com.rasterfoundry.common._
-import com.rasterfoundry.common.ast._
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.common.ast.MapAlgebraAST
-import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._
 import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.database.ToolRunDao
 
@@ -18,12 +14,8 @@ import cats.effect.IO
 import doobie.util.transactor.Transactor
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 import java.util.UUID
-import scala.concurrent.ExecutionContext.Implicits.global
 
 trait ToolRunRoutes
     extends Authentication

--- a/app-backend/api/src/main/scala/tools/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/tools/QueryParameters.scala
@@ -1,8 +1,5 @@
 package com.rasterfoundry.api.tool
 
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.queryparams._
 

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -1,14 +1,12 @@
 package com.rasterfoundry.api.tool
 
 import com.rasterfoundry.akkautil._
-import com.rasterfoundry.common._
 import com.rasterfoundry.common.ast._
 import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.database.ToolDao
 
-import io.circe._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Route
 import cats.implicits._
@@ -17,9 +15,6 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import cats.effect.IO
 import doobie._
 import doobie.implicits._
-import doobie.Fragments.in
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 import java.util.UUID
 

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -17,7 +17,6 @@ import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, PaginationDirectives}
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 trait UploadRoutes

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -5,20 +5,15 @@ import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, GenericHttpCredentials}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import cats.effect.IO
 import com.rasterfoundry.api.utils.{
   Auth0Exception,
   Config,
   ManagementBearerToken
 }
-import com.rasterfoundry.database.UserDao
 import com.rasterfoundry.common.datamodel.User
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-import doobie._
-import doobie.implicits._
-import doobie.postgres.implicits._
 import io.circe._
 import io.circe.generic.JsonCodec
 import io.circe.syntax._

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -18,7 +18,6 @@ import com.lonelyplanet.akka.http.extensions.PaginationDirectives
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 
 import scala.collection.JavaConverters._
@@ -101,7 +100,6 @@ trait UserRoutes
 
   def getDropboxAccessToken: Route = authenticate { user =>
     entity(as[DropboxAuthRequest]) { dbxAuthRequest =>
-      val redirectURI = dbxAuthRequest.redirectURI
       val (dbxKey, dbxSecret) =
         (sys.env.get("DROPBOX_KEY"), sys.env.get("DROPBOX_SECRET")) match {
           case (Some(key), Some(secret)) => (key, secret)

--- a/app-backend/api/src/main/scala/user/package.scala
+++ b/app-backend/api/src/main/scala/user/package.scala
@@ -1,5 +1,3 @@
 package com.rasterfoundry.api
 
-import com.rasterfoundry.common.datamodel._
-
 package object user

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.api.utils.queryparams
 
-import com.rasterfoundry.api._
 import com.rasterfoundry.common.datamodel._
 
 import akka.http.scaladsl.server.Directives._

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -5,13 +5,11 @@ import java.net.URLDecoder
 import com.rasterfoundry.backsplash.color._
 import geotrellis.vector.{io => _, _}
 import geotrellis.raster.{io => _, _}
-import geotrellis.raster.histogram._
 import geotrellis.raster.resample.NearestNeighbor
 import geotrellis.spark.SpatialKey
 import geotrellis.proj4.WebMercator
 import geotrellis.server.vlm.RasterSourceUtils
 import geotrellis.contrib.vlm.geotiff.GeoTiffRasterSource
-import io.circe.syntax._
 import java.util.UUID
 
 import com.typesafe.scalalogging.LazyLogging

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -4,7 +4,6 @@ import geotrellis.vector._
 import geotrellis.raster.histogram._
 import geotrellis.server._
 
-
 import cats.implicits._
 import cats.data.{NonEmptyList => _}
 import cats.data.Validated._

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -1,18 +1,12 @@
 package com.rasterfoundry.backsplash
 
 import geotrellis.vector._
-import geotrellis.raster._
 import geotrellis.raster.histogram._
-import geotrellis.raster.resample.NearestNeighbor
-import geotrellis.proj4.CRS
 import geotrellis.server._
 
-import com.azavea.maml.ast._
-import com.azavea.maml.eval._
 
-import cats._
 import cats.implicits._
-import cats.data.{NonEmptyList => NEL}
+import cats.data.{NonEmptyList => _}
 import cats.data.Validated._
 import cats.effect._
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -4,23 +4,17 @@ import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.HistogramStore.ToHistogramStoreOps
 
-import geotrellis.proj4.{LatLng, WebMercator}
+import geotrellis.proj4.WebMercator
 import geotrellis.vector._
 import geotrellis.raster._
 import geotrellis.raster.histogram._
 import geotrellis.raster.reproject._
-import geotrellis.raster.resample.NearestNeighbor
-import geotrellis.proj4.CRS
 import geotrellis.server._
 import com.azavea.maml.ast._
-import com.azavea.maml.eval._
-import cats._
 import cats.implicits._
 import cats.data.{NonEmptyList => NEL}
-import cats.data.Validated._
 import cats.effect._
 import scalacache._
-import scalacache.caffeine._
 import scalacache.memoization._
 import scalacache.CatsEffect.modes._
 import ProjectStore._
@@ -30,7 +24,6 @@ import HasRasterExtents._
 import TmsReification._
 import com.typesafe.scalalogging.LazyLogging
 
-import java.util.UUID
 
 class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
     extends ToTmsReificationOps

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -24,7 +24,6 @@ import HasRasterExtents._
 import TmsReification._
 import com.typesafe.scalalogging.LazyLogging
 
-
 class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
     extends ToTmsReificationOps
     with ToExtentReificationOps

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.backsplash
 
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.color.{Implicits => ColorImplicits}
 
 import com.azavea.maml.ast.Expression
@@ -12,7 +11,6 @@ import geotrellis.raster._
 import geotrellis.vector._
 import geotrellis.server._
 import cats.effect._
-import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 
 sealed trait PaintableTool extends ColorImplicits with LazyLogging {

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ProjectStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ProjectStore.scala
@@ -1,10 +1,7 @@
 package com.rasterfoundry.backsplash
 
 import cats.data.{NonEmptyList => NEL}
-import cats.effect._
-import com.azavea.maml.ast._
 import geotrellis.vector.{Polygon, Projected}
-import geotrellis.server._
 import simulacrum._
 
 import java.util.UUID

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorCorrect.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorCorrect.scala
@@ -2,7 +2,6 @@ package com.rasterfoundry.backsplash.color
 
 import io.circe.generic.JsonCodec
 import geotrellis.raster._
-import geotrellis.raster.equalization.HistogramEqualization
 import geotrellis.raster.histogram.Histogram
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.math3.util.FastMath

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
@@ -6,7 +6,6 @@ import geotrellis.raster.{io => _, _}
 import geotrellis.raster.render._
 import geotrellis.raster.render.png._
 import io.circe.{Decoder, Encoder, KeyEncoder, KeyDecoder}
-import io.circe.generic.semiauto._
 
 import scala.math.abs
 import scala.util.Try

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -2,15 +2,11 @@ package com.rasterfoundry.backsplash.error
 
 import cats._
 import cats.data._
-import cats.effect._
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import org.http4s._
 import org.http4s.dsl._
-import org.http4s.dsl.io._
-import org.http4s.implicits._
 
-import java.lang.IllegalArgumentException
 
 sealed trait BacksplashException extends Exception
 // When there's something wrong with stored metadata for the calculations we'd like to do

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -7,7 +7,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.http4s._
 import org.http4s.dsl._
 
-
 sealed trait BacksplashException extends Exception
 // When there's something wrong with stored metadata for the calculations we'd like to do
 final case class MetadataException(message: String) extends BacksplashException

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -7,7 +7,7 @@ import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.backsplash.color.{Implicits => ColorImplicits}
 
 import cats.data.Validated._
-import cats.effect.{ContextShift, IO, Fiber}
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.{io => _, _}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -4,8 +4,6 @@ import cats._
 import cats.data._
 import cats.implicits._
 import org.http4s._
-import org.http4s.server._
-import org.http4s.server.middleware._
 
 /** Removes a trailing slash from [[Request]] path
   *

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
@@ -1,12 +1,9 @@
 package com.rasterfoundry.backsplash.server
 
 import org.http4s._
-import org.http4s.server._
-import org.http4s.server.middleware._
 
 import cats._
 import cats.data._
-import cats.implicits._
 
 /** Removes the given prefix from the beginning of the path of the [[Request]].
   */

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authenticators.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authenticators.scala
@@ -1,15 +1,13 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash.Parameters._
-import com.rasterfoundry.database.{MapTokenDao, ProjectDao, UserDao}
+import com.rasterfoundry.database.{MapTokenDao, ProjectDao}
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.{MapToken, Project, User, Visibility}
 import com.rasterfoundry.{http4s => RFHttp4s}
 
 import cats.data._
 import cats.effect.IO
-import cats.implicits._
-import com.typesafe.config.ConfigFactory
 import doobie.ConnectionIO
 import doobie.implicits._
 import org.http4s._
@@ -18,13 +16,8 @@ import org.http4s.server._
 import org.http4s.util.CaseInsensitiveString
 import com.typesafe.scalalogging.LazyLogging
 import doobie.util.transactor.Transactor
-import scalacache.memoization._
-import scalacache.CatsEffect.modes._
-import scalacache.Flags
 
-import java.net.URL
 import java.util.UUID
-import scala.concurrent.duration._
 
 class Authenticators(val xa: Transactor[IO])
     extends LazyLogging

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -8,14 +8,11 @@ import com.rasterfoundry.database.{
   SceneDao,
   ToolRunDao
 }
-import com.rasterfoundry.database.util.RFTransactor
 
 import cats.effect._
 import doobie.Transactor
 import doobie.implicits._
 import com.typesafe.scalalogging.LazyLogging
-import scalacache._
-import scalacache.caffeine._
 import scalacache.memoization._
 import scalacache.CatsEffect.modes._
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -6,8 +6,6 @@ import com.rasterfoundry.http4s.{Cache => Http4sUtilCache}
 import com.typesafe.scalalogging.LazyLogging
 import scalacache._
 import scalacache.caffeine._
-import scalacache.memoization._
-import scalacache.CatsEffect.modes._
 
 object Cache extends LazyLogging {
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -8,7 +8,6 @@ import com.typesafe.scalalogging.LazyLogging
 import doobie.util.invariant.InvariantViolation
 import org.http4s._
 import org.http4s.dsl._
-import org.http4s.dsl.io._
 import java.lang.IllegalArgumentException
 
 class ForeignErrorHandler[F[_], E <: Throwable, U](implicit M: MonadError[F, E])

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HealthcheckService.scala
@@ -3,14 +3,11 @@ package com.rasterfoundry.backsplash.server
 import com.rasterfoundry.backsplash.Cache.tileCache
 
 import cats._
-import cats.data._
 import cats.effect._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import io.circe.Json
 import org.http4s._
-import org.http4s.circe._
 import org.http4s.dsl._
 import scalacache.modes.sync._
 import sup._

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HistogramStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/HistogramStoreImplicits.scala
@@ -7,12 +7,8 @@ import com.rasterfoundry.database.LayerAttributeDao
 import doobie.Transactor
 import geotrellis.raster.histogram._
 import geotrellis.raster.io.json._
-import geotrellis.spark.LayerId
 
 import java.util.UUID
-
-import spray.json._
-import DefaultJsonProtocol._
 
 trait HistogramStoreImplicits
     extends ToHistogramStoreOps

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -4,47 +4,29 @@ import com.rasterfoundry.database.{
   LayerAttributeDao,
   SceneDao,
   SceneToLayerDao,
-  SceneToProjectDao,
   ToolRunDao
 }
 import com.rasterfoundry.common.datamodel.User
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.MosaicImplicits
-import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.database.util.RFTransactor
 
-import cats.Applicative
 import cats.data.OptionT
-import cats.data.Validated._
 import cats.effect._
 import cats.implicits._
 import com.olegpy.meow.hierarchy._
-import fs2.Stream
-import geotrellis.proj4.{LatLng, WebMercator}
-import geotrellis.raster.io.geotiff.MultibandGeoTiff
-import geotrellis.server._
-import io.circe._
-import io.circe.syntax._
 import org.http4s._
-import org.http4s.circe._
-import org.http4s.dsl.io._
-import org.http4s.headers._
 import org.http4s.server.middleware.{AutoSlash, CORS, CORSConfig, Timeout}
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.Router
 import org.http4s.syntax.kleisli._
-import org.http4s.util.CaseInsensitiveString
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.typesafe.scalalogging.LazyLogging
-import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 import java.util.concurrent.{Executors, TimeUnit}
-import java.util.UUID
 
 object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
 
@@ -73,7 +55,6 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
   )
 
   val projectStoreImplicits = new ProjectStoreImplicits(xa)
-  import projectStoreImplicits.projectStore
 
   val timeout: FiniteDuration =
     new FiniteDuration(Config.server.timeoutSeconds, TimeUnit.SECONDS)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -4,17 +4,11 @@ import com.rasterfoundry.database.SceneToProjectDao
 import com.rasterfoundry.common.ast.{MapAlgebraAST, NodeMetadata}
 import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.error._
-import com.rasterfoundry.database.util.RFTransactor
 
 import com.azavea.maml.ast._
 import com.azavea.maml.util.{NeighborhoodConversion, ClassMap => MamlClassMap}
-import geotrellis.vector.io._
-import cats._
 import cats.effect.IO
-import cats.implicits._
-import doobie.implicits._
 import doobie.util.transactor.Transactor
-import io.circe.Json
 
 class BacksplashMamlAdapter[HistStore: HistogramStore](
     mosaicImplicits: MosaicImplicits[HistStore],

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -6,10 +6,8 @@ import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.common.utils.TileUtils
 
-import cats.Applicative
-import cats.data.{NonEmptyList => NEL}
 import cats.data.Validated._
-import cats.effect.{ContextShift, Fiber, IO}
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.io.geotiff.MultibandGeoTiff

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -5,8 +5,6 @@ import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.{SceneDao, SceneToLayerDao, SceneToProjectDao}
-import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel.MosaicDefinition
 import com.rasterfoundry.common.datamodel.color.{
   BandGamma => RFBandGamma,

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -5,6 +5,7 @@ import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.{SceneDao, SceneToLayerDao, SceneToProjectDao}
+import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.MosaicDefinition
 import com.rasterfoundry.common.datamodel.color.{
   BandGamma => RFBandGamma,

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
@@ -7,7 +7,6 @@ import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.common.datamodel.User
 import com.rasterfoundry.common.utils.TileUtils
 
-import cats.Applicative
 import cats.data.Validated._
 import cats.effect._
 import cats.implicits._
@@ -16,8 +15,6 @@ import geotrellis.server._
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers._
-
-import java.util.UUID
 
 class SceneService[ProjStore: ProjectStore, HistStore: HistogramStore](
     scenes: ProjStore,

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -1,12 +1,9 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash._
-import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
-import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.ToolRunDao
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.ast.MapAlgebraAST
 import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -1,24 +1,13 @@
 package com.rasterfoundry.backsplash
 
-import com.rasterfoundry.database.ToolRunDao
-import com.rasterfoundry.database.util.RFTransactor
-
-import cats.effect.IO
-import doobie.implicits._
-import geotrellis.raster.{io => _, Tile}
 import geotrellis.raster.io._
 import geotrellis.raster.histogram._
-import geotrellis.raster.render._
-import geotrellis.raster.render.png._
 import geotrellis.raster.summary._
 import io.circe.{Encoder, Json, KeyEncoder}
 import io.circe.generic.semiauto._
 import io.circe.parser._
 import io.circe.syntax._
 import spray.json._
-import DefaultJsonProtocol._
-
-import java.util.UUID
 
 package object server {
 

--- a/app-backend/batch/src/main/scala/Job.scala
+++ b/app-backend/batch/src/main/scala/Job.scala
@@ -3,10 +3,7 @@ package com.rasterfoundry.batch
 import com.rasterfoundry.batch.util.conf.Config
 import com.rasterfoundry.common.RollbarNotifier
 
-import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
 import cats.effect._
-import cats.implicits._
 
 import scala.concurrent.forkjoin.ForkJoinPool
 

--- a/app-backend/batch/src/main/scala/SparkJob.scala
+++ b/app-backend/batch/src/main/scala/SparkJob.scala
@@ -1,8 +1,6 @@
 package com.rasterfoundry.batch
 
-import com.rasterfoundry.common.RollbarNotifier
-
-import cats.effect.{IO, Resource, IOApp, ExitCode}
+import cats.effect.{IO, Resource, IOApp}
 
 import org.apache.spark._
 

--- a/app-backend/batch/src/main/scala/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/aoi/FindAOIProjects.scala
@@ -7,7 +7,6 @@ import com.rasterfoundry.database.util.RFTransactor
 
 import cats.effect.IO
 import cats.syntax.option._
-import com.typesafe.scalalogging.LazyLogging
 import doobie.implicits._
 import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor

--- a/app-backend/batch/src/main/scala/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/aoi/UpdateAOIProject.scala
@@ -1,9 +1,8 @@
 package com.rasterfoundry.batch.aoi
 
 import com.rasterfoundry.batch.Job
-import com.rasterfoundry.batch.util._
 import com.rasterfoundry.batch.util.conf.Config
-import com.rasterfoundry.common.{AWSBatch, RollbarNotifier}
+import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.notification.Email.NotificationEmail
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database._
@@ -14,7 +13,6 @@ import cats.effect.IO
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import doobie.util.transactor.Transactor

--- a/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
@@ -3,28 +3,18 @@ package com.rasterfoundry.batch.cogMetadata
 import com.rasterfoundry.batch.Job
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.utils.CogUtils
-import com.rasterfoundry.common.datamodel.{
-  LayerAttribute,
-  Scene,
-  SceneType,
-  TiffWithMetadata
-}
+import com.rasterfoundry.common.datamodel.{LayerAttribute, TiffWithMetadata}
 import com.rasterfoundry.database.util.RFTransactor
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.{LayerAttributeDao, SceneDao}
 
-import cats.data._
-import cats.effect.{ExitCode, IO, IOApp}
-import cats.syntax._
+import cats.effect.IO
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.io.json.HistogramJsonFormats
 import io.circe.parser._
-import io.circe.syntax._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 

--- a/app-backend/batch/src/main/scala/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/export/CreateExportDef.scala
@@ -14,7 +14,6 @@ import cats.effect.IO
 import cats.implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
 

--- a/app-backend/batch/src/main/scala/export/UpdateExportStatus.scala
+++ b/app-backend/batch/src/main/scala/export/UpdateExportStatus.scala
@@ -9,7 +9,6 @@ import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 
-import com.typesafe.scalalogging.LazyLogging
 import cats.effect.IO
 import cats.implicits._
 import doobie.{ConnectionIO, Transactor}

--- a/app-backend/batch/src/main/scala/landsat8/ImportLandsat8.scala
+++ b/app-backend/batch/src/main/scala/landsat8/ImportLandsat8.scala
@@ -1,11 +1,9 @@
 package com.rasterfoundry.batch.landsat8
 
 import com.rasterfoundry.batch.Job
-import com.rasterfoundry.batch.util._
 import com.rasterfoundry.batch.util.conf.Config
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.{S3, S3RegionString}
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 
 import cats.effect.IO

--- a/app-backend/batch/src/main/scala/landsat8/ImportLandsat8C1.scala
+++ b/app-backend/batch/src/main/scala/landsat8/ImportLandsat8C1.scala
@@ -7,7 +7,6 @@ import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.{S3, S3RegionString}
 import com.rasterfoundry.common.utils.AntimeridianUtils
 import com.rasterfoundry.database._
-import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 
@@ -23,9 +22,6 @@ import io.circe.syntax._
 import geotrellis.proj4.CRS
 import geotrellis.vector._
 
-import scala.collection.parallel.ForkJoinTaskSupport
-import scala.collection.parallel.immutable.ParSeq
-import scala.concurrent.forkjoin.ForkJoinPool
 import scala.sys.process._
 import java.io.File
 import java.time.{LocalDate, ZoneOffset}

--- a/app-backend/batch/src/main/scala/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/notification/NotifyIngestStatus.scala
@@ -8,7 +8,6 @@ import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.{PlatformDao, ProjectDao, SceneDao}
 import com.rasterfoundry.common.datamodel._
-import com.typesafe.scalalogging.LazyLogging
 
 import cats.effect.IO
 import cats.implicits._

--- a/app-backend/batch/src/main/scala/sentinel2/ImportSentinel2.scala
+++ b/app-backend/batch/src/main/scala/sentinel2/ImportSentinel2.scala
@@ -7,14 +7,12 @@ import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.utils.AntimeridianUtils
 import com.rasterfoundry.common.{S3, S3RegionString}
 import com.rasterfoundry.database._
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import cats.implicits._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
 import io.circe._
@@ -27,7 +25,6 @@ import java.net.URI
 import java.security.InvalidParameterException
 import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 import java.util.UUID
-import java.util.concurrent.Executors
 
 final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(
                                    ZoneOffset.UTC))(implicit xa: Transactor[IO])
@@ -175,11 +172,6 @@ final case class ImportSentinel2(startDate: LocalDate = LocalDate.now(
     val correctedDataFootprint = AntimeridianUtils.correctDataFootprint(
       intersects,
       dataFootprint,
-      sentinel2Config.targetProjCRS
-    )
-    val correctedTileFootprint = AntimeridianUtils.correctTileFootprint(
-      intersects,
-      tileFootprint,
       sentinel2Config.targetProjCRS
     )
     val awsBase = s"https://${sentinel2Config.bucketName}.s3.amazonaws.com"

--- a/app-backend/batch/src/main/scala/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/stac/ReadStacFeature.scala
@@ -261,7 +261,6 @@ object ReadStacFeature extends Config with LazyLogging {
       val thumb = ImageIO.read(getStream(new URI(link.href), rootUri))
       // create thumbnail
       val width = thumb.getWidth
-      val height = thumb.getHeight
       Some(
         Thumbnail.Identified(
           id = None,

--- a/app-backend/batch/src/main/scala/util/HadoopConfiguration.scala
+++ b/app-backend/batch/src/main/scala/util/HadoopConfiguration.scala
@@ -20,6 +20,4 @@ final case class HadoopConfiguration(var conf: Configuration)
     conf.readFields(in)
   }
 
-  private def readObjectNoData(): Unit =
-    conf = new Configuration()
 }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -69,7 +69,8 @@ lazy val commonSettings = Seq(
   autoCompilerPlugins := true,
   addCompilerPlugin(
     "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-  addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
+  addCompilerPlugin(scalafixSemanticdb), // enable SemanticDB
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4")
 ) ++ publishSettings
 
 lazy val noPublishSettings = Seq(
@@ -257,7 +258,6 @@ lazy val db = Project("db", file("db"))
     )
   })
   .settings(
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4")
   )
 
 lazy val migrations = Project("migrations", file("migrations"))
@@ -361,7 +361,6 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
       Dependencies.catsMeow
     ),
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
-    addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
     addCompilerPlugin(
       "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   )
@@ -392,7 +391,6 @@ lazy val backsplashServer = Project("backsplash-server",
     )
   })
   .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))
-  .settings(addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"))
   .settings(assemblyMergeStrategy in assembly := {
     case m if m.toLowerCase.endsWith("manifest.mf")     => MergeStrategy.discard
     case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard
@@ -422,4 +420,3 @@ lazy val http4sUtil = Project("http4s-util", file("http4s-util"))
     )
   })
   .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))
-  .settings(addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"))

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -32,8 +32,10 @@ lazy val commonSettings = Seq(
     "-language:experimental.macros",
     "-Xmax-classfile-name",
     "100",
+    "-Yrangepos",
     "-Ywarn-value-discard",
     "-Ywarn-unused",
+    "-Ywarn-unused-import",
     "-Ypartial-unification",
     "-Ypatmat-exhaust-depth",
     "100"
@@ -66,7 +68,8 @@ lazy val commonSettings = Seq(
   // https://www.scala-sbt.org/0.13/docs/Compiler-Plugins.html
   autoCompilerPlugins := true,
   addCompilerPlugin(
-    "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+    addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
 ) ++ publishSettings
 
 lazy val noPublishSettings = Seq(

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -69,7 +69,7 @@ lazy val commonSettings = Seq(
   autoCompilerPlugins := true,
   addCompilerPlugin(
     "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
-    addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
+  addCompilerPlugin(scalafixSemanticdb) // enable SemanticDB
 ) ++ publishSettings
 
 lazy val noPublishSettings = Seq(

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -258,7 +258,7 @@ lazy val db = Project("db", file("db"))
     )
   })
   .settings(
-  )
+    )
 
 lazy val migrations = Project("migrations", file("migrations"))
   .settings(commonSettings: _*)

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -19,7 +19,6 @@ import org.apache.commons.io.IOUtils
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.util.Properties
 import scala.collection.mutable
 
 sealed trait S3Region

--- a/app-backend/common/src/main/scala/ast/ClassMap.scala
+++ b/app-backend/common/src/main/scala/ast/ClassMap.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.common.ast
 
-import io.circe.generic.JsonCodec
 import geotrellis.raster._
 import geotrellis.raster.render._
 import spire.std.any._

--- a/app-backend/common/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
+++ b/app-backend/common/src/main/scala/ast/codec/MapAlgebraUtilityCodecs.scala
@@ -9,7 +9,6 @@ import geotrellis.raster.render._
 import geotrellis.raster.mapalgebra.focal._
 import cats.syntax.either._
 import spray.json._
-import DefaultJsonProtocol._
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.semiauto._

--- a/app-backend/common/src/main/scala/ast/package.scala
+++ b/app-backend/common/src/main/scala/ast/package.scala
@@ -1,18 +1,9 @@
 package com.rasterfoundry.common
 
-import com.rasterfoundry.common.datamodel.{Tool, ToolRun, User}
-
-import geotrellis.raster.render._
-import cats._
-import cats.data._
-import cats.implicits._
-import cats.data.Validated.{Invalid, Valid}
 import io.circe._
 import io.circe.optics.JsonPath._
 
-import java.lang.IllegalArgumentException
 import java.util.UUID
-import scala.concurrent.{ExecutionContext, Future}
 
 package object ast {
 

--- a/app-backend/common/src/main/scala/datamodel/AOI.scala
+++ b/app-backend/common/src/main/scala/datamodel/AOI.scala
@@ -4,7 +4,6 @@ import java.sql.Timestamp
 import java.time.Instant
 import java.util.{Date, UUID}
 
-import geotrellis.vector.{Geometry, Projected}
 import io.circe._
 import io.circe.generic.JsonCodec
 

--- a/app-backend/common/src/main/scala/datamodel/Annotation.scala
+++ b/app-backend/common/src/main/scala/datamodel/Annotation.scala
@@ -5,10 +5,9 @@ import java.util.UUID
 
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
-import com.vividsolutions.jts.{geom => jts}
 import geotrellis.geotools._
 import geotrellis.proj4.{CRS, WebMercator}
-import geotrellis.vector.{Geometry, Projected, io => _, _}
+import geotrellis.vector.{Geometry, Projected, io => _}
 import geotrellis.vector.reproject.Reproject
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras._

--- a/app-backend/common/src/main/scala/datamodel/GeoJSONSerializable.scala
+++ b/app-backend/common/src/main/scala/datamodel/GeoJSONSerializable.scala
@@ -2,8 +2,6 @@ package com.rasterfoundry.common.datamodel
 
 import geotrellis.vector.{Geometry, Projected}
 
-import io.circe.generic.JsonCodec
-
 trait GeoJSONFeature {
   val id: Any
   val properties: Any

--- a/app-backend/common/src/main/scala/datamodel/GroupType.scala
+++ b/app-backend/common/src/main/scala/datamodel/GroupType.scala
@@ -3,8 +3,6 @@ package com.rasterfoundry.common.datamodel
 import io.circe._
 import cats.syntax.either._
 
-import java.util.UUID
-
 sealed abstract class GroupType(val repr: String) {
   override def toString = repr
 }

--- a/app-backend/common/src/main/scala/datamodel/HistogramAttribute.scala
+++ b/app-backend/common/src/main/scala/datamodel/HistogramAttribute.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.common.datamodel
 
-import io.circe.generic.JsonCodec
 import io.circe.generic.semiauto._
 
 case class HistogramAttribute(

--- a/app-backend/common/src/main/scala/datamodel/InputDefinition.scala
+++ b/app-backend/common/src/main/scala/datamodel/InputDefinition.scala
@@ -8,7 +8,6 @@ import com.rasterfoundry.common.ast.MapAlgebraAST
 import geotrellis.vector.MultiPolygon
 import io.circe._
 import io.circe.generic.semiauto._
-import io.circe.parser._
 import io.circe.syntax._
 
 final case class InputDefinition(resolution: Int, style: InputStyle)

--- a/app-backend/common/src/main/scala/datamodel/MosaicDefinition.scala
+++ b/app-backend/common/src/main/scala/datamodel/MosaicDefinition.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.common.datamodel
 
 import com.rasterfoundry.common._
-import geotrellis.vector.{MultiPolygon, Projected}
+import geotrellis.vector.MultiPolygon
 import io.circe.Json
 import io.circe.generic.JsonCodec
 

--- a/app-backend/common/src/main/scala/datamodel/ObjectAccessControlRule.scala
+++ b/app-backend/common/src/main/scala/datamodel/ObjectAccessControlRule.scala
@@ -1,8 +1,5 @@
 package com.rasterfoundry.common.datamodel
 
-import java.sql.Timestamp
-import java.util.UUID
-
 import io.circe.generic.JsonCodec
 
 @JsonCodec

--- a/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
+++ b/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
@@ -1,14 +1,8 @@
 package com.rasterfoundry.common.datamodel
 
-import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
-import cats.syntax.either._
-import geotrellis.vector.io.json.GeoJsonSupport
 import geotrellis.vector.{Geometry, Projected}
-import io.circe._
 import io.circe.generic.JsonCodec
-import io.circe.generic.semiauto._
-import io.circe.syntax._
 
 import java.sql.Timestamp
 import java.util.UUID

--- a/app-backend/common/src/main/scala/datamodel/RenderDefinition.scala
+++ b/app-backend/common/src/main/scala/datamodel/RenderDefinition.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.common.datamodel
 
-import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
 import io.circe.generic.semiauto._

--- a/app-backend/common/src/main/scala/datamodel/SceneToProject.scala
+++ b/app-backend/common/src/main/scala/datamodel/SceneToProject.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.common.datamodel
 
 import geotrellis.vector.{Geometry, Projected}
-import io.circe.generic.JsonCodec
 import io.circe.Json
 
 import java.util.UUID

--- a/app-backend/common/src/main/scala/datamodel/User.scala
+++ b/app-backend/common/src/main/scala/datamodel/User.scala
@@ -111,9 +111,6 @@ final case class User(id: String,
                       isActive: Boolean,
                       visibility: UserVisibility,
                       personalInfo: User.PersonalInfo) {
-  private val rootOrganizationId =
-    UUID.fromString("9e2bef18-3f46-426b-a5bd-9913ee1ff840")
-
   def getDefaultExportSource(export: Export, dataBucket: String): URI =
     new URI(
       s"s3://$dataBucket/user-exports/${URLEncoder.encode(id, "UTF-8")}/${export.id}"

--- a/app-backend/common/src/main/scala/datamodel/WhiteBalance.scala
+++ b/app-backend/common/src/main/scala/datamodel/WhiteBalance.scala
@@ -78,9 +78,6 @@ object WhiteBalance {
 
     type MemoizedFn = Memo[I, K, O]
 
-    implicit def encode(input: MemoizedFn#Input): MemoizedFn#Key =
-      (input._1, input._2, input._3)
-
     def rgbToYuv(rb: Int, gb: Int, bb: Int): YUV = {
       val (r, g, b) = (rb, gb, bb)
       val W_r = 0.299
@@ -150,7 +147,7 @@ object WhiteBalance {
         rgb => {
           val bands =
             rgb.toList.map((i: Int) => if (isData(i)) Some(i) else None)
-          val r :: g :: b :: xs = bands
+          val r :: g :: b :: _ = bands
           val rgbs = (r, g, b)
           val yuv = rgbs match {
             case (Some(rd), Some(gr), Some(bl)) => Some(RgbToYuv(rd, gr, bl))

--- a/app-backend/common/src/main/scala/notification/Email.scala
+++ b/app-backend/common/src/main/scala/notification/Email.scala
@@ -3,7 +3,6 @@ package com.rasterfoundry.common.notification.Email
 import com.rasterfoundry.common.RollbarNotifier
 
 import org.apache.commons.mail._
-import org.apache.commons.mail.Email._
 import org.apache.commons.mail.HtmlEmail
 
 import java.lang.IllegalArgumentException

--- a/app-backend/common/src/main/scala/utils/Antimeridian.scala
+++ b/app-backend/common/src/main/scala/utils/Antimeridian.scala
@@ -67,7 +67,6 @@ object AntimeridianUtils extends LazyLogging {
       inputCRS: CRS,
       outputCRS: CRS): Projected[MultiPolygon] = {
     val latLngFootprint = multi.reproject(inputCRS, LatLng)
-    val antiMeridian = Projected(Line(Point(180, -90), Point(180, 90)), 4326)
     val longitudeShifted = MultiPolygon(
       latLngFootprint.polygons.map(
         poly => Polygon(poly.vertices.map(shiftPoint(_, 0, 1, false, 360)))
@@ -113,7 +112,6 @@ object AntimeridianUtils extends LazyLogging {
                          targetCRS: CRS): Projected[MultiPolygon] = {
 
     val latLngFootprint = multi.reproject(targetCRS, LatLng)
-    val antiMeridian = Projected(Line(Point(180, -90), Point(180, 90)), 4326)
     val longitudeShifted = MultiPolygon(
       latLngFootprint.polygons.map(
         poly => Polygon(poly.vertices.map(shiftPoint(_, 0, 1, false, 360)))

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -5,10 +5,8 @@ import com.rasterfoundry.common.cache.kryo._
 import com.rasterfoundry.common.{Config => CommonConfig}
 import com.rasterfoundry.common.datamodel.TiffWithMetadata
 
-import com.amazonaws.services.s3.AmazonS3URI
 import geotrellis.vector._
 import geotrellis.raster._
-import geotrellis.raster.crop._
 import geotrellis.raster.resample._
 import geotrellis.raster.histogram._
 import geotrellis.raster.reproject._
@@ -17,9 +15,6 @@ import geotrellis.raster.io.geotiff.reader.{GeoTiffReader, TiffTagsReader}
 import geotrellis.util._
 import geotrellis.proj4._
 import geotrellis.spark._
-import geotrellis.spark.io._
-import geotrellis.spark.io.s3._
-import geotrellis.spark.io.s3.util._
 import geotrellis.spark.tiling._
 import geotrellis.vector.Projected
 
@@ -30,7 +25,6 @@ import cats.data._
 import cats.implicits._
 
 import scala.concurrent._
-import java.net.URLDecoder
 
 object CogUtils {
   lazy val cacheConfig = CommonConfig.memcached
@@ -182,9 +176,6 @@ object CogUtils {
           val cellSize = CellSize(tiff.extent, width, height)
           val overview =
             closestTiffOverview(tiff, cellSize, AutoHigherResolution)
-          val overviewRasterCellSize = overview.raster.cellSize
-          val overviewExtentWidth = overview.extent.width
-          val overviewExtentHeight = overview.extent.height
           val normalized = tiff.tile.bandCount match {
             case x if x >= 3 => {
               val tile = Raster(overview.tile, overview.extent).tile

--- a/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
+++ b/app-backend/common/src/main/scala/utils/RangeReaderUtils.scala
@@ -4,7 +4,6 @@ import java.net.{URI, URL}
 import java.nio.charset.Charset
 import java.nio.file.Paths
 
-import com.amazonaws.services.s3.{AmazonS3ClientBuilder, AmazonS3URI}
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.spark.io.http.util.HttpRangeReader
 import geotrellis.spark.io.s3.AmazonS3Client

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/UploadSpec.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/UploadSpec.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.common.datamodel
 
-import io.circe._
 import io.circe.syntax._
 import org.scalatest._
 

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -43,7 +43,8 @@ object AnnotationDao extends Dao[Annotation] {
       .toList
   }
 
-  def listForExport(projectF: Fragment, layerF: Fragment): ConnectionIO[List[Annotation]] =
+  def listForExport(projectF: Fragment,
+                    layerF: Fragment): ConnectionIO[List[Annotation]] =
     AnnotationDao.query.filter(projectF).filter(layerF).list
 
   // list default project layer annotations if exportAll is None or Some(false)
@@ -63,7 +64,8 @@ object AnnotationDao extends Dao[Annotation] {
       )
     } yield { annotations }
 
-  def listForLayerExport(projectId: UUID, layerId: UUID): ConnectionIO[List[Annotation]] =
+  def listForLayerExport(projectId: UUID,
+                         layerId: UUID): ConnectionIO[List[Annotation]] =
     listForExport(fr"project_id=$projectId", fr"project_layer_id=$layerId")
 
   // look for default project layer

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -5,10 +5,8 @@ import java.util.UUID
 import cats.implicits._
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 

--- a/app-backend/db/src/main/scala/AnnotationGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationGroupDao.scala
@@ -97,7 +97,8 @@ object AnnotationGroupDao extends Dao[AnnotationGroup] {
                          agId: UUID): ConnectionIO[Option[AnnotationGroup]] =
     query.filter(fr"project_id = $projectId").filter(agId).selectOption
 
-  def getAnnotationGroupSummaryF(annotationGroupId: UUID, layerId: UUID): Fragment = sql"""
+  def getAnnotationGroupSummaryF(annotationGroupId: UUID,
+                                 layerId: UUID): Fragment = sql"""
     SELECT
         annots.label, jsonb_object_agg(annots.quality, coalesce(counts.count, 0)) as counts
     FROM (
@@ -136,12 +137,15 @@ object AnnotationGroupDao extends Dao[AnnotationGroup] {
   // get annotation group summary by project layer
   // if layerId not provided, look at the default project layer
   def getAnnotationGroupSummary(
-      projectId: UUID, annotationGroupId: UUID, layerIdO: Option[UUID] = None): ConnectionIO[List[LabelSummary]] = {
+      projectId: UUID,
+      annotationGroupId: UUID,
+      layerIdO: Option[UUID] = None): ConnectionIO[List[LabelSummary]] = {
     for {
       project <- ProjectDao.unsafeGetProjectById(projectId)
       layerId = ProjectDao.getProjectLayerId(layerIdO, project)
       summary <- getAnnotationGroupSummaryF(annotationGroupId, layerId)
-        .query[LabelSummary].to[List]
+        .query[LabelSummary]
+        .to[List]
     } yield { summary }
   }
 

--- a/app-backend/db/src/main/scala/AnnotationGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationGroupDao.scala
@@ -3,13 +3,9 @@ package com.rasterfoundry.database
 import java.sql.Timestamp
 import java.util.UUID
 
-import cats.implicits._
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 

--- a/app-backend/db/src/main/scala/AoiDao.scala
+++ b/app-backend/db/src/main/scala/AoiDao.scala
@@ -3,13 +3,11 @@ package com.rasterfoundry.database
 import java.util.UUID
 
 import cats.implicits._
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util._
 import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 

--- a/app-backend/db/src/main/scala/BandDao.scala
+++ b/app-backend/db/src/main/scala/BandDao.scala
@@ -1,23 +1,13 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import doobie.postgres.circe.jsonb.implicits._
-import doobie.Fragments
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
 
-import java.util.UUID
 
 object BandDao extends Dao[Band] {
 

--- a/app-backend/db/src/main/scala/BandDao.scala
+++ b/app-backend/db/src/main/scala/BandDao.scala
@@ -7,8 +7,6 @@ import doobie.implicits._
 import doobie.postgres.implicits._
 import cats.implicits._
 
-
-
 object BandDao extends Dao[Band] {
 
   val tableName = "bands"

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -10,7 +10,6 @@ import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 import doobie.{LogHandler => _, _}
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.util.log._
 import doobie.util.{Read, Write}

--- a/app-backend/db/src/main/scala/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/DatasourceDao.scala
@@ -8,7 +8,6 @@ import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 

--- a/app-backend/db/src/main/scala/ExportDao.scala
+++ b/app-backend/db/src/main/scala/ExportDao.scala
@@ -7,10 +7,8 @@ import com.rasterfoundry.common.ast._
 import cats.implicits._
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 

--- a/app-backend/db/src/main/scala/FeatureFlagDao.scala
+++ b/app-backend/db/src/main/scala/FeatureFlagDao.scala
@@ -5,7 +5,6 @@ import com.rasterfoundry.common.datamodel.FeatureFlag
 import doobie.implicits._
 import doobie.postgres.implicits._
 
-
 object FeatureFlagDao extends Dao[FeatureFlag] {
 
   val tableName = "feature_flags"

--- a/app-backend/db/src/main/scala/FeatureFlagDao.scala
+++ b/app-backend/db/src/main/scala/FeatureFlagDao.scala
@@ -2,11 +2,9 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel.FeatureFlag
 
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie.implicits._
+import doobie.postgres.implicits._
 
-import java.util.UUID
 
 object FeatureFlagDao extends Dao[FeatureFlag] {
 

--- a/app-backend/db/src/main/scala/ImageDao.scala
+++ b/app-backend/db/src/main/scala/ImageDao.scala
@@ -8,7 +8,6 @@ import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 

--- a/app-backend/db/src/main/scala/ImageWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/ImageWithRelatedDao.scala
@@ -1,18 +1,13 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.util.Page
 import com.rasterfoundry.common.datamodel._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
 import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/ImageWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/ImageWithRelatedDao.scala
@@ -8,7 +8,6 @@ import doobie.postgres.circe.jsonb.implicits._
 import cats.data._
 import cats.implicits._
 
-
 import java.util.UUID
 
 import com.rasterfoundry.database.Implicits._

--- a/app-backend/db/src/main/scala/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/LayerAttributeDao.scala
@@ -2,12 +2,10 @@ package com.rasterfoundry.database
 
 import cats.effect.IO
 import cats.implicits._
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.LayerAttribute
 import doobie.Fragments._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import geotrellis.spark.LayerId
@@ -15,10 +13,8 @@ import spray.json._
 import DefaultJsonProtocol._
 import java.util.UUID
 
-import geotrellis.raster.histogram.{Histogram, StreamingHistogram}
+import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.io.json._
-import io.circe.{Encoder, Json}
-import io.circe.parser.parse
 
 case class LayerAttributeDao() extends HistogramJsonFormats {
   def getHistogram(layerId: UUID,

--- a/app-backend/db/src/main/scala/LicenseDao.scala
+++ b/app-backend/db/src/main/scala/LicenseDao.scala
@@ -1,18 +1,10 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util._
 
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
+import doobie.implicits._
 
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
-import com.lonelyplanet.akka.http.extensions.PageRequest
 
-import scala.concurrent.Future
-import java.sql.Timestamp
-import java.util.{Date, UUID}
 
 object LicenseDao extends Dao[License] {
 

--- a/app-backend/db/src/main/scala/LicenseDao.scala
+++ b/app-backend/db/src/main/scala/LicenseDao.scala
@@ -4,8 +4,6 @@ import com.rasterfoundry.common.datamodel._
 
 import doobie.implicits._
 
-
-
 object LicenseDao extends Dao[License] {
 
   val tableName = "licenses"

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -1,20 +1,14 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 import java.sql.Timestamp
-import java.util.{Date, UUID}
+import java.util.UUID
 
-import scala.concurrent.Future
 
 object MapTokenDao extends Dao[MapToken] {
 

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import java.sql.Timestamp
 import java.util.UUID
 
-
 object MapTokenDao extends Dao[MapToken] {
 
   val tableName = "map_tokens"

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -4,11 +4,7 @@ import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.Implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/OrganizationDao.scala
+++ b/app-backend/db/src/main/scala/OrganizationDao.scala
@@ -10,7 +10,6 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import geotrellis.spark.io.s3.AmazonS3Client
 import org.apache.commons.codec.binary.{Base64 => ApacheBase64}

--- a/app-backend/db/src/main/scala/OrganizationFeatureDao.scala
+++ b/app-backend/db/src/main/scala/OrganizationFeatureDao.scala
@@ -1,11 +1,9 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.OrgFeatures
 
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie.implicits._
+import doobie.postgres.implicits._
 
 object OrganizationFeatureDao extends Dao[OrgFeatures] {
 

--- a/app-backend/db/src/main/scala/PlatformDao.scala
+++ b/app-backend/db/src/main/scala/PlatformDao.scala
@@ -7,9 +7,7 @@ import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.Email
 import com.rasterfoundry.common.datamodel._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
-import doobie.free.connection
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.{Fragment, Fragments, _}
 

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -6,14 +6,12 @@ import java.util.UUID
 import cats.data._
 import cats.implicits._
 import com.rasterfoundry.common.AWSBatch
-import com.rasterfoundry.database.util.Page
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.color._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import io.circe._

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -529,8 +529,12 @@ object ProjectDao
       .filter(objectId)
       .exists
 
-  def authProjectLayerExist(projectId: UUID, layerId: UUID, user: User, actionType: ActionType): ConnectionIO[Boolean] = for {
-    authProject <- authorized(user, ObjectType.Project, projectId, actionType)
-    layerExist <- ProjectLayerDao.layerIsInProject(layerId, projectId)
-  } yield { authProject && layerExist }
+  def authProjectLayerExist(projectId: UUID,
+                            layerId: UUID,
+                            user: User,
+                            actionType: ActionType): ConnectionIO[Boolean] =
+    for {
+      authProject <- authorized(user, ObjectType.Project, projectId, actionType)
+      layerExist <- ProjectLayerDao.layerIsInProject(layerId, projectId)
+    } yield { authProject && layerExist }
 }

--- a/app-backend/db/src/main/scala/ProjectDatasourcesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDatasourcesDao.scala
@@ -1,18 +1,12 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.Page
 import com.rasterfoundry.common.datamodel._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.implicits._
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -3,15 +3,11 @@ package com.rasterfoundry.database
 import java.sql.Timestamp
 import java.util.UUID
 
-import cats.implicits._
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import doobie.postgres.circe.jsonb.implicits._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 
 object ProjectLayerDao extends Dao[ProjectLayer] {

--- a/app-backend/db/src/main/scala/ProjectScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectScenesDao.scala
@@ -1,17 +1,13 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.Page
 import com.rasterfoundry.common.datamodel._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -9,7 +9,6 @@ import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import geotrellis.vector.{Geometry, Polygon, Projected}

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -1,20 +1,17 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 
 import cats.Applicative
-import cats.data.{NonEmptyList => NEL, _}
+import cats.data.{NonEmptyList => NEL}
 import cats.implicits._
 import doobie._
 import doobie.Fragments._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import fs2.Stream
 import geotrellis.vector.{MultiPolygon, Polygon, Projected}
-import io.circe.syntax._
 import com.typesafe.scalalogging.LazyLogging
 
 import java.util.UUID

--- a/app-backend/db/src/main/scala/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/SceneToProjectDao.scala
@@ -1,20 +1,15 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel._
 
-import cats.Applicative
-import cats.data.{NonEmptyList => NEL, _}
+import cats.data.{NonEmptyList => NEL}
 import cats.implicits._
 import doobie._
-import doobie.Fragments._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import fs2.Stream
-import geotrellis.vector.{MultiPolygon, Polygon, Projected}
-import io.circe.syntax._
+import geotrellis.vector.{Polygon, Projected}
 import com.typesafe.scalalogging.LazyLogging
 
 import java.util.UUID

--- a/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
@@ -8,7 +8,6 @@ import cats.implicits._
 import com.lonelyplanet.akka.http.extensions.PageRequest
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 

--- a/app-backend/db/src/main/scala/ShapeDao.scala
+++ b/app-backend/db/src/main/scala/ShapeDao.scala
@@ -11,11 +11,7 @@ import com.rasterfoundry.common.datamodel.{
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/TeamDao.scala
+++ b/app-backend/db/src/main/scala/TeamDao.scala
@@ -1,23 +1,18 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
 import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 
-import java.util.{Date, UUID}
+import java.util.UUID
 import java.sql.Timestamp
 
-import scala.concurrent.Future
 
 object TeamDao extends Dao[Team] {
   val tableName = "teams"

--- a/app-backend/db/src/main/scala/TeamDao.scala
+++ b/app-backend/db/src/main/scala/TeamDao.scala
@@ -13,7 +13,6 @@ import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
 import java.util.UUID
 import java.sql.Timestamp
 
-
 object TeamDao extends Dao[Team] {
   val tableName = "teams"
 

--- a/app-backend/db/src/main/scala/ThumbnailDao.scala
+++ b/app-backend/db/src/main/scala/ThumbnailDao.scala
@@ -1,11 +1,11 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.common.datamodel.{Thumbnail, User}
+import com.rasterfoundry.common.datamodel.Thumbnail
 
 import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie.postgres.implicits._
+import cats.implicits._
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/ToolCategoryDao.scala
+++ b/app-backend/db/src/main/scala/ToolCategoryDao.scala
@@ -1,14 +1,9 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.{ToolCategory, User}
 
 import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
 
-import java.sql.Timestamp
-import java.util.UUID
 
 object ToolCategoryDao extends Dao[ToolCategory] {
 

--- a/app-backend/db/src/main/scala/ToolCategoryDao.scala
+++ b/app-backend/db/src/main/scala/ToolCategoryDao.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.common.datamodel.{ToolCategory, User}
 
 import doobie._, doobie.implicits._
 
-
 object ToolCategoryDao extends Dao[ToolCategory] {
 
   val tableName = "tool_categories"

--- a/app-backend/db/src/main/scala/ToolCategoryToToolDao.scala
+++ b/app-backend/db/src/main/scala/ToolCategoryToToolDao.scala
@@ -1,11 +1,9 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.ToolCategoryToTool
 
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie.implicits._
+import doobie.postgres.implicits._
 
 object ToolCategoryToToolDao extends Dao[ToolCategoryToTool] {
 

--- a/app-backend/db/src/main/scala/ToolDao.scala
+++ b/app-backend/db/src/main/scala/ToolDao.scala
@@ -3,7 +3,6 @@ package com.rasterfoundry.database
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.{
   Tool,
-  ToolRun,
   User,
   ObjectType,
   GroupType,
@@ -12,16 +11,10 @@ import com.rasterfoundry.common.datamodel.{
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.implicits._
 import java.util.UUID
 
-import scala.concurrent.Future
 import java.sql.Timestamp
 
 object ToolDao extends Dao[Tool] with ObjectPermissions[Tool] {

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.common.datamodel.{
   ToolRun,
   User,
@@ -10,20 +9,14 @@ import com.rasterfoundry.common.datamodel.{
   ActionType
 }
 import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._
-import com.rasterfoundry.common.ast.MapAlgebraAST._
 import com.rasterfoundry.common.ast._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
-import scala.concurrent.Future
 import java.sql.Timestamp
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/ToolTagDao.scala
+++ b/app-backend/db/src/main/scala/ToolTagDao.scala
@@ -1,16 +1,10 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.datamodel.{ToolTag, User}
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.implicits._
 
 import java.util.UUID
 import java.sql.Timestamp

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -6,14 +6,9 @@ import com.rasterfoundry.common.datamodel._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
-import cats.syntax._
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -6,17 +6,9 @@ import com.rasterfoundry.database.Implicits._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
-import scala.concurrent.Future
 import java.sql.Timestamp
-import java.util.UUID
 
 object UserDao extends Dao[User] with Sanitization {
 

--- a/app-backend/db/src/main/scala/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/UserGroupRoleDao.scala
@@ -3,15 +3,12 @@ package com.rasterfoundry.database
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.filter.Filters._
 import com.rasterfoundry.database.notification.{GroupNotifier, MessageType}
-import com.rasterfoundry.database.notification.templates.PlainGroupRequest
 import com.rasterfoundry.common.datamodel._
 
 import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.util.transactor.Transactor
-import cats._, cats.data._, cats.effect.IO, cats.implicits._
+import doobie.postgres.implicits._
+import cats._, cats.implicits._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
-import io.circe._
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -9,7 +9,6 @@ import com.typesafe.scalalogging.LazyLogging
 import doobie.Fragments.in
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
 import geotrellis.vector._
 

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -1,18 +1,13 @@
 package com.rasterfoundry.database.filter
 
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database._
 
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
 
-import Fragments.{in, whereAndOpt}
+import Fragments.in
 
 object Filters {
 

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -1,21 +1,12 @@
 package com.rasterfoundry.database.meta
 
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.common.datamodel.ColorCorrect._
 
 import doobie._
-import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.util.invariant.InvalidObjectMapping
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
-import org.postgresql.util.PGobject
 
 import scala.reflect.runtime.universe.TypeTag
 import java.net.URI

--- a/app-backend/db/src/main/scala/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/meta/EnumMeta.scala
@@ -2,10 +2,8 @@ package com.rasterfoundry.database.meta
 
 import com.rasterfoundry.common.datamodel._
 
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.util.invariant.InvalidObjectMapping
-import cats._, cats.data._, cats.effect.IO
+import doobie._
+import doobie.postgres.implicits._
 
 trait EnumMeta {
   implicit val annotationQualityMeta: Meta[AnnotationQuality] =

--- a/app-backend/db/src/main/scala/meta/GtWktMeta.scala
+++ b/app-backend/db/src/main/scala/meta/GtWktMeta.scala
@@ -1,8 +1,6 @@
 package com.rasterfoundry.database.meta
 
 import doobie._
-import doobie.postgres._
-import doobie.postgres.implicits._
 import doobie.postgres.pgisimplicits._
 import doobie.util.invariant.InvalidObjectMapping
 import geotrellis.vector._

--- a/app-backend/db/src/main/scala/meta/PermissionsMeta.scala
+++ b/app-backend/db/src/main/scala/meta/PermissionsMeta.scala
@@ -2,14 +2,7 @@ package com.rasterfoundry.database.meta
 
 import com.rasterfoundry.common.datamodel._
 
-import cats._
-import cats.effect.IO
-import cats.implicits._
 import doobie._
-import doobie.implicits._
-import io.circe._
-import io.circe.jawn._
-import io.circe.syntax._
 
 trait PermissionsMeta {
   implicit val ObjectAccessControlRuleMeta: Meta[ObjectAccessControlRule] =

--- a/app-backend/db/src/main/scala/notification/templates/UploadFailure.scala
+++ b/app-backend/db/src/main/scala/notification/templates/UploadFailure.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.database.notification.templates
 
 import com.rasterfoundry.database._
-import com.rasterfoundry.common.datamodel._
 
 import doobie.ConnectionIO
 

--- a/app-backend/db/src/main/scala/notification/templates/UploadSuccess.scala
+++ b/app-backend/db/src/main/scala/notification/templates/UploadSuccess.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.database.notification.templates
 
 import com.rasterfoundry.database._
-import com.rasterfoundry.common.datamodel._
 
 import cats.implicits._
 import doobie.ConnectionIO

--- a/app-backend/db/src/main/scala/util/Ownership.scala
+++ b/app-backend/db/src/main/scala/util/Ownership.scala
@@ -3,7 +3,6 @@ package com.rasterfoundry.database.util
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.filter.Filterables
 
-
 object Ownership extends Filterables {
 
   def checkOwner(createUser: User, ownerUserId: Option[String]): String = {

--- a/app-backend/db/src/main/scala/util/Ownership.scala
+++ b/app-backend/db/src/main/scala/util/Ownership.scala
@@ -3,8 +3,6 @@ package com.rasterfoundry.database.util
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.filter.Filterables
 
-import doobie._
-import doobie.implicits._
 
 object Ownership extends Filterables {
 

--- a/app-backend/db/src/main/scala/util/Page.scala
+++ b/app-backend/db/src/main/scala/util/Page.scala
@@ -1,12 +1,9 @@
 package com.rasterfoundry.database.util
 
 import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
 import doobie.util.fragment.Fragment
-import cats.Reducible
 import cats.implicits._
 import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
-import doobie.Fragments
 
 object Page {
 

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -1,8 +1,6 @@
 package com.rasterfoundry.database.util
 
 import cats.effect._
-import cats.implicits._
-import doobie.util.ExecutionContexts
 import doobie.hikari.HikariTransactor
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -53,8 +53,7 @@ class AnnotationDaoSpec
          labelerC: User.Create) =>
           {
             val annotationsInsertIO = for {
-              oupInsert <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = oupInsert
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               labeler <- UserDao.create(labelerC)
               insertedAnnotations <- AnnotationDao.insertAnnotations(
                 annotations.map(annotationCreate =>
@@ -130,8 +129,7 @@ class AnnotationDaoSpec
          verifierCreate: User.Create) =>
           {
             val annotationInsertWithUserAndProjectIO = for {
-              oupInsert <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = oupInsert
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               annotations <- AnnotationDao.insertAnnotations(
                 List(annotationInsert),
                 dbProject.id,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -2,18 +2,12 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
 import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
+import cats.effect.IO
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.util.UUID
 
 class AnnotationDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
@@ -4,16 +4,11 @@ import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
+import doobie.implicits._
+import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.util.UUID
 
 class AnnotationGroupDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationGroupDaoSpec.scala
@@ -37,7 +37,7 @@ class AnnotationGroupDaoSpec
                 }
               }
             }
-            val (annotationGroup, dbUser, dbProject) = xa
+            val (annotationGroup, _, _) = xa
               .use(t =>
                 annotationGroupInsertWithUserAndProjectIO
                   .transact(t))
@@ -62,8 +62,9 @@ class AnnotationGroupDaoSpec
          agc3: AnnotationGroup.Create) =>
           {
             val annotationGroupIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project1)
-              (dbOrg, dbUser, dbProject1) = orgUserProject
+              (_, dbUser, dbProject1) <- insertUserOrgProject(user,
+                                                              org,
+                                                              project1)
               dbProject2 <- ProjectDao.insertProject(project2, dbUser)
               agDb1 <- AnnotationGroupDao.createAnnotationGroup(dbProject1.id,
                                                                 agc1,
@@ -81,7 +82,7 @@ class AnnotationGroupDaoSpec
             } yield
               (agDb1, agDb2, agDb3, p1AnnotationGroups, p2AnnotationGroups)
 
-            val (ag1, ag2, ag3, p1ag, p2ag) =
+            val (_, _, _, p1ag, p2ag) =
               xa.use(t => annotationGroupIO.transact(t)).unsafeRunSync()
 
             assert(p1ag.length == 2 && p2ag.length == 1,
@@ -104,8 +105,9 @@ class AnnotationGroupDaoSpec
          agc2Annotations: List[Annotation.Create]) =>
           {
             val annotationGroupIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project1)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user,
+                                                             org,
+                                                             project1)
               agDb1 <- AnnotationGroupDao.createAnnotationGroup(dbProject.id,
                                                                 agc1,
                                                                 dbUser)
@@ -135,7 +137,7 @@ class AnnotationGroupDaoSpec
                projectAnnotationGroups,
                deleteCount)
 
-            val (deletedAnnotations,
+            val (_,
                  remainingAnnotations,
                  projectAnnotations,
                  projectAnnotationGroups,
@@ -166,8 +168,7 @@ class AnnotationGroupDaoSpec
          agAnnotations: List[Annotation.Create]) =>
           {
             val annotationGroupIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               annotationGroupDB <- AnnotationGroupDao.createAnnotationGroup(
                 dbProject.id,
                 ag,
@@ -226,8 +227,9 @@ class AnnotationGroupDaoSpec
          annotations: List[Annotation.Create]) =>
           {
             val annotationGroupIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project1)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user,
+                                                             org,
+                                                             project1)
               dbAnnotations <- AnnotationDao.insertAnnotations(
                 annotations,
                 dbProject.id,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -73,8 +73,7 @@ class AoiDaoSpec
          shapeUpdate: Shape.Create) =>
           {
             val aoiInsertWithOrgUserProjectIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               shape <- ShapeDao.insertShape(shapeInsert, dbUser)
               dbAoi <- AoiDao.createAOI(
                 fixupAoiCreate(dbUser, dbProject, aoiInsert, shape),
@@ -87,11 +86,7 @@ class AoiDaoSpec
               updatedAoi <- AoiDao.unsafeGetAoiById(dbAoi.id)
             } yield
               (dbAoi, shape, updatedRows, updatedAoi, newShape) //shape, aoi, dbOrg, dbUser, dbProject, update, updatedRows, updatedAoi)
-            val (originalAoi,
-                 originalShape,
-                 affectedRows,
-                 updatedAoi,
-                 updatedShape) = xa
+            val (_, _, affectedRows, updatedAoi, updatedShape) = xa
               .use(t => aoiInsertWithOrgUserProjectIO.transact(t))
               .unsafeRunSync
 
@@ -153,8 +148,9 @@ class AoiDaoSpec
          aois2: List[AOI.Create]) =>
           {
             val aoisInsertWithProjectUserIO = for {
-              userOrgProj1 <- insertUserOrgProject(user, org, project1)
-              (dbOrg, dbUser, dbProject1) = userOrgProj1
+              (_, dbUser, dbProject1) <- insertUserOrgProject(user,
+                                                              org,
+                                                              project1)
               dbProject2 <- ProjectDao.insertProject(
                 fixupProjectCreate(dbUser, project2),
                 dbUser)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AoiDaoSpec.scala
@@ -2,18 +2,10 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import io.circe._
-import io.circe.syntax._
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import cats.syntax.either._
 import com.lonelyplanet.akka.http.extensions.PageRequest
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
-import geotrellis.vector._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -2,15 +2,8 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.syntax.either._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -40,8 +40,7 @@ class AuthorizationSpec
               } yield { (dbUser1, dbUser2, dbOrg1) }
 
             val usersAuthedIO: ConnectionIO[(Boolean, Boolean)] = for {
-              users <- usersWithOrgOneIO
-              (user1, user2, dbOrg1) = users
+              (user1, user2, _) <- usersWithOrgOneIO
               project <- ProjectDao.insertProject(
                 fixupProjectCreate(user1, projectCreate).copy(
                   visibility = Visibility.Private),
@@ -99,8 +98,7 @@ class AuthorizationSpec
             } yield { (dbUser1, dbUser2, dbOrg1, dbPlatform1) }
 
             val usersAuthedIO = for {
-              usersOrgPlatform <- usersAndOrgOnePlatformOneIO
-              (user1, user2, org1, platform1) = usersOrgPlatform
+              (user1, user2, _, platform1) <- usersAndOrgOnePlatformOneIO
               project <- ProjectDao.insertProject(
                 fixupProjectCreate(user1, projectCreate).copy(
                   visibility = Visibility.Private),
@@ -208,10 +206,9 @@ class AuthorizationSpec
           {
             val insertManyAcrsIO = for {
               dbPlatform <- PlatformDao.create(platform)
-              orgUser <- insertUserAndOrg(
+              (_, user) <- insertUserAndOrg(
                 userCreate,
                 orgCreate.copy(platformId = dbPlatform.id))
-              (org, user) = orgUser
               project <- ProjectDao.insertProject(
                 fixupProjectCreate(user, projectCreate).copy(
                   visibility = Visibility.Private),
@@ -246,10 +243,9 @@ class AuthorizationSpec
           {
             val listUserActionsIO = for {
               dbPlatform <- PlatformDao.create(platform)
-              orgUser <- insertUserAndOrg(
+              (_, user) <- insertUserAndOrg(
                 userCreate,
                 orgCreate.copy(platformId = dbPlatform.id))
-              (org, user) = orgUser
               project <- ProjectDao.insertProject(
                 fixupProjectCreate(user, projectCreate).copy(
                   visibility = Visibility.Private),
@@ -288,10 +284,9 @@ class AuthorizationSpec
           {
             val listUserActionsIO = for {
               dbPlatform <- PlatformDao.create(platform)
-              orgUser <- insertUserAndOrg(
+              (_, user) <- insertUserAndOrg(
                 userCreate,
                 orgCreate.copy(platformId = dbPlatform.id))
-              (org, user) = orgUser
               project <- ProjectDao.insertProject(
                 fixupProjectCreate(user, projectCreate).copy(
                   visibility = Visibility.Private),
@@ -368,10 +363,9 @@ class AuthorizationSpec
           {
             val listUserActionsIO = for {
               dbPlatform <- PlatformDao.create(platform)
-              orgUser <- insertUserAndOrg(
+              (_, user) <- insertUserAndOrg(
                 userCreate,
                 orgCreate.copy(platformId = dbPlatform.id))
-              (org, user) = orgUser
               project <- ProjectDao.insertProject(
                 fixupProjectCreate(user, projectCreate).copy(
                   visibility = Visibility.Private),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/BandDaoSpec.scala
@@ -1,17 +1,7 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
-
-import java.util.UUID
 
 /** We only need to test the list query, since insertion is checked when creating a
   * scene from a Scene.Create

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -4,12 +4,7 @@ import com.rasterfoundry.database.Implicits._
 
 import doobie._, doobie.implicits._
 import doobie.hikari._
-import doobie.hikari.implicits._
-import doobie.postgres._
 import doobie.postgres.implicits._
-import doobie.util.ExecutionContexts
-import cats._
-import cats.data._
 import cats.effect._
 import cats.implicits._
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DatasourceDaoSpec.scala
@@ -21,8 +21,7 @@ class DatasourceDaoSpec
          orgCreate: Organization.Create,
          dsCreate: Datasource.Create) => {
           val createDsIO = for {
-            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
-            (orgInsert, userInsert) = orgAndUserInsert
+            (_, userInsert) <- insertUserAndOrg(userCreate, orgCreate)
             dsInsert <- fixupDatasource(dsCreate, userInsert)
           } yield dsInsert
           val createDs = xa.use(t => createDsIO.transact(t)).unsafeRunSync
@@ -39,8 +38,7 @@ class DatasourceDaoSpec
          orgCreate: Organization.Create,
          dsCreate: Datasource.Create) => {
           val getDsIO = for {
-            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
-            (orgInsert, userInsert) = orgAndUserInsert
+            (_, userInsert) <- insertUserAndOrg(userCreate, orgCreate)
             dsInsert <- fixupDatasource(dsCreate, userInsert)
             dsGet <- DatasourceDao.getDatasourceById(dsInsert.id)
           } yield dsGet
@@ -58,8 +56,7 @@ class DatasourceDaoSpec
          orgCreate: Organization.Create,
          dsCreate: Datasource.Create) => {
           val getDsUnsafeIO = for {
-            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
-            (orgInsert, userInsert) = orgAndUserInsert
+            (_, userInsert) <- insertUserAndOrg(userCreate, orgCreate)
             dsInsert <- fixupDatasource(dsCreate, userInsert)
             dsGetUnsafe <- DatasourceDao.unsafeGetDatasourceById(dsInsert.id)
           } yield dsGetUnsafe
@@ -78,8 +75,7 @@ class DatasourceDaoSpec
          dsCreate: Datasource.Create,
          dsUpdate: Datasource.Create) => {
           val updateDsIO = for {
-            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
-            (orgInsert, userInsert) = orgAndUserInsert
+            (_, userInsert) <- insertUserAndOrg(userCreate, orgCreate)
             dsInsert <- fixupDatasource(dsCreate, userInsert)
             dsUpdated <- fixupDatasource(dsUpdate, userInsert)
             rowUpdated <- DatasourceDao.updateDatasource(dsUpdated,
@@ -107,8 +103,7 @@ class DatasourceDaoSpec
          orgCreate: Organization.Create,
          dsCreate: Datasource.Create) => {
           val deleteDsIO = for {
-            orgAndUserInsert <- insertUserAndOrg(userCreate, orgCreate)
-            (orgInsert, userInsert) = orgAndUserInsert
+            (_, userInsert) <- insertUserAndOrg(userCreate, orgCreate)
             dsInsert <- fixupDatasource(dsCreate, userInsert)
             rowDeleted <- DatasourceDao.deleteDatasource(dsInsert.id)
           } yield rowDeleted
@@ -132,8 +127,7 @@ class DatasourceDaoSpec
          orgCreate: Organization.Create,
          dsCreate: Datasource.Create) => {
           val isDsDeletableIO = for {
-            orgAndOwnerInsert <- insertUserAndOrg(ownerCreate, orgCreate)
-            (orgInsert, ownerInsert) = orgAndOwnerInsert
+            (_, ownerInsert) <- insertUserAndOrg(ownerCreate, orgCreate)
             userInsert <- UserDao.create(userCreate)
             dsInsert <- fixupDatasource(dsCreate, ownerInsert)
             isDeletableUser <- DatasourceDao.isDeletable(dsInsert.id,
@@ -164,8 +158,7 @@ class DatasourceDaoSpec
          orgCreate: Organization.Create,
          dsCreate: Datasource.Create) => {
           val isDsDeletableIO = for {
-            orgAndOwnerInsert <- insertUserAndOrg(ownerCreate, orgCreate)
-            (orgInsert, ownerInsert) = orgAndOwnerInsert
+            (_, ownerInsert) <- insertUserAndOrg(ownerCreate, orgCreate)
             dsInsert <- fixupDatasource(dsCreate, ownerInsert)
             _ <- DatasourceDao.addPermission(
               dsInsert.id,
@@ -196,11 +189,10 @@ class DatasourceDaoSpec
          upload: Upload.Create) => {
           @SuppressWarnings(Array("TraversableHead"))
           val isDsDeletableIO = for {
-            orgUserPlatProject <- insertUserOrgPlatProject(userCreate,
-                                                           orgCreate,
-                                                           platform,
-                                                           project)
-            (dbUser, dbOrg, dbPlatform, dbProject) = orgUserPlatProject
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
+                                                                  orgCreate,
+                                                                  platform,
+                                                                  project)
             datasource <- fixupDatasource(dsCreate, dbUser)
             _ <- UploadDao.insert(
               fixupUploadCreate(dbUser, dbProject, datasource, upload),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DatasourceDaoSpec.scala
@@ -1,24 +1,11 @@
 package com.rasterfoundry.database
 
-import java.sql.Timestamp
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
-import doobie._
 import doobie.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._
-import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import io.circe._
-import io.circe.syntax._
-import java.util.UUID
 
 class DatasourceDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
@@ -1,18 +1,7 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.postgres.circe.jsonb.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
-import io.circe._
-import io.circe.syntax._
 
 class ExportDaoSpec extends FunSuite with Matchers with DBTestConfig {
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/FeatureFlagDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/FeatureFlagDaoSpec.scala
@@ -1,13 +1,6 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel.FeatureFlag
-import com.rasterfoundry.database.Implicits._
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
 
 class FeatureFlagDaoSpec extends FunSuite with Matchers with DBTestConfig {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
@@ -25,8 +25,7 @@ class ImageDaoSpec
          scene: Scene.Create,
          image: Image.Banded) => {
           val sceneInsertIO = for {
-            orgAndUser <- insertUserAndOrg(user, org)
-            (insertedOrg, insertedUser) = orgAndUser
+            (_, insertedUser) <- insertUserAndOrg(user, org)
             datasource <- unsafeGetRandomDatasource
             insertedScene <- SceneDao.insert(
               fixupSceneCreate(insertedUser, datasource, scene),
@@ -64,8 +63,7 @@ class ImageDaoSpec
          imageBanded: Image.Banded,
          imageUpdate: Image) => {
           val sceneInsertIO = for {
-            orgAndUser <- insertUserAndOrg(user, org)
-            (insertedOrg, insertedUser) = orgAndUser
+            (_, insertedUser) <- insertUserAndOrg(user, org)
             datasource <- unsafeGetRandomDatasource
             insertedScene <- SceneDao.insert(
               fixupSceneCreate(insertedUser, datasource, scene),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ImageDaoSpec.scala
@@ -1,25 +1,11 @@
 package com.rasterfoundry.database
 
-import java.sql.Timestamp
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
-import doobie._
 import doobie.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.scalatest.imports._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import io.circe._
-import io.circe.syntax._
-import java.util.UUID
 
 /** We only need to test inserting a single image and listing images because inserting
   *  many is tested in inserting a scene from a Scene.Create

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LayerAttributeDaoSpec.scala
@@ -2,14 +2,9 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.common.datamodel.LayerAttribute
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import io.circe.syntax._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/LicenseDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/LicenseDaoSpec.scala
@@ -1,13 +1,6 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.scalatest.imports._
 
 import org.scalatest._
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
@@ -2,13 +2,8 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
 import org.scalacheck.Prop.forAll
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationDaoSpec.scala
@@ -2,13 +2,8 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie._, doobie.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationFeatureDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/OrganizationFeatureDaoSpec.scala
@@ -1,13 +1,6 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._
 import doobie.implicits._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.scalatest.imports._
 
 import org.scalatest._
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PlatformDaoSpec.scala
@@ -2,22 +2,11 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
-import doobie._
 import doobie.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._
-import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import io.circe._
-import io.circe.syntax._
 import com.lonelyplanet.akka.http.extensions.PageRequest
-import java.util.UUID
 
 class PlatformDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -145,8 +145,7 @@ class ProjectDaoSpec
          pageRequest: PageRequest) =>
           {
             val projectsListIO = for {
-              orgAndUser <- insertUserAndOrg(user, org)
-              (dbOrg, dbUser) = orgAndUser
+              (_, dbUser) <- insertUserAndOrg(user, org)
               _ <- ProjectDao.insertProject(fixupProjectCreate(dbUser, project),
                                             dbUser)
               listedProjects <- {
@@ -185,8 +184,7 @@ class ProjectDaoSpec
          datasource: Datasource.Create) =>
           {
             val addScenesIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               dbDatasource <- fixupDatasource(datasource, dbUser)
               insertedScenes <- scenes traverse { scene =>
                 SceneDao.insert(fixupSceneCreate(dbUser, dbDatasource, scene),
@@ -246,8 +244,7 @@ class ProjectDaoSpec
          datasource: Datasource.Create) =>
           {
             val listScenesIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               dbDatasource <- fixupDatasource(datasource, dbUser)
               scenes <- scenes traverse { scene =>
                 SceneDao.insert(fixupSceneCreate(dbUser, dbDatasource, scene),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -1,28 +1,16 @@
 package com.rasterfoundry.database
 
-import java.sql.Timestamp
 import scala.util.Random
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
-import doobie._
 import doobie.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
-import cats.syntax._
-import doobie.postgres._
-import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import io.circe._
-import io.circe.syntax._
 import com.lonelyplanet.akka.http.extensions.PageRequest
-import java.util.UUID
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class ProjectDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -2,21 +2,12 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
-import org.scalacheck.Prop.{forAll, exists}
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.sql.Timestamp
-import java.time.LocalDate
 
 class ProjectDatasourcesDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDatasourcesDaoSpec.scala
@@ -39,10 +39,9 @@ class ProjectDatasourcesDaoSpec
             val expected = expected1 + expected2
 
             val createDsIO = for {
-              orgUserProjectInsert <- insertUserOrgProject(userCreate,
-                                                           orgCreate,
-                                                           project)
-              (dbOrg, dbUser, dbProject) = orgUserProjectInsert
+              (_, dbUser, dbProject) <- insertUserOrgProject(userCreate,
+                                                             orgCreate,
+                                                             project)
               dsInsert1 <- fixupDatasource(dsCreate1, dbUser)
               dsInsert2 <- fixupDatasource(dsCreate2, dbUser)
               dsInsert3 <- fixupDatasource(dsCreate3, dbUser)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
@@ -29,8 +29,7 @@ class ProjectScenesDaoSpec
          csq: CombinedSceneQueryParams) =>
           {
             val scenesInsertWithUserProjectIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
                                                  dbUser)
               scenesInsert <- (scenes map {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectScenesDaoSpec.scala
@@ -2,20 +2,14 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import org.scalacheck.Prop.{forAll, exists}
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.sql.Timestamp
-import java.time.LocalDate
 
 class ProjectScenesDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
@@ -26,8 +26,7 @@ class SceneDaoSpec
         (user: User.Create, org: Organization.Create, scene: Scene.Create) =>
           {
             val sceneInsertIO = for {
-              orgAndUser <- insertUserAndOrg(user, org)
-              (dbOrg, dbUser) = orgAndUser
+              (_, dbUser) <- insertUserAndOrg(user, org)
               datasource <- unsafeGetRandomDatasource
               fixedUpSceneCreate = fixupSceneCreate(dbUser, datasource, scene)
               sceneInsert <- SceneDao.insert(fixedUpSceneCreate, dbUser)
@@ -72,8 +71,7 @@ class SceneDaoSpec
         (user: User.Create, org: Organization.Create, scene: Scene.Create) =>
           {
             val sceneInsertIO = for {
-              orgAndUser <- insertUserAndOrg(user, org)
-              (dbOrg, dbUser) = orgAndUser
+              (_, dbUser) <- insertUserAndOrg(user, org)
               datasource <- unsafeGetRandomDatasource
               fixedUpSceneCreate = fixupSceneCreate(dbUser, datasource, scene)
               sceneInsert <- SceneDao.insertMaybe(fixedUpSceneCreate, dbUser)
@@ -124,8 +122,7 @@ class SceneDaoSpec
          updateScene: Scene.Create) =>
           {
             val sceneUpdateIO = for {
-              orgAndUser <- insertUserAndOrg(user, org)
-              (dbOrg, dbUser) = orgAndUser
+              (_, dbUser) <- insertUserAndOrg(user, org)
               datasource <- unsafeGetRandomDatasource
               fixedUpSceneCreate = fixupSceneCreate(dbUser,
                                                     datasource,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneDaoSpec.scala
@@ -2,12 +2,8 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
+import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToLayerDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToLayerDaoSpec.scala
@@ -4,18 +4,14 @@ import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
 import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import org.scalacheck.Prop.{forAll, exists}
+import doobie.postgres.implicits._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.sql.Timestamp
-import java.time.LocalDate
 
 class SceneToLayerDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToLayerDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToLayerDaoSpec.scala
@@ -75,8 +75,7 @@ class SceneToLayerDaoSpec
          csq: CombinedSceneQueryParams) =>
           {
             val mdAndStpsIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
                                                  dbUser)
               scenesInsert <- (scenes map {
@@ -104,7 +103,7 @@ class SceneToLayerDaoSpec
                 .list
             } yield (mds, stls, selectedSceneIds)
 
-            val (mds, stls, selectedIds) =
+            val (mds, stls, _) =
               xa.use(t => mdAndStpsIO.transact(t)).unsafeRunSync
 
             // Mapping of scene ids to scene order

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
@@ -4,18 +4,14 @@ import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
 import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import org.scalacheck.Prop.{forAll, exists}
+import doobie.postgres.implicits._
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import java.sql.Timestamp
-import java.time.LocalDate
 
 class SceneToProjectDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneToProjectDaoSpec.scala
@@ -31,8 +31,7 @@ class SceneToProjectDaoSpec
          csq: CombinedSceneQueryParams) =>
           {
             val acceptedSceneAndStpIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
                                                  dbUser)
               scenesInsert <- (scenes map {
@@ -74,8 +73,7 @@ class SceneToProjectDaoSpec
          csq: CombinedSceneQueryParams) =>
           {
             val mdAndStpsIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               datasource <- DatasourceDao.create(dsCreate.toDatasource(dbUser),
                                                  dbUser)
               scenesInsert <- (scenes map {
@@ -103,7 +101,7 @@ class SceneToProjectDaoSpec
                 .list
             } yield (mds, stps, selectedSceneIds)
 
-            val (mds, stps, selectedIds) =
+            val (mds, stps, _) =
               xa.use(t => mdAndStpsIO.transact(t)).unsafeRunSync
 
             // Mapping of scene ids to scene order

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -88,8 +88,7 @@ class SceneWithRelatedDaoSpec
          scenes: List[Scene.Create]) =>
           {
             val scenesInsertWithUserProjectIO = for {
-              orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
               datasource <- unsafeGetRandomDatasource
               scenesInsert <- (scenes map {
                 fixupSceneCreate(dbUser, datasource, _)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -2,15 +2,12 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import com.lonelyplanet.akka.http.extensions.{PageRequest, Order}
+import com.lonelyplanet.akka.http.extensions.PageRequest
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
+import doobie.implicits._
 import cats.implicits._
-import doobie.postgres._, doobie.postgres.implicits._
-import org.scalacheck.Prop.{forAll, exists}
+import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ShapeDaoSpec.scala
@@ -2,19 +2,11 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel.{User, Organization, Shape}
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import cats.syntax.option._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import geotrellis.vector.{MultiPolygon, Polygon, Point}
 
 class ShapeDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -1,25 +1,12 @@
 package com.rasterfoundry.database
 
-import java.sql.Timestamp
-
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database._
-import doobie._
 import doobie.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._
-import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import io.circe._
-import io.circe.syntax._
-import java.util.UUID
 import com.lonelyplanet.akka.http.extensions.PageRequest
 
 class TeamDaoSpec

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TeamDaoSpec.scala
@@ -322,7 +322,7 @@ class TeamDaoSpec
                 insertedTeam.id)
             } yield { (originalUserGroupRole, updatedUserGroupRoles) }
 
-            val (dbOldUGR, dbNewUGRs) =
+            val (_, dbNewUGRs) =
               xa.use(t => setTeamRoleIO.transact(t)).unsafeRunSync
 
             assert(dbNewUGRs.filter((ugr) => ugr.isActive == false).size == 1,
@@ -349,7 +349,7 @@ class TeamDaoSpec
               userOrgPlatform <- insertUserOrgPlatform(userCreate,
                                                        orgCreate,
                                                        platform)
-              (dbUser, dbOrg, dbPlatform) = userOrgPlatform
+              (dbUser, dbOrg, _) = userOrgPlatform
               team1 <- TeamDao.create(fixupTeam(teamCreate1, dbOrg, dbUser))
               team2 <- TeamDao.create(fixupTeam(teamCreate2, dbOrg, dbUser))
               _ <- UserGroupRoleDao.create(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ThumbnailDaoSpec.scala
@@ -2,15 +2,11 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
+import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import java.util.UUID
 
 class ThumbnailDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryDaoSpec.scala
@@ -1,13 +1,8 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel.{ToolCategory, User}
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
 
 class ToolCategoryDaoSpec extends FunSuite with Matchers with DBTestConfig {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryToToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolCategoryToToolDaoSpec.scala
@@ -1,13 +1,6 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
 
 class ToolCategoryToToolDaoSpec

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
@@ -1,15 +1,6 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._
-import doobie.postgres.implicits._
-import doobie.postgres.circe.jsonb.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
 
 class ToolDaoSpec extends FunSuite with Matchers with DBTestConfig {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolRunDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolRunDaoSpec.scala
@@ -4,9 +4,7 @@ import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
 import com.rasterfoundry.database.Implicits._
 
-import doobie._
 import doobie.implicits._
-import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolTagDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolTagDaoSpec.scala
@@ -1,13 +1,6 @@
 package com.rasterfoundry.database
 
-import com.rasterfoundry.common.datamodel._
-import com.rasterfoundry.database.Implicits._
-
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
+import doobie.implicits._
 import org.scalatest._
 
 class ToolTagDaoSpec extends FunSuite with Matchers with DBTestConfig {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
@@ -30,11 +30,10 @@ class UploadDaoSpec
          upload: Upload.Create) =>
           {
             val uploadInsertIO = for {
-              orgUserProject <- insertUserOrgPlatProject(user,
-                                                         org,
-                                                         platform,
-                                                         project)
-              (dbUser, dbOrg, _, dbProject) = orgUserProject
+              (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(user,
+                                                                    org,
+                                                                    platform,
+                                                                    project)
               datasource <- unsafeGetRandomDatasource
               insertedUpload <- UploadDao.insert(
                 fixupUploadCreate(dbUser, dbProject, datasource, upload),

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
@@ -2,12 +2,8 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
+import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -2,17 +2,11 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
 
-import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
+import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-
-import scala.util.Random
 
 import com.typesafe.scalalogging.LazyLogging
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -52,13 +52,12 @@ class UserDaoSpec
               orgCreate
                 .copy(platformId = insertedPlatform.id)
                 .toOrganization(true))
-            newUserAndRoles <- {
+            (newUser, _) <- {
               val newUserFields =
                 jwtFields.copy(platformId = insertedPlatform.id,
                                organizationId = insertedOrg.id)
               UserDao.createUserWithJWT(creatingUser, newUserFields)
             }
-            (newUser, roles) = newUserAndRoles
             userRoles <- UserGroupRoleDao.listByUser(newUser)
           } yield (newUser, userRoles)
 
@@ -304,7 +303,7 @@ class UserDaoSpec
           }
           xa.use(t => orgsIO.transact(t)).unsafeRunSync
 
-          val (u1, u2, u3, u4, u1users, u2users, u3users, u3usersAdmin) =
+          val (u1, _, u3, u4, u1users, u2users, u3users, u3usersAdmin) =
             xa.use(t => orgsIO.transact(t)).unsafeRunSync
           val u1userids = u1users.toSet.map { u: User =>
             u.id

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserGroupRoleDaoSpec.scala
@@ -2,24 +2,12 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.Generators.Implicits._
-import com.rasterfoundry.database.Implicits._
-import doobie._
 import doobie.implicits._
-import cats._
-import cats.data._
-import cats.effect.IO
 import cats.implicits._
-import cats.syntax.either._
 import com.lonelyplanet.akka.http.extensions.PageRequest
-import doobie.postgres._
-import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatest.prop.Checkers
-import io.circe._
-import io.circe.syntax._
-import java.util.UUID
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class UserGroupRoleDaoSpec
     extends FunSuite

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/meta/CirceJsonbMetaSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/meta/CirceJsonbMetaSpec.scala
@@ -1,19 +1,11 @@
 package com.rasterfoundry.database.meta
 
-import com.rasterfoundry.common.datamodel.AOI
-import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database._
 
 import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
-import doobie.postgres._
-import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import doobie.util.invariant.InvalidObjectMapping
-import doobie.scalatest.imports._
 import org.scalatest._
 
 class CirceJsonbMetaSpec extends FunSpec with Matchers with DBTestConfig {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/meta/GtVectorMetaSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/meta/GtVectorMetaSpec.scala
@@ -1,14 +1,9 @@
 package com.rasterfoundry.database.meta
 
-import com.rasterfoundry.common.datamodel.AOI
 import com.rasterfoundry.database._
 import com.rasterfoundry.database.Implicits._
 
 import doobie._, doobie.implicits._
-import cats._, cats.data._, cats.effect.IO
-import cats.syntax.either._
-import doobie.postgres._, doobie.postgres.implicits._
-import doobie.scalatest.imports._
 import org.scalatest._
 import geotrellis.vector._
 

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Cache.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Cache.scala
@@ -5,8 +5,6 @@ import com.rasterfoundry.common.datamodel.User
 import com.typesafe.scalalogging.LazyLogging
 import scalacache._
 import scalacache.caffeine._
-import scalacache.memoization._
-import scalacache.CatsEffect.modes._
 
 object Cache extends LazyLogging {
 

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -23,3 +23,5 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.8")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.1")


### PR DESCRIPTION
## Overview

This PR removes a bunch of things that weren't in use using scalafix and some manual work.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Some of the things here were manual -- for example, scalafix didn't seem to want to remove unused values bound in for comprehensions. It also does a weird thing with unused private vals where it removes the assignment... but still does whatever computation was being assigned. I think this is because it can't tell from a return type whether there are important side effects happening, but it's still pretty funny looking. Anyway, in cases where that happened, I just deleted things.

There's also a [`scalafix --check`](https://scalacenter.github.io/scalafix/docs/users/installation.html#enforce-in-ci) command that we can add an alias for -- unclear whether we want that though

## Testing Instructions

 * use the app normally and confirm everything is fine -- get some lab tiles, view some projects, look at some datasources... you know, be like a user

Closes #4500