### PR TITLE
Add layer source and remove scene / COG rasters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added publishing of lambda functions to CI build process [\#4586](https://github.com/raster-foundry/raster-foundry/pull/4586)
 - Added tile server support for masked analyses [\#4571](https://github.com/raster-foundry/raster-foundry/pull/4571)
 - Added project layer navigation bar [\#4581](https://github.com/raster-foundry/raster-foundry/pull/4581)
+- Added backend support for rendering tiles and fetching histograms for analyses with project layers at their leaves [\#4603](https://github.com/raster-foundry/raster-foundry/pull/4603)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Added backend support for rendering tiles and fetching histograms for analyses with project layers at their leaves [\#4603](https://github.com/raster-foundry/raster-foundry/pull/4603)
 
 ### Changed
 
@@ -22,7 +23,6 @@
 - Added publishing of lambda functions to CI build process [\#4586](https://github.com/raster-foundry/raster-foundry/pull/4586)
 - Added tile server support for masked analyses [\#4571](https://github.com/raster-foundry/raster-foundry/pull/4571)
 - Added project layer navigation bar [\#4581](https://github.com/raster-foundry/raster-foundry/pull/4581)
-- Added backend support for rendering tiles and fetching histograms for analyses with project layers at their leaves [\#4603](https://github.com/raster-foundry/raster-foundry/pull/4603)
 
 ### Fixed
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -10,9 +10,12 @@ import com.rasterfoundry.backsplash.error._
 import com.azavea.maml.ast._
 import com.azavea.maml.util.{ClassMap => _}
 
-class BacksplashMamlAdapter[HistStore, ProjStore: ProjectStore](
+class BacksplashMamlAdapter[HistStore: HistogramStore,
+                            ProjStore: ProjectStore,
+                            LayerStore: ProjectStore](
     mosaicImplicits: MosaicImplicits[HistStore],
-    projStore: ProjStore) {
+    projStore: ProjStore,
+    layerStore: LayerStore) {
   import mosaicImplicits._
 
   def asMaml(ast: MapAlgebraAST)
@@ -36,6 +39,20 @@ class BacksplashMamlAdapter[HistStore, ProjStore: ProjectStore](
                   None,
                   None
                 ) map { backsplashIm =>
+                backsplashIm.copy(subsetBands = List(bandActual))
+              }
+            )
+          )
+        }
+        case MapAlgebraAST.LayerRaster(_, layerId, band, _, _) => {
+          val bandActual = band.getOrElse(
+            throw SingleBandOptionsException(
+              "Band must be provided to evaluate AST")
+          )
+          Map[String, BacksplashMosaic](
+            s"${layerId.toString}_${bandActual}" -> (
+              layerStore
+                .read(layerId, None, None, None) map { backsplashIm =>
                 backsplashIm.copy(subsetBands = List(bandActual))
               }
             )

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -10,7 +10,7 @@ import com.rasterfoundry.backsplash.error._
 import com.azavea.maml.ast._
 import com.azavea.maml.util.{ClassMap => _}
 
-class BacksplashMamlAdapter[HistStore: HistogramStore,
+class BacksplashMamlAdapter[HistStore,
                             ProjStore: ProjectStore,
                             LayerStore: ProjectStore](
     mosaicImplicits: MosaicImplicits[HistStore],

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -10,7 +10,7 @@ import com.rasterfoundry.common.ast.MapAlgebraAST
 import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._
 
 import cats.effect.IO
-import com.typesafe.scalalogging.LazyLogging
+import cats.implicits._
 import doobie._
 import doobie.implicits._
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -10,7 +10,7 @@ import com.rasterfoundry.common.ast.MapAlgebraAST
 import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._
 
 import cats.effect.IO
-import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.error._
-import com.rasterfoundry.database.SceneToProjectDao
+import com.rasterfoundry.database.{SceneToLayerDao, SceneToProjectDao}
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.ToolRunDao
 import com.rasterfoundry.common.datamodel._
@@ -25,7 +25,9 @@ class ToolStoreImplicits[HistStore](mosaicImplicits: MosaicImplicits[HistStore],
   implicit val tmsReification = rawMosaicTmsReification
 
   val mamlAdapter =
-    new BacksplashMamlAdapter(mosaicImplicits, SceneToProjectDao())
+    new BacksplashMamlAdapter(mosaicImplicits,
+                              SceneToProjectDao(),
+                              SceneToLayerDao())
 
   private def toolToColorRd(toolRd: RenderDefinition): RenderDefinition = {
     val scaleOpt = toolRd.scale match {

--- a/app-backend/common/src/main/scala/ast/MamlConversion.scala
+++ b/app-backend/common/src/main/scala/ast/MamlConversion.scala
@@ -37,7 +37,7 @@ object MamlConversion {
         case MapAlgebraAST.Classification(_, _, _, classmap) =>
           Classification(args, MamlClassMap(classmap.classifications))
         case MapAlgebraAST.Masking(_, _, _, mask) =>
-          Masking(GeomLit(mask.toGeoJson.toString) +: args)
+          Masking(GeomLit(mask.toGeoJson) +: args)
         case MapAlgebraAST.Equality(_, _, _)       => Equal(args)
         case MapAlgebraAST.Inequality(_, _, _)     => Unequal(args)
         case MapAlgebraAST.Greater(_, _, _)        => Greater(args)

--- a/app-backend/common/src/main/scala/ast/MamlConversion.scala
+++ b/app-backend/common/src/main/scala/ast/MamlConversion.scala
@@ -16,6 +16,10 @@ object MamlConversion {
           val bandActual = band.getOrElse(1)
           RasterVar(s"${projId.toString}_${bandActual}")
         }
+        case MapAlgebraAST.LayerRaster(_, layerId, band, celltype, _) => {
+          val bandActual = band.getOrElse(1)
+          RasterVar(s"${layerId.toString}_${bandActual}")
+        }
 
         case MapAlgebraAST.Constant(_, const, _) => DblLit(const)
         case MapAlgebraAST.LiteralTile(_, lt, _) =>

--- a/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
@@ -673,6 +673,7 @@ object MapAlgebraAST {
                            band: Option[Int],
                            celltype: Option[CellType],
                            metadata: Option[NodeMetadata])
+      extends MapAlgebraLeaf
       with RFMLRaster {
     val `type` = "projectSrc"
     def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)

--- a/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
@@ -668,45 +668,11 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  final case class SceneRaster(id: UUID,
-                               sceneId: UUID,
-                               band: Option[Int],
-                               celltype: Option[CellType],
-                               metadata: Option[NodeMetadata])
-      extends MapAlgebraLeaf
-      with RFMLRaster {
-    val `type` = "sceneSrc"
-    def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)
-    def substitute(
-        substitutions: Map[UUID, MapAlgebraAST]): Option[MapAlgebraAST] =
-      Some(this)
-    def withMetadata(newMd: NodeMetadata): MapAlgebraAST =
-      copy(metadata = Some(newMd))
-  }
-
-  final case class CogRaster(id: UUID,
-                             sceneId: UUID,
-                             band: Option[Int],
-                             celltype: Option[CellType],
-                             metadata: Option[NodeMetadata],
-                             location: String)
-      extends MapAlgebraLeaf
-      with RFMLRaster {
-    val `type` = "cogSrc"
-    def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)
-    def substitute(
-        substitutions: Map[UUID, MapAlgebraAST]): Option[MapAlgebraAST] =
-      Some(this)
-    def withMetadata(newMd: NodeMetadata): MapAlgebraAST =
-      copy(metadata = Some(newMd))
-  }
-
-  final case class ProjectRaster(id: UUID,
-                                 projId: UUID,
-                                 band: Option[Int],
-                                 celltype: Option[CellType],
-                                 metadata: Option[NodeMetadata])
-      extends MapAlgebraLeaf
+  case class ProjectRaster(id: UUID,
+                           projId: UUID,
+                           band: Option[Int],
+                           celltype: Option[CellType],
+                           metadata: Option[NodeMetadata])
       with RFMLRaster {
     val `type` = "projectSrc"
     def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)
@@ -716,6 +682,22 @@ object MapAlgebraAST {
     def withMetadata(newMd: NodeMetadata): MapAlgebraAST =
       copy(metadata = Some(newMd))
 
+  }
+
+  case class LayerRaster(id: UUID,
+                         layerId: UUID,
+                         band: Option[Int],
+                         celltype: Option[CellType],
+                         metadata: Option[NodeMetadata])
+      extends MapAlgebraLeaf
+      with RFMLRaster {
+    val `type` = "layerSrc"
+    def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)
+    def substitute(
+        substitutions: Map[UUID, MapAlgebraAST]): Option[MapAlgebraAST] =
+      Some(this)
+    def withMetadata(newMd: NodeMetadata): MapAlgebraAST =
+      copy(metadata = Some(newMd))
   }
 
   final case class ToolReference(id: UUID, toolId: UUID)

--- a/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
@@ -668,7 +668,7 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class ProjectRaster(id: UUID,
+  final case class ProjectRaster(id: UUID,
                            projId: UUID,
                            band: Option[Int],
                            celltype: Option[CellType],
@@ -685,7 +685,7 @@ object MapAlgebraAST {
 
   }
 
-  case class LayerRaster(id: UUID,
+  final case class LayerRaster(id: UUID,
                          layerId: UUID,
                          band: Option[Int],
                          celltype: Option[CellType],

--- a/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
@@ -669,10 +669,10 @@ object MapAlgebraAST {
   }
 
   final case class ProjectRaster(id: UUID,
-                           projId: UUID,
-                           band: Option[Int],
-                           celltype: Option[CellType],
-                           metadata: Option[NodeMetadata])
+                                 projId: UUID,
+                                 band: Option[Int],
+                                 celltype: Option[CellType],
+                                 metadata: Option[NodeMetadata])
       extends MapAlgebraLeaf
       with RFMLRaster {
     val `type` = "projectSrc"
@@ -686,10 +686,10 @@ object MapAlgebraAST {
   }
 
   final case class LayerRaster(id: UUID,
-                         layerId: UUID,
-                         band: Option[Int],
-                         celltype: Option[CellType],
-                         metadata: Option[NodeMetadata])
+                               layerId: UUID,
+                               band: Option[Int],
+                               celltype: Option[CellType],
+                               metadata: Option[NodeMetadata])
       extends MapAlgebraLeaf
       with RFMLRaster {
     val `type` = "layerSrc"

--- a/app-backend/common/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
+++ b/app-backend/common/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
@@ -20,8 +20,8 @@ trait MapAlgebraLeafCodecs {
           ma.as[MapAlgebraAST.ToolReference]
         case Some("const") =>
           ma.as[MapAlgebraAST.Constant]
-        case Some("sceneSrc") =>
-          ma.as[MapAlgebraAST.SceneRaster]
+        case Some("layerSrc") =>
+          ma.as[MapAlgebraAST.LayerRaster]
         case Some("projectSrc") =>
           ma.as[MapAlgebraAST.ProjectRaster]
         case _ =>
@@ -36,8 +36,8 @@ trait MapAlgebraLeafCodecs {
           reference.asJson
         case const: MapAlgebraAST.Constant =>
           const.asJson
-        case sceneSrc: MapAlgebraAST.SceneRaster =>
-          sceneSrc.asJson
+        case layerSrc: MapAlgebraAST.LayerRaster =>
+          layerSrc.asJson
         case projectSrc: MapAlgebraAST.ProjectRaster =>
           projectSrc.asJson
         case _ =>
@@ -45,17 +45,17 @@ trait MapAlgebraLeafCodecs {
       }
     }
 
-  implicit lazy val decodeSceneSource: Decoder[MapAlgebraAST.SceneRaster] =
-    Decoder.forProduct5("id", "sceneId", "band", "celltype", "metadata")(
-      MapAlgebraAST.SceneRaster.apply)
-  implicit lazy val encodeSceneSource: Encoder[MapAlgebraAST.SceneRaster] =
+  implicit lazy val decodeLayerSource: Decoder[MapAlgebraAST.LayerRaster] =
+    Decoder.forProduct5("id", "layerId", "band", "celltype", "metadata")(
+      MapAlgebraAST.LayerRaster.apply)
+  implicit lazy val encodeLayerSource: Encoder[MapAlgebraAST.LayerRaster] =
     Encoder.forProduct6("type",
                         "id",
-                        "sceneId",
+                        "layerId",
                         "band",
                         "celltype",
                         "metadata")(src =>
-      (src.`type`, src.id, src.sceneId, src.band, src.celltype, src.metadata))
+      (src.`type`, src.id, src.layerId, src.band, src.celltype, src.metadata))
 
   implicit lazy val decodeProjectSource: Decoder[MapAlgebraAST.ProjectRaster] =
     Decoder.forProduct5("id", "projId", "band", "celltype", "metadata")(


### PR DESCRIPTION
## Overview

This PR adds `LayerRaster`s to `MapAlgebraLeaf`s, so we can use layers for evaluating ASTs.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

SceneToProjectDao project store implicits weren't removed, because we don't have a good way to rewrite the project source to point to a layer at the point where we're doing that read -- I could cheat and throw in an `unsafeRunSync` but I'd feel pretty gross about it, especially since it'd required `backsplash-core` to depend on the `db` subproject

## Testing Instructions

 * reassemble your servers, bring them up
 * make an analysis from the `Local File Single Scene` project
 * update its execution parameters in the database to:

```json
{
  "id": "6278bbbb-1ae2-4244-85cb-624502dc521d",
  "args": [
    {
      "id": "75d675a3-2797-4c19-a289-2099ae26aa1d",
      "band": 0,
      "type": "layerSrc",
      "layerId": "<YOUR DEFAULT LAYER ID>",
      "metadata": {
        "label": "A"
      }
    },
    {
      "id": "d4740942-c65f-4b37-9ae8-b9b1120dcc04",
      "band": 1,
      "type": "layerSrc",
      "layerId": "<YOUR DEFAULT LAYER ID>",
      "metadata": {
        "label": "B"
      }
    }
  ],
  "apply": "+",
  "metadata": {
    "label": "add",
    "collapsable": true
  }
}
```
 * try to visualize the histogram and the tiles for the analysis
 * you should get both successfully

Closes #4519 
