### PR TITLE
Add license fk and single source to tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added owner query parameter to tools and tool-runs endpoints, support multiple owner qp's on applicable endpoints [\#4689](https://github.com/raster-foundry/raster-foundry/pull/4689)
 - Added Rollbar error reporting to backsplash [\#4691](https://github.com/raster-foundry/raster-foundry/pull/4691)
 - Added PLATFORM_USERS webpack overrides variable and make default platform filter use those ids [\#4692](https://github.com/raster-foundry/raster-foundry/pull/4692)
+- Added flag for whether tools can sensibly be run with only a single layer as input [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701)
 
 ### Changed
 
@@ -26,6 +27,7 @@
 - Swap trash icon for "Remove" text on scene item components [\#4621](https://github.com/raster-foundry/raster-foundry/pull/4621)
 - Bumped Nginx buffer size for scene creation requests [\#4672](https://github.com/raster-foundry/raster-foundry/pull/4672)
 - Use layer geometry to add a mask when creating analyses [\#4694](https://github.com/raster-foundry/raster-foundry/pull/4694)
+- Made tools reference licenses by id [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/tools/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/tools/QueryParameters.scala
@@ -3,10 +3,18 @@ package com.rasterfoundry.api.tool
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.api.utils.queryparams._
 
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.directives.ParameterDirectives.parameters
+
 trait ToolQueryParameterDirective extends QueryParametersCommon {
+
+  val toolSpecificQueryParams = parameters(
+    'singleSource.as[Boolean].?
+  ).as(ToolQueryParameters.apply _)
   def combinedToolQueryParams =
     (
-      orgQueryParams &
+      toolSpecificQueryParams &
+        orgQueryParams &
         userQueryParameters &
         timestampQueryParameters &
         searchParams &

--- a/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
+++ b/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
@@ -163,8 +163,20 @@ object AoiQueryParameters {
     deriveDecoder[AoiQueryParameters]
 }
 
+final case class ToolQueryParameters(
+    singleSource: Option[Boolean] = None
+)
+
+object ToolQueryParameters {
+  implicit def encToolQueryParameters: Encoder[ToolQueryParameters] =
+    deriveEncoder[ToolQueryParameters]
+  implicit def decToolQueryParameters: Decoder[ToolQueryParameters] =
+    deriveDecoder[ToolQueryParameters]
+}
+
 /** Combined tool query parameters */
 final case class CombinedToolQueryParameters(
+    toolParams: ToolQueryParameters = ToolQueryParameters(),
     orgParams: OrgQueryParameters = OrgQueryParameters(),
     userParams: UserQueryParameters = UserQueryParameters(),
     timestampParams: TimestampQueryParameters = TimestampQueryParameters(),

--- a/app-backend/common/src/main/scala/datamodel/Tool.scala
+++ b/app-backend/common/src/main/scala/datamodel/Tool.scala
@@ -17,11 +17,12 @@ final case class Tool(id: UUID,
                       title: String,
                       description: String,
                       requirements: String,
-                      license: String,
+                      license: Option[Int],
                       visibility: Visibility,
                       compatibleDataSources: List[String] = List.empty,
                       stars: Float = 0.0f,
-                      definition: Json) {
+                      definition: Json,
+                      singleSource: Boolean) {
   def withRelatedFromComponents(
       toolTags: Seq[ToolTag],
       toolCategories: Seq[ToolCategory],
@@ -42,6 +43,7 @@ final case class Tool(id: UUID,
     this.compatibleDataSources,
     this.stars,
     this.definition,
+    this.singleSource,
     toolTags,
     toolCategories
   )
@@ -64,6 +66,7 @@ final case class Tool(id: UUID,
     this.compatibleDataSources,
     this.stars,
     this.definition,
+    this.singleSource,
     toolTagIds,
     toolCategorySlugs
   )
@@ -79,12 +82,13 @@ object Tool {
   final case class Create(title: String,
                           description: String,
                           requirements: String,
-                          license: String,
+                          license: Option[Int],
                           visibility: Visibility,
                           compatibleDataSources: List[String],
                           owner: Option[String],
                           stars: Float,
                           definition: Json,
+                          singleSource: Boolean,
                           tags: Seq[UUID],
                           categories: Seq[String])
       extends OwnerCheck {
@@ -109,7 +113,8 @@ object Tool {
         visibility,
         compatibleDataSources,
         stars,
-        definition
+        definition,
+        singleSource
       )
 
       val toolTagToTools = tags.map(tagId => ToolTagToTool(tagId, toolId))
@@ -143,11 +148,12 @@ object Tool {
                                title: String,
                                description: String,
                                requirements: String,
-                               license: String,
+                               license: Option[Int],
                                visibility: Visibility,
                                compatibleDataSources: List[String] = List.empty,
                                stars: Float = 0.0f,
                                definition: Json,
+                               singleSource: Boolean,
                                tags: Seq[ToolTag],
                                categories: Seq[ToolCategory])
 
@@ -186,12 +192,13 @@ object Tool {
                                     title: String,
                                     description: String,
                                     requirements: String,
-                                    license: String,
+                                    license: Option[Int],
                                     visibility: Visibility,
                                     compatibleDataSources: List[String] =
                                       List.empty,
                                     stars: Float = 0.0f,
                                     definition: Json,
+                                    singleSource: Boolean,
                                     tags: Seq[UUID],
                                     categories: Seq[String])
 }

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -719,12 +719,13 @@ object Generators extends ArbitraryInstances {
       title <- nonEmptyStringGen
       description <- nonEmptyStringGen
       requirements <- nonEmptyStringGen
-      license <- Gen.const("BSD-3")
+      license <- Gen.const(Option.empty[Int])
       visibility <- visibilityGen
       compatibleDataSources <- Gen.const(List.empty)
       owner <- Gen.const(None)
       stars <- Gen.const(9999.9f) // good tools only :sunglasses:
       definition <- Gen.const(().asJson)
+      singleSource <- arbitrary[Boolean]
       // not super into dealing with tags or categories in testing-land right now
       tags <- Gen.const(Seq.empty)
       categories <- Gen.const(Seq.empty)
@@ -739,6 +740,7 @@ object Generators extends ArbitraryInstances {
         owner,
         stars,
         definition,
+        singleSource,
         tags,
         categories
       )
@@ -939,6 +941,14 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbToolCreate: Arbitrary[Tool.Create] =
       Arbitrary { toolCreateGen }
+
+    implicit def arbListToolCreate: Arbitrary[List[Tool.Create]] =
+      Arbitrary {
+        Gen.oneOf(
+          Gen.listOfN(7, toolCreateGen),
+          Gen.listOfN(0, toolCreateGen)
+        )
+      }
 
     implicit def arbToolRunCreate: Arbitrary[ToolRun.Create] =
       Arbitrary { toolRunCreateGen }

--- a/app-backend/db/src/main/scala/ToolDao.scala
+++ b/app-backend/db/src/main/scala/ToolDao.scala
@@ -23,7 +23,8 @@ object ToolDao extends Dao[Tool] with ObjectPermissions[Tool] {
   val selectF = sql"""
     SELECT
       id, created_at, modified_at, created_by, modified_by, owner, title,
-      description, requirements, license, visibility, compatible_data_sources, stars, definition
+      description, requirements, license, visibility, compatible_data_sources, stars, definition,
+      single_source
     FROM """ ++ tableF
 
   def insert(newTool: Tool.Create, user: User): ConnectionIO[Tool] = {
@@ -34,11 +35,12 @@ object ToolDao extends Dao[Tool] with ObjectPermissions[Tool] {
     sql"""
        INSERT INTO tools
          (id, created_at, modified_at, created_by, modified_by, owner, title,
-          description, requirements, license, visibility, compatible_data_sources, stars, definition)
+          description, requirements, license, visibility, compatible_data_sources, stars, definition,
+          single_source)
        VALUES
          (${id}, ${now}, ${now}, ${user.id}, ${user.id}, ${ownerId}, ${newTool.title},
           ${newTool.description}, ${newTool.requirements}, ${newTool.license}, ${newTool.visibility},
-          ${newTool.compatibleDataSources}, ${newTool.stars}, ${newTool.definition})
+          ${newTool.compatibleDataSources}, ${newTool.stars}, ${newTool.definition}, ${newTool.singleSource})
        """.update.withUniqueGeneratedKeys[Tool](
       "id",
       "created_at",
@@ -53,7 +55,8 @@ object ToolDao extends Dao[Tool] with ObjectPermissions[Tool] {
       "visibility",
       "compatible_data_sources",
       "stars",
-      "definition"
+      "definition",
+      "single_source"
     )
   }
 
@@ -72,7 +75,8 @@ object ToolDao extends Dao[Tool] with ObjectPermissions[Tool] {
          visibility = ${tool.visibility},
          compatible_data_sources = ${tool.compatibleDataSources},
          stars = ${tool.stars},
-         definition = ${tool.definition}
+         definition = ${tool.definition},
+         single_source = ${tool.singleSource}
      """ ++ Fragments.whereAndOpt(Some(idFilter))).update.run
   }
 

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -96,7 +96,8 @@ trait Filterables extends RFMeta with LazyLogging {
           Filters.searchQP(
             toolParams.searchParams,
             List("title", "description")
-          )
+          ) ++
+          Filters.toolQP(toolParams.toolParams)
     }
 
   implicit val annotationQueryparamsFilter

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -10,6 +10,12 @@ import Fragments.in
 
 object Filters {
 
+  def toolQP(toolParams: ToolQueryParameters): List[Option[Fragment]] = {
+    List(toolParams.singleSource map { p =>
+      fr"single_source = $p"
+    })
+  }
+
   def userQP(userParams: UserQueryParameters): List[Option[Fragment]] = {
     onlyUserQP(userParams.onlyUserParams) :::
       ownerQP(userParams.ownerParams) :::

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
@@ -1,14 +1,105 @@
 package com.rasterfoundry.database
 
-import doobie.implicits._
-import org.scalatest._
+import com.rasterfoundry.common.datamodel._
+import com.rasterfoundry.common.datamodel.Generators.Implicits._
+import com.rasterfoundry.database.Implicits._
 
-class ToolDaoSpec extends FunSuite with Matchers with DBTestConfig {
+import cats.implicits._
+import doobie.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+class ToolDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
   test("selection types") {
     xa.use(t => ToolDao.query.list.transact(t))
       .unsafeRunSync
       .length should be >= 0
   }
 
-  // TODO add select and update tests (that will have to test creation)
+  test("list tools") {
+    check {
+      forAll {
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         toolCreates: List[Tool.Create]) =>
+          {
+            val toolListIO = for {
+              (_, dbUser) <- insertUserAndOrg(userCreate, orgCreate)
+              dbTools <- toolCreates traverse { toolCreate =>
+                ToolDao.insert(toolCreate, dbUser)
+              }
+              listed <- ToolDao
+                .authQuery(dbUser,
+                           ObjectType.Template,
+                           ownershipTypeO = Some("owned"))
+                .list
+            } yield (dbTools, listed)
+
+            val (inserted, listed) =
+              xa.use(t => toolListIO.transact(t)).unsafeRunSync
+
+            assert(toolCreates.length == inserted.length,
+                   "all of the tools were inserted into the db")
+            assert(inserted.length == listed.length,
+                   "counts of inserted and listed tools match")
+            assert(Set(toolCreates map { _.title }) == Set(listed map {
+              _.title
+            }), "titles of listed tools are the same as the Tool.Creates")
+            true
+          }
+      }
+    }
+  }
+
+  test("update a tool") {
+    check {
+      forAll {
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         toolCreate1: Tool.Create,
+         toolCreate2: Tool.Create) =>
+          {
+            val updateIO = for {
+              (_, dbUser) <- insertUserAndOrg(userCreate, orgCreate)
+              dbTool1 <- ToolDao.insert(toolCreate1, dbUser)
+              dbTool2 <- ToolDao.insert(toolCreate1, dbUser)
+              _ <- ToolDao.update(dbTool2, dbTool1.id, dbUser)
+              fetched <- ToolDao.query.filter(dbTool1.id).select
+            } yield (dbTool2, fetched)
+
+            val (updateTool, fetched) =
+              xa.use(t => updateIO.transact(t)).unsafeRunSync
+            assert(
+              fetched.title == updateTool.title,
+              "Title of fetched tool should be the title of the udpate tool")
+            assert(
+              fetched.description == updateTool.description,
+              "Description of fetched tool should be the description of the udpate tool")
+            assert(
+              fetched.requirements == updateTool.requirements,
+              "Requirements of fetched tool should be the requirements of the udpate tool")
+            assert(
+              fetched.visibility == updateTool.visibility,
+              "Visibility of fetched tool should be the visibility of the udpate tool")
+            assert(
+              fetched.compatibleDataSources == updateTool.compatibleDataSources,
+              "CompatibleDataSources of fetched tool should be the compatibleDataSources of the udpate tool"
+            )
+            assert(
+              fetched.stars == updateTool.stars,
+              "Stars of fetched tool should be the stars of the udpate tool")
+            assert(
+              fetched.singleSource == updateTool.singleSource,
+              "SingleSource of fetched tool should be the singleSource of the udpate tool")
+            true
+          }
+      }
+    }
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ToolDaoSpec.scala
@@ -9,4 +9,6 @@ class ToolDaoSpec extends FunSuite with Matchers with DBTestConfig {
       .unsafeRunSync
       .length should be >= 0
   }
+
+  // TODO add select and update tests (that will have to test creation)
 }

--- a/app-backend/migrations/src/main/scala/migrations/168.scala
+++ b/app-backend/migrations/src/main/scala/migrations/168.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/168.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -165,4 +165,5 @@ object MigrationSummary {
   M165
   M166
   M167
+  M168
 }

--- a/app-backend/migrations/src_migrations/main/scala/168.scala
+++ b/app-backend/migrations/src_migrations/main/scala/168.scala
@@ -1,0 +1,15 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M168 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(168)(
+    List(
+      sqlu"""
+ALTER TABLE licenses ADD CONSTRAINT id_is_unique UNIQUE (id);
+ALTER TABLE tools DROP COLUMN license;
+ALTER TABLE tools
+  ADD COLUMN license integer references licenses(id),
+  ADD COLUMN single_source boolean NOT NULL DEFAULT false;
+"""
+    ))
+}


### PR DESCRIPTION
## Overview

This PR adds `singleSource` to `Tool`s and changes the license field to be a nullable foreign key to licenses.

TODO:

- [x] add query parameter for single source
- [ ] add query parameter for license? I'm not sure about this

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated (raster-foundry/raster-foundry-api-spec#92)
- [x] Symlinks from new migrations present or corrected for any new migrations
- [x] Any new SQL strings have tests

## Testing Instructions

 * run migrations
 * bring up your servers and frontend
 * copy an API query for tools from the frontend
 * update some of your tools to have `single_source = true` in the db
 * run the API query you copied but with `singleSource=true`
 * observe that you only get back those tools where you set that to be the case

Closes #4675 
