### PR TITLE
Fix calculation of hasNext for scene paginated responses

### DIFF
--- a/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
+++ b/app-backend/db/src/main/scala/SceneWithRelatedDao.scala
@@ -42,13 +42,13 @@ object SceneWithRelatedDao
           .filter(shapeO map { _.geometry })
           .filter(sceneParams)
       }
-      scenes <- sceneSearchBuilder.page(
+      scenesPage <- sceneSearchBuilder.page(
         pageRequest,
         Map("acquisitionDatetime" -> Order.Desc) ++ pageRequest.sort,
         false
-      ) map { _.results toList }
+      )
       sceneBrowses <- scenesToSceneBrowse(
-        scenes,
+        scenesPage.results toList,
         sceneParams.sceneParams.project,
         sceneParams.sceneParams.layer
       )
@@ -56,11 +56,10 @@ object SceneWithRelatedDao
         sceneParams.sceneSearchModeParams.exactCount)
     } yield {
       val hasPrevious = pageRequest.offset > 0
-      val hasNext = sceneBrowses.size > pageRequest.limit
       PaginatedResponse[Scene.Browse](
         count,
         hasPrevious,
-        hasNext,
+        scenesPage.hasNext,
         pageRequest.offset,
         pageRequest.limit,
         sceneBrowses.take(pageRequest.limit)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/SceneWithRelatedDaoSpec.scala
@@ -86,6 +86,10 @@ class SceneWithRelatedDaoSpec
               "Listing with datasource should count the same number of scenes we started with"
             )
             assert(
+              listedScenes.hasNext == insertedScenes.length > pageRequest.limit,
+              "Has next correctly reflects whether there are more scenes"
+            )
+            assert(
               listedWithDS.results.length == (listedWithDS.count `min` pageRequest.limit),
               "Listing with datasource should return from the db the same number of scenes we started with"
             )


### PR DESCRIPTION
## Overview

This PR fixes `hasNext` calculations for inexact counts on scenes. It also makes sure that the test for scene pagination confirms that not only do we get the right number of scenes, but that we calculate `hasNext` correctly as well.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ staging only
- [x] Any new SQL strings have tests

## Testing Instructions

 * tests
 * browse for scenes in frontend
 * confirm you sometimes get a `load more scenes` button

Closes #4714
