### PR TITLE
Fix run_database_migrations method in scripts/update

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -20,26 +20,25 @@ function run_database_migrations() {
     # Check if database migrations have already been initialized
     set +e
     docker-compose \
-        exec -T postgres gosu postgres psql -d rasterfoundry -c 'select 1 from __migrations__' &>/dev/null
+        exec -T postgres \
+        psql -U rasterfoundry -d rasterfoundry -c 'select 1 from __migrations__'
     status_check=$?
     set -e
-    if [ $status_check == 0 ]
-    then
+    if [ $status_check == 0 ]; then
         echo "Migrations already initialized"
     else
         # Initialize the database for migrations.
         docker-compose \
-            run --rm api-server "mg init"
+            run --rm api-server \
+            "migrations/run init"
     fi
 
     # Run database migrations. The way scala-forklift works requires this to be called twice:
     # the first run figures out the migrations to run and the second run applies them.
     docker-compose \
-        run --rm api-server "mg update"
-    docker-compose \
-        run --rm api-server "mg apply"
+        run --rm api-server \
+        ";migrations/run update;migrations/run apply"
 }
-
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then


### PR DESCRIPTION
## Overview

This check wasn't working. `run_database_migrations()` would try to run initialize migrations even if they already were initialized, and then the script would die. I applied a similar fix as in #4626. 

Not sure what the underlying problem is, but it may have to do with the new images we built in https://github.com/azavea/docker-postgis/pull/16.

## Testing Instructions

Run `update` and see that migrations are applied as they should, the first and second times:

```bash
vagrant@vagrant:/opt/raster-foundry$ ./scripts/update
...
Running application database migrations
ERROR:  relation "__migrations__" does not exist
LINE 1: select 1 from __migrations__
                      ^
Starting raster-foundry_postgres_1  ... done
Starting raster-foundry_memcached_1 ... done
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /opt/raster-foundry/app-backend/project
[info] Loading settings from version.sbt,build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Resolving key references (11180 settings) ...
[info] Set current project to root (in build file:/opt/raster-foundry/app-backend/)
[info] Running RFMigrations init
[success] Total time: 6 s, completed Feb 18, 2019 8:51:46 PM
Starting raster-foundry_memcached_1 ... done
Starting raster-foundry_postgres_1  ... done
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /opt/raster-foundry/app-backend/project
[info] Loading settings from version.sbt,build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Resolving key references (11180 settings) ...
[info] Set current project to root (in build file:/opt/raster-foundry/app-backend/)
[info] Compiling 1 Scala source to /opt/raster-foundry/app-backend/migrations/target/scala-2.11/classes ...
[info] Done compiling.
[info] Packaging /opt/raster-foundry/app-backend/migrations/target/scala-2.11/migrations_2.11-1.19.0-SNAPSHOT.jar ...
[info] Done packaging.
[info] Running RFMigrations update
[success] Total time: 9 s, completed Feb 18, 2019 8:52:14 PM
[info] Compiling 1 Scala source to /opt/raster-foundry/app-backend/migrations/target/scala-2.11/classes ...
[info] Done compiling.
[info] Packaging /opt/raster-foundry/app-backend/migrations/target/scala-2.11/migrations_2.11-1.19.0-SNAPSHOT.jar ...
[info] Done packaging.
[info] Running RFMigrations apply
applying migrations: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 160, 161, 162, 163, 164, 165
[success] Total time: 5 s, completed Feb 18, 2019 8:52:19 PM
```

```bash
vagrant@vagrant:/opt/raster-foundry$ ./scripts/update
...
Running application database migrations
 ?column?
----------
...
        1
...
(164 rows)

Migrations already initialized
Starting raster-foundry_postgres_1 ... done
Starting raster-foundry_memcached_1 ... done
[info] Loading settings from plugins.sbt ...
[info] Loading project definition from /opt/raster-foundry/app-backend/project
[info] Loading settings from version.sbt,build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Loading settings from build.sbt ...
[info] Resolving key references (11180 settings) ...
[info] Set current project to root (in build file:/opt/raster-foundry/app-backend/)
[info] Running RFMigrations update
[success] Total time: 5 s, completed Feb 18, 2019 8:55:05 PM
[info] Running RFMigrations apply
applying migrations:
[success] Total time: 2 s, completed Feb 18, 2019 8:55:07 PM
```