### PR TITLE
Bump sbt-pgp to version 1.1.2

### DIFF
--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 


### PR DESCRIPTION
## Overview

Bump [sbt-pgp](https://github.com/sbt/sbt-pgp) to version `1.1.2` to fix the ability to re-run CI builds in same workspace. 

The original problem was caused by [a bug](https://github.com/sbt/sbt/issues/3725) in sbt-pgp where the sbt `overwrite` value was being hardcoded to `false`.

We use sbt-pgp in part of the pipeline to sign and publish build artifacts to Sonatype OSSRH and Maven Central.

Fixes https://github.com/azavea/raster-foundry-platform/issues/615

## Testing Instructions

First, grab the signing private key from the Jenkins server:

```bash
> rbreslow@maiden raster-foundry (feature/jrb/sbt-pgp-1.1.2) $ ssh rfjenkins
ubuntu@ip-172-31-52-80:~$ sudo cp /var/lib/jenkins/.gnupg/secring.gpg .
ubuntu@ip-172-31-52-80:~$ sudo chown ubuntu:ubuntu secring.gpg
```

```bash
> rbreslow@maiden raster-foundry (feature/jrb/sbt-pgp-1.1.2) $ scp rfjenkins:~/secring.gpg .
```

```bash
ubuntu@ip-172-31-52-80:~$ rm secring.gpg
```

Apply this diff:

```bash
diff --git a/Vagrantfile b/Vagrantfile
index a06e71829..4ff4a52e7 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|

   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder ".", "/opt/raster-foundry", type: "rsync",
-    rsync__exclude: [".git/", "app-backend/.ensime/",
+    rsync__exclude: ["app-backend/.ensime/",
                      "app-backend/.ensime_cache/", "app-backend/.idea/",
                      "app-backend/project/.boot/", "app-backend/project/.ivy/",
                      "app-backend/project/.sbtboot/", "app-server/**/target/",
```

Reload the VM and move the private key into position:

```bash
$ vagrant reload
$ vagrant rsync
$ vagrant ssh
vagrant@vagrant:/opt/raster-foundry$ sudo mkdir -p ~/.gnupg/
vagrant@vagrant:/opt/raster-foundry$ sudo mv secring.gpg ~/.gnupg/secring.gpg
```

Publish the artifacts:

```bash
vagrant@vagrant:/opt/raster-foundry$ export RF_SETTINGS_BUCKET=rasterfoundry-testing-config-us-east-1
vagrant@vagrant:/opt/raster-foundry$ ./scripts/bootstrap --env
vagrant@vagrant:/opt/raster-foundry$ echo SONATYPE_USERNAME=sonatype_username >> .env
vagrant@vagrant:/opt/raster-foundry$ echo SONATYPE_PASSWORD=sonatype_password >> .env
vagrant@vagrant:/opt/raster-foundry$ echo PGP_HEX_KEY=pgp_hex_key >> .env
vagrant@vagrant:/opt/raster-foundry$ echo PGP_PASSPHRASE=pgp_passphrase >> .env
vagrant@vagrant:/opt/raster-foundry$ docker-compose -f "docker-compose.test.yml" run --rm --no-deps build gitSnapshots publishSigned
vagrant@vagrant:/opt/raster-foundry$ echo $?
0
```

Publish the same artifacts again:

```bash
vagrant@vagrant:/opt/raster-foundry$ docker-compose -f "docker-compose.test.yml" run --rm --no-deps build gitSnapshots publishSigned
vagrant@vagrant:/opt/raster-foundry$ echo $?
0
```

Clean up the private key:

```bash
vagrant@vagrant:/opt/raster-foundry$ sudo rm -rf ~/.gnupg
```

DM me on Slack and I can point you in the right directions for getting those credentials.
