### PR TITLE
Handle other OGC params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Enabled project layer selection in lab input raster nodes [\#4732](https://github.com/raster-foundry/raster-foundry/pull/4732)
 - OGC
   - Added GetCapabilities WMS and WCS endpoints for projects [\#4767](https://github.com/raster-foundry/raster-foundry/pull/4767)
+  - Added parameter handling for DescribeCoverage, GetCoverage, and GetMap requests [\#4782](https://github.com/raster-foundry/raster-foundry/pull/4782)
   - Added map token authentication to OGC services [\#4778](https://github.com/raster-foundry/raster-foundry/pull/4778)
 
 ### Changed

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/OgcStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/OgcStore.scala
@@ -1,14 +1,16 @@
 package com.rasterfoundry.backsplash
 
 import cats.effect.IO
-import geotrellis.server.ogc.RasterSourcesModel
+import geotrellis.server.ogc.wms.WmsModel
+import geotrellis.server.ogc.wcs.WcsModel
 import opengis.wms.Service
 import simulacrum._
 
 import java.util.UUID
 
 @typeclass trait OgcStore[A] {
-  @op("getModel") def getModel(self: A, id: UUID): IO[RasterSourcesModel]
+  @op("getWcsModel") def getWcsModel(self: A, id: UUID): IO[WcsModel]
+  @op("getWmsModel") def getWmsModel(self: A, id: UUID): IO[WmsModel]
   @op("getWmsServiceMetadata") def getWmsServiceMetadata(self: A,
                                                          id: UUID): IO[Service]
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -39,6 +39,13 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
 
   val xa = RFTransactor.transactor(dbContextShift)
 
+
+  val ogcUrlPrefix = Properties.env("ENVIRONMENT") match {
+    case Some("Production") => "https://tiles.rasterfoundry.com"
+    case Some("Staging") => "https://tiles.staging.rasterfoundry.com"
+    case _ => "http://localhost:8081"
+  }
+
   override protected implicit def contextShift: ContextShift[IO] =
     IO.contextShift(
       ExecutionContext.fromExecutor(
@@ -128,13 +135,13 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
 
   val wcsService = authenticators.tokensAuthMiddleware(
     AuthedAutoSlash(
-      new WcsService(ProjectDao()).routes
+      new WcsService(ProjectDao(), ogcUrlPrefix).routes
     )
   )
 
   val wmsService = authenticators.tokensAuthMiddleware(
     AuthedAutoSlash(
-      new WmsService(ProjectDao()).routes
+      new WmsService(ProjectDao(), ogcUrlPrefix).routes
     )
   )
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
@@ -9,7 +9,8 @@ import cats.implicits._
 import doobie.Transactor
 import doobie.implicits._
 import geotrellis.proj4.{LatLng, WebMercator}
-import geotrellis.server.ogc.{OgcSource, SimpleSource}
+import geotrellis.raster.render.ColorRamps
+import geotrellis.server.ogc.{OgcSource, SimpleSource, StyleModel}
 import geotrellis.server.ogc.ows._
 import geotrellis.server.ogc.wcs.WcsModel
 import geotrellis.server.ogc.wms.{WmsModel, WmsParentLayerMeta}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WcsService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WcsService.scala
@@ -6,22 +6,24 @@ import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.common.datamodel.User
 
 import cats.data.Validated
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import geotrellis.server.ogc.wcs.params.{
+  DescribeCoverageWcsParams,
   GetCapabilitiesWcsParams,
+  GetCoverageWcsParams,
   WcsParams,
   WcsParamsError
 }
-import geotrellis.server.ogc.wcs.ops.Operations
+import geotrellis.server.ogc.wcs.ops.{GetCoverage, Operations}
 import org.http4s._
 import org.http4s.dsl.io._
 import org.http4s.scalaxml._
 
 import com.typesafe.scalalogging.LazyLogging
 
-class WcsService[LayerReader: OgcStore](layers: LayerReader)
-    extends ToOgcStoreOps
-    with LazyLogging {
+class WcsService[LayerReader: OgcStore](layers: LayerReader)(
+    implicit contextShift: ContextShift[IO])
+    extends ToOgcStoreOps with LazyLogging {
 
   // TODO lookup from environment
   private val urlPrefix = "https://tiles.staging.rasterfoundry.com"
@@ -44,9 +46,24 @@ class WcsService[LayerReader: OgcStore](layers: LayerReader)
           p match {
             case params: GetCapabilitiesWcsParams =>
               for {
-                rsm <- layers.getModel(projectId)
+                rsm <- layers.getWcsModel(projectId)
                 resp <- Ok(Operations.getCapabilities(serviceUrl, rsm, params))
               } yield resp
+
+            case params: DescribeCoverageWcsParams =>
+              for {
+                rsm <- layers.getWcsModel(projectId)
+                resp <- Ok(Operations.describeCoverage(rsm, params))
+              } yield {
+                resp
+              }
+
+            case params: GetCoverageWcsParams =>
+              for {
+                rsm <- layers.getWcsModel(projectId)
+                resp <- Ok(new GetCoverage(rsm).build(params))
+              } yield resp
+
             case _ =>
               BadRequest("not yet implemented")
           }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WcsService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WcsService.scala
@@ -21,12 +21,11 @@ import org.http4s.scalaxml._
 
 import com.typesafe.scalalogging.LazyLogging
 
-class WcsService[LayerReader: OgcStore](layers: LayerReader)(
+import scala.util.Properties
+
+class WcsService[LayerReader: OgcStore](layers: LayerReader, urlPrefix: String)(
     implicit contextShift: ContextShift[IO])
     extends ToOgcStoreOps with LazyLogging {
-
-  // TODO lookup from environment
-  private val urlPrefix = "https://tiles.staging.rasterfoundry.com"
 
   private def requestToServiceUrl(request: Request[IO]) = {
     List(urlPrefix, request.scriptName, request.pathInfo).mkString

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
@@ -1,26 +1,33 @@
 package com.rasterfoundry.backsplash.server
 
+import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.OgcStore
 import com.rasterfoundry.backsplash.OgcStore.ToOgcStoreOps
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.common.datamodel.User
 
-import cats.data.Validated
-import cats.effect.IO
-import geotrellis.proj4.WebMercator
+import cats.data.Validated._
+import cats.effect.{ContextShift, IO}
+import cats.implicits._
+import com.azavea.maml.eval.Interpreter
+import io.circe.syntax._
+import geotrellis.raster._
+import geotrellis.server._
+import geotrellis.server.ogc._
 import geotrellis.server.ogc.params.ParamError
 import geotrellis.server.ogc.wms.{CapabilitiesView, WmsParams}
 import org.http4s._
-import org.http4s.scalaxml._
+import org.http4s.circe._
 import org.http4s.dsl.io._
+import org.http4s.scalaxml._
 
 import com.typesafe.scalalogging.LazyLogging
 
 import java.net.URL
 
-class WmsService[LayerReader: OgcStore](layers: LayerReader)
-    extends ToOgcStoreOps
-    with LazyLogging {
+class WmsService[LayerReader: OgcStore](layers: LayerReader)(
+    implicit contextShift: ContextShift[IO])
+    extends ToOgcStoreOps with LazyLogging {
 
   private val urlPrefix = "https://tiles.staging.rasterfoundry.com/"
 
@@ -32,21 +39,69 @@ class WmsService[LayerReader: OgcStore](layers: LayerReader)
     case authedReq @ GET -> Root / UUIDWrapper(projectId) as user =>
       val serviceUrl = requestToServiceUrl(authedReq.req)
       WmsParams(authedReq.req.multiParams) match {
-        case Validated.Invalid(errors) =>
+        case Invalid(errors) =>
           BadRequest(s"Error parsing parameters: ${ParamError
             .generateErrorMessage(errors.toList)}")
-        case Validated.Valid(p) =>
+        case Valid(p) =>
           p match {
             case params: WmsParams.GetCapabilities =>
               for {
-                rsm <- layers.getModel(projectId)
+                rsm <- layers.getWmsModel(projectId)
                 metadata <- layers.getWmsServiceMetadata(projectId)
-                resp <- Ok(
-                  new CapabilitiesView(rsm,
-                                       new URL(serviceUrl),
-                                       metadata,
-                                       defaultCrs = WebMercator).toXML)
+                resp <- Ok(new CapabilitiesView(rsm, new URL(serviceUrl)).toXML)
               } yield resp
+            case params: WmsParams.GetMap =>
+              val re =
+                RasterExtent(params.boundingBox, params.width, params.height)
+              for {
+                rsm <- layers.getWmsModel(projectId)
+                layer = rsm.getLayer(params.crs,
+                                     params.layers.headOption,
+                                     params.styles.headOption) getOrElse {
+                  params.layers.headOption match {
+                    case None =>
+                      throw RequirementFailedException(
+                        "WMS Request must specify layers")
+                    case Some(l) =>
+                      throw RequirementFailedException(
+                        s"Layer ${l} not found or something else went wrong")
+                  }
+                }
+                (evalExtent, evalHistogram) = layer match {
+                  case sl @ SimpleOgcLayer(_, _, _, _, _) =>
+                    (LayerExtent.identity(sl), LayerHistogram.identity(sl, 512))
+                  case MapAlgebraOgcLayer(_, _, _, parameters, expr, _) =>
+                    (LayerExtent(IO.pure(expr),
+                                 IO.pure(parameters),
+                                 Interpreter.DEFAULT),
+                     LayerHistogram(IO.pure(expr),
+                                    IO.pure(parameters),
+                                    Interpreter.DEFAULT,
+                                    512))
+                }
+                respIO <- (evalExtent(re.extent, re.cellSize), evalHistogram)
+                  .parMapN {
+                    case (Valid(mbTile), Valid(hists)) =>
+                      Ok(Render(mbTile, layer.style, params.format, hists))
+                    // at least one is invalid, we don't care which, and we want all the errors
+                    // if both are
+                    case (a, b) =>
+                      // map from Validated[Errs, ?] to Validated[Errs, ()] for both, since we already
+                      // know that at least one is invalid
+                      (a map { _ =>
+                        ()
+                      }) combine (b map { _ =>
+                        ()
+                      }) match {
+                        case Invalid(errs) =>
+                          BadRequest(errs asJson)
+                        case _ =>
+                          BadRequest("compiler can't tell this is unreachable")
+                      }
+                  }
+                resp <- respIO
+              } yield resp
+
             case _ =>
               BadRequest("not yet implemented")
           }

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -26,7 +26,7 @@ object Version {
   val findbugAnnotations = "3.0.1u2"
   val geotools = "17.1"
   val geotrellis = "2.2.0"
-  val geotrellisServer = "0.16.3-JS-SNAPSHOT"
+  val geotrellisServer = "0.16.6-JS-SNAPSHOT"
   val hadoop = "2.8.4"
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M4"

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -26,7 +26,7 @@ object Version {
   val findbugAnnotations = "3.0.1u2"
   val geotools = "17.1"
   val geotrellis = "2.2.0"
-  val geotrellisServer = "0.16.1-JS-SNAPSHOT"
+  val geotrellisServer = "0.16.3-JS-SNAPSHOT"
   val hadoop = "2.8.4"
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M4"


### PR DESCRIPTION
## Overview

This PR adds enough to get map tiles from wcs / wms layers. It leaves one thing on the table to do, which is to use existing histogram fetching and coloring logic to render tiles.

### Checklist

- [x] Description of PR is in an appropriate se
ction of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![ogc](https://user-images.githubusercontent.com/5702984/54708328-8dfdd900-4b19-11e9-93c5-982f639bb84c.gif)

## Testing Instructions

 * add a project with layers as a wms and a wcs source in qgis
 * pick one of the layers (ideally one with 4 bands, since histogram logic isn't in place to fetch from the db, so it's really slow for multi-spectral imagery)
 * view it
 * looooooooook

Closes #4748 
