### PR TITLE
UI for project layer uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added scene counts to project layer items [\#4625](https://github.com/raster-foundry/raster-foundry/pull/4625)
 - Added project analyses list view [\#4585](https://github.com/raster-foundry/raster-foundry/pull/4585)
 - Added backend support for project layer async exports [\#4619](https://github.com/raster-foundry/raster-foundry/pull/4619)
+- Added front-end support for importing to project layers [\#4646](https://github.com/raster-foundry/raster-foundry/pull/4646)
 
 ### Changed
 

--- a/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.js
@@ -119,6 +119,7 @@ class LayerScenesController {
             component: 'rfSceneImportModal',
             resolve: {
                 project: () => this.project,
+                layer: () => this.layer,
                 origin: () => 'project'
             }
         });

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -120,6 +120,17 @@ class ProjectLayersPageController {
             ),
             menu: true
         };
+        const importAction = {
+            name: 'Import',
+            callback: () => this.modalService.open({
+                component: 'rfSceneImportModal',
+                resolve: {
+                    project: () => this.project,
+                    layer: () => layer,
+                    origin: () => 'project'
+                }
+            })
+        };
         const settingsAction = {
             name: 'Settings',
             callback: () => this.$state.go(
@@ -138,15 +149,12 @@ class ProjectLayersPageController {
         };
 
         const unimplementedActions = [publishAction, exportAction, settingsAction];
-        const layerActions = [editAction];
+        const layerActions = [editAction, importAction];
         if (!isDefaultLayer) {
             layerActions.push(setDefaultAction);
         }
 
-        return [
-            editAction,
-            ...!isDefaultLayer ? [setDefaultAction, deleteAction] : []
-        ];
+        return layerActions;
     }
 
     allVisibleSelected() {

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -121,7 +121,7 @@ class ProjectLayersPageController {
             menu: true
         };
         const importAction = {
-            name: 'Import',
+            name: 'Import imagery',
             callback: () => this.modalService.open({
                 component: 'rfSceneImportModal',
                 resolve: {
@@ -130,6 +130,13 @@ class ProjectLayersPageController {
                     origin: () => 'project'
                 }
             })
+        };
+        const browseAction = {
+            name: 'Browse for imagery',
+            callback: () => this.$state.go(
+                'project.layer.browse',
+                {projectId: this.project.id, layerId: layer.id}
+            )
         };
         const settingsAction = {
             name: 'Settings',
@@ -149,7 +156,7 @@ class ProjectLayersPageController {
         };
 
         const unimplementedActions = [publishAction, exportAction, settingsAction];
-        const layerActions = [editAction, importAction];
+        const layerActions = [editAction, importAction, browseAction];
         if (!isDefaultLayer) {
             layerActions.push(setDefaultAction);
         }

--- a/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
+++ b/app-frontend/src/app/components/scenes/sceneImportModal/sceneImportModal.controller.js
@@ -42,23 +42,29 @@ export default class SceneImportModalController {
             this.gdalImportError = true;
             this.$log.error('There was an error while fetching the gdal dependencies.');
         }, 'gdal');
+
         this.initSteps();
         this.importType = 'local';
+
         this.s3Config = {
             bucket: '',
             prefix: ''
         };
+
         this.cogConfig = {
             url: ''
         };
+
         this.isCog = false;
         this.planetSceneIds = '';
         this.selectedFileDatasets = [];
         this.selectedFiles = [];
+
         this.sceneData = {
             acquisitionDate: new Date(),
             cloudCover: 0
         };
+
         this.uploadProgressPct = {};
         this.uploadProgressFlexString = {};
         this.abortedUploadCount = 0;
@@ -365,7 +371,8 @@ export default class SceneImportModalController {
         this.sceneService.createCogScene({
             metadata: this.sceneData,
             location: this.cogConfig.url,
-            projectId: _.get(this, 'resolve.project.id') || false
+            projectId: _.get(this, 'resolve.project.id', false),
+            layerId: _.get(this, 'resolve.layer.id', false)
         }, this.datasource).then(() => {
             this.handleNext();
         }, err => {
@@ -409,7 +416,7 @@ export default class SceneImportModalController {
             visibility: 'PRIVATE',
             organizationId: user.organizationId,
             metadata: {acquisitionDate: this.sceneData.acquisitionDate,
-                       cloudCover: this.sceneData.cloudCover}
+                cloudCover: this.sceneData.cloudCover}
         };
 
         if (this.importType === 'local') {
@@ -441,6 +448,9 @@ export default class SceneImportModalController {
 
         if (this.resolve.project) {
             uploadObject.projectId = this.resolve.project.id;
+        }
+        if (this.resolve.layer) {
+            uploadObject.layerId = this.resolve.layer.id;
         }
 
         return this.uploadService.create(uploadObject);
@@ -551,7 +561,8 @@ export default class SceneImportModalController {
                     return this.sceneService.createCogScene({
                         metadata: this.sceneData,
                         location: encodeURI(f),
-                        projectId: _.get(this, 'resolve.project.id') || false
+                        projectId: _.get(this, 'resolve.project.id', false),
+                        layerId: _.get(this, 'resolve.layer.id', false)
                     }, this.datasource);
                 }));
             } else {
@@ -591,7 +602,7 @@ export default class SceneImportModalController {
         let datasetPromises = files.map(file => {
             return this.$q.resolve(loamOpen(file))
                 .catch((error) => {
-                    //eslint-disable-next-line
+                    // eslint-disable-next-line
                     console.log("Error in loam caught", error);
                 });
         });
@@ -664,7 +675,7 @@ export default class SceneImportModalController {
             .finally(() => {
                 this.isLoadingDatasources = false;
             }
-        );
+            );
     }
 
     preventInterruptions() {

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -226,15 +226,6 @@ export default (app) => {
                             projectId: '@projectId',
                             layerId: '@layerId'
                         }
-                    },
-                    addScenesToLayer: {
-                        method: 'POST',
-                        // eslint-disable-next-line max-len
-                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/layers/:layerId/scenes/`,
-                        params: {
-                            projectId: '@projectId',
-                            layerId: '@layerId'
-                        }
                     }
                 }
             );

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -226,6 +226,15 @@ export default (app) => {
                             projectId: '@projectId',
                             layerId: '@layerId'
                         }
+                    },
+                    addScenesToLayer: {
+                        method: 'POST',
+                        // eslint-disable-next-line max-len
+                        url: `${BUILDCONFIG.API_HOST}/api/projects/:projectId/layers/:layerId/scenes/`,
+                        params: {
+                            projectId: '@projectId',
+                            layerId: '@layerId'
+                        }
                     }
                 }
             );
@@ -353,7 +362,8 @@ export default (app) => {
 
         addScenesToLayer(projectId, layerId, sceneIds) {
             return this.Project.addScenesToLayer(
-                {projectId, layerId}, sceneIds
+                {projectId, layerId},
+                sceneIds
             ).$promise;
         }
 
@@ -637,7 +647,7 @@ export default (app) => {
         }
 
         getProjectPermissions(project, user) {
-            //TODO replace uses with permissionsService.getEditableObjectPermission
+            // TODO replace uses with permissionsService.getEditableObjectPermission
             return this.$q((resolve, reject) => {
                 if (project.owner.id === user.id || project.owner === user.id) {
                     resolve([

--- a/app-frontend/src/app/services/scenes/scene.service.js
+++ b/app-frontend/src/app/services/scenes/scene.service.js
@@ -106,7 +106,12 @@ export default (app) => {
                         sceneType: 'COG'
                     }).$promise;
                 });
-                if (scene.projectId) {
+                if (scene.projectId && scene.layerId) {
+                    sceneP.then(newScene => {
+                        this.projectService
+                            .addScenesToLayer(scene.projectId, scene.layerId, [newScene.id]);
+                    });
+                } else if (scene.projectId) {
                     sceneP.then(newScene => {
                         this.projectService.addScenes(scene.projectId, [newScene.id]);
                     });
@@ -159,7 +164,7 @@ export default (app) => {
         // set the default floor to 25 to brighten up images -- this was a fine value for
         // MODIS Terra scenes, but other datasources may need to pass a different parameter
         cogThumbnail(sceneId, token, width = 128, height = 128,
-                     red = 0, green = 1, blue = 2, floor = 25) {
+            red = 0, green = 1, blue = 2, floor = 25) {
             return this.$http({
                 method: 'GET',
                 url: `${BUILDCONFIG.API_HOST}/api/scenes/${sceneId}/thumbnail`,


### PR DESCRIPTION
## Overview

This PR makes some changes to the import modal and the scene and project services to handle importing imagery directly to layers.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/2442245/52877919-66d27700-3129-11e9-86e7-73059fe961c0.png)

### Notes

Waiting for #4615 to get merged so that it can be added to the project layer scene list view. As of now, it only is visible as an option for each project layer on the project layers list view.

## Testing Instructions

 * Create a layer in a project that is not the default layer
 * Upload both COG and non-COG to and see that they end up in the right layer (since one is POSTed by the front-end and the other by the batch job)

Closes #4587
