### PR TITLE
Add layer analyses histogram component and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,8 @@
 - Added endpoint for splitting layers up by date and datasource [\#4738](https://github.com/raster-foundry/raster-foundry/pull/4738)
 - Added the map part of analysis data visualization UI [\#4739](https://github.com/raster-foundry/raster-foundry/pull/4739)
 - Enabled project layer selection in lab input raster nodes [\#4732](https://github.com/raster-foundry/raster-foundry/pull/4732)
-- Enabled project layer splitting on frontend  [\#4766](https://github.com/raster-foundry/raster-foundry/pull/4766)
+- Enabled project layer splitting on frontend [\#4766](https://github.com/raster-foundry/raster-foundry/pull/4766)
+- Added the histogram part of analysis data visualization UI [\#4756](https://github.com/raster-foundry/raster-foundry/pull/4756)
 
 ### Changed
 

--- a/app-frontend/src/app/components/common/listItemWidgets/listItemSelector/index.html
+++ b/app-frontend/src/app/components/common/listItemWidgets/listItemSelector/index.html
@@ -9,9 +9,9 @@
          ng-click="!$ctrl.disableSelection && $ctrl.onSelect({id: $ctrl.id})"
   />
 </label>
-<style ng-if="$ctrl.color">
+<style ng-if="$ctrl.colorValue">
  label.checkbox.list-item-{{$ctrl.id}}::after {
-     border: 2px solid {{$ctrl.color}};
+     border: 2px solid {{$ctrl.colorValue}};
  }
 </style>
 <style>

--- a/app-frontend/src/app/components/common/listItemWidgets/listItemSelector/index.js
+++ b/app-frontend/src/app/components/common/listItemWidgets/listItemSelector/index.js
@@ -10,12 +10,17 @@ class ListItemSelectorController {
         if (!this.id) {
             this.id = this.uuid4.generate();
         }
-        const rx = /^#(?:[0-9a-f]{3}){1,2}$/i;
-        const color = this.color;
-        if (color && color.match(rx)) {
-            this.color = color;
-        } else {
-            this.color = 'black';
+    }
+
+    $onChanges(changes) {
+        if (changes.color) {
+            const rx = /^#(?:[0-9a-f]{3}){1,2}$/i;
+            const color = changes.color.currentValue;
+            if (color && color.match(rx)) {
+                this.colorValue = color;
+            } else {
+                this.colorValue = 'black';
+            }
         }
     }
 }

--- a/app-frontend/src/app/components/histogram/dataVizHistogram/index.html
+++ b/app-frontend/src/app/components/histogram/dataVizHistogram/index.html
@@ -1,0 +1,4 @@
+<div class="graph-container" style="width: 60vw;">
+  <svg ng-attr-id="graph-{{$ctrl.id}}" height="50px" width="100%"></svg>
+  <ng-transclude></ng-transclude>
+</div>

--- a/app-frontend/src/app/components/histogram/dataVizHistogram/index.html
+++ b/app-frontend/src/app/components/histogram/dataVizHistogram/index.html
@@ -1,4 +1,7 @@
-<div class="graph-container" style="width: 60vw;">
+<div class="graph-container text-center data-viz-histogram mask" ng-if="$ctrl.isLoadingHistogram">
+  <h5>Loading histograms<i class="icon-load animate-spin"></i></h5>
+</div>
+<div class="graph-container data-viz-histogram">
   <svg ng-attr-id="graph-{{$ctrl.id}}" height="50px" width="100%"></svg>
   <ng-transclude></ng-transclude>
 </div>

--- a/app-frontend/src/app/components/histogram/dataVizHistogram/index.js
+++ b/app-frontend/src/app/components/histogram/dataVizHistogram/index.js
@@ -1,10 +1,10 @@
-import _ from 'lodash';
+import { min, max, range, get } from 'lodash';
 import tpl from './index.html';
 import { Map } from 'immutable';
 
 class DataVizHistogramController {
     constructor(
-        $rootScope, $scope, $log, $q, $element,
+        $rootScope, $scope, $log, $q, $element, $window,
         graphService
     ) {
         'ngInject';
@@ -12,21 +12,52 @@ class DataVizHistogramController {
     }
 
     $postLink() {
+        this.isLoadingHistogram = true;
         this.$q.all({
-            histStat: this.histogram,
-            bounds: this.bounds
-        }).then(({histStat, bounds}) => {
-            const {histogram, statistics} = histStat;
-            this.$scope.$evalAsync(() => this.initGraph(histogram, bounds));
-            this.getGraph().then(graph => {
-                this.createPlotFromHistogram(histogram, bounds, statistics);
-                graph.setData({histogram: this.plot})
-                    .render();
-            });
+            histStat: this.histogramPromise,
+            histBounds: this.boundsPromise
+        }).then(({histStat, histBounds}) => {
+            const { histogram } = histStat;
+            this.histogramData = histogram;
+            this.histogramBounds = histBounds;
+            if (this.histogramData &&
+                this.histogramBounds &&
+                get(this.histogramData, 'buckets.length')
+            ) {
+                this.$scope.$evalAsync(() => {
+                    this.initGraphOptions(this.histogramBounds);
+                    this.visualizeHistogram();
+                });
+            }
+        });
+
+        this.$window.addEventListener('resize', this.onWindowResize.bind(this));
+    }
+
+    $onDestroy() {
+        if (this.onWindowResize) {
+            this.$window.removeEventListener('resize', this.onWindowResize);
+        }
+        this.graphService.deregister(this.id);
+    }
+
+    onWindowResize() {
+        this.getGraph().then(graph => {
+            graph.render();
         });
     }
 
-    initGraph(histogram, bounds) {
+    visualizeHistogram() {
+        this.initGraph();
+        this.getGraph().then(graph => {
+            const plot =
+                this.createPlotFromHistogram(this.histogramData, this.histogramBounds);
+            graph.setData({ histogram: plot }).render();
+            this.isLoadingHistogram = false;
+        });
+    }
+
+    initGraphOptions(bounds) {
         this.options = {
             dataRange: {
                 min: bounds.min,
@@ -44,7 +75,9 @@ class DataVizHistogramController {
                 left: 0
             }
         };
+    }
 
+    initGraph() {
         const elem = this.$element.find('.graph-container svg')[0];
         this.graph = this.graphService.register(elem, this.id, this.options);
     }
@@ -53,35 +86,34 @@ class DataVizHistogramController {
         return this.graphService.getGraph(this.id);
     }
 
-    createPlotFromHistogram(histogram, bounds, statistics) {
-        let diff = (bounds.max - bounds.min) / 100;
-        let magnitude = Math.round(Math.log10(diff));
+    createPlotFromHistogram(histogram, bounds) {
+        const diff = (bounds.max - bounds.min) / 100;
+        const magnitude = Math.round(Math.log10(diff));
         this.precision = Math.pow(10, magnitude);
 
-        let buckets = histogram.buckets;
+        const buckets = histogram.buckets;
         let plot;
         if (buckets.length < 100) {
             let valueMap = new Map();
             buckets.forEach(([bucket, value]) => {
-                let roundedBucket = Math.round(bucket / this.precision) * this.precision;
+                const roundedBucket = Math.round(bucket / this.precision) * this.precision;
                 valueMap = valueMap.set(roundedBucket, value);
             });
-            _.range(0, 100).forEach((mult) => {
-                let key = Math.round(
+            range(0, 100).forEach((mult) => {
+                const key = Math.round(
                     (mult * diff + this.options.dataRange.min) / this.precision
                 ) * this.precision;
-                let value = valueMap.get(key, 0);
+                const value = valueMap.get(key, 0);
                 valueMap = valueMap.set(key, value);
             });
 
             plot = valueMap.entrySeq()
                 .sort(([K1], [K2]) => K1 - K2)
                 .map(([key, value]) => ({
-                    x: _.min([_.max([key, histogram.minimum]), histogram.maximum]),
+                    x: min([max([key, histogram.minimum]), histogram.maximum]),
                     y: value}))
                 .toArray();
         } else {
-            // TODO fix this so it acts like above
             plot = buckets.map((bucket) => {
                 return {
                     x: Math.round(bucket[0]), y: bucket[1]
@@ -89,15 +121,15 @@ class DataVizHistogramController {
             });
         }
 
-        this.plot = plot;
+        return plot;
     }
 }
 
 const component = {
     bindings: {
         id: '<',
-        histogram: '<',
-        bounds: '<'
+        histogramPromise: '<',
+        boundsPromise: '<'
     },
     templateUrl: tpl,
     controller: DataVizHistogramController.name,

--- a/app-frontend/src/app/components/histogram/dataVizHistogram/index.js
+++ b/app-frontend/src/app/components/histogram/dataVizHistogram/index.js
@@ -1,0 +1,111 @@
+import _ from 'lodash';
+import tpl from './index.html';
+import { Map } from 'immutable';
+
+class DataVizHistogramController {
+    constructor(
+        $rootScope, $scope, $log, $q, $element,
+        graphService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $postLink() {
+        this.$q.all({
+            histStat: this.histogram,
+            bounds: this.bounds
+        }).then(({histStat, bounds}) => {
+            const {histogram, statistics} = histStat;
+            this.$scope.$evalAsync(() => this.initGraph(histogram, bounds));
+            this.getGraph().then(graph => {
+                this.createPlotFromHistogram(histogram, bounds, statistics);
+                graph.setData({histogram: this.plot})
+                    .render();
+            });
+        });
+    }
+
+    initGraph(histogram, bounds) {
+        this.options = {
+            dataRange: {
+                min: bounds.min,
+                max: bounds.max
+            },
+            height: 50,
+            style: {
+                height: '50px'
+            },
+            type: 'stat',
+            margin: {
+                top: 0,
+                bottom: 0,
+                right: 0,
+                left: 0
+            }
+        };
+
+        const elem = this.$element.find('.graph-container svg')[0];
+        this.graph = this.graphService.register(elem, this.id, this.options);
+    }
+
+    getGraph() {
+        return this.graphService.getGraph(this.id);
+    }
+
+    createPlotFromHistogram(histogram, bounds, statistics) {
+        let diff = (bounds.max - bounds.min) / 100;
+        let magnitude = Math.round(Math.log10(diff));
+        this.precision = Math.pow(10, magnitude);
+
+        let buckets = histogram.buckets;
+        let plot;
+        if (buckets.length < 100) {
+            let valueMap = new Map();
+            buckets.forEach(([bucket, value]) => {
+                let roundedBucket = Math.round(bucket / this.precision) * this.precision;
+                valueMap = valueMap.set(roundedBucket, value);
+            });
+            _.range(0, 100).forEach((mult) => {
+                let key = Math.round(
+                    (mult * diff + this.options.dataRange.min) / this.precision
+                ) * this.precision;
+                let value = valueMap.get(key, 0);
+                valueMap = valueMap.set(key, value);
+            });
+
+            plot = valueMap.entrySeq()
+                .sort(([K1], [K2]) => K1 - K2)
+                .map(([key, value]) => ({
+                    x: _.min([_.max([key, histogram.minimum]), histogram.maximum]),
+                    y: value}))
+                .toArray();
+        } else {
+            // TODO fix this so it acts like above
+            plot = buckets.map((bucket) => {
+                return {
+                    x: Math.round(bucket[0]), y: bucket[1]
+                };
+            });
+        }
+
+        this.plot = plot;
+    }
+}
+
+const component = {
+    bindings: {
+        id: '<',
+        histogram: '<',
+        bounds: '<'
+    },
+    templateUrl: tpl,
+    controller: DataVizHistogramController.name,
+    transclude: true
+};
+
+export default angular
+    .module('components.histogram.dataVizHistogram', [])
+    .controller(DataVizHistogramController.name, DataVizHistogramController)
+    .component('rfDataVizHistogram', component)
+    .name;

--- a/app-frontend/src/app/components/histogram/dataVizStatistics/index.html
+++ b/app-frontend/src/app/components/histogram/dataVizStatistics/index.html
@@ -1,34 +1,32 @@
-<div class="flex-display flex-row">
-  <div class="row" style="width: 100%">
-    <div class="column-2">
-        <span style="color: blue;">&#19968;</span>Mean
-        <br/>
-        {{$ctrl.stat.mean | number}}
-    </div>
-    <div class="column-2">
-        <span style="color: green;">&#19968;</span>Median
-        <br/>
-        {{$ctrl.stat.median | number}}
-    </div>
-    <div class="column-2">
-        <span style="color: cyan;">&#19968;</span>Mode
-        <br/>
-        {{$ctrl.stat.mode | number}}
-    </div>
-    <div class="column-2">
-        <span style="color: purple;">&#19968;</span>Mean&plusmn;StdDev
-        <br/>
-        {{$ctrl.stat.stddev | number}}
-    </div>
-    <div class="column-2">
-        <span style="color: black;">&#19968;</span>Min
-        <br/>
-        {{$ctrl.stat.zmin | number}}
-    </div>
-    <div class="column-2">
-      <span style="color: black;">&#19968;</span>Max
+<div class="row">
+  <div class="column-2 flex-display no-padding histogram-stat-numbers">
+      <span class="color-gray-lighter">&#19968;&nbsp;</span>Mean
       <br/>
-        {{$ctrl.stat.zmax | number}}
-    </div>
+      {{$ctrl.stat.mean | number : 2}}
+  </div>
+  <div class="column-2 flex-display no-padding histogram-stat-numbers">
+      <span class="color-green">&#19968;&nbsp;</span>Median
+      <br/>
+      {{$ctrl.stat.median | number : 2}}
+  </div>
+  <div class="column-2 flex-display no-padding histogram-stat-numbers">
+      <span class="color-tertiary">&#19968;&nbsp;</span>Mode
+      <br/>
+      {{$ctrl.stat.mode | number : 2}}
+  </div>
+  <div class="column-2 flex-display no-padding histogram-stat-numbers">
+      <span class="color-danger">&#19968;&nbsp;</span>Mean&nbsp;&plusmn;&nbsp;StdDev
+      <br/>
+      {{$ctrl.stat.median | number : 2}}&nbsp;&plusmn;&nbsp;{{$ctrl.stat.stddev | number : 2}}
+  </div>
+  <div class="column-2 flex-display no-padding histogram-stat-numbers">
+      <span class="color-black">&#19968;&nbsp;</span>Min
+      <br/>
+      {{$ctrl.stat.zmin | number : 2}}
+  </div>
+  <div class="column-2 flex-display no-padding histogram-stat-numbers">
+    <span class="color-black">&#19968;&nbsp;</span>Max
+    <br/>
+      {{$ctrl.stat.zmax | number : 2}}
   </div>
 </div>

--- a/app-frontend/src/app/components/histogram/dataVizStatistics/index.html
+++ b/app-frontend/src/app/components/histogram/dataVizStatistics/index.html
@@ -1,0 +1,34 @@
+<div class="flex-display flex-row">
+  <div class="row" style="width: 100%">
+    <div class="column-2">
+        <span style="color: blue;">&#19968;</span>Mean
+        <br/>
+        {{$ctrl.stat.mean | number}}
+    </div>
+    <div class="column-2">
+        <span style="color: green;">&#19968;</span>Median
+        <br/>
+        {{$ctrl.stat.median | number}}
+    </div>
+    <div class="column-2">
+        <span style="color: cyan;">&#19968;</span>Mode
+        <br/>
+        {{$ctrl.stat.mode | number}}
+    </div>
+    <div class="column-2">
+        <span style="color: purple;">&#19968;</span>Mean&plusmn;StdDev
+        <br/>
+        {{$ctrl.stat.stddev | number}}
+    </div>
+    <div class="column-2">
+        <span style="color: black;">&#19968;</span>Min
+        <br/>
+        {{$ctrl.stat.zmin | number}}
+    </div>
+    <div class="column-2">
+      <span style="color: black;">&#19968;</span>Max
+      <br/>
+        {{$ctrl.stat.zmax | number}}
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/histogram/dataVizStatistics/index.js
+++ b/app-frontend/src/app/components/histogram/dataVizStatistics/index.js
@@ -1,0 +1,30 @@
+import tpl from './index.html';
+
+class DataVizStatisticsController {
+    constructor(
+        $rootScope, $scope, $log, $q
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.statistics.then(stat => {
+            this.stat = stat;
+        });
+    }
+}
+
+const component = {
+    bindings: {
+        statistics: '<'
+    },
+    templateUrl: tpl,
+    controller: DataVizStatisticsController.name
+};
+
+export default angular
+    .module('components.histogram.dataVizStatistics', [])
+    .controller(DataVizStatisticsController.name, DataVizStatisticsController)
+    .component('rfDataVizStatistics', component)
+    .name;

--- a/app-frontend/src/app/components/histogram/histogramBar/index.html
+++ b/app-frontend/src/app/components/histogram/histogramBar/index.html
@@ -1,0 +1,5 @@
+<div
+    ng-repeat="bar in $ctrl.bars track by $index"
+    style="left: {{bar.value}}%;background-color: {{bar.color}}"
+>
+</div>

--- a/app-frontend/src/app/components/histogram/histogramBar/index.html
+++ b/app-frontend/src/app/components/histogram/histogramBar/index.html
@@ -1,5 +1,6 @@
 <div
     ng-repeat="bar in $ctrl.bars track by $index"
-    style="left: {{bar.value}}%;background-color: {{bar.color}}"
+    ng-style="$ctrl.getStyle(bar.value)"
+    ng-class="bar.class"
 >
 </div>

--- a/app-frontend/src/app/components/histogram/histogramBar/index.js
+++ b/app-frontend/src/app/components/histogram/histogramBar/index.js
@@ -1,0 +1,73 @@
+import { min, max, head, last } from 'lodash';
+
+import tpl from './index.html';
+
+class HistogramBarController {
+    constructor(
+        $rootScope, $scope, $q, $element, $log,
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.bars = [];
+        this.$q.all({
+            statistics: this.statistics,
+            bounds: this.bounds,
+            histStats: this.histogram
+        }).then(({statistics, bounds, histStats}) => {
+            const { histogram } = histStats;
+            this.bars = [
+                {
+                    value: this.valueToPercentage(bounds, statistics.mean),
+                    color: 'blue'
+                },
+                {
+                    value: this.valueToPercentage(bounds, statistics.median),
+                    color: 'green'
+                },
+                {
+                    value: this.valueToPercentage(bounds, statistics.mode),
+                    color: 'cyan'
+                },
+                {
+                    value: this.valueToPercentage(bounds, statistics.mean - statistics.stddev),
+                    color: 'purple'
+                },
+                {
+                    value: this.valueToPercentage(bounds, statistics.mean + statistics.stddev),
+                    color: 'purple'
+                },
+                {
+                    value: this.valueToPercentage(bounds, statistics.zmin),
+                    color: 'black'
+                },
+                {
+                    value: this.valueToPercentage(bounds, statistics.zmax),
+                    color: 'black'
+                }
+            ];
+        });
+    }
+
+    valueToPercentage(bounds, val) {
+        return (val - bounds.min) / (bounds.max - bounds.min) * 100;
+    }
+}
+
+const component = {
+    bindings: {
+        statistics: '<',
+        bounds: '<',
+        histogram: '<'
+    },
+    templateUrl: tpl,
+    controller: HistogramBarController.name
+};
+
+export default angular
+    .module('components.histogram.histogramBar', [])
+    .controller(HistogramBarController.name, HistogramBarController)
+    .component('rfHistogramBar', component)
+    .name;

--- a/app-frontend/src/app/components/histogram/histogramBar/index.js
+++ b/app-frontend/src/app/components/histogram/histogramBar/index.js
@@ -1,5 +1,3 @@
-import { min, max, head, last } from 'lodash';
-
 import tpl from './index.html';
 
 class HistogramBarController {
@@ -14,38 +12,38 @@ class HistogramBarController {
         this.bars = [];
         this.$q.all({
             statistics: this.statistics,
-            bounds: this.bounds,
-            histStats: this.histogram
+            bounds: this.boundsPromise,
+            histStats: this.histogramPromise
         }).then(({statistics, bounds, histStats}) => {
             const { histogram } = histStats;
             this.bars = [
                 {
                     value: this.valueToPercentage(bounds, statistics.mean),
-                    color: 'blue'
+                    class: 'bg-gray-lighter'
                 },
                 {
                     value: this.valueToPercentage(bounds, statistics.median),
-                    color: 'green'
+                    class: 'bg-green '
                 },
                 {
                     value: this.valueToPercentage(bounds, statistics.mode),
-                    color: 'cyan'
+                    class: 'bg-tertiary'
                 },
                 {
                     value: this.valueToPercentage(bounds, statistics.mean - statistics.stddev),
-                    color: 'purple'
+                    class: 'bg-danger'
                 },
                 {
                     value: this.valueToPercentage(bounds, statistics.mean + statistics.stddev),
-                    color: 'purple'
+                    class: 'bg-danger'
                 },
                 {
                     value: this.valueToPercentage(bounds, statistics.zmin),
-                    color: 'black'
+                    class: 'bg-black'
                 },
                 {
                     value: this.valueToPercentage(bounds, statistics.zmax),
-                    color: 'black'
+                    class: 'bg-black'
                 }
             ];
         });
@@ -54,13 +52,17 @@ class HistogramBarController {
     valueToPercentage(bounds, val) {
         return (val - bounds.min) / (bounds.max - bounds.min) * 100;
     }
+
+    getStyle(val) {
+        return { left: val + '%' };
+    }
 }
 
 const component = {
     bindings: {
         statistics: '<',
-        bounds: '<',
-        histogram: '<'
+        boundsPromise: '<',
+        histogramPromise: '<'
     },
     templateUrl: tpl,
     controller: HistogramBarController.name

--- a/app-frontend/src/app/components/histogram/index.js
+++ b/app-frontend/src/app/components/histogram/index.js
@@ -1,0 +1,9 @@
+import dataVizHistogram from './dataVizHistogram';
+import dataVizStatistics from './dataVizStatistics';
+import histogramBar from './histogramBar';
+
+export default [
+    dataVizHistogram,
+    dataVizStatistics,
+    histogramBar
+];

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
@@ -4,7 +4,7 @@
     </div>
     <div class="page-card analysis-maps-card">
       <div class="row">
-        <div class="column-4 flex-display analysis-viz-container" ng-repeat="analysis in $ctrl.analyses track by $index">
+        <div class="column-4 flex-display analysis-viz-container" ng-repeat="analysis in $ctrl.analyses track by analysis.id">
           <rf-analysis-map-item
               class="panel panel-off-white project-item"
               analysis-id="analysis.id"
@@ -20,7 +20,33 @@
         </div>
       </div>
     </div>
-    <div class="page-card analysis-histogram-card">
-      Histogram
-    </div>
+
+    <rf-list-item ng-repeat="analysis in $ctrl.analyses track by analysis.id" class="histogram-item">
+      <item-selector>
+        <rf-list-item-selector
+            id="analysis.id"
+            color="$ctrl.layerColorHex[analysis.id]"
+        ></rf-list-item-selector>
+      </item-selector>
+      <item-title>{{$ctrl.analysesMap.get(analysis.id).name}}</item-title>
+      <item-date>{{$ctrl.analysesMap.get(analysis.id).modifiedAt | date: 'medium'}}</item-date>
+      <item-actions>
+        <rf-data-viz-histogram
+            histogram="analysis.histogram"
+            id="analysis.id"
+            bounds="$ctrl.histogramBounds"
+        >
+            <rf-histogram-bar
+                statistics="analysis.statistics"
+                bounds="$ctrl.histogramBounds"
+                histogram="analysis.histogram"
+            >
+            </rf-histogram-bar>
+        </rf-data-viz-histogram>
+        <div style="height:50px;">
+          <rf-data-viz-statistics statistics="analysis.statistics">
+          </rf-data-viz-statistics>
+        </div>
+      </item-actions>
+    </rf-list-item>
 </div>

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
@@ -2,17 +2,23 @@
     <div class="page-header wide">
         <h3>Key metrics</h3>
     </div>
-    <div class="page-card analysis-maps-card">
+    <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.isLoadingAnalysis">
+      <h3>Loading histograms and maps<i class="icon-load animate-spin"></i></h3>
+    </div>
+    <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.isLoadingAnalysisError">
+      <h3 class="color-danger"><i class="icon-warning"></i>Failed to load histograms and maps. Please try again later.</h3>
+    </div>
+    <div class="page-card analysis-maps-card" ng-if="!$ctrl.isLoadingAnalysis">
       <div class="row">
-        <div class="column-4 flex-display analysis-viz-container" ng-repeat="analysis in $ctrl.analyses track by analysis.id">
+        <div class="column-4 flex-display" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId">
           <rf-analysis-map-item
               class="panel panel-off-white project-item"
-              analysis-id="analysis.id"
+              analysis-id="analysis.trackId"
               analysis-tile="analysis.analysisTile">
               <item-selector>
                 <rf-list-item-selector
-                    id="analysis.id"
-                    selected="$ctrl.selected.has(analysis.id)"
+                    id="analysis.trackId"
+                    selected="$ctrl.selected.has(analysis.trackId)"
                     color="$ctrl.layerColorHex[analysis.id]"
                 ></rf-list-item-selector>
               </item-selector>
@@ -20,33 +26,44 @@
         </div>
       </div>
     </div>
-
-    <rf-list-item ng-repeat="analysis in $ctrl.analyses track by analysis.id" class="histogram-item">
-      <item-selector>
-        <rf-list-item-selector
-            id="analysis.id"
-            color="$ctrl.layerColorHex[analysis.id]"
-        ></rf-list-item-selector>
-      </item-selector>
-      <item-title>{{$ctrl.analysesMap.get(analysis.id).name}}</item-title>
-      <item-date>{{$ctrl.analysesMap.get(analysis.id).modifiedAt | date: 'medium'}}</item-date>
-      <item-actions>
-        <rf-data-viz-histogram
-            histogram="analysis.histogram"
-            id="analysis.id"
-            bounds="$ctrl.histogramBounds"
-        >
-            <rf-histogram-bar
-                statistics="analysis.statistics"
-                bounds="$ctrl.histogramBounds"
-                histogram="analysis.histogram"
-            >
-            </rf-histogram-bar>
-        </rf-data-viz-histogram>
-        <div style="height:50px;">
+    <div class="page-card analysis-histogram-card" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId" ng-if="!$ctrl.isLoadingAnalysis">
+      <div class="row">
+        <div class="column-3 flex-display">
+          <rf-list-item-selector
+              id="analysis.trackId"
+              color="$ctrl.layerColorHex[analysis.id]"
+          ></rf-list-item-selector>
+          <div class="list-group-overflow">
+            <div class="text-overflow-ellipsis">
+              <strong>{{$ctrl.analysesMap.get(analysis.trackId).name}}</strong>
+            </div>
+            <div class="text-overflow-ellipsis">
+              {{$ctrl.analysesMap.get(analysis.trackId).modifiedAt | date: 'medium'}}
+            </div>
+          </div>
+        </div>
+        <div class="column-9 flex-display">
+          <rf-data-viz-histogram
+              id="analysis.trackId"
+              histogram-promise="analysis.histogram"
+              bounds-promise="$ctrl.histogramBounds"
+          >
+              <rf-histogram-bar
+                  statistics="analysis.statistics"
+                  bounds-promise="$ctrl.histogramBounds"
+                  histogram-promise="analysis.histogram"
+              >
+              </rf-histogram-bar>
+          </rf-data-viz-histogram>
+        </div>
+      </div>
+      <div class="row">
+        <div class="column-3 flex-display no-padding">
+        </div>
+        <div class="column-9 flex-display no-padding">
           <rf-data-viz-statistics statistics="analysis.statistics">
           </rf-data-viz-statistics>
         </div>
-      </item-actions>
-    </rf-list-item>
+      </div>
+    </div>
 </div>

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
@@ -20,4 +20,7 @@
         </div>
       </div>
     </div>
+    <div class="page-card analysis-histogram-card">
+      Histogram
+    </div>
 </div>

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
@@ -1,5 +1,5 @@
 import { Map } from 'immutable';
-import { get } from 'lodash';
+import { get, min, max } from 'lodash';
 
 import tpl from './index.html';
 import {createRenderDefinition} from '_redux/histogram-utils';
@@ -7,7 +7,7 @@ import {nodesFromAst, astFromNodes} from '_redux/node-utils';
 
 class AnalysesVisualizeController {
     constructor(
-        $rootScope, $scope, $state, $log,
+        $rootScope, $scope, $state, $log, $q,
         mapService, projectService, analysisService
     ) {
         'ngInject';
@@ -16,14 +16,29 @@ class AnalysesVisualizeController {
 
     $onInit() {
         this.selected = new Map();
+        this.analysesMap = new Map();
         this.projectId = this.$state.params.projectId;
         this.layerColorHex = {};
         this.analyses = this.getAnalysisIds().map(analysisId => {
+            const analysisPromise = this.mapLayerFromAnalysis(analysisId);
             return {
                 id: analysisId,
-                analysisTile: this.mapLayerFromAnalysis(analysisId)
+                analysisTile: analysisPromise.then(a => a.analysisTile),
+                histogram: analysisPromise.then(a => (
+                    {histogram: a.histogram, statistics: a.statistics})),
+                statistics: analysisPromise.then(a => a.statistics)
             };
         });
+
+        this.histogramBounds = this.$q.all(this.analyses.map(a => a.statistics))
+            .then(statistics => {
+                return statistics.reduce((acc, stat) => {
+                    return {
+                        min: min([acc.min, stat.zmin]),
+                        max: max([acc.max, stat.zmax])
+                    };
+                }, {});
+            });
     }
 
     getAnalysisIds() {
@@ -35,32 +50,39 @@ class AnalysesVisualizeController {
     }
 
     mapLayerFromAnalysis(analysisId) {
-        return this.analysisService.getAnalysis(analysisId).then(analysis => {
-            this.analysisService.getNodeHistogram(analysisId).then(histogram => {
-                const {
-                    renderDefinition,
-                    histogramOptions
-                } = createRenderDefinition(histogram);
-                const newNodeDefinition = Object.assign(
-                    {}, analysis.executionParameters,
-                    {
-                        metadata: Object.assign({}, analysis.executionParameters.metadata, {
-                            renderDefinition,
-                            histogramOptions
-                        })
-                    }
-                );
-                const nodes = nodesFromAst(analysis.executionParameters);
-                const updatedAnalysis = astFromNodes({analysis, nodes}, [newNodeDefinition]);
-                return this.analysisService.updateAnalysis(updatedAnalysis);
-            });
+        return this.$q.all({
+            analysis: this.analysisService.getAnalysis(analysisId),
+            histogram: this.analysisService.getNodeHistogram(analysisId),
+            statistics: this.analysisService.getNodeStatistics(analysisId)
+        }).then(({analysis, histogram, statistics}) => {
+            this.analysesMap = this.analysesMap.set(analysis.id, analysis);
             this.setLayerColorHex(analysis);
-            return analysis;
-        }).then((analysis) => {
+            const {
+                renderDefinition,
+                histogramOptions
+            } = createRenderDefinition(histogram);
+            const newNodeDefinition = Object.assign(
+                {}, analysis.executionParameters,
+                {
+                    metadata: Object.assign({}, analysis.executionParameters.metadata, {
+                        renderDefinition,
+                        histogramOptions
+                    })
+                }
+            );
+            const nodes = nodesFromAst(analysis.executionParameters);
+            const updatedAnalysis = astFromNodes({analysis, nodes}, [newNodeDefinition]);
+            this.analysisService.updateAnalysis(updatedAnalysis);
+            return {analysis, histogram, statistics};
+        }).then(({analysis, histogram, statistics}) => {
             const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
             return {
-                analysis,
-                mapTile: L.tileLayer(tileUrl, {maxZoom: 30})
+                histogram,
+                statistics,
+                analysisTile: {
+                    analysis,
+                    mapTile: L.tileLayer(tileUrl, {maxZoom: 30})
+                }
             };
         });
     }

--- a/app-frontend/src/app/index.components.js
+++ b/app-frontend/src/app/index.components.js
@@ -4,6 +4,8 @@ import projectComponents from './components/projects';
 import sceneComponents from './components/scenes';
 import commonComponents from './components/common';
 import exportComponents from './components/exports';
+import histogramComponent from './components/histogram';
+
 export default angular.module('index.components', [
     //admin components
     require('./components/admin/editableLogo/editableLogo.js').default.name,
@@ -129,6 +131,7 @@ export default angular.module('index.components', [
     require('./components/histogram/nodeHistogram/nodeHistogram.module.js').default.name,
     require('./components/histogram/histogramBreakpoint/histogramBreakpoint.module.js').default.name,
     require('./components/histogram/reclassifyHistogram/reclassifyHistogram.module.js').default.name,
+    ...histogramComponent,
 
     // pages
     ...pages

--- a/app-frontend/src/app/services/common/graph.service.js
+++ b/app-frontend/src/app/services/common/graph.service.js
@@ -130,6 +130,57 @@ class ChannelHistogram extends D3Element {
     }
 }
 
+class StatHistogram extends D3Element {
+    render() {
+        // render d3 el
+        let svg = d3.select(this.el);
+        let defs = svg.select('defs');
+        if (!defs.nodes().length) {
+            defs = svg.append('defs');
+        }
+
+        if (this.data && this.data.histogram) {
+            this.calculateAxis(svg, defs);
+            this.renderData(svg, defs);
+        }
+
+        return super.render();
+    }
+
+    calculateAxis(svg, defs) {
+        const xRange = [this.options.margin.left,
+            this.el.width.baseVal.value - this.options.margin.right];
+        const yRange = [this.options.height - this.options.margin.bottom,
+            this.options.margin.top];
+        this.xScale = d3.scaleLinear()
+            .domain([this.options.dataRange.min, this.options.dataRange.max])
+            .range(xRange);
+        this.yScale = d3.scaleLinear()
+            .domain([d3.min(this.data.histogram, d => d.y), d3.max(this.data.histogram, d => d.y)])
+            .range(yRange);
+    }
+
+    renderData(svg, defs) {
+        let area = d3.area()
+            .x(v => this.xScale(v.x))
+            .y0(this.options.height - this.options.margin.bottom)
+            .y1(v => this.yScale(v.y))
+            .curve(d3.curveStepAfter);
+
+
+        let areaPath = svg.select('#area-path');
+        if (!areaPath.nodes().length) {
+            areaPath = svg.append('path');
+        }
+
+        areaPath.data([this.data.histogram])
+            .attr('id', 'area-path')
+            .attr('class', 'data-fill')
+            .attr('z-index', 11)
+            .attr('d', area);
+    }
+}
+
 class SinglebandHistogram extends D3Element {
     render() {
         // render d3 el
@@ -289,6 +340,9 @@ export default (app) => {
             switch (options.type) {
             case 'channel':
                 graph = new ChannelHistogram(el, id, options);
+                break;
+            case 'stat':
+                graph = new StatHistogram(el, id, options);
                 break;
             case 'single':
             default:

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3379,6 +3379,9 @@ rf-project-publishing-page {
         box-shadow: none;
         padding: 0;
     }
+    &.analysis-histogram-card {
+        max-width: 1284px;
+    }
 }
 
 .page-card-header {
@@ -3638,9 +3641,9 @@ rf-aoi-draw-toolbar {
     display: flex;
 }
 
-.analysis-viz-container {
-    padding: 1rem 3rem 1rem 0rem !important;
-}
+// .analysis-viz-container {
+//     padding: 1rem 3rem 1rem 0rem !important;
+// }
 
 .panel-analysis-viz-container {
     background-color: $white;

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -223,7 +223,6 @@ rf-project-editor .leaflet-tile {
     }
 }
 
-
 .mask-item {
     padding: 1rem 2rem;
     border-bottom: 1px solid $border-color-default;
@@ -2473,6 +2472,16 @@ rf-histogram-breakpoint {
             border: 1px solid $brand-primary;
         }
     }
+    &.data-viz-histogram {
+          width: 100%;
+          height: 50px;
+
+        &.mask {
+            position: absolute;
+            z-index: 100;
+            background-color: $white;
+        }
+    }
 }
 
 .histogram-spacer {
@@ -3301,7 +3310,6 @@ rf-project-scene-item {
     margin: 0.5em;
 }
 
-
 rf-project-settings-page,
 rf-project-options-page,
 rf-project-permissions-page,
@@ -3348,8 +3356,6 @@ rf-project-publishing-page {
     }
 }
 
-
-
 .page-card {
     flex: none;
     width: 100%;
@@ -3381,6 +3387,7 @@ rf-project-publishing-page {
     }
     &.analysis-histogram-card {
         max-width: 1284px;
+        padding: 1rem;
     }
 }
 
@@ -3464,6 +3471,11 @@ rf-list-item {
     margin: 0.5em;
     &[ng-click] {
         cursor: pointer;
+    }
+
+    &.histogram-item {
+        margin: 0.5rem auto;
+        max-width: 1288px;
     }
 }
 
@@ -3641,10 +3653,6 @@ rf-aoi-draw-toolbar {
     display: flex;
 }
 
-// .analysis-viz-container {
-//     padding: 1rem 3rem 1rem 0rem !important;
-// }
-
 .panel-analysis-viz-container {
     background-color: $white;
     box-shadow: 0px 3px 8px rgba($shade-normal, 0.2);
@@ -3660,9 +3668,48 @@ rf-aoi-draw-toolbar {
 }
 
 .no-border {
-  border: none !important;
+    border: none !important;
 }
 
 .input-cursor-pointer {
-  cursor: pointer !important;
+    cursor: pointer !important;
+}
+
+rf-data-viz-histogram {
+    position: relative;
+    display: block;
+    width: 100%;
+    .data-fill {
+        fill: #465076 !important;
+        fill-opacity: 1 !important;
+    }
+    ng-transclude {
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        position: absolute;
+    }
+}
+
+rf-histogram-bar {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    position: absolute;
+
+    div {
+        height: 50px;
+        width: 2px;
+        position: absolute;
+    }
+}
+
+rf-data-viz-statistics {
+    width: 100%;
+}
+
+.histogram-stat-numbers {
+    justify-content: center;
 }

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -58,6 +58,18 @@
     color: $green !important;
 }
 
+.color-gray-lighter {
+    color: $gray-lighter !important;
+}
+
+.color-tertiary {
+    color: $brand-tertiary;
+}
+
+.color-black {
+    color: black;
+}
+
 // background helpers
 .bg-primary {
     background-color: $brand-primary !important;
@@ -73,6 +85,22 @@
 
 .bg-danger {
     background-color: $danger !important;
+}
+
+.bg-gray-lighter {
+    background-color: $gray-lighter !important;
+}
+
+.bg-green {
+    background-color: $green !important;
+}
+
+.bg-tertiary {
+    background-color: $brand-tertiary !important;
+}
+
+.bg-black {
+    background-color: black !important;
 }
 
 // link helpers


### PR DESCRIPTION
## Overview

Paired with @Lknechtli on this one. 

~Marked as WIP since it needs some styling and code clean-ups. More to come once all done.~

This PR:
- adds three components: `dataVizHistogram`, `dataVizStatistics`, `histogramBar`
- updates analysis data viz UI to include the histograms


### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

![Screen Shot 2019-03-11 at 7 34 23 PM](https://user-images.githubusercontent.com/16109558/54165085-9aa57180-4435-11e9-884f-331184f01b30.png)


## Testing Instructions

 * On lab template UI, create some templates with `This template can be run with only one project` checked
 * Go to a project's v2 UI
 * Add some layers
 * Define layer AOIs **(important)**
 * Add some scenes to these layers
 * Create some analyses with these new layers using the template(s) created from step one
 * On the analyses list UI, select multiple analyses (no more than three, see notes section), click on `Visualize` (if more than three, this button is disabled)
 * Make sure the above step takes you to analyses visualization page and:
     - map tiles load
     - histograms show up
     - stats show up

Closes #4685 
