### PR TITLE
Make templates editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added flag for whether tools can sensibly be run with only a single layer as input [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701) and used it to filter templates for layer analysis creation [\#4711](https://github.com/raster-foundry/raster-foundry/pull/4711)
 - Added AOI creation UI and component [\#4702](https://github.com/raster-foundry/raster-foundry/pull/4702)
 - Added single band options to project layers [\#4712](https://github.com/raster-foundry/raster-foundry/pull/4712)
+- Made templates editable except for their formulas [\#4729](https://github.com/raster-foundry/raster-foundry/pull/4729)
 
 ### Changed
 

--- a/app-backend/common/src/main/scala/datamodel/License.scala
+++ b/app-backend/common/src/main/scala/datamodel/License.scala
@@ -6,4 +6,5 @@ import io.circe.generic.JsonCodec
 final case class License(shortName: String,
                          name: String,
                          url: String,
-                         osiApproved: Boolean)
+                         osiApproved: Boolean,
+                         id: Long)

--- a/app-backend/db/src/main/scala/LicenseDao.scala
+++ b/app-backend/db/src/main/scala/LicenseDao.scala
@@ -11,7 +11,7 @@ object LicenseDao extends Dao[License] {
   val selectF =
     fr"""
        SELECT
-         short_name, name, url, osi_approved
+         short_name, name, url, osi_approved, id
        FROM
       """ ++ tableF
 }

--- a/app-frontend/src/app/components/lab/templateCreateModal/templateCreateModal.html
+++ b/app-frontend/src/app/components/lab/templateCreateModal/templateCreateModal.html
@@ -30,6 +30,24 @@
                 ng-disabled="$ctrl.isProcessing">
         </div>
         <div class="form-group">
+          <label for="name">This template can be run with only one project</label>
+          <rf-toggle value="$ctrl.templateBuffer.singleSource" on-change="$ctrl.toggleTemplateSingleSource()">
+          </rf-toggle>
+        </div>
+        <div class="form-group">
+          <label for="license">License (optional)</label>
+          <select
+              class="form-control"
+              name="license"
+              ng-model="$ctrl.templateBuffer.license">
+            <option ng-repeat="license in $ctrl.availableLicenses"
+                    value="{{ license.id }}"
+                    >
+              {{ license.shortName }}
+            </option>
+          </select>
+        </div>
+        <div class="form-group" ng-if="!$ctrl.editing">
           <label for="name">Template Definition</label>
           <p>
             Enter an algebraic expression that represents the operation to compute. Here are some hints:
@@ -68,8 +86,14 @@
     </div>
     <div class="footer-section right">
       <button type="button" class="btn btn-primary"
-              ng-if="!$ctrl.isProcessing"
-              ng-click="$ctrl.createTemplate()"
+              ng-if="!$ctrl.isProcessing && $ctrl.editing""
+              ng-click="$ctrl.flushBuffer()"
+              ng-disabled="!$ctrl.isValid()">
+        Update Template
+      </button>
+      <button type="button" class="btn btn-primary"
+              ng-if="!$ctrl.isProcessing && !$ctrl.editing""
+              ng-click="$ctrl.flushBuffer()"
               ng-disabled="!$ctrl.isValid()">
         Create Template
       </button>

--- a/app-frontend/src/app/components/lab/templateItem/templateItem.html
+++ b/app-frontend/src/app/components/lab/templateItem/templateItem.html
@@ -28,6 +28,9 @@
     </button>
     <ul class="dropdown-menu slim dropdown-menu-light dropdown-menu-right" uib-dropdown-menu role="menu" >
       <li class="dropdown-list-item" ng-if="$ctrl.showShare">
+        <a ng-click="$ctrl.onEditClick()">Edit</a>
+      </li>
+      <li class="dropdown-list-item" ng-if="$ctrl.showShare">
         <a ng-click="$ctrl.onShareClick()">Share</a>
       </li>
       <li class="dropdown-menu-item divider" ng-if="$ctrl.showShare && $ctrl.showDelete">

--- a/app-frontend/src/app/components/lab/templateItem/templateItem.module.js
+++ b/app-frontend/src/app/components/lab/templateItem/templateItem.module.js
@@ -8,6 +8,7 @@ const TemplateItemComponent = {
         templateData: '<',
         onTemplateDelete: '&',
         onShareClick: '&',
+        onEditClick: '&',
         hideActions: '<'
     }
 };

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.html
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.html
@@ -57,6 +57,7 @@
         template-data="template"
         on-template-delete="$ctrl.onTemplateDelete(templateId)"
         on-share-click="$ctrl.onTemplateShareClick(template)"
+        on-edit-click="$ctrl.onTemplateEditClick(template)"
       ></rf-template-item>
       <div
         ng-if="!$ctrl.currentQuery && !$ctrl.search && $ctrl.pagination && !$ctrl.pagination.count"

--- a/app-frontend/src/app/pages/lab/browse/templates/templates.js
+++ b/app-frontend/src/app/pages/lab/browse/templates/templates.js
@@ -79,6 +79,18 @@ class LabBrowseTemplatesController {
             }
         });
     }
+
+    onTemplateEditClick(template) {
+        this.modalService.open({
+            component: 'rfTemplateCreateModal',
+            resolve: {
+                existingTemplate: () => template
+            }
+        }).result.then( data => {
+            let idx = this.results.findIndex( tpl => tpl.id === data.id );
+            this.results[idx] = data;
+        });
+    }
 }
 
 export default angular.module('pages.lab.browse.results', [])

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -13,7 +13,7 @@ export default (app) => {
                     id: '@properties.id'
                 }, {
                     query: {
-                        method: 'GET',
+                      method: 'GET',
                         cache: false
                     },
                     get: {
@@ -22,6 +22,12 @@ export default (app) => {
                     },
                     create: {
                         method: 'POST'
+                    },
+                    update: {
+                        method: 'PUT',
+                        params: {
+                            id: '@id'
+                        }
                     },
                     delete: {
                         method: 'DELETE'
@@ -357,6 +363,10 @@ export default (app) => {
                 this.isLoadingTemplate = false;
             });
             return request;
+        }
+
+        updateTemplate(template) {
+            return this.Template.update(template).$promise;
         }
 
         getAnalysisActions(id) {


### PR DESCRIPTION
## Overview

This PR makes it so that templates can be edited and so that licenses and single source options can be specified on templates at creation and edit time.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Notes

Does not implement compatible datasources. I don't have any idea what that's supposed to look like and I still don't think we have a good sense of what that constraint looks like. I didn't see compatible datasource in designs.

## Testing Instructions

 * reassemble your API server and bring it back up
 * filter to templates you own
 * edit a template you own
 * set a license
 * change single source
 * update the template
 * reopen the modal
 * your options should have persisted

Closes #4726 

Closes #4674