### PR TITLE
Include shared public projects in "shared with me"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
 
 ### Fixed
 
+- No longer exclude public objects from searches for shared objects, except for scenes [\#4754](https://github.com/raster-foundry/raster-foundry/pull/4754)
+
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 
 ### Fixed

--- a/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
+++ b/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
@@ -7,7 +7,6 @@ import io.circe.{Decoder, Encoder}
 import io.circe.generic.JsonCodec
 import io.circe.generic.semiauto._
 import io.circe._
-import cats.syntax.either._
 
 import java.sql.Timestamp
 import java.util.UUID

--- a/app-backend/common/src/main/scala/datamodel/SplitOptions.scala
+++ b/app-backend/common/src/main/scala/datamodel/SplitOptions.scala
@@ -1,6 +1,5 @@
 package com.rasterfoundry.common.datamodel
 
-import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
 import io.circe._
 import cats.syntax.either._

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -161,14 +161,14 @@ trait ObjectPermissions[Model] {
                         tableName: String): Fragment =
     (objectType, actionType) match {
       case (ObjectType.Shape, ActionType.View) =>
-        Fragment.const("")
+        Fragment.empty
       case (_, ActionType.View) | (ObjectType.Scene, ActionType.Download) |
           (ObjectType.Project, ActionType.Export) |
           (ObjectType.Project, ActionType.Annotate) |
           (ObjectType.Analysis, ActionType.Export) =>
         Fragment.const(s"${tableName}visibility = 'PUBLIC' OR")
       case _ =>
-        Fragment.const("")
+        Fragment.empty
     }
 
   def createInheritedF(user: User,

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -14,7 +14,6 @@ import doobie.postgres.circe.jsonb.implicits._
 import io.circe._
 import io.circe.syntax._
 import java.sql.Timestamp
-import java.time.temporal.IsoFields
 import java.util.UUID
 
 object ProjectDao

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -60,7 +60,6 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       sceneParams: ProjectSceneQueryParameters
   ): ConnectionIO[PaginatedResponse[Scene.ProjectScene]] = {
 
-    val layerQuery = ProjectLayerDao.query.filter(layerId).select
     val andPendingF: Option[Fragment] =
       sceneParams.accepted match {
         case Some(true)  => Some(fr"accepted = true")


### PR DESCRIPTION
## Overview

This PR explicitly excludes PUBLIC objects from `owner=shared` only for scenes.
 
### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests (at least it's tested whether they break SQL)

## Testing Instructions

 * share a project with a user and make it public
 * log in as that user
 * view projects shared with you
 * you should see the project
 * get an api token
 * `export RF_API_TOKEN=<your api token>`
 * `http :9091/api/scenes/ owner==shared Authorization:$RF_API_TOKEN | jq ".count"`
 * it shouldn't be in the thousands

Closes #4751 
