### PR TITLE
Use layer geometry to add a mask when creating analysis in v2 ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Updated `gdal-js` and `requests` [\#4618](https://github.com/raster-foundry/raster-foundry/pull/4618)
 - Swap trash icon for "Remove" text on scene item components [\#4621](https://github.com/raster-foundry/raster-foundry/pull/4621)
 - Bumped Nginx buffer size for scene creation requests [\#4672](https://github.com/raster-foundry/raster-foundry/pull/4672)
+- Use layer geometry to add a mask when creating analyses [\#4694](https://github.com/raster-foundry/raster-foundry/pull/4694)
 
 ### Deprecated
 

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.js
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.js
@@ -241,7 +241,11 @@ class ProjectCreateAnalysisPageController {
             projectId: this.project.id,
             projectLayerId: layer.id,
             templateId: template.id,
-            executionParameters: _.cloneDeep(template.definition)
+            executionParameters: layer.geometry ? {
+                id: this.uuid4.generate(),
+                args: [_.cloneDeep(template.definition)],
+                mask: layer.geometry
+            } : _.cloneDeep(template.definition)
         };
         let root = analysis.executionParameters;
         let nodes = root.args ? [...root.args] : [];

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.js
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.js
@@ -245,6 +245,7 @@ class ProjectCreateAnalysisPageController {
                 id: this.uuid4.generate(),
                 args: [_.cloneDeep(template.definition)],
                 mask: layer.geometry,
+                apply: 'mask',
                 metadata: {
                     label: 'Layer Mask',
                     collapsable: false

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.js
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.js
@@ -236,7 +236,7 @@ class ProjectCreateAnalysisPageController {
         // use template to create an analysis for layer
         const analysis = {
             id: this.uuid4.generate(),
-            name: template.title,
+            name: `${template.title}: ${layer.name}`,
             visibility: 'PRIVATE',
             projectId: this.project.id,
             projectLayerId: layer.id,
@@ -244,13 +244,20 @@ class ProjectCreateAnalysisPageController {
             executionParameters: layer.geometry ? {
                 id: this.uuid4.generate(),
                 args: [_.cloneDeep(template.definition)],
-                mask: layer.geometry
+                mask: layer.geometry,
+                metadata: {
+                    label: 'Layer Mask',
+                    collapsable: false
+                }
             } : _.cloneDeep(template.definition)
         };
         let root = analysis.executionParameters;
         let nodes = root.args ? [...root.args] : [];
         while (nodes.length) {
             const node = nodes.pop();
+            if (node.args && node.args.length) {
+                nodes = nodes.concat(node.args);
+            }
             if (['projectSrc', 'layerSrc'].includes(_.get(node, 'type'))) {
                 Object.assign(node, {
                     type: 'layerSrc',

--- a/app-frontend/src/app/components/projects/layerItem/index.js
+++ b/app-frontend/src/app/components/projects/layerItem/index.js
@@ -17,7 +17,7 @@ class LayerItemController {
         }
 
         const geometry = _.get(this.itemInfo, 'colorGroupHex');
-        this.hasGeom = _.get(this.itemInfo, 'geometry.features.length');
+        this.hasGeom = _.get(this.itemInfo, 'geometry.type');
     }
 }
 


### PR DESCRIPTION
## Overview
Use the layer geometry to wrap the tool-run in a mask node

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/53274774-7c661480-36c6-11e9-838b-9d5870733546.png)


### Notes
This assumes that if the geometry has a type, it isn't null. Not all valid geometries have features (most of our shapes are polygons for instance)


## Testing Instructions

 * Add a valid geometry to a layer 
eg: `update project_layers set geometry = (select extent from projects where id = '{project id}') where id = '{layer id}';
* Using that layer, create a new analysis and verify that it has a mask node in the network panel
* Create a new analysis using a layer that doesn't have a geometry and verify that it doesn't break, and doesn't wrap it in a mask node.
* In the database, edit the mask node by reprojecting it to EPSG3857 (from 4326), and edit the input bands to ones other than 0 (see related issue for why we need to reproject: https://github.com/raster-foundry/raster-foundry/issues/4700)
* check that you can open the analysis in the lab. The input nodes will not show up because the lab does not recognize layerSrc as inputs, but you should be able to fetch a histogram on the mask node and preview it if the coordinates overlap the actual data in the correct projection

Closes #4668 
