### PR TITLE
Fix duplicated V2 UI bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+
 - Added backend support for rendering tiles and fetching histograms for analyses with project layers at their leaves [\#4603](https://github.com/raster-foundry/raster-foundry/pull/4603)
 - Added scene counts to project layer items [\#4625](https://github.com/raster-foundry/raster-foundry/pull/4625)
 - Added project layer analyses list view [\#4585](https://github.com/raster-foundry/raster-foundry/pull/4585)
@@ -26,6 +27,10 @@
 ### Removed
 
 - Removed layer re-ordering, layer sorting, layer type selection from UI [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
+
+### Fixed
+
+- Fixed a bug in V2 UI so that views don't show up twice [\#4690](https://github.com/raster-foundry/raster-foundry/pull/4690)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@
 
 ### Fixed
 
-- Fixed a bug in V2 UI so that views don't show up twice [\#4690](https://github.com/raster-foundry/raster-foundry/pull/4690)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-frontend/src/app/components/pages/project/project/index.html
+++ b/app-frontend/src/app/components/pages/project/project/index.html
@@ -1,6 +1,6 @@
 <div
     ui-view="navbar-secondary"
-    ng-show="!('project.create-analysis' | includedByState)"
+    ng-if="!('project.create-analysis' | includedByState)"
 >
     <div class="navbar light-navbar">
         <div class="navbar-section">
@@ -44,7 +44,7 @@
             'with-secondary-navbar':
               ('project.settings' | includedByState)
             }"
-    ng-show="
+    ng-if="
             ('project.settings' | includedByState) ||
             ('project.create-analysis' | includedByState)
             "
@@ -52,7 +52,7 @@
 ></div>
 <div
     class="container column-stretch container-not-scrollable with-secondary-navbar"
-    ng-show="
+    ng-if="
             !('project.settings' | includedByState) &&
             !('project.create-analysis' | includedByState)
             "
@@ -61,7 +61,7 @@
     <div class="main">
         <rf-map-container
             map-id="project"
-            ng-show="!$ctrl.showPreviewmap"
+            ng-if="!$ctrl.showPreviewmap"
             initial-center="$ctrl.initialCenter"
             initial-zoom="$ctrl.initialZoom"
         >
@@ -69,27 +69,7 @@
     </div>
 </div>
 <div
-    class="container column-stretch container-not-scrollable with-secondary-navbar"
-    ng-if="('project.settings' | includedByState)"
-    ui-view
-></div>
-<div
-    class="container column-stretch container-not-scrollable with-secondary-navbar"
-    ng-if="!('project.settings' | includedByState)"
->
-    <div class="sidebar" ui-view></div>
-    <div class="main">
-        <rf-map-container
-            map-id="project"
-            ng-show="!$ctrl.showPreviewmap"
-            initial-center="$ctrl.initialCenter"
-            initial-zoom="$ctrl.initialZoom"
-        >
-        </rf-map-container>
-    </div>
-</div>
-<div
-    ng-show="('project.layer.browse' | includedByState)"
+    ng-if="('project.layer.browse' | includedByState)"
     class="sidebar project-side-modal"
     ui-view="project-sidemodal"
 ></div>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,7 +61,7 @@ services:
     env_file: .env
     environment:
       - RF_LOG_LEVEL=DEBUG
-      - TILE_SERVER_LOCATION=
+      - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
     ports:
       - "9000:9000"


### PR DESCRIPTION
## Overview

This PR fixes a bug in V2 UI so that it won't show duplicated views (which probably due to a bad merge or rebase lately).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Use the V2 UI and make sure the views look correct
