### PR TITLE
Add project analysis data visualization map UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Added project analyses edit modal for v2 UI [\#4709](https://github.com/raster-foundry/raster-foundry/pull/4709)
 - Added query parameter to limit scene search by layer AOI and updated filters on the frontend [\#4733](https://github.com/raster-foundry/raster-foundry/pull/4733)
 - Added endpoint for splitting layers up by date and datasource [\#4738](https://github.com/raster-foundry/raster-foundry/pull/4738)
+- Added the map part of analysis data visualization UI [\#4739](https://github.com/raster-foundry/raster-foundry/pull/4739)
 
 ### Changed
 

--- a/app-frontend/src/app/components/common/listItemWidgets/listItemSelector/index.html
+++ b/app-frontend/src/app/components/common/listItemWidgets/listItemSelector/index.html
@@ -14,3 +14,8 @@
      border: 2px solid {{$ctrl.color}};
  }
 </style>
+<style>
+ label.checkbox.list-item-{{$ctrl.id}}::after {
+     background-color: inherit !important;
+ }
+</style>

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.html
@@ -39,7 +39,7 @@
             tooltip-side="bottom"
         >
             <button
-                class="btn btn-transparent"
+                class="btn btn-transparent btn-tiny"
                 ng-click="$ctrl.editAnalyses()"
                 ng-disabled="!$ctrl.canEditSelection()"
             >
@@ -47,7 +47,7 @@
             </button>
         </span>
         <button
-            class="btn btn-transparent"
+            class="btn btn-transparent btn-tiny"
             ng-click="$ctrl.deleteProjectAnalyses($ctrl.selected.valueSeq().toArray())"
         >
             Delete

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.html
@@ -20,6 +20,19 @@
     >
         <span
             tooltips
+            tooltip-template="View maps and histograms of selected analyses on one page"
+            tooltip-size="small"
+            tooltip-class="rf-tooltip shrink"
+            tooltip-side="bottom">
+          <button class="btn btn-transparent btn-tiny"
+                  ng-click="$ctrl.visualizeAnalyses()"
+                  ng-disabled="!$ctrl.canVisualize()"
+          >
+            Visualize
+          </button>
+        </span>
+        <span
+            tooltips
             tooltip-template="Edit analyses created from the same template"
             tooltip-size="small"
             tooltip-class="rf-tooltip shrink"

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -184,7 +184,7 @@ class AnalysesListController {
                 let updatedAnalysis = astFromNodes({analysis, nodes}, [newNodeDefinition]);
                 return this.analysisService.updateAnalysis(updatedAnalysis);
             });
-        }).then( () => {
+        }).then(() => {
             const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
             return L.tileLayer(tileUrl, {maxZoom: 30});
         });
