### PR TITLE
Give the connection pool as many threads as the transactor

### DIFF
--- a/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/DBTestConfig.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext
 
 trait DBTestConfig {
 
-  val connectExecutorService = Executors.newFixedThreadPool(10)
+  val connectExecutorService = Executors.newFixedThreadPool(20)
   val transactExecutorService = Executors.newFixedThreadPool(20)
   val connectEc = ExecutionContext.fromExecutorService(
     connectExecutorService,


### PR DESCRIPTION
## Overview

This PR anchors work to fight the deadlocks.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Attempt 1: make sure the connection threadpool has as many threads as the transaction threadpool, based on this commit message -- https://github.com/kwark/slick-deadlock/commit/82525fc5494c8e7c0d790373aaf10260c047f08a. The reasoning is that the following can happen:

- connection pool is out of threads
- some transactions are waiting for threads and hanging out
- they try to create or update or delete identical rows

## Testing Instructions

 * run ci like a hundred times

Closes #4610 
