### PR TITLE
Remove version.sbt

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -15,6 +15,9 @@ git.gitTagToVersionNumber in ThisBuild := { tag: String =>
 cancelable in Global := true
 
 lazy val commonSettings = Seq(
+  version := {
+    "dev"
+  },
   // https://github.com/lucidsoftware/neo-sbt-scalafmt
   scalafmtOnCompile := true,
   // https://github.com/sksamuel/sbt-scapegoat

--- a/app-backend/version.sbt
+++ b/app-backend/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.19.0-SNAPSHOT"


### PR DESCRIPTION
## Overview

Remove `version.sbt` file and replace with a default value of `dev` in `build.sbt`.

Closes #4693

After merging, remove https://github.com/azavea/raster-foundry-deployment/wiki/Release-Workflow#bump-version-in-sbt-raster-foundryraster-foundry-only

## Testing Instructions

It looks like the `version` value is used in POM metadata and when packaging JAR artifacts:

```bash
root > api/package
[info] Packaging /opt/raster-foundry/app-backend/api/target/scala-2.11/api_2.11-dev.jar ...
[info] Done packaging.
[success] Total time: 6 s, completed Mar 6, 2019 7:19:22 PM
```
```bash
root > api/publishLocal
[info] Writing Ivy file /opt/raster-foundry/app-backend/api/target/scala-2.11/resolution-cache/com.rasterfoundry/api_2.11/dev/resolved.xml.xml
[info] Wrote /opt/raster-foundry/app-backend/api/target/scala-2.11/api_2.11-dev.pom
[info] Packaging /opt/raster-foundry/app-backend/api/target/scala-2.11/api_2.11-dev-sources.jar ...
[info] Done packaging.
[info] Main Scala API documentation to /opt/raster-foundry/app-backend/api/target/scala-2.11/api...
[info] Packaging /opt/raster-foundry/app-backend/api/target/scala-2.11/api_2.11-dev.jar ...
[info] Done packaging.
model contains 134 documentable templates
[info] Main Scala API documentation successful.
[info] Packaging /opt/raster-foundry/app-backend/api/target/scala-2.11/api_2.11-dev-javadoc.jar ...
[info] Done packaging.
[info] :: delivering :: com.rasterfoundry#api_2.11;dev :: dev :: release :: Wed Mar 06 19:00:56 UTC 2019
[info]  delivering ivy file to /opt/raster-foundry/app-backend/api/target/scala-2.11/ivy-dev.xml
[info]  published api_2.11 to /opt/raster-foundry/app-backend/project/.ivy/local/com.rasterfoundry/api_2.11/dev/poms/api_2.11.pom
[info]  published api_2.11 to /opt/raster-foundry/app-backend/project/.ivy/local/com.rasterfoundry/api_2.11/dev/jars/api_2.11.jar
[info]  published api_2.11 to /opt/raster-foundry/app-backend/project/.ivy/local/com.rasterfoundry/api_2.11/dev/srcs/api_2.11-sources.jar
[info]  published api_2.11 to /opt/raster-foundry/app-backend/project/.ivy/local/com.rasterfoundry/api_2.11/dev/docs/api_2.11-javadoc.jar
[info]  published ivy to /opt/raster-foundry/app-backend/project/.ivy/local/com.rasterfoundry/api_2.11/dev/ivys/ivy.xml
[success] Total time: 55 s, completed Mar 6, 2019 7:00:58 PM
```

When we actually publish development artifacts in `cipublish`, and release artifacts in `Jenkinsfile.release`, the version value is overridden, so I don't think we need to worry about maintaining it in `version.sbt` anymore.

Also, most of the time in dev we're building assembly JARs, so there weren't many times the old value in `version.sbt` would even see the light of day.