### PR TITLE
Add frontend support for splitting layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added endpoint for splitting layers up by date and datasource [\#4738](https://github.com/raster-foundry/raster-foundry/pull/4738)
 - Added the map part of analysis data visualization UI [\#4739](https://github.com/raster-foundry/raster-foundry/pull/4739)
 - Enabled project layer selection in lab input raster nodes [\#4732](https://github.com/raster-foundry/raster-foundry/pull/4732)
+- Enabled project layer splitting on frontend  [\#4766](https://github.com/raster-foundry/raster-foundry/pull/4766)
 
 ### Changed
 

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -78,7 +78,10 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       .filter(sceneParams)
 
     val paginatedScenes = for {
-      page <- filterQ.page(pageRequest, manualOrder)
+      page <- pageRequest.sort.isEmpty match {
+        case true => filterQ.page(pageRequest, manualOrder)
+        case false => filterQ.page(pageRequest)
+      }
     } yield page
     paginatedScenes.flatMap { (pr: PaginatedResponse[Scene]) =>
       scenesToProjectScenes(pr.results.toList, layerId).map(

--- a/app-frontend/src/app/components/projects/index.js
+++ b/app-frontend/src/app/components/projects/index.js
@@ -8,6 +8,7 @@ import analysisEditModal from './analysisEditModal';
 import analysisMapItem from './analysisMapItem';
 import projectLayerSelectModal from './projectLayerSelectModal';
 import projectLayerItem from './projectLayerItem';
+import layerSplitModal from './layerSplitModal';
 
 export default [
     projectSettingsNavbar,
@@ -19,5 +20,6 @@ export default [
     analysisEditModal,
     analysisMapItem,
     projectLayerSelectModal,
-    projectLayerItem
+    projectLayerItem,
+    layerSplitModal
 ];

--- a/app-frontend/src/app/components/projects/layerSplitModal/index.html
+++ b/app-frontend/src/app/components/projects/layerSplitModal/index.html
@@ -1,0 +1,169 @@
+<div class="modal-scrollable-body modal-sidebar-header">
+  <div class="modal-header">
+    <button
+      type="button"
+      class="close"
+      aria-label="Close"
+      ng-click="$ctrl.close()"
+      ng-disabled="$ctrl.isSplittingLayer"
+    >
+      <span aria-hidden="true">&times;</span>
+    </button>
+    <h4 class="modal-title">
+      Split Layer
+    </h4>
+    <p>Split this layer into multiple layers</p>
+  </div>
+
+  <div class="modal-body" ng-if="$ctrl.noScene">
+    <div class="modal-inner-container small">
+      <div class="content">
+        <div class="text-center">
+          <h5 class="error color-danger">This layer has no imagery. It cannot be split.</h5>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal-body" ng-if="!$ctrl.noScene">
+    <div class="modal-inner-container small">
+      <div class="content">
+        <div ng-if="$ctrl.hasSplitLayerError" class="text-center">
+          <h5 class="error color-danger">There was an error splitting this project layer.</h5>
+          <button type="button"
+                  class="btn btn-primary"
+                  ng-click="$ctrl.resetModal()">
+            Try again
+          </button>
+        </div>
+        <form name="layerSplit" autocomplete="off" ng-if="!$ctrl.hasSplitLayerError">
+          <h5 class="modal-content-header-thin">
+            New layer names
+            <span class="error color-danger" ng-show="layerSplit.layerName.$error.required">
+              (required)
+            </span>
+          </h5>
+          <div class="form-group all-in-one">
+            <input class="form-control"
+                   id="layerName"
+                   name="layerName"
+                   type="text"
+                   placeholder="My custom layer name"
+                   ng-model="$ctrl.layerSplitBuffer.name"
+                   required>
+          </div>
+          <h5 class="modal-content-header-thin">Color</h5>
+          <div class="form-group all-in-one">
+            <input class="form-control color-picker"
+                   type="color"
+                   id="color"
+                   ng-init="$ctrl.layerSplitBuffer.colorGroupHex"
+                   ng-model="$ctrl.layerSplitBuffer.colorGroupHex">
+          </div>
+          <h5 class="modal-content-header-thin">Split frequency</h5>
+          <div class="form-group all-in-one no-margin">
+            <select
+              class="form-control"
+              name="frequency"
+              ng-model="$ctrl.layerSplitBuffer.period"
+            >
+              <option
+                value="{{frequency.value}}"
+                ng-repeat="frequency in $ctrl.frequencies track by $index"
+              >
+                {{frequency.name}}
+              </option>
+            </select>
+          </div>
+          <p>
+            <i>A new layer will be created for <span class="font-700">every {{ $ctrl.layerSplitBuffer.period | lowercase }}</span> imagery is found.</i>
+          </p>
+          <div class="flex-display">
+            <h5 class="modal-content-header-thin">Start date</h5>
+            <h5 class="modal-content-header-thin">End date</h5>
+          </div>
+          <div
+            class="form-group all-in-one"
+            ng-class="{'no-margin': !$ctrl.isValidDateRange}"
+          >
+            <input class="form-control input-cursor-pointer"
+                   id="rangeStart"
+                   name="rangeStart"
+                   type="text"
+                   ng-value="$ctrl.startDateDisplay"
+                   ng-click="$ctrl.onDateChange('rangeStart')"
+                   required
+                   readonly>
+            <button
+              class="btn btn-small right-gray-border-only background-inherit"
+              ng-click="$ctrl.onDateChange('rangeStart')"
+            >
+             <span class="sr-only">Set range start date</span>
+             <i class="icon-calendar" aria-hidden="true"></i>
+            </button>
+            <input class="form-control input-cursor-pointer"
+                  id="rangeEnd"
+                  name="rangeEnd"
+                  type="text"
+                  ng-value="$ctrl.endDateDisplay"
+                  ng-click="$ctrl.onDateChange('rangeEnd')"
+                  required
+                  readonly>
+            <button
+              class="btn btn-small background-inherit no-border"
+              ng-click="$ctrl.onDateChange('rangeEnd')"
+            >
+             <span class="sr-only">Set range end date</span>
+             <i class="icon-calendar" aria-hidden="true"></i>
+            </button>
+          </div>
+          <p class="color-danger" ng-if="!$ctrl.isValidDateRange">
+            <i>Start and end date range is invalid.</i>
+          </p>
+          <h5 class="modal-content-header-thin">Remove imagery after splitting</h5>
+          <div class="flex-display">
+            <p class="flex-fill">
+              <i><span class="color-warning">Warning:</span> Removing imagery from the layer could adversely affect annotations and/or analyses, but prevents duplicate layers if the layer were to be split again in the future.</i>
+            </p>
+            <button class="btn select-button btn-tiny" ng-click="$ctrl.onCheckRemoveImages()">
+                <label
+                    class="checkbox"
+                    ng-class="{active: $ctrl.layerSplitBuffer.removeFromLayer}"
+                >
+                    <input
+                        type="checkbox"
+                        ng-checked="$ctrl.layerSplitBuffer.removeFromLayer"
+                        ng-click="$ctrl.onCheckRemoveImages()"
+                    />
+                </label>
+                <span>
+                    Remove imagery
+                </span>
+            </button>
+          </div>
+          <div ng-if="$ctrl.hasMultipleDatasources">
+            <h5 class="modal-content-header-thin">Multiple datasources</h5>
+            <p><i class="icon-warning color-warning"></i>Imagery in this layer uses multiple datasources. Splitting this layer will also split by datasource.</p>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <div class="footer-section left">
+      <button type="button"
+              class="btn"
+              ng-disabled="$ctrl.isSplittingLayer"
+              ng-click="$ctrl.dismiss()">
+        Close
+      </button>
+    </div>
+    <div class="footer-section right">
+      <button type="button"
+              class="btn btn-primary"
+              ng-click="$ctrl.onClickSplit()"
+              ng-disabled="$ctrl.isSplitLayerDisabled()">
+        Create layers
+      </button>
+    </div>
+  </div>
+</div>

--- a/app-frontend/src/app/components/projects/layerSplitModal/index.js
+++ b/app-frontend/src/app/components/projects/layerSplitModal/index.js
@@ -1,0 +1,172 @@
+import angular from 'angular';
+import { get } from 'lodash';
+
+import tpl from './index.html';
+
+const defaultLayerSplit = {
+    period: 'DAY',
+    splitOnDatasource: true,
+    removeFromLayer: true
+};
+
+const frequencies = [
+    {
+        value: 'WEEK',
+        name: '1 week'
+    },
+    {
+        value: 'DAY',
+        name: '1 day'
+    }
+];
+
+const dateDisplayFormat = 'MMMM Do, YYYY';
+
+class LayerSplitModalController {
+    constructor($rootScope, $log, $q, $state, moment, projectService, modalService) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.projectId = this.resolve.projectId;
+        this.layerId = this.resolve.layerId;
+        this.defaultLayerSplit = defaultLayerSplit;
+        this.frequencies = frequencies;
+        this.dateDisplayFormat = dateDisplayFormat;
+        this.layerSplitBuffer = {};
+
+        this.populateLayerSplitBuffer();
+        this.getLayerDatasources();
+    }
+
+    populateLayerSplitBuffer() {
+        const promises = {
+            layer: this.projectService.getProjectLayer(this.projectId, this.layerId),
+            firstScene: this.projectService.getProjectLayerScenes(this.projectId, this.layerId, {
+                page: 0,
+                pageSize: 1,
+                sort: 'acquisitionDatetime,asc'
+            }),
+            lastScene: this.projectService.getProjectLayerScenes(this.projectId, this.layerId, {
+                page: 0,
+                pageSize: 1,
+                sort: 'acquisitionDatetime,desc'
+            })
+        };
+        this.$q.all(promises).then(({ layer, firstScene, lastScene }) => {
+            if (!firstScene.count) {
+                this.noScene = true;
+                return;
+            }
+            this.layerSplitBuffer = Object.assign(
+                {},
+                {
+                    colorGroupHex: layer.colorGroupHex,
+                    rangeStart: get(firstScene, 'results[0].filterFields.acquisitionDate'),
+                    rangeEnd: get(lastScene, 'results[0].filterFields.acquisitionDate')
+                },
+                this.defaultLayerSplit
+            );
+            this.setFormattedDate();
+            this.validateDateRange();
+        });
+    }
+
+    isSplitLayerDisabled() {
+        return (
+            this.noScene ||
+            !get(this, 'layerSplitBuffer.name.length') ||
+            this.isSplittingLayer ||
+            !this.isValidDateRange ||
+            this.hasSplitLayerError
+        );
+    }
+
+    setFormattedDate() {
+        this.startDateDisplay = this.moment(this.layerSplitBuffer.rangeStart).format(
+            this.dateDisplayFormat
+        );
+        this.endDateDisplay = this.moment(this.layerSplitBuffer.rangeEnd).format(
+            this.dateDisplayFormat
+        );
+    }
+
+    onDateChange(rangeType) {
+        const modal = this.modalService.open(
+            {
+                component: 'rfDatePickerModal',
+                windowClass: 'auto-width-modal',
+                resolve: {
+                    config: () =>
+                        Object({
+                            selectedDay: this.layerSplitBuffer[rangeType]
+                        })
+                }
+            },
+            false
+        ).result;
+
+        modal.then(selectedDate => {
+            this.layerSplitBuffer[rangeType] = selectedDate.toISOString();
+            this.setFormattedDate();
+            this.validateDateRange();
+        });
+    }
+
+    validateDateRange() {
+        this.isValidDateRange =
+            this.moment(this.layerSplitBuffer.rangeEnd).diff(
+                this.moment(this.layerSplitBuffer.rangeStart)
+            ) >= 0;
+    }
+
+    onCheckRemoveImages() {
+        this.layerSplitBuffer.removeFromLayer = !this.layerSplitBuffer.removeFromLayer;
+    }
+
+    getLayerDatasources() {
+        this.projectService
+            .getProjectLayerDatasources(this.projectId, this.layerId)
+            .then(datasources => {
+                this.hasMultipleDatasources = datasources.length;
+            });
+    }
+
+    onClickSplit() {
+        this.isSplittingLayer = true;
+        this.projectService
+            .splitLayers(this.projectId, this.layerId, this.layerSplitBuffer)
+            .then(resp => {
+                this.$state.go('project.layers', { projectId: this.projectId });
+            })
+            .catch(err => {
+                this.$log.error(err);
+                this.hasSplitLayerError = true;
+            })
+            .finally(() => {
+                this.isSplittingLayer = false;
+            });
+    }
+
+    resetModal() {
+        this.hasSplitLayerError = false;
+        this.populateLayerSplitBuffer();
+    }
+}
+
+const LayerSplitModalComponent = {
+    templateUrl: tpl,
+    bindings: {
+        close: '&',
+        dismiss: '&',
+        modalInstance: '<',
+        resolve: '<'
+    },
+    controller: 'LayerSplitModalController'
+};
+
+export default angular
+    .module('components.projects.layerSplitModal', [])
+    .controller('LayerSplitModalController', LayerSplitModalController)
+    .component('rfLayerSplitModal', LayerSplitModalComponent).name;

--- a/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.html
+++ b/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.html
@@ -39,12 +39,30 @@
                   }">
         Area of interest</a>
     </nav>
-    <nav>
-      <a ui-sref="project.layer.settings"
-         ng-class="{
-                  active: ('project.layer.settings' | includedByState)
-                  }"
-      ><i class="icon-settings" title="Project Settings"></i></a>
+    <nav class="nav-bar-dropdown-toggle">
+      <div uib-dropdown class="display-ib">
+        <button class="btn btn-text btn-transparent"
+                uib-dropdown-toggle
+        >
+          <i class="icon-menu"></i>
+          <span class="sr-only">More options</span>
+        </button>
+          <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+            <li role="menuitem"
+                ng-repeat="action in $ctrl.actions | filter: {menu: true}"
+            >
+              <a
+                class="menu-item"
+                ng-click="action.callback($event)"
+                ng-if="action.name"
+                ng-attr-title="{{action.title}}"
+                ng-class="{'with-bottom-border': action.separator}"
+              >
+                {{action.name}}
+              </a>
+            </li>
+          </ul>
+      </div>
     </nav>
   </div>
 </div>

--- a/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
+++ b/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
@@ -1,6 +1,90 @@
 import tpl from './index.html';
 
 class ProjectLayerSecondaryNavbarController {
+    constructor(
+        $rootScope, $state, $scope, $log,
+        modalService, projectService
+    ) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onInit() {
+        this.projectId = this.$state.params.projectId;
+        this.layerId = this.$state.params.layerId;
+        this.setLayerActions();
+    }
+
+    setLayerActions() {
+        const splitLayer = {
+            name: 'Split layer',
+            title: 'split-layer',
+            menu: true,
+            separator: true,
+            callback: () => this.openSplitLayerModal()
+        };
+
+        const publishing = {
+            name: 'Publishing',
+            title: 'publishing',
+            menu: true,
+            callback: () => this.$state.go(
+                'project.settings.publishing',
+                { projectId: this.projectId }
+            )
+        };
+
+        const layerSettings = {
+            name: 'Layer settings',
+            title: 'layer-settings',
+            menu: true,
+            callback: () => this.$state.go(
+                'project.settings',
+                { projectId: this.projectId }
+            )
+        };
+
+        const deleteLayer = {
+            name: 'Delete layer',
+            title: 'delete-layer',
+            menu: true,
+            callback: () => this.openLayerDeleteModal()
+        };
+
+        this.actions = [splitLayer, publishing, layerSettings, deleteLayer];
+    }
+
+    openSplitLayerModal() {}
+
+    openLayerDeleteModal() {
+        const modal = this.modalService.open({
+            component: 'rfFeedbackModal',
+            resolve: {
+                title: () => 'Really delete this layer?',
+                subtitle: () => 'Deleting a layer cannot be undone',
+                content: () =>
+                    '<h2>Do you wish to continue?</h2>'
+                    + '<p>Future attempts to access this '
+                    + 'layer or associated annotations, tiles, and scenes will fail.',
+                feedbackIconType: () => 'danger',
+                feedbackIcon: () => 'icon-warning',
+                feedbackBtnType: () => 'btn-danger',
+                feedbackBtnText: () => 'Delete layer',
+                cancelText: () => 'Cancel'
+            }
+        }).result;
+
+        modal.then(() => {
+            this.projectService
+                .deleteProjectLayer(this.projectId, this.layerId)
+                .then(() => {
+                    this.$state.go('project.layers', { projectId: this.projectId});
+                }).catch(e => {
+                    this.$window.alert('This layer cannot be deleted this time.');
+                    this.$log.error(e);
+                });
+        }).catch(() => {});
+    }
 }
 
 const component = {

--- a/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
+++ b/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
@@ -1,10 +1,7 @@
 import tpl from './index.html';
 
 class ProjectLayerSecondaryNavbarController {
-    constructor(
-        $rootScope, $state, $scope, $log,
-        modalService, projectService
-    ) {
+    constructor($rootScope, $state, $scope, $log, modalService, projectService) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
     }
@@ -28,20 +25,15 @@ class ProjectLayerSecondaryNavbarController {
             name: 'Publishing',
             title: 'publishing',
             menu: true,
-            callback: () => this.$state.go(
-                'project.settings.publishing',
-                { projectId: this.projectId }
-            )
+            callback: () =>
+                this.$state.go('project.settings.publishing', { projectId: this.projectId })
         };
 
         const layerSettings = {
             name: 'Layer settings',
             title: 'layer-settings',
             menu: true,
-            callback: () => this.$state.go(
-                'project.settings',
-                { projectId: this.projectId }
-            )
+            callback: () => this.$state.go('project.settings', { projectId: this.projectId })
         };
 
         const deleteLayer = {
@@ -54,18 +46,28 @@ class ProjectLayerSecondaryNavbarController {
         this.actions = [splitLayer, publishing, layerSettings, deleteLayer];
     }
 
-    openSplitLayerModal() {}
+    openSplitLayerModal() {
+        const modal = this.modalService.open({
+            component: 'rfLayerSplitModal',
+            resolve: {
+                projectId: () => this.projectId,
+                layerId: () => this.layerId
+            }
+        });
+
+        modal.result.then(() => this.fetchPage()).catch(() => {});
+    }
 
     openLayerDeleteModal() {
         const modal = this.modalService.open({
             component: 'rfFeedbackModal',
             resolve: {
-                title: () => 'Really delete this layer?',
+                title: () => 'Are you sure you want to delete this layer?',
                 subtitle: () => 'Deleting a layer cannot be undone',
                 content: () =>
-                    '<h2>Do you wish to continue?</h2>'
-                    + '<p>Future attempts to access this '
-                    + 'layer or associated annotations, tiles, and scenes will fail.',
+                    '<h2>Do you wish to continue?</h2>' +
+                    '<p>Future attempts to access this ' +
+                    'layer or associated annotations, tiles, and scenes will fail.',
                 feedbackIconType: () => 'danger',
                 feedbackIcon: () => 'icon-warning',
                 feedbackBtnType: () => 'btn-danger',
@@ -74,22 +76,26 @@ class ProjectLayerSecondaryNavbarController {
             }
         }).result;
 
-        modal.then(() => {
-            this.projectService
-                .deleteProjectLayer(this.projectId, this.layerId)
-                .then(() => {
-                    this.$state.go('project.layers', { projectId: this.projectId});
-                }).catch(e => {
-                    this.$window.alert('This layer cannot be deleted this time.');
-                    this.$log.error(e);
-                });
-        }).catch(() => {});
+        modal
+            .then(() => {
+                this.projectService
+                    .deleteProjectLayer(this.projectId, this.layerId)
+                    .then(() => {
+                        this.$state.go('project.layers', { projectId: this.projectId });
+                    })
+                    .catch(e => {
+                        this.$window.alert(
+                            'There was an error deleting this layer. Please try again later.'
+                        );
+                        this.$log.error(e);
+                    });
+            })
+            .catch(() => {});
     }
 }
 
 const component = {
-    bindings: {
-    },
+    bindings: {},
     templateUrl: tpl,
     controller: ProjectLayerSecondaryNavbarController.name
 };
@@ -97,5 +103,4 @@ const component = {
 export default angular
     .module('components.projects.projectLayerSecondaryNavbar', [])
     .controller(ProjectLayerSecondaryNavbarController.name, ProjectLayerSecondaryNavbarController)
-    .component('rfProjectLayerSecondaryNavbar', component)
-    .name;
+    .component('rfProjectLayerSecondaryNavbar', component).name;

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -283,6 +283,17 @@ export default app => {
                             projectId: '@projectId',
                             layerId: '@layerId'
                         }
+                    },
+                    splitLayers: {
+                        method: 'POST',
+                        url:
+                            `${BUILDCONFIG.API_HOST}/api/projects/:projectId/` +
+                            'layers/:layerId/split/',
+                        params: {
+                            projectId: '@projectId',
+                            layerId: '@layerId'
+                        },
+                        isArray: true
                     }
                 }
             );
@@ -842,6 +853,10 @@ export default app => {
 
         getAllowedActions(projectId) {
             return this.Project.actions({ projectId }).$promise;
+        }
+
+        splitLayers(projectId, layerId, splitOptions) {
+            return this.Project.splitLayers({ projectId, layerId }, splitOptions).$promise;
         }
     }
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -723,7 +723,9 @@ rf-box-select-item {
 }
 
 .modal-content-header-thin {
-    margin: 0 0 1rem 0;
+    margin: 2rem 0 0.5rem 0;
+    flex: 1;
+    font-style: normal;
 }
 
 .list-group-item.no-flex {
@@ -3643,4 +3645,21 @@ rf-aoi-draw-toolbar {
 .panel-analysis-viz-container {
     background-color: $white;
     box-shadow: 0px 3px 8px rgba($shade-normal, 0.2);
+}
+
+.right-gray-border-only {
+    border: none !important;
+    border-right: 1px solid $gray-lightest !important;
+}
+
+.background-inherit {
+    background: inherit !important;
+}
+
+.no-border {
+  border: none !important;
+}
+
+.input-cursor-pointer {
+  cursor: pointer !important;
 }

--- a/app-frontend/src/assets/styles/sass/layout/_navbar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_navbar.scss
@@ -45,6 +45,13 @@
       background: $shade-dark;
       border-radius: $border-radius-base $border-radius-base 0 0;
     }
+
+    &.nav-bar-dropdown-toggle {
+      .open .dropdown-toggle {
+        background: $off-white;
+        border-radius: $border-radius-base $border-radius-base 0 0;
+      }
+    }
   }
 
   .dropdown > a {
@@ -122,6 +129,17 @@
           &.aoi-draw-toolbar-menu {
             padding: 0.5rem 1rem;
             box-shadow: none;
+          }
+
+          &.menu-item {
+            padding: 0.5rem 1rem;
+            box-shadow: none;
+            color: $shade-light;
+            font-weight: 500;
+
+            &.with-bottom-border {
+              border-bottom: 1px solid $gray-lightest;
+            }
           }
       }
 


### PR DESCRIPTION
## Overview

This PR:
- updates the layer scene listing endpoint to use the `pageRequest`'s `sort` query parameter as well
- adds frontend support for splitting project layers

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

Layer options:
![Screen Shot 2019-03-13 at 5 21 23 PM](https://user-images.githubusercontent.com/16109558/54315475-994e8300-45b4-11e9-8e2d-8690fd60e668.png)

Layer splitting modal
![Screen Shot 2019-03-13 at 4 59 16 PM](https://user-images.githubusercontent.com/16109558/54314815-095c0980-45b3-11e9-85b8-d7be6a46a1fb.png)


### Notes

Not sure why, but passing in a date to the `datePickerModal` does not seem to make the modal go to the passed in date...


## Testing Instructions

* `api/assembly`
*  Spin up your server and create a project
* Add scenes from multiple days / weeks to one of the layers
* For testing, truncate your `scenes_to_projects` table (there will be a foreign key conflict on it otherwise, there's a task to drop that table soon)
* Go to this layer's v2 UI
* On top right, click on the three dots and select `Split layer` to bring up the layer splitting modal
* Use this modal to make sure it does what you expect
* Remember to truncate your `scenes_to_projects` table if you want to test this again to avoid the foreign key conflict
* Test cases like:
    - split a layer that does not have any scene in it
    - create split failure (like check `offline` in devtools when all modal fields are populated)
* Use the top right three dot's other options, and make sure they react as you expect


Closes https://github.com/raster-foundry/raster-foundry/issues/4677
