### PR TITLE
Implement project layer scenes and browse views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,15 @@
 - Added publishing of lambda functions to CI build process [\#4586](https://github.com/raster-foundry/raster-foundry/pull/4586)
 - Added tile server support for masked analyses [\#4571](https://github.com/raster-foundry/raster-foundry/pull/4571)
 - Added project layer navigation bar [\#4581](https://github.com/raster-foundry/raster-foundry/pull/4581)
+- Added layer parameter to /api/scenes and added inLayer property to scene browse responses [\#4615](https://github.com/raster-foundry/raster-foundry/pull/4615)
 
 ### Fixed
 
 - Removed unused imports and assignments [\#4579](https://github.com/raster-foundry/raster-foundry/pull/4579)
 - Included geometry filter in backsplash scene service to prevent erroneous 500s [\#4580](https://github.com/raster-foundry/raster-foundry/pull/4580)
 - Made scapegoat less angry [\#4611](https://github.com/raster-foundry/raster-foundry/pull/4611)
+- Set hasNext correctly on /api/scenes when there are more than 100 scenes [\#4615](https://github.com/raster-foundry/raster-foundry/pull/4615)
+- Use sane default when the accepted query parameter is not set on /api/project/{}/layer/{}/scenes [\#4615](https://github.com/raster-foundry/raster-foundry/pull/4615)
 
 ### Security
 

--- a/app-backend/api/src/main/scala/scene/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/scene/QueryParameters.scala
@@ -28,6 +28,7 @@ trait SceneQueryParameterDirective extends QueryParametersCommon {
       'bbox.as[String].*,
       'point.as[String].?,
       'project.as[UUID].?,
+      'layer.as[UUID].?,
       'ingested.as[Boolean].?,
       'ingestStatus.as[String].*,
       'pending.as[Boolean].?,

--- a/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
+++ b/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
@@ -53,6 +53,7 @@ final case class SceneQueryParameters(
     bbox: Iterable[String] = Seq.empty[String],
     point: Option[String] = None,
     project: Option[UUID] = None,
+    layer: Option[UUID] = None,
     ingested: Option[Boolean] = None,
     ingestStatus: Iterable[String] = Seq.empty[String],
     pending: Option[Boolean] = None,

--- a/app-backend/common/src/main/scala/datamodel/Scene.scala
+++ b/app-backend/common/src/main/scala/datamodel/Scene.scala
@@ -89,7 +89,8 @@ final case class Scene(
   def browseFromComponents(
       thumbnails: List[Thumbnail],
       datasource: Datasource,
-      inProject: Option[Boolean]
+      inProject: Option[Boolean],
+      inLayer: Option[Boolean]
   ): Scene.Browse = Scene.Browse(
     this.id,
     this.createdAt,
@@ -110,7 +111,8 @@ final case class Scene(
     this.filterFields,
     this.statusFields,
     this.sceneType,
-    inProject
+    inProject,
+    inLayer
   )
 
   def projectSceneFromComponents(
@@ -258,7 +260,8 @@ object Scene {
       filterFields: SceneFilterFields = new SceneFilterFields(),
       statusFields: SceneStatusFields,
       sceneType: Option[SceneType] = None,
-      inProject: Option[Boolean] = None
+      inProject: Option[Boolean] = None,
+      inLayer: Option[Boolean] = None
   ) {
     def toScene: Scene =
       Scene(

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -46,10 +46,12 @@ object ProjectLayerScenesDao extends Dao[Scene] {
   ): ConnectionIO[PaginatedResponse[Scene.ProjectScene]] = {
 
     val layerQuery = ProjectLayerDao.query.filter(layerId).select
-    val andPendingF: Fragment = sceneParams.accepted match {
-      case Some(true) => fr"accepted = true"
-      case _          => fr"accepted = false"
-    }
+    val andPendingF: Option[Fragment] =
+      sceneParams.accepted match {
+        case Some(true)  => Some(fr"accepted = true")
+        case Some(false) => Some(fr"accepted = false")
+        case _           => None
+      }
 
     val manualOrder = Map(
       "scene_order" -> Order.Asc,

--- a/app-frontend/src/app/components/pages/project/layer/layer/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/layer/index.html
@@ -1,3 +1,2 @@
-<div>Layer for project: {{$ctrl.projectId}}, id: {{$ctrl.layerId}} </div>
 <ui-view>
 </ui-view>

--- a/app-frontend/src/app/components/pages/project/layer/layer/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/layer/index.js
@@ -1,7 +1,10 @@
 import tpl from './index.html';
 
 class ProjectLayerController {
-
+    constructor($rootScope) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
 }
 
 const component = {

--- a/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.html
@@ -1,1 +1,138 @@
-browse
+<div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0 ">
+  <a class="btn btn-small btn-transparent" ui-sref="project.layer.scenes">
+    <i class="icon-caret-left"></i>Back
+  </a>
+  <div style="flex: 1;"></div>
+  <button class="btn btn-small btn-transparent" ng-click="$ctrl.showFilterPane = true">
+    Filter...
+  </button>
+  <!-- <select class="btn btn-small btn-transparent" -->
+  <!-- ng-model="$ctrl.ordering"> -->
+  <!-- <option value="">Newest</option> -->
+  <!-- <option value="manual">Manual</option> -->
+  <!-- <option value="date">Date</option> -->
+  <!-- </select> -->
+  <button class="btn btn-small btn-transparent"
+          ng-click="$ctrl.visibleScenes.size > 0 && $ctrl.hideAll()"
+          ng-disabled="$ctrl.visibleScenes.size === 0"
+          title="Hide all visible scene boundaries on map"
+  >
+    Hide all
+  </button>
+</div>
+<div class="sidebar-actions-group with-selected" ng-show="$ctrl.selected.size > 0">
+  <rf-selected-actions-bar
+      checked="$ctrl.allVisibleSelected()"
+      on-click="$ctrl.selectAll()"
+      action-text="$ctrl.selectText"
+  >
+    <button class="btn btn-transparent" ng-click="$ctrl.addScenesToLayer()">Add to layer</button>
+  </rf-selected-actions-bar>
+</div>
+<div class="list-group" ng-if="!$ctrl.fetchingScenes">
+  <div class="list-group-item"
+       ng-if="$ctrl.currentRepository && !$ctrl.currentRepository.service.defaultRepository"
+  >
+    <div class="alert alert-default">
+      <div class="alert-message">Any scenes added from this repository will also appear in your imports</div>
+    </div>
+  </div>
+  <div class="list-group-item" ng-if="$ctrl.sceneCount !== '0'">
+    <strong class="color-dark">
+      1 - {{$ctrl.sceneList.length}} of {{$ctrl.sceneCount}} scenes
+    </strong>
+  </div>
+  <div class="list-group-item" ng-if="$ctrl.fetchError">
+    <strong class="color-danger">
+      There was an error fetching scenes
+    </strong>
+    <button type="button" class="btn btn-secondary"
+            ng-click="$ctrl.fetchNextScenes()">
+      Try again <i icon="icon-refresh"></i>
+    </button>
+  </div>
+</div>
+<div class="list-group" ng-if="$ctrl.fetchingScenes">
+  <div class="list-group-item">
+    <i class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetchingScenes}"
+       ng-show="$ctrl.fetchingScenes"></i>
+    <strong class="color-dark">
+      Loading scenes...
+    </strong>
+  </div>
+</div>
+<div class="list-group"
+     ng-if="$ctrl.sceneList &&
+            $ctrl.sceneList.length === 0 &&
+            !$ctrl.fetchingScenes &&
+            !$ctrl.fetchError">
+  <div class="list-group-item">
+    <strong class="color-dark">
+      No scenes match this filter
+    </strong>
+  </div>
+</div>
+<div class="sidebar-scrollable list-group">
+  <rf-project-scene-item
+      ng-repeat="scene in $ctrl.sceneList track by $index"
+      scene="scene"
+      selected="$ctrl.isSelected(scene)"
+      on-select="$ctrl.onSelect(scene)"
+      processing="$ctrl.scenesBeingAdded.has(scene.id)"
+      is-previewable="true"
+  >
+    <div class="btn btn-text btn-transparent"
+         ng-repeat="action in $ctrl.sceneActions.get(scene.id) | filter: {menu: false}"
+         ng-title="{{action.title}}"
+         ng-click="action.callback()"
+         tooltips
+         tooltip-template="{{action.tooltip}}"
+         tooltip-size="small"
+         tooltip-class="rf-tooltip"
+         tooltip-side="left"
+         tooltip-hidden="{{!action.tooltip}}"
+    >
+      <i ng-class="action.icon" ng-if="action.icon"></i>
+      <i ng-class="icon.icon"
+         ng-if="icon.isActive()"
+         ng-repeat="icon in action.icons"></i>
+    </div>
+    <button class="btn btn-text btn-transparent"
+            uib-dropdown
+            ng-show="($ctrl.sceneActions.get(scene.id) | filter: {menu: true}).length > 0"
+            uib-dropdown-toggle
+    >
+      <i class="icon-menu"></i>
+      <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+        <li role="menuitem"
+            ng-repeat="action in $ctrl.sceneActions.get(scene.id) | filter: {menu: true}">
+          <a href ng-click="action.callback()"
+             ng-show="action.name"
+             ng-attr-title="{{action.title}}">{{action.name}}</a>
+          <span class="menu-separator" ng-show="action.separator"></span>
+        </li>
+      </ul>
+    </button>
+   </rf-project-scene-item>
+   <div class="sidebar-content">
+     <button class="btn btn-block btn-secondary"
+             ng-show="$ctrl.sceneList.length"
+             ng-disabled="!$ctrl.hasNext || $ctrl.fetchingScenes"
+             ng-click="$ctrl.fetchNextScenes()">
+       Load More Scenes
+       <i class="icon-load animate-spin" ng-class="{'stop': !$ctrl.fetchingScenes}"
+          ng-show="$ctrl.fetchingScenes"></i>
+     </button>
+   </div>
+</div>
+<div class="sidebar project-side-modal"
+     ng-show="$ctrl.showFilterPane"
+     style="z-index: 1001"
+>
+  <rf-scene-filter-pane
+      data-opened="$ctrl.showFilterPane"
+      data-repositories="$ctrl.repositories"
+      on-repository-change="$ctrl.onRepositoryChange(fetchScenes, repository)"
+  >
+  </rf-scene-filter-pane>
+</div>

--- a/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.html
@@ -20,7 +20,7 @@
     Hide all
   </button>
 </div>
-<div class="sidebar-actions-group with-selected" ng-show="$ctrl.selected.size > 0">
+<div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
   <rf-selected-actions-bar
       checked="$ctrl.allVisibleSelected()"
       on-click="$ctrl.selectAll()"

--- a/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.js
@@ -1,11 +1,393 @@
+/* global BUILDCONFIG */
+
+import { Set, Map } from 'immutable';
+import _ from 'lodash';
+
 import tpl from './index.html';
 
-class LayerScenesBrowseController {
+const mapLayerName = 'Project Layer';
 
+class LayerScenesBrowseController {
+    constructor(
+        $rootScope, $location, $state, $scope, $timeout,
+        mapService, featureFlags, authService, planetLabsService, sessionStorage,
+        modalService, sceneService, projectService,
+        RasterFoundryRepository, PlanetRepository, CMRRepository
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.selected = new Map();
+        this.visibleScenes = new Map();
+        this.scenesOnMap = new Set();
+        this.sceneActions = new Map();
+        this.repositories = [
+            {
+                label: 'Raster Foundry',
+                overrideLabel: BUILDCONFIG.APP_NAME,
+                service: this.RasterFoundryRepository
+            }
+        ];
+
+        if (this.featureFlags.isOnByDefault('external-source-browse-planet')) {
+            this.repositories.push({
+                label: 'Planet Labs',
+                service: this.PlanetRepository
+            });
+        }
+
+        if (this.featureFlags.isOnByDefault('external-source-browse-cmr')) {
+            this.repositories.push({
+                label: 'NASA CMR',
+                service: this.CMRRepository
+            });
+        }
+
+        this.projectScenesReady = false;
+        this.registerClick = true;
+        this.sceneList = [];
+        this.sceneCount = null;
+        this.planetThumbnailUrls = new Map();
+        this.scenesBeingAdded = new Set();
+
+        this.setBboxParam = _.debounce((bbox) => {
+            this.$location.search('bbox', bbox).replace();
+        }, 500);
+        this.debouncedSceneFetch = _.debounce(this.fetchNextScenes.bind(this), 500);
+
+        this.resetParams();
+        this.initMap();
+        this.setMapLayers();
+    }
+
+    $onDestroy() {
+        this.removeMapLayers();
+        this.hideAll();
+        this.getMap().then(mapContainer => {
+            mapContainer.deleteLayers('filterBboxLayer');
+            mapContainer.deleteThumbnail();
+            this.scenesOnMap.forEach((id) => {
+                mapContainer.deleteGeojson(id);
+            });
+            this.mapListeners.forEach(listener => {
+                mapContainer.off(listener);
+            });
+        });
+    }
+
+    hideAll() {
+        this.getMap().then(mapContainer => {
+            this.visibleScenes = new Map();
+            this.syncVisibleScenes();
+        });
+    }
+
+    resetParams() {
+        this.queryParams = this.$location.search();
+    }
+
+    getMap() {
+        return this.mapService.getMap('project');
+    }
+
+    setMapLayers() {
+        let mapLayer = this.projectService.mapLayerFromLayer(this.project, this.layer);
+        return this.getMap().then(map => {
+            map.setLayer(mapLayerName, mapLayer, true);
+        });
+    }
+
+    removeMapLayers() {
+        return this.getMap().then(map => {
+            map.deleteLayers(mapLayerName);
+        });
+    }
+
+    initMap() {
+        this.resetParams();
+        if (this.queryParams.bbox) {
+            this.bounds = this.parseBBoxString(this.queryParams.bbox);
+        } else if (this.project && this.project.extent) {
+            this.bounds = L.geoJSON(this.project.extent).getBounds();
+        } else {
+            this.bounds = [[-30, -90], [50, 0]];
+        }
+        this.getMap().then(mapContainer => {
+            mapContainer.map.fitBounds(this.bounds);
+            this.mapListeners = [
+                mapContainer.on('contextmenu', ($event) => {
+                    $event.originalEvent.preventDefault();
+                    return false;
+                }),
+                mapContainer.on('movestart', () => {
+                    this.registerClick = false;
+                    return false;
+                }),
+                mapContainer.on('moveend', ($event, mapWrapper) => {
+                    this.$timeout(() => {
+                        this.registerClick = true;
+                    }, 125);
+                    this.onViewChange(
+                        mapWrapper.map.getBounds(),
+                        mapWrapper.map.getCenter(),
+                        mapWrapper.map.getZoom()
+                    );
+                })
+            ];
+        });
+    }
+
+    fetchNextScenes() {
+        this.fetchingScenes = true;
+        this.fetchError = false;
+        this.hasNext = false;
+        this.sceneCount = null;
+        let factoryFn = this.bboxFetchFactory;
+        let fetchScenes = this.fetchNextScenesForBbox;
+        this.fetchNextScenesForBbox().then(({scenes, hasNext, count}) => {
+            if (fetchScenes === this.fetchNextScenesForBbox &&
+                factoryFn === this.bboxFetchFactory) {
+                this.fetchingScenes = false;
+                this.fetchError = false;
+                this.sceneList = this.sceneList.concat(scenes);
+                this.sceneActions = this.sceneActions.merge(
+                    new Map(
+                        scenes.map(
+                            this.addSceneActions.bind(this))));
+                this.hasNext = hasNext;
+                this.sceneCount = count;
+            }
+        }, (err) => {
+            if (fetchScenes === this.fetchNextScenesForBbox &&
+                factoryFn === this.bboxFetchFactory) {
+                this.fetchingScenes = false;
+                if (err !== 'No more scenes to fetch') {
+                    this.fetchError = err;
+                }
+                this.hasNext = false;
+            }
+        });
+    }
+
+    addSceneActions(scene) {
+        // details, view layers, hide (unapprove), remove (delete from layer)
+        let actions = [{
+            icons: [
+                {
+                    icon: 'icon-eye',
+                    isActive: () => this.visibleScenes.has(scene.id)
+                }, {
+                    icon: 'icon-eye-off',
+                    isActive: () => !this.visibleScenes.has(scene.id)
+                }
+            ],
+            name: 'Preview',
+            tooltip: 'Show image boundaries on map',
+            callback: () => this.toggleVisibleScene(scene),
+            menu: false
+        }];
+
+        if (this.hasDownloadPermission(scene)) {
+            actions.unshift({
+                icon: 'icon-download',
+                name: 'Download',
+                tooltip: 'Download raw image data',
+                callback: () => this.modalService.open({
+                    component: 'rfSceneDownloadModal',
+                    resolve: {
+                        scene: () => scene
+                    }
+                }).result.catch(() => {}),
+                menu: false
+            });
+        } else {
+            actions.unshift({
+                icon: 'icon-item-lock',
+                name: 'This imagery requires additional access ' +
+                    `${this.currentRepository.service.permissionSource}`,
+                title: 'Download raw image data',
+                menu: false
+            });
+        }
+
+        return [scene.id, actions];
+    }
+
+    /**
+     * Convert a string in Leaflet bbox coordinate format ("swlng,swlat,nelng,nelat") to array
+     * @param {string} bboxString The bbox coordinate string to parse
+     * @return {array} lat/lon coordinates specifying bounding box corners ([[0,0], [1.0, 1.0]])
+     */
+    parseBBoxString(bboxString) {
+        let bbox = [];
+        if (bboxString && bboxString.length) {
+            let coordsStrings = bboxString.split(',');
+            let coords = _.map(coordsStrings, str => parseFloat(str));
+            // Leaflet expects nested coordinate arrays
+            bbox = [
+                [coords[1], coords[0]],
+                [coords[3], coords[2]]
+            ];
+        }
+        return bbox;
+    }
+
+    onRepositoryChange(bboxFetchFactory, repository) {
+        this.bboxFetchFactory = bboxFetchFactory;
+        this.currentRepository = repository;
+
+        this.sceneList = [];
+        this.sceneActions = new Map();
+        this.getMap().then((mapWrapper) => {
+            if (this.bboxCoords || this.queryParams && this.queryParams.bbox) {
+                this.fetchNextScenesForBbox = this.bboxFetchFactory(
+                    this.bboxCoords || this.queryParams.bbox
+                );
+                this.fetchNextScenes();
+            } else {
+                this.onViewChange(
+                    mapWrapper.map.getBounds(),
+                    mapWrapper.map.getCenter(),
+                    mapWrapper.map.getZoom()
+                );
+            }
+        });
+    }
+
+    onViewChange(newBounds, newCenter, zoom) {
+        // This gives 400 status code under planet data filter
+        // when the map extent is at a too big area
+        this.bboxCoords = newBounds.toBBoxString();
+        this.zoom = zoom;
+        this.center = newCenter;
+
+        this.setBboxParam(this.bboxCoords);
+
+        this.onBboxChange();
+    }
+
+    onBboxChange() {
+        let queryParams = this.$location.search();
+        if (this.bboxFetchFactory && !queryParams.shape) {
+            this.fetchNextScenesForBbox = this.bboxFetchFactory(this.bboxCoords);
+            this.sceneList = [];
+            this.sceneActions = new Map();
+            this.debouncedSceneFetch();
+        }
+    }
+
+    isSelected(scene) {
+        return this.selected.has(scene.id);
+    }
+
+    onSelect(scene) {
+        if (this.selected.has(scene.id)) {
+            this.selected = this.selected.delete(scene.id);
+        } else {
+            this.selected = this.selected.set(scene.id, scene);
+        }
+        this.updateSelectText();
+    }
+
+    allVisibleSelected() {
+        let sceneSet = new Set(this.sceneList.map(s => s.id));
+        return this.selected.keySeq().toSet().intersect(sceneSet).size === sceneSet.size;
+    }
+
+    selectAll() {
+        if (this.allVisibleSelected()) {
+            this.selected = this.selected.clear();
+        } else {
+            this.selected = this.selected.merge(
+                _.filter(this.sceneList.map(s => [s.id, s]), s => !s.inLayer)
+            );
+        }
+        this.updateSelectText();
+    }
+
+    updateSelectText() {
+        if (this.allVisibleSelected()) {
+            this.selectText = 'Clear selected';
+        } else {
+            this.selectText = 'Select all visible';
+        }
+    }
+
+    hasDownloadPermission(scene) {
+        if (this.currentRepository.service.getScenePermissions(scene).includes('download')) {
+            return true;
+        }
+        return false;
+    }
+
+    isInProject(scene) {
+        return scene && scene.inProject;
+    }
+
+    isInLayer(scene) {
+        return scene && scene.inLayer;
+    }
+
+    addScenesToLayer() {
+        // add spinner to all scenes which are in this.scenesBeingAdded
+        let addedScenes = this.selected.filterNot((scene) => this.scenesBeingAdded.has(scene.id));
+        let addedSceneIds = addedScenes.keySeq().toSet();
+        this.scenesBeingAdded = this.scenesBeingAdded.union(addedSceneIds);
+        this.currentAddRequest = this.currentRepository
+            .service
+            .addToLayer(this.project.id, this.layer.id, addedScenes.valueSeq().toArray())
+            .then(() => {
+                this.scenesBeingAdded = this.scenesBeingAdded.subtract(addedSceneIds);
+                this.selected = this.selected.filterNot((s, id) => addedSceneIds.has(id));
+                this.sceneList.filter(s => addedSceneIds.has(s.id)).forEach(s => {
+                    s.inProject = true;
+                    s.inLayer = true;
+                });
+                this.removeMapLayers().then(() => this.setMapLayers());
+            }, (e) => {
+                this.scenesBeingAdded.subtract(addedSceneIds);
+                this.errorAddingScenes =
+                    'There was an error adding scenes to the layer. Please try again.';
+                this.$timeout(() => {
+                    delete this.errorAddingScenes;
+                }, 5);
+            });
+    }
+
+    toggleVisibleScene(scene) {
+        if (this.visibleScenes.has(scene.id)) {
+            this.visibleScenes = this.visibleScenes.delete(scene.id);
+        } else {
+            this.visibleScenes = this.visibleScenes.set(scene.id, scene);
+        }
+
+        this.syncVisibleScenes();
+    }
+
+    syncVisibleScenes() {
+        this.getMap().then(map => {
+            // find scenes to be removed
+            // find scenes to be added
+            let newSceneIds = this.visibleScenes.keySeq().toSet();
+            let removedSceneIds = this.scenesOnMap.subtract(newSceneIds);
+            let addedScenes = this.visibleScenes.filterNot((s) => this.scenesOnMap.has(s.id));
+            removedSceneIds.forEach((id) => {
+                map.deleteGeojson(id);
+            });
+            addedScenes.forEach((scene) => {
+                map.setGeojson(scene.id, this.sceneService.getStyledFootprint(scene));
+            });
+            this.scenesOnMap = newSceneIds;
+        });
+    }
 }
 
 const component = {
     bindings: {
+        project: '<',
+        layer: '<'
     },
     templateUrl: tpl,
     controller: LayerScenesBrowseController.name

--- a/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/browse/index.js
@@ -292,7 +292,7 @@ class LayerScenesBrowseController {
     }
 
     allVisibleSelected() {
-        let sceneSet = new Set(this.sceneList.map(s => s.id));
+        let sceneSet = new Set(this.sceneList.map(s => s.id).filter(s => !s.inLayer));
         return this.selected.keySeq().toSet().intersect(sceneSet).size === sceneSet.size;
     }
 
@@ -311,7 +311,7 @@ class LayerScenesBrowseController {
         if (this.allVisibleSelected()) {
             this.selectText = 'Clear selected';
         } else {
-            this.selectText = 'Select all visible';
+            this.selectText = 'Select listed';
         }
     }
 

--- a/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.html
@@ -1,2 +1,104 @@
-Scenes
-<ui-view></ui-view>
+<div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0">
+  <div uib-dropdown uib-dropdown-toggle>
+    <a class="btn btn-small btn-transparent">
+      <i class="icon-plus"></i>Add imagery
+    </a>
+    <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
+      <li role="menuitem">
+        <a href ng-click="$ctrl.browseScenes()">Browse</a>
+      </li>
+      <li role="menuitem">
+        <a href ng-click="$ctrl.openImportModal()">Import</a>
+      </li>
+    </ul>
+  </div>
+  <div style="flex: 1;"></div>
+  <!-- <button class="btn btn-small btn-transparent">Filter...</button> -->
+  <!-- <select class="btn btn-small btn-transparent"> -->
+  <!-- <option value="">Newest</option> -->
+  <!-- <option value="manual">Manual</option> -->
+  <!-- <option value="manual">Ingest date</option> -->
+  <!-- </select> -->
+</div>
+<div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
+  <rf-selected-actions-bar
+      checked="$ctrl.allVisibleSelected()"
+      on-click="$ctrl.selectAll()"
+      action-text="$ctrl.selectText"
+  >
+    <button class="btn btn-transparent"
+            ng-click="$ctrl.removeScenes($ctrl.selected.valueSeq().toArray())">
+      Remove
+    </button>
+  </rf-selected-actions-bar>
+</div>
+<div class="list-group" ng-if="!$ctrl.currentQuery">
+  <div class="list-group-item" ng-if="$ctrl.fetchError">
+    <strong class="color-danger">
+      There was an error fetching scenes
+    </strong>
+    <button type="button" class="btn btn-secondary"
+            ng-click="$ctrl.fetchPage()">
+      Try again <i icon="icon-refresh"></i>
+    </button>
+  </div>
+</div>
+<div class="list-group" ng-if="$ctrl.currentQuery">
+  <div class="list-group-item">
+    <i class="icon-load animate-spin" ng-class="{'stop': !$ctrl.currentQuery}"
+       ng-show="$ctrl.currentQuery"></i>
+    <strong class="color-dark">
+      Loading scenes...
+    </strong>
+  </div>
+</div>
+<div class="list-group"
+     ng-if="$ctrl.sceneList &&
+            $ctrl.sceneList.length === 0 &&
+            !$ctrl.currentQuery &&
+            !$ctrl.fetchError">
+  <div class="list-group-item">
+    <strong class="color-dark">
+      This layer has no scenes in it
+    </strong>
+  </div>
+</div>
+<div class="sidebar-scrollable list-group">
+  <rf-project-scene-item
+      ng-repeat="scene in $ctrl.sceneList track by $index"
+      scene="scene"
+      selected="$ctrl.isSelected(scene)"
+      on-select="$ctrl.onSelect(scene)"
+      is-previewable="true"
+  >
+    <button class="btn btn-text btn-transparent"
+            ng-repeat="action in $ctrl.sceneActions.get(scene.id) | filter: {menu: false}"
+            ng-attr-title="{{action.title}}"
+            ng-click="action.callback()"
+    >
+      <i ng-attr-class="{{action.icon}}"></i>
+    </button>
+    <button class="btn btn-text btn-transparent"
+            uib-dropdown
+            ng-show="($ctrl.sceneActions.get(scene.id) | filter: {menu: true}).length > 0"
+            uib-dropdown-toggle
+    >
+      <i class="icon-menu"></i>
+      <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+        <li role="menuitem"
+            ng-repeat="action in $ctrl.sceneActions.get(scene.id) | filter: {menu: true}">
+          <a href ng-click="action.callback()"
+             ng-show="action.name"
+             ng-attr-title="{{action.title}}">{{action.name}}</a>
+          <span class="menu-separator" ng-show="action.separator"></span>
+        </li>
+      </ul>
+    </button>
+   </rf-project-scene-item>
+   <rf-pagination-controls
+       pagination="$ctrl.pagination"
+       is-loading="$ctrl.currentQuery"
+       on-change="$ctrl.fetchPage(value)"
+       ng-show="!$ctrl.currentQuery && !$ctrl.fetchError"
+   ></rf-pagination-controls>
+</div>

--- a/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.js
@@ -1,11 +1,204 @@
 import tpl from './index.html';
+import { Set, Map } from 'immutable';
+import _ from 'lodash';
+
+const mapLayerName = 'Project Layer';
 
 class LayerScenesController {
+    constructor(
+        $rootScope, $scope, $state,
+        projectService, RasterFoundryRepository, paginationService, modalService, authService,
+        mapService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
 
+    $onInit() {
+        this.selected = new Map();
+        this.permissionsPromise = this.projectService
+            .getProjectPermissions(this.project, this.authService.user)
+            .then((permissions) => {
+                this.permissions = permissions;
+            });
+        this.fetchPage();
+        this.setMapLayers();
+    }
+
+    $onDestroy() {
+        this.removeMapLayers();
+    }
+
+    getMap() {
+        return this.mapService.getMap('project');
+    }
+
+    setMapLayers() {
+        let mapLayer = this.projectService.mapLayerFromLayer(this.project, this.layer);
+        return this.getMap().then(map => {
+            map.setLayer(mapLayerName, mapLayer, true);
+        });
+    }
+
+    removeMapLayers() {
+        return this.getMap().then(map => {
+            map.deleteLayers(mapLayerName);
+        });
+    }
+
+
+    fetchPage(page = this.$state.params.page || 1, filter, order) {
+        // TODO do we need to list ingesting scenes? that stuff goes under filter?
+        // this.getIngestingSceneCount();
+        delete this.fetchError;
+        this.sceneList = [];
+        const currentQuery = this.projectService.getProjectLayerScenes(
+            this.projectId,
+            this.layerId,
+            {
+                pageSize: this.projectService.scenePageSize,
+                page: page - 1
+            }
+        ).then((paginatedResponse) => {
+            this.sceneList = paginatedResponse.results;
+            this.sceneActions = new Map(this.sceneList.map(this.addSceneActions.bind(this)));
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageParam(page);
+            if (this.currentQuery === currentQuery) {
+                delete this.fetchError;
+            }
+        }, (e) => {
+            if (this.currentQuery === currentQuery) {
+                this.fetchError = e;
+            }
+        }).finally(() => {
+            if (this.currentQuery === currentQuery) {
+                delete this.currentQuery;
+            }
+        });
+        this.currentQuery = currentQuery;
+        return currentQuery;
+    }
+
+    hasDownloadPermission(scene) {
+        if (this.RasterFoundryRepository.getScenePermissions(scene).includes('download')) {
+            return true;
+        }
+        return false;
+    }
+
+    addSceneActions(scene) {
+        // details, view layers, hide (unapprove), remove (delete from layer)
+        let actions = [{
+            name: 'Remove',
+            title: 'Remove image from layer',
+            callback: () => this.removeScenes([scene]),
+            menu: true
+        }];
+
+        if (this.hasDownloadPermission(scene)) {
+            actions.unshift({
+                icon: 'icon-download',
+                name: 'Download',
+                title: 'Download raw image data',
+                callback: () => this.modalService.open({
+                    component: 'rfSceneDownloadModal',
+                    resolve: {
+                        scene: () => scene
+                    }
+                }).result.catch(() => {}),
+                menu: false
+            });
+        }
+
+        return [scene.id, actions];
+    }
+
+    openImportModal() {
+        const activeModal = this.modalService.open({
+            component: 'rfSceneImportModal',
+            resolve: {
+                project: () => this.project,
+                origin: () => 'project'
+            }
+        });
+
+        activeModal
+            .result
+            .catch(() => {});
+    }
+
+    isSelected(scene) {
+        return this.selected.has(scene.id);
+    }
+
+    onSelect(scene) {
+        if (this.selected.has(scene.id)) {
+            this.selected = this.selected.delete(scene.id);
+        } else {
+            this.selected = this.selected.set(scene.id, scene);
+        }
+        this.updateSelectText();
+    }
+
+    allVisibleSelected() {
+        let sceneSet = new Set(this.sceneList.map(s => s.id));
+        return this.selected.keySeq().toSet().intersect(sceneSet).size === sceneSet.size;
+    }
+
+    selectAll() {
+        if (this.allVisibleSelected()) {
+            this.selected = this.selected.clear();
+        } else {
+            this.selected = this.selected.merge(
+                _.filter(this.sceneList.map(s => [s.id, s]), s => !s.inLayer)
+            );
+        }
+        this.updateSelectText();
+    }
+
+    updateSelectText() {
+        if (this.allVisibleSelected()) {
+            this.selectText = 'Clear selected';
+        } else {
+            this.selectText = 'Select all visible';
+        }
+    }
+
+    browseScenes() {
+        this.getMap().then(mapWrapper => {
+            const bbox = mapWrapper.map.getBounds().toBBoxString();
+            this.$state.go('project.layer.browse', {bbox});
+        });
+    }
+
+    removeScenes(scenes) {
+        // TODO remove any scenes from the map
+        let sceneIds = scenes.map(s => s.id);
+        // make api call
+        this.projectService.removeScenesFromLayer(this.projectId, this.layerId, sceneIds).then(
+            () => {
+                // reset hovered scene outlines
+                // re-render project layer
+                let idSet = new Set(sceneIds);
+                this.selected = this.selected.filterNot((scene) => idSet.has(scene.id));
+                this.fetchPage();
+                this.removeMapLayers().then(() => this.setMapLayers());
+            },
+            () => {
+                this.error = 'Error removing scene from project.';
+            }
+        );
+        // remove from selected map
+    }
 }
 
 const component = {
     bindings: {
+        projectId: '<',
+        project: '<',
+        layerId: '<',
+        layer: '<'
     },
     templateUrl: tpl,
     controller: LayerScenesController.name

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -1,7 +1,7 @@
-<div class="sidebar-actions-group">
-  <button class="btn btn-small btn-transparent" ng-click="$ctrl.showNewLayerModal()">
+<div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0">
+  <a class="btn btn-small btn-transparent" ng-click="$ctrl.showNewLayerModal()">
     <i class="icon-plus"></i> New Layer
-  </button>
+  </a>
   <div style="flex: 1;"></div>
   <div class="btn btn-small btn-transparent" uib-dropdown uib-dropdown-toggle>
     Layer Visibility
@@ -12,6 +12,25 @@
         <a href ng-click="$ctrl.showPageLayers()">Show all on page</a></li>
     </ul>
   </div>
+</div>
+<div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
+  <rf-selected-actions-bar
+      checked="$ctrl.allVisibleSelected()"
+      on-click="$ctrl.selectAll()"
+      action-text="$ctrl.selectText"
+  >
+    <div class="btn btn-transparent" uib-dropdown uib-dropdown-toggle>
+      Create...
+      <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+        <li role="menuitem">
+          <a ng-click="$ctrl.createAnalysis()">Analysis</a></li>
+      </ul>
+    </div>
+    <button class="btn btn-transparent"
+            ng-click="$ctrl.removeScenes($ctrl.selected.valueSeq().toArray())">
+      Delete
+    </button>
+  </rf-selected-actions-bar>
 </div>
 <div class="sidebar-scrollable list-group">
   <rf-layer-item

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -149,6 +149,30 @@ class ProjectLayersPageController {
         ];
     }
 
+    allVisibleSelected() {
+        let layerSet = new Set(this.itemList.map(l => l.id));
+        return this.selected.intersect(layerSet).size === layerSet.size;
+    }
+
+    selectAll() {
+        if (this.allVisibleSelected()) {
+            this.selected = this.selected.clear();
+        } else {
+            this.selected = this.selected.union(
+                this.itemList.map(i => i.id)
+            );
+        }
+        this.updateSelectText();
+    }
+
+    updateSelectText() {
+        if (this.allVisibleSelected()) {
+            this.selectText = 'Clear selected';
+        } else {
+            this.selectText = 'Select listed';
+        }
+    }
+
     onSelect(id) {
         if (this.selected.has(id)) {
             this.selected = this.selected.delete(id);

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -224,19 +224,11 @@ class ProjectLayersPageController {
         }
     }
 
-    mapLayerFromLayer(layer) {
-        let url = this.projectService.getProjectLayerTileUrl(
-            this.project, layer, {token: this.authService.token()}
-        );
-        let mapLayer = L.tileLayer(url, {
-            maxZoom: 30
-        });
-        return mapLayer;
-    }
-
     syncMapLayersToVisible() {
         // TODO do this more efficiently (don't re-add existing layers)
-        let mapLayers = this.visible.toArray().map(this.mapLayerFromLayer.bind(this));
+        let mapLayers = this.visible
+            .toArray()
+            .map(layer => this.projectService.mapLayerFromLayer(this.project, layer));
         this.getMap().then(map => {
             map.setLayer('Project Layers', mapLayers, true);
         });

--- a/app-frontend/src/app/components/pages/project/project/index.html
+++ b/app-frontend/src/app/components/pages/project/project/index.html
@@ -1,37 +1,39 @@
-<div class="navbar light-navbar">
-  <div class="navbar-section">
-    <nav>
-      <a ui-sref="project.layers"
-      ng-class="{
-        active: ('project.layers' | includedByState)
-      }"
-      >Layers</a>
-    </nav>
-    <nav>
-      <a ui-sref="project.analyses"
-         ng-class="{
-                  active: ('project.analyses' | includedByState)
-                  }"
-      >Analyses</a>
-    </nav>
-  </div>
-  <div class="navbar-section secondary">
-    <nav>
-      <a>Smart Layers</a>
-    </nav>
-    <nav>
-      <a ui-sref="project.settings"
-         ng-class="{
-                  active: ('project.settings' | includedByState)
-                  }"
-      ><i class="icon-settings" title="Project Settings"></i></a>
-    </nav>
+<div ui-view="navbar-secondary">
+  <div class="navbar light-navbar">
+    <div class="navbar-section">
+      <nav>
+        <a ui-sref="project.layers"
+           ng-class="{
+                    active: ('project.layers' | includedByState)
+                    }"
+        >Layers</a>
+      </nav>
+      <nav>
+        <a ui-sref="project.analyses"
+           ng-class="{
+                    active: ('project.analyses' | includedByState)
+                    }"
+        >Analyses</a>
+      </nav>
+    </div>
+    <div class="navbar-section secondary">
+      <!-- <nav> -->
+      <!-- <a>Smart Layers</a> -->
+      <!-- </nav> -->
+      <nav>
+        <a ui-sref="project.settings"
+           ng-class="{
+                    active: ('project.settings' | includedByState)
+                    }"
+        ><i class="icon-settings" title="Project Settings"></i></a>
+      </nav>
+    </div>
   </div>
 </div>
-<div class="container column-stretch container-not-scrollable"
+<div class="container column-stretch container-not-scrollable with-secondary-navbar"
      ng-show="('project.settings' | includedByState)"
      ui-view></div>
-<div class="container column-stretch container-not-scrollable"
+<div class="container column-stretch container-not-scrollable with-secondary-navbar"
      ng-show="!('project.settings' | includedByState)">
   <div class="sidebar" ui-view></div>
   <div class="main">
@@ -41,4 +43,8 @@
                       initial-zoom="$ctrl.initialZoom">
     </rf-map-container>
   </div>
+</div>
+<div ng-show="('project.layer.browse' | includedByState)"
+     class="sidebar project-side-modal"
+     ui-view="project-sidemodal">
 </div>

--- a/app-frontend/src/app/components/projects/index.js
+++ b/app-frontend/src/app/components/projects/index.js
@@ -1,9 +1,13 @@
 import layerItem from './layerItem';
 import layerStats from './layerStats';
+import projectLayerSecondaryNavbar from './projectLayerSecondaryNavbar';
+import selectedActionsBar from './selectedActionsBar';
 import navbar from './navbar';
 
 export default [
     layerItem,
     layerStats,
+    projectLayerSecondaryNavbar,
+    selectedActionsBar,
     navbar
 ];

--- a/app-frontend/src/app/components/projects/navbar/index.js
+++ b/app-frontend/src/app/components/projects/navbar/index.js
@@ -4,7 +4,7 @@ import {Set} from 'immutable';
 
 class ProjectLayersNavController {
     constructor(
-        $rootScope, $state, $scope, $transitions
+        $rootScope, $state, $scope, $transitions, $log
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -14,6 +14,7 @@ class ProjectLayersNavController {
         this.navs = [];
         this.onStateCurrentChange(this.$state.current);
         this.$transitions.onSuccess({}, transition => {
+            this.$log.info('transition:', transition);
             const toState = transition.to();
             this.onStateCurrentChange(toState);
         });
@@ -45,10 +46,10 @@ class ProjectLayersNavController {
             stateCurrent.name.includes('project.layer.')
         ) {
             this.navs.push({
-                title: this.layer.name,
+                title: this.layer && this.layer.name,
                 sref: `project.layer({
                     projectId: '${this.project.id}',
-                    layerId: '${this.layer.id}'
+                    layerId: '${this.layer && this.layer.id}'
                 })`
             });
         }
@@ -58,7 +59,7 @@ class ProjectLayersNavController {
                 title: 'Color correct',
                 sref: `project.layer.corrections({
                     projectId: '${this.project.id}',
-                    layerId: '${this.layer.id}'
+                    layerId: '${this.layer && this.layer.id}'
                 })`
             });
         }
@@ -68,7 +69,7 @@ class ProjectLayersNavController {
                 title: 'Browse imagery',
                 sref: `project.layer.scenes.browse({
                     projectId: '${this.project.id}',
-                    layerId: '${this.layer.id}'
+                    layerId: '${this.layer && this.layer.id}'
                 })`
             });
         }

--- a/app-frontend/src/app/components/projects/navbar/index.js
+++ b/app-frontend/src/app/components/projects/navbar/index.js
@@ -14,7 +14,6 @@ class ProjectLayersNavController {
         this.navs = [];
         this.onStateCurrentChange(this.$state.current);
         this.$transitions.onSuccess({}, transition => {
-            this.$log.info('transition:', transition);
             const toState = transition.to();
             this.onStateCurrentChange(toState);
         });

--- a/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.html
+++ b/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.html
@@ -1,0 +1,43 @@
+<div class="navbar light-navbar">
+  <div class="navbar-section">
+    <nav>
+      <a ui-sref="project.layer.scenes"
+         ng-class="{
+                  active: ('project.layer.scenes' | includedByState) ||
+                          ('project.layer.browse' | includedByState)
+                  }"
+      >Images</a>
+    </nav>
+    <nav>
+      <a ui-sref="project.layer.annotations"
+         ng-class="{
+                  active: ('project.layer.annotations' | includedByState)
+                  }"
+      >Annotations</a>
+    </nav>
+    <nav>
+      <a ui-sref="project.layer.colormode"
+         ng-class="{
+                  active: ('project.layer.colormode' | includedByState) ||
+                          ('project.layer.corrections' | includedByState)
+                  }"
+      >Color options</a>
+    </nav>
+  </div>
+  <div class="navbar-section secondary">
+    <nav>
+      <a ui-sref="project.layer.aoi"
+         ng-class="{
+                  active: ('project.layer.aoi' | includedByState)
+                  }">
+        Area of interest</a>
+    </nav>
+    <nav>
+      <a ui-sref="project.layer.settings"
+         ng-class="{
+                  active: ('project.layer.settings' | includedByState)
+                  }"
+      ><i class="icon-settings" title="Project Settings"></i></a>
+    </nav>
+  </div>
+</div>

--- a/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
+++ b/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
@@ -1,0 +1,17 @@
+import tpl from './index.html';
+
+class ProjectLayerSecondaryNavbarController {
+}
+
+const component = {
+    bindings: {
+    },
+    templateUrl: tpl,
+    controller: ProjectLayerSecondaryNavbarController.name
+};
+
+export default angular
+    .module('components.projects.projectLayerSecondaryNavbar', [])
+    .controller(ProjectLayerSecondaryNavbarController.name, ProjectLayerSecondaryNavbarController)
+    .component('rfProjectLayerSecondaryNavbar', component)
+    .name;

--- a/app-frontend/src/app/components/projects/selectedActionsBar/index.html
+++ b/app-frontend/src/app/components/projects/selectedActionsBar/index.html
@@ -1,0 +1,19 @@
+<div class="navbar-section">
+  <button class="btn select-button" ng-click="$ctrl.onClick()">
+    <label class="checkbox"
+           ng-class="{
+                  active: $ctrl.checked
+                  }"
+    >
+      <input type="checkbox"
+             ng-checked="$ctrl.checked">
+    </label>
+    {{ $ctrl.actionText || 'Select all'}}
+  </button>
+</div>
+<div class="separator"></div>
+<div class="navbar-section">
+  <div class="navbar-section">
+    <ng-transclude></ng-transclude>
+  </div>
+</div>

--- a/app-frontend/src/app/components/projects/selectedActionsBar/index.js
+++ b/app-frontend/src/app/components/projects/selectedActionsBar/index.js
@@ -1,0 +1,20 @@
+import tpl from './index.html';
+class SelectedActionsBar {
+}
+
+const component = {
+    bindings: {
+        checked: '<',
+        onClick: '&',
+        actionText: '<'
+    },
+    templateUrl: tpl,
+    controller: SelectedActionsBar.name,
+    transclude: true
+};
+
+export default angular
+    .module('components.projects.selectedActionsBar', [])
+    .controller(SelectedActionsBar.name, SelectedActionsBar)
+    .component('rfSelectedActionsBar', component)
+    .name;

--- a/app-frontend/src/app/components/scenes/index.js
+++ b/app-frontend/src/app/components/scenes/index.js
@@ -1,0 +1,4 @@
+import projectSceneItem from './projectSceneItem';
+export default [
+    projectSceneItem
+];

--- a/app-frontend/src/app/components/scenes/projectSceneItem/index.html
+++ b/app-frontend/src/app/components/scenes/projectSceneItem/index.html
@@ -1,0 +1,58 @@
+<div class="list-group-item">
+  <div class="list-item-left-actions"
+       tooltips
+       tooltip-template="Image is already in {{$ctrl.scene.inLayer ? 'layer' : 'project'}}"
+       tooltip-size="small"
+       tooltip-class="rf-tooltip shrink"
+       tooltip-side="right"
+       tooltip-hidden="{{!$ctrl.scene.inLayer && !$ctrl.scene.inProject}}"
+       ng-if="!$ctrl.processing"
+  >
+    <label class="checkbox"
+           ng-class="{
+                  active: $ctrl.selected || $ctrl.scene.inLayer,
+                  'partial-active': $ctrl.scene.inProject
+                  }"
+           ng-disabled="$ctrl.scene.inLayer"
+    >
+      <input type="checkbox"
+             ng-checked="$ctrl.selected"
+             ng-click="$ctrl.scene.inLayer || $ctrl.onSelect({scene: $ctrl.scene})"
+      />
+    </label>
+  </div>
+  <div class="list-item-left-actions"
+       ng-if="$ctrl.processing"
+  >
+    <i class="icon-load animate-spin"
+       ng-class="{'stop': !$ctrl.processing}"
+       ></i>
+  </div>
+  <div class="item-img-container"
+       ng-class="{'previewable': $ctrl.isPreviewable}"
+       ng-click="$ctrl.isPreviewable && $ctrl.openSceneDetailModal($event)"
+  >
+    <img ng-attr-src="{{$ctrl.thumbnail}}"
+         ng-if="$ctrl.thumbnail && !$ctrl.imageError"
+         class="rounded-img item-img">
+    <div ng-if="!$ctrl.thumbnail || $ctrl.imageError"
+         class="rounded-img item-img image-placeholder">
+      <div>No preview available</div>
+    </div>
+  </div>
+  <div class="list-group-overflow">
+    <div>
+      <span title="{{$ctrl.scene.name}}">
+        <strong class="color-dark">
+          {{($ctrl.getReferenceDate() | date : 'mediumDate' : '+0000') + ' (UTC)'}}
+        </strong>
+      </span>
+    </div>
+    <div>
+      <span>{{$ctrl.scene.datasource.name}}</span>
+    </div>
+  </div>
+  <div class="list-group-right">
+    <ng-transclude></ng-transclude>
+  </div>
+</div>

--- a/app-frontend/src/app/components/scenes/projectSceneItem/index.js
+++ b/app-frontend/src/app/components/scenes/projectSceneItem/index.js
@@ -1,0 +1,98 @@
+import tpl from './index.html';
+import _ from 'lodash';
+
+class ProjectSceneItemController {
+    constructor($rootScope, sceneService, RasterFoundryRepository, authService, modalService) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+        this.repository = {service: RasterFoundryRepository};
+    }
+
+    $onInit() {
+        this.datasource = this.scene.datasource;
+        this.updateThumbnails();
+    }
+
+    getReferenceDate() {
+        if (!this.scene) {
+            return '';
+        }
+        let acqDate = this.scene.filterFields.acquisitionDate;
+        return acqDate ? acqDate : this.scene.createdAt;
+    }
+
+    updateThumbnails() {
+        if (this.scene.sceneType === 'COG') {
+            let redBand = _.get(this.datasource.bands.find(x => {
+                return x.name.toLowerCase() === 'red';
+            }), 'number');
+            let greenBand = _.get(this.datasource.bands.find(x => {
+                return x.name.toLowerCase() === 'green';
+            }), 'number');
+            let blueBand = _.get(this.datasource.bands.find(x => {
+                return x.name.toLowerCase() === 'blue';
+            }), 'number');
+            let bands = {};
+            let atLeastThreeBands = this.datasource.bands.length >= 3;
+            if (atLeastThreeBands) {
+                bands.red = parseInt(redBand || 0, 10);
+                bands.green = parseInt(greenBand || 1, 10);
+                bands.blue = parseInt(blueBand || 2, 10);
+            } else {
+                bands.red = 0;
+                bands.green = 0;
+                bands.blue = 0;
+            }
+            this.sceneService.cogThumbnail(
+                this.scene.id,
+                this.authService.token(),
+                128,
+                128,
+                bands.red,
+                bands.green,
+                bands.blue
+            ).then(res => {
+                // Because 504s aren't rejections, apparently
+                if (_.isString(res)) {
+                    this.thumbnail = `data:image/png;base64,${res}`;
+                }
+            }).catch(() => {
+                this.imageError = true;
+            });
+        } else {
+            this.RasterFoundryRepository.getThumbnail(this.scene).then((thumbnail) => {
+                this.thumbnail = thumbnail;
+            });
+        }
+    }
+
+    openSceneDetailModal(e) {
+        e.stopPropagation();
+        this.modalService.open({
+            component: 'rfSceneDetailModal',
+            resolve: {
+                scene: () => this.scene,
+                repository: () => this.repository
+            }
+        }).result.catch(() => {});
+    }
+}
+
+const component = {
+    bindings: {
+        scene: '<',
+        selected: '<',
+        onSelect: '&',
+        isPreviewable: '<',
+        processing: '<'
+    },
+    templateUrl: tpl,
+    controller: ProjectSceneItemController.name,
+    transclude: true
+};
+
+export default angular
+    .module('components.scenes.projectSceneItem', [])
+    .controller(ProjectSceneItemController.name, ProjectSceneItemController)
+    .component('rfProjectSceneItem', component)
+    .name;

--- a/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
+++ b/app-frontend/src/app/components/scenes/sceneFilterPane/sceneFilterPane.module.js
@@ -128,7 +128,10 @@ class FilterPaneController {
 
         this.debouncedOnRepositoryChange({
             fetchScenes: this.currentRepository.service.fetchScenes(
-                this.filterParams, this.$state.params.projectid
+                this.filterParams,
+                // support old routes
+                this.$state.params.projectId || this.$state.params.projectid,
+                this.$state.params.layerId
             ),
             repository: this.currentRepository
         });

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import pages from './components/pages';
 import projectComponents from './components/projects';
+import sceneComponents from './components/scenes';
 export default angular.module('index.components', [
     //admin components
     require('./components/admin/editableLogo/editableLogo.js').default.name,
@@ -21,6 +22,7 @@ export default angular.module('index.components', [
     require('./components/scenes/sceneDownloadModal/sceneDownloadModal.module.js').default.name,
     require('./components/scenes/sceneFilterPane/sceneFilterPane.module.js').default.name,
     require('./components/scenes/planetSceneDetailModal/planetSceneDetailModal.module.js').default.name,
+    ...sceneComponents,
 
     // vector components
     require('./components/vectors/vectorImportModal/vectorImportModal.module.js').default.name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -1,5 +1,6 @@
 /* eslint max-len: 0 */
 import _ from 'lodash';
+import {Map} from 'immutable';
 
 import rootTpl from './pages/root/root.html';
 import loginTpl from './pages/login/login.html';
@@ -112,7 +113,7 @@ function shareStatesV2($stateProvider) {
 }
 
 function projectStatesV2($stateProvider) {
-    let addScenesQueryParams = [
+    let addScenesQueryParamsList = [
         'maxCloudCover',
         'minCloudCover',
         'minAcquisitionDatetime',
@@ -126,7 +127,12 @@ function projectStatesV2($stateProvider) {
         'point',
         'ingested',
         'owner'
-    ].join('&');
+    ];
+    let dynamicSceneParams = addScenesQueryParamsList.reduce(
+        (acc, param) => acc.set(param, {dynamic: true}),
+        new Map()
+    ).toJSON();
+    let addScenesQueryParams = addScenesQueryParamsList.join('&');
 
     $stateProvider
         .state('project', {
@@ -196,10 +202,14 @@ function projectStatesV2($stateProvider) {
                 'projectlayernav@root': {
                     component: 'rfProjectLayersNav'
                 },
+                'navbar-secondary': {
+                    component: 'rfProjectLayerSecondaryNavbar'
+                },
                 '': {
                     component: 'rfProjectLayerPage'
                 }
-            }
+            },
+            redirectTo: 'project.layer.scenes'
         })
     // project layer routes
         .state('project.layer.aoi', {
@@ -222,10 +232,15 @@ function projectStatesV2($stateProvider) {
             url: '/scenes?page',
             component: 'rfProjectLayerScenesPage'
         })
-        .state('project.layer.scenes.browse', {
+        .state('project.layer.browse', {
             title: 'Find Scenes',
             url: '/browse?' + addScenesQueryParams,
-            component: 'rfProjectLayerScenesBrowsePage'
+            views: {
+                'project-sidemodal@project': {
+                    component: 'rfProjectLayerScenesBrowsePage'
+                }
+            },
+            params: dynamicSceneParams
         })
         .state('project.layer.exports', {
             title: 'Project Layer Exports',
@@ -241,11 +256,6 @@ function projectStatesV2($stateProvider) {
             title: 'Project Layer Annotations',
             url: '/annotations?page',
             component: 'rfProjectLayerAnnotationsPage'
-        })
-        .state('project.layer.annotate', {
-            title: 'Project Layer Annotate',
-            url: '/annotate',
-            component: 'rfProjectLayerAnnotatePage'
         })
     // Project analyses routes
         .state('project.analyses.compare', {

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -91,6 +91,15 @@ export default (app) => {
                             projectId: '@projectId'
                         }
                     },
+                    addScenesToLayer: {
+                        method: 'POST',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/` +
+                            'layers/:layerId/scenes/',
+                        params: {
+                            projectId: '@projectId',
+                            layerId: '@layerId'
+                        }
+                    },
                     projectDatasources: {
                         method: 'GET',
                         cache: false,
@@ -106,6 +115,16 @@ export default (app) => {
                         url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/scenes`,
                         params: {
                             projectId: '@projectId'
+                        }
+                    },
+                    layerScenes: {
+                        method: 'GET',
+                        cache: false,
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/`
+                            + 'layers/:layerId/scenes',
+                        params: {
+                            projectId: '@projectId',
+                            layerId: '@layerId'
                         }
                     },
                     projectAois: {
@@ -332,6 +351,12 @@ export default (app) => {
             ).$promise;
         }
 
+        addScenesToLayer(projectId, layerId, sceneIds) {
+            return this.Project.addScenesToLayer(
+                {projectId, layerId}, sceneIds
+            ).$promise;
+        }
+
         getProjectCorners(id) {
             // TODO Use project extent instead here
             throw new Error('ERROR: Update project.service getProjectCorners to use the ' +
@@ -379,6 +404,17 @@ export default (app) => {
             ).$promise;
         }
 
+        getProjectLayerScenes(projectId, layerId, params = {}) {
+            return this.Project.layerScenes(
+                Object.assign({}, {
+                    projectId, layerId,
+                    pending: false,
+                    page: 0,
+                    pageSize: 30
+                }, params)
+            ).$promise;
+        }
+
         getProjectDatasources(projectId, params = {}) {
             return this.Project.projectDatasources({...params, projectId}).$promise;
         }
@@ -417,6 +453,15 @@ export default (app) => {
             return this.$http({
                 method: 'DELETE',
                 url: `${BUILDCONFIG.API_HOST}/api/projects/${projectId}/scenes/`,
+                data: scenes,
+                headers: {'Content-Type': 'application/json;charset=utf-8'}
+            });
+        }
+
+        removeScenesFromLayer(projectId, layerId, scenes) {
+            return this.$http({
+                method: 'DELETE',
+                url: `${BUILDCONFIG.API_HOST}/api/projects/${projectId}/layers/${layerId}/scenes/`,
                 data: scenes,
                 headers: {'Content-Type': 'application/json;charset=utf-8'}
             });
@@ -631,9 +676,6 @@ export default (app) => {
             return this.Project.createLayer({projectId}, params).$promise;
         }
 
-        getProjectLayer(projectId, layerId) {
-            return this.Project.getLayer({projectId, layerId}).$promise;
-        }
 
         getProjectLayerStats(projectId) {
             return this.Project.getLayerStats({projectId}).$promise;
@@ -641,6 +683,18 @@ export default (app) => {
 
         deleteProjectLayer(projectId, layerId) {
             return this.Project.deleteLayer({projectId, layerId}).$promise;
+        }
+
+        mapLayerFromLayer(
+            project, layer, tag = (new Date()).valueOf(), token = this.authService.token()
+        ) {
+            let url = this.getProjectLayerTileUrl(
+                project, layer, {token, tag}
+            );
+            let mapLayer = L.tileLayer(url, {
+                maxZoom: 30
+            });
+            return mapLayer;
         }
     }
 

--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -215,7 +215,7 @@ export default (app) => {
             };
         }
 
-        sceneToUploadObject(scene, projectId, user) {
+        sceneToUploadObject(scene, projectId, layerId, user) {
             const datasource = this.datasources.find(d => d.id === scene.datasource);
             return {
                 files: datasource.fileAdapter(scene),
@@ -226,6 +226,7 @@ export default (app) => {
                 visibility: 'PRIVATE',
                 organizationId: user.organizationId,
                 projectId,
+                layerId,
                 metadata: {}
             };
         }
@@ -236,10 +237,22 @@ export default (app) => {
         */
         addToProject(projectId, scenes) {
             return this.authService.getCurrentUser().then(user => {
-                const uploads = scenes.map(s => this.sceneToUploadObject(s, projectId, user));
+                const uploads = scenes.map(
+                    s => this.sceneToUploadObject(s, projectId, null, user)
+                );
                 return this.$q.all(
                     uploads.map(u => this.uploadService.create(u))
                 );
+            });
+        }
+
+        addToLayer(projectId, layerId, scenes) {
+            return this.authService.getCurrentUser().then(user => {
+                const uploads = scenes.map(
+                    s => this.sceneToUploadObject(s, projectId, layerId, user)
+                );
+                return this.$q.all(
+                    uploads.map(u => this.uploadService.create(u)));
             });
         }
     }

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -592,6 +592,9 @@ rf-project-editor .leaflet-tile {
 .rf-tooltip {
   min-width: 250px;
   text-align: left;
+  &.shrink {
+      min-width: 0;
+  }
 }
 
 .layer-item-tooltip {
@@ -3261,19 +3264,23 @@ rf-navbar-search {
 }
 
 rf-project-layers-page,
-rf-project-analyses-page {
+rf-project-analyses-page,
+rf-project-layer-page,
+rf-project-layer-scenes-browse-page {
     flex: 1;
     display: flex;
     flex-direction: column;
     background: $off-white;
     min-height: 0; // firefox flexbox compatability
+    height: 100%;
 
-    rf-layer-item {
+    rf-layer-item,
+    rf-project-scene-item {
         display: block;
         background: $white;
         border: 1px solid $gray-lightest;
         border-radius: 3px;
-        margin: .25em;
+        margin: .5em;
     }
 }
 
@@ -3286,4 +3293,109 @@ rf-project-analyses-page {
     justify-content: space-between;
     flex-direction: column;
     align-self: stretch;
+}
+
+.project-side-modal {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    background: $off-white;
+    display: block;
+    // TODO replace other styles with this once we remove the other components
+    rf-scene-filter-pane {
+        .filter {
+            label,
+            .selectize-input {
+                color: $shade-dark;
+            }
+            .selectize-input {
+                background-color: $white;
+                border-color: $shade-light;
+                color: $shade-dark;
+            }
+        }
+        .browse-source-drop-down {
+            background-color: $white;
+            border-color: $shade-light;
+            color: $shade-dark;
+        }
+        .form-group.all-in-one.input-dark {
+            border-color: $shade-light;
+            background-color: $white;
+            .input {
+                color: $shade-dark;
+            }
+        }
+        .date-range-select > *,
+        .date-range-select i {
+            color: $shade-dark;
+        }
+        .shapefilter-box {
+            background: $white;
+            border: 1px solid $shade-light;
+            color: $shade-dark;
+        }
+        .btn-toggle {
+            &.active {
+                background: $brand-primary;
+                border-color: $brand-primary;
+                color: $white;
+            }
+            background: $white;
+            border-color: $shade-light;
+            color: $brand-primary;
+        }
+    }
+}
+
+rf-project-page {
+    display: block;
+    position: relative;
+}
+
+.separator {
+    flex: 1;
+}
+
+.selected-actions-group {
+    a {
+        box-shadow: initial;
+        padding: 1.25rem 1rem;
+        margin: 0.25rem;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+
+    rf-selected-actions-bar {
+        width: 100%;
+        background: $white;
+        display: flex;
+        justify-content: space-between;
+        padding: 0 0.5rem;
+    }
+
+    .navbar-section {
+        flex: initial;
+    }
+
+    .select-button {
+        box-shadow: initial;
+        padding: 0.55rem 1rem;
+        margin: 0.6rem;
+        border: 1px solid $shade-light;
+        border-radius: 1.5em;
+        background: $white;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+
+        label.checkbox {
+            &:after {
+                border: 2px solid $shade-light;
+            }
+            cursor: pointer;
+        }
+    }
 }

--- a/app-frontend/src/assets/styles/sass/components/_form.scss
+++ b/app-frontend/src/assets/styles/sass/components/_form.scss
@@ -249,6 +249,8 @@ div.checkbox {
   align-items: center;
   margin: 0;
   color: $text-base;
+  user-select: none;
+  cursor: pointer;
 
   label {
     margin: 0 5px;
@@ -306,10 +308,21 @@ div.checkbox {
 
     &:not(.custom-icon):before,
     &.custom-icon i {
+      content: "\e911"; // see fontello.css .icon-check:before
       visibility: visible;
       opacity: 1;
       transform: scale(1);
     }
+  }
+
+  &.partial-active {
+      transition: 0.2s ease-in-out color;
+      &:before {
+          content: "\e92c";
+          visibility: visible;
+          opacity: 1;
+          transform: scale(1);
+      }
   }
 
   &:not(.active) {

--- a/app-frontend/src/assets/styles/sass/layout/_container.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_container.scss
@@ -59,7 +59,8 @@ $navbar-secondary-height: 4.7rem !default;
   ); // Fixes flex + height issue in some browsers
 
   .secondary-navbar ~ &,
-  .light-navbar ~ & {
+  .light-navbar ~ &,
+  &.with-secondary-navbar {
     height: calc(100vh - #{$navbar-height + $navbar-secondary-height});
     max-height: calc(
       100vh - #{$navbar-height + $navbar-secondary-height}

--- a/app-frontend/src/assets/styles/sass/layout/_navbar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_navbar.scss
@@ -90,6 +90,13 @@
       border-bottom: 1px solid $brand-primary;
       margin-bottom: -1px;
     }
+
+    &[ui-view] {
+        > {
+            flex: 1;
+            display: f
+        }
+    }
   }
 
   &.light-navbar {

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -129,6 +129,15 @@
   justify-content: space-between;
   align-items: center;
 
+  a {
+      box-shadow: initial;
+      padding: 1.25rem 1rem;
+      margin: 0.25rem;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+  }
+
   label,
   .label {
     margin: 6px 0;


### PR DESCRIPTION
## Overview
Add project layer scene and browse views
Add layer parameter to /api/scenes, update datamodel to have inLayer property
Set hasNext correctly on /api/scenes if there are > 100 scenes
Use a sane default for the accepted query parameter on /api/project/{}/layer/{}/scenes endpoint

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated [updated here](https://github.com/raster-foundry/raster-foundry-api-spec/pull/87)
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME` The styles are probably all very broken for non-RF core themes. @designmatty will need to do a pass over all of our styles before we do the full switch over to project layers on production
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/52582889-425e5e00-2dfc-11e9-9ef1-dd572d5603a1.png)


### Notes
I'm pretty sure there are some missing features, but this has been worked on for long enough at this point that other issues should be made for them


## Testing Instructions
 * View an existing layer with scenes in it and verify that they load
* Verify that both options on the add imagery dropdown work
* Add a couple scenes to the first layer
* verify that you can preview scenes in the browse view by clicking on the icon
* Verify that the filter view works as expected (does not reload controllers etc)
* Verify that when you select a scene in the browse view, an option to add it to your layer apepars
* Verify that the checkbox is replaced with a loading icon while the scene is being added to the layer
* Verify that they show up in the browse view as already being in the layer
* Create another layer and browse with the same parameters / location, and verify that a third state exists for scenes which are in the project, but not the layer
* verify that you can still add scenes in a project to a second layer
* verify that the eye icon sticks the scene's geometry onto the map
* Verify that there are a reasonable number of requests when the browse view is initialized (2 vs 20)
* Verify that the download / delete buttons on the scenes view work as expected
* Verify that you can select and delete a set of scenes
* verify that when selecting scenes, the "select all visible" button works and interacts as expected (selects all scenes that are loaded into the UI)
* verify that you can view more than the first 100 scenes while browsing @jmorrison1847 this one's for you, the change should fix it for the old browse view as well


Closes #4537 
