### PR TITLE
Use docker-compose for copying files

### DIFF
--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -49,7 +49,9 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             docker-compose -f "${DIR}/../docker-compose.test.yml" \
                            run --rm --no-deps lambda \
                            pip install -t opt/ ./
-            cp -r "${DIR}/../app-lambda/rflambda/" "${DIR}/../app-lambda/opt/"
+            docker-compose -f "${DIR}/../docker-compose.test.yml" \
+                           run --rm --no-deps lambda \
+                           cp -r "/opt/raster-foundry/app-lambda/rflambda/" "/opt/raster-foundry/app-lambda/opt/"
             pushd "${DIR}/../app-lambda/opt/"
               zip -9 -r ../package.zip ./*
             popd


### PR DESCRIPTION
## Overview

This is to get around a permissions problem that sometimes happens
when using docker if the `app-lambda/opt` directory is generated via
docker at some point