### PR TITLE
Export performance enhancement

### DIFF
--- a/app-backend/backsplash-export/src/main/resources/reference.conf
+++ b/app-backend/backsplash-export/src/main/resources/reference.conf
@@ -34,3 +34,8 @@ rasterSource {
   enableGDAL = false
   enableGDAL = ${?BACKSPLASH_ENABLE_GDAL}
 }
+
+export {
+  tileSize = 1024
+  tileSize = ${?EXPORT_TILE_SIZE}
+}

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportConfig.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportConfig.scala
@@ -1,0 +1,25 @@
+package com.rasterfoundry.backsplash
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+
+object ExportConfig extends LazyLogging {
+
+  private val config = ConfigFactory.load()
+
+  object Export {
+    private val exportConfig = config.getConfig("export")
+    val tileSize: Int = {
+      val tileSize = exportConfig.getInt("tileSize")
+      logger.debug(s"Using Tile Size: ${tileSize}")
+      tileSize
+    }
+
+  }
+
+  object RasterSource {
+    private val rasterSourceConfig = config.getConfig("rasterSource")
+    val enableGDAL: Boolean = rasterSourceConfig.getBoolean("enableGDAL")
+  }
+
+}

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportableInstances.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportableInstances.scala
@@ -2,7 +2,6 @@ package com.rasterfoundry.backsplash.export
 
 import com.rasterfoundry.common.datamodel.export._
 import TileReification._
-
 import geotrellis.raster._
 import geotrellis.proj4._
 import geotrellis.raster.rasterize.Rasterizer
@@ -44,7 +43,10 @@ trait ExportableInstances extends LazyLogging {
               case Valid(mbtile) =>
                 logger.debug(s"Constructed Multiband tile @${zoom}/$x/$y")
                 val tileExtent =
-                  TileReification.tmsLevels(zoom).mapTransform.keyToExtent(x, y)
+                  TileReification
+                    .getLayoutDefinition(zoom)
+                    .mapTransform
+                    .keyToExtent(x, y)
                 mbtile.mask(
                   tileExtent,
                   List(self.source.area.reproject(LatLng, WebMercator)),
@@ -111,7 +113,10 @@ trait ExportableInstances extends LazyLogging {
                 logger.debug(
                   s"Constructed Multiband tile @${zoom}/$x/$y with bands ${mbtile.bandCount}")
                 val tileExtent =
-                  TileReification.tmsLevels(zoom).mapTransform.keyToExtent(x, y)
+                  TileReification
+                    .getLayoutDefinition(zoom)
+                    .mapTransform
+                    .keyToExtent(x, y)
                 mbtile.mask(
                   tileExtent,
                   List(self.source.area.reproject(LatLng, WebMercator)),

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportableInstances.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportableInstances.scala
@@ -124,7 +124,7 @@ trait ExportableInstances extends LazyLogging {
                         "Tile location list must contain *some* tile locations"))
                   val explicitBandcount = first._2.length
                   if (explicitBandcount < 1) {
-                    getRasterSource(first._1).bandCount
+                    RasterSources.getOrUpdate(first._1).bandCount
                   } else {
                     explicitBandcount
                   }

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExtentOfTiles.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExtentOfTiles.scala
@@ -1,16 +1,14 @@
 package com.rasterfoundry.backsplash.export
 
-import geotrellis.spark.tiling._
 import geotrellis.vector.Extent
-import geotrellis.proj4._
 
 object ExtentOfTiles {
   // Find the extent which covers the provided list of tile coordinates at the provided zoom
   def webMercator(tiles: List[(Int, Int)], zoom: Int): Extent = {
+
     val keyToExtent =
-      ZoomedLayoutScheme(WebMercator, 256)
-        .levelForZoom(zoom)
-        .layout
+      TileReification
+        .getLayoutDefinition(zoom)
         .mapTransform
         .keyToExtent _
 

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/RasterSources.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/RasterSources.scala
@@ -1,0 +1,19 @@
+package com.rasterfoundry.backsplash.export
+
+import geotrellis.contrib.vlm.RasterSource
+
+import scala.collection.mutable
+
+object RasterSources {
+  private val sources: mutable.Map[String, RasterSource] =
+    mutable.Map[String, RasterSource]()
+
+  def getOrUpdate(key: String) = sources.get(key) match {
+    case Some(rs) =>
+      rs
+    case None =>
+      val rs = getRasterSource(key)
+      sources += (key -> rs)
+      rs
+  }
+}

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
@@ -47,7 +47,7 @@ object TileReification extends LazyLogging {
                   "Tile location list must contain *some* tile locations"))
           val explicitBandcount = first._2.length
           if (explicitBandcount < 1) {
-            getRasterSource(first._1).bandCount
+            RasterSources.getOrUpdate(first._1).bandCount
           } else {
             explicitBandcount
           }
@@ -56,7 +56,8 @@ object TileReification extends LazyLogging {
           self.traverse {
             case (uri, bands, ndOverride) =>
               IO {
-                getRasterSource(uri)
+                RasterSources
+                  .getOrUpdate(uri)
                   .reproject(WebMercator, NearestNeighbor)
                   .tileToLayout(ld, NearestNeighbor)
                   .read(SpatialKey(x, y), bands) match {
@@ -115,7 +116,8 @@ object TileReification extends LazyLogging {
         val subTilesIO: IO[List[Option[MultibandTile]]] = self.traverse {
           case (uri, band, ndOverride) =>
             IO {
-              getRasterSource(uri)
+              RasterSources
+                .getOrUpdate(uri)
                 .reproject(WebMercator, NearestNeighbor)
                 .tileToLayout(ld, NearestNeighbor)
                 .read(SpatialKey(x, y), Seq(band)) match {

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
@@ -53,7 +53,7 @@ object TileReification extends LazyLogging {
           }
         }
         val subTilesIO: IO[List[Option[MultibandTile]]] =
-          self.traverse {
+          self.parTraverse {
             case (uri, bands, ndOverride) =>
               IO {
                 RasterSources
@@ -113,7 +113,7 @@ object TileReification extends LazyLogging {
       ): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
         val ld = tmsLevels(z)
         val extent = ld.mapTransform.keyToExtent(x, y)
-        val subTilesIO: IO[List[Option[MultibandTile]]] = self.traverse {
+        val subTilesIO: IO[List[Option[MultibandTile]]] = self.parTraverse {
           case (uri, band, ndOverride) =>
             IO {
               RasterSources

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
@@ -9,24 +9,41 @@ import geotrellis.server._
 import com.azavea.maml.ast._
 import cats.effect._
 import cats.implicits._
+import com.rasterfoundry.backsplash.ExportConfig
 import com.typesafe.scalalogging.LazyLogging
 
 object TileReification extends LazyLogging {
-  val tmsLevels: Array[LayoutDefinition] = {
-    val scheme = ZoomedLayoutScheme(WebMercator, 256)
-    for (zoom <- 0 to 64) yield scheme.levelForZoom(zoom).layout
-  }.toArray
 
-  private def md5Hash(text: String): String =
-    java.security.MessageDigest
-      .getInstance("MD5")
-      .digest(text.getBytes())
-      .map(0xFF & _)
-      .map { "%02x".format(_) }
-      .foldLeft("") { _ + _ }
+  private val tileSize = ExportConfig.Export.tileSize
 
-  val invisiCellType = DoubleConstantNoDataCellType
-  val invisiTile = ArrayTile.empty(invisiCellType, 256, 256)
+  def getLayoutDefinition(zoom: Int): LayoutDefinition = {
+    val webMercator = ZoomedLayoutScheme(WebMercator, 256)
+    val cellSize = webMercator.levelForZoom(zoom).layout.cellSize
+    FloatingLayoutScheme(tileSize)
+      .levelFor(WebMercator.worldExtent, cellSize)
+      .layout
+  }
+
+  def getNoDataValue(cellType: CellType): Option[Double] = {
+    cellType match {
+      case ByteUserDefinedNoDataCellType(value)   => Some(value.toDouble)
+      case UByteUserDefinedNoDataCellType(value)  => Some(value.toDouble)
+      case UByteConstantNoDataCellType            => Some(0)
+      case ShortUserDefinedNoDataCellType(value)  => Some(value.toDouble)
+      case UShortUserDefinedNoDataCellType(value) => Some(value.toDouble)
+      case UShortConstantNoDataCellType           => Some(0)
+      case IntUserDefinedNoDataCellType(value)    => Some(value.toDouble)
+      case FloatUserDefinedNoDataCellType(value)  => Some(value.toDouble)
+      case DoubleUserDefinedNoDataCellType(value) => Some(value.toDouble)
+      case _: NoNoData                            => Some(Double.NaN)
+      case _: ConstantNoData[_]                   => Some(Double.NaN)
+    }
+  }
+
+  val invisiCellType: DoubleConstantNoDataCellType.type =
+    DoubleConstantNoDataCellType
+  val invisiTile: MutableArrayTile =
+    ArrayTile.empty(invisiCellType, tileSize, tileSize)
 
   implicit val mosaicExportTmsReification =
     new TmsReification[List[(String, List[Int], Option[Double])]] {
@@ -37,8 +54,9 @@ object TileReification extends LazyLogging {
                          buffer: Int)(
           implicit contextShift: ContextShift[IO]
       ): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
-        val ld = tmsLevels(z)
-        val extent = ld.mapTransform.keyToExtent(x, y)
+        val layoutDefinition = getLayoutDefinition(z)
+        val extent = layoutDefinition.mapTransform.keyToExtent(x, y)
+        logger.debug(s"Extent of Tile ($x, $y): ${extent}")
         val bandCount = {
           val first =
             self.headOption
@@ -56,30 +74,24 @@ object TileReification extends LazyLogging {
           self.parTraverse {
             case (uri, bands, ndOverride) =>
               IO {
-                val rs = RasterSources.getOrUpdate(uri)
+                val rs = RasterSources
+                  .getOrUpdate(uri)
+                  .reproject(WebMercator, NearestNeighbor)
+                logger.debug(s"Raster Source Extent: ${rs.extent}")
                 if (rs.extent.intersects(extent)) {
-                  rs.reproject(WebMercator, NearestNeighbor)
-                    .tileToLayout(ld, NearestNeighbor)
+                  rs.tileToLayout(layoutDefinition, NearestNeighbor)
                     .read(SpatialKey(x, y), bands) match {
-                    case Some(mbtile) =>
-                      logger.debug(
-                        s"--HIT-- uri: ${uri}; celltype: ${mbtile.cellType}, zxy: $z/$x/$y")
-                      mbtile.bands.zipWithIndex.map {
-                        case (band, idx) =>
-                          logger.trace(s"b$idx hash: ${md5Hash(
-                            band.toArray.take(100).mkString(""))}, vals ${band.toArray.take(10).toList}")
-                      }
-
-                      ndOverride.map { nd =>
-                        val currentCT = mbtile.cellType
-                        mbtile.interpretAs(currentCT.withNoData(Some(nd)))
-                      } orElse {
-                        Some(mbtile)
-                      }
-                    case None =>
+                    case Some(mbtile) => {
+                      val noDataValue = getNoDataValue(mbtile.cellType)
+                      Some(
+                        mbtile.interpretAs(
+                          mbtile.cellType.withNoData(noDataValue)))
+                    }
+                    case None => {
                       logger.debug(
                         s"--CRITICAL MISS-- uri: ${uri}; zxy: $z/$x/$y")
                       None
+                    }
                   }
                 } else {
                   logger.debug(s"--MISS-- uri: ${uri}; zxy: $z/$x/$y")
@@ -90,7 +102,7 @@ object TileReification extends LazyLogging {
         val exportTile: IO[Raster[MultibandTile]] = subTilesIO.map { subtiles =>
           subtiles.flatten.reduceOption({ (t1, t2) =>
             logger.debug(
-              s"Merging celltypes ct1: ${t1.cellType}; ct2: ${t2.cellType}")
+              s"Merging celltypes ct1: ${t1.cellType} ; ct2: ${t2.cellType}")
             t1 merge t2
           }) match {
             case Some(mbtile) =>
@@ -115,25 +127,22 @@ object TileReification extends LazyLogging {
                          buffer: Int)(
           implicit contextShift: ContextShift[IO]
       ): (Int, Int, Int) => IO[Literal] = (z: Int, x: Int, y: Int) => {
-        val ld = tmsLevels(z)
-        val extent = ld.mapTransform.keyToExtent(x, y)
+        val layoutDefinition = getLayoutDefinition(z)
+        val extent = layoutDefinition.mapTransform.keyToExtent(x, y)
         val subTilesIO: IO[List[Option[MultibandTile]]] = self.parTraverse {
           case (uri, band, ndOverride) =>
             IO {
               val rs = RasterSources.getOrUpdate(uri)
               if (rs.extent.intersects(extent)) {
                 rs.reproject(WebMercator, NearestNeighbor)
-                  .tileToLayout(ld, NearestNeighbor)
+                  .tileToLayout(layoutDefinition, NearestNeighbor)
                   .read(SpatialKey(x, y), Seq(band)) match {
                   case Some(tile) =>
                     logger.debug(
                       s"--HIT-- uri: ${uri}; celltype: ${tile.cellType}, zxy: $z/$x/$y")
-                    ndOverride.map { nd =>
-                      val currentCT = tile.cellType
-                      tile.interpretAs(currentCT.withNoData(Some(nd)))
-                    } orElse {
-                      Some(tile)
-                    }
+                    val noDataValue = getNoDataValue(tile.cellType)
+                    Some(
+                      tile.interpretAs(tile.cellType.withNoData(noDataValue)))
                   case None =>
                     logger.debug(s"--MISS-- uri: ${uri}; zxy: $z/$x/$y")
                     None

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
@@ -132,7 +132,9 @@ object TileReification extends LazyLogging {
         val subTilesIO: IO[List[Option[MultibandTile]]] = self.parTraverse {
           case (uri, band, ndOverride) =>
             IO {
-              val rs = RasterSources.getOrUpdate(uri)
+              val rs = RasterSources
+                .getOrUpdate(uri)
+                .reproject(WebMercator, NearestNeighbor)
               if (rs.extent.intersects(extent)) {
                 rs.reproject(WebMercator, NearestNeighbor)
                   .tileToLayout(layoutDefinition, NearestNeighbor)

--- a/app-backend/backsplash-export/src/test/scala/com/rasterfoundry/backsplash/TilesForExtentTest.scala
+++ b/app-backend/backsplash-export/src/test/scala/com/rasterfoundry/backsplash/TilesForExtentTest.scala
@@ -12,11 +12,10 @@ class TilesForExtentSpec extends FunSuite with Checkers with Matchers {
                         42.22851735620852)
 
     val tileAddresses = TilesForExtent.latLng(extent, 5)
-    assert(tileAddresses.contains((6, 11)))
-    assert(tileAddresses.contains((6, 12)))
-    assert(tileAddresses.contains((7, 11)))
-    assert(tileAddresses.contains((7, 12)))
+    println(tileAddresses)
+    assert(tileAddresses.contains((1, 2)))
+    assert(tileAddresses.contains((1, 3)))
   }
 }
 
-// tileRangeAtZoom5 = 7,11 / 7,12 / 6,11 / 6,12
+// tileRangeAtZoom5 = 1,2 / 1,3

--- a/app-backend/backsplash-export/src/test/scala/com/rasterfoundry/backsplash/TilesForExtentTest.scala
+++ b/app-backend/backsplash-export/src/test/scala/com/rasterfoundry/backsplash/TilesForExtentTest.scala
@@ -12,10 +12,7 @@ class TilesForExtentSpec extends FunSuite with Checkers with Matchers {
                         42.22851735620852)
 
     val tileAddresses = TilesForExtent.latLng(extent, 5)
-    println(tileAddresses)
     assert(tileAddresses.contains((1, 2)))
     assert(tileAddresses.contains((1, 3)))
   }
 }
-
-// tileRangeAtZoom5 = 1,2 / 1,3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,8 @@ services:
       - RF_HOST=http://rasterfoundry.com:9000
       - LOCAL_INGEST_CORES=2
       - LOCAL_INGEST_MEM_GB=4
+      - EXPORT_TILE_SIZE=1024
+      - BACKSPLASH_ENABLE_GDAL=false
     command: rf
     links:
       - postgres:database.service.rasterfoundry.internal


### PR DESCRIPTION
## Overview

This PR contains some attempts to pluck the low hanging fruit related to tiff export performance.

So far:
* In mem caching for raster sources
* Limiting requests to those tiffs which apparently intersect the segment being produced
* Using `parTraverse` to parallelize reads per segment

## Demo
Creating Project Export
![image](https://user-images.githubusercontent.com/898060/53577188-389a6180-3b43-11e9-93a6-c07693418045.png)

Running Export
![export-console](https://user-images.githubusercontent.com/898060/53577496-c6764c80-3b43-11e9-9c84-ef0739c3e20b.gif)

Viewing Project Export
![image](https://user-images.githubusercontent.com/898060/53578441-b3fd1280-3b45-11e9-9b4a-07d4c1d35b9c.png)


## Testing Instructions

* Create an export for a project with multiple scenes
* Rebuild assembly for backsplash export (`./scripts/console sbt`, `project bacskplash-export`, `assembly`)
* Rebuild assembly for batch(`project batch`, `assembly`)
* Note the export ID in the server logs and run the following command in the batch container: (`./scripts/console batch "rf export <export id>"`)
* Download export and inspect with `gdalinfo`, internal tile size should be what is configured `1024x1024` by default
* Open export in QGIS or other program, there should not be any black/nodata values on seams where scenes over lap
* Export an analysis and inspect with `gdalinfo` and visually as well

Closes #4613 