### PR TITLE
Use singleSource param to find valid templates for single layer analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Added owner query parameter to tools and tool-runs endpoints, support multiple owner qp's on applicable endpoints [\#4689](https://github.com/raster-foundry/raster-foundry/pull/4689)
 - Added Rollbar error reporting to backsplash [\#4691](https://github.com/raster-foundry/raster-foundry/pull/4691)
 - Added PLATFORM_USERS webpack overrides variable and make default platform filter use those ids [\#4692](https://github.com/raster-foundry/raster-foundry/pull/4692)
-- Added flag for whether tools can sensibly be run with only a single layer as input [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701)
+- Added flag for whether tools can sensibly be run with only a single layer as input [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701) and used it to filter templates for layer analysis creation [\#4711](https://github.com/raster-foundry/raster-foundry/pull/4711)
 
 ### Changed
 

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.html
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.html
@@ -64,7 +64,7 @@
             start-index="$ctrl.pagination.startingItem"
             end-index="$ctrl.pagination.endingItem"
             total="$ctrl.pagination.count"
-            item-name="analyses"
+            item-name="templates"
         >
           <span ng-if="$ctrl.search">while searching for <strong>{{ $ctrl.search }}</strong></span>
         </rf-pagination-count>

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.js
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.js
@@ -63,7 +63,8 @@ class ProjectCreateAnalysisPageController {
         let params = {
             sort: 'createdAt,desc',
             pageSize: 10,
-            page: page - 1
+            page: page - 1,
+            singleSource: true
         };
 
         if (this.search) {

--- a/app-frontend/src/app/components/pages/project/createAnalysis/index.js
+++ b/app-frontend/src/app/components/pages/project/createAnalysis/index.js
@@ -78,7 +78,7 @@ class ProjectCreateAnalysisPageController {
             this.templateList = paginatedResponse.results;
             this.itemActions = new Map(this.templateList.map(this.addItemActions.bind(this)));
             this.fetchCreators(this.templateList).then((creators) => {
-                if (creators.has(_.first(this.templateList).id)) {
+                if (creators.has(_.get(_.first(this.templateList), 'id'))) {
                     this.templateCreators = creators;
                 }
             });

--- a/app-frontend/src/app/components/pages/project/layer/colormode/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/colormode/index.js
@@ -113,8 +113,6 @@ class LayerColormodeController {
             );
         });
 
-        console.log(key);
-
         if (!key) {
             this.initCustomColorMode();
             return 'custom';


### PR DESCRIPTION
## Overview

This PR uses the `singleSource` param from #4701 to filter to templates that layers can use for analyses.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I think it's fine that the analysis can't be rendered right now, since execution params aren't saturated? Hydrated? I don't remember what word we picked:

```json
{
  "id": "a2816828-3e34-42c4-9085-e681acf8de61",
  "args": [
    {
      "id": "7f8fdbda-fcc0-4ba7-8193-95741abaed78",
      "args": [
        {
          "id": "39c2812f-fa5d-435a-b92a-77cf7995a0ad",
          "type": "src",
          "metadata": {
            "label": "NIR"
          }
        },
        {
          "id": "7ceb6ca9-774b-4681-adae-ecb3a1bd2d75",
          "type": "src",
          "metadata": {
            "label": "SWIR2"
          }
        }
      ],
      "apply": "-",
      "metadata": {
        "label": "subtract"
      }
    },
    {
      "id": "4e19f95e-0240-4c18-8360-89f9f7f14103",
      "args": [
        {
          "id": "39c2812f-fa5d-435a-b92a-77cf7995a0ad",
          "type": "src",
          "metadata": {
            "label": "NIR"
          }
        },
        {
          "id": "7ceb6ca9-774b-4681-adae-ecb3a1bd2d75",
          "type": "src",
          "metadata": {
            "label": "SWIR2"
          }
        }
      ],
      "apply": "+",
      "metadata": {
        "label": "add"
      }
    }
  ],
  "apply": "/",
  "metadata": {
    "label": "divide"
  }
}
```

Anyway if that's _not_ fine, and it matters that we're getting null pointer exceptions in backsplash after creating analyses / that we're not autofilling the execution params with something we can use to paint a picture, then I can work on that as well, but I think that's what #4605 is for.

## Testing Instructions

 * try to create an analysis from a layer
 * note that you don't have any templates listed
 * set a reasonable template in your database to `single_source = true` (I used NBR, NDVI would also be fine)
 * reload the page
 * confirm you can see only that one

Closes #4678 
