### PR TITLE
Update Ansible group_vars to reflect Jenkins upgrade

### DIFF
--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -1,8 +1,8 @@
 ---
-aws_cli_version: "1.14.64"
+aws_cli_version: "1.16.*"
 
-docker_version: "18.*"
-docker_compose_version: "1.21.*"
+docker_version: "5:18.*"
+docker_compose_version: "1.23.*"
 
 shellcheck_version: "0.3.*"
 

--- a/deployment/ansible/group_vars/jenkins.yml
+++ b/deployment/ansible/group_vars/jenkins.yml
@@ -3,7 +3,7 @@ docker_users:
   - "vagrant"
   - "jenkins"
 
-java_version: "8u171*"
+java_version: "8u191*"
 java_major_version: "8"
 
 packer_version: "1.0.4"


### PR DESCRIPTION
## Overview

Update the following dependencies so that they align with the recent Jenkins operating system upgrade to Ubuntu Xenial:

- AWS CLI (this was to get on a more recent version)
- Docker
- Docker Compose (this was to get on a more recent version)
- JDK 8

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Styleguide updated, if necessary
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [ ] Symlinks from new migrations present or corrected for any new migrations
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

## Testing Instructions

- Execute the following steps while on the office network with your `raster-foundry-stg.pem` SSH key added to local authentication agent:

```console
$ cd deployment/ansible
$ ansible-galaxy install -f -r roles.yml -p roles
$ ansible-playbook -i inventory/jenkins raster-foundry-jenkins.yml
```

- Ensure that the `ansible-playbook` run applies cleanly.
- Check the output of a [recent](http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/develop/1188/) `develop` job that was executed after the changes in this branch were applied.

Closes https://github.com/azavea/raster-foundry-platform/issues/635