### PR TITLE
Fix port mappings and remove publish-jars from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,31 +131,32 @@ Due to active development to Raster Foundry, some aspects of theming might break
 The Vagrant configuration maps the following host ports to services running in the virtual machines. Ports can be overridden for individual developers using environment variables
 
 | Service                   | Port                            | Environment Variable |
-|---------------------------|---------------------------------|----------------------|
+| ------------------------- | ------------------------------- | -------------------- |
 | Application Frontend      | [`9091`](http://localhost:9091) | `RF_PORT_9091`       |
 | Nginx (api)               | [`9100`](http://localhost:9100) | `RF_PORT_9100`       |
-| Nginx (tiler)             | [`9101`](http://localhost:9101) | `RF_PORT_9101`       |
+| Nginx (tiler)             | [`9101`](http://localhost:8081) | `RF_PORT_8081`       |
 | Application Server (akka) | [`9000`](http://localhost:9000) | `RF_PORT_9000`       |
-| Tile Server (akka)        | [`9900`](http://localhost:9900) | `RF_PORT_9900`       |
+| Tile Server (http4s)      | [`9900`](http://localhost:8080) | `RF_PORT_8080`       |
+| Application Server (JMX)  | `9010`                          | `RF_PORT_9010`       |
+| Tile Server (JMX)         | `9030`                          | `RF_PORT_9030`       |
 
 ## Scripts
 
 Helper and development scripts are located in the `./scripts` directory at the root of this project. These scripts are designed to encapsulate and perform commonly used actions such as starting a development server, accessing a development console, or running tests.
 
-| Script Name               | Purpose                                                      |
-|---------------------------|--------------------------------------------------------------|
-| `bootstrap`               | Pulls/builds necessary containers                            |
-| `setup`                   | Provision development VM                                     |
-| `update`                  | Runs migrations, installs dependencies, etc.                 |
-| `server`                  | Starts a development server                                  |
-| `console`                 | Gives access to a running container via `docker-compose run` |
-| `psql`                    | Drops you into a `psql` console.                             |
-| `test`                    | Runs tests and linters for project                           |
-| `cibuild`                 | Invoked by CI server and makes use of `test`.                |
-| `cipublish`               | Publish container images to container image repositories.    |
-| `load_development_data`   | Load data for development purposes from S3                   |
-| `publish-jars`            | Publish JAR artifacts to S3                                  |
-| `rsync-back`              | Perform a one-way `rsync` from the VM to the host.           |
+| Script Name             | Purpose                                                      |
+| ----------------------- | ------------------------------------------------------------ |
+| `bootstrap`             | Pulls/builds necessary containers                            |
+| `setup`                 | Provision development VM                                     |
+| `update`                | Runs migrations, installs dependencies, etc.                 |
+| `server`                | Starts a development server                                  |
+| `console`               | Gives access to a running container via `docker-compose run` |
+| `psql`                  | Drops you into a `psql` console.                             |
+| `test`                  | Runs tests and linters for project                           |
+| `cibuild`               | Invoked by CI server and makes use of `test`.                |
+| `cipublish`             | Publish container images to container image repositories.    |
+| `load_development_data` | Load data for development purposes from S3                   |
+| `rsync-back`            | Perform a one-way `rsync` from the VM to the host.           |
 
 ## Testing
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,12 +23,12 @@ Vagrant.configure(2) do |config|
 
   # application server
   config.vm.network :forwarded_port, guest: 9000, host: Integer(ENV.fetch("RF_PORT_9000", 9000))
-  # tileserver
-  config.vm.network :forwarded_port, guest: 9900, host: Integer(ENV.fetch("RF_PORT_9900", 9900))
+  # backsplash tileserver
+  config.vm.network :forwarded_port, guest: 8080, host: Integer(ENV.fetch("RF_PORT_8080", 8080))
   # nginx-api
   config.vm.network :forwarded_port, guest: 9100, host: Integer(ENV.fetch("RF_PORT_9100", 9100))
-  # nginx-tileserver
-  config.vm.network :forwarded_port, guest: 9101, host: Integer(ENV.fetch("RF_PORT_9101", 9101))
+  # nginx backsplash tileserver
+  config.vm.network :forwarded_port, guest: 8081, host: Integer(ENV.fetch("RF_PORT_8081", 8081))
   # spark master
   config.vm.network :forwarded_port, guest: 8888, host: Integer(ENV.fetch("RF_PORT_8888", 8888))
   # spark worker
@@ -38,11 +38,7 @@ Vagrant.configure(2) do |config|
   # jmx api
   config.vm.network :forwarded_port, guest: 9010, host: Integer(ENV.fetch("RF_PORT_9010", 9010))
   # jmx tile
-  config.vm.network :forwarded_port, guest: 9020, host: Integer(ENV.fetch("RF_PORT_9020", 9020))
-  # backsplash tileserver
-  config.vm.network :forwarded_port, guest: 8080, host: Integer(ENV.fetch("RF_PORT_8080", 8080))
-  # nginx backsplash tileserver
-  config.vm.network :forwarded_port, guest: 8081, host: Integer(ENV.fetch("RF_PORT_8081", 8081))
+  config.vm.network :forwarded_port, guest: 9030, host: Integer(ENV.fetch("RF_PORT_9030", 9030))
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 8096


### PR DESCRIPTION
## Overview

Updates the port mapping table in the README to more accurately represent the Vagrant port mapping. Also, remove the stray reference to `publish-jars` STRTA.

### Checklist

~- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
~- [ ] Styleguide updated, if necessary~
~- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

## Testing Instructions

See rendered version of the `README`. Ensure that references to `publish-jars` are no longer present. Also, ensure that the port mappings within the `Vagrantfile` align with Docker Compose configuration and `README`.

Closes https://github.com/raster-foundry/raster-foundry/issues/4643
Closes https://github.com/raster-foundry/raster-foundry/issues/4644
