### PR TITLE
Remove deprecated export interaction

### DIFF
--- a/app-backend/backsplash-export/src/main/resources/log4j.xml
+++ b/app-backend/backsplash-export/src/main/resources/log4j.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration debug="false"
+                     xmlns:log4j='http://jakarta.apache.org/log4j/'>
+
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n" />
+        </layout>
+    </appender>
+    <logger name="com.rasterfoundry">
+        <level value="${env:RF_LOG_LEVEL}"/>
+    </logger>
+
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="console" />
+    </root>
+
+</log4j:configuration>

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.html
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.html
@@ -37,24 +37,6 @@
     <i class="icon-info"></i>
   </li> -->
   <!-- Dropdown for output processing -->
-  <li class="separator">
-    <span class="label">Output Processing</span>
-    <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>
-      <a class="btn dropdown-label">
-        {{$ctrl.getCurrentProcessingOption().label}}
-      </a>
-      <button type="button" class="btn btn-default dropdown-toggle">
-        <i class="icon-caret-down"></i>
-      </button>
-      <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
-        <li ng-repeat="option in $ctrl.availableProcessingOptions" role="menuitem">
-          <a ng-click="$ctrl.onOutputProcessingChange(option)">
-            {{option.label}}
-          </a>
-        </li>
-      </ul>
-    </div>
-  </li>
   <li ng-class="{'separator': !$ctrl.shouldShowTargetParams()}" ng-if="$ctrl.enableExportTargets">
     <span class="label">Export to...</span>
     <div class="dropdown btn-group fixedwidth" uib-dropdown uib-dropdown-toggle>

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.html
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.html
@@ -20,7 +20,6 @@
     <button class="btn btn-default fixedwidth" ng-click="$ctrl.startDrawing()">
       Define area to export
     </button>
-    <i class="icon-info"></i>
   </li>
   <!-- Opens the output processing panel -->
   <!-- <li class="separator">
@@ -55,7 +54,6 @@
         </li>
       </ul>
     </div>
-    <i class="icon-info"></i>
   </li>
   <li ng-class="{'separator': !$ctrl.shouldShowTargetParams()}" ng-if="$ctrl.enableExportTargets">
     <span class="label">Export to...</span>
@@ -72,7 +70,6 @@
         </li>
       </ul>
     </div>
-    <i class="icon-info"></i>
   </li>
   <li class="separator" ng-show="$ctrl.shouldShowTargetParams()">
     <input type="url" class="form-control slim" placeholder="S3 Bucket URI" ng-model="$ctrl.exportTargetURI">
@@ -96,7 +93,6 @@
         </li>
       </ul>
     </div>
-    <i class="icon-info"></i>
   </li>
 </ul>
 <div class="sidebar-content" ng-if="$ctrl.project">

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
@@ -214,7 +214,7 @@ class NewExportController {
         if (this.getCurrentTarget().value === 'externalS3') {
             validationState = validationState && this.exportTargetURI;
         }
-        return validationState;
+        return validationState && this.mask !== undefined;
     }
 
     startExport() {

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
@@ -107,7 +107,7 @@ class NewExportController {
             this.exportOptions,
             this.getCurrentProcessingOption().exportOptions,
             this.mask ? {mask: this.mask} : {},
-            this.bands ? {bands: this.bands} : {bands: this.defaultBands},
+            {bands: this.defaultBands},
             options
         );
     }

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,9 +1,5 @@
 FROM quay.io/azavea/openjdk-gdal:2.3-jdk8-slim
 
-ENV SPARK_VERSION 2.1.0
-ENV HADOOP_VERSION 2.7
-ENV PATH=${PATH}:/usr/lib/spark/sbin:/usr/lib/spark/bin
-
 COPY rf/requirements.txt /tmp/
 RUN set -ex \
     && gdalDeps=' \
@@ -21,10 +17,7 @@ RUN set -ex \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && apt-get purge -y build-essential python-dev \
     && apt-get -y autoremove \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /usr/lib/spark \
-    && wget -qO- http://d3kbcqa49mib13.cloudfront.net/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
-      | tar -xzC /usr/lib/spark --strip-components=1
+    && rm -rf /var/lib/apt/lists/*
 
 COPY jars/ /opt/raster-foundry/jars/
 

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -7,10 +7,9 @@ from urlparse import urlparse
 
 import boto3
 import click
-from rasterfoundry.api import API
 
 from ..utils.exception_reporting import wrap_rollbar
-from ..utils.io import s3_upload_export, dropbox_upload_export, get_jwt, get_tempdir
+from ..utils.io import s3_upload_export, dropbox_upload_export, get_tempdir
 logger = logging.getLogger(__name__)
 
 HOST = os.getenv('RF_HOST')
@@ -33,17 +32,17 @@ def export(export_id):
         export_uri = create_export_definition(export_id)
         logger.info('Retrieving Export Definition %s', export_uri)
         export_definition = get_export_definition(export_uri)
-        with get_tempdir() as local_dir:
+        with get_tempdir(True) as local_dir:
             logger.info('Created Working Directory %s', local_dir)
             logger.info('Rewriting Export Definition')
             local_path = write_export_definition(export_definition, local_dir)
             logger.info('Rewrote export definition to %s', local_path)
             logger.info('Preparing to Run Export')
             run_export('file://' + local_path, export_id)
-            logger.info('Post Processing Tiffs')
-            merged_tiff_path = post_process_exports(export_definition, local_dir)
-            logger.info('Uploading Processed Tiffs')
-            upload_processed_tif(merged_tiff_path, export_definition)
+            out_path = local_tif_path_from_export_definition(
+                export_definition, local_dir
+            ).replace('file://', '')
+            upload_processed_tif(out_path, export_definition)
     except subprocess.CalledProcessError as e:
         logger.error('Output from failed command: %s', e.output)
         final_status = 'FAILED'
@@ -57,10 +56,15 @@ def export(export_id):
         # in the deployment repo. Please make sure that both areas are updated if
         # this needs to be changed to a configurable variable
         if final_status == 'EXPORTED' or int(RETRY) >= 3:
-            logger.info('Sending email notifications for export %s on try: %s', export_id, RETRY)
+            logger.info('Sending email notifications for export %s on try: %s',
+                        export_id, RETRY)
             update_export_status(export_id, final_status)
         else:
             logger.info('Export failed, on try %s/3', RETRY)
+
+
+def local_tif_path_from_export_definition(export_definition, local_dir):
+    return 'file://{}/{}.tif'.format(local_dir, export_definition['id'])
 
 
 def create_export_definition(export_id):
@@ -72,10 +76,11 @@ def create_export_definition(export_id):
     bucket = os.getenv('DATA_BUCKET')
     key = 'export-definitions/{}'.format(export_id)
     logger.info('Creating export definition for %s', export_id)
-    command = ['java', '-cp',
-               '/opt/raster-foundry/jars/batch-assembly.jar',
-               'com.rasterfoundry.batch.Main', 'create_export_def',
-               export_id, bucket, key]
+    command = [
+        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
+        'com.rasterfoundry.batch.Main', 'create_export_def', export_id, bucket,
+        key
+    ]
     logger.info('Running Command %s', ' '.join(command))
     subprocess.check_call(command)
 
@@ -98,75 +103,24 @@ def write_export_definition(export_definition, local_dir):
     local_ed_path = os.path.join(local_dir, 'export_definition.json')
     copied = deepcopy(export_definition)
     # Only two slashes in file:// because local_dir is an absolute unix path
-    # copied['output']['source'] = 's3://rasterfoundry-development-data-us-east-1/chris-test-local/'
-    copied['output']['source'] = 'file://{}'.format(local_dir)
-    # copied['output']['source'] = 'file:/{}.tif'.format(local_dir)
+    copied['output']['destination'] = local_tif_path_from_export_definition(
+        export_definition, local_dir)
     with open(local_ed_path, 'w') as outf:
         outf.write(json.dumps(copied))
     return local_ed_path
 
 
-def post_process_exports(export_definition, tiff_directory):
-    """Run GDAL commands to make exports sane
-
-    Returns: path to final tif file
-    """
-    jwt = get_jwt()
-    root_url = os.getenv('RF_HOST')
-    parsed_url = urlparse(root_url)
-    api = API(api_token=jwt, host=parsed_url.netloc, scheme=parsed_url.scheme)
-    logger.info('Retrieving Export: %s', export_definition['id'])
-    export_obj = api.client.Imagery.get_exports_exportID(exportID=export_definition['id']).result()
-    temp_geojson = os.path.join(tiff_directory, 'cut.json')
-    with open(temp_geojson, 'wb') as fh:
-        geojson = {
-            'type': 'FeatureCollection',
-            'features': [
-                {
-                    "type": "Feature",
-                    "properties": {},
-                    "geometry": export_obj.exportOptions.mask
-                }
-            ]
-        }
-        json.dump(geojson, fh)
-
-    tiff_files = [os.path.join(tiff_directory, f) for f in os.listdir(tiff_directory) if f.endswith('tiff')]
-    logger.info('Found %s files to merge', len(tiff_files))
-    merged_tiff = os.path.join(tiff_directory, 'combined.tiff')
-    translated_tiff = os.path.join(tiff_directory, 'translated.tiff')
-    export_tiff = os.path.join(tiff_directory, 'export.tiff')
-    merge_command = ['gdal_merge.py', '-o', merged_tiff] + tiff_files
-    warp_command = []
-    if export_obj.exportOptions.mask is None:
-        warp_command = ['gdalwarp', '-co', 'COMPRESS=DEFLATE',
-                        '-co', 'TILED=YES', merged_tiff, export_tiff]
-    else:
-        warp_command = ['gdalwarp', '-co', 'COMPRESS=DEFLATE',
-                        '-co', 'TILED=YES', '-crop_to_cutline',
-                        '-cutline', temp_geojson, merged_tiff, export_tiff]
-    translate_command = ['gdal_translate', '-co', 'COMPRESS=DEFLATE', '-co', 'TILED=YES', '-stats',
-                         export_tiff, translated_tiff]
-    logger.info('Running Merge Command: %s', ' '.join(merge_command))
-    subprocess.check_call(merge_command)
-    logger.info('Running Warp Command: %s', ' '.join(warp_command))
-    subprocess.check_call(warp_command)
-    logger.info('Running Translate Command: %s', ' '.join(translate_command))
-    subprocess.check_call(translate_command)
-    logger.info('Finished post-processing export: %s', export_tiff)
-    return translated_tiff
-
-
 def upload_processed_tif(merged_tiff_path, export_definition):
     """Uses original export definition location to upload to s3 or dropbox"""
-    dest = os.path.join(export_definition['output']['source'], 'export.tif')
+    dest = os.path.join(export_definition['output']['destination'], 'export.tif')
     logger.info('Preparing to upload processed export to: %s', dest)
     export_type = 's3' if dest.startswith('s3') else 'dropbox'
     dropbox_access_token = export_definition['output'].get('dropboxCredential')
     if export_type == 's3':
         s3_upload_export(merged_tiff_path, dest)
     else:
-        dropbox_upload_export(dropbox_access_token, merged_tiff_path, dest.replace('dropbox:///', '/'))
+        dropbox_upload_export(dropbox_access_token, merged_tiff_path,
+                              dest.replace('dropbox:///', '/'))
 
 
 def run_export(export_s3_uri, export_id):
@@ -177,18 +131,16 @@ def run_export(export_s3_uri, export_id):
         export_id (str): ID of export job to process
 
     """
-    export_cores = os.getenv('LOCAL_INGEST_CORES', 32)
-    export_memory = os.getenv('LOCAL_INGEST_MEM_GB', 48)
-    status_uri = 's3://{}/export-statuses/{}'.format(os.getenv('DATA_BUCKET'), export_id)
+    status_uri = 's3://{}/export-statuses/{}'.format(
+        os.getenv('DATA_BUCKET'), export_id)
 
-    command = ['spark-submit',
-               '--master', 'local[{}]'.format(export_cores),
-               '--driver-memory', '{}g'.format(export_memory),
-               '--class', 'com.rasterfoundry.batch.export.spark.Export',
-               '/opt/raster-foundry/jars/batch-assembly.jar',
-               '-j', export_s3_uri, '-b', status_uri]
+    command = [
+        'java', '-jar',
+        '/opt/raster-foundry/export/backsplash-export-assembly.jar', '-d',
+        export_s3_uri
+    ]
     subprocess.check_call(command)
-    logger.info('Finished exporting %s in spark local', export_s3_uri)
+    logger.info('Finished exporting %s', export_s3_uri)
     return status_uri
 
 
@@ -201,11 +153,8 @@ def update_export_status(export_id, export_status):
     """
 
     command = [
-        'java', '-cp',
-        '/opt/raster-foundry/jars/batch-assembly.jar',
-        'com.rasterfoundry.batch.Main',
-        'update_export_status',
-        export_id,
+        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
+        'com.rasterfoundry.batch.Main', 'update_export_status', export_id,
         export_status
     ]
     logger.info('Preparing to update export status with command: %s', command)


### PR DESCRIPTION
## Overview

This PR updates the python cli for the `batch` container to use the commands from fancy new COG export introduced in #4515. It also updates the project export frontend to send some fields that are necessary for exports to cooperate.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * **note that exports require masks now**
 * make a non-dropbox export of a project
 * `rf export <export id>` from the `batch` container
 * should succeed and write your export where you expected to write it
 * update that project in the db to point to a tool run
 * run it again
 * should succeed and write your export where you expected to write it
 * make a dropbox export
 * export it
 * it should succeed and write your export where you expected to write it