### PR TITLE
Enforce project layer AOI existence when browsing for scenes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added AOI creation UI and component [\#4702](https://github.com/raster-foundry/raster-foundry/pull/4702)
 - Added single band options to project layers [\#4712](https://github.com/raster-foundry/raster-foundry/pull/4712)
 - Added project layer export creation UI [\#4718](https://github.com/raster-foundry/raster-foundry/pull/4718)
+- Enforced project layer AOI existence when browsing for scenes [\#4724](https://github.com/raster-foundry/raster-foundry/pull/4724)
 
 ### Changed
 

--- a/app-frontend/src/app/components/common/confirmationModal/confirmationModal.html
+++ b/app-frontend/src/app/components/common/confirmationModal/confirmationModal.html
@@ -12,14 +12,16 @@
   <div ng-bind-html="$ctrl.resolve.content"></div>
 </div>
 <div class="modal-footer">
-	<div class="pull-left">
-  <button type="button" class="btn"
-          ng-click="$ctrl.dismiss()">
-    {{$ctrl.resolve.cancelText}}
-  </button>
-  </div>
-    <button type="button"  class="btn btn-primary"
+	<div class="footer-section left">
+		<button type="button" class="btn"
+	          ng-click="$ctrl.dismiss()">
+	    {{$ctrl.resolve.cancelText}}
+	  </button>
+	</div>
+	<div class="footer-section right">
+		<button type="button"  class="btn btn-primary"
             ng-click="$ctrl.close()">
       {{$ctrl.resolve.confirmText}}
     </button>
+	</div>    
 </div>


### PR DESCRIPTION
## Overview

This PR checks layer AOI existence and routes to AOI creation UI if otherwise, when `Browse` is clicked on layer scene list UI.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Go to a layer with AOI defined and browse scenes. It should allow you to do so.
 * Go to a layer with AOI undefined and browse scenes. A modal should pop up and route you to AOI creation UI. After creating an AOI, it should bring you back to scene list UI. From here, browse for scenes again. It should allow you to do so this time.

Closes https://github.com/raster-foundry/raster-foundry/issues/4669
