### PR TITLE
Add PLATFORM_USERS override variable to webpack overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added project settings pages for v2 UI [\#4637](https://github.com/raster-foundry/raster-foundry/pull/4637)
 - Added owner query parameter to tools and tool-runs endpoints, support multiple owner qp's on applicable endpoints [\#4689](https://github.com/raster-foundry/raster-foundry/pull/4689)
 - Added Rollbar error reporting to backsplash [\#4691](https://github.com/raster-foundry/raster-foundry/pull/4691)
+- Added PLATFORM_USERS webpack overrides variable and make default platform filter use those ids [\#4692](https://github.com/raster-foundry/raster-foundry/pull/4692)
 
 ### Changed
 

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -21,6 +21,7 @@ const HERE_APP_CODE = '5pn07ENomTHOap0u7nQSFA';
 
 const INTERCOM_APP_ID = '';
 const GOOGLE_TAG_ID = 'GTM-54XHDBP';
+const PLATFORM_USERS = JSON.stringify(['default']);
 
 const basemaps = JSON.stringify({
     layers: {
@@ -319,7 +320,8 @@ module.exports = function (_path) {
                         'https://blog.rasterfoundry.com/latest?format=json'
                     ),
                     MAP_CENTER: JSON.stringify([-6.8, 39.2]),
-                    MAP_ZOOM: 5
+                    MAP_ZOOM: 5,
+                    PLATFORM_USERS: PLATFORM_USERS
                 },
                 'HELPCONFIG': {
                     API_DOCS_URL: JSON.stringify('https://docs.rasterfoundry.com/'),

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -40,6 +40,8 @@ const basemaps = JSON.stringify({
     default: 'Light'
 });
 
+const PLATFORM_USERS = JSON.stringify(['default']);
+
 module.exports = function (_path) {
     return {
         plugins: [
@@ -65,7 +67,8 @@ module.exports = function (_path) {
                     LOGOFILE: JSON.stringify('raster-foundry-logo.svg'),
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
-                    FEED_SOURCE: JSON.stringify(FEED_SOURCE)
+                    FEED_SOURCE: JSON.stringify(FEED_SOURCE),
+                    PLATFORM_USERS: PLATFORM_USERS
                 },
                 'HELPCONFIG': {
                     HELP_DOCS: JSON.stringify(HELP_DOCS)

--- a/app-frontend/src/app/components/lab/templateItem/templateItem.module.js
+++ b/app-frontend/src/app/components/lab/templateItem/templateItem.module.js
@@ -44,7 +44,7 @@ class TemplateItemController {
     }
 
     getTemplateOwner() {
-        if (this.templateData.owner === 'default') {
+        if (this.BUILDCONFIG.PLATFORM_USERS.includes(this.templateData.owner)) {
             this.templateOwner = this.BUILDCONFIG.APP_NAME;
         } else {
             this.userService.getUserById(this.templateData.owner).then(user => {

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.html
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.html
@@ -18,7 +18,8 @@
           ng-model="$ctrl.currentOwnershipFilter"
           ng-change="$ctrl.handleOwnershipFilterChange()"
         >
-          <option value="">All</option>
+          <option value="">Platform</option>
+          <option value="all">All</option>
           <option value="owned">Owned by me</option>
           <option value="shared">Shared with me</option>
         </select>

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.html
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.html
@@ -18,7 +18,7 @@
           ng-model="$ctrl.currentOwnershipFilter"
           ng-change="$ctrl.handleOwnershipFilterChange()"
         >
-          <option value="">Platform</option>
+          <option value="">{{$ctrl.BUILDCONFIG.APP_NAME}}</option>
           <option value="all">All</option>
           <option value="owned">Owned by me</option>
           <option value="shared">Shared with me</option>

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.js
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.js
@@ -1,4 +1,4 @@
-/* global _ */
+/* global _ BUILDCONFIG */
 
 class LabBrowseTemplatesController {
     constructor( // eslint-disable-line max-params
@@ -8,6 +8,7 @@ class LabBrowseTemplatesController {
     ) {
         'ngInject';
         $scope.autoInject(this, arguments);
+        this.BUILDCONFIG = BUILDCONFIG;
     }
 
     $onInit() {
@@ -19,30 +20,38 @@ class LabBrowseTemplatesController {
         this.search = search && search.length ? search : null;
         delete this.fetchError;
         this.results = [];
-        let currentQuery = this.analysisService.fetchTemplates({
+        const queryParams = {
             sort: 'createdAt,desc',
             pageSize: 10,
             page: page - 1,
-            search: this.search,
-            ownershipType: this.currentOwnershipFilter
-        }).then(paginatedResponse => {
-            this.results = paginatedResponse.results;
-            this.pagination = this.paginationService.buildPagination(paginatedResponse);
-            this.paginationService.updatePageParam(page, this.search, null, {
-                ownership: this.currentOwnershipFilter
+            search: this.search
+        };
+        if (!this.currentOwnershipFilter) {
+            queryParams.owner = this.BUILDCONFIG.PLATFORM_USERS;
+        } else if (this.currentOwnershipFilter !== 'all') {
+            queryParams.ownershipType = this.currentOwnershipFilter;
+        }
+
+        let currentQuery = this.analysisService
+            .fetchTemplates(queryParams)
+            .then(paginatedResponse => {
+                this.results = paginatedResponse.results;
+                this.pagination = this.paginationService.buildPagination(paginatedResponse);
+                this.paginationService.updatePageParam(page, this.search, null, {
+                    ownership: this.currentOwnershipFilter
+                });
+                if (this.currentQuery === currentQuery) {
+                    delete this.fetchError;
+                }
+            }, (e) => {
+                if (this.currentQuery === currentQuery) {
+                    this.fetchError = e;
+                }
+            }).finally(() => {
+                if (this.currentQuery === currentQuery) {
+                    delete this.currentQuery;
+                }
             });
-            if (this.currentQuery === currentQuery) {
-                delete this.fetchError;
-            }
-        }, (e) => {
-            if (this.currentQuery === currentQuery) {
-                this.fetchError = e;
-            }
-        }).finally(() => {
-            if (this.currentQuery === currentQuery) {
-                delete this.currentQuery;
-            }
-        });
         this.currentQuery = currentQuery;
     }
 


### PR DESCRIPTION
## Overview
Filter to platform users by default and show them as being owned by the platform

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/53271067-525b2500-36bb-11e9-947c-1b7861453ae8.png)


## Testing Instructions

 * Load the templates page and verify that it filters to the expected templates
* add your own user to the PLATFORM_USERS variable's array, restart webpack, and verify that your own templates show up but are shown as owned by the platform

Closes https://github.com/azavea/raster-foundry-platform/issues/640
