### PR TITLE
Add endpoint to support splitting layers by date and datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Made templates editable except for their formulas [\#4729](https://github.com/raster-foundry/raster-foundry/pull/4729)
 - Added project analyses edit modal for v2 UI [\#4709](https://github.com/raster-foundry/raster-foundry/pull/4709)
 - Added query parameter to limit scene search by layer AOI and updated filters on the frontend [\#4733](https://github.com/raster-foundry/raster-foundry/pull/4733)
+- Added endpoint for splitting layers up by date and datasource [\#4738](https://github.com/raster-foundry/raster-foundry/pull/4738)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/project/ProjectLayerRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerRoutes.scala
@@ -122,6 +122,27 @@ trait ProjectLayerRoutes
       }
   }
 
+  def splitProjectLayer(projectId: UUID, layerId: UUID): Route =
+    authenticate { user =>
+      authorizeAsync {
+        ProjectDao
+          .authProjectLayerExist(projectId, layerId, user, ActionType.View)
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        entity(as[SplitOptions]) { splitOptions =>
+          onSuccess(
+            ProjectLayerDao
+              .splitProjectLayer(projectId, layerId, splitOptions, user)
+              .transact(xa)
+              .unsafeToFuture
+          ) { splitLayers =>
+            complete(StatusCodes.Created, splitLayers)
+          }
+        }
+      }
+    }
+
   def getProjectLayerMosaicDefinition(projectId: UUID, layerId: UUID): Route =
     authenticate { user =>
       authorizeAsync {

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -104,6 +104,13 @@ trait ProjectRoutes
                       deleteProjectLayer(projectId, layerId)
                     }
                 } ~
+                  pathPrefix("split") {
+                    pathEndOrSingleSlash {
+                      post {
+                        splitProjectLayer(projectId, layerId)
+                      }
+                    }
+                  } ~
                   pathPrefix("color-mode") {
                     pathEndOrSingleSlash {
                       post {

--- a/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
+++ b/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
@@ -6,6 +6,8 @@ import geotrellis.vector.{Geometry, Projected}
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import io.circe.generic.semiauto._
+import io.circe._
+import cats.syntax.either._
 
 import java.sql.Timestamp
 import java.util.UUID
@@ -42,6 +44,9 @@ final case class ProjectLayer(
     )
   )
 }
+final case class LayerQueryResult(timestamp: Option[Timestamp],
+                                  datasource: Option[UUID],
+                                  count: Int)
 
 @JsonCodec
 final case class ProjectLayerProperties(

--- a/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
+++ b/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
@@ -44,9 +44,6 @@ final case class ProjectLayer(
     )
   )
 }
-final case class LayerQueryResult(timestamp: Option[Timestamp],
-                                  datasource: Option[UUID],
-                                  count: Int)
 
 @JsonCodec
 final case class ProjectLayerProperties(

--- a/app-backend/common/src/main/scala/datamodel/SplitOptions.scala
+++ b/app-backend/common/src/main/scala/datamodel/SplitOptions.scala
@@ -1,0 +1,49 @@
+package com.rasterfoundry.common.datamodel
+
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.generic.JsonCodec
+import io.circe._
+import cats.syntax.either._
+
+import java.sql.Timestamp
+
+sealed abstract class SplitPeriod(val repr: String) {
+  override def toString = repr
+}
+
+object SplitPeriod {
+  case object Day extends SplitPeriod("DAY")
+  case object Week extends SplitPeriod("WEEK")
+
+  def fromString(s: String): SplitPeriod = s.toUpperCase match {
+    case "DAY"  => Day
+    case "WEEK" => Week
+    case _      => throw new Exception(s"Invalid string: $s")
+  }
+
+  implicit val splitPeriodEncoder: Encoder[SplitPeriod] =
+    Encoder.encodeString.contramap[SplitPeriod](_.toString)
+
+  implicit val splitPeriodDecoder: Decoder[SplitPeriod] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(fromString(str)).leftMap(t => "SplitPeriod")
+    }
+}
+
+/*
+ * Current methods of splitting:
+ *  - By period
+ *  - By datasource
+ * Possible future splits:
+ *  - Geometry (one group per polygon in a multipolygon or feature in featureGroup)
+ */
+@JsonCodec
+final case class SplitOptions(
+    name: String,
+    colorGroupHex: Option[String],
+    rangeStart: Timestamp,
+    rangeEnd: Timestamp,
+    period: SplitPeriod,
+    splitOnDatasource: Option[Boolean] = Some(true),
+    removeFromLayer: Option[Boolean] = Some(false)
+)

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -2,14 +2,24 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.Implicits._
-
+import cats.implicits._
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import com.lonelyplanet.akka.http.extensions.PageRequest
-
+import cats.implicits._
 import java.sql.Timestamp
+import java.time.temporal.IsoFields
+import java.time.temporal.TemporalAdjusters
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
+
+import cats.free.Free
+import doobie.free.connection
+
+import scala.collection.immutable
 
 object ProjectLayerDao extends Dao[ProjectLayer] {
   val tableName = "project_layers"
@@ -28,6 +38,7 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
     query
       .filter(fr"project_id = ${projectId}")
       .page(page)
+
   }
 
   def insertProjectLayer(
@@ -89,6 +100,140 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
 
   def updateProjectLayer(pl: ProjectLayer, plId: UUID): ConnectionIO[Int] = {
     updateProjectLayerQ(pl, plId).run
+  }
+
+  def getLayerScenes(
+      layerId: UUID,
+      splitOptions: SplitOptions): ConnectionIO[List[Scene.ProjectScene]] =
+    ProjectLayerScenesDao.listLayerScenesRaw(layerId, splitOptions)
+
+  def batchCreateLayers(
+      groupedScenes: Map[(Option[(Timestamp, Timestamp)], Option[String]),
+                         List[Scene.ProjectScene]],
+      layer: ProjectLayer,
+      splitOptions: SplitOptions): ConnectionIO[List[ProjectLayer]] = {
+    val projectLayersAndScenes
+      : Map[ProjectLayer.Create, List[Scene.ProjectScene]] = groupedScenes.map {
+      case ((Some((start, end)), datasourceO), scenes) =>
+        (ProjectLayer.Create(
+           datasourceO match {
+             case Some(datasource) =>
+               s"${splitOptions.name} | " +
+                 s"${datasource}"
+             case _ =>
+               s"${splitOptions.name}"
+           },
+           layer.projectId,
+           splitOptions.colorGroupHex.getOrElse(layer.colorGroupHex),
+           Some(layer.id),
+           Some(start),
+           Some(end),
+           layer.geometry,
+           layer.isSingleBand,
+           layer.singleBandOptions
+         ),
+         scenes)
+      case ((_, datasourceO), scenes) =>
+        (ProjectLayer.Create(
+           datasourceO match {
+             case Some(datasource) =>
+               s"${splitOptions.name} | " +
+                 s"${datasource}"
+             case _ =>
+               s"${splitOptions.name}"
+           },
+           layer.projectId,
+           splitOptions.colorGroupHex.getOrElse(layer.colorGroupHex),
+           Some(layer.id),
+           None,
+           None,
+           layer.geometry,
+           layer.isSingleBand,
+           layer.singleBandOptions
+         ),
+         scenes)
+    }
+    val createdProjectLayers = projectLayersAndScenes.toList traverse {
+      case (projectLayerC: ProjectLayer.Create,
+            scenes: List[Scene.ProjectScene]) =>
+        (scenes.toNel, layer.projectId) match {
+          case (Some(s), Some(pId)) =>
+            for {
+              insertedLayer <- insertProjectLayer(projectLayerC.toProjectLayer)
+              _ <- ProjectDao.addScenesToProject(
+                s.map(_.id),
+                pId,
+                true,
+                Some(insertedLayer.id)
+              )
+            } yield insertedLayer
+          case _ =>
+            throw new java.lang.IllegalArgumentException(
+              s"Cannot add scenes to a layer which is not in a project: ${layer.id}"
+            )
+        }
+    }
+    createdProjectLayers
+  }
+
+  def getDayRangeFromTimestamp(date: Timestamp): (Timestamp, Timestamp) = {
+    val startOfDay =
+      date.toLocalDateTime.toLocalDate.atStartOfDay
+    (new Timestamp(startOfDay.toEpochSecond(ZoneOffset.UTC) * 1000),
+     new Timestamp(
+       startOfDay.plusHours(24).toEpochSecond(ZoneOffset.UTC) * 1000))
+  }
+  def getWeekRangeFromTimestamp(date: Timestamp): (Timestamp, Timestamp) = {
+    val week = date.toLocalDateTime.get(IsoFields.WEEK_OF_WEEK_BASED_YEAR)
+    val year = date.toLocalDateTime.get(IsoFields.WEEK_BASED_YEAR)
+    val datetimeWeek = LocalDate
+      .now()
+      .`with`(IsoFields.WEEK_OF_WEEK_BASED_YEAR, week)
+      .`with`(IsoFields.WEEK_BASED_YEAR, year)
+      .`with`(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+
+    val startOfDay = datetimeWeek.atStartOfDay
+    (new Timestamp(startOfDay.toEpochSecond(ZoneOffset.UTC) * 1000),
+     new Timestamp(startOfDay.plusDays(7).toEpochSecond(ZoneOffset.UTC) * 1000))
+  }
+
+  def groupScenesBySplitOptions(splitOptions: SplitOptions)
+    : Scene.ProjectScene => (Option[(Timestamp, Timestamp)], Option[String]) = {
+    scene: Scene.ProjectScene =>
+      (splitOptions.period, splitOptions.splitOnDatasource) match {
+        case (SplitPeriod.Day, Some(true)) =>
+          (scene.filterFields.acquisitionDate.map(getDayRangeFromTimestamp),
+           Some(scene.datasource.name))
+        case (SplitPeriod.Week, Some(true)) =>
+          (scene.filterFields.acquisitionDate.map(getWeekRangeFromTimestamp),
+           Some(scene.datasource.name))
+        case (SplitPeriod.Day, _) =>
+          (scene.filterFields.acquisitionDate.map(getDayRangeFromTimestamp),
+           None)
+        case (SplitPeriod.Week, _) =>
+          (scene.filterFields.acquisitionDate.map(getWeekRangeFromTimestamp),
+           None)
+      }
+  }
+
+  def splitProjectLayer(projectId: UUID,
+                        layerId: UUID,
+                        splitOptions: SplitOptions,
+                        user: User): ConnectionIO[List[ProjectLayer]] = {
+    // TODO migration to rename smart_layer_id to parent_layer_id `with` dependency on itself
+    for {
+      layer <- unsafeGetProjectLayerById(layerId)
+      scenes <- getLayerScenes(layerId, splitOptions)
+      groupedScenes = scenes.groupBy(groupScenesBySplitOptions(splitOptions))
+      newLayers <- batchCreateLayers(groupedScenes, layer, splitOptions)
+      _ <- splitOptions.removeFromLayer match {
+        case Some(true) =>
+          ProjectDao.deleteScenesFromProject(scenes.map(_.id),
+                                             projectId,
+                                             Some(layerId))
+        case _ => 0.pure[ConnectionIO]
+      }
+    } yield newLayers
   }
 
   def layerIsInProject(layerId: UUID,


### PR DESCRIPTION
## Overview
Allow splitting project layers by date (day / week) and datasource to aid in creating time series comparisons

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated [spec pr here](https://github.com/raster-foundry/raster-foundry-api-spec/pull/95)
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~ Created this issue: https://github.com/raster-foundry/raster-foundry/issues/4740

### Demo
![image](https://user-images.githubusercontent.com/4392704/53912922-08adfb00-4028-11e9-9082-7b044235e87a.png)

Http request made using httpie cli
```
> $ http POST :9091/api/projects/d103408d-c2d1-40fc-a5c8-6b7030671724/layers/bc5f360a-cdb8-4995-abfb-ef47e589dc33/split name='Week Split' colorGroupHex=#eeeeee rangeStart=2017-04-07T00:00:00.000Z rangeEnd=2017-04-20T00:00:00.000Z period=WEEK Authorization:'Bearer {{token}}'
HTTP/1.1 201 Created
X-Powered-By: Express
connection: close
content-length: 1732
content-type: application/json
date: Wed, 06 Mar 2019 20:51:49 GMT
server: nginx
strict-transport-security: max-age=15552000; preload
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block

[
    {
        "colorGroupHex": "#738FFC",
        "createdAt": "2019-03-06T20:51:49.682Z",
        "geometry": {
            "coordinates": [
                [
                    [
                        [
                            -127.353516,
                            49.15297
                        ],
                        [
                            -71.982422,
                            48.40003200000001
                        ],
                        [
                            -70.3125,
                            26.509905
                        ],
                        [
                            -125.41992200000001,
                            25.403585
                        ],
                        [
                            -127.353516,
                            49.15297
                        ]
                    ]
                ]
            ],
            "type": "MultiPolygon"
        },
        "id": "fe290507-5d7b-4c3e-849d-5c5f7f8dfd14",
        "isSingleBand": false,
        "modifiedAt": "2019-03-06T20:51:49.682Z",
        "name": "Week Split",
        "projectId": "d103408d-c2d1-40fc-a5c8-6b7030671724",
        "rangeEnd": "2017-04-10T00:00:00Z",
        "rangeStart": "2017-04-03T00:00:00Z",
        "singleBandOptions": null,
        "smartLayerId": "bc5f360a-cdb8-4995-abfb-ef47e589dc33"
    },
    {
        "colorGroupHex": "#738FFC",
        "createdAt": "2019-03-06T20:51:49.683Z",
        "geometry": {
            "coordinates": [
                [
                    [
                        [
                            -127.353516,
                            49.15297
                        ],
                        [
                            -71.982422,
                            48.40003200000001
                        ],
                        [
                            -70.3125,
                            26.509905
                        ],
                        [
                            -125.41992200000001,
                            25.403585
                        ],
                        [
                            -127.353516,
                            49.15297
                        ]
                    ]
                ]
            ],
            "type": "MultiPolygon"
        },
        "id": "dc284c1a-8434-4467-bb2d-e2382fe29e43",
        "isSingleBand": false,
        "modifiedAt": "2019-03-06T20:51:49.683Z",
        "name": "Week Split",
        "projectId": "d103408d-c2d1-40fc-a5c8-6b7030671724",
        "rangeEnd": "2017-04-17T00:00:00Z",
        "rangeStart": "2017-04-10T00:00:00Z",
        "singleBandOptions": null,
        "smartLayerId": "bc5f360a-cdb8-4995-abfb-ef47e589dc33"
    },
    {
        "colorGroupHex": "#738FFC",
        "createdAt": "2019-03-06T20:51:49.683Z",
        "geometry": {
            "coordinates": [
                [
                    [
                        [
                            -127.353516,
                            49.15297
                        ],
                        [
                            -71.982422,
                            48.40003200000001
                        ],
                        [
                            -70.3125,
                            26.509905
                        ],
                        [
                            -125.41992200000001,
                            25.403585
                        ],
                        [
                            -127.353516,
                            49.15297
                        ]
                    ]
                ]
            ],
            "type": "MultiPolygon"
        },
        "id": "d525f110-4a00-4857-bb8e-9d2953b32048",
        "isSingleBand": false,
        "modifiedAt": "2019-03-06T20:51:49.683Z",
        "name": "Week Split",
        "projectId": "d103408d-c2d1-40fc-a5c8-6b7030671724",
        "rangeEnd": "2017-04-24T00:00:00Z",
        "rangeStart": "2017-04-17T00:00:00Z",
        "singleBandOptions": null,
        "smartLayerId": "bc5f360a-cdb8-4995-abfb-ef47e589dc33"
    }
]
```
### Notes



## Testing Instructions

 *  Create a project
* Add scenes from multiple days / weeks to one of the layers
* for testing, truncate your scenes_to_projects table (there will be a foreign key conflict on it otherwise, there's a task to drop that table soon)
* Make a post request to the `/projects/{}/layers/{}/split` endpoint with a json object that looks like:
```
{
name: "some name",
colorGroupHex: "#{{SomeHexCode}}",
rangeStart: "{{ISO format date less than the oldest scene in your layer}}",
rangeEnd: "{{ISO formate date greater than the youngest scene in your layer}}",
period: "DAY"
}
```
* Verify that the default values for splitOnDatasource and removeFromLayer are respected
* delete the created layers and truncate the scenes_to_projects table again
* Run the http request again with period = "WEEK" and verify that it works correctly (weeks start on monday)
* verify that they are split correctly
* Run the above again with splitOnDatasource set to false and verify that it works as expected
* Run one of the above with removeFromLayer set to true and verify that it removed the scenes from the source layer

Closes #4684 