### PR TITLE
Add create-analysis route / components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added backend support for rendering tiles and fetching histograms for analyses with project layers at their leaves [\#4603](https://github.com/raster-foundry/raster-foundry/pull/4603)
 - Added scene counts to project layer items [\#4625](https://github.com/raster-foundry/raster-foundry/pull/4625)
 - Added project analyses list view [\#4585](https://github.com/raster-foundry/raster-foundry/pull/4585)
+- Added project analyses create view [\#4659](https://github.com/raster-foundry/raster-foundry/pull/4659)
 - Added backend support for project layer async exports [\#4619](https://github.com/raster-foundry/raster-foundry/pull/4619)
 - Added front-end support for importing to project layers [\#4646](https://github.com/raster-foundry/raster-foundry/pull/4646)
 - Added project layer export list UI [\#4663](https://github.com/raster-foundry/raster-foundry/pull/4663)

--- a/app-frontend/src/app/components/common/index.js
+++ b/app-frontend/src/app/components/common/index.js
@@ -1,0 +1,5 @@
+import listItem from './listItem';
+
+export default [
+    listItem
+];

--- a/app-frontend/src/app/components/common/listItem/index.html
+++ b/app-frontend/src/app/components/common/listItem/index.html
@@ -1,0 +1,29 @@
+<div class="list-group-item">
+  <div class="list-group-overflow">
+    <div class="list-group-left">
+      <div class="list-item-left-actions" ng-show="$ctrl.onSelect">
+        <label class="checkbox layer-checkbox list-item-{{$ctrl.id}}"
+               ng-class="{
+                      active: $ctrl.selected
+                      }"
+        >
+          <input type="checkbox"
+                 ng-checked="$ctrl.selected"
+                 ng-click="$ctrl.onSelect({id: $ctrl.id})"
+          />
+        </label>
+        <style ng-if="$ctrl.color">
+         label.checkbox.list-item-{{$ctrl.id}}::after {
+             border: 2px solid {{$ctrl.color}};
+         }
+        </style>
+      </div>
+      <div><strong>{{$ctrl.title}}</strong></div>
+      <div ng-show="$ctrl.subtitle"><span>{{$ctrl.subtitle}}</span></div>
+      <div>{{$ctrl.date | date}}</div>
+    </div>
+  </div>
+  <div class="list-group-right">
+    <ng-transclude></ng-transclude>
+  </div>
+</div>

--- a/app-frontend/src/app/components/common/listItem/index.js
+++ b/app-frontend/src/app/components/common/listItem/index.js
@@ -1,0 +1,37 @@
+import _ from 'lodash';
+import tpl from './index.html';
+
+class ListItemController {
+    $onInit() {
+        const rx = /^#(?:[0-9a-f]{3}){1,2}$/i;
+        const color = this.color;
+        if (color && color.match(rx)) {
+            this.color = color;
+        } else {
+            this.color = 'black';
+        }
+    }
+}
+
+const component = {
+    bindings: {
+        id: '<',
+        color: '<',
+        title: '<',
+        subtitle: '<',
+        date: '<',
+        getImage: '&?',
+        onImageClick: '&?',
+        selected: '<',
+        onSelect: '&?'
+    },
+    templateUrl: tpl,
+    controller: ListItemController.name,
+    transclude: true
+};
+
+export default angular
+    .module('components.common.listItem', [])
+    .controller(ListItemController.name, ListItemController)
+    .component('rfListItem', component)
+    .name;

--- a/app-frontend/src/app/components/pages/project/analysis/index.html
+++ b/app-frontend/src/app/components/pages/project/analysis/index.html
@@ -1,0 +1,1 @@
+project analysis page

--- a/app-frontend/src/app/components/pages/project/analysis/index.js
+++ b/app-frontend/src/app/components/pages/project/analysis/index.js
@@ -1,0 +1,16 @@
+import tpl from './index.html';
+
+class ProjectAnalysisPageController {
+}
+
+const component = {
+    bindings: {},
+    templateUrl: tpl,
+    controller: ProjectAnalysisPageController.name
+};
+
+export default angular
+    .module('components.pages.projects.analysis', [])
+    .controller(ProjectAnalysisPageController.name, ProjectAnalysisPageController)
+    .component('rfProjectAnalysisPage', component)
+    .name;

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.html
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.html
@@ -1,0 +1,132 @@
+<div class="container column-stretch container-not-scrollable">
+  <div class="sidebar">
+    <div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0">
+      <a class="btn btn-small btn-transparent"
+         ui-sref="project">
+        <i class="icon-caret-left"></i>Back
+      </a>
+    </div>
+    <div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
+      <rf-selected-actions-bar
+          checked="$ctrl.allVisibleSelected()"
+          on-click="$ctrl.selectAll()"
+          action-text="$ctrl.selectText"
+      >
+        <button class="btn btn-transparent"
+                ng-click="$ctrl.removeLayers()">
+          Remove
+        </button>
+      </rf-selected-actions-bar>
+    </div>
+    <div class="sidebar-scrollable list-group">
+      <rf-layer-item
+          ng-repeat="layer in $ctrl.layerList track by layer.id"
+          item-info="layer"
+          item-actions="$ctrl.layerActions.get(layer.id)"
+          selected="$ctrl.isSelected(layer.id)"
+          on-select="$ctrl.onSelect(id)"
+      >
+      </rf-layer-item>
+    </div>
+  </div>
+  <div class="container fit-height column-stretch analysis-list">
+    <div class="row content stack-sm">
+      <div class="column-12">
+        <div class="dashboard-header">
+          <h3>Choose an analysis to run</h3>
+          <div class="flex-fill"></div>
+          <rf-search on-search="$ctrl.fetchTemplates(1, value)"  value="$ctrl.search"  placeholder="Search for analysis" auto-focus="false">
+          </rf-search>
+          <select
+              class="form-control"
+              ng-model="$ctrl.currentOwnershipFilter"
+              ng-change="$ctrl.handleOwnershipFilterChange()"
+          >
+            <option value="">All</option>
+            <option value="owned">Owned by me</option>
+            <option value="shared">Shared with me</option>
+          </select>
+        </div>
+        <div class="column-spacer"></div>
+        <div class="column-9">
+          <div class="text-center" ng-show="$ctrl.currentTemplateQuery">
+            <div>Loading Templates</div>
+            <span class="list-placeholder h3">
+              <i
+                  class="icon-load animate-spin"
+                  ng-class="{'stop': !$ctrl.currentTemplateQuery}"
+              ></i>
+            </span>
+          </div>
+        </div>
+        <rf-pagination-count
+            ng-if="!$ctrl.currentTemplateQuery && !$ctrl.templateFetchError && $ctrl.pagination.count"
+            start-index="$ctrl.pagination.startingItem"
+            end-index="$ctrl.pagination.endingItem"
+            total="$ctrl.pagination.count"
+            item-name="analyses"
+        >
+          <span ng-if="$ctrl.search">while searching for <strong>{{ $ctrl.search }}</strong></span>
+        </rf-pagination-count>
+        <div class="row stack-sm">
+          <div class="column-6 flex-display" ng-show="$ctrl.creationPromise">
+            Creating analyses...
+          </div>
+          <div class="column-12 flex-display color-danger" ng-show="$ctrl.createError">
+            API Error: There was an error while creating analyses.<br />
+            Please try another template or contact support for more information.
+          </div>
+          <div class="column-6 flex-display"
+               ng-repeat="analysis in $ctrl.templateList track by analysis.id"
+               ng-show="!$ctrl.creationPromise"
+          >
+            <rf-list-item
+                class="clickable"
+                ng-click="$ctrl.onAnalysisClick($event, analysis)"
+                data-title="analysis.title"
+                data-date="analysis.createdAt"
+                data-subtitle="$ctrl.templateCreators.get(analysis.id)"
+            >
+              <div class="btn btn-text btn-transparent"
+                ng-repeat="action in $ctrl.itemActions.get(analysis.id) | filter: {menu: false}"
+                ng-attr-title="{{action.name}}"
+                ng-click="action.callback($event)"
+              >
+                <span ng-attr-class="{{action.icon}}"
+                      tooltips
+                      tooltip-template="{{action.tooltip}}"
+                      tooltip-size="small"
+                      tooltip-class="layer-item-tooltip"
+                      tooltip-side="left"
+                      tooltip-hidden="!$ctrl.action.tooltip"
+                ></span>
+              </div>
+              <button class="btn btn-text btn-transparent"
+                      uib-dropdown
+                      ng-show="($ctrl.itemActions.get(analysis.id) | filter: {menu: true}).length > 0"
+                      uib-dropdown-toggle
+              >
+                <i class="icon-menu"></i>
+                <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+                  <li role="menuitem"
+                      ng-repeat="action in $ctrl.itemActions.get(scene.id) | filter: {menu: true}">
+                    <a href ng-click="action.callback($event)"
+                       ng-show="action.name"
+                       ng-attr-title="{{action.title}}">{{action.name}}</a>
+                    <span class="menu-separator" ng-show="action.separator"></span>
+                  </li>
+                </ul>
+              </button>
+            </rf-list-item>
+          </div>
+        </div>
+        <rf-pagination-controls
+            pagination="$ctrl.pagination"
+            is-loading="$ctrl.currentTemplateQuery"
+            on-change="$ctrl.fetchTemplates(value)"
+            ng-show="!$ctrl.currentTemplateQuery && !$ctrl.templateFetchError"
+        ></rf-pagination-controls>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.js
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.js
@@ -1,0 +1,293 @@
+/* global BUILDCONFIG */
+import { Set, Map } from 'immutable';
+import _ from 'lodash';
+import tpl from './index.html';
+
+class ProjectCreateAnalysisPageController {
+    constructor(
+        $rootScope, $q, $state, $timeout, uuid4,
+        projectService, paginationService, analysisService, modalService, userService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+        this.BUILDCONFIG = BUILDCONFIG;
+    }
+
+    $onInit() {
+        this.currentOwnershipFilter = this.$state.params.ownership || '';
+        this.selected = new Set();
+        this.itemActions = new Map();
+        this.fetchLayers();
+        this.templateCreators = new Map();
+        this.fetchTemplates();
+    }
+
+    fetchLayers() {
+        if (this.layers && this.layers.length) {
+            this.layerList = this.layers.map(this.toLayerInfo);
+        } else {
+            this.currentQuery = this.projectService
+                .getProjectLayer(this.project.id, this.project.defaultLayerId)
+                .then((layer) => {
+                    delete this.currentQuery;
+                    this.layerList = [this.toLayerInfo(layer)];
+                }).catch(e => {
+                    delete this.currentQuery;
+                    this.fetchError = e;
+                });
+        }
+    }
+
+    toLayerInfo(layer) {
+        return {
+            id: layer.id,
+            name: layer.name,
+            subtext: layer.subtext,
+            date: layer.createdAt,
+            colorGroupHex: layer.colorGroupHex,
+            geometry: layer.geometry
+        };
+    }
+
+    handleOwnershipFilterChange() {
+        this.fetchTemplates(1);
+    }
+
+    fetchTemplates(page = this.$state.params.page || 1, search = this.$state.params.search) {
+        this.search = search && search.length ? search : null;
+        delete this.templateFetchError;
+        this.templateList = [];
+        // TODO add sort filters
+
+        let params = {
+            sort: 'createdAt,desc',
+            pageSize: 10,
+            page: page - 1
+        };
+
+        if (this.search) {
+            params.search = this.search;
+        }
+        if (this.currentOwnershipFilter) {
+            params.ownershipType = this.currentOwnershipFilter;
+        }
+
+        let currentQuery = this.analysisService.fetchTemplates(params).then(paginatedResponse => {
+            this.templateList = paginatedResponse.results;
+            this.itemActions = new Map(this.templateList.map(this.addItemActions.bind(this)));
+            this.fetchCreators(this.templateList).then((creators) => {
+                if (creators.has(_.first(this.templateList).id)) {
+                    this.templateCreators = creators;
+                }
+            });
+            // TODO fetch template owner information using
+            // userService like in templateItem.module.js
+            this.pagination = this.paginationService.buildPagination(paginatedResponse);
+            this.paginationService.updatePageparam(page, this.search, null, {
+                ownership: this.currentOwnershipFilter
+            });
+            if (this.currentTemplateQuery === currentQuery) {
+                delete this.templateFetchError;
+            }
+        }).catch(e => {
+            if (this.currentQuery === currentQuery) {
+                this.templateFetchError = e;
+            }
+        }).finally(() => {
+            if (this.currentTemplateQuery === currentQuery) {
+                delete this.currentTemplateQuery;
+            }
+        });
+
+        this.currentTemplateQuery = currentQuery;
+    }
+
+    fetchCreators(templates) {
+        const ownerPromises = templates.map(template => {
+            if (template.owner === 'default') {
+                return this.$q.resolve([template.id, this.BUILDCONFIG.APP_NAME]);
+            }
+            return this.userService.getUserById(template.owner).then(user => {
+                const owner = user.personalInfo.firstName.trim() &&
+                    user.personalInfo.lastName.trim() ?
+                    `${user.personalInfo.firstName.trim()} ${user.personalInfo.lastName.trim()}` :
+                    user.name || 'Anonymous';
+                return [template.id, owner];
+            }).catch(e => {
+                return [template.id, this.BUILDCONFIG.APP_NAME];
+            });
+        });
+        return this.$q.all(ownerPromises).then(
+            (templatesAndOwners) => {
+                return new Map(
+                    templatesAndOwners
+                        .filter(([id, owner]) => owner)
+                        .map(([id, owner]) => {
+                            return [id, `Created by: ${owner}`];
+                        })
+                );
+            }
+        );
+    }
+
+    addItemActions(item) {
+        let actions = [{
+            icon: 'icon-share',
+            name: 'View algorithm',
+            tooltip: 'View algorithm',
+            callback: (event) => this.confirmViewAnalysis(event, item),
+            menu: false
+        }];
+        if (item.description) {
+            actions.push({
+                icon: 'icon-help',
+                name: 'Description',
+                tooltip: item.description,
+                menu: false
+            });
+        }
+        return [item.id, actions];
+    }
+
+    isSelected(layerId) {
+        return this.selected.has(layerId);
+    }
+
+    onSelect(layerId) {
+        if (this.isSelected(layerId)) {
+            this.selected = this.selected.delete(layerId);
+        } else {
+            this.selected = this.selected.add(layerId);
+        }
+    }
+
+    confirmViewAnalysis(event, template) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (this.creationPromise) {
+            return;
+        }
+        const modal = this.modalService.open({
+            component: 'rfConfirmationModal',
+            resolve: {
+                title: () => 'View analysis template',
+                subtitle: () => 'Leave layer analysis creation to view template?',
+                content: () =>
+                    '<div class="text-center">' +
+                    'Viewing the analysis template will cancel analysis creation.' +
+                    '</div>',
+                confirmText: () => 'Continue',
+                cancelText: () => 'Go back'
+            }
+        });
+        modal.result.then(() => {
+            this.$state.go('lab.startAnalysis', {templateid: template.id});
+        }).catch(() => {
+        });
+    }
+
+    onAnalysisClick(event, template) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (this.creationPromise) {
+            return;
+        }
+        const modal = this.modalService.open({
+            component: 'rfConfirmationModal',
+            resolve: {
+                title: () => 'Create analyses',
+                content: () =>
+                    '<div class="text-center">' +
+                    'This will create new analysis for each layer you\'ve selected on' +
+                    `your project using the "${template.title}" template` +
+                    '</div>',
+                confirmText: () => 'Create analyses',
+                cancelText: () => 'Go back'
+            }
+        });
+        modal.result.then(() => {
+            const creationPromises = this.layerList.map((layer) => {
+                const layerTemplate = this.createLayerAnalysis(layer, template);
+                return this.analysisService.createAnalysis(layerTemplate);
+            });
+            this.creationPromise = this.$q.all(creationPromises);
+            return this.creationPromise;
+        }).then(() => {
+            this.$state.go('project.analyses');
+        }).catch((error) => {
+            if (!error || typeof error === 'string' &&
+                (error.includes('backdrop') ||
+                 error.includes('escape'))
+               ) {
+                return;
+            }
+            this.createError = true;
+            this.$timeout(() => {
+                delete this.createError;
+            }, 10000);
+        }).finally(() => {
+            delete this.creationPromise;
+        });
+    }
+
+    createLayerAnalysis(layer, template) {
+        // get layer datasources?
+        // note: just set all of them to 0 at the start. they will be changed later
+        // use template to create an analysis for layer
+        const analysis = {
+            id: this.uuid4.generate(),
+            name: template.title,
+            visibility: 'PRIVATE',
+            projectId: this.project.id,
+            projectLayerId: layer.id,
+            templateId: template.id,
+            executionParameters: _.cloneDeep(template.definition)
+        };
+        let root = analysis.executionParameters;
+        let nodes = root.args ? [...root.args] : [];
+        while (nodes.length) {
+            const node = nodes.pop();
+            if (['projectSrc', 'layerSrc'].includes(_.get(node, 'type'))) {
+                Object.assign(node, {
+                    type: 'layerSrc',
+                    band: 0,
+                    layerId: layer.id
+                });
+            }
+        }
+        return analysis;
+    }
+
+    removeLayers() {
+        this.layerList = _.filter(this.layerList, (l) => !this.selected.has(l.id));
+        this.selected = this.selected.clear();
+    }
+
+    selectAll() {
+        if (this.allVisibleSelected()) {
+            this.selected = this.selected.clear();
+        } else {
+            this.selected = this.selected.union(new Set(this.layerList.map(l => l.id)));
+        }
+    }
+
+    allVisibleSelected() {
+        return this.layerList && this.selected.size === this.layerList.length;
+    }
+}
+
+const component = {
+    bindings: {
+        user: '<',
+        project: '<',
+        layers: '<'
+    },
+    templateUrl: tpl,
+    controller: ProjectCreateAnalysisPageController.name
+};
+
+export default angular
+    .module('components.pages.projects.createAnalysis', [])
+    .controller(ProjectCreateAnalysisPageController.name, ProjectCreateAnalysisPageController)
+    .component('rfProjectCreateAnalysisPage', component)
+    .name;

--- a/app-frontend/src/app/components/pages/project/index.js
+++ b/app-frontend/src/app/components/pages/project/index.js
@@ -4,6 +4,8 @@ import autoInject from '_appRoot/autoInject';
 import layerPages from './layer';
 import projectPage from './project';
 import layersPage from './layers';
+import createAnalysisPage from './createAnalysis';
+import analysisPage from './analysis';
 import settingsPages from './settings';
 import analysesPages from './analyses';
 
@@ -47,6 +49,8 @@ export {
 export default [
     layersPage,
     projectPage,
+    createAnalysisPage,
+    analysisPage,
     ...layerPages,
     ...settingsPages,
     ...analysesPages

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -19,13 +19,10 @@
       on-click="$ctrl.selectAll()"
       action-text="$ctrl.selectText"
   >
-    <div class="btn btn-transparent" uib-dropdown uib-dropdown-toggle>
-      Create...
-      <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
-        <li role="menuitem">
-          <a ng-click="$ctrl.createAnalysis()">Analysis</a></li>
-      </ul>
-    </div>
+    <button class="btn btn-transparent"
+            ng-click="$ctrl.createAnalysis()">
+      Create Analysis
+    </button>
     <button class="btn btn-transparent"
             ng-click="$ctrl.removeScenes($ctrl.selected.valueSeq().toArray())">
       Delete

--- a/app-frontend/src/app/components/pages/project/project/index.html
+++ b/app-frontend/src/app/components/pages/project/project/index.html
@@ -1,4 +1,4 @@
-<div ui-view="navbar-secondary">
+<div ui-view="navbar-secondary" ng-show="!('project.create-analysis' | includedByState)">
   <div class="navbar light-navbar">
     <div class="navbar-section">
       <nav>
@@ -30,11 +30,21 @@
     </div>
   </div>
 </div>
-<div class="container column-stretch container-not-scrollable with-secondary-navbar"
-     ng-show="('project.settings' | includedByState)"
+<div class="container column-stretch container-not-scrollable"
+     ng-class="{
+            'with-secondary-navbar':
+              ('project.settings' | includedByState)
+            }"
+     ng-show="
+            ('project.settings' | includedByState) ||
+            ('project.create-analysis' | includedByState)
+            "
      ui-view></div>
 <div class="container column-stretch container-not-scrollable with-secondary-navbar"
-     ng-show="!('project.settings' | includedByState)">
+     ng-show="
+            !('project.settings' | includedByState) &&
+            !('project.create-analysis' | includedByState)
+            ">
   <div class="sidebar" ui-view></div>
   <div class="main">
     <rf-map-container map-id="project"

--- a/app-frontend/src/app/components/pages/project/project/index.js
+++ b/app-frontend/src/app/components/pages/project/project/index.js
@@ -3,7 +3,7 @@ import tpl from './index.html';
 
 class ProjectPageController {
     constructor(
-        $rootScope, $state, $location, mapService, mapUtilsService,
+        $rootScope, $state, $location, $transitions, mapService, mapUtilsService,
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -13,6 +13,15 @@ class ProjectPageController {
         if (!this.$location.search().bbox) {
             this.fitProjectExtent();
         }
+        this.getMap().then((map) => {
+            this.$transitions.onFinish({
+                to: 'project.*'
+            }, (transition) => {
+                if (!transition.to().name.includes('create-analysis')) {
+                    map.map.invalidateSize();
+                }
+            });
+        });
     }
 
     getMap() {

--- a/app-frontend/src/app/components/projects/layerItem/index.html
+++ b/app-frontend/src/app/components/projects/layerItem/index.html
@@ -54,8 +54,8 @@
                  tooltip-class="layer-item-tooltip"
                  tooltip-side="left"></span>
       </div>
-
       <div class="btn btn-text btn-transparent"
+           ng-show="$ctrl.onHide"
            ng-click="$ctrl.onHide({id: $ctrl.itemInfo.id})">
         <span class="icon-eye"
               tooltips

--- a/app-frontend/src/app/components/projects/layerItem/index.js
+++ b/app-frontend/src/app/components/projects/layerItem/index.js
@@ -10,7 +10,7 @@ class LayerItemController {
     $onInit() {
         const rx = /^#(?:[0-9a-f]{3}){1,2}$/i;
         const color = _.get(this.itemInfo, 'colorGroupHex');
-        if (color.match(rx)) {
+        if (color && color.match(rx)) {
             this.color = color;
         } else {
             this.color = 'white';
@@ -26,9 +26,9 @@ const component = {
         itemInfo: '<',
         itemActions: '<',
         selected: '<',
-        onSelect: '&',
+        onSelect: '&?',
         visible: '<',
-        onHide: '&',
+        onHide: '&?',
         isAnalysis: '<?',
         isExport: '<?',
         onDownloadExport: '&?'

--- a/app-frontend/src/app/components/projects/navbar/index.js
+++ b/app-frontend/src/app/components/projects/navbar/index.js
@@ -26,6 +26,7 @@ class ProjectLayersNavController {
             stateCurrent.name === 'project.layers' ||
             stateCurrent.name.includes('project.analyses') ||
             stateCurrent.name.includes('project.settings') ||
+            stateCurrent.name.includes('project.create-analysis') ||
             stateCurrent.name.includes('project.layer')
         ) {
             this.navs.push({
@@ -38,6 +39,12 @@ class ProjectLayersNavController {
             this.navs.push({
                 title: 'Settings',
                 sref: `project.settings({projectId: '${this.project.id}'})`
+            });
+        }
+
+        if (stateCurrent.name.includes('project.create-analysis')) {
+            this.navs.push({
+                title: 'Create Analysis'
             });
         }
 

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -2,6 +2,7 @@
 import pages from './components/pages';
 import projectComponents from './components/projects';
 import sceneComponents from './components/scenes';
+import commonComponents from './components/common';
 export default angular.module('index.components', [
     //admin components
     require('./components/admin/editableLogo/editableLogo.js').default.name,
@@ -111,6 +112,7 @@ export default angular.module('index.components', [
     require('./components/common/paginationControls/paginationControls.js').default.name,
     require('./components/common/navbarSearch/navbarSearch.js').default.name,
     require('./components/common/itemActionButtons/itemActionButtons.js').default.name,
+    ...commonComponents,
 
     // Single components for new domains
     require('./components/aoiFilterPane/aoiFilterPane.module.js').default.name,

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -294,6 +294,30 @@ function projectStatesV2($stateProvider) {
             url: '/visualize',
             component: 'rfProjectAnalysesVisualizePage'
         })
+        .state('project.analysis', {
+            title: 'Project Analysis',
+            url: '/analysis/:analsisId',
+            component: 'rfProjectAnalysis'
+        })
+        .state('project.create-analysis', {
+            title: 'Create project analysis',
+            url: '/create-analysis?page&search',
+            component: 'rfProjectCreateAnalysisPage',
+            params: {
+                layers: {
+                    array: true
+                },
+                page: {
+                    dynamic: true
+                },
+                search: {
+                    dynamic: true
+                }
+            },
+            resolve: {
+                layers: ['$transition$', ($transition$) => $transition$.params().layers]
+            }
+        })
     // project settings routes
         .state('project.settings.options', {
             title: 'Project Options',

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -39,6 +39,7 @@ export default (app) => {
                     id: '@id'
                 }, {
                     create: {
+                        url: `${BUILDCONFIG.API_HOST}/api/tool-runs/`,
                         method: 'POST'
                     },
                     get: {
@@ -175,10 +176,12 @@ export default (app) => {
                 (user) => {
                     return this.Analysis.create(Object.assign(analysis, {
                         organizationId: user.organizationId
-                    })).$promise;
+                    })).$promise.catch(e => {
+                        throw e;
+                    });
                 },
-                () => {
-
+                (e) => {
+                    throw e;
                 }
             );
         }

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3267,7 +3267,8 @@ rf-project-layers-page,
 rf-project-analyses-page,
 rf-project-layer-page,
 rf-project-layer-scenes-browse-page,
-rf-project-layer-exports-page {
+rf-project-layer-exports-page,
+rf-project-create-analysis-page {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -3282,6 +3283,43 @@ rf-project-layer-exports-page {
         border: 1px solid $gray-lightest;
         border-radius: 3px;
         margin: .5em;
+    }
+}
+
+rf-project-create-analysis-page {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    background: $white;
+    min-height: 0; // firefox flexbox compatability
+    height: 100%;
+    .sidebar {
+        background: $off-white;
+    }
+
+    .analysis-list {
+        margin-top: 0;
+        background: $white;
+    }
+
+    .analysis-list-header {
+    }
+}
+
+rf-list-item {
+    display: block;
+    background: $white;
+    border: 1px solid $gray-lightest;
+    border-radius: 3px;
+    margin: .5em;
+    &[ng-click] {
+        cursor: pointer;
+    }
+}
+
+.column-6 {
+    rf-list-item {
+        width: 100%;
     }
 }
 

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -188,3 +188,8 @@
 .no-padding {
   padding: 0 !important;
 }
+
+.fit-height {
+    max-height: 100%;
+    overflow: auto;
+}


### PR DESCRIPTION
## Overview
Allow selecting multiple layers and creating analyses for them

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/53032082-1fefc480-343c-11e9-9e09-93d6a2ef20d2.png)

## notes
The edit views and aoi views are separate issues

## Testing Instructions

 * From the layers view:
   * use the dropdown menu on a layer to go to the create-analysis view, and verify that the correct layer is listed on the left
   * Select multiple layers and use the select bar Create -> analysis menu to go to the create-analysis view
   * Load the create-analysis view directly and verify that it uses the default layer
* after selecting and visiting the create-analysis page with multiple layers, click a template to use it. Verify that the tool-runs which are created use the layer for app inputs, any projectSrc nodes are changed into layerSrc nodes, and the projectId, projecLayerId, and templateId fields are filled in correctly.
* Verify that you can go directly to the template view page for a template by clicking on the graph-like icon.

Closes #4539 