@@ -195,7 +195,7 @@ class AnalysesListController {
         this.getMap().then(map => {
             this.$q.all(
                 visibleAnalysisIds.map(this.mapLayerFromAnalysis.bind(this)),
-            ).then( layers => {
+            ).then(layers => {
                 map.setLayer(
                     'Project Analyses',
                     layers,
@@ -344,6 +344,15 @@ class AnalysesListController {
         }).catch(() => {
             // modal closed
         });
+    }
+
+    visualizeAnalyses() {
+        this.$log.log(this.selected.size);
+        this.$state.go('project.analyses.visualize', {analysis: this.selected.keySeq().toArray()});
+    }
+
+    canVisualize() {
+        return this.selected.size <= 2;
     }
 }
 

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -347,12 +347,11 @@ class AnalysesListController {
     }
 
     visualizeAnalyses() {
-        this.$log.log(this.selected.size);
         this.$state.go('project.analyses.visualize', {analysis: this.selected.keySeq().toArray()});
     }
 
     canVisualize() {
-        return this.selected.size <= 2;
+        return this.selected.size <= 3;
     }
 }
 

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
@@ -1,1 +1,23 @@
-visualize
+<div class="page-content-container">
+    <div class="page-header wide">
+        <h3>Key metrics</h3>
+    </div>
+    <div class="page-card analysis-maps-card">
+      <div class="row">
+        <div class="column-4 flex-display analysis-viz-container" ng-repeat="analysis in $ctrl.analyses track by $index">
+          <rf-analysis-map-item
+              class="panel panel-off-white project-item"
+              analysis-id="analysis.id"
+              analysis-tile="analysis.analysisTile">
+              <item-selector>
+                <rf-list-item-selector
+                    id="analysis.id"
+                    selected="$ctrl.selected.has(analysis.id)"
+                    color="$ctrl.layerColorHex[analysis.id]"
+                ></rf-list-item-selector>
+              </item-selector>
+          </rf-analysis-map-item>
+        </div>
+      </div>
+    </div>
+</div>

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
@@ -1,7 +1,81 @@
+import { Map } from 'immutable';
+import { get } from 'lodash';
+
 import tpl from './index.html';
+import {createRenderDefinition} from '_redux/histogram-utils';
+import {nodesFromAst, astFromNodes} from '_redux/node-utils';
 
 class AnalysesVisualizeController {
+    constructor(
+        $rootScope, $scope, $state, $log,
+        mapService, projectService, analysisService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
 
+    $onInit() {
+        this.selected = new Map();
+        this.projectId = this.$state.params.projectId;
+        this.layerColorHex = {};
+        this.analyses = this.getAnalysisIds().map(analysisId => {
+            return {
+                id: analysisId,
+                analysisTile: this.mapLayerFromAnalysis(analysisId)
+            };
+        });
+    }
+
+    getAnalysisIds() {
+        const analysis = this.$state.params.analysis;
+        if (typeof this.$state.params.analysis === 'string') {
+            return [analysis];
+        }
+        return analysis;
+    }
+
+    mapLayerFromAnalysis(analysisId) {
+        return this.analysisService.getAnalysis(analysisId).then(analysis => {
+            this.analysisService.getNodeHistogram(analysisId).then(histogram => {
+                const {
+                    renderDefinition,
+                    histogramOptions
+                } = createRenderDefinition(histogram);
+                const newNodeDefinition = Object.assign(
+                    {}, analysis.executionParameters,
+                    {
+                        metadata: Object.assign({}, analysis.executionParameters.metadata, {
+                            renderDefinition,
+                            histogramOptions
+                        })
+                    }
+                );
+                const nodes = nodesFromAst(analysis.executionParameters);
+                const updatedAnalysis = astFromNodes({analysis, nodes}, [newNodeDefinition]);
+                return this.analysisService.updateAnalysis(updatedAnalysis);
+            });
+            this.setLayerColorHex(analysis);
+            return analysis;
+        }).then((analysis) => {
+            const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
+            return {
+                analysis,
+                mapTile: L.tileLayer(tileUrl, {maxZoom: 30})
+            };
+        });
+    }
+
+    setLayerColorHex(analysis) {
+        const projectLayerId = get(analysis, 'projectLayerId');
+        if (projectLayerId) {
+            this.projectService
+                .getProjectLayer(this.projectId, projectLayerId)
+                .then(layer => {
+                    this.layerColorHex[analysis.id] = layer.colorGroupHex;
+                })
+                .catch(() => {});
+        }
+    }
 }
 
 const component = {

--- a/app-frontend/src/app/components/pages/project/project/index.html
+++ b/app-frontend/src/app/components/pages/project/project/index.html
@@ -1,6 +1,6 @@
 <div
     ui-view="navbar-secondary"
-    ng-if="!('project.create-analysis' | includedByState)"
+    ng-if="!('project.create-analysis' | includedByState) && !('project.analyses.visualize' | includedByState)"
 >
     <div class="navbar light-navbar">
         <div class="navbar-section">
@@ -54,7 +54,8 @@
     class="container column-stretch container-not-scrollable with-secondary-navbar"
     ng-if="
             !('project.settings' | includedByState) &&
-            !('project.create-analysis' | includedByState)
+            !('project.create-analysis' | includedByState) &&
+            !('project.analyses.visualize' | includedByState)
             "
 >
     <div class="sidebar" ui-view></div>
@@ -72,4 +73,9 @@
     ng-if="('project.layer.browse' | includedByState)"
     class="sidebar project-side-modal"
     ui-view="project-sidemodal"
+></div>
+<div
+    ng-if="('project.analyses.visualize' | includedByState)"
+    class="container column-stretch container-not-scrollable"
+    ui-view="analyses-visualize"
 ></div>

--- a/app-frontend/src/app/components/projects/analysisMapItem/index.html
+++ b/app-frontend/src/app/components/projects/analysisMapItem/index.html
@@ -1,0 +1,21 @@
+<div class="panel-body panel-analysis-viz-container">
+  <div class="analysis-map-item-top-bar">
+    <div class="list-item-left-actions" ng-transclude="selector"></div>
+    <div class="list-group-overflow">
+      <div class="text-overflow-ellipsis">
+        <strong ng-attr-title="{{item.name}}">{{$ctrl.analysis.name}}</strong>
+      </div>
+      <div class="text-overflow-ellipsis">
+        {{$ctrl.analysis.modifiedAt | date : 'medium'}}
+      </div>
+    </div>
+  </div>
+  <div class="project-preview analysis-viz-map">
+    <div class="project-preview-container placeholder analysis-map"
+          style="background-image: url({{$ctrl.projectPlaceholder}})">
+      <rf-static-map
+        map-id="{{$ctrl.mapId}}"
+        options="$ctrl.mapOptions"></rf-static-map>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/projects/analysisMapItem/index.js
+++ b/app-frontend/src/app/components/projects/analysisMapItem/index.js
@@ -1,0 +1,77 @@
+import { get } from 'lodash';
+
+import tpl from './index.html';
+import projectPlaceholder from '../../../../assets/images/transparent.svg';
+
+const analysisLayerName = 'Analysis Viz';
+const offset = -2;
+
+class AnalysisMapItemController {
+    constructor(
+        $rootScope, $state, $scope, $log, $timeout,
+        analysisService, mapService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.analysisLayerName = analysisLayerName;
+        this.mapOptions = {attributionControl: false};
+        this.mapId = `analysis-viz-${this.analysisId}`;
+        this.offset = offset;
+        this.setAnalysisAndTiles();
+    }
+
+    getMap() {
+        return this.mapService.getMap(this.mapId);
+    }
+
+    setAnalysisAndTiles() {
+        this.getMap().then(map => {
+            this.analysisTile.then(analysisTile => {
+                const { analysis, mapTile } = analysisTile;
+                this.analysis = analysis;
+                if (get(this, 'analysis.executionParameters.mask.type')) {
+                    this.updateMapView(this.analysis.executionParameters.mask, map);
+                }
+                map.setLayer(this.analysisLayerName, mapTile);
+            });
+        });
+    }
+
+    transformWmCoords(coord) {
+        return this.analysisService.transformWmPointToLatLngArray(L.point(coord[0], coord[1]));
+    }
+
+    updateMapView(multipolygon, mapWrapper) {
+        // we know that the backend returns only multipolygon
+        // and the coordinates are web mercator
+        mapWrapper.map.invalidateSize();
+        const updatedMultipolygon = Object.assign({}, multipolygon, {
+            coordinates: [[multipolygon.coordinates[0][0].map(this.transformWmCoords.bind(this))]]
+        });
+        mapWrapper.map.fitBounds(L.geoJson(updatedMultipolygon).getBounds(), {
+            padding: [this.offset, this.offset],
+            animate: false
+        });
+    }
+}
+
+const component = {
+    bindings: {
+        analysisId: '<',
+        analysisTile: '<'
+    },
+    transclude: {
+        selector: '?itemSelector'
+    },
+    templateUrl: tpl,
+    controller: AnalysisMapItemController.name
+};
+
+export default angular
+    .module('components.projects.analysisMapItem', [])
+    .controller(AnalysisMapItemController.name, AnalysisMapItemController)
+    .component('rfAnalysisMapItem', component)
+    .name;

--- a/app-frontend/src/app/components/projects/index.js
+++ b/app-frontend/src/app/components/projects/index.js
@@ -5,6 +5,7 @@ import navbar from './navbar';
 import projectSettingsNavbar from './projectSettingsNavbar';
 import aoiDrawToolbar from './aoiDrawToolbar';
 import analysisEditModal from './analysisEditModal';
+import analysisMapItem from './analysisMapItem';
 
 export default [
     projectSettingsNavbar,
@@ -13,5 +14,6 @@ export default [
     selectedActionsBar,
     navbar,
     aoiDrawToolbar,
-    analysisEditModal
+    analysisEditModal,
+    analysisMapItem
 ];

--- a/app-frontend/src/app/components/projects/navbar/index.js
+++ b/app-frontend/src/app/components/projects/navbar/index.js
@@ -48,6 +48,12 @@ class ProjectLayersNavController {
             });
         }
 
+        if (stateCurrent.name.includes('project.analyses.visualize')) {
+            this.navs.push({
+                title: 'Data visualizations'
+            });
+        }
+
         if (stateCurrent.name === 'project.layer' ||
             stateCurrent.name.includes('project.layer.')
         ) {

--- a/app-frontend/src/app/components/projects/navbar/index.js
+++ b/app-frontend/src/app/components/projects/navbar/index.js
@@ -50,6 +50,10 @@ class ProjectLayersNavController {
 
         if (stateCurrent.name.includes('project.analyses.visualize')) {
             this.navs.push({
+                title: 'Analyses',
+                sref: `project.analyses({projectId: '${this.project.id}'})`
+            },
+            {
                 title: 'Data visualizations'
             });
         }

--- a/app-frontend/src/app/index.routes.js
+++ b/app-frontend/src/app/index.routes.js
@@ -294,8 +294,21 @@ function projectStatesV2($stateProvider) {
         })
         .state('project.analyses.visualize', {
             title: 'Project Analyses Visualization',
-            url: '/visualize',
-            component: 'rfProjectAnalysesVisualizePage'
+            url: '/visualize?analysis',
+            params: {
+                analysis: {
+                    array: 'auto'
+                }
+            },
+            views: {
+                'projectlayernav@root': {
+                    component: 'rfProjectLayersNav'
+                },
+                'analyses-visualize@project': {
+                    component: 'rfProjectAnalysesVisualizePage'
+                }
+            }
+            // component: 'rfProjectAnalysesVisualizePage'
         })
         .state('project.create-analysis', {
             title: 'Create project analysis',

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -380,6 +380,11 @@ export default (app) => {
                 `?token=${token}${node}&tag=${new Date().getTime()}`;
         }
 
+        transformWmPointToLatLngArray(wmPoint) {
+            const latLng = L.Projection.SphericalMercator.unproject(wmPoint);
+            return [latLng.lng, latLng.lat];
+        }
+
         // @TODO: implement getting related tags and categories
     }
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3296,10 +3296,12 @@ rf-project-scene-item {
     margin: 0.5em;
 }
 
+
 rf-project-settings-page,
 rf-project-options-page,
 rf-project-permissions-page,
-rf-project-publishing-page {
+rf-project-publishing-page,
+rf-project-analyses-visualize-page {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -3335,7 +3337,13 @@ rf-project-publishing-page {
     h6 {
         margin: 0;
     }
+
+    &.wide {
+        max-width: 1300px;
+    }
 }
+
+
 
 .page-card {
     flex: none;
@@ -3357,6 +3365,14 @@ rf-project-publishing-page {
     }
     &.cozy {
         margin-bottom: 1.5rem;
+    }
+    &.analysis-maps-card {
+        max-width: 1300px;
+        background: none;
+        border: none;
+        border-radius: none;
+        box-shadow: none;
+        padding: 0;
     }
 }
 
@@ -3611,4 +3627,17 @@ rf-aoi-draw-toolbar {
         width: 100%;
         height: 100%;
     }
+}
+
+.analysis-map-item-top-bar {
+    display: flex;
+}
+
+.analysis-viz-container {
+    padding: 1rem 3rem 1rem 0rem !important;
+}
+
+.panel-analysis-viz-container {
+    background-color: $white;
+    box-shadow: 0px 3px 8px rgba($shade-normal, 0.2);
 }

--- a/app-frontend/src/assets/styles/sass/components/_project-item.scss
+++ b/app-frontend/src/assets/styles/sass/components/_project-item.scss
@@ -89,6 +89,9 @@
   overflow: hidden;
   position: relative;
   z-index: 1;
+  &.analysis-viz-map {
+    margin-top: 2rem;
+  }
 }
 
 .project-ownership {

--- a/app-frontend/src/assets/styles/sass/pages/_dashboard.scss
+++ b/app-frontend/src/assets/styles/sass/pages/_dashboard.scss
@@ -107,4 +107,8 @@
     background-repeat: no-repeat;
     background-position: center;
   }
+
+  &.analysis-map {
+      height: 300px;
+  }
 }


### PR DESCRIPTION
## Overview

This PR adds the map visualization part of the analysis data viz UI. It also creates a new analysis map item component containing the map, tiles, analysis info shown in the demo section.

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

<img width="1511" alt="screen shot 2019-03-08 at 1 15 12 pm" src="https://user-images.githubusercontent.com/16109558/54047567-60be3c00-41a5-11e9-88a4-3055de4a69e3.png">

### Notes

We only support visualizing at most three analysis results per discussions during RRP

## Testing Instructions
 * On lab template UI, create some templates with `This template can be run with only one project` checked
 * Go to a project's v2 UI
 * Add some layers
 * Define layer AOIs
 * Add some scenes to these layers
 * Create some analyses with these new layers using the template(s) created from step one
 * On the analyses list UI, select multiple analyses (no more than three, see notes section), click on `Visualize` (if more than three, this button is disabled)
 * Make sure the above step takes you to analyses visualization page and make sure the tiles load and the map zooms to corresponding layer's AOI, and make sure the checkboxes can be checked and unchecked

Closes https://github.com/raster-foundry/raster-foundry/issues/4676
