### PR TITLE
Add layer stats to project layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Added
 - Added backend support for rendering tiles and fetching histograms for analyses with project layers at their leaves [\#4603](https://github.com/raster-foundry/raster-foundry/pull/4603)
+- Added scene counts to project layer items [\#4625](https://github.com/raster-foundry/raster-foundry/pull/4625)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -88,6 +88,12 @@ trait ProjectRoutes
                 get {
                   listProjectLayers(projectId)
                 }
+            } ~ pathPrefix("stats") {
+              pathEndOrSingleSlash {
+                get {
+                  getProjectLayerSceneCounts(projectId)
+                }
+              }
             } ~
               pathPrefix(JavaUUID) { layerId =>
                 pathEndOrSingleSlash {
@@ -1977,6 +1983,24 @@ trait ProjectRoutes
                                        annotationGroupId,
                                        Some(layerId))
             .transact(xa)
+            .unsafeToFuture
+        }
+      }
+    }
+
+  def getProjectLayerSceneCounts(projectId: UUID): Route =
+    authenticate { user =>
+      authorizeAsync {
+        ProjectDao
+          .authorized(user, ObjectType.Project, projectId, ActionType.View)
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        complete {
+          ProjectLayerScenesDao
+            .countLayerScenes(projectId)
+            .transact(xa)
+            .map(Map(_: _*))
             .unsafeToFuture
         }
       }

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -767,6 +767,25 @@ object Generators extends ArbitraryInstances {
       MapToken.Create(name, None, None, None)
     }
 
+  private def projectLayerCreateGen: Gen[ProjectLayer.Create] =
+    for {
+      name <- nonEmptyStringGen
+      projectId <- Gen.const(None)
+      colorGroupHex <- Gen.const("#ABCDEF")
+      smartLayerId <- Gen.const(None)
+      rangeStart <- Gen.const(None)
+      rangeEnd <- Gen.const(None)
+      geometry <- Gen.const(None)
+    } yield {
+      ProjectLayer.Create(name,
+                          projectId,
+                          colorGroupHex,
+                          smartLayerId,
+                          rangeStart,
+                          rangeEnd,
+                          geometry)
+    }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
       credentialGen
@@ -923,5 +942,17 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbMapTokenCreate: Arbitrary[MapToken.Create] =
       Arbitrary { mapTokenCreateGen }
+
+    implicit def arbProjectLayerCreate: Arbitrary[ProjectLayer.Create] =
+      Arbitrary { projectLayerCreateGen }
+
+    implicit def arbProjectLayerCreateWithScenes
+      : Arbitrary[List[(ProjectLayer.Create, List[Scene.Create])]] = {
+      val tupGen = for {
+        projectLayerCreate <- arbitrary[ProjectLayer.Create]
+        sceneCreates <- arbitrary[List[Scene.Create]]
+      } yield { (projectLayerCreate, sceneCreates) }
+      Arbitrary { Gen.listOfN(5, tupGen) }
+    }
   }
 }

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -25,6 +25,20 @@ object ProjectLayerScenesDao extends Dao[Scene] {
           s.acquisition_date, s.sun_azimuth, s.sun_elevation, s.thumbnail_status,
           s.boundary_status, s.ingest_status, s.scene_type FROM""" ++ tableF
 
+  def countLayerScenes(
+      projectId: UUID
+  ): ConnectionIO[List[(UUID, Int)]] = {
+    (Fragment.const(
+      """
+      | SELECT project_layer_id, count(1)
+      | FROM
+      | (scenes_to_layers JOIN project_layers ON scenes_to_layers.project_layer_id = project_layers.id) s2lpl
+      | JOIN projects ON s2lpl.project_id = projects.id
+      """.trim.stripMargin) ++ Fragments.whereAnd(fr"project_id = ${projectId}") ++ fr"GROUP BY project_layer_id")
+      .query[(UUID, Int)]
+      .to[List]
+  }
+
   def listLayerScenes(
       layerId: UUID,
       pageRequest: PageRequest,
@@ -72,9 +86,6 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       scenes: List[Scene],
       layerId: UUID
   ): ConnectionIO[List[Scene.ProjectScene]] = {
-    // "The astute among you will note that we don’t actually need a monad to do this;
-    // an applicative functor is all we need here."
-    // let's roll, doobie
     val componentsIO: ConnectionIO[
       (List[Thumbnail], List[Datasource], List[SceneToLayer])
     ] = {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -31,7 +31,7 @@ class ProjectLayerDatasourceDaoSpec
           {
             val scenesInsertWithUserProjectIO = for {
               orgUserProject <- insertUserOrgProject(user, org, project)
-              (dbOrg, dbUser, dbProject) = orgUserProject
+              (_, dbUser, dbProject) = orgUserProject
               datasource <- DatasourceDao.create(
                 dsCreate.toDatasource(dbUser),
                 dbUser

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerScenesDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerScenesDaoSpec.scala
@@ -85,4 +85,63 @@ class LayerScenesDaoSpec
       }
     }
   }
+
+  test("count scenes in layers for a project") {
+    check {
+      forAll {
+        (
+            user: User.Create,
+            org: Organization.Create,
+            project: Project.Create,
+            layersWithScenes: List[(ProjectLayer.Create, List[Scene.Create])],
+            dsCreate: Datasource.Create
+        ) =>
+          {
+            val countsWithCountedIO = for {
+              (_, dbUser, dbProject) <- insertUserOrgProject(user, org, project)
+              dbDatasource <- fixupDatasource(dsCreate, dbUser)
+              dbLayersWithSceneCounts <- layersWithScenes traverse {
+                case (projectLayerCreate, scenesList) =>
+                  for {
+                    dbProjectLayer <- ProjectLayerDao.insertProjectLayer(
+                      projectLayerCreate
+                        .copy(projectId = Some(dbProject.id))
+                        .toProjectLayer
+                    )
+                    dbScenes <- scenesList traverse { scene =>
+                      SceneDao.insert(fixupSceneCreate(dbUser,
+                                                       dbDatasource,
+                                                       scene),
+                                      dbUser)
+                    }
+                    _ <- ProjectDao.addScenesToProject(dbScenes map { _.id },
+                                                       dbProject.id,
+                                                       true,
+                                                       Some(dbProjectLayer.id))
+                  } yield { (dbProjectLayer.id, dbScenes.length) }
+              }
+              counted <- ProjectLayerScenesDao.countLayerScenes(dbProject.id)
+            } yield (counted, dbLayersWithSceneCounts)
+
+            val (counted, expectedCounts) =
+              xa.use(t => countsWithCountedIO.transact(t)) map {
+                case (tups1, tups2) => (Map(tups1: _*), Map(tups2: _*))
+              } unsafeRunSync
+
+            val expectation =
+              if (counted.isEmpty) {
+                expectedCounts.values.foldLeft(0)(_ + _) == 0
+              } else {
+                expectedCounts.filter(kvPair => kvPair._2 != 0) == counted
+              }
+
+            assert(
+              expectation,
+              "Counts by layer id should equal the counts of scenes added to each layer")
+
+            true
+          }
+      }
+    }
+  }
 }

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -17,7 +17,6 @@
 <div class="sidebar-scrollable list-group">
   <rf-layer-item
       layer="layer"
-      layer-stats="$ctrl.layerStats"
       layer-actions="$ctrl.layerActions[$index]"
       subtext="layer.subtext"
       selected="$ctrl.isSelected(layer.id)"
@@ -25,6 +24,7 @@
       visible="$ctrl.isVisible(layer.id)"
       on-hide="$ctrl.onHide(layerId)"
       ng-repeat="layer in $ctrl.layerList track by layer.id">
+    <rf-layer-stats scene-count="$ctrl.getSceneCount(layer.id)"></rf-layer-stats">
   </rf-layer-item>
   <rf-pagination-controls
       pagination="$ctrl.pagination"

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -17,6 +17,7 @@
 <div class="sidebar-scrollable list-group">
   <rf-layer-item
       layer="layer"
+      layer-stats="$ctrl.layerStats"
       layer-actions="$ctrl.layerActions[$index]"
       subtext="layer.subtext"
       selected="$ctrl.isSelected(layer.id)"

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -19,6 +19,10 @@ class ProjectLayersPageController {
             permissions => {
                 this.permissions = permissions.map(p => p.actionType);
             });
+        this.projectService.getProjectLayerStats(this.project.id).then(
+            layerSceneCounts => {
+                this.layerStats = layerSceneCounts;
+            });
         this.fetchPage();
     }
 

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -37,6 +37,10 @@ class ProjectLayersPageController {
         return this.mapService.getMap('project');
     }
 
+    getSceneCount(layerId) {
+        return this.layerStats ? this.layerStats[layerId] : null;
+    }
+
     fetchPage(page = this.$state.params.page || 1) {
         this.layerList = [];
         this.layerActions = {};

--- a/app-frontend/src/app/components/projects/index.js
+++ b/app-frontend/src/app/components/projects/index.js
@@ -1,7 +1,9 @@
 import layerItem from './layerItem';
+import layerStats from './layerStats';
 import navbar from './navbar';
 
 export default [
     layerItem,
+    layerStats,
     navbar
 ];

--- a/app-frontend/src/app/components/projects/layerItem/index.html
+++ b/app-frontend/src/app/components/projects/layerItem/index.html
@@ -20,54 +20,55 @@
     <div><strong>{{$ctrl.layer.name}}</strong></div>
     <div ng-show="$ctrl.layer.subtext"><span>{{$ctrl.layer.subtext}}</span></div>
     <div>{{$ctrl.layer.createdAt | date}}</div>
-    <rf-layer-stats
-        scene-count="$ctrl.getSceneCount()"></rf-layer-stats>
   </div>
-  <div class="list-group-right">
-    <div class="btn btn-text btn-transparent"
-            ng-show="!$ctrl.hasGeom"
-    >
-      <span class="icon-warning color-danger"
-            tooltips
-            tooltip-template="No AOI defined for this layer"
-            tooltip-size="small"
-            tooltip-class="layer-item-tooltip"
-            tooltip-side="left"
-      ></span>
+  <div class="list-group-right list-group-vertical">
+    <div>
+      <div class="btn btn-text btn-transparent"
+           ng-show="!$ctrl.hasGeom"
+      >
+        <span class="icon-warning color-danger"
+              tooltips
+              tooltip-template="No AOI defined for this layer"
+              tooltip-size="small"
+              tooltip-class="layer-item-tooltip"
+              tooltip-side="left"
+        ></span>
+      </div>
+      <div class="btn btn-text btn-transparent"
+           ng-click="$ctrl.onHide({layerId: $ctrl.layer.id})"
+      >
+        <span class="icon-eye"
+              tooltips
+              tooltip-template="Hide layer on map"
+              tooltip-size="small"
+              tooltip-class="layer-item-tooltip"
+              tooltip-side="left"
+              ng-if="$ctrl.visible"
+        ></span>
+        <span class="icon-eye-off"
+              tooltips
+              tooltip-template="Show layer on map"
+              tooltip-size="small"
+              tooltip-class="layer-item-tooltip"
+              tooltip-side="left"
+              ng-if="!$ctrl.visible"
+        ></span>
+      </div>
+      <div class="btn btn-text btn-transparent"
+           uib-dropdown
+           ng-show="$ctrl.layerActions && $ctrl.layerActions.length"
+           uib-dropdown-toggle
+      >
+        <i class="icon-menu"></i>
+        <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+          <li role="menuitem"
+              ng-repeat="action in $ctrl.layerActions">
+            <a href ng-click="action.callback()" ng-show="action.name">{{action.name}}</a>
+            <span class="menu-separator" ng-show="action.separator"></span>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="btn btn-text btn-transparent"
-            ng-click="$ctrl.onHide({layerId: $ctrl.layer.id})"
-    >
-      <span class="icon-eye"
-            tooltips
-            tooltip-template="Hide layer on map"
-            tooltip-size="small"
-            tooltip-class="layer-item-tooltip"
-            tooltip-side="left"
-            ng-if="$ctrl.visible"
-      ></span>
-      <span class="icon-eye-off"
-            tooltips
-            tooltip-template="Show layer on map"
-            tooltip-size="small"
-            tooltip-class="layer-item-tooltip"
-            tooltip-side="left"
-            ng-if="!$ctrl.visible"
-      ></span>
-    </div>
-    <div class="btn btn-text btn-transparent"
-            uib-dropdown
-            ng-show="$ctrl.layerActions && $ctrl.layerActions.length"
-            uib-dropdown-toggle
-    >
-      <i class="icon-menu"></i>
-      <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
-        <li role="menuitem"
-            ng-repeat="action in $ctrl.layerActions">
-          <a href ng-click="action.callback()" ng-show="action.name">{{action.name}}</a>
-          <span class="menu-separator" ng-show="action.separator"></span>
-        </li>
-      </ul>
-    </div>
+    <ng-transclude></ng-transclude>
   </div>
 </div>

--- a/app-frontend/src/app/components/projects/layerItem/index.html
+++ b/app-frontend/src/app/components/projects/layerItem/index.html
@@ -20,6 +20,8 @@
     <div><strong>{{$ctrl.layer.name}}</strong></div>
     <div ng-show="$ctrl.layer.subtext"><span>{{$ctrl.layer.subtext}}</span></div>
     <div>{{$ctrl.layer.createdAt | date}}</div>
+    <rf-layer-stats
+        scene-count="$ctrl.getSceneCount()"></rf-layer-stats>
   </div>
   <div class="list-group-right">
     <div class="btn btn-text btn-transparent"

--- a/app-frontend/src/app/components/projects/layerItem/index.js
+++ b/app-frontend/src/app/components/projects/layerItem/index.js
@@ -19,11 +19,16 @@ class LayerItemController {
         const geometry = _.get(this.layer, 'colorGroupHex');
         this.hasGeom = _.get(geometry, 'features.length');
     }
+
+    getSceneCount() {
+        return this.layerStats ? this.layerStats[this.layer.id] : null;
+    }
 }
 
 const component = {
     bindings: {
         layer: '<',
+        layerStats: '<',
         layerActions: '<',
         subtext: '<',
         selected: '<',

--- a/app-frontend/src/app/components/projects/layerItem/index.js
+++ b/app-frontend/src/app/components/projects/layerItem/index.js
@@ -19,16 +19,11 @@ class LayerItemController {
         const geometry = _.get(this.layer, 'colorGroupHex');
         this.hasGeom = _.get(geometry, 'features.length');
     }
-
-    getSceneCount() {
-        return this.layerStats ? this.layerStats[this.layer.id] : null;
-    }
 }
 
 const component = {
     bindings: {
         layer: '<',
-        layerStats: '<',
         layerActions: '<',
         subtext: '<',
         selected: '<',
@@ -37,7 +32,8 @@ const component = {
         onHide: '&'
     },
     templateUrl: tpl,
-    controller: LayerItemController.name
+    controller: LayerItemController.name,
+    transclude: true
 };
 
 export default angular

--- a/app-frontend/src/app/components/projects/layerStats/index.html
+++ b/app-frontend/src/app/components/projects/layerStats/index.html
@@ -1,0 +1,3 @@
+<div ng-if="$ctrl.sceneCount">
+  Number of scenes: {{ $ctrl.sceneCount }}
+</div>

--- a/app-frontend/src/app/components/projects/layerStats/index.html
+++ b/app-frontend/src/app/components/projects/layerStats/index.html
@@ -1,3 +1,5 @@
 <div ng-if="$ctrl.sceneCount">
-  {{ $ctrl.sceneCount }} images
+  <ng-pluralize count="$ctrl.sceneCount"
+                when="{'one': '{} image', 'other': '{} images'}">
+  </ng-pluralize>
 </div>

--- a/app-frontend/src/app/components/projects/layerStats/index.html
+++ b/app-frontend/src/app/components/projects/layerStats/index.html
@@ -1,3 +1,3 @@
 <div ng-if="$ctrl.sceneCount">
-  {{ $ctrl.sceneCount }} scenes
+  {{ $ctrl.sceneCount }} images
 </div>

--- a/app-frontend/src/app/components/projects/layerStats/index.html
+++ b/app-frontend/src/app/components/projects/layerStats/index.html
@@ -1,3 +1,3 @@
 <div ng-if="$ctrl.sceneCount">
-  Number of scenes: {{ $ctrl.sceneCount }}
+  {{ $ctrl.sceneCount }} scenes
 </div>

--- a/app-frontend/src/app/components/projects/layerStats/index.js
+++ b/app-frontend/src/app/components/projects/layerStats/index.js
@@ -1,0 +1,23 @@
+import tpl from './index.html';
+import _ from 'lodash';
+
+class LayerStatsController {
+    constructor($rootScope, $scope, $state) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+}
+
+const component = {
+    bindings: {
+        sceneCount: '<'
+    },
+    templateUrl: tpl,
+    controller: LayerStatsController.name
+};
+
+export default angular
+    .module('components.projects.layerStats', [])
+    .controller(LayerStatsController.name, LayerStatsController)
+    .component('rfLayerStats', component)
+    .name;

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -186,6 +186,13 @@ export default (app) => {
                             layerId: '@layerId'
                         }
                     },
+                    getLayerStats: {
+                        method: 'GET',
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/layers/stats`,
+                        params: {
+                            projectId: '@projectId'
+                        }
+                    },
                     createLayer: {
                         method: 'POST',
                         url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/layers`,
@@ -622,6 +629,10 @@ export default (app) => {
 
         getProjectLayer(projectId, layerId) {
             return this.Project.getLayer({projectId, layerId}).$promise;
+        }
+
+        getProjectLayerStats(projectId) {
+            return this.Project.getLayerStats({projectId}).$promise;
         }
 
         deleteProjectLayer(projectId, layerId) {

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3279,3 +3279,11 @@ rf-project-layers-page {
 .form-control.color-picker {
   cursor: pointer;
 }
+
+.list-group-vertical {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+    align-self: stretch;
+}
+


### PR DESCRIPTION
## Overview

This PR adds an `rf-layer-stats` component for displaying scene counts for each layer and a route for fetching scene counts for all layers in a project at once.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [x] Any new SQL strings have tests

### Demo

![image](https://user-images.githubusercontent.com/5702984/52652129-84020e00-2ebb-11e9-90f6-b1f1b62d4873.png)

### Notes

I opted for a new endpoint that fetches all the counts at once over firing off 50 requests for counts (1 / layer * page size).I did this because it was easy and it gives us an anchor to attach more stats to, should we wish to calculate them.
 
## Testing Instructions

 * reassemble your api server
 * bring up your server
 * get a project id and navigate to `/v2/project/<id>`
 * observe that you have counts of scenes for all the layers that have scenes in them

Closes #4572