### PR TITLE
Add Project Layer Export Create UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added flag for whether tools can sensibly be run with only a single layer as input [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701) and used it to filter templates for layer analysis creation [\#4711](https://github.com/raster-foundry/raster-foundry/pull/4711)
 - Added AOI creation UI and component [\#4702](https://github.com/raster-foundry/raster-foundry/pull/4702)
 - Added single band options to project layers [\#4712](https://github.com/raster-foundry/raster-foundry/pull/4712)
+- Added project layer export creation UI [\#4718](https://github.com/raster-foundry/raster-foundry/pull/4718)
 
 ### Changed
 

--- a/app-frontend/src/app/components/pages/project/layer/aoi/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/aoi/index.js
@@ -8,9 +8,18 @@ const defaultColor = '#738FFC';
 
 class ProjectLayerAoiController {
     constructor(
-        $rootScope, $scope, $state, $log, $window,
-        uuid4, moment, projectService, paginationService, mapService,
-        modalService, shapesService
+        $rootScope,
+        $scope,
+        $state,
+        $log,
+        $window,
+        uuid4,
+        moment,
+        projectService,
+        paginationService,
+        mapService,
+        modalService,
+        shapesService
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -73,21 +82,21 @@ class ProjectLayerAoiController {
         this.itemList = [];
         let fetchedList = [];
         const currentQuery = this.projectService
-            .getProjectLayers(this.project.id, {pageSize: 30, page: page - 1})
-            .then((paginatedResponse) => {
+            .getProjectLayers(this.project.id, { pageSize: 30, page: page - 1 })
+            .then(paginatedResponse => {
                 fetchedList = paginatedResponse.results;
-                this.itemList = fetchedList.filter(
-                    fl => fl.geometry && fl.id !== this.layer.id
-                ).map(fl => {
-                    return {
-                        id: fl.id,
-                        name: fl.name,
-                        subtext: '',
-                        date: fl.createdAt,
-                        colorGroupHex: fl.colorGroupHex,
-                        geometry: fl.geometry
-                    };
-                });
+                this.itemList = fetchedList
+                    .filter(fl => fl.geometry && fl.id !== this.layer.id)
+                    .map(fl => {
+                        return {
+                            id: fl.id,
+                            name: fl.name,
+                            subtext: '',
+                            date: fl.createdAt,
+                            colorGroupHex: fl.colorGroupHex,
+                            geometry: fl.geometry
+                        };
+                    });
                 if (this.itemList.length) {
                     this.onSelect(this.layer.id);
                 }
@@ -97,7 +106,7 @@ class ProjectLayerAoiController {
                     delete this.fetchError;
                 }
             })
-            .catch((e) => {
+            .catch(e => {
                 if (this.currentQuery === currentQuery) {
                     this.fetchError = e;
                 }
@@ -115,8 +124,9 @@ class ProjectLayerAoiController {
         this.itemList = [];
         let fetchedList = [];
 
-        const currentQuery = this.shapesService.query({pageSize: 30, page: page - 1})
-            .then((paginatedResponse) => {
+        const currentQuery = this.shapesService
+            .query({ pageSize: 30, page: page - 1 })
+            .then(paginatedResponse => {
                 fetchedList = paginatedResponse.features;
                 this.itemList = fetchedList.map(fl => {
                     return {
@@ -134,7 +144,7 @@ class ProjectLayerAoiController {
                     delete this.fetchError;
                 }
             })
-            .catch((e) => {
+            .catch(e => {
                 if (this.currentQuery === currentQuery) {
                     this.fetchError = e;
                 }
@@ -164,8 +174,8 @@ class ProjectLayerAoiController {
             this.$window.alert('The supplied AOI geometry is incorrect. Please try again.');
             return;
         }
-        const layerGeomToUpdate = this.generateFeature(geom);
-        const updatedLayer = Object.assign({}, this.layer, {geometry: layerGeomToUpdate});
+        const layerGeomToUpdate = this.shapesService.generateFeature(geom);
+        const updatedLayer = Object.assign({}, this.layer, { geometry: layerGeomToUpdate });
         this.projectService
             .updateProjectLayer(updatedLayer)
             .then(newLayer => {
@@ -179,8 +189,9 @@ class ProjectLayerAoiController {
             })
             .catch(err => {
                 this.$log.error(err);
-                this.$window.alert('There was an error updating this layer\'s AOI.'
-                    + ' Please try again later');
+                this.$window.alert(
+                    'There was an error updating this layer\'s AOI.' + ' Please try again later'
+                );
             });
     }
 
@@ -206,52 +217,35 @@ class ProjectLayerAoiController {
             component: 'rfEnterTokenModal',
             resolve: {
                 title: () => 'Enter a name for the vector data',
-                token: () => `${this.project.name} - ${layer.name} AOI `
-                    + `- ${this.formatDateDisplay(layer.createdAt)}`
+                token: () =>
+                    `${this.project.name} - ${layer.name} AOI ` +
+                    `- ${this.formatDateDisplay(layer.createdAt)}`
             }
         });
 
-        modal.result.then((name) => {
-            const geom = this.getMultipolygonGeom(layer.geometry);
+        modal.result
+            .then(name => {
+                const geom = this.getMultipolygonGeom(layer.geometry);
 
-            if (!geom) {
-                this.$window('The supplied geometry is incorrect, please try again.');
-                return;
-            }
+                if (!geom) {
+                    this.$window('The supplied geometry is incorrect, please try again.');
+                    return;
+                }
 
-            this.shapesService
-                .createShape(this.generateFeatureCollection(geom, name))
-                .then(() => {
-                    this.$state.go('project.layer');
-                })
-                .catch(err => {
-                    this.$window.alert('There was an error adding this layer\'s AOI as vector data.'
-                        + ' Please try again later');
-                    this.$log.error(err);
-                });
-        }).catch(() => {});
-    }
-
-    generateFeatureCollection(geometry, name = '') {
-        return {
-            type: 'FeatureCollection',
-            features: [this.generateFeature(geometry, name)]
-        };
-    }
-
-    generateFeature(geometry, name = '') {
-        let result = {
-            type: 'Feature',
-            properties: {},
-            geometry
-        };
-
-        if (name.length) {
-            result.id = this.uuid4.generate();
-            result.properties = { name };
-        }
-
-        return result;
+                this.shapesService
+                    .createShape(this.shapesService.generateFeatureCollection([geom], name))
+                    .then(() => {
+                        this.$state.go('project.layer');
+                    })
+                    .catch(err => {
+                        this.$window.alert(
+                            'There was an error adding this layer\'s AOI as vector data.' +
+                                ' Please try again later'
+                        );
+                        this.$log.error(err);
+                    });
+            })
+            .catch(() => {});
     }
 
     onCancelDrawAoi() {
@@ -303,5 +297,4 @@ const component = {
 export default angular
     .module('components.pages.project.layer.aoi', [])
     .controller(ProjectLayerAoiController.name, ProjectLayerAoiController)
-    .component('rfProjectLayerAoiPage', component)
-    .name;
+    .component('rfProjectLayerAoiPage', component).name;

--- a/app-frontend/src/app/components/pages/project/layer/export/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/export/index.html
@@ -1,1 +1,67 @@
-Export
+<div class="sidebar-overlay" ng-if="$ctrl.isDrawAoiClicked || $ctrl.isDrawing"></div>
+<rf-aoi-draw-toolbar
+  ng-if="$ctrl.isDrawAoiClicked"
+  map-id="$ctrl.mapId"
+  geom-draw-type="$ctrl.geomDrawType"
+  on-cancel="$ctrl.onCancelDrawAoi()"
+  on-confirm-aoi="$ctrl.onConfirmAoi(aoiGeojson, isSaveShape)"
+  on-shape-op="$ctrl.onShapeOp(isInProgress)""
+  >
+</rf-aoi-draw-toolbar>
+<div class="sidebar-scrollable with-padding">
+  <div class="page-card page-card-form with-thin-bottom-margin">
+    <div class="form-group" ng-if="$ctrl.availableTargets && $ctrl.availableTargets.length">
+      <label for="export-target">Export to</label>
+      <div class="input-group">
+        <select
+          class="form-control"
+          name="export-target"
+          ng-model="$ctrl.exportTarget"
+          ng-change="$ctrl.onExportTargetChange()"
+        >
+        <option value={{target.value}} ng-repeat="target in $ctrl.availableTargets track by $index">
+          {{target.label}}
+        </option>
+        </select>
+      </div>
+    </div>
+    <div class="form-group" ng-if="$ctrl.availableResolutions && $ctrl.availableResolutions.length">
+      <label for="export-resolution">Zoom level</label>
+      <div class="input-group">
+        <select
+          class="form-control"
+          name="export-resolution"
+          ng-model="$ctrl.resolution"
+          ng-change="$ctrl.onResolutionChange()"
+        >
+          <option value="{{resolution.value.toString()}}" ng-repeat="resolution in $ctrl.availableResolutions track by $index">
+            {{resolution.value}} ({{resolution.label}}&sup2;)
+          </option>
+        </select>
+      </div>
+    </div>
+    <div class="form-group" ng-if="$ctrl.availableResolutions && $ctrl.availableResolutions.length">
+      <label>Area to export</label>
+      <div class="sidebar-actions-group">
+        <p>Define an area you want to export.</p>
+        <div class="column-4 nogutter btn-group">
+          <button
+            type="button"
+            class="btn btn-gohst"
+            ng-click="$ctrl.onClickDefineAoi()"
+          >
+            Define
+          </button>
+        </div>
+      </div>
+    </div>
+</div>
+<button
+  type="button"
+  class="btn btn-light"
+  ng-class="{'btn-primary': $ctrl.isValidExportDef()}"
+  ng-disabled="!$ctrl.isValidExportDef()"
+  ng-click="$ctrl.onClickCreateExport()"
+>
+  Create export
+</button>

--- a/app-frontend/src/app/components/pages/project/layer/export/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/export/index.html
@@ -3,6 +3,7 @@
   ng-if="$ctrl.isDrawAoiClicked"
   map-id="$ctrl.mapId"
   geom-draw-type="$ctrl.geomDrawType"
+  layer-aoi-geom="$ctrl.layerGeom"
   on-cancel="$ctrl.onCancelDrawAoi()"
   on-confirm-aoi="$ctrl.onConfirmAoi(aoiGeojson, isSaveShape)"
   on-shape-op="$ctrl.onShapeOp(isInProgress)""
@@ -25,6 +26,14 @@
         </select>
       </div>
     </div>
+    <div class="form-group" ng-if="$ctrl.exportTarget === 'externalS3'">
+      <div class="input-group">
+        <input type="url"
+               class="form-control"
+               placeholder="S3 Bucket URI"
+               ng-model="$ctrl.exportSource">
+      </div>
+    </div>
     <div class="form-group" ng-if="$ctrl.availableResolutions && $ctrl.availableResolutions.length">
       <label for="export-resolution">Zoom level</label>
       <div class="input-group">
@@ -32,7 +41,6 @@
           class="form-control"
           name="export-resolution"
           ng-model="$ctrl.resolution"
-          ng-change="$ctrl.onResolutionChange()"
         >
           <option value="{{resolution.value.toString()}}" ng-repeat="resolution in $ctrl.availableResolutions track by $index">
             {{resolution.value}} ({{resolution.label}}&sup2;)
@@ -50,7 +58,7 @@
             class="btn btn-gohst"
             ng-click="$ctrl.onClickDefineAoi()"
           >
-            Define
+            {{$ctrl.mask.type ? 'Update' : 'Define'}}
           </button>
         </div>
       </div>
@@ -63,5 +71,5 @@
   ng-disabled="!$ctrl.isValidExportDef()"
   ng-click="$ctrl.onClickCreateExport()"
 >
-  Create export
+  {{$ctrl.isCreatingExport ? 'Creating export...' : 'Create export'}}
 </button>

--- a/app-frontend/src/app/components/pages/project/layer/export/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/export/index.html
@@ -1,4 +1,4 @@
-<div class="sidebar-overlay" ng-if="$ctrl.isDrawAoiClicked || $ctrl.isDrawing"></div>
+<div class="sidebar-overlay" ng-if="$ctrl.isDrawAoiClicked || $ctrl.isDrawing || $ctrl.isCreatingExport"></div>
 <rf-aoi-draw-toolbar
   ng-if="$ctrl.isDrawAoiClicked"
   map-id="$ctrl.mapId"
@@ -10,7 +10,7 @@
   >
 </rf-aoi-draw-toolbar>
 <div class="sidebar-scrollable with-padding">
-  <div class="page-card page-card-form with-thin-bottom-margin">
+  <div class="page-card page-card-form cozy">
     <div class="form-group" ng-if="$ctrl.availableTargets && $ctrl.availableTargets.length">
       <label for="export-target">Export to</label>
       <div class="input-group">

--- a/app-frontend/src/app/components/pages/project/layer/export/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/export/index.js
@@ -300,6 +300,7 @@ class LayerExportCreateController {
 
     finishExport() {
         this.$timeout(() => {
+            this.isCreatingExport = false;
             this.$state.go('project.layer.exports', {
                 projectId: this.project.id,
                 layerId: this.layer.id

--- a/app-frontend/src/app/components/pages/project/layer/export/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/export/index.js
@@ -1,11 +1,112 @@
 import tpl from './index.html';
 
-class LayerExportCreateController {
+const mapName = 'project';
+const mapLayerName = 'Project Layer';
+const shapeLayerName = 'Export AOI';
+const geomDrawType = 'Polygon';
 
+class LayerExportCreateController {
+    constructor(
+        $rootScope,
+        $scope,
+        $state,
+        $log,
+        projectService,
+        mapService,
+        exportService,
+        authService,
+        modalService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.initExportTarget();
+        this.initResolutions();
+        this.setMapLayers();
+        this.initAoiDrawToolbar();
+    }
+
+    $onDestroy() {
+        this.removeMapLayers();
+        this.removeExportAois();
+    }
+
+    initAoiDrawToolbar() {
+        this.mapId = mapName;
+        this.geomDrawType = geomDrawType;
+        this.isDrawAoiClicked = false;
+    }
+
+    initExportTarget() {
+        this.availableTargets = this.exportService.getAvailableTargets();
+        const defaultTarget = this.availableTargets.find(target => target.default);
+        if (defaultTarget) {
+            this.exportTarget = defaultTarget.value;
+        }
+    }
+
+    initResolutions() {
+        this.availableResolutions = this.exportService.getAvailableResolutions();
+        const defaultResolution = this.availableResolutions[0];
+        if (defaultResolution) {
+            this.resolution = defaultResolution.value.toString();
+        }
+    }
+
+    getMap() {
+        return this.mapService.getMap(mapName);
+    }
+
+    setMapLayers() {
+        let mapLayer = this.projectService.mapLayerFromLayer(this.project, this.layer);
+        return this.getMap().then(map => {
+            map.setLayer(mapLayerName, mapLayer, true);
+        });
+    }
+
+    removeMapLayers() {
+        this.getMap().then(map => {
+            map.deleteLayers(mapLayerName);
+        });
+    }
+
+    removeExportAois() {
+        this.getMap().then(map => {
+            map.deleteGeojson(shapeLayerName);
+        });
+    }
+
+    onCancelDrawAoi() {
+        this.$log.log('cancel');
+        this.isDrawAoiClicked = false;
+    }
+
+    onConfirmAoi(aoiGeojson, isSaveShape) {
+        this.$log.log('confirm', aoiGeojson, isSaveShape);
+    }
+
+    onClickDefineAoi() {
+        this.isDrawAoiClicked = true;
+    }
+
+    isValidExportDef() {
+        const isValidTarget = this.exportTarget.value;
+        const isValidResolution = this.resolution;
+        // const isValidGeom = this.
+        return false;
+    }
+
+    onShapeOp(isInProgress) {
+        this.isDrawing = isInProgress;
+    }
 }
 
 const component = {
     bindings: {
+        project: '<',
+        layer: '<'
     },
     templateUrl: tpl,
     controller: LayerExportCreateController.name
@@ -14,5 +115,4 @@ const component = {
 export default angular
     .module('components.pages.project.layer.export', [])
     .controller(LayerExportCreateController.name, LayerExportCreateController)
-    .component('rfProjectLayerExportPage', component)
-    .name;
+    .component('rfProjectLayerExportPage', component).name;

--- a/app-frontend/src/app/components/projects/aoiDrawToolbar/index.html
+++ b/app-frontend/src/app/components/projects/aoiDrawToolbar/index.html
@@ -2,13 +2,13 @@
      ng-style="$ctrl.eleStyle">
   <div class="navbar-section aoi-draw-toolbar-left"
        ng-style="$ctrl.leftStyle">
-    <button class="btn btn-small btn-transparent"
+    <button class="btn btn-small btn-primary btn-aoi-actions"
             ng-click="$ctrl.onDrawAoi()"
             ng-disabled="$ctrl.isDrawingAoi"
             ng-if="!$ctrl.isValidGeometry()">
       <i class="icon-plus"></i> Draw AOI
     </button>
-    <button class="btn btn-small btn-transparent"
+    <button class="btn btn-small btn-primary btn-aoi-actions"
             ng-if="$ctrl.isValidGeometry()"
             ng-disabled="$ctrl.isEditingAoi"
             uib-dropdown

--- a/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
+++ b/app-frontend/src/app/pages/projects/edit/exports/new/new.module.js
@@ -4,9 +4,15 @@ import { min, range, isUndefined } from 'lodash';
 
 class NewExportController {
     constructor(
-        $scope, $state, $timeout,
-        projectService, analysisService, mapService,
-        projectEditService, exportService, authService,
+        $scope,
+        $state,
+        $timeout,
+        projectService,
+        analysisService,
+        mapService,
+        projectEditService,
+        exportService,
+        authService,
         modalService
     ) {
         'ngInject';
@@ -46,25 +52,27 @@ class NewExportController {
         this.exportProcessingOption = this.getDefaultProcessingOption();
         this.exportTarget = this.getDefaultTarget();
 
-        this.projectEditService.fetchCurrentProject().then(project => {
-            this.project = project;
-        }).then( () => {
-            this.projectService.getProjectDatasources(this.project.id).then(
-                datasources => {
-                    let minBands = min(datasources.map((datasource) => {
-                        return datasource.bands.length;
-                    }));
+        this.projectEditService
+            .fetchCurrentProject()
+            .then(project => {
+                this.project = project;
+            })
+            .then(() => {
+                this.projectService.getProjectDatasources(this.project.id).then(datasources => {
+                    let minBands = min(
+                        datasources.map(datasource => {
+                            return datasource.bands.length;
+                        })
+                    );
                     this.defaultBands = range(0, minBands);
-                }
-            );
-        });
-
+                });
+            });
 
         this.$scope.$on('$destroy', this.$onDestroy.bind(this));
     }
 
     $onDestroy() {
-        this.getMap().then((mapWrapper) => {
+        this.getMap().then(mapWrapper => {
             mapWrapper.deleteLayers('Export Area');
         });
     }
@@ -73,22 +81,20 @@ class NewExportController {
         return this.mapService.getMap('edit');
     }
 
-
     getDefaultTarget() {
-        return this.availableTargets.find(t => t.default) ||
-               this.availableTargets[0];
+        return this.availableTargets.find(t => t.default) || this.availableTargets[0];
     }
 
-
     getDefaultProcessingOption() {
-        return this.availableProcessingOptions.find(o => o.default) ||
-               this.availableProcessingOptions[0];
+        return (
+            this.availableProcessingOptions.find(o => o.default) ||
+            this.availableProcessingOptions[0]
+        );
     }
 
     getCurrentResolution() {
         const resolutionValue = this.exportOptions.resolution;
-        return this.availableResolutions
-            .find(r => r.value === resolutionValue);
+        return this.availableResolutions.find(r => r.value === resolutionValue);
     }
 
     getCurrentTarget() {
@@ -97,17 +103,15 @@ class NewExportController {
 
     getCurrentProcessingOption() {
         const option = this.exportProcessingOption;
-        return this.availableProcessingOptions
-            .find(o => o.value === option.value);
+        return this.availableProcessingOptions.find(o => o.value === option.value);
     }
-
 
     getExportOptions(options = {}) {
         return Object.assign(
             this.exportOptions,
             this.getCurrentProcessingOption().exportOptions,
-            this.mask ? {mask: this.mask} : {},
-            {bands: this.defaultBands},
+            this.mask ? { mask: this.mask } : {},
+            { bands: this.defaultBands },
             options
         );
     }
@@ -117,9 +121,7 @@ class NewExportController {
     }
 
     shouldShowProcessingParams(option) {
-        return this.isCurrentProcessingOption(option) &&
-               option.templateId &&
-               !this.isAnalysis;
+        return this.isCurrentProcessingOption(option) && option.templateId && !this.isAnalysis;
     }
 
     shouldShowTargetParams() {
@@ -136,7 +138,8 @@ class NewExportController {
 
     updateTarget(target) {
         if (target.value === 'dropbox') {
-            let hasDropbox = this.authService.user.dropboxCredential &&
+            let hasDropbox =
+                this.authService.user.dropboxCredential &&
                 this.authService.user.dropboxCredential.length;
             if (hasDropbox) {
                 this.exportTarget = target;
@@ -151,17 +154,20 @@ class NewExportController {
     }
 
     displayDropboxModal() {
-        this.modalService.open({
-            component: 'rfConfirmationModal',
-            resolve: {
-                title: () => 'You don\'t have Dropbox credential set',
-                content: () => 'Go to your API connections page and set one?',
-                confirmText: () => 'Add Dropbox credential',
-                cancelText: () => 'Cancel'
-            }
-        }).result.then((resp) => {
-            this.$state.go('user.settings.connections');
-        }).catch(() => {});
+        this.modalService
+            .open({
+                component: 'rfConfirmationModal',
+                resolve: {
+                    title: () => 'You don\'t have Dropbox credential set',
+                    content: () => 'Go to your API connections page and set one?',
+                    confirmText: () => 'Add Dropbox credential',
+                    cancelText: () => 'Cancel'
+                }
+            })
+            .result.then(resp => {
+                this.$state.go('user.settings.connections');
+            })
+            .catch(() => {});
     }
 
     handleOptionChange(state, option) {
@@ -193,13 +199,12 @@ class NewExportController {
         this.isAnalysis = true;
         this.currentAnalysisSources = null;
         this.templateRequest = this.analysisService.getTemplate(templateId);
-        this.templateRequest
-            .then(t => {
-                this.currentTemplate = t;
-                this.currentAnalysisSources = this.analysisService.generateSourcesFromAST(t);
-                this.currentAnalysis = this.analysisService.generateAnalysis(t);
-                this.isAnalysis = false;
-            });
+        this.templateRequest.then(t => {
+            this.currentTemplate = t;
+            this.currentAnalysisSources = this.analysisService.generateSourcesFromAST(t);
+            this.currentAnalysis = this.analysisService.generateAnalysis(t);
+            this.isAnalysis = false;
+        });
     }
 
     finalizeExportOptions() {
@@ -226,9 +231,7 @@ class NewExportController {
         if (this.getCurrentTarget().value === 'externalS3') {
             validationState = validationState && this.exportTargetURI;
         }
-        return validationState &&
-            !isUndefined(this.mask) &&
-            !isUndefined(this.defaultBands);
+        return validationState && !isUndefined(this.mask) && !isUndefined(this.defaultBands);
     }
 
     startExport() {
@@ -242,28 +245,29 @@ class NewExportController {
     }
 
     createAnalysisExport() {
-        this.analysisService
-            .createAnalysis(this.currentAnalysis)
-            .then(tr => {
-                this.projectService
-                    .export(
-                        this.project, {
-                            analysisId: tr.id
-                        },
-                        this.getExportOptions()
-                    )
-                    .finally(() => {
-                        this.finishExport();
-                    });
-            });
+        this.analysisService.createAnalysis(this.currentAnalysis).then(tr => {
+            this.projectService
+                .export(
+                    this.project,
+                    {
+                        analysisId: tr.id
+                    },
+                    this.getExportOptions()
+                )
+                .finally(() => {
+                    this.finishExport();
+                });
+        });
     }
 
     createBasicExport() {
         let exportOpts = this.getExportOptions();
         this.projectService
-            .export(this.project,
-                    {exportType: this.getCurrentTarget().value === 'dropbox' ? 'Dropbox' : 'S3' },
-                    this.getExportOptions())
+            .export(
+                this.project,
+                { exportType: this.getCurrentTarget().value === 'dropbox' ? 'Dropbox' : 'S3' },
+                this.getExportOptions()
+            )
             .finally(() => {
                 this.finishExport();
             });
@@ -291,11 +295,11 @@ class NewExportController {
                     };
                 }
             });
-            this.getMap().then((mapWrapper) => {
+            this.getMap().then(mapWrapper => {
                 mapWrapper.setLayer('Export Area', exportAreaLayer, true);
             });
         } else {
-            this.getMap().then((mapWrapper) => {
+            this.getMap().then(mapWrapper => {
                 mapWrapper.deleteLayers('Export Area');
             });
         }
@@ -303,14 +307,14 @@ class NewExportController {
 
     onDrawCancel() {
         this.drawing = false;
-        this.getMap().then((mapWrapper) => {
+        this.getMap().then(mapWrapper => {
             mapWrapper.showLayers('Export Area', true);
         });
     }
 
     startDrawing() {
         this.drawing = true;
-        this.getMap().then((mapWrapper) => {
+        this.getMap().then(mapWrapper => {
             mapWrapper.hideLayers('Export Area', false);
         });
     }

--- a/app-frontend/src/app/services/projects/export.service.js
+++ b/app-frontend/src/app/services/projects/export.service.js
@@ -1,6 +1,6 @@
 /* globals BUILDCONFIG */
 
-export default (app) => {
+export default app => {
     class ExportService {
         constructor($resource, $q, authService) {
             'ngInject';
@@ -8,9 +8,11 @@ export default (app) => {
             this.authService = authService;
 
             this.Export = $resource(
-                `${BUILDCONFIG.API_HOST}/api/exports/:id/`, {
+                `${BUILDCONFIG.API_HOST}/api/exports/:id/`,
+                {
                     id: '@properties.id'
-                }, {
+                },
+                {
                     query: {
                         method: 'GET',
                         cache: false,
@@ -40,15 +42,17 @@ export default (app) => {
 
         getFiles(exportObject) {
             const token = this.authService.token();
-            return this.$q((resolve) => {
-                this.Export
-                    .getFiles({ exportId: exportObject.id }).$promise
-                    .then(files => {
-                        resolve(files.map(f => {
+            return this.$q(resolve => {
+                this.Export.getFiles({ exportId: exportObject.id }).$promise.then(files => {
+                    resolve(
+                        files.map(f => {
                             // eslint-disable-next-line
-                            return `${BUILDCONFIG.API_HOST}/api/exports/${exportObject.id}/files/${f}?token=${token}`;
-                        }));
-                    });
+                            return `${BUILDCONFIG.API_HOST}/api/exports/${
+                                exportObject.id
+                            }/files/${f}?token=${token}`;
+                        })
+                    );
+                });
             });
         }
 
@@ -73,14 +77,14 @@ export default (app) => {
             const userRequest = this.authService.getCurrentUser();
 
             return userRequest.then(
-                (user) => {
+                user => {
                     return this.Export.createExport(
                         Object.assign(finalSettings, {
                             owner: user.id
                         })
                     ).$promise;
                 },
-                (error) => {
+                error => {
                     return error;
                 }
             );
@@ -141,16 +145,19 @@ export default (app) => {
                     label: 'Download',
                     value: 'internalS3',
                     default: true
-                }, {
+                },
+                {
                     label: 'Dropbox',
-                    value: 'dropbox'
+                    value: 'dropbox',
+                    default: false
                 }
             ];
 
             if (includeS3) {
                 targets.push({
                     label: 'S3 Bucket',
-                    value: 'externalS3'
+                    value: 'externalS3',
+                    default: false
                 });
             }
 
@@ -158,14 +165,13 @@ export default (app) => {
         }
 
         deleteExport(id) {
-            return this.Export.delete({id}).$promise;
+            return this.Export.delete({ id }).$promise;
         }
 
         deleteExports(ids) {
             return this.$q.all(ids.map(id => this.deleteExport(id)));
         }
     }
-
 
     app.service('exportService', ExportService);
 };

--- a/app-frontend/src/app/services/vectors/shapes.service.js
+++ b/app-frontend/src/app/services/vectors/shapes.service.js
@@ -1,26 +1,31 @@
 /* globals BUILDCONFIG */
-export default (app) => {
+export default app => {
     class ShapesService {
-        constructor($resource) {
-            this.shapeApi = $resource(`${BUILDCONFIG.API_HOST}/api/shapes/:id`, {
-                id: '@properties.id'
-            }, {
-                query: {
-                    method: 'GET',
-                    cache: false
+        constructor(uuid4, $resource) {
+            this.shapeApi = $resource(
+                `${BUILDCONFIG.API_HOST}/api/shapes/:id`,
+                {
+                    id: '@properties.id'
                 },
-                get: {
-                    method: 'GET',
-                    cache: false
-                },
-                delete: {
-                    method: 'DELETE'
-                },
-                create: {
-                    method: 'POST',
-                    isArray: true
+                {
+                    query: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    get: {
+                        method: 'GET',
+                        cache: false
+                    },
+                    delete: {
+                        method: 'DELETE'
+                    },
+                    create: {
+                        method: 'POST',
+                        isArray: true
+                    }
                 }
-            });
+            );
+            this.uuid4 = uuid4;
         }
 
         query(params = {}) {
@@ -37,6 +42,28 @@ export default (app) => {
 
         createShape(shape) {
             return this.shapeApi.create(shape).$promise;
+        }
+
+        generateFeatureCollection(geometryArray, name = '') {
+            return {
+                type: 'FeatureCollection',
+                features: geometryArray.map(geom => this.generateFeature(geom, name))
+            };
+        }
+
+        generateFeature(geometry, name = '') {
+            let result = {
+                type: 'Feature',
+                properties: {},
+                geometry
+            };
+
+            if (name.length) {
+                result.id = this.uuid4.generate();
+                result.properties = { name };
+            }
+
+            return result;
         }
     }
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -1688,11 +1688,7 @@ rf-node-statistics {
     justify-content: flex-end;
     flex-direction: column;
     &.overlayed {
-        background: linear-gradient(
-            0deg,
-            rgba(255, 255, 255, 1) 10%,
-            rgba(255, 255, 255, 0.15)
-        );
+        background: linear-gradient(0deg, rgba(255, 255, 255, 1) 10%, rgba(255, 255, 255, 0.15));
         position: absolute;
         top: 0;
         right: 0;
@@ -3264,7 +3260,8 @@ rf-project-create-analysis-page,
 rf-project-layer-annotations-page,
 rf-project-layer-colormode-page,
 rf-project-layer-corrections-page,
-rf-project-layer-aoi-page {
+rf-project-layer-aoi-page,
+rf-project-layer-export-page {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -3285,9 +3282,9 @@ rf-project-layer-aoi-page {
     }
 
     rf-layer-item {
-      .with-aoi-component {
-        z-index: 1040;
-      }
+        .with-aoi-component {
+            z-index: 1040;
+        }
     }
 }
 
@@ -3597,8 +3594,8 @@ rf-selected-actions-bar {
     z-index: 1400;
 }
 rf-aoi-draw-toolbar {
-  position: absolute;
-  width: 100vw;
-  z-index: 1040;
-  bottom: 100%;
+    position: absolute;
+    width: 100vw;
+    z-index: 1040;
+    bottom: 100%;
 }

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3598,4 +3598,10 @@ rf-aoi-draw-toolbar {
     width: 100vw;
     z-index: 1040;
     bottom: 100%;
+
+    button {
+        &.btn-aoi-actions {
+            margin-left: 1rem;
+        }
+    }
 }

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -156,6 +156,10 @@ rf-selected-actions-bar {
     &.with-padding {
         padding: 0.5rem 1.5rem;
     }
+
+    p {
+        margin: 0;
+    }
 }
 
 .sidebar-scrollable {


### PR DESCRIPTION
## Overview

This PR adds the project layer export creation UI using the new AOI creation component that defines an area for export.

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- [X] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- ~Any new SQL strings have tests~

### Demo

<img width="1198" alt="screen shot 2019-03-01 at 1 58 46 pm" src="https://user-images.githubusercontent.com/16109558/53659728-3c54e380-3c2a-11e9-90e1-de59ae38c795.png">

## Testing Instructions

 * Go to v2 UI's project layer export list
 * Click on `New export` on top
 * Create an export on this export create UI with different export targets and resolutions
 * Use the AOI definition component
 * Make sure they create exports successfully
 * Run `rf export <exportID>` command to check that the exports created with this UI works

Closes https://github.com/raster-foundry/raster-foundry/issues/4607
