### PR TITLE
fixes text overflow issue throughout app

### DIFF
--- a/app-frontend/src/app/components/common/listItem/index.html
+++ b/app-frontend/src/app/components/common/listItem/index.html
@@ -18,7 +18,7 @@
          }
         </style>
       </div>
-      <div><strong>{{$ctrl.title}}</strong></div>
+      <div class="text-overflow-ellipsis"><strong>{{$ctrl.title}}</strong></div>
       <div ng-show="$ctrl.subtitle"><span>{{$ctrl.subtitle}}</span></div>
       <div>{{$ctrl.date | date}}</div>
     </div>

--- a/app-frontend/src/app/components/common/listItem/index.html
+++ b/app-frontend/src/app/components/common/listItem/index.html
@@ -18,7 +18,7 @@
          }
         </style>
       </div>
-      <div class="text-overflow-ellipsis"><strong>{{$ctrl.title}}</strong></div>
+      <div class="text-overflow-ellipsis" title="{{$ctrl.title}}"><strong>{{$ctrl.title}}</strong></div>
       <div ng-show="$ctrl.subtitle"><span>{{$ctrl.subtitle}}</span></div>
       <div>{{$ctrl.date | date}}</div>
     </div>

--- a/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
+++ b/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
@@ -1,7 +1,7 @@
 <div class="list-group-item">
   <div class="list-group-overflow">
     <div class="list-group-left">
-      <div class="text-overflow-ellipsis"><strong class="color-dark">{{$ctrl.datasource.name}}</strong></div>
+      <div class="text-overflow-ellipsis" title="{{$ctrl.datasource.name}}"><strong class="color-dark">{{$ctrl.datasource.name}}</strong></div>
       <div>
         <div class="visibility"
              ng-if="$ctrl.isOwner"

--- a/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
+++ b/app-frontend/src/app/components/datasources/datasourceItem/datasourceItem.html
@@ -1,7 +1,7 @@
 <div class="list-group-item">
   <div class="list-group-overflow">
     <div class="list-group-left">
-      <div><strong class="color-dark">{{$ctrl.datasource.name}}</strong></div>
+      <div class="text-overflow-ellipsis"><strong class="color-dark">{{$ctrl.datasource.name}}</strong></div>
       <div>
         <div class="visibility"
              ng-if="$ctrl.isOwner"

--- a/app-frontend/src/app/components/exports/exportItem/exportItem.html
+++ b/app-frontend/src/app/components/exports/exportItem/exportItem.html
@@ -3,7 +3,7 @@
 </div>
 <div class="list-group-item {{$ctrl.isDisabled ? 'is-disabled' : ''}}">
   <div class="list-group-overflow">
-    <div class="text-overflow-ellipsis">
+    <div class="text-overflow-ellipsis" title="{{$ctrl.export.createdAt | date : 'medium'}}">
       <strong class="color-dark">{{$ctrl.export.createdAt | date : 'medium'}}</strong>
     </div>
   </div>

--- a/app-frontend/src/app/components/exports/exportItem/exportItem.html
+++ b/app-frontend/src/app/components/exports/exportItem/exportItem.html
@@ -3,10 +3,8 @@
 </div>
 <div class="list-group-item {{$ctrl.isDisabled ? 'is-disabled' : ''}}">
   <div class="list-group-overflow">
-    <div>
-      <span>
-        <strong class="color-dark">{{$ctrl.export.createdAt | date : 'medium'}}</strong>
-      </span>
+    <div class="text-overflow-ellipsis">
+      <strong class="color-dark">{{$ctrl.export.createdAt | date : 'medium'}}</strong>
     </div>
   </div>
   <div class="list-group-right">

--- a/app-frontend/src/app/components/projects/layerItem/index.html
+++ b/app-frontend/src/app/components/projects/layerItem/index.html
@@ -13,7 +13,7 @@
     </style>
   </div>
   <div class="list-group-overflow">
-    <div><strong>{{$ctrl.itemInfo.name}}</strong></div>
+    <div class="text-overflow-ellipsis"><strong>{{$ctrl.itemInfo.name}}</strong></div>
     <div ng-if="$ctrl.itemInfo.subtext"><span>{{$ctrl.itemInfo.subtext}}</span></div>
     <div ng-class="{'export-date-subtext': $ctrl.isExport}">
       <span ng-if="$ctrl.isExport">{{$ctrl.itemInfo.date | date: 'medium'}}</span>

--- a/app-frontend/src/app/components/projects/layerItem/index.html
+++ b/app-frontend/src/app/components/projects/layerItem/index.html
@@ -13,7 +13,7 @@
     </style>
   </div>
   <div class="list-group-overflow">
-    <div class="text-overflow-ellipsis"><strong>{{$ctrl.itemInfo.name}}</strong></div>
+    <div class="text-overflow-ellipsis" title="{{$ctrl.itemInfo.name}}"><strong>{{$ctrl.itemInfo.name}}</strong></div>
     <div ng-if="$ctrl.itemInfo.subtext"><span>{{$ctrl.itemInfo.subtext}}</span></div>
     <div ng-class="{'export-date-subtext': $ctrl.isExport}">
       <span ng-if="$ctrl.isExport">{{$ctrl.itemInfo.date | date: 'medium'}}</span>

--- a/app-frontend/src/app/components/scenes/projectSceneItem/index.html
+++ b/app-frontend/src/app/components/scenes/projectSceneItem/index.html
@@ -41,12 +41,10 @@
     </div>
   </div>
   <div class="list-group-overflow">
-    <div>
-      <span title="{{$ctrl.scene.name}}">
-        <strong class="color-dark">
-          {{($ctrl.getReferenceDate() | date : 'mediumDate' : '+0000') + ' (UTC)'}}
-        </strong>
-      </span>
+    <div class="text-overflow-ellipsis" title="{{$ctrl.scene.name}}">
+      <strong class="color-dark">
+        {{($ctrl.getReferenceDate() | date : 'mediumDate' : '+0000') + ' (UTC)'}}
+      </strong>
     </div>
     <div>
       <span>{{$ctrl.scene.datasource.name}}</span>

--- a/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
+++ b/app-frontend/src/app/components/scenes/sceneItem/sceneItem.html
@@ -46,12 +46,10 @@
     </div>
   </div>
   <div class="list-group-overflow">
-    <div>
-      <span title="{{$ctrl.scene.name}}">
-        <strong class="color-dark">
-          {{($ctrl.getReferenceDate() | date : 'mediumDate' : '+0000') + ' (UTC)'}}
-        </strong>
-      </span>
+    <div class="text-overflow-ellipsis" title="{{$ctrl.scene.name}}">
+      <strong class="color-dark">
+        {{($ctrl.getReferenceDate() | date : 'mediumDate' : '+0000') + ' (UTC)'}}
+      </strong>
     </div>
     <div>
       <span>{{$ctrl.datasource ? $ctrl.datasource.name : 'Loading datasource'}}</span>

--- a/app-frontend/src/app/components/vectors/shapeItem/shapeItem.html
+++ b/app-frontend/src/app/components/vectors/shapeItem/shapeItem.html
@@ -2,12 +2,10 @@
      ng-class="{'disabled': $ctrl.isDisabled,
                 'clickable': $ctrl.isClickable}">
   <div class="list-group-overflow">
-    <div>
-      <span title="{{$ctrl.shape.properties.name}}">
-        <strong class="color-dark">
-          {{$ctrl.shape.properties.name}}
-        </strong>
-      </span>
+    <div class="text-overflow-ellipsis" title="{{$ctrl.shape.properties.name}}">
+      <strong class="color-dark">
+        {{$ctrl.shape.properties.name}}
+      </strong>
     </div>
     <div>
       <span title="{{$ctrl.shape.properties.modifiedAt}}">

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1432,7 +1432,7 @@ table.upload-info {
   border-bottom: 1px solid $gray-lightest;
 }
 .list-group-overflow {
-  overflow: visible;
+  //overflow: visible;
 }
 
 rf-export-item {


### PR DESCRIPTION
## Overview

Fixes #4681

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
<img width="453" alt="screen shot 2019-02-22 at 1 04 34 pm" src="https://user-images.githubusercontent.com/1928955/53261949-554a1b80-36a3-11e9-92e9-f0e7deab3eff.png">
<img width="883" alt="screen shot 2019-02-22 at 1 04 56 pm" src="https://user-images.githubusercontent.com/1928955/53261950-554a1b80-36a3-11e9-9854-d4fc2de317c8.png">


### Notes

I made a soft attempt at standardizing the html for text overflows throughout at the app. Some changes might not have been needed, but now the code should be near identical in each portion of the app that this technique is used.


## Testing Instructions

 * Open v2 projects and check a long named analysis for ellipsis overflowing.
