### PR TITLE
Swap Backsplash base image

### DIFF
--- a/app-backend/Dockerfile.backsplash
+++ b/app-backend/Dockerfile.backsplash
@@ -1,8 +1,0 @@
-FROM openjdk:8-jre
-
-RUN apt-get update && \
-  apt-get install -yq apt-transport-https && \
-  echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \
-  apt-get update && \
-  apt-get install -yq sbt

--- a/app-backend/Dockerfile.build
+++ b/app-backend/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre
+FROM quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
 
 RUN set -ex && \
 	apt-get update && \

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,5 +1,9 @@
 FROM quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
 
+RUN \
+      addgroup -S rf \
+      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf
+
 COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
 
 USER rf

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,8 +1,7 @@
 FROM quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
 
 RUN \
-      addgroup -S rf \
-      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf
+	adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf
 
 COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
 

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
 
 RUN \
-	adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf
+    adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf
 
 COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
 

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,14 +1,4 @@
-FROM daunnc/openjdk-gdal:2.3.2
-
-ENV ASPECTJ_WEAVER_VERSION 1.8.10
-
-RUN \
-  adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf \
-  && apt-get install apt-transport-https \
-  && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
-  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 \
-  && apt-get update \
-  && apt-get install -yq sbt
+FROM quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
 
 COPY ./target/scala-2.11/backsplash-assembly.jar /var/lib/rf/
 

--- a/app-backend/backsplash/Dockerfile
+++ b/app-backend/backsplash/Dockerfile
@@ -1,7 +1,0 @@
-FROM daunnc/openjdk-gdal:2.3.2
-
-RUN apt-get install apt-transport-https && \
-  echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823 && \
-  apt-get update && \
-  apt-get install -yq sbt

--- a/docker-compose.java.yml
+++ b/docker-compose.java.yml
@@ -15,7 +15,7 @@ services:
       start_period: 10s
 
   sbt:
-    image: daunnc/openjdk-gdal:2.3.2
+    image: quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
     build:
       context: app-backend
     links:
@@ -106,10 +106,7 @@ services:
       - "api-assembly.jar"
 
   backsplash:
-    image: daunnc/openjdk-gdal:2.3.2
-    build:
-      context: app-backend
-      dockerfile: Dockerfile.backsplash
+    image: quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Overview

* Remove duplicate Backsplash Dockerfiles
* Use blessed [azavea/openjdk-gdal](https://github.com/azavea/docker-openjdk-gdal) container image in `app-backend/backsplash-server/Dockerfile`

Resolves #4464 

## Testing Instructions

Build `api` and `backsplash-server` assembly JARs:

```bash
vagrant@vagrant:/opt/raster-foundry$ ./scripts/console sbt
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /opt/raster-foundry/app-backend/project
[info] Loading settings from version.sbt,build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Resolving key references (11180 settings) ...
[info] Set current project to root (in build file:/opt/raster-foundry/app-backend/)
[info] sbt server started at local://project/.sbtboot/server/68c1553bc263085c70ef/sock
root > ;api/assembly;backsplash-server/assembly
```

Bring everything up with `server`:

```bash
vagrant@vagrant:/opt/raster-foundry$ ./scripts/server
```

Make sure the application is working correctly at http://localhost:9100.

I tested cycling the Backsplash container image onto staging here:

http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/test%252Fswap-backsplash-base-images/5/console