### PR TITLE
Resolve SC2120/SC2119 in scripts/bootstrap

### DIFF
--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -9,6 +9,7 @@
 
   roles:
     - role: "raster-foundry.docker"
+    - role: "raster-foundry.shellcheck"
     - role: "raster-foundry.aws-cli"
 
   tasks:

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -46,17 +46,17 @@ function pull_env() {
     popd
 }
 
+function override_build_repos() {
+    echo "Overriding repository configuration for ${1}"
+    echo "-Dsbt.override.build.repos=true" >> app-backend/.sbtopts
+    echo "-Dsbt.repository.config=project/${1}/repositories" >> app-backend/.sbtopts
+}
+
 function generate_sbtopts() {
     echo "Generating .sbtopts"
     pushd "${DIR}"
 
     cp app-backend/.sbtopts.sample app-backend/.sbtopts
-
-    function override_build_repos() {
-        echo "Overriding repository configuration for ${1}"
-        echo "-Dsbt.override.build.repos=true" >> app-backend/.sbtopts
-        echo "-Dsbt.repository.config=project/${1}/repositories" >> app-backend/.sbtopts
-    }
 
     if host nexus.internal.azavea.com; then
         override_build_repos "development"


### PR DESCRIPTION
## Overview

I uncovered this when working on https://github.com/azavea/raster-foundry-platform/issues/635.

`shellcheck=0.3.7` from Ubuntu 16.04 yields:

```bash
vagrant@vagrant:/opt/raster-foundry$ find ./scripts -type f -print0 | xargs -0 -r shellcheck

In ./scripts/bootstrap line 49:
function generate_sbtopts() {
^-- SC2120: generate_sbtopts references arguments, but none are ever passed.


In ./scripts/bootstrap line 81:
        generate_sbtopts
        ^-- SC2119: Use generate_sbtopts "$@" if function's $1 should mean script's $1.


In ./scripts/bootstrap line 84:
        generate_sbtopts
        ^-- SC2119: Use generate_sbtopts "$@" if function's $1 should mean script's $1.
```

We're running `shellcheck=0.3.3` in the Ubuntu 14.04 CI box right now.

According to the [change log](https://github.com/koalaman/shellcheck/blob/master/CHANGELOG.md#v032---2014-03-22
), `SC2120` and `SC2119` were added in `0.3.2`, so I don't understand why we aren't seeing this already.

This error doesn't surface in the Ubuntu 16.04 development VM, because we're not installing `shellcheck`, so `scripts/test` skips over executing that code block:

```bash
        if which shellcheck &>/dev/null; then
            echo "Linting STRTA scripts"
            find ./scripts -type f -print0 | xargs -0 -r shellcheck
        fi
```

If you install `shellcheck` in the Ubuntu 16.04 development VM, you can reproduce this error. It looks like it's just not getting picked up by the Ubuntu 14.04 apt repository's version of `shellcheck`.

## Testing Instructions

Install `shellcheck` on the development VM and see that linting fails on `develop`:

```bash
vagrant@vagrant:/opt/raster-foundry$ sudo apt-get install shellcheck
vagrant@vagrant:/opt/raster-foundry$ find ./scripts -type f -print0 | xargs -0 -r shellcheck

In ./scripts/bootstrap line 49:
function generate_sbtopts() {
^-- SC2120: generate_sbtopts references arguments, but none are ever passed.


In ./scripts/bootstrap line 81:
        generate_sbtopts
        ^-- SC2119: Use generate_sbtopts "$@" if function's $1 should mean script's $1.


In ./scripts/bootstrap line 84:
        generate_sbtopts
        ^-- SC2119: Use generate_sbtopts "$@" if function's $1 should mean script's $1.

vagrant@vagrant:/opt/raster-foundry$
```

Checkout this branch and `rsync` the changes into the development VM:

```bash
$ git checkout feature/jrb/fix-sc2120
$ vagrant rsync
```

Make sure that `shellcheck` linting passes:

```bash
vagrant@vagrant:/opt/raster-foundry$ find ./scripts -type f -print0 | xargs -0 -r shellcheck
vagrant@vagrant:/opt/raster-foundry$
```