### PR TITLE
Change scope of version = dev to fix failing builds on CI

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -15,9 +15,6 @@ git.gitTagToVersionNumber in ThisBuild := { tag: String =>
 cancelable in Global := true
 
 lazy val commonSettings = Seq(
-  version := {
-    "dev"
-  },
   // https://github.com/lucidsoftware/neo-sbt-scalafmt
   scalafmtOnCompile := true,
   // https://github.com/sksamuel/sbt-scapegoat

--- a/app-backend/version.sbt
+++ b/app-backend/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "dev"


### PR DESCRIPTION
## Overview

This PR moves the `version := "dev"` definition back to a `version.sbt` file in the context of `ThisBuild`.

See https://github.com/raster-foundry/raster-foundry/pull/4736 for the context of why this definition was moved to `build.sbt`.

What I believe was happening is we were defining the "fallback" version within a scope that takes precedent over `ThisBuild`. When `cipublish` was calling `gitSnapshots` to override the version, it was just being ignored.

**How I figured this out:**

I saw one build on `develop` pass, and it published artifacts named `-dev`. This made me think that the original PR was successful. All the builds after that failed, because they were also trying to publish artifacts named `-dev`.

Fixes https://github.com/azavea/raster-foundry-platform/issues/615

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Styleguide updated, if necessary
- [ ] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated
- [ ] Symlinks from new migrations present or corrected for any new migrations
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

## Testing Instructions

TBD.