### PR TITLE
Allow users with edit permissions to share analysis in lab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 ### Fixed
 
 - No longer exclude public objects from searches for shared objects, except for scenes [\#4754](https://github.com/raster-foundry/raster-foundry/pull/4754)
+- Users that have edit permissions on an analysis can now share the analysis from within the lab interface
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 ### Fixed
 
 - No longer exclude public objects from searches for shared objects, except for scenes [\#4754](https://github.com/raster-foundry/raster-foundry/pull/4754)
-- Users that have edit permissions on an analysis can now share the analysis from within the lab interface
+- Users that have edit permissions on an analysis can now share the analysis from within the lab interface [\#4797](https://github.com/raster-foundry/raster-foundry/pull/4797)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -262,7 +262,7 @@ trait ToolRunRoutes
   def listUserAnalysisActions(analysisId: UUID): Route = authenticate { user =>
     authorizeAsync {
       ToolRunDao
-        .authorized(user, ObjectType.Analysis, analysisId, ActionType.Edit)
+        .authorized(user, ObjectType.Analysis, analysisId, ActionType.View)
         .transact(xa)
         .unsafeToFuture
     } {

--- a/app-frontend/src/app/components/projects/layerSplitModal/index.js
+++ b/app-frontend/src/app/components/projects/layerSplitModal/index.js
@@ -139,6 +139,7 @@ class LayerSplitModalController {
             .splitLayers(this.projectId, this.layerId, this.layerSplitBuffer)
             .then(resp => {
                 this.$state.go('project.layers', { projectId: this.projectId });
+                this.dismiss();
             })
             .catch(err => {
                 this.$log.error(err);

--- a/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
+++ b/app-frontend/src/app/components/projects/projectLayerSecondaryNavbar/index.js
@@ -21,21 +21,6 @@ class ProjectLayerSecondaryNavbarController {
             callback: () => this.openSplitLayerModal()
         };
 
-        const publishing = {
-            name: 'Publishing',
-            title: 'publishing',
-            menu: true,
-            callback: () =>
-                this.$state.go('project.settings.publishing', { projectId: this.projectId })
-        };
-
-        const layerSettings = {
-            name: 'Layer settings',
-            title: 'layer-settings',
-            menu: true,
-            callback: () => this.$state.go('project.settings', { projectId: this.projectId })
-        };
-
         const deleteLayer = {
             name: 'Delete layer',
             title: 'delete-layer',
@@ -43,7 +28,7 @@ class ProjectLayerSecondaryNavbarController {
             callback: () => this.openLayerDeleteModal()
         };
 
-        this.actions = [splitLayer, publishing, layerSettings, deleteLayer];
+        this.actions = [splitLayer, deleteLayer];
     }
 
     openSplitLayerModal() {

--- a/app-frontend/src/app/pages/lab/analysis/analysis.html
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.html
@@ -1,102 +1,121 @@
 <div class="navbar secondary-navbar">
-  <div class="container dashboard">
-    <div class="navbar-section primary">
-      <nav>
-        <a ui-sref="lab.analysis({analysisid: $ctrl.analysis.id, analysis: $ctrl.analysis})"
-           ui-sref-active="active">
-          <i class="icon-model"></i>
-          <span>Diagram</span>
-        </a>
-        <a href
-           ng-click="$ctrl.permissionsModal()"
-           ng-if="$ctrl.permissions && $ctrl.permissions.length"
-        >
-          <i class="icon-key"></i>
-          <span>Permissions</span>
-        </a>
-      </nav>
+    <div class="container dashboard">
+        <div class="navbar-section primary">
+            <nav>
+                <a
+                    ui-sref="lab.analysis({analysisid: $ctrl.analysis.id, analysis: $ctrl.analysis})"
+                    ui-sref-active="active"
+                >
+                    <i class="icon-model"></i>
+                    <span>Diagram</span>
+                </a>
+                <a href ng-click="$ctrl.permissionsModal()" ng-if="$ctrl.userCanEdit()">
+                    <i class="icon-key"></i>
+                    <span>Permissions</span>
+                </a>
+            </nav>
+        </div>
     </div>
-  </div>
 </div>
 <div class="container column-stretch container-not-scrollable">
-  <div class="main with-position">
-    <div class="lab-container">
-      <div class="lab-left"
-           ng-show="$ctrl.isShowingPreview && !!$ctrl.showMap"
-           ng-style="$ctrl.labLeftStyle" draggable="false">
-        <rf-lab-map
-            map-id="lab-preview"
-            analysis-id="{{$ctrl.analysisId}}"
-            enable-node-export="true"
-            on-close="$ctrl.onPreviewClose()"
-            comparing="$ctrl.frameControlAdded"
-            on-compare-click="$ctrl.onCompareClick()"
-            on-node-export="$ctrl.onNodeExport(bbox, zoom, node)"
-            set-default-export-node="$ctrl.setDefaultExportNode(nodeId)"
-        ></rf-lab-map>
-        <rf-node-selector
-            data-node-map="$ctrl.nodeMap"
-            data-selected="$ctrl.leftPreviewSelection"
-            data-position="$ctrl.leftPreviewPosition"
-            on-select="$ctrl.onLeftSelect(node)"
-            on-close="$ctrl.onLeftClose()"
-            ng-if="$ctrl.frameControlAdded"></rf-node-selector>
-        <rf-node-selector
-            data-node-map="$ctrl.nodeMap"
-            data-selected="$ctrl.rightPreviewSelection"
-            data-position="$ctrl.rightPreviewPosition"
-            on-select="$ctrl.onRightSelect(node)"
-            on-close="$ctrl.onRightClose()"
-            ng-if="$ctrl.frameControlAdded"></rf-node-selector>
-        <rf-node-selector
-            data-node-map="$ctrl.nodeMap"
-            data-selected="$ctrl.singlePreviewSelection"
-            data-position="$ctrl.singlePreviewPosition"
-            on-select="$ctrl.onSingleSelect(node)"
-            on-close="$ctrl.onSingleClose()"
-            ng-if="!$ctrl.frameControlAdded && $ctrl.singlePreviewSelection"></rf-node-selector>
-      </div>
-      <div class="resize-separator"
-           ng-style="$ctrl.resizeHandleStyle"
-           ng-show="$ctrl.isShowingPreview"
-           draggable="false">
-        <div class="resize-handle-grabber"
-             ng-mousedown="$ctrl.startLabSplitDrag($event)"
-             ng-touchstart="$ctrl.startLabSplitDrag($event)"
-             draggable="false"
-             title="Drag to resize Preview">
-          <div class="icon-gripper" draggable="false"></div>
+    <div class="main with-position">
+        <div class="lab-container">
+            <div
+                class="lab-left"
+                ng-show="$ctrl.isShowingPreview && !!$ctrl.showMap"
+                ng-style="$ctrl.labLeftStyle"
+                draggable="false"
+            >
+                <rf-lab-map
+                    map-id="lab-preview"
+                    analysis-id="{{ $ctrl.analysisId }}"
+                    enable-node-export="true"
+                    on-close="$ctrl.onPreviewClose()"
+                    comparing="$ctrl.frameControlAdded"
+                    on-compare-click="$ctrl.onCompareClick()"
+                    on-node-export="$ctrl.onNodeExport(bbox, zoom, node)"
+                    set-default-export-node="$ctrl.setDefaultExportNode(nodeId)"
+                ></rf-lab-map>
+                <rf-node-selector
+                    data-node-map="$ctrl.nodeMap"
+                    data-selected="$ctrl.leftPreviewSelection"
+                    data-position="$ctrl.leftPreviewPosition"
+                    on-select="$ctrl.onLeftSelect(node)"
+                    on-close="$ctrl.onLeftClose()"
+                    ng-if="$ctrl.frameControlAdded"
+                ></rf-node-selector>
+                <rf-node-selector
+                    data-node-map="$ctrl.nodeMap"
+                    data-selected="$ctrl.rightPreviewSelection"
+                    data-position="$ctrl.rightPreviewPosition"
+                    on-select="$ctrl.onRightSelect(node)"
+                    on-close="$ctrl.onRightClose()"
+                    ng-if="$ctrl.frameControlAdded"
+                ></rf-node-selector>
+                <rf-node-selector
+                    data-node-map="$ctrl.nodeMap"
+                    data-selected="$ctrl.singlePreviewSelection"
+                    data-position="$ctrl.singlePreviewPosition"
+                    on-select="$ctrl.onSingleSelect(node)"
+                    on-close="$ctrl.onSingleClose()"
+                    ng-if="!$ctrl.frameControlAdded && $ctrl.singlePreviewSelection"
+                ></rf-node-selector>
+            </div>
+            <div
+                class="resize-separator"
+                ng-style="$ctrl.resizeHandleStyle"
+                ng-show="$ctrl.isShowingPreview"
+                draggable="false"
+            >
+                <div
+                    class="resize-handle-grabber"
+                    ng-mousedown="$ctrl.startLabSplitDrag($event)"
+                    ng-touchstart="$ctrl.startLabSplitDrag($event)"
+                    draggable="false"
+                    title="Drag to resize Preview"
+                >
+                    <div class="icon-gripper" draggable="false"></div>
+                </div>
+            </div>
+            <div
+                class="resize-ghost"
+                ng-style="$ctrl.labResizingStyle"
+                ng-show="$ctrl.labResizing"
+                draggable="false"
+            >
+                <div
+                    class="resize-ghost-text"
+                    ng-show="$ctrl.splitPercentX && $ctrl.splitPercentX > 90"
+                >
+                    Maximize Map
+                </div>
+                <div
+                    class="resize-ghost-text"
+                    ng-show="$ctrl.splitPercentX && $ctrl.splitPercentX < 10"
+                >
+                    Maximize Diagram
+                </div>
+            </div>
+            <div
+                class="lab-right"
+                draggable="false"
+                ng-style="$ctrl.labRightStyle"
+                ng-show="!!$ctrl.showDiagram || !$ctrl.isShowingPreview"
+            >
+                <rf-diagram-container
+                    ng-if="$ctrl.analysis && $ctrl.analysis.id === $ctrl.analysisId"
+                    enable-node-sharing="$ctrl.userCanEdit()"
+                    class="with-position"
+                >
+                </rf-diagram-container>
+            </div>
         </div>
-      </div>
-      <div class="resize-ghost"
-           ng-style="$ctrl.labResizingStyle"
-           ng-show="$ctrl.labResizing"
-           draggable="false">
-        <div class="resize-ghost-text" ng-show="$ctrl.splitPercentX && $ctrl.splitPercentX > 90">
-          Maximize Map
+        <div class="lab-footer" ng-show="$ctrl.warning">
+            <span class="icon-warning"></span>
+            {{ $ctrl.warning }}
+            <button class="btn-transparent btn-text" ng-click="$ctrl.clearWarning()">
+                <span class="icon-close"></span>
+            </button>
         </div>
-        <div class="resize-ghost-text" ng-show="$ctrl.splitPercentX && $ctrl.splitPercentX < 10">
-          Maximize Diagram
-        </div>
-      </div>
-      <div class="lab-right" draggable="false"
-         ng-style="$ctrl.labRightStyle"
-         ng-show="!!$ctrl.showDiagram || !$ctrl.isShowingPreview">
-        <rf-diagram-container
-            ng-if="$ctrl.analysis && $ctrl.analysis.id === $ctrl.analysisId"
-            enable-node-sharing="$ctrl.analysis.owner === $ctrl.user.id"
-            class="with-position"
-        >
-        </rf-diagram-container>
-      </div>
     </div>
-    <div class="lab-footer"
-         ng-show="$ctrl.warning">
-      <span class="icon-warning"></span>
-      {{$ctrl.warning}}
-      <button class="btn-transparent btn-text" ng-click="$ctrl.clearWarning()">
-        <span class="icon-close"></span>
-      </button>
-    </div>
-  </div>
 </div>

--- a/app-frontend/src/app/pages/lab/analysis/analysis.js
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.js
@@ -8,7 +8,8 @@ class LabAnalysisController {
     constructor(
         $ngRedux, $scope, $rootScope, $state, $timeout, $element, $window, $document, modalService,
         mapService, projectService, authService, mapUtilsService, analysisService, tokenService,
-        platform, user, permissionsService,
+        permissionsService,
+        platform, user, permissions,
         APP_CONFIG,
     ) {
         'ngInject';
@@ -52,6 +53,11 @@ class LabAnalysisController {
         this.initAnalysis();
     }
 
+    userCanEdit() {
+        return this.permissions.includes('EDIT') ||
+            this.permissions.includes('*');
+    }
+
     getMap() {
         return this.mapService.getMap('lab-preview');
     }
@@ -65,20 +71,6 @@ class LabAnalysisController {
         } else if (!this.analysisId) {
             this.$state.go('lab.browse.analyses');
         }
-        let watchAnalysis = this.$scope.$watch('$ctrl.analysis', (current) => {
-            if (current) {
-                this.fetchAnalysisPermissions(current);
-                watchAnalysis();
-            }
-        });
-    }
-
-    fetchAnalysisPermissions(analysis) {
-        this.permissionsService
-            .getEditableObjectPermissions('tool-runs', 'ANALYSIS', analysis, this.authService.user)
-            .then(permissions => {
-                this.permissions = permissions;
-            });
     }
 
     onAnalysisParameterChange(nodeid, project, band, override, renderDef, position) {
@@ -606,7 +598,9 @@ LabAnalysisModule.resolve = {
         );
 
         return platformService.getPlatform(platformRole.groupId);
-    }
+    },
+    permissions: ($stateParams, analysisService) =>
+        analysisService.getAnalysisActions($stateParams.analysisid)
 };
 
 autoInject(LabAnalysisModule);


### PR DESCRIPTION
## Overview

This PR uses the `analysis/{id}/actions` endpoint to conditionally allow sharing of analyses from within the lab UI.

There were a bunch of formatting changes, so I've pointed out the functionally new pieces.

Previously, we waited to fetch the analysis permissions until after the page has loaded. For this PR, I moved this async op to the page resolves which saves us from dealing with the promise mechanics inside the controller.

This PR also fixes the split layer modal by adding a call to `this.dismiss()` when the `Create layers` button is pressed.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible


## Testing Instructions

 * For an analysis you own, view it in the lab and ensure you can see the permissions tab at the top of the lab interface as well as the share button on every node that isn't a constant
 * For an analysis shared with you with at least edit permissions, ensure you can also see the permissions and sharing buttons as above
 * For an analysis shared with you with only view permissions, ensure you can't see the permissions or sharing buttons

Closes #4771 
Closes #4790 