### PR TITLE
Add rollbar to backsplash, move error-handling to routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added project layer annotation UI support [\#4665](https://github.com/raster-foundry/raster-foundry/pull/4665)
 - Added project settings pages for v2 UI [\#4637](https://github.com/raster-foundry/raster-foundry/pull/4637)
 - Added owner query parameter to tools and tool-runs endpoints, support multiple owner qp's on applicable endpoints [\#4689](https://github.com/raster-foundry/raster-foundry/pull/4689)
+- Added Rollbar error reporting to backsplash [\#4691](https://github.com/raster-foundry/raster-foundry/pull/4691)
 
 ### Changed
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/AnalysisService.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.common.datamodel.User
-import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.Parameters._
 
 import cats.effect.IO
@@ -9,38 +8,28 @@ import org.http4s._
 import org.http4s.dsl.io._
 
 class AnalysisService[Param, HistStore](
-    analysisManager: AnalysisManager[Param, HistStore])(
-    implicit H: HttpErrorHandler[IO, BacksplashException, User],
-    ForeignError: HttpErrorHandler[IO, Throwable, User]) {
+    analysisManager: AnalysisManager[Param, HistStore]) {
 
-  val routes: AuthedService[User, IO] = H.handle {
-    ForeignError.handle {
-      AuthedService {
-        case GET -> Root / UUIDWrapper(analysisId) / "histogram"
-              :? NodeQueryParamMatcher(node) as user =>
-          analysisManager.histogram(user, analysisId, node)
+  val routes: AuthedService[User, IO] =
+    AuthedService {
+      case GET -> Root / UUIDWrapper(analysisId) / "histogram"
+            :? NodeQueryParamMatcher(node) as user =>
+        analysisManager.histogram(user, analysisId, node)
 
-        case GET -> Root / UUIDWrapper(analysisId) / "statistics"
-              :? NodeQueryParamMatcher(node) as user =>
-          analysisManager.statistics(user, analysisId, node)
+      case GET -> Root / UUIDWrapper(analysisId) / "statistics"
+            :? NodeQueryParamMatcher(node) as user =>
+        analysisManager.statistics(user, analysisId, node)
 
-        case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
-              y)
-              :? NodeQueryParamMatcher(node) as user =>
-          analysisManager.tile(user, analysisId, node, z, x, y)
+      case GET -> Root / UUIDWrapper(analysisId) / IntVar(z) / IntVar(x) / IntVar(
+            y)
+            :? NodeQueryParamMatcher(node) as user =>
+        analysisManager.tile(user, analysisId, node, z, x, y)
 
-        case authedReq @ GET -> Root / UUIDWrapper(analysisId) / "raw"
-              :? ExtentQueryParamMatcher(extent)
-              :? ZoomQueryParamMatcher(zoom)
-              :? NodeQueryParamMatcher(node) as user =>
-          analysisManager.export(authedReq,
-                                 user,
-                                 analysisId,
-                                 node,
-                                 extent,
-                                 zoom)
-      }
+      case authedReq @ GET -> Root / UUIDWrapper(analysisId) / "raw"
+            :? ExtentQueryParamMatcher(extent)
+            :? ZoomQueryParamMatcher(zoom)
+            :? NodeQueryParamMatcher(node) as user =>
+        analysisManager.export(authedReq, user, analysisId, node, extent, zoom)
     }
-  }
 
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MosaicService.scala
@@ -2,7 +2,6 @@ package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.common.datamodel.User
 import com.rasterfoundry.backsplash._
-import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.common.utils.TileUtils
 
@@ -28,9 +27,7 @@ class MosaicService[LayerStore: ProjectStore, HistStore, ToolStore](
     layers: LayerStore,
     mosaicImplicits: MosaicImplicits[HistStore],
     analysisManager: AnalysisManager[ToolStore, HistStore],
-    xa: Transactor[IO])(implicit cs: ContextShift[IO],
-                        H: HttpErrorHandler[IO, BacksplashException, User],
-                        ForeignError: HttpErrorHandler[IO, Throwable, User]) {
+    xa: Transactor[IO])(implicit cs: ContextShift[IO]) {
 
   import mosaicImplicits._
 
@@ -42,190 +39,185 @@ class MosaicService[LayerStore: ProjectStore, HistStore, ToolStore](
   val authorizers = new Authorizers(xa)
 
   val routes: AuthedService[User, IO] =
-    H.handle {
-      ForeignError.handle {
-        AuthedService {
-          case GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
-                layerId) / IntVar(z) / IntVar(x) / IntVar(y) :? BandOverrideQueryParamDecoder(
-                bandOverride) as user =>
-            val polygonBbox: Projected[Polygon] =
-              TileUtils.getTileBounds(z, x, y)
-            val eval = LayerTms.identity(
-              layers.read(layerId, Some(polygonBbox), bandOverride, None)
-            )
+    AuthedService {
+      case GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+            layerId) / IntVar(z) / IntVar(x) / IntVar(y) :? BandOverrideQueryParamDecoder(
+            bandOverride) as user =>
+        val polygonBbox: Projected[Polygon] =
+          TileUtils.getTileBounds(z, x, y)
+        val eval = LayerTms.identity(
+          layers.read(layerId, Some(polygonBbox), bandOverride, None)
+        )
 
-            for {
-              fiberAuthProject <- authorizers.authProject(user, projectId).start
-              fiberAuthLayer <- authorizers
-                .authProjectLayer(projectId, layerId)
-                .start
-              fiberResp <- eval(z, x, y).start
-              _ <- (fiberAuthProject, fiberAuthLayer).tupled.join
-                .handleErrorWith { error =>
-                  fiberResp.cancel *> IO.raiseError(error)
+        for {
+          fiberAuthProject <- authorizers.authProject(user, projectId).start
+          fiberAuthLayer <- authorizers
+            .authProjectLayer(projectId, layerId)
+            .start
+          fiberResp <- eval(z, x, y).start
+          _ <- (fiberAuthProject, fiberAuthLayer).tupled.join
+            .handleErrorWith { error =>
+              fiberResp.cancel *> IO.raiseError(error)
+            }
+          resp <- fiberResp.join flatMap {
+            case Valid(tile) =>
+              Ok(tile.renderPng.bytes, pngType)
+            case Invalid(e) =>
+              BadRequest(s"Could not produce tile: $e")
+          }
+        } yield resp
+
+      case GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+            layerId) / "histogram" :? BandOverrideQueryParamDecoder(overrides) as user =>
+        for {
+          authFiber <- authorizers.authProject(user, projectId).start
+          mosaic = layers.read(layerId, None, overrides, None)
+          histFiber <- LayerHistogram.identity(mosaic, 4000).start
+          _ <- authFiber.join.handleErrorWith { error =>
+            histFiber.cancel *> IO.raiseError(error)
+          }
+          resp <- histFiber.join.flatMap {
+            case Valid(hists) =>
+              Ok(hists map { hist =>
+                Map(hist.binCounts: _*)
+              } asJson)
+            case Invalid(e) =>
+              BadRequest(s"Histograms could not be produced: $e")
+          }
+        } yield resp
+
+      case authedReq @ POST -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+            layerId) / "histogram"
+            :? BandOverrideQueryParamDecoder(overrides) as user =>
+        // Compile to a byte array, decode that as a string, and do something with the results
+        authedReq.req.body.compile.to[Array] flatMap { uuids =>
+          decode[List[UUID]](
+            uuids map { _.toChar } mkString
+          ) match {
+            case Right(uuids) =>
+              for {
+                authFiber <- authorizers.authProject(user, projectId).start
+                mosaic = layers.read(layerId, None, overrides, uuids.toNel)
+                histFiber <- LayerHistogram.identity(mosaic, 4000).start
+                _ <- authFiber.join.handleErrorWith { error =>
+                  histFiber.cancel *> IO.raiseError(error)
                 }
-              resp <- fiberResp.join flatMap {
-                case Valid(tile) =>
-                  Ok(tile.renderPng.bytes, pngType)
-                case Invalid(e) =>
-                  BadRequest(s"Could not produce tile: $e")
-              }
-            } yield resp
-
-          case GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
-                layerId) / "histogram" :? BandOverrideQueryParamDecoder(
-                overrides) as user =>
-            for {
-              authFiber <- authorizers.authProject(user, projectId).start
-              mosaic = layers.read(layerId, None, overrides, None)
-              histFiber <- LayerHistogram.identity(mosaic, 4000).start
-              _ <- authFiber.join.handleErrorWith { error =>
-                histFiber.cancel *> IO.raiseError(error)
-              }
-              resp <- histFiber.join.flatMap {
-                case Valid(hists) =>
-                  Ok(hists map { hist =>
-                    Map(hist.binCounts: _*)
-                  } asJson)
-                case Invalid(e) =>
-                  BadRequest(s"Histograms could not be produced: $e")
-              }
-            } yield resp
-
-          case authedReq @ POST -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
-                layerId) / "histogram"
-                :? BandOverrideQueryParamDecoder(overrides) as user =>
-            // Compile to a byte array, decode that as a string, and do something with the results
-            authedReq.req.body.compile.to[Array] flatMap { uuids =>
-              decode[List[UUID]](
-                uuids map { _.toChar } mkString
-              ) match {
-                case Right(uuids) =>
-                  for {
-                    authFiber <- authorizers.authProject(user, projectId).start
-                    mosaic = layers.read(layerId, None, overrides, uuids.toNel)
-                    histFiber <- LayerHistogram.identity(mosaic, 4000).start
-                    _ <- authFiber.join.handleErrorWith { error =>
-                      histFiber.cancel *> IO.raiseError(error)
-                    }
-                    resp <- histFiber.join.flatMap {
-                      case Valid(hists) => Ok(hists asJson)
-                      case Invalid(e) =>
-                        BadRequest(s"Unable to produce histograms: $e")
-                    }
-                  } yield resp
-                case _ =>
-                  BadRequest(
-                    """
+                resp <- histFiber.join.flatMap {
+                  case Valid(hists) => Ok(hists asJson)
+                  case Invalid(e) =>
+                    BadRequest(s"Unable to produce histograms: $e")
+                }
+              } yield resp
+            case _ =>
+              BadRequest(
+                """
                     | Could not decode body as sequence of UUIDs.
                     | Format should be, e.g.,
                     | ["342a82e2-a5c1-4b35-bb6b-0b9dd6a52fa7", "8f3bb3fc-4bd6-49e8-9b25-6fa075cc0c77
 "]""".trim.stripMargin)
-              }
-            }
-
-          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
-                layerId) / "export"
-                :? ExtentQueryParamMatcher(extent)
-                :? ZoomQueryParamMatcher(zoom)
-                :? BandOverrideQueryParamDecoder(bandOverride) as user =>
-            val projectedExtent = extent.reproject(LatLng, WebMercator)
-            val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
-            val eval = authedReq.req.headers
-              .get(CaseInsensitiveString("Accept")) match {
-              case Some(Header(_, "image/tiff")) =>
-                LayerExtent.identity(
-                  layers.read(layerId,
-                              Some(Projected(projectedExtent, 3857)),
-                              bandOverride,
-                              None))(rawMosaicExtentReification, cs)
-              case _ =>
-                LayerExtent.identity(
-                  layers.read(layerId,
-                              Some(Projected(projectedExtent, 3857)),
-                              bandOverride,
-                              None))(paintedMosaicExtentReification, cs)
-            }
-            for {
-              authFiber <- authorizers.authProject(user, projectId).start
-              respFiber <- eval(projectedExtent, cellSize).start
-              _ <- authFiber.join.handleErrorWith { error =>
-                respFiber.cancel *> IO.raiseError(error)
-              }
-              resp <- respFiber.join.flatMap {
-                case Valid(tile) =>
-                  authedReq.req.headers
-                    .get(CaseInsensitiveString("Accept")) match {
-                    case Some(Header(_, "image/tiff")) =>
-                      Ok(
-                        MultibandGeoTiff(tile, projectedExtent, WebMercator).toByteArray,
-                        tiffType
-                      )
-                    case _ =>
-                      Ok(tile.renderPng.bytes, pngType)
-                  }
-                case Invalid(e) => BadRequest(s"Could not produce extent: $e")
-              }
-            } yield resp
-
-          case GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
-                analysisId) / IntVar(z) / IntVar(x) / IntVar(y)
-                :? NodeQueryParamMatcher(node) as user =>
-            for {
-              authFiber <- authorizers.authProject(user, projectId).start
-              respFiber <- analysisManager
-                .tile(user, analysisId, node, z, x, y)
-                .start
-              _ <- authFiber.join.handleErrorWith { error =>
-                respFiber.cancel *> IO.raiseError(error)
-              }
-              resp <- respFiber.join
-            } yield resp
-
-          case GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
-                analysisId) / "histogram" :? NodeQueryParamMatcher(node) as user =>
-            for {
-              authFiber <- authorizers.authProject(user, projectId).start
-              respFiber <- analysisManager
-                .histogram(user, analysisId, node)
-                .start
-              _ <- authFiber.join.handleErrorWith { error =>
-                respFiber.cancel *> IO.raiseError(error)
-              }
-              resp <- respFiber.join
-            } yield resp
-
-          case GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
-                analysisId) / "statistics" :? NodeQueryParamMatcher(node) as user =>
-            for {
-              authFiber <- authorizers.authProject(user, projectId).start
-              respFiber <- analysisManager
-                .statistics(user, analysisId, node)
-                .start
-              _ <- authFiber.join.handleErrorWith { error =>
-                respFiber.cancel *> IO.raiseError(error)
-              }
-              resp <- respFiber.join
-            } yield resp
-
-          case authedReq @ GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
-                analysisId) / "raw"
-                :? ExtentQueryParamMatcher(extent)
-                :? ZoomQueryParamMatcher(zoom)
-                :? NodeQueryParamMatcher(node) as user =>
-            for {
-              authFiber <- authorizers
-                .authProjectAnalysis(user, projectId, analysisId)
-                .start
-              respFiber <- analysisManager
-                .export(authedReq, user, analysisId, node, extent, zoom)
-                .start
-              _ <- authFiber.join.handleErrorWith { error =>
-                respFiber.cancel *> IO.raiseError(error)
-              }
-              resp <- respFiber.join
-            } yield resp
+          }
         }
-      }
+
+      case authedReq @ GET -> Root / UUIDWrapper(projectId) / "layers" / UUIDWrapper(
+            layerId) / "export"
+            :? ExtentQueryParamMatcher(extent)
+            :? ZoomQueryParamMatcher(zoom)
+            :? BandOverrideQueryParamDecoder(bandOverride) as user =>
+        val projectedExtent = extent.reproject(LatLng, WebMercator)
+        val cellSize = BacksplashImage.tmsLevels(zoom).cellSize
+        val eval = authedReq.req.headers
+          .get(CaseInsensitiveString("Accept")) match {
+          case Some(Header(_, "image/tiff")) =>
+            LayerExtent.identity(
+              layers.read(layerId,
+                          Some(Projected(projectedExtent, 3857)),
+                          bandOverride,
+                          None))(rawMosaicExtentReification, cs)
+          case _ =>
+            LayerExtent.identity(
+              layers.read(layerId,
+                          Some(Projected(projectedExtent, 3857)),
+                          bandOverride,
+                          None))(paintedMosaicExtentReification, cs)
+        }
+        for {
+          authFiber <- authorizers.authProject(user, projectId).start
+          respFiber <- eval(projectedExtent, cellSize).start
+          _ <- authFiber.join.handleErrorWith { error =>
+            respFiber.cancel *> IO.raiseError(error)
+          }
+          resp <- respFiber.join.flatMap {
+            case Valid(tile) =>
+              authedReq.req.headers
+                .get(CaseInsensitiveString("Accept")) match {
+                case Some(Header(_, "image/tiff")) =>
+                  Ok(
+                    MultibandGeoTiff(tile, projectedExtent, WebMercator).toByteArray,
+                    tiffType
+                  )
+                case _ =>
+                  Ok(tile.renderPng.bytes, pngType)
+              }
+            case Invalid(e) => BadRequest(s"Could not produce extent: $e")
+          }
+        } yield resp
+
+      case GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
+            analysisId) / IntVar(z) / IntVar(x) / IntVar(y)
+            :? NodeQueryParamMatcher(node) as user =>
+        for {
+          authFiber <- authorizers.authProject(user, projectId).start
+          respFiber <- analysisManager
+            .tile(user, analysisId, node, z, x, y)
+            .start
+          _ <- authFiber.join.handleErrorWith { error =>
+            respFiber.cancel *> IO.raiseError(error)
+          }
+          resp <- respFiber.join
+        } yield resp
+
+      case GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
+            analysisId) / "histogram" :? NodeQueryParamMatcher(node) as user =>
+        for {
+          authFiber <- authorizers.authProject(user, projectId).start
+          respFiber <- analysisManager
+            .histogram(user, analysisId, node)
+            .start
+          _ <- authFiber.join.handleErrorWith { error =>
+            respFiber.cancel *> IO.raiseError(error)
+          }
+          resp <- respFiber.join
+        } yield resp
+
+      case GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
+            analysisId) / "statistics" :? NodeQueryParamMatcher(node) as user =>
+        for {
+          authFiber <- authorizers.authProject(user, projectId).start
+          respFiber <- analysisManager
+            .statistics(user, analysisId, node)
+            .start
+          _ <- authFiber.join.handleErrorWith { error =>
+            respFiber.cancel *> IO.raiseError(error)
+          }
+          resp <- respFiber.join
+        } yield resp
+
+      case authedReq @ GET -> Root / UUIDWrapper(projectId) / "analyses" / UUIDWrapper(
+            analysisId) / "raw"
+            :? ExtentQueryParamMatcher(extent)
+            :? ZoomQueryParamMatcher(zoom)
+            :? NodeQueryParamMatcher(node) as user =>
+        for {
+          authFiber <- authorizers
+            .authProjectAnalysis(user, projectId, analysisId)
+            .start
+          respFiber <- analysisManager
+            .export(authedReq, user, analysisId, node, extent, zoom)
+            .start
+          _ <- authFiber.join.handleErrorWith { error =>
+            respFiber.cancel *> IO.raiseError(error)
+          }
+          resp <- respFiber.join
+        } yield resp
     }
 }

--- a/app-backend/common/src/main/scala/Rollbar.scala
+++ b/app-backend/common/src/main/scala/Rollbar.scala
@@ -26,12 +26,16 @@ trait RollbarNotifier extends LazyLogging {
       .build())
 
   def sendError(e: Throwable): Unit = {
-    if (this.environment != "development")
+    if (this.environment != "development") {
       rollbarClient.error(e)
+    } else {
+      logger.error("What I would have sent to rollbar:", e)
+    }
   }
 
   def sendError(s: String): Unit = {
-    if (this.environment != "development")
+    if (this.environment != "development") {
       rollbarClient.error(s)
+    }
   }
 }


### PR DESCRIPTION
## Overview

This PR

- adds rollbar reporting to backsplash
- reorganizes error handling so that it doesn't have to be included in every service
- has the rollbar notifier print what it would have sent to rollbar if it's development

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I made some sort of ad hoc choices about which errors should be sent to rollbar and which we don't care about. The `BacksplashError`s that don't get sent to rollbar are:

- `RequirementFailedException` (e.g. band 3 does not exist because we rarely do anything useful with it)
- `WrappedDoobieException`
- `WrappedS3Exception`
- `NotAuthorizedException`
- `NoDataInRegionException`

Everything else will be sent to rollbar

## Testing Instructions

 * copy one of the NAIP tifs to `data/test-tif.tif`
 * create a new project pointing to that scene
 * move the scene
 * try to view tiles
 * observe the server telling you that it would have sent an `UnknownException` to rollbar
 * try to make the same request with a bad token (or no token)
 * observe that the server doesn't want to send the auth failure to rollbar, even though it's an exception 

Closes #4488 