### PR TITLE
Fix default layer color group; Remove layer re-ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@
 
 ### Changed
 
+- Updated default project layer color group hex code [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
+
 ### Deprecated
 
 ### Removed
+
+- Removed layer re-ordering, layer sorting, layer type selection from UI [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
 
 ### Fixed
 

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -88,7 +88,7 @@ object ProjectDao
                      now,
                      "Project default layer",
                      None,
-                     "#FFFFFF",
+                     "#738FFC",
                      None,
                      None,
                      None,

--- a/app-backend/migrations/src/main/scala/migrations/164.scala
+++ b/app-backend/migrations/src/main/scala/migrations/164.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/164.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -161,4 +161,5 @@ object MigrationSummary {
   M161
   M162
   M163
+  M164
 }

--- a/app-backend/migrations/src_migrations/main/scala/164.scala
+++ b/app-backend/migrations/src_migrations/main/scala/164.scala
@@ -1,0 +1,10 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M164 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(164)(List(
+    sqlu"""
+    UPDATE project_layers SET color_group_hex = '#738FFC' WHERE color_group_hex = '#FFFFFF';
+    """
+  ))
+}

--- a/app-backend/migrations/src_migrations/main/scala/164.scala
+++ b/app-backend/migrations/src_migrations/main/scala/164.scala
@@ -2,9 +2,10 @@ import slick.jdbc.PostgresProfile.api._
 import com.liyaos.forklift.slick.SqlMigration
 
 object M164 {
-  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(164)(List(
-    sqlu"""
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(164)(
+    List(
+      sqlu"""
     UPDATE project_layers SET color_group_hex = '#738FFC' WHERE color_group_hex = '#FFFFFF';
     """
-  ))
+    ))
 }

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -3,12 +3,6 @@
     <i class="icon-plus"></i> New Layer
   </button>
   <div style="flex: 1;"></div>
-  <select class="btn btn-small btn-transparent"
-          ng-model="$ctrl.ordering">
-    <option value="">Newest</option>
-    <option value="manual">Manual</option>
-    <option value="date">Date</option>
-  </select>
   <div class="btn btn-small btn-transparent" uib-dropdown uib-dropdown-toggle>
     Layer Visibility
     <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">

--- a/app-frontend/src/app/components/projects/layerItem/index.html
+++ b/app-frontend/src/app/components/projects/layerItem/index.html
@@ -15,9 +15,6 @@
          border: 2px solid {{$ctrl.color}};
      }
     </style>
-    <div ng-attr-title="Drag to reorder this layer">
-      <i class="icon-gripper"></i>
-    </div>
   </div>
   <div class="list-group-overflow">
     <div><strong>{{$ctrl.layer.name}}</strong></div>

--- a/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.html
+++ b/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.html
@@ -44,13 +44,6 @@
                    ng-init="$ctrl.projectLayerCreateBuffer.colorGroupHex"
                    ng-model="$ctrl.projectLayerCreateBuffer.colorGroupHex">
           </div>
-          <h5 class="modal-content-header-thin">Layer type</h5>
-          <div class="form-group all-in-one">
-            <select class="form-control">
-              <option value="standard">Standard layer</option>
-              <option value="smart" ng-if="$ctrl.showSmartLayerOption">Smart layer</option>
-            </select>
-          </div>
         </form>
       </div>
     </div>

--- a/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.js
+++ b/app-frontend/src/app/components/projects/projectLayerCreateModal/projectLayerCreateModal.js
@@ -22,7 +22,6 @@ class ProjectLayerCreateModalController {
     }
 
     $onInit() {
-        this.showSmartLayerOption = false;
         this.setProjectLayerCreate();
     }
 


### PR DESCRIPTION
## Overview

This PR:
 - adds a migration to update existing default layer color group hex code from `#FFFFFF` to `#738FFC`, which is a `$brand-primary` color
 - updates `ProjectDao` to use same color as above when inserting project default layer upon creating a new project
 - removes layer re-ordering in layer list UI
 - removes layer sorting in layer list UI
 - removes layer type drop down in layer create modal UI

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- [X] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

<img width="1386" alt="screen shot 2019-02-11 at 2 12 22 pm" src="https://user-images.githubusercontent.com/16109558/52587072-201e0d80-2e07-11e9-92ae-41fcf27e5f54.png">


## Testing Instructions

 * Run migrations
 * Go to `v2/project/<projectId>/layers` UI and check if the project default layer's checkbox has a color
 * Create a new project, go to the similar UI as above to check the default layer checkbox color
 * Check that the layer re-ordering handle and the layer sorting filter are gone
 * Check that the layer type drop down is gone in layer creation modal

Closes https://github.com/raster-foundry/raster-foundry/issues/4592
Closes https://github.com/raster-foundry/raster-foundry/issues/4591
