### PR TITLE
Add maptoken support to project annotation listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Enabled project layer splitting on frontend [\#4766](https://github.com/raster-foundry/raster-foundry/pull/4766)
 - Added the histogram part of analysis data visualization UI [\#4756](https://github.com/raster-foundry/raster-foundry/pull/4756)
 - Add v2 project share page with layers and analyses [\#4768](https://github.com/raster-foundry/raster-foundry/pull/4768)
+- Added support for listing annotations on public projects without auth or with a map token query parameter [\#4795](https://github.com/raster-foundry/raster-foundry/pull/4795)
 
 ### Changed
 


### PR DESCRIPTION
## Overview

Adds support to project annotation listing for using `mapToken` for authentication to support listing annotations on the publish/share page.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] [Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated

## Testing Instructions

 * Have a clean development environment (basically ensure that there are no map tokens on the `dfc52922-dfc3-4155-9828-d8dfe9fd0f11` project.
 * Testing includes usage of `httpie` (plus [`http-jwt-auth`](https://github.com/teracyhq/httpie-jwt-auth)) and `jq` - so you'll need to install those.
 * Get a valid JWT for your development environment and in a shell run: `export JWT_AUTH_TOKEN=<jwt>` 
 * Go through the following steps to verify input/output is expected
```
# Create an annotation
echo '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Point","coordinates":[-80.092243,42.10058]},"properties":{"label":"","description":""}}]}' | http --auth-type=jwt POST :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations

# Should Return a 401
http GET :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations

# Make Project Public
echo '{"id":"dfc52922-dfc3-4155-9828-d8dfe9fd0f11","createdAt":"2019-01-21T17:56:53.664Z","modifiedAt":"2019-03-22T14:19:01.220Z","createdBy":"auth0|59318a9d2fbbca3e16bcfc92","modifiedBy":"auth0|59318a9d2fbbca3e16bcfc92","owner":"auth0|59318a9d2fbbca3e16bcfc92","name":"Local File Many Scenes","slugLabel":"Local File Many Scenes","description":"","visibility":"PUBLIC","tileVisibility":"PUBLIC","isAOIProject":false,"aoiCadenceMillis":604800000,"aoisLastChecked":"2019-01-21T17:56:53.664Z","tags":[],"extent":{"type":"Polygon","coordinates":[[[-80.25439506189069,41.99673676686244],[-80.25439506189069,42.12826046115263],[-79.99534057918225,42.12826046115263],[-79.99534057918225,41.99673676686244],[-80.25439506189069,41.99673676686244]]]},"manualOrder":true,"isSingleBand":false,"singleBandOptions":{"band":0,"dataType":"SEQUENTIAL","colorBins":0,"colorScheme":["#440154","#482374","#404387","#345E8D","#29788E","#208F8C","#22A784","#42BE71","#79D151","#BADE27"],"legendOrientation":"left","extraNoData":[]},"defaultAnnotationGroup":"cec72ce4-5d96-4025-ab67-4829d6a577a9","extras":null,"defaultLayerId":"1a8d9fc6-c357-42b0-b149-c57f1fbfa610"}' | http --auth-type=jwt PUT :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/

# Should be a 200
http GET :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations

# Make project private again
echo '{"id":"dfc52922-dfc3-4155-9828-d8dfe9fd0f11","createdAt":"2019-01-21T17:56:53.664Z","modifiedAt":"2019-03-22T14:19:01.220Z","createdBy":"auth0|59318a9d2fbbca3e16bcfc92","modifiedBy":"auth0|59318a9d2fbbca3e16bcfc92","owner":"auth0|59318a9d2fbbca3e16bcfc92","name":"Local File Many Scenes","slugLabel":"Local File Many Scenes","description":"","visibility":"PRIVATE","tileVisibility":"PRIVATE","isAOIProject":false,"aoiCadenceMillis":604800000,"aoisLastChecked":"2019-01-21T17:56:53.664Z","tags":[],"extent":{"type":"Polygon","coordinates":[[[-80.25439506189069,41.99673676686244],[-80.25439506189069,42.12826046115263],[-79.99534057918225,42.12826046115263],[-79.99534057918225,41.99673676686244],[-80.25439506189069,41.99673676686244]]]},"manualOrder":true,"isSingleBand":false,"singleBandOptions":{"band":0,"dataType":"SEQUENTIAL","colorBins":0,"colorScheme":["#440154","#482374","#404387","#345E8D","#29788E","#208F8C","#22A784","#42BE71","#79D151","#BADE27"],"legendOrientation":"left","extraNoData":[]},"defaultAnnotationGroup":"cec72ce4-5d96-4025-ab67-4829d6a577a9","extras":null,"defaultLayerId":"1a8d9fc6-c357-42b0-b149-c57f1fbfa610"}' | http --auth-type=jwt PUT :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/

# Create a map token and save it to an environment variables
export MAP_TOKEN=$(echo '{"name":"Test Annotation Label","project":"dfc52922-dfc3-4155-9828-d8dfe9fd0f11"}' | http --auth-type=jwt POST :9091/api/map-tokens | jq .id | sed -e 's/^"//' -e 's/"$//')

# Just a Map Token Should work
http GET :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations?mapToken=$MAP_TOKEN

# Map Token + JWT Header Should work
http --auth-type=jwt GET :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations?mapToken=$MAP_TOKEN

# Just JWT Header Should work
http --auth-type=jwt GET :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations

# Should not work
http GET :9091/api/projects/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/annotations
```

Closes #4773
