### PR TITLE
Warn unused only in compile

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -33,12 +33,14 @@ lazy val commonSettings = Seq(
     "-Xmax-classfile-name",
     "100",
     "-Yrangepos",
-    "-Ywarn-value-discard",
-    "-Ywarn-unused",
-    "-Ywarn-unused-import",
     "-Ypartial-unification",
     "-Ypatmat-exhaust-depth",
     "100"
+  ),
+  scalacOptions in (Compile) ++= Seq(
+    "-Ywarn-value-discard",
+    "-Ywarn-unused",
+    "-Ywarn-unused-import"
   ),
   // https://github.com/sbt/sbt/issues/3570
   updateOptions := updateOptions.value.withGigahorse(false),


### PR DESCRIPTION
## Overview

The `console` in subproject contexts became unusable due to unused warnings even in the `console` stage. This PR moves the `warn-unused` settings to the `Compile` stage only.

## Notes

Fixed in pursuit of something unrelated that I'ved failed to fix yet, but useful in case anyone else ever wants to use the console

## Testing Instructions

 * open the console in a subproject that has startup scala commands (like `db`)
 * it shouldn't die with initialization errors
 * import something that you haven't used yet
 * the console shouldn't be mad at you