### PR TITLE
replaces trash icon with text: remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Updated default project layer color group hex code [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
+- Swap trash icon for "Remove" text on scene item components [\#4621](https://github.com/raster-foundry/raster-foundry/pull/4621)
 
 ### Deprecated
 

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -80,7 +80,7 @@
         <i class="icon-download"></i>
       </button>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
-        remove
+        Remove
       </button>
     </rf-scene-item>
     <rf-scene-item
@@ -98,7 +98,7 @@
         <i class="icon-download"></i>
       </button>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
-        remove
+        Remove
       </button>
     </rf-scene-item>
   </div>

--- a/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
+++ b/app-frontend/src/app/pages/projects/edit/scenes/scenes.html
@@ -80,7 +80,7 @@
         <i class="icon-download"></i>
       </button>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
-        <i class="icon-trash"></i>
+        remove
       </button>
     </rf-scene-item>
     <rf-scene-item
@@ -98,7 +98,7 @@
         <i class="icon-download"></i>
       </button>
       <button class="btn btn-tiny" ng-click="$ctrl.removeSceneFromProject(scene, $event)">
-        <i class="icon-trash"></i>
+        remove
       </button>
     </rf-scene-item>
   </div>


### PR DESCRIPTION
## Overview

This change was overwritten a few months ago and this is just putting it back to the intended state. On project scene list, instead of displaying a trash icon, we display the text remove. This will help users understand they're not deleting a scene from the app, but simply removing it from the project.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
![image](https://user-images.githubusercontent.com/1928955/52643693-8f4d3d80-2eab-11e9-897c-f4b4ba9b147c.png)

Closes #2827
