### PR TITLE
Use geom filter in scene service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- Included geometry filter in backsplash scene service to prevent erroneous 500s [\#4580](https://github.com/raster-foundry/raster-foundry/pull/4580)
+
 ### Security
 
 ## [1.17.1](https://github.com/raster-foundry/raster-foundry/tree/1.17.1) (2019-02-04)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -138,9 +138,6 @@ class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
         val imageBandOverride = bandOverride map { ovr =>
           List(ovr.red, ovr.green, ovr.blue)
         } getOrElse { List(0, 1, 2) }
-        // we could also look this up by the datasource at some point -- which would
-        // probably help with
-        // https://github.com/raster-foundry/raster-foundry/issues/4468
         val colorCorrectParams = ColorCorrect.paramsFromBandSpecOnly(0, 1, 2)
         BacksplashImage(
           scene.id,

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
@@ -5,6 +5,7 @@ import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.common.datamodel.User
+import com.rasterfoundry.common.utils.TileUtils
 
 import cats.Applicative
 import cats.data.Validated._
@@ -41,8 +42,10 @@ class SceneService[ProjStore: ProjectStore, HistStore: HistogramStore](
           case GET -> Root / UUIDWrapper(sceneId) / IntVar(z) / IntVar(x) / IntVar(
                 y)
                 :? BandOverrideQueryParamDecoder(bandOverride) as user =>
+            val bbox = TileUtils.getTileBounds(z, x, y)
             val eval =
-              LayerTms.identity(scenes.read(sceneId, None, bandOverride, None))
+              LayerTms.identity(
+                scenes.read(sceneId, Some(bbox), bandOverride, None))
             for {
               fiberAuth <- authorizers.authScene(user, sceneId).start
               fiberResp <- eval(z, x, y).start


### PR DESCRIPTION
## Overview

This PR includes a geometry filter in trying to read scenes for putting scenes outside of projects on the map with backsplash.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * open the preview modal for a scene while watching your network tab
 * you shouldn't see any 500s

Closes #4525 
