### PR TITLE
Enable project layer single-band color mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added project settings pages for v2 UI [\#4637](https://github.com/raster-foundry/raster-foundry/pull/4637)
 - Added project layer color-mode UI [\#4706](https://github.com/raster-foundry/raster-foundry/pull/4706)
 - Added project layer color-correction UI [\#4722](https://github.com/raster-foundry/raster-foundry/pull/4722)
+- Added single-band color-mode support to project layer color-mode UI [\#4728](https://github.com/raster-foundry/raster-foundry/pull/4728)
 - Added owner query parameter to tools and tool-runs endpoints, support multiple owner qp's on applicable endpoints [\#4689](https://github.com/raster-foundry/raster-foundry/pull/4689)
 - Added Rollbar error reporting to backsplash [\#4691](https://github.com/raster-foundry/raster-foundry/pull/4691)
 - Added PLATFORM_USERS webpack overrides variable and make default platform filter use those ids [\#4692](https://github.com/raster-foundry/raster-foundry/pull/4692)

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -116,7 +116,7 @@ object SceneToLayerDao extends Dao[SceneToLayer] with LazyLogging {
     val select = fr"""
     SELECT
       scene_id, project_id, project_layer_id, accepted, scene_order, mosaic_definition, scene_type, ingest_location,
-      data_footprint, is_single_band, single_band_options
+      data_footprint, project_layers.is_single_band, project_layers.single_band_options
     FROM (
       scenes_to_layers
     LEFT JOIN

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -116,7 +116,7 @@ object SceneToLayerDao extends Dao[SceneToLayer] with LazyLogging {
     val select = fr"""
     SELECT
       scene_id, project_id, project_layer_id, accepted, scene_order, mosaic_definition, scene_type, ingest_location,
-      data_footprint, project_layers.is_single_band, project_layers.single_band_options
+      data_footprint, is_single_band, single_band_options
     FROM (
       scenes_to_layers
     LEFT JOIN

--- a/app-frontend/src/app/components/pages/project/layer/colormode/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/colormode/index.html
@@ -32,8 +32,8 @@
     ng-show="!$ctrl.isLoading && $ctrl.pagination && $ctrl.pagination.count"
 >
     <div class="page-card" ng-if="!$ctrl.isLoading && !$ctrl.bands.length">
-        There are currently no bands defined for one or more datasources used in this
-        project. Some color options are not available unless bands are defined.
+        There are currently no bands defined for one or more datasources used in this project. Some
+        color options are not available unless bands are defined.
         <br />
         <br />
 
@@ -70,7 +70,7 @@
                 </select>
             </div>
         </div>
-        <div ng-if="$ctrl.bands.length && $ctrl.projectBuffer.isSingleBand">
+        <div ng-if="$ctrl.bands.length && $ctrl.layerBuffer.isSingleBand">
             <div class="form-group">
                 <label for="color-mode">Band</label>
                 <rf-band-select
@@ -89,7 +89,7 @@
             </div>
         </div>
         <div
-            ng-if="$ctrl.bands.length && !$ctrl.projectBuffer.isSingleBand && $ctrl.activeColorModeKey === 'custom'"
+            ng-if="$ctrl.bands.length && !$ctrl.layerBuffer.isSingleBand && $ctrl.activeColorModeKey === 'custom'"
         >
             <div class="form-group">
                 <label for="color-mode">Blue</label>

--- a/app-frontend/src/app/components/pages/project/layer/colormode/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/colormode/index.html
@@ -58,7 +58,7 @@
                     ng-model="$ctrl.activeColorModeKey"
                     ng-change="$ctrl.setActiveColorMode()"
                 >
-                    <option value="singleband" ng-if="$ctrl.singleBandEnabled">
+                    <option value="singleband">
                         Single band
                     </option>
                     <option

--- a/app-frontend/src/app/components/pages/project/layer/colormode/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/colormode/index.js
@@ -24,7 +24,6 @@ class LayerColormodeController {
     $onInit() {
         this.isLoading = true;
         this.currentBands = null;
-        this.singleBandEnabled = true;
         this.defaultColorModes = {
             custom: {
                 label: 'Custom',
@@ -38,7 +37,6 @@ class LayerColormodeController {
         };
         this.setMapLayers();
         this.initColorModes();
-        console.log(this.layer.isSingleBand, this.layer.singleBandOptions);
     }
 
     $onDestroy() {

--- a/app-frontend/src/app/components/pages/project/layer/colormode/index.js
+++ b/app-frontend/src/app/components/pages/project/layer/colormode/index.js
@@ -19,13 +19,12 @@ class LayerColormodeController {
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
-        this.$parent = $scope.$parent.$ctrl;
     }
 
     $onInit() {
         this.isLoading = true;
         this.currentBands = null;
-        this.singleBandEnabled = false;
+        this.singleBandEnabled = true;
         this.defaultColorModes = {
             custom: {
                 label: 'Custom',
@@ -39,6 +38,7 @@ class LayerColormodeController {
         };
         this.setMapLayers();
         this.initColorModes();
+        console.log(this.layer.isSingleBand, this.layer.singleBandOptions);
     }
 
     $onDestroy() {
@@ -95,7 +95,7 @@ class LayerColormodeController {
                             ...this.defaultColorModes,
                             ...composites
                         };
-                        this.initProjectBuffer();
+                        this.initLayerBuffer();
                         this.isLoading = false;
                         this.activeColorModeKey = this.initActiveColorMode();
                     });
@@ -103,6 +103,10 @@ class LayerColormodeController {
     }
 
     initActiveColorMode() {
+        if (this.layer.isSingleBand) {
+            return 'singleband';
+        }
+
         const key = Object.keys(this.unifiedComposites).find(k => {
             const c = this.unifiedComposites[k].value;
 
@@ -128,33 +132,33 @@ class LayerColormodeController {
         this.currentBands.mode = 'custom-rgb';
     }
 
-    initProjectBuffer() {
+    initLayerBuffer() {
         this.initSingleBandDefaults();
-        this.projectBuffer = Object.assign({}, this.project);
-        if (this.projectBuffer.isSingleBand) {
+        this.layerBuffer = Object.assign({}, this.layer);
+        if (this.layerBuffer.isSingleBand) {
             this.initActiveScheme();
         }
     }
 
     initActiveScheme() {
-        this.projectBuffer.singleBandOptions = Object.assign(
+        this.layerBuffer.singleBandOptions = Object.assign(
             {},
             this.defaultSingleBandOptions,
-            this.projectBuffer.singleBandOptions
+            this.layerBuffer.singleBandOptions
         );
 
-        this.maskedValues = this.projectBuffer.singleBandOptions.extraNoData;
+        this.maskedValues = this.layerBuffer.singleBandOptions.extraNoData;
 
         this.activeColorSchemeType = this.colorSchemeService.defaultColorSchemeTypes.find(
-            t => t.value === this.projectBuffer.singleBandOptions.dataType
+            t => t.value === this.layerBuffer.singleBandOptions.dataType
         );
 
         this.activeColorScheme = this.colorSchemeService.matchSingleBandOptions(
-            this.projectBuffer.singleBandOptions
+            this.layerBuffer.singleBandOptions
         );
 
         this.activeColorBlendMode = this.colorSchemeService.defaultColorBlendModes.find(
-            m => m.value === this.projectBuffer.singleBandOptions.colorBins
+            m => m.value === this.layerBuffer.singleBandOptions.colorBins
         );
     }
 
@@ -200,20 +204,20 @@ class LayerColormodeController {
     }
 
     getSerializedSingleBandOptions() {
-        return angular.toJson(this.projectBuffer.singleBandOptions);
+        return angular.toJson(this.layerBuffer.singleBandOptions);
     }
 
     toggleProjectSingleBandMode(state) {
         this.initSingleBandDefaults();
-        if (!this.projectBuffer) {
+        if (!this.layerBuffer) {
             return;
         } else if (typeof state !== 'undefined') {
-            this.projectBuffer.isSingleBand = state;
+            this.layerBuffer.isSingleBand = state;
         } else {
-            this.projectBuffer.isSingleBand = !this.projectBuffer.isSingleBand;
+            this.layerBuffer.isSingleBand = !this.layerBuffer.isSingleBand;
         }
         this.initActiveScheme();
-        this.updateProjectFromBuffer();
+        this.updateLayerFromBuffer();
     }
 
     getActiveBand(bandName) {
@@ -221,12 +225,12 @@ class LayerColormodeController {
     }
 
     setActiveSingleBand(bandValue) {
-        this.projectBuffer.singleBandOptions.band = bandValue;
-        this.updateProjectFromBuffer();
+        this.layerBuffer.singleBandOptions.band = bandValue;
+        this.updateLayerFromBuffer();
     }
 
     getActiveSingleBand() {
-        return this.projectBuffer.singleBandOptions.band;
+        return this.layerBuffer.singleBandOptions.band;
     }
 
     getActiveColorScheme() {
@@ -252,21 +256,21 @@ class LayerColormodeController {
             this.activeColorSchemeType = this.colorSchemeService.defaultColorSchemeTypes.find(
                 t => t.value === scheme.type
             );
-            this.projectBuffer.singleBandOptions.dataType = scheme.type;
-            this.projectBuffer.singleBandOptions.extraNoData = _.filter(masked, isFinite);
+            this.layerBuffer.singleBandOptions.dataType = scheme.type;
+            this.layerBuffer.singleBandOptions.extraNoData = _.filter(masked, isFinite);
             if (scheme.type !== 'CATEGORICAL') {
-                this.projectBuffer.singleBandOptions.colorScheme = this.colorSchemeService
+                this.layerBuffer.singleBandOptions.colorScheme = this.colorSchemeService
                     .colorStopsToProportionalArray(
                         this.activeColorScheme.colors
                     );
             } else if (scheme.breaks) {
-                this.projectBuffer.singleBandOptions.colorScheme = this.colorSchemeService
+                this.layerBuffer.singleBandOptions.colorScheme = this.colorSchemeService
                     .schemeFromBreaksAndColors(
                         this.activeColorScheme.breaks,
                         this.activeColorScheme.colors
                     );
             } else {
-                this.projectBuffer.singleBandOptions.colorScheme = this.colorSchemeService
+                this.layerBuffer.singleBandOptions.colorScheme = this.colorSchemeService
                     .colorsToSequentialScheme(
                         this.colorSchemeService.colorStopsToProportionalArray(
                             this.activeColorScheme.colors
@@ -274,30 +278,34 @@ class LayerColormodeController {
                     );
             }
             if (save) {
-                this.updateProjectFromBuffer();
+                this.updateLayerFromBuffer();
             }
         }
     }
 
     shouldShowColorScheme() {
         return (
-            this.projectBuffer.singleBandOptions &&
-                this.projectBuffer.singleBandOptions.dataType === 'SEQUENTIAL' ||
-            this.projectBuffer.singleBandOptions.dataType === 'DIVERGING'
+            this.layerBuffer.singleBandOptions &&
+                this.layerBuffer.singleBandOptions.dataType === 'SEQUENTIAL' ||
+            this.layerBuffer.singleBandOptions.dataType === 'DIVERGING'
         );
     }
 
     shouldShowColorSchemeBuilder() {
-        return this.projectBuffer.singleBandOptions.dataType === 'CATEGORICAL';
+        return this.layerBuffer.singleBandOptions.dataType === 'CATEGORICAL';
     }
 
     shouldShowBlendMode() {
-        return this.projectBuffer.singleBandOptions.dataType !== 'CATEGORICAL';
+        return this.layerBuffer.singleBandOptions.dataType !== 'CATEGORICAL';
     }
 
-    updateProjectFromBuffer() {
-        this.projectEditService.updateCurrentProject(this.projectBuffer).then(() => {
-            this.project = this.projectBuffer;
+    updateLayerFromBuffer() {
+        this.projectService.updateLayer({
+            ...this.layerBuffer,
+            projectId: this.project.id,
+            layerId: this.layer.id
+        }).then(() => {
+            this.layer = this.layerBuffer;
             this.setMapLayers();
         });
     }
@@ -339,8 +347,8 @@ class LayerColormodeController {
     }
 
     isActiveColorMode(key) {
-        if (!this.isLoading && this.projectBuffer) {
-            return !this.projectBuffer.isSingleBand && key === this.activeColorModeKey;
+        if (!this.isLoading && this.layerBuffer) {
+            return !this.layerBuffer.isSingleBand && key === this.activeColorModeKey;
         }
         return false;
     }
@@ -386,26 +394,26 @@ class LayerColormodeController {
     }
 
     onColorSchemeChange(colorSchemeOptions) {
-        let oldOptions = this.projectBuffer.singleBandOptions;
+        let oldOptions = this.layerBuffer.singleBandOptions;
         this.activeColorSchemeType = oldOptions.dataType;
         if (
             JSON.stringify(colorSchemeOptions.colorScheme) !==
             JSON.stringify(oldOptions.colorScheme)
         ) {
             this.activeColorSchemeType = colorSchemeOptions.dataType;
-            this.projectBuffer.singleBandOptions = Object.assign(
+            this.layerBuffer.singleBandOptions = Object.assign(
                 {},
-                this.projectBuffer.singleBandOptions,
+                this.layerBuffer.singleBandOptions,
                 colorSchemeOptions
             );
-            this.updateProjectFromBuffer();
+            this.updateLayerFromBuffer();
         }
     }
 
     correctionsDisabled() {
         return (
-            this.projectBuffer && this.projectBuffer.isSingleBand ||
-            !this.projectBuffer ||
+            this.layerBuffer && this.layerBuffer.isSingleBand ||
+            !this.layerBuffer ||
             this.pagination && this.pagination.count > this.projectService.scenePageSize
         );
     }


### PR DESCRIPTION
## Overview

This PR enables the single-band color mode within the project-layer UI.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/2442245/53824893-032ab500-3f43-11e9-8acc-679bb9d59669.png)

![image](https://user-images.githubusercontent.com/2442245/53824910-0cb41d00-3f43-11e9-9849-f9b44f866131.png)

## Testing Instructions

 * Set a layer within a project to use single band mode and change the band and scheme and see that it is visualized correctly
 * Ensure that other layers within the project are not affected by those single band options.

Closes #4705 
