### PR TITLE
Fetch histogram and update render definition for layer analyses

### DIFF
--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -1,6 +1,6 @@
 import tpl from './index.html';
 import {colorStopsToRange, createRenderDefinition} from '_redux/histogram-utils';
-import {nodesFromAst, astFromNodesStateless} from '_redux/node-utils';
+import {nodesFromAst, astFromNodes} from '_redux/node-utils';
 import _ from 'lodash';
 
 class AnalysesListController {
@@ -174,7 +174,7 @@ class AnalysesListController {
                     }
                 );
                 let nodes = nodesFromAst(analysis.executionParameters);
-                let updatedAnalysis = astFromNodesStateless(analysis, nodes, [newNodeDefinition]);
+                let updatedAnalysis = astFromNodes({analysis, nodes}, [newNodeDefinition]);
                 return this.analysisService.updateAnalysis(updatedAnalysis);
             });
         }).then( () => {

--- a/app-frontend/src/app/redux/node-utils.js
+++ b/app-frontend/src/app/redux/node-utils.js
@@ -5,9 +5,7 @@ import {authedRequest} from '../api/authentication';
 import {colorStopsToRange} from '_redux/histogram-utils';
 import {createRenderDefinition} from '_redux/histogram-utils';
 
-export function astFromNodes(labState, updatedNodes) {
-    const analysis = labState.analysis;
-    const nodes = labState.nodes;
+export function astFromNodesStateless(analysis, nodes, updatedNodes) {
     let root = Object.assign({}, _.first(nodes.filter((node) => !node.parent).toArray()));
     let stack = [root];
     const updatedNodeMap = updatedNodes.reduce((m, node) => m.set(node.id, node), new Map());
@@ -28,7 +26,8 @@ export function astFromNodes(labState, updatedNodes) {
         delete currentNode.parent;
         if (currentNode.args && currentNode.args.length) {
             currentNode.args = currentNode.args.map(arg => {
-                let node = Object.assign({}, nodes.get(arg), {parent: currentNode});
+                let key = arg.id ? arg.id : arg;
+                let node = Object.assign({}, nodes.get(key), {parent: currentNode});
                 return node;
             });
             stack = stack.concat(currentNode.args);
@@ -36,6 +35,12 @@ export function astFromNodes(labState, updatedNodes) {
     }
 
     return Object.assign({}, analysis, {executionParameters: root});
+}
+
+export function astFromNodes(labState, updatedNodes) {
+    const analysis = labState.analysis;
+    const nodes = labState.nodes;
+    return astFromNodesStateless(analysis, nodes, updatedNodes);
 }
 
 export function getNodeArgs(node) {

--- a/app-frontend/src/app/redux/node-utils.js
+++ b/app-frontend/src/app/redux/node-utils.js
@@ -5,7 +5,7 @@ import {authedRequest} from '../api/authentication';
 import {colorStopsToRange} from '_redux/histogram-utils';
 import {createRenderDefinition} from '_redux/histogram-utils';
 
-export function astFromNodesStateless(analysis, nodes, updatedNodes) {
+export function astFromNodes({analysis, nodes}, updatedNodes) {
     let root = Object.assign({}, _.first(nodes.filter((node) => !node.parent).toArray()));
     let stack = [root];
     const updatedNodeMap = updatedNodes.reduce((m, node) => m.set(node.id, node), new Map());
@@ -35,12 +35,6 @@ export function astFromNodesStateless(analysis, nodes, updatedNodes) {
     }
 
     return Object.assign({}, analysis, {executionParameters: root});
-}
-
-export function astFromNodes(labState, updatedNodes) {
-    const analysis = labState.analysis;
-    const nodes = labState.nodes;
-    return astFromNodesStateless(analysis, nodes, updatedNodes);
 }
 
 export function getNodeArgs(node) {


### PR DESCRIPTION
## Overview

This PR updates the tool run's render definition prior to rendering the tool run in the layer UI.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ Rendering problem was only present in staging

### Demo

![image](https://user-images.githubusercontent.com/5702984/53751731-f2167100-3e7a-11e9-8548-cfa1ae6cf17a.png)

## Testing Instructions

 * create an analysis that adds things from a project layer (if there's any subtraction involved, the band selection will force the whole result to 0 right now -- I'm not sure what the plans are to make that different)
 * view it
 * tile viz should be consistent

Closes #4666 
