### PR TITLE
Add export jar assembly to CI build process

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -26,7 +26,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         echo "Pulling down configuration settings for test environment"
-        
+
         ./scripts/bootstrap --env
         ./scripts/bootstrap --sbtopts
 
@@ -53,6 +53,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         cp "${DIR}/../app-backend/batch/target/scala-2.11/batch-assembly.jar" \
            "${DIR}/../app-tasks/jars/batch-assembly.jar"
+
+
+        docker-compose \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm --no-deps \
+            build backsplash-export/assembly
+
+        cp "${DIR}/../app-backend/backsplash-export/target/scala-2.11/backsplash-export-assembly.jar" \
+           "${DIR}/../app-tasks/jars/backsplash-export-assembly.jar"
 
         echo "Building Batch container image"
         GIT_COMMIT="${GIT_COMMIT}" docker-compose \


### PR DESCRIPTION
## Overview

Add missing export jar to cibuild process

### Demo

```
cbrown@trout:~/Projects/raster-foundry/app-tasks/jars$ ls -lh
total 461M
-rw-r--r-- 1 cbrown cbrown 207M Feb 11 08:52 backsplash-export-assembly.jar
-rw-r--r-- 1 cbrown cbrown 255M Feb 11 08:50 batch-assembly.jar
cbrown@trout:~/Projects/raster-foundry/app-tasks/jars$ 
```
