### PR TITLE
Make runBatch value calculation much more readable

### DIFF
--- a/app-backend/common/src/main/scala/AWSBatch.scala
+++ b/app-backend/common/src/main/scala/AWSBatch.scala
@@ -31,9 +31,7 @@ trait AWSBatch extends RollbarNotifier with LazyLogging {
     logger.info(s"Using ${awsbatchConfig.environment} in AWS Batch")
 
     val runBatch: Boolean = {
-      awsbatchConfig.environment
-        .toLowerCase() == "staging" || awsbatchConfig.environment
-        .toLowerCase() == "production"
+      List("production", "staging").contains(awsbatchConfig.environment.toLowerCase())
     }
 
     if (runBatch) {


### PR DESCRIPTION
While digging into the source code of the aws batch I found this piece of code that I thought could be much more readable.
