### PR TITLE
fixes issue with layer menu dropdown on firefox

### DIFF
--- a/app-frontend/src/app/components/common/listItemWidgets/listItemActions/index.html
+++ b/app-frontend/src/app/components/common/listItemWidgets/listItemActions/index.html
@@ -17,19 +17,21 @@
         ng-if="icon.isActive()"
   ></span>
 </div>
-<button class="btn btn-text btn-transparent"
-        uib-dropdown
-        ng-if="($ctrl.actions | filter: {menu: true}).length > 0"
-        uib-dropdown-toggle
->
-  <i class="icon-menu"></i>
-  <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
-    <li role="menuitem"
-        ng-repeat="action in $ctrl.actions | filter: {menu: true}">
-      <a href ng-click="action.callback($event)"
-         ng-show="action.name"
-         ng-attr-title="{{action.title}}">{{action.name}}</a>
-      <span class="menu-separator" ng-show="action.separator"></span>
-    </li>
-  </ul>
-</button>
+<div uib-dropdown class="display-ib">
+  <button class="btn btn-text btn-transparent"
+          ng-if="($ctrl.actions | filter: {menu: true}).length > 0"
+          uib-dropdown-toggle
+  >
+    <i class="icon-menu"></i>
+    <span class="sr-only">More actions</span>
+  </button>
+    <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+      <li role="menuitem"
+          ng-repeat="action in $ctrl.actions | filter: {menu: true}">
+        <a href ng-click="action.callback($event)"
+          ng-show="action.name"
+          ng-attr-title="{{action.title}}">{{action.name}}</a>
+        <span class="menu-separator" ng-show="action.separator"></span>
+      </li>
+    </ul>
+</div>

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -171,6 +171,26 @@
   flex: none !important;
 }
 
+.display-i {
+  display: inline;
+}
+
+.display-ib {
+  display: inline-block;
+}
+
+.display-b {
+  display: block;
+}
+
+.display-if {
+  display: inline-flex;
+}
+
+.display-f {
+  display: flex;
+}
+
 // Text overflow
 .text-overflow-ellipsis {
   overflow: hidden;


### PR DESCRIPTION
## Overview

Layers dropdown were not clickable in firefox.
- Fixes #4734

### Demo
**Before**
![firefox-broken](https://user-images.githubusercontent.com/1928955/53978539-7d8d3d80-40d9-11e9-927b-88c1be175696.gif)

**After**
![firefox-dropdown](https://user-images.githubusercontent.com/1928955/53977339-cbed0d00-40d6-11e9-8dc8-10387943c81f.gif)


### Notes

For future, don't nest dropdown `ul` inside of `button` tags / the element that toggles opening the dropdown. If you nest the dropdown menu inside the thing that toggles it open, whenever you click on the dropdown, you are technically clicking the toggle, thus closing the dropdown.


## Testing Instructions

 * Open in firefox
 * Open layer dropdown and click on a link within dropdown
