### PR TITLE
Strip "Bearer " from tokens in credentials service

### DIFF
--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -182,7 +182,10 @@ trait UploadRoutes
               .transact(xa)
               .unsafeToFuture) {
             case Some(_) =>
-              complete(CredentialsService.getCredentials(user, uploadId, jwt))
+              complete(
+                CredentialsService.getCredentials(user,
+                                                  uploadId,
+                                                  jwt.split(" ").last))
             case None => complete(StatusCodes.NotFound)
           }
         case _ =>


### PR DESCRIPTION
## Overview

This PR strips `Bearer ` from JWTs in the credentials service so that we can upload imagery again. The bug was introduced in #4656 when I changed the results of `extractTokenHeader` and didn't include testing uploads, which changed, as part of the testing instructions.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ staging bug only

## Testing Instructions

 * try to upload a tif from a local file
 * you shouldn't get stuck

Closes azavea/raster-foundry-platform#645
