### PR TITLE
Upgrade gdal-js and requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 
 - Updated default project layer color group hex code [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
+- Updated gdal-js [\#4618](https://github.com/raster-foundry/raster-foundry/pull/4618)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Changed
 
 - Updated default project layer color group hex code [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
-- Updated gdal-js [\#4618](https://github.com/raster-foundry/raster-foundry/pull/4618)
+- Updated `gdal-js` and `requests` [\#4618](https://github.com/raster-foundry/raster-foundry/pull/4618)
 
 ### Deprecated
 

--- a/app-frontend/package.json
+++ b/app-frontend/package.json
@@ -54,7 +54,7 @@
     "bootstrap-sass": "~3.3.6",
     "d3": "5.7.0",
     "es6-map": "^0.1.5",
-    "gdal-js": "^1.1.0",
+    "gdal-js": "^1.1.2",
     "immutable": "^3.8.2",
     "jointjs": "~2.1.4",
     "jquery": "~3.1.1",

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
@@ -260,7 +260,6 @@ class NewExportController {
 
     createBasicExport() {
         let exportOpts = this.getExportOptions();
-        console.log(exportOpts);
         this.projectService
             .export(this.project,
                     {exportType: this.getCurrentTarget().value === 'dropbox' ? 'Dropbox' : 'S3' },

--- a/app-frontend/yarn.lock
+++ b/app-frontend/yarn.lock
@@ -4963,6 +4963,11 @@ gdal-js@^1.1.0:
   resolved "https://registry.yarnpkg.com/gdal-js/-/gdal-js-1.1.0.tgz#78da0e024f98e122206e64ae4f627662acfee5ad"
   integrity sha1-eNoOAk+Y4SIgbmSuT2J2Yqz+5a0=
 
+gdal-js@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/gdal-js/-/gdal-js-1.1.2.tgz#40ab4ee0131cca204da4e23fe937b8cc0af80cff"
+  integrity sha1-QKtO4BMcyiBNpOI/6Te4zAr4DP8=
+
 generate-function@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.0.0.tgz#6858fe7c0969b7d4e9093337647ac79f60dfbe74"

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -14,4 +14,4 @@ click==6.7
 dropbox==9.0.0
 rasterfoundry==0.7.1
 psycopg2-binary==2.7.6
-requests==2.16.2
+requests==2.21.0


### PR DESCRIPTION
## Overview

This PR upgrades gdal-js so it can read jpeg-compressed tiffs.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

 * `gdal_translate -scale -ot Byte -of GTiff -co COMPRESS=JPEG some-tiff.tiff jpeg-compressed.tiff`
 * try to upload your tiff
 * observe that gdal-js can read it and understand what's inside
 * rebuild your batch container
 * process the upload (this uses requests to do api interaction for uploads and scenes)
 * observe that you get an obviously lossy compressed image at the end

Closes #3621 

Closes #4577 