### PR TITLE
Add owner qp to tools and tool-runs, support multiple owner qps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Added layer ID query parameter to export list endpoint [\#4663](https://github.com/raster-foundry/raster-foundry/pull/4663)
 - Added project layer annotation UI support [\#4665](https://github.com/raster-foundry/raster-foundry/pull/4665)
 - Added project settings pages for v2 UI [\#4637](https://github.com/raster-foundry/raster-foundry/pull/4637)
+- Added owner query parameter to tools and tool-runs endpoints, support multiple owner qp's on applicable endpoints [\#4689](https://github.com/raster-foundry/raster-foundry/pull/4689)
+
 ### Changed
 
 - Updated default project layer color group hex code [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)

--- a/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/toolrun/QueryParameters.scala
@@ -19,6 +19,7 @@ trait ToolRunQueryParametersDirective extends QueryParametersCommon {
   val toolRunQueryParameters = (
     toolRunSpecificQueryParams &
       timestampQueryParameters &
+      ownerQueryParameters &
       ownershipTypeQueryParameters &
       groupQueryParameters &
       userQueryParameters &

--- a/app-backend/api/src/main/scala/tools/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/tools/QueryParameters.scala
@@ -10,6 +10,7 @@ trait ToolQueryParameterDirective extends QueryParametersCommon {
         userQueryParameters &
         timestampQueryParameters &
         searchParams &
+        ownerQueryParameters &
         ownershipTypeQueryParameters &
         groupQueryParameters
     ).as(CombinedToolQueryParameters.apply _)

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -57,7 +57,7 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
 
   def ownerQueryParameters =
     parameters(
-      'owner.as[String].?
+      'owner.as[String].*
     ).as(OwnerQueryParameters.apply _)
 
   def ownershipTypeQueryParameters =

--- a/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
+++ b/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
@@ -169,6 +169,7 @@ final case class CombinedToolQueryParameters(
     userParams: UserQueryParameters = UserQueryParameters(),
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
     searchParams: SearchQueryParameters = SearchQueryParameters(),
+    ownerQueryParams: OwnerQueryParameters = OwnerQueryParameters(),
     ownershipTypeParams: OwnershipTypeQueryParameters =
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters()
@@ -237,7 +238,8 @@ object UserAuditQueryParameters {
 }
 
 /** Query parameters to filter by owners */
-final case class OwnerQueryParameters(owner: Option[String] = None)
+final case class OwnerQueryParameters(
+    owner: Iterable[String] = List.empty[String])
 
 object OwnerQueryParameters {
   implicit def encOwnerQueryParameters: Encoder[OwnerQueryParameters] =
@@ -335,6 +337,7 @@ object ToolRunQueryParameters {
 final case class CombinedToolRunQueryParameters(
     toolRunParams: ToolRunQueryParameters = ToolRunQueryParameters(),
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),
+    ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
     ownershipTypeParams: OwnershipTypeQueryParameters =
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -25,7 +25,11 @@ object Filters {
   }
 
   def ownerQP(ownerParams: OwnerQueryParameters): List[Option[Fragment]] = {
-    List(ownerParams.owner.map(owner => fr"owner = $owner"))
+    List(
+      ownerParams.owner.toList.toNel
+        .map({ owners =>
+          Fragments.in(fr"owner", owners)
+        }))
   }
 
   def organizationQP(orgParams: OrgQueryParameters): List[Option[Fragment]] = {

--- a/app-frontend/src/app/services/auth/permissions.service.js
+++ b/app-frontend/src/app/services/auth/permissions.service.js
@@ -74,7 +74,7 @@ export default (app) => {
                         objectType,
                         objectId: object.id
                     }).$promise.then(permissions => {
-                        resolve(permissions.filter(p => matchingIds.includdes(p.subjectId)));
+                        resolve(permissions.filter(p => matchingIds.includes(p.subjectId)));
                     }).catch((e) => {
                         // can't view permissions, don't have edit
                         if (e.status === 403) {


### PR DESCRIPTION
## Overview
Add owner query parameters to tools and tool runs
Support multiple owner query parameters and check that owners are in the list of owners.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated https://github.com/raster-foundry/raster-foundry-api-spec/pull/91
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * run `api/assembly` in sbt and start your webserver
* Make a query to `api/tools/?owner=default` and observe that it works
* Make a second query to `api/tools/?owner=default&owner={another user id}` and observe that results from both users appear
* repeat the above with `api/tool-runs/?owner=default&owner={another user id}`. You may need to create some fake tool-runs to filter in/out

Closes https://github.com/azavea/raster-foundry-platform/issues/639
