### PR TITLE
Update load_development_data

### DIFF
--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -49,7 +49,7 @@ function load_database_backup() {
     # Command to create database backup
     # gosu postgres pg_dump -Fc rasterfoundry > database.pgdump
     docker-compose \
-        exec -T postgres gosu postgres pg_restore -Fc -d rasterfoundry /tmp/data/database.pgdump &>/dev/null
+        exec -T postgres pg_restore -U rasterfoundry -Fc -d rasterfoundry /tmp/data/database.pgdump &>/dev/null
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -49,7 +49,7 @@ function load_database_backup() {
     # Command to create database backup
     # gosu postgres pg_dump -Fc rasterfoundry > database.pgdump
     docker-compose \
-        exec -T postgres pg_restore -U rasterfoundry -Fc -d rasterfoundry /tmp/data/database.pgdump &>/dev/null
+        exec -T postgres pg_restore -U rasterfoundry -Fc -d rasterfoundry /tmp/data/database.pgdump
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]


### PR DESCRIPTION
## Overview

This PR fixes the `pg_restore` command to use the `rasterfoundry` user.


## Testing Instructions

 * Run `load_development_data` with an empty DB and see that it is properly restored