### PR TITLE
Remove or suppress warnings when scapegoat is mad at us

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Removed unused imports and assignments [\#4579](https://github.com/raster-foundry/raster-foundry/pull/4579)
 - Included geometry filter in backsplash scene service to prevent erroneous 500s [\#4580](https://github.com/raster-foundry/raster-foundry/pull/4580)
+- Made scapegoat less angry [\#4611](https://github.com/raster-foundry/raster-foundry/pull/4611)
 
 ### Security
 

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -128,7 +128,7 @@ trait Authentication extends Directives with LazyLogging {
     )
   }
 
-  @SuppressWarnings(Array("TraversableHead"))
+  @SuppressWarnings(Array("TraversableHead", "PartialFunctionInsteadOfMatch"))
   def authenticateWithToken(tokenString: String): Directive1[User] = {
     val result = verifyJWT(tokenString)
     result match {

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -44,6 +44,7 @@ object Main extends App with Config with Router {
 
   sys.addShutdownHook {
     terminate()
+    ()
   }
 
   Http().bindAndHandle(routes, httpHost, httpPort)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -1483,7 +1483,7 @@ trait ProjectRoutes
         rejectEmptyResponse {
           complete {
             ProjectLayerDao
-              .getProjectLayer(projectId, layerId, user)
+              .getProjectLayer(projectId, layerId)
               .transact(xa)
               .unsafeToFuture
           }
@@ -1678,7 +1678,7 @@ trait ProjectRoutes
         } {
           complete {
             ProjectLayerDatasourcesDao
-              .listProjectLayerDatasources(projectId, layerId)
+              .listProjectLayerDatasources(layerId)
               .transact(xa)
               .unsafeToFuture
           }

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -67,7 +67,7 @@ trait ThumbnailRoutes
     authenticateWithParameter { _ =>
       val bucketAndPrefix =
         sentinelS3client.bucketAndPrefixFromURI(
-          new URI(URLDecoder.decode(thumbnailUri)))
+          new URI(URLDecoder.decode(thumbnailUri, "UTF-8")))
       val s3Object =
         sentinelS3client.getObject(bucketAndPrefix._1, bucketAndPrefix._2, true)
       val metaData = S3.getObjectMetadata(s3Object)

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -17,8 +17,6 @@ import doobie.implicits._
 
 import java.util.UUID
 
-import java.util.UUID
-
 trait ToolRunRoutes
     extends Authentication
     with PaginationDirectives

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -18,8 +18,6 @@ import doobie.implicits._
 
 import java.util.UUID
 
-import java.util.UUID
-
 trait ToolRoutes
     extends Authentication
     with ToolQueryParameterDirective

--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -44,5 +44,7 @@ class DummySessionStore extends DbxSessionStore {
     }
   }
   def set(s: String): Unit = this.setToken(s)
+  /** This method exists just for class compatibility but doesn't do anything */
+  @SuppressWarnings(Array("EmptyMethod"))
   def clear(): Unit = ()
 }

--- a/app-backend/api/src/main/scala/user/DropboxUser.scala
+++ b/app-backend/api/src/main/scala/user/DropboxUser.scala
@@ -44,6 +44,7 @@ class DummySessionStore extends DbxSessionStore {
     }
   }
   def set(s: String): Unit = this.setToken(s)
+
   /** This method exists just for class compatibility but doesn't do anything */
   @SuppressWarnings(Array("EmptyMethod"))
   def clear(): Unit = ()

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -37,7 +37,7 @@ import scalacache.modes.sync._
   * @param corrections description + operations for how to correct image
   * @param singleBandOptions band + options of how to color a single band
   */
-case class BacksplashImage(
+final case class BacksplashImage(
     imageId: UUID,
     @cacheKeyExclude projectLayerId: UUID,
     @cacheKeyExclude uri: String,
@@ -109,7 +109,7 @@ object BacksplashImage extends RasterSourceUtils with LazyLogging {
     if (enableGDAL) {
       logger.debug(s"Using GDAL Raster Source: ${uri}")
       // Do not bother caching - let GDAL internals worry about that
-      GDALRasterSource(URLDecoder.decode(uri))
+      GDALRasterSource(URLDecoder.decode(uri, "UTF-8"))
     } else {
       memoizeSync(None) {
         logger.debug(s"Using GeoTiffRasterSource: ${uri}")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -57,9 +57,11 @@ object BacksplashMosaic extends ToHistogramStoreOps {
   }
 
   /** We're in the non-Nil branch of the match, so we definitely have histograms
-    * at the point where we're asking for the head of the list
+    * at the point where we're asking for the head of the list.
+    * Also, messing with the map instead of match thing messes up the types for reasons
+    * that I disagree with, so suppressing.
     */
-  @SuppressWarnings(Array("TraversableHead"))
+  @SuppressWarnings(Array("TraversableHead", "PartialFunctionInsteadOfMatch"))
   def getStoreHistogram[T: HistogramStore](mosaic: BacksplashMosaic,
                                            histStore: T)(
       implicit hasRasterExtents: HasRasterExtents[BacksplashMosaic],

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -10,7 +10,7 @@ import com.rasterfoundry.backsplash.error._
 import com.azavea.maml.ast._
 import com.azavea.maml.util.{ClassMap => _}
 
-class BacksplashMamlAdapter[HistStore: HistogramStore, ProjStore: ProjectStore](
+class BacksplashMamlAdapter[HistStore, ProjStore: ProjectStore](
     mosaicImplicits: MosaicImplicits[HistStore],
     projStore: ProjStore) {
   import mosaicImplicits._

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -108,7 +108,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
             .map(_.fold(0)(_ + _))
           _ <- {
             if (bandCount == 0) {
-              IO.raiseError(NoDataInRegionException())
+              IO.raiseError(NoDataInRegionException)
             } else IO.unit
           }
           filtered = BacksplashMosaic.filterRelevant(self)
@@ -220,7 +220,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
         } yield {
           RasterLit(mosaic)
         }).attempt.map {
-          case Left(NoDataInRegionException()) =>
+          case Left(NoDataInRegionException) =>
             RasterLit(
               Raster(MultibandTile(invisiTile, invisiTile, invisiTile),
                      Extent(0, 0, 256, 256)))

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -29,8 +29,7 @@ object PaintableTool {
       expr: Expression,
       paramMap: Map[String, Param],
       renderDef: Option[RenderDefinition],
-      interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT,
-      paint: Boolean = true // whether to paint the tile or return raw values
+      interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
   ): PaintableTool = new PaintableTool {
 
     def tms(z: Int, x: Int, y: Int)(

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ProjectStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/ProjectStore.scala
@@ -6,7 +6,7 @@ import simulacrum._
 
 import java.util.UUID
 
-case class BandOverride(
+final case class BandOverride(
     red: Int,
     green: Int,
     blue: Int

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorCorrect.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorCorrect.scala
@@ -247,8 +247,8 @@ object ColorCorrect extends LazyLogging {
             rgbHist: Array[Histogram[Double]],
             params: Params,
             nodataValue: Option[Double]): MultibandTile = {
-    var _rgbTile = rgbTile
-    var _rgbHist = rgbHist
+    val _rgbTile = rgbTile
+    val _rgbHist = rgbHist
     val gammas = params.getGamma
 
     val layerRgbClipping = {

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/Implicits.scala
@@ -15,10 +15,10 @@ trait Implicits {
 
   // Without this keyencoder/keydecoder we can't derive serialization for render defs
   implicit val decodeKeyDouble: KeyDecoder[Double] = new KeyDecoder[Double] {
-    final def apply(key: String): Option[Double] = Try(key.toDouble).toOption
+    def apply(key: String): Option[Double] = Try(key.toDouble).toOption
   }
   implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
-    final def apply(key: Double): String = key.toString
+    def apply(key: Double): String = key.toString
   }
 
   // necessary for fallbacks in RenderDefinition
@@ -49,7 +49,7 @@ trait Implicits {
       "#" + rgba.red.toHexString + rgba.blue.toHexString + rgba.green.toHexString + rgba.alpha.toHexString
     }
 
-  implicit class renderTileWithDefinition(tile: Tile) {
+  implicit class RenderTileWithDefinition(tile: Tile) {
 
     /** This function produces a function from cell value to color appropriate to the color
       * space defined by the provided [[RenderDefinition]]
@@ -61,7 +61,7 @@ trait Implicits {
       }
 
     /** RGB color interpolation logic */
-    private def RgbLerp(color1: RGBA, color2: RGBA, proportion: Double): Int = {
+    private def rgbLerp(color1: RGBA, color2: RGBA, proportion: Double): Int = {
       val r = (color1.red + (color2.red - color1.red) * proportion).toInt
       val g = (color1.green + (color2.green - color1.green) * proportion).toInt
       val b = (color1.blue + (color2.blue - color1.blue) * proportion).toInt
@@ -98,7 +98,7 @@ trait Implicits {
           val higher = breaks(higherIdx)
           val proportion = (dbl - lower) / (higher - lower)
 
-          RgbLerp(colors(lowerIdx), colors(higherIdx), proportion)
+          rgbLerp(colors(lowerIdx), colors(higherIdx), proportion)
         } else {
           // Direct hit
           colors(insertionPoint)

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -54,7 +54,7 @@ class BacksplashHttpErrorHandler[F[_], U](
     case UnknownSceneTypeException(m)  => BadRequest(m)
     case BadAnalysisASTException(m)    => BadRequest(m)
     case RequirementFailedException(m) => BadRequest(m)
-    case NoDataInRegionException => BadRequest("No Data in Region")
+    case NoDataInRegionException       => BadRequest("No Data in Region")
     case t @ NotAuthorizedException(_) =>
       Forbidden(
         "Resource does not exist or user is not authorized to access this resource")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/error/Error.scala
@@ -32,7 +32,7 @@ final case class RequirementFailedException(message: String)
 final case class WrappedDoobieException(message: String)
     extends BacksplashException
 // When an area is requested completely outside the extent of a project/scene/analysis
-final case class NoDataInRegionException() extends BacksplashException
+case object NoDataInRegionException extends BacksplashException
 
 // When we get any S3 error
 final case class WrappedS3Exception(message: String) extends BacksplashException
@@ -54,7 +54,7 @@ class BacksplashHttpErrorHandler[F[_], U](
     case UnknownSceneTypeException(m)  => BadRequest(m)
     case BadAnalysisASTException(m)    => BadRequest(m)
     case RequirementFailedException(m) => BadRequest(m)
-    case NoDataInRegionException()     => BadRequest("No Data in Region")
+    case NoDataInRegionException => BadRequest("No Data in Region")
     case t @ NotAuthorizedException(_) =>
       Forbidden(
         "Resource does not exist or user is not authorized to access this resource")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -8,6 +8,6 @@ package object backsplash {
   type BacksplashMosaic = fs2.Stream[IO, BacksplashImage]
 
   implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
-    final def apply(key: Double): String = key.toString
+    def apply(key: Double): String = key.toString
   }
 }

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/Exportable.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/Exportable.scala
@@ -28,16 +28,19 @@ import cats.effect._
 
   @op("exportDestination") def exportDestination(self: A): String
 
-  @op("toGeoTiff") def toGeoTiff(self: A, compression: Compression)(
+  /** It's fine, maybe */
+  @op("toGeoTiff")
+  def toGeoTiff(self: A, compression: Compression)(
       implicit cs: ContextShift[IO]): MultibandGeoTiff = {
-    val tifftile = GeoTiffBuilder[MultibandTile]
+    @SuppressWarnings(Array("AsInstanceOf"))
+    def tifftile: GeoTiffMultibandTile = GeoTiffBuilder[MultibandTile]
       .makeTile(
         keyedTileSegments(self, exportZoom(self)),
         segmentLayout = segmentLayout(self),
         cellType = exportCellType(self),
         compression = compression
       )
-      .asInstanceOf[GeoTiffMultibandTile] // This hurts :(
+      .asInstanceOf[GeoTiffMultibandTile]
     val latLngExtent = exportExtent(self)
     val tilesForExtent = TilesForExtent.latLng(latLngExtent, exportZoom(self))
     val outputExtent =

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/Exportable.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/Exportable.scala
@@ -28,10 +28,10 @@ import cats.effect._
 
   @op("exportDestination") def exportDestination(self: A): String
 
-  /** It's fine, maybe */
   @op("toGeoTiff")
   def toGeoTiff(self: A, compression: Compression)(
       implicit cs: ContextShift[IO]): MultibandGeoTiff = {
+    /** It's fine, maybe */
     @SuppressWarnings(Array("AsInstanceOf"))
     def tifftile: GeoTiffMultibandTile = GeoTiffBuilder[MultibandTile]
       .makeTile(

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/Exportable.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/Exportable.scala
@@ -31,16 +31,18 @@ import cats.effect._
   @op("toGeoTiff")
   def toGeoTiff(self: A, compression: Compression)(
       implicit cs: ContextShift[IO]): MultibandGeoTiff = {
+
     /** It's fine, maybe */
     @SuppressWarnings(Array("AsInstanceOf"))
-    def tifftile: GeoTiffMultibandTile = GeoTiffBuilder[MultibandTile]
-      .makeTile(
-        keyedTileSegments(self, exportZoom(self)),
-        segmentLayout = segmentLayout(self),
-        cellType = exportCellType(self),
-        compression = compression
-      )
-      .asInstanceOf[GeoTiffMultibandTile]
+    def tifftile: GeoTiffMultibandTile =
+      GeoTiffBuilder[MultibandTile]
+        .makeTile(
+          keyedTileSegments(self, exportZoom(self)),
+          segmentLayout = segmentLayout(self),
+          cellType = exportCellType(self),
+          compression = compression
+        )
+        .asInstanceOf[GeoTiffMultibandTile]
     val latLngExtent = exportExtent(self)
     val tilesForExtent = TilesForExtent.latLng(latLngExtent, exportZoom(self))
     val outputExtent =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -13,8 +13,7 @@ import org.http4s._
   */
 object AuthedAutoSlash {
   def apply[T, F[_]](http: AuthedService[T, F])(
-      implicit F: MonoidK[OptionT[F, ?]],
-      ev: Functor[F]): AuthedService[T, F] = Kleisli { authedReq =>
+      implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] = Kleisli { authedReq =>
     {
       http(authedReq) <+> {
         val pathInfo = authedReq.req.pathInfo

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedAutoSlash.scala
@@ -13,26 +13,27 @@ import org.http4s._
   */
 object AuthedAutoSlash {
   def apply[T, F[_]](http: AuthedService[T, F])(
-      implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] = Kleisli { authedReq =>
-    {
-      http(authedReq) <+> {
-        val pathInfo = authedReq.req.pathInfo
-        val scriptName = authedReq.req.scriptName
+      implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] = Kleisli {
+    authedReq =>
+      {
+        http(authedReq) <+> {
+          val pathInfo = authedReq.req.pathInfo
+          val scriptName = authedReq.req.scriptName
 
-        if (pathInfo.isEmpty || pathInfo.charAt(pathInfo.length - 1) != '/') {
-          F.empty
-        } else if (scriptName.isEmpty) {
-          // Request has not been translated already
-          http.apply(
-            authedReq.copy(req = authedReq.req.withPathInfo(
-              pathInfo.substring(0, pathInfo.length - 1))))
-        } else {
-          val translated = AuthedTranslateUri(scriptName)(http)
-          translated.apply(
-            authedReq.copy(req = authedReq.req.withPathInfo(
-              pathInfo.substring(0, pathInfo.length - 1))))
+          if (pathInfo.isEmpty || pathInfo.charAt(pathInfo.length - 1) != '/') {
+            F.empty
+          } else if (scriptName.isEmpty) {
+            // Request has not been translated already
+            http.apply(
+              authedReq.copy(req = authedReq.req.withPathInfo(
+                pathInfo.substring(0, pathInfo.length - 1))))
+          } else {
+            val translated = AuthedTranslateUri(scriptName)(http)
+            translated.apply(
+              authedReq.copy(req = authedReq.req.withPathInfo(
+                pathInfo.substring(0, pathInfo.length - 1))))
+          }
         }
       }
-    }
   }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
@@ -10,8 +10,7 @@ import cats.data._
 object AuthedTranslateUri {
 
   def apply[F[_], T](prefix: String)(http: AuthedService[T, F])(
-      implicit F: MonoidK[OptionT[F, ?]],
-      ev: Functor[F]): AuthedService[T, F] =
+      implicit F: MonoidK[OptionT[F, ?]]): AuthedService[T, F] =
     if (prefix.isEmpty || prefix == "/") http
     else {
       val (slashedPrefix, unslashedPrefix) =
@@ -35,7 +34,7 @@ object AuthedTranslateUri {
 
     }
 
-  private def setCaret[F[_]: Functor](req: Request[F],
+  private def setCaret[F[_]](req: Request[F],
                                       newCaret: Int): Request[F] = {
     val oldCaret = req.attributes
       .get(Request.Keys.PathInfoCaret)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AuthedTranslateUri.scala
@@ -34,8 +34,7 @@ object AuthedTranslateUri {
 
     }
 
-  private def setCaret[F[_]](req: Request[F],
-                                      newCaret: Int): Request[F] = {
+  private def setCaret[F[_]](req: Request[F], newCaret: Int): Request[F] = {
     val oldCaret = req.attributes
       .get(Request.Keys.PathInfoCaret)
       .getOrElse(0)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authenticators.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authenticators.scala
@@ -19,6 +19,8 @@ import doobie.util.transactor.Transactor
 
 import java.util.UUID
 
+/** List append is slow for large lists -- but we have a list of 3 elements */
+@SuppressWarnings(Array("ListAppend"))
 class Authenticators(val xa: Transactor[IO])
     extends LazyLogging
     with RFHttp4s.Authenticators {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -107,7 +107,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
   val sceneMosaicService: HttpRoutes[IO] =
     authenticators.tokensAuthMiddleware(
       AuthedAutoSlash(
-        new SceneService(SceneDao(), mosaicImplicits, LayerAttributeDao(), xa).routes
+        new SceneService(SceneDao(), mosaicImplicits, xa).routes
       )
     )
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -24,7 +24,7 @@ import geotrellis.vector.{Polygon, Projected}
 
 import java.util.UUID
 
-class MosaicService[LayerStore: ProjectStore, HistStore: HistogramStore](
+class MosaicService[LayerStore: ProjectStore, HistStore](
     layers: LayerStore,
     mosaicImplicits: MosaicImplicits[HistStore],
     xa: Transactor[IO])(implicit cs: ContextShift[IO],

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ProjectStoreImplicits.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash._
-import com.rasterfoundry.backsplash.color._
 import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.database.{SceneDao, SceneToLayerDao, SceneToProjectDao}
@@ -137,7 +136,7 @@ class ProjectStoreImplicits(xa: Transactor[IO]) extends ToProjectStoreOps {
         val imageBandOverride = bandOverride map { ovr =>
           List(ovr.red, ovr.green, ovr.blue)
         } getOrElse { List(0, 1, 2) }
-        val colorCorrectParams = ColorCorrect.paramsFromBandSpecOnly(0, 1, 2)
+        val colorCorrectParams = BSColorCorrect.paramsFromBandSpecOnly(0, 1, 2)
         BacksplashImage(
           scene.id,
           randomProjectId,

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
@@ -16,7 +16,7 @@ import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers._
 
-class SceneService[ProjStore : ProjectStore, HistStore](
+class SceneService[ProjStore: ProjectStore, HistStore](
     scenes: ProjStore,
     mosaicImplicits: MosaicImplicits[HistStore],
     xa: Transactor[IO])(implicit cs: ContextShift[IO],

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/SceneService.scala
@@ -16,10 +16,9 @@ import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.headers._
 
-class SceneService[ProjStore: ProjectStore, HistStore: HistogramStore](
+class SceneService[ProjStore : ProjectStore, HistStore](
     scenes: ProjStore,
     mosaicImplicits: MosaicImplicits[HistStore],
-    histStore: HistStore,
     xa: Transactor[IO])(implicit cs: ContextShift[IO],
                         H: HttpErrorHandler[IO, BacksplashException, User],
                         ForeignError: HttpErrorHandler[IO, Throwable, User])

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -10,14 +10,13 @@ import com.rasterfoundry.common.ast.MapAlgebraAST
 import com.rasterfoundry.common.ast.codec.MapAlgebraCodec._
 
 import cats.effect.IO
-import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
 
 import java.util.UUID
 
-class ToolStoreImplicits[HistStore: HistogramStore](
+class ToolStoreImplicits[HistStore](
     mosaicImplicits: MosaicImplicits[HistStore],
     xa: Transactor[IO])
     extends ProjectStoreImplicits(xa)
@@ -72,6 +71,10 @@ class ToolStoreImplicits[HistStore: HistogramStore](
 
   implicit val toolRunDaoStore: ToolStore[ToolRunDao] =
     new ToolStore[ToolRunDao] {
+      /** Unclear what un-matching this would even be -- I think scapegoat was mad about the
+        * de-sugared code? Annoying
+        */
+      @SuppressWarnings(Array("PartialFunctionInsteadOfMatch"))
       def read(self: ToolRunDao,
                analysisId: UUID,
                nodeId: Option[UUID]): IO[PaintableTool] =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/ToolStoreImplicits.scala
@@ -16,9 +16,8 @@ import doobie.implicits._
 
 import java.util.UUID
 
-class ToolStoreImplicits[HistStore](
-    mosaicImplicits: MosaicImplicits[HistStore],
-    xa: Transactor[IO])
+class ToolStoreImplicits[HistStore](mosaicImplicits: MosaicImplicits[HistStore],
+                                    xa: Transactor[IO])
     extends ProjectStoreImplicits(xa)
     with LazyLogging {
 
@@ -71,6 +70,7 @@ class ToolStoreImplicits[HistStore](
 
   implicit val toolRunDaoStore: ToolStore[ToolRunDao] =
     new ToolStore[ToolRunDao] {
+
       /** Unclear what un-matching this would even be -- I think scapegoat was mad about the
         * de-sugared code? Annoying
         */

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -13,12 +13,12 @@ package object server {
 
   // Without this keyencoder we can't encode the bincounts from double histograms
   implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
-    final def apply(key: Double): String = key.toString
+    def apply(key: Double): String = key.toString
   }
 
   // utility codec for any spray json value
   implicit val sprayJsonEncoder: Encoder[JsValue] = new Encoder[JsValue] {
-    final def apply(jsvalue: JsValue): Json =
+    def apply(jsvalue: JsValue): Json =
       parse(jsvalue.compactPrint) match {
         case Right(success) => success
         case Left(fail)     => throw fail
@@ -28,7 +28,7 @@ package object server {
   // use spray's encoder (above) to encode histograms
   implicit val histogramEncoder: Encoder[Histogram[Double]] =
     new Encoder[Histogram[Double]] {
-      final def apply(hist: Histogram[Double]): Json = hist.toJson.asJson
+      def apply(hist: Histogram[Double]): Json = hist.toJson.asJson
     }
 
   implicit val statsEncoder: Encoder[Statistics[Double]] = deriveEncoder

--- a/app-backend/batch/src/main/scala/aoi/FindAOIProjects.scala
+++ b/app-backend/batch/src/main/scala/aoi/FindAOIProjects.scala
@@ -56,6 +56,7 @@ final case class FindAOIProjects(implicit val xa: Transactor[IO])
     val projectIds = aoiProjectsToUpdate.transact(xa).unsafeRunSync
     logger.info(s"Found the following projects to update: ${projectIds}")
     projectIds.map(kickoffAOIUpdateProject)
+    ()
   }
 }
 

--- a/app-backend/batch/src/main/scala/aoi/UpdateAOIProject.scala
+++ b/app-backend/batch/src/main/scala/aoi/UpdateAOIProject.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.batch.aoi
 import com.rasterfoundry.batch.Job
 import com.rasterfoundry.batch.util.conf.Config
 import com.rasterfoundry.common.RollbarNotifier
-import com.rasterfoundry.common.notification.Email.NotificationEmail
+import com.rasterfoundry.common.notification.Email.{EmailConfig, NotificationEmail}
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database._
 import com.rasterfoundry.database.util.RFTransactor
@@ -100,11 +100,11 @@ final case class UpdateAOIProject(projectId: UUID)(
             val (subject, html, plain) =
               aoiEmailContent(project, platform, user, sceneCount)
             email
-              .setEmail(host,
+              .setEmail(EmailConfig(host,
                         port,
                         encryption,
                         platSmtpUserName,
-                        pw,
+                        pw),
                         userEmail,
                         subject,
                         html,

--- a/app-backend/batch/src/main/scala/export/CreateExportDef.scala
+++ b/app-backend/batch/src/main/scala/export/CreateExportDef.scala
@@ -42,6 +42,7 @@ final case class CreateExportDef(exportId: UUID, bucket: String, key: String)(
 
     try {
       s3Client.putObjectString(bucket, key, exportDef.noSpaces)
+      ()
     } catch {
       case e: Throwable => {
         logger.error(

--- a/app-backend/batch/src/main/scala/export/UpdateExportStatus.scala
+++ b/app-backend/batch/src/main/scala/export/UpdateExportStatus.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.batch.export
 import com.rasterfoundry.batch.Job
 import com.rasterfoundry.batch.util.conf.Config
 import com.rasterfoundry.common.RollbarNotifier
-import com.rasterfoundry.common.notification.Email.NotificationEmail
+import com.rasterfoundry.common.notification.Email.{EmailConfig, NotificationEmail}
 import com.rasterfoundry.database._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
@@ -171,11 +171,11 @@ final case class UpdateExportStatus(
             val (subject, html, plain) =
               exportEmailContent(status, user, platform, name, id, exportType)
             email
-              .setEmail(host,
+              .setEmail(EmailConfig(host,
                         port,
                         encryption,
                         platSmtpUserName,
-                        pw,
+                        pw),
                         userEmail,
                         subject,
                         html,

--- a/app-backend/batch/src/main/scala/notification/NotifyIngestStatus.scala
+++ b/app-backend/batch/src/main/scala/notification/NotifyIngestStatus.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.batch.notification
 import com.rasterfoundry.batch.Job
 import com.rasterfoundry.batch.util.conf.Config
 import com.rasterfoundry.common.RollbarNotifier
-import com.rasterfoundry.common.notification.Email.NotificationEmail
+import com.rasterfoundry.common.notification.Email.{EmailConfig, NotificationEmail}
 import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.{PlatformDao, ProjectDao, SceneDao}
@@ -176,11 +176,11 @@ final case class NotifyIngestStatus(sceneId: UUID)(
               val (ingestEmailSubject, htmlBody, plainBody) =
                 createIngestEmailContentForConsumers(pU, scene, ingestStatus)
               email
-                .setEmail(host,
+                .setEmail(EmailConfig(host,
                           port,
                           encryption,
                           platSmtpUserName,
-                          pw,
+                          pw),
                           userEmail,
                           ingestEmailSubject,
                           htmlBody,
@@ -232,11 +232,11 @@ final case class NotifyIngestStatus(sceneId: UUID)(
             val (ingestEmailSubject, htmlBody, plainBody) =
               createIngestEmailContentForOwner(pO, scene, ingestStatus)
             email
-              .setEmail(host,
+              .setEmail(EmailConfig(host,
                         port,
                         encryption,
                         platSmtpUserName,
-                        pw,
+                        pw),
                         userEmail,
                         ingestEmailSubject,
                         htmlBody,
@@ -271,6 +271,7 @@ final case class NotifyIngestStatus(sceneId: UUID)(
                                          ingestStatus)
       case _ => logger.warn(s"Scene ${sceneId} is not in any project yet.")
     }
+    ()
   }
 
   def notifyOwners(scene: Scene, ingestStatus: String): Unit = {

--- a/app-backend/batch/src/main/scala/stac/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/stac/ReadStacFeature.scala
@@ -92,6 +92,7 @@ object ReadStacFeature extends Config with LazyLogging {
               s"Test run, so scene was not actually created:\n${scene}")
           case _ =>
             writeSceneToDb(scene)
+            ()
         }
       case Left(error) =>
         logger.error(

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -22,8 +22,8 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 sealed trait S3Region
-case class S3RegionEnum(s3Region: Regions) extends S3Region
-case class S3RegionString(s3Region: String) extends S3Region
+final case class S3RegionEnum(s3Region: Regions) extends S3Region
+final case class S3RegionString(s3Region: String) extends S3Region
 
 final case class S3(credentialsProviderChain: AWSCredentialsProvider =
                       new DefaultAWSCredentialsProviderChain,

--- a/app-backend/common/src/main/scala/ast/ClassMap.scala
+++ b/app-backend/common/src/main/scala/ast/ClassMap.scala
@@ -4,7 +4,7 @@ import geotrellis.raster._
 import geotrellis.raster.render._
 import spire.std.any._
 
-case class ClassMap(
+final case class ClassMap(
     classifications: Map[Double, Int]
 ) {
   // How exposed should this be to the api?
@@ -33,7 +33,7 @@ case class ClassMap(
 }
 
 object ClassMap {
-  case class Options(
+  final case class Options(
       boundaryType: ClassBoundaryType = LessThanOrEqualTo,
       ndValue: Int = NODATA,
       fallback: Int = NODATA

--- a/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
+++ b/app-backend/common/src/main/scala/ast/MapAlgebraAST.scala
@@ -72,9 +72,9 @@ object MapAlgebraAST {
   }
 
   /** Operations which should only have one argument. */
-  case class Addition(args: List[MapAlgebraAST],
-                      id: UUID,
-                      metadata: Option[NodeMetadata])
+  final case class Addition(args: List[MapAlgebraAST],
+                            id: UUID,
+                            metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "+"
 
@@ -84,9 +84,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Subtraction(args: List[MapAlgebraAST],
-                         id: UUID,
-                         metadata: Option[NodeMetadata])
+  final case class Subtraction(args: List[MapAlgebraAST],
+                               id: UUID,
+                               metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "-"
 
@@ -96,9 +96,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Multiplication(args: List[MapAlgebraAST],
-                            id: UUID,
-                            metadata: Option[NodeMetadata])
+  final case class Multiplication(args: List[MapAlgebraAST],
+                                  id: UUID,
+                                  metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "*"
 
@@ -108,9 +108,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Division(args: List[MapAlgebraAST],
-                      id: UUID,
-                      metadata: Option[NodeMetadata])
+  final case class Division(args: List[MapAlgebraAST],
+                            id: UUID,
+                            metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "/"
 
@@ -120,9 +120,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Max(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Max(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "max"
 
@@ -132,9 +132,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Min(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Min(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "min"
 
@@ -144,9 +144,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Equality(args: List[MapAlgebraAST],
-                      id: UUID,
-                      metadata: Option[NodeMetadata])
+  final case class Equality(args: List[MapAlgebraAST],
+                            id: UUID,
+                            metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "=="
 
@@ -156,9 +156,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Inequality(args: List[MapAlgebraAST],
-                        id: UUID,
-                        metadata: Option[NodeMetadata])
+  final case class Inequality(args: List[MapAlgebraAST],
+                              id: UUID,
+                              metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "!="
 
@@ -168,9 +168,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Greater(args: List[MapAlgebraAST],
-                     id: UUID,
-                     metadata: Option[NodeMetadata])
+  final case class Greater(args: List[MapAlgebraAST],
+                           id: UUID,
+                           metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = ">"
 
@@ -180,9 +180,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class GreaterOrEqual(args: List[MapAlgebraAST],
-                            id: UUID,
-                            metadata: Option[NodeMetadata])
+  final case class GreaterOrEqual(args: List[MapAlgebraAST],
+                                  id: UUID,
+                                  metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = ">="
 
@@ -192,9 +192,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Less(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Less(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "<"
 
@@ -204,9 +204,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class LessOrEqual(args: List[MapAlgebraAST],
-                         id: UUID,
-                         metadata: Option[NodeMetadata])
+  final case class LessOrEqual(args: List[MapAlgebraAST],
+                               id: UUID,
+                               metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "<="
 
@@ -216,9 +216,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class And(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class And(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "and"
 
@@ -228,9 +228,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Or(args: List[MapAlgebraAST],
-                id: UUID,
-                metadata: Option[NodeMetadata])
+  final case class Or(args: List[MapAlgebraAST],
+                      id: UUID,
+                      metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "or"
 
@@ -240,9 +240,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Xor(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Xor(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "xor"
 
@@ -252,9 +252,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Pow(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Pow(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "^"
 
@@ -264,9 +264,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Atan2(args: List[MapAlgebraAST],
-                   id: UUID,
-                   metadata: Option[NodeMetadata])
+  final case class Atan2(args: List[MapAlgebraAST],
+                         id: UUID,
+                         metadata: Option[NodeMetadata])
       extends Operation {
     val symbol = "atan2"
 
@@ -278,10 +278,10 @@ object MapAlgebraAST {
 
   sealed trait UnaryOperation extends Operation with Serializable
 
-  case class Masking(args: List[MapAlgebraAST],
-                     id: UUID,
-                     metadata: Option[NodeMetadata],
-                     mask: MultiPolygon)
+  final case class Masking(args: List[MapAlgebraAST],
+                           id: UUID,
+                           metadata: Option[NodeMetadata],
+                           mask: MultiPolygon)
       extends UnaryOperation {
     val symbol = "mask"
 
@@ -291,10 +291,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Classification(args: List[MapAlgebraAST],
-                            id: UUID,
-                            metadata: Option[NodeMetadata],
-                            classMap: ClassMap)
+  final case class Classification(args: List[MapAlgebraAST],
+                                  id: UUID,
+                                  metadata: Option[NodeMetadata],
+                                  classMap: ClassMap)
       extends UnaryOperation {
     val symbol = "classify"
 
@@ -304,9 +304,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class IsDefined(args: List[MapAlgebraAST],
-                       id: UUID,
-                       metadata: Option[NodeMetadata])
+  final case class IsDefined(args: List[MapAlgebraAST],
+                             id: UUID,
+                             metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "isdefined"
 
@@ -316,9 +316,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class IsUndefined(args: List[MapAlgebraAST],
-                         id: UUID,
-                         metadata: Option[NodeMetadata])
+  final case class IsUndefined(args: List[MapAlgebraAST],
+                               id: UUID,
+                               metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "isundefined"
 
@@ -328,9 +328,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class SquareRoot(args: List[MapAlgebraAST],
-                        id: UUID,
-                        metadata: Option[NodeMetadata])
+  final case class SquareRoot(args: List[MapAlgebraAST],
+                              id: UUID,
+                              metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "sqrt"
 
@@ -340,9 +340,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Log(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Log(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "log"
 
@@ -352,9 +352,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Log10(args: List[MapAlgebraAST],
-                   id: UUID,
-                   metadata: Option[NodeMetadata])
+  final case class Log10(args: List[MapAlgebraAST],
+                         id: UUID,
+                         metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "log10"
 
@@ -364,9 +364,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Round(args: List[MapAlgebraAST],
-                   id: UUID,
-                   metadata: Option[NodeMetadata])
+  final case class Round(args: List[MapAlgebraAST],
+                         id: UUID,
+                         metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "round"
 
@@ -376,9 +376,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Floor(args: List[MapAlgebraAST],
-                   id: UUID,
-                   metadata: Option[NodeMetadata])
+  final case class Floor(args: List[MapAlgebraAST],
+                         id: UUID,
+                         metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "floor"
 
@@ -388,9 +388,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Ceil(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Ceil(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "ceil"
 
@@ -400,9 +400,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class NumericNegation(args: List[MapAlgebraAST],
-                             id: UUID,
-                             metadata: Option[NodeMetadata])
+  final case class NumericNegation(args: List[MapAlgebraAST],
+                                   id: UUID,
+                                   metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "neg"
 
@@ -412,9 +412,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class LogicalNegation(args: List[MapAlgebraAST],
-                             id: UUID,
-                             metadata: Option[NodeMetadata])
+  final case class LogicalNegation(args: List[MapAlgebraAST],
+                                   id: UUID,
+                                   metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "not"
 
@@ -424,9 +424,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Abs(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Abs(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "abs"
 
@@ -436,9 +436,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Sin(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Sin(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "sin"
 
@@ -448,9 +448,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Cos(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Cos(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "cos"
 
@@ -460,9 +460,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Tan(args: List[MapAlgebraAST],
-                 id: UUID,
-                 metadata: Option[NodeMetadata])
+  final case class Tan(args: List[MapAlgebraAST],
+                       id: UUID,
+                       metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "tan"
 
@@ -472,9 +472,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Sinh(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Sinh(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "sinh"
 
@@ -484,9 +484,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Cosh(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Cosh(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "cosh"
 
@@ -496,9 +496,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Tanh(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Tanh(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "tanh"
 
@@ -508,9 +508,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Asin(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Asin(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "asin"
 
@@ -520,9 +520,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Acos(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Acos(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "acos"
 
@@ -532,9 +532,9 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class Atan(args: List[MapAlgebraAST],
-                  id: UUID,
-                  metadata: Option[NodeMetadata])
+  final case class Atan(args: List[MapAlgebraAST],
+                        id: UUID,
+                        metadata: Option[NodeMetadata])
       extends UnaryOperation {
     val symbol = "atan"
 
@@ -548,10 +548,10 @@ object MapAlgebraAST {
     def neighborhood: Neighborhood
   }
 
-  case class FocalMax(args: List[MapAlgebraAST],
-                      id: UUID,
-                      metadata: Option[NodeMetadata],
-                      neighborhood: Neighborhood)
+  final case class FocalMax(args: List[MapAlgebraAST],
+                            id: UUID,
+                            metadata: Option[NodeMetadata],
+                            neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalMax"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -560,10 +560,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class FocalMin(args: List[MapAlgebraAST],
-                      id: UUID,
-                      metadata: Option[NodeMetadata],
-                      neighborhood: Neighborhood)
+  final case class FocalMin(args: List[MapAlgebraAST],
+                            id: UUID,
+                            metadata: Option[NodeMetadata],
+                            neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalMin"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -572,10 +572,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class FocalMean(args: List[MapAlgebraAST],
-                       id: UUID,
-                       metadata: Option[NodeMetadata],
-                       neighborhood: Neighborhood)
+  final case class FocalMean(args: List[MapAlgebraAST],
+                             id: UUID,
+                             metadata: Option[NodeMetadata],
+                             neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalMean"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -584,10 +584,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class FocalMedian(args: List[MapAlgebraAST],
-                         id: UUID,
-                         metadata: Option[NodeMetadata],
-                         neighborhood: Neighborhood)
+  final case class FocalMedian(args: List[MapAlgebraAST],
+                               id: UUID,
+                               metadata: Option[NodeMetadata],
+                               neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalMedian"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -596,10 +596,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class FocalMode(args: List[MapAlgebraAST],
-                       id: UUID,
-                       metadata: Option[NodeMetadata],
-                       neighborhood: Neighborhood)
+  final case class FocalMode(args: List[MapAlgebraAST],
+                             id: UUID,
+                             metadata: Option[NodeMetadata],
+                             neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalMode"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -608,10 +608,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class FocalSum(args: List[MapAlgebraAST],
-                      id: UUID,
-                      metadata: Option[NodeMetadata],
-                      neighborhood: Neighborhood)
+  final case class FocalSum(args: List[MapAlgebraAST],
+                            id: UUID,
+                            metadata: Option[NodeMetadata],
+                            neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalSum"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -620,10 +620,10 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class FocalStdDev(args: List[MapAlgebraAST],
-                         id: UUID,
-                         metadata: Option[NodeMetadata],
-                         neighborhood: Neighborhood)
+  final case class FocalStdDev(args: List[MapAlgebraAST],
+                               id: UUID,
+                               metadata: Option[NodeMetadata],
+                               neighborhood: Neighborhood)
       extends FocalOperation {
     val symbol = "focalStdDev"
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST =
@@ -641,9 +641,9 @@ object MapAlgebraAST {
     def withArgs(newArgs: List[MapAlgebraAST]): MapAlgebraAST = this
   }
 
-  case class Constant(id: UUID,
-                      constant: Double,
-                      metadata: Option[NodeMetadata])
+  final case class Constant(id: UUID,
+                            constant: Double,
+                            metadata: Option[NodeMetadata])
       extends MapAlgebraLeaf {
     val `type` = "const"
     def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List()
@@ -655,7 +655,9 @@ object MapAlgebraAST {
   }
 
   /** Map Algebra sources */
-  case class LiteralTile(id: UUID, lt: Tile, metadata: Option[NodeMetadata])
+  final case class LiteralTile(id: UUID,
+                               lt: Tile,
+                               metadata: Option[NodeMetadata])
       extends MapAlgebraLeaf {
     val `type` = "rasterLiteral"
     def sources: Seq[MapAlgebraAST.MapAlgebraLeaf] = List(this)
@@ -666,11 +668,11 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class SceneRaster(id: UUID,
-                         sceneId: UUID,
-                         band: Option[Int],
-                         celltype: Option[CellType],
-                         metadata: Option[NodeMetadata])
+  final case class SceneRaster(id: UUID,
+                               sceneId: UUID,
+                               band: Option[Int],
+                               celltype: Option[CellType],
+                               metadata: Option[NodeMetadata])
       extends MapAlgebraLeaf
       with RFMLRaster {
     val `type` = "sceneSrc"
@@ -682,12 +684,12 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class CogRaster(id: UUID,
-                       sceneId: UUID,
-                       band: Option[Int],
-                       celltype: Option[CellType],
-                       metadata: Option[NodeMetadata],
-                       location: String)
+  final case class CogRaster(id: UUID,
+                             sceneId: UUID,
+                             band: Option[Int],
+                             celltype: Option[CellType],
+                             metadata: Option[NodeMetadata],
+                             location: String)
       extends MapAlgebraLeaf
       with RFMLRaster {
     val `type` = "cogSrc"
@@ -699,11 +701,11 @@ object MapAlgebraAST {
       copy(metadata = Some(newMd))
   }
 
-  case class ProjectRaster(id: UUID,
-                           projId: UUID,
-                           band: Option[Int],
-                           celltype: Option[CellType],
-                           metadata: Option[NodeMetadata])
+  final case class ProjectRaster(id: UUID,
+                                 projId: UUID,
+                                 band: Option[Int],
+                                 celltype: Option[CellType],
+                                 metadata: Option[NodeMetadata])
       extends MapAlgebraLeaf
       with RFMLRaster {
     val `type` = "projectSrc"
@@ -716,7 +718,8 @@ object MapAlgebraAST {
 
   }
 
-  case class ToolReference(id: UUID, toolId: UUID) extends MapAlgebraLeaf {
+  final case class ToolReference(id: UUID, toolId: UUID)
+      extends MapAlgebraLeaf {
     val `type` = "ref"
 
     def metadata: Option[NodeMetadata] = None

--- a/app-backend/common/src/main/scala/ast/NodeMetadata.scala
+++ b/app-backend/common/src/main/scala/ast/NodeMetadata.scala
@@ -7,7 +7,7 @@ import geotrellis.raster.histogram._
 import geotrellis.raster.render._
 import io.circe._
 
-case class NodeMetadata(
+final case class NodeMetadata(
     label: Option[String] = None,
     description: Option[String] = None,
     histogram: Option[Histogram[Double]] = None,

--- a/app-backend/common/src/main/scala/ast/codec/MapAlgebraCodec.scala
+++ b/app-backend/common/src/main/scala/ast/codec/MapAlgebraCodec.scala
@@ -14,7 +14,7 @@ trait MapAlgebraCodec
 
   /** TODO: Add codec paths besides `raster source` and `operation` when supported */
   implicit def mapAlgebraDecoder = Decoder.instance[MapAlgebraAST] { ma =>
-    ma._symbol match {
+    ma.symbolOpt match {
       case Some(_) =>
         ma.as[MapAlgebraAST.Operation]
       case None =>
@@ -24,7 +24,7 @@ trait MapAlgebraCodec
 
   implicit def mapAlgebraEncoder: Encoder[MapAlgebraAST] =
     new Encoder[MapAlgebraAST] {
-      final def apply(ast: MapAlgebraAST): Json = ast match {
+      def apply(ast: MapAlgebraAST): Json = ast match {
         case operation: MapAlgebraAST.Operation =>
           operation.asJson
         case leaf: MapAlgebraAST.MapAlgebraLeaf =>

--- a/app-backend/common/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
+++ b/app-backend/common/src/main/scala/ast/codec/MapAlgebraLeafCodecs.scala
@@ -15,7 +15,7 @@ trait MapAlgebraLeafCodecs {
   /** TODO: Add codec paths besides `raster source` and `operation` when supported */
   implicit def mapAlgebraLeafDecoder =
     Decoder.instance[MapAlgebraAST.MapAlgebraLeaf] { ma =>
-      ma._type match {
+      ma.typeOpt match {
         case Some("ref") =>
           ma.as[MapAlgebraAST.ToolReference]
         case Some("const") =>
@@ -31,7 +31,7 @@ trait MapAlgebraLeafCodecs {
 
   implicit def mapAlgebraLeafEncoder: Encoder[MapAlgebraAST.MapAlgebraLeaf] =
     new Encoder[MapAlgebraAST.MapAlgebraLeaf] {
-      final def apply(ast: MapAlgebraAST.MapAlgebraLeaf): Json = ast match {
+      def apply(ast: MapAlgebraAST.MapAlgebraLeaf): Json = ast match {
         case reference: MapAlgebraAST.ToolReference =>
           reference.asJson
         case const: MapAlgebraAST.Constant =>

--- a/app-backend/common/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/common/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -14,7 +14,7 @@ trait MapAlgebraOperationCodecs extends MapAlgebraUtilityCodecs {
   // Codec routing for Operations
   implicit lazy val decodeOperations =
     Decoder.instance[MapAlgebraAST.Operation] { ma =>
-      ma._symbol match {
+      ma.symbolOpt match {
         case Some("+")           => ma.as[MapAlgebraAST.Addition]
         case Some("-")           => ma.as[MapAlgebraAST.Subtraction]
         case Some("/")           => ma.as[MapAlgebraAST.Division]

--- a/app-backend/common/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
+++ b/app-backend/common/src/main/scala/ast/codec/MapAlgebraOperationCodecs.scala
@@ -74,7 +74,7 @@ trait MapAlgebraOperationCodecs extends MapAlgebraUtilityCodecs {
 
   implicit lazy val encodeOperations: Encoder[MapAlgebraAST.Operation] =
     new Encoder[MapAlgebraAST.Operation] {
-      final def apply(op: MapAlgebraAST.Operation): Json = op match {
+      def apply(op: MapAlgebraAST.Operation): Json = op match {
         case addition: MapAlgebraAST.Addition =>
           addition.asJson
         case subtraction: MapAlgebraAST.Subtraction =>

--- a/app-backend/common/src/main/scala/ast/package.scala
+++ b/app-backend/common/src/main/scala/ast/package.scala
@@ -8,24 +8,24 @@ import java.util.UUID
 package object ast {
 
   implicit class CirceMapAlgebraJsonMethods(val self: Json) {
-    def _id: Option[UUID] =
+    def idOpt: Option[UUID] =
       root.id.string.getOption(self).map(UUID.fromString(_))
-    def _type: Option[String] = root.`type`.string.getOption(self)
-    def _label: Option[String] = root.metadata.label.string.getOption(self)
-    def _symbol: Option[String] =
+    def typeOpt: Option[String] = root.`type`.string.getOption(self)
+    def labelOpt: Option[String] = root.metadata.label.string.getOption(self)
+    def symbolOpt: Option[String] =
       root.selectDynamic("apply").string.getOption(self)
 
-    def _keys: Seq[String] =
-      root.obj.getOption(self).map(_.keys.toSeq).getOrElse(Seq())
+    def keysSeq: Seq[String] =
+      root.obj.getOption(self).map(_.keys.toSeq).getOrElse(Seq.empty)
   }
 
   implicit class CirceMapAlgebraHCursorMethods(val self: HCursor) {
-    def _id: Option[UUID] = self.value._id
-    def _type: Option[String] = self.value._type
-    def _label: Option[String] = self.value._label
-    def _symbol: Option[String] = self.value._symbol
+    def idOpt: Option[UUID] = self.value.idOpt
+    def typeOpt: Option[String] = self.value.typeOpt
+    def labelOpt: Option[String] = self.value.labelOpt
+    def symbolOpt: Option[String] = self.value.symbolOpt
 
-    def _keys: Seq[String] = self.value._keys
+    def keysSeq: Seq[String] = self.value.keysSeq
   }
 
   implicit class MapAlgebraASTHelperMethods(val self: MapAlgebraAST) {

--- a/app-backend/common/src/main/scala/cache/CacheClient.scala
+++ b/app-backend/common/src/main/scala/cache/CacheClient.scala
@@ -51,7 +51,10 @@ class CacheClient(client: => MemcachedClient)
     body(abbreviateKey(key))
 
   def delete(key: String): Unit =
-    if (cacheEnabled) withAbbreviatedKey(key)(client.delete)
+    if (cacheEnabled) {
+      withAbbreviatedKey(key)(client.delete)
+      ()
+    } else { () }
 
   def setValue[T](key: String, value: T, ttlSeconds: Int = 0): Unit =
     withAbbreviatedKey(key) { key =>

--- a/app-backend/common/src/main/scala/datamodel/HistogramAttribute.scala
+++ b/app-backend/common/src/main/scala/datamodel/HistogramAttribute.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.common.datamodel
 
 import io.circe.generic.semiauto._
 
-case class HistogramAttribute(
+final case class HistogramAttribute(
     buckets: List[(Float, Int)],
     maximum: Float,
     minimum: Float,

--- a/app-backend/common/src/main/scala/datamodel/ObjectAccessControlRule.scala
+++ b/app-backend/common/src/main/scala/datamodel/ObjectAccessControlRule.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.common.datamodel
 import io.circe.generic.JsonCodec
 
 @JsonCodec
-case class ObjectAccessControlRule(
+final case class ObjectAccessControlRule(
     subjectType: SubjectType,
     subjectId: Option[String],
     actionType: ActionType

--- a/app-backend/common/src/main/scala/datamodel/Scene.scala
+++ b/app-backend/common/src/main/scala/datamodel/Scene.scala
@@ -284,7 +284,7 @@ object Scene {
   }
 
   @JsonCodec
-  case class ProjectScene(
+  final case class ProjectScene(
       id: UUID,
       createdAt: Timestamp,
       createdBy: String,

--- a/app-backend/common/src/main/scala/datamodel/TiffWithMetadata.scala
+++ b/app-backend/common/src/main/scala/datamodel/TiffWithMetadata.scala
@@ -3,7 +3,7 @@ import geotrellis.raster._
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.tags.TiffTags
 
-case class TiffWithMetadata(
+final case class TiffWithMetadata(
     tiff: GeoTiff[MultibandTile],
     tiffTags: TiffTags
 )

--- a/app-backend/common/src/main/scala/datamodel/export/AnalysisExportSource.scala
+++ b/app-backend/common/src/main/scala/datamodel/export/AnalysisExportSource.scala
@@ -6,7 +6,7 @@ import com.azavea.maml.ast.codec.tree._
 import geotrellis.vector.MultiPolygon
 import _root_.io.circe.generic.semiauto._
 
-case class AnalysisExportSource(
+final case class AnalysisExportSource(
     zoom: Int,
     area: MultiPolygon,
     ast: Expression,

--- a/app-backend/common/src/main/scala/datamodel/export/ExportDefinition.scala
+++ b/app-backend/common/src/main/scala/datamodel/export/ExportDefinition.scala
@@ -18,7 +18,7 @@ final case class ExportDefinition[SourceDefinition](
 
 object ExportDefinition {
 
-  implicit def encodeExportDefinition[SourceDefinition : Encoder]
+  implicit def encodeExportDefinition[SourceDefinition: Encoder]
     : Encoder[ExportDefinition[SourceDefinition]] =
     new Encoder[ExportDefinition[SourceDefinition]] {
       def apply(exportDef: ExportDefinition[SourceDefinition]): Json =
@@ -29,7 +29,7 @@ object ExportDefinition {
         )
     }
 
-  implicit def decodeExportDefinition[SourceDefinition : Decoder]
+  implicit def decodeExportDefinition[SourceDefinition: Decoder]
     : Decoder[ExportDefinition[SourceDefinition]] =
     new Decoder[ExportDefinition[SourceDefinition]] {
       def apply(

--- a/app-backend/common/src/main/scala/datamodel/export/ExportDefinition.scala
+++ b/app-backend/common/src/main/scala/datamodel/export/ExportDefinition.scala
@@ -10,7 +10,7 @@ import cats.implicits._
 import java.util.UUID
 
 // The information necessary to export a tif
-case class ExportDefinition[SourceDefinition: Encoder: Decoder](
+final case class ExportDefinition[SourceDefinition](
     id: UUID,
     source: SourceDefinition,
     output: OutputDefinition
@@ -18,10 +18,10 @@ case class ExportDefinition[SourceDefinition: Encoder: Decoder](
 
 object ExportDefinition {
 
-  implicit def encodeExportDefinition[SourceDefinition: Encoder: Decoder]
+  implicit def encodeExportDefinition[SourceDefinition : Encoder]
     : Encoder[ExportDefinition[SourceDefinition]] =
     new Encoder[ExportDefinition[SourceDefinition]] {
-      final def apply(exportDef: ExportDefinition[SourceDefinition]): Json =
+      def apply(exportDef: ExportDefinition[SourceDefinition]): Json =
         Json.obj(
           ("id", exportDef.id.asJson),
           ("src", exportDef.source.asJson),
@@ -29,10 +29,10 @@ object ExportDefinition {
         )
     }
 
-  implicit def decodeExportDefinition[SourceDefinition: Encoder: Decoder]
+  implicit def decodeExportDefinition[SourceDefinition : Decoder]
     : Decoder[ExportDefinition[SourceDefinition]] =
     new Decoder[ExportDefinition[SourceDefinition]] {
-      final def apply(
+      def apply(
           c: HCursor): Decoder.Result[ExportDefinition[SourceDefinition]] =
         for {
           id <- c.downField("id").as[UUID]

--- a/app-backend/common/src/main/scala/datamodel/export/MosaicExportSource.scala
+++ b/app-backend/common/src/main/scala/datamodel/export/MosaicExportSource.scala
@@ -4,7 +4,7 @@ import com.rasterfoundry.common._
 import geotrellis.vector.MultiPolygon
 import _root_.io.circe.generic.semiauto._
 
-case class MosaicExportSource(
+final case class MosaicExportSource(
     zoom: Int,
     area: MultiPolygon,
     layers: List[(String, List[Int], Option[Double])]

--- a/app-backend/common/src/main/scala/datamodel/export/OutputDefinition.scala
+++ b/app-backend/common/src/main/scala/datamodel/export/OutputDefinition.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.common.datamodel.export
 import geotrellis.proj4.CRS
 import _root_.io.circe.generic.semiauto._
 
-case class OutputDefinition(
+final case class OutputDefinition(
     crs: Option[CRS],
     destination: String,
     dropboxCredential: Option[String]

--- a/app-backend/common/src/main/scala/datamodel/package.scala
+++ b/app-backend/common/src/main/scala/datamodel/package.scala
@@ -22,10 +22,10 @@ import scala.util._
 trait JsonCodecs {
   // Double key serialization
   implicit val decodeKeyDouble: KeyDecoder[Double] = new KeyDecoder[Double] {
-    final def apply(key: String): Option[Double] = Try(key.toDouble).toOption
+    def apply(key: String): Option[Double] = Try(key.toDouble).toOption
   }
   implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
-    final def apply(key: Double): String = key.toString
+    def apply(key: Double): String = key.toString
   }
 
   // RGBA deserialization

--- a/app-backend/common/src/main/scala/notification/Email.scala
+++ b/app-backend/common/src/main/scala/notification/Email.scala
@@ -7,6 +7,14 @@ import org.apache.commons.mail.HtmlEmail
 
 import java.lang.IllegalArgumentException
 
+final case class EmailConfig(
+    host: String,
+    port: Int,
+    encryption: String,
+    uName: String,
+    uPw: String
+)
+
 class NotificationEmail extends RollbarNotifier {
 
   def isValidEmailSettings(host: String,
@@ -32,11 +40,7 @@ class NotificationEmail extends RollbarNotifier {
   def platformNotSubscribedWarning(platId: String): String =
     s"Platform ${platId} did not subscribe to this notification service."
 
-  def setEmail(host: String,
-               port: Int,
-               encryption: String,
-               uName: String,
-               uPw: String,
+  def setEmail(conf: EmailConfig,
                to: String,
                subject: String,
                bodyHtml: String,
@@ -48,15 +52,15 @@ class NotificationEmail extends RollbarNotifier {
 
     try {
       email.setDebug(true)
-      email.setHostName(host)
-      if (encryption == "starttls") {
+      email.setHostName(conf.host)
+      if (conf.encryption == "starttls") {
         email.setStartTLSEnabled(true)
-        email.setSmtpPort(port);
+        email.setSmtpPort(conf.port);
       } else {
         email.setSSLOnConnect(true)
-        email.setSslSmtpPort(port.toString)
+        email.setSslSmtpPort(conf.port.toString)
       }
-      email.setAuthenticator(new DefaultAuthenticator(uName, uPw))
+      email.setAuthenticator(new DefaultAuthenticator(conf.uName, conf.uPw))
       email.setFrom(emailFrom, emailFromDisplayName)
       email.setSubject(subject)
       email.setHtmlMsg(bodyHtml)

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -198,14 +198,14 @@ object Dao extends LazyLogging {
       }
     }
 
-    def pageOffset[T: Read: Write](
+    def pageOffset[T: Read](
         pageRequest: PageRequest): ConnectionIO[List[T]] =
       (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest))
         .query[T]
         .to[List]
 
     /** Provide a list of responses within the PaginatedResponse wrapper */
-    def page[T: Read: Write](
+    def page[T: Read](
         pageRequest: PageRequest,
         selectF: Fragment,
         countF: Fragment,

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -198,8 +198,7 @@ object Dao extends LazyLogging {
       }
     }
 
-    def pageOffset[T: Read](
-        pageRequest: PageRequest): ConnectionIO[List[T]] =
+    def pageOffset[T: Read](pageRequest: PageRequest): ConnectionIO[List[T]] =
       (selectF ++ Fragments.whereAndOpt(filters: _*) ++ Page(pageRequest))
         .query[T]
         .to[List]

--- a/app-backend/db/src/main/scala/LayerAttributeDao.scala
+++ b/app-backend/db/src/main/scala/LayerAttributeDao.scala
@@ -17,7 +17,8 @@ import geotrellis.raster.io.json._
 
 import java.util.UUID
 
-case class LayerAttributeDao() extends HistogramJsonFormats {
+@SuppressWarnings(Array("EmptyCaseClass"))
+final case class LayerAttributeDao() extends HistogramJsonFormats {
   def getHistogram(layerId: UUID,
                    xa: Transactor[IO]): IO[Array[Histogram[Double]]] = {
     LayerAttributeDao

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -87,15 +87,15 @@ trait ObjectPermissions[Model] {
 
   def getPermissions(
       id: UUID): ConnectionIO[List[Option[ObjectAccessControlRule]]] =
-      isValidObject(id) flatMap {
-        case false => throw new Exception(s"Invalid ${tableName} object ${id}")
-        case true =>
-          getPermissionsF(id)
-            .query[List[String]]
-            .unique
-            .map(acrStringsToList(_))
+    isValidObject(id) flatMap {
+      case false => throw new Exception(s"Invalid ${tableName} object ${id}")
+      case true =>
+        getPermissionsF(id)
+          .query[List[String]]
+          .unique
+          .map(acrStringsToList(_))
 
-      }
+    }
 
   def addPermission(id: UUID, acr: ObjectAccessControlRule)
     : ConnectionIO[List[Option[ObjectAccessControlRule]]] =

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -87,18 +87,15 @@ trait ObjectPermissions[Model] {
 
   def getPermissions(
       id: UUID): ConnectionIO[List[Option[ObjectAccessControlRule]]] =
-    for {
-      // TODO restrict to the user's permissions if the user does not have edit permissions
-      isValidObject <- isValidObject(id)
-      getPermissions <- isValidObject match {
+      isValidObject(id) flatMap {
         case false => throw new Exception(s"Invalid ${tableName} object ${id}")
         case true =>
           getPermissionsF(id)
             .query[List[String]]
             .unique
             .map(acrStringsToList(_))
+
       }
-    } yield { getPermissions }
 
   def addPermission(id: UUID, acr: ObjectAccessControlRule)
     : ConnectionIO[List[Option[ObjectAccessControlRule]]] =

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -56,7 +56,7 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
 
   def updateProjectLayerQ(projectLayer: ProjectLayer, id: UUID): Update0 = {
     val updateTime = new Timestamp((new java.util.Date()).getTime)
-    val idFilter = fr"id = ${projectLayer.id}"
+    val idFilter = fr"id = ${id}"
     val query = (fr"UPDATE" ++ tableF ++ fr"""SET
       modified_at = ${updateTime},
       name = ${projectLayer.name},
@@ -68,15 +68,13 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
   }
 
   def createProjectLayer(
-      projectId: UUID,
       projectLayer: ProjectLayer
   ): ConnectionIO[ProjectLayer] =
     insertProjectLayer(projectLayer)
 
   def getProjectLayer(
       projectId: UUID,
-      layerId: UUID,
-      user: User
+      layerId: UUID
   ): ConnectionIO[Option[ProjectLayer]] =
     query.filter(fr"project_id = ${projectId}").filter(layerId).selectOption
 

--- a/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
@@ -19,7 +19,6 @@ object ProjectLayerDatasourcesDao extends Dao[Datasource] {
         d.name, d.visibility, d.composites, d.extras, d.bands, d.license_name
           FROM""" ++ tableF
   def listProjectLayerDatasources(
-      projectId: UUID,
       projectLayerId: UUID
   ): ConnectionIO[List[Datasource]] = {
     query.filter(fr"sl.project_layer_id=$projectLayerId").list

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -67,7 +67,7 @@ object ProjectLayerScenesDao extends Dao[Scene] {
   }
 
   // We know the datasources list head exists because of the foreign key relationship
-  @SuppressWarnings(Array("TraversableHead"))
+  @SuppressWarnings(Array("OptionGet"))
   def scenesToProjectScenes(
       scenes: List[Scene],
       layerId: UUID
@@ -96,7 +96,7 @@ object ProjectLayerScenesDao extends Dao[Scene] {
         scenes map { scene: Scene =>
           scene.projectSceneFromComponents(
             groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail]),
-            datasources.filter(_.id == scene.datasource).head,
+            datasources.find(_.id == scene.datasource).get,
             sceneToLayers.find(_.sceneId == scene.id).map(_.sceneOrder).flatten
           )
         }

--- a/app-backend/db/src/main/scala/ProjectScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectScenesDao.scala
@@ -74,7 +74,7 @@ object ProjectScenesDao extends Dao[Scene] {
   }
 
   // We know the datasources list head exists because of the foreign key relationship
-  @SuppressWarnings(Array("TraversableHead"))
+  @SuppressWarnings(Array("OptionGet"))
   def scenesToProjectScenes(
       scenes: List[Scene],
       projectId: UUID
@@ -103,7 +103,7 @@ object ProjectScenesDao extends Dao[Scene] {
         scenes map { scene: Scene =>
           scene.projectSceneFromComponents(
             groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail]),
-            datasources.filter(_.id == scene.datasource).head,
+            datasources.find(_.id == scene.datasource).get,
             sceneToProjects
               .find(_.sceneId == scene.id)
               .map(_.sceneOrder)

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -18,7 +18,8 @@ import scala.concurrent.duration._
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
-case class SceneDao()
+@SuppressWarnings(Array("EmptyCaseClass"))
+final case class SceneDao()
 
 object SceneDao
     extends Dao[Scene]
@@ -259,8 +260,7 @@ object SceneDao
     for {
       sceneO <- SceneDao.query.filter(sceneId).filter(polygonF).selectOption
     } yield {
-      sceneO match {
-        case Some(scene: Scene) =>
+      sceneO map { (scene: Scene) =>
           Seq(
             MosaicDefinition(
               scene.id,
@@ -288,8 +288,7 @@ object SceneDao
               false,
               Some(().asJson)
             ))
-        case _ => Seq.empty
-      }
+      } getOrElse { Seq.empty }
     }
   }
 

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -261,33 +261,33 @@ object SceneDao
       sceneO <- SceneDao.query.filter(sceneId).filter(polygonF).selectOption
     } yield {
       sceneO map { (scene: Scene) =>
-          Seq(
-            MosaicDefinition(
-              scene.id,
-              ColorCorrect.Params(
-                redBand,
-                greenBand,
-                blueBand,
-                BandGamma(enabled = false, None, None, None),
-                PerBandClipping(enabled = false,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None,
-                                None),
-                MultiBandClipping(enabled = false, None, None),
-                SigmoidalContrast(enabled = false, None, None),
-                Saturation(enabled = false, None),
-                Equalization(false),
-                AutoWhiteBalance(false)
-              ),
-              scene.sceneType,
-              scene.ingestLocation,
-              scene.dataFootprint map { _.geom },
-              false,
-              Some(().asJson)
-            ))
+        Seq(
+          MosaicDefinition(
+            scene.id,
+            ColorCorrect.Params(
+              redBand,
+              greenBand,
+              blueBand,
+              BandGamma(enabled = false, None, None, None),
+              PerBandClipping(enabled = false,
+                              None,
+                              None,
+                              None,
+                              None,
+                              None,
+                              None),
+              MultiBandClipping(enabled = false, None, None),
+              SigmoidalContrast(enabled = false, None, None),
+              Saturation(enabled = false, None),
+              Equalization(false),
+              AutoWhiteBalance(false)
+            ),
+            scene.sceneType,
+            scene.ingestLocation,
+            scene.dataFootprint map { _.geom },
+            false,
+            Some(().asJson)
+          ))
       } getOrElse { Seq.empty }
     }
   }

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -16,7 +16,8 @@ import com.typesafe.scalalogging.LazyLogging
 
 import java.util.UUID
 
-case class SceneToLayerDao()
+@SuppressWarnings(Array("EmptyCaseClass"))
+final case class SceneToLayerDao()
 
 object SceneToLayerDao extends Dao[SceneToLayer] with LazyLogging {
 

--- a/app-backend/db/src/main/scala/SceneToProjectDao.scala
+++ b/app-backend/db/src/main/scala/SceneToProjectDao.scala
@@ -14,7 +14,8 @@ import com.typesafe.scalalogging.LazyLogging
 
 import java.util.UUID
 
-case class SceneToProjectDao()
+@SuppressWarnings(Array("EmptyCaseClass"))
+final case class SceneToProjectDao()
 
 object SceneToProjectDao extends Dao[SceneToProject] with LazyLogging {
 

--- a/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
@@ -152,7 +152,7 @@ object SceneWithRelatedDao
           scene.browseFromComponents(
             groupedThumbs.getOrElse(scene.id, List.empty[Thumbnail]),
             datasources.filter(_.id == scene.datasource).head,
-            inProjects.filter(_._1 == scene.id).headOption.map(_._2)
+            inProjects.find(_._1 == scene.id).map(_._2)
           )
         }
     }

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -20,7 +20,8 @@ import cats.implicits._
 import java.sql.Timestamp
 import java.util.UUID
 
-case class ToolRunDao()
+@SuppressWarnings(Array("EmptyCaseClass"))
+final case class ToolRunDao()
 
 object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
 

--- a/app-backend/db/src/main/scala/notification/Notify.scala
+++ b/app-backend/db/src/main/scala/notification/Notify.scala
@@ -1,7 +1,10 @@
 package com.rasterfoundry.database.notification
 
 import com.rasterfoundry.common.RollbarNotifier
-import com.rasterfoundry.common.notification.Email.{EmailConfig, NotificationEmail}
+import com.rasterfoundry.common.notification.Email.{
+  EmailConfig,
+  NotificationEmail
+}
 import com.rasterfoundry.database._
 import com.rasterfoundry.database.notification.templates._
 import com.rasterfoundry.common.datamodel._

--- a/app-backend/db/src/main/scala/notification/Notify.scala
+++ b/app-backend/db/src/main/scala/notification/Notify.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.database.notification
 
 import com.rasterfoundry.common.RollbarNotifier
-import com.rasterfoundry.common.notification.Email.NotificationEmail
+import com.rasterfoundry.common.notification.Email.{EmailConfig, NotificationEmail}
 import com.rasterfoundry.database._
 import com.rasterfoundry.database.notification.templates._
 import com.rasterfoundry.common.datamodel._
@@ -26,11 +26,13 @@ object Notify extends RollbarNotifier {
         case "" => ().pure[ConnectionIO]
         case s => {
           val preparedEmail = email.setEmail(
-            publicSettings.emailSmtpHost,
-            publicSettings.emailSmtpPort,
-            publicSettings.emailSmtpEncryption,
-            publicSettings.emailSmtpUserName,
-            privateSettings.emailPassword,
+            EmailConfig(
+              publicSettings.emailSmtpHost,
+              publicSettings.emailSmtpPort,
+              publicSettings.emailSmtpEncryption,
+              publicSettings.emailSmtpUserName,
+              privateSettings.emailPassword
+            ),
             to,
             subject,
             messageRich,
@@ -62,8 +64,6 @@ object Notify extends RollbarNotifier {
       platform <- PlatformDao.unsafeGetPlatformById(platformId)
       publicSettings = platform.publicSettings
       privateSettings = platform.privateSettings
-      platformHost = publicSettings.platformHost.getOrElse(
-        "app.rasterfoundry.com")
       emailData <- builder(messageType)
       _ <- logger.debug("Fetching users").pure[ConnectionIO]
       recipients <- userFinder(messageType)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -56,7 +56,6 @@ class ProjectLayerDatasourceDaoSpec
                 ) flatMap { _ =>
                   {
                     ProjectLayerDatasourcesDao.listProjectLayerDatasources(
-                      dbProject.id,
                       dbProject.defaultLayerId
                     ) map { datasources: List[Datasource] =>
                       (dbScenes.map { _.datasource }, datasources)


### PR DESCRIPTION
## Overview

This PR zeros out all the infos, warnings, and errors coming from scapegoat in all the subprojects.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Lots of this:

```
backsplash-export > scapegoat
[info] [scapegoat] Removing scapegoat class directory: /opt/raster-foundry/app-backend/backsplash-export/target/scala-2.11/scapegoat-classes
[info] [scapegoat] setting output dir to [/opt/raster-foundry/app-backend/backsplash-export/target/scala-2.11/scapegoat-report]
[info] Compiling 10 Scala sources to /opt/raster-foundry/app-backend/backsplash-export/target/scala-2.11/scapegoat-classes ...
[info] [info] [scapegoat] 117 activated inspections
[info] [info] [scapegoat] Analysis complete: 10 files - 0 errors 0 warns 0 infos
```

## Notes

Apparently we can't fail for infos / warnings anymore? https://github.com/sksamuel/sbt-scapegoat/issues/72

That's a drag

## Testing Instructions

 * `scapegoat` from `root` or from all of common, db, akkautil, http4s-util, backsplash-core, backsplash-server, backsplash-export, batch, and api
 * look no warnings

Closes #3758 
