### PR TITLE
Preserve state of visible layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   - Added parameter handling for DescribeCoverage, GetCoverage, and GetMap requests [\#4782](https://github.com/raster-foundry/raster-foundry/pull/4782)
   - Added map token authentication to OGC services [\#4778](https://github.com/raster-foundry/raster-foundry/pull/4778)
   - Added style creation from bands and color composites on datasources [\#4789](https://github.com/raster-foundry/raster-foundry/pull/4789)
+- Preserve state of visible layers [\#4802](https://github.com/raster-foundry/raster-foundry/pull/4802)
 
 ### Changed
 

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -4,7 +4,7 @@ import {Set, Map} from 'immutable';
 
 class ProjectLayersPageController {
     constructor(
-        $rootScope, $state, $q,
+        $rootScope, $state, $q, $log, $scope,
         projectService, paginationService, modalService, authService, mapService
     ) {
         'ngInject';
@@ -13,7 +13,8 @@ class ProjectLayersPageController {
 
     $onInit() {
         this.selected = new Map();
-        this.visible = new Set([this.project.defaultLayerId]);
+        const visibleLayers = this.projectService.getVisibleProjectLayers();
+        this.visible = visibleLayers.size ? visibleLayers : Set([this.project.defaultLayerId]);
         this.syncMapLayersToVisible();
         this.projectService.getProjectPermissions(this.project, this.user).then(
             permissions => {
@@ -24,6 +25,12 @@ class ProjectLayersPageController {
                 this.layerStats = layerSceneCounts;
             });
         this.fetchPage();
+
+        this.$scope.$watch('$ctrl.visible', (visibleProjectLayers) => {
+            if (visibleProjectLayers) {
+                this.projectService.setVisibleProjectLayers(visibleProjectLayers);
+            }
+        });
     }
 
     $onDestroy() {
@@ -198,7 +205,7 @@ class ProjectLayersPageController {
     }
 
     allVisibleSelected() {
-        let layerSet = new Set(this.layerList.map(l => l.id));
+        let layerSet = Set(this.layerList.map(l => l.id));
         return layerSet.intersect(this.selected.keySeq()).size === layerSet.size;
     }
 
@@ -315,7 +322,7 @@ class ProjectLayersPageController {
     }
 
     showDefaultLayer() {
-        this.visible = new Set([this.project.defaultLayerId]);
+        this.visible = Set([this.project.defaultLayerId]);
         this.syncMapLayersToVisible();
     }
 

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -13,7 +13,8 @@ class ProjectLayersPageController {
         paginationService,
         modalService,
         authService,
-        mapService
+        mapService,
+        projectEditService
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -21,7 +22,7 @@ class ProjectLayersPageController {
 
     $onInit() {
         this.selected = new Map();
-        const visibleLayers = this.projectService.getVisibleProjectLayers();
+        const visibleLayers = this.projectEditService.getVisibleProjectLayers();
         this.visible = visibleLayers.size ? visibleLayers : Set([this.project.defaultLayerId]);
         this.syncMapLayersToVisible();
         this.projectService.getProjectPermissions(this.project, this.user).then(permissions => {
@@ -31,12 +32,6 @@ class ProjectLayersPageController {
             this.layerStats = layerSceneCounts;
         });
         this.fetchPage();
-
-        this.$scope.$watch('$ctrl.visible', visibleProjectLayers => {
-            if (visibleProjectLayers) {
-                this.projectService.setVisibleProjectLayers(visibleProjectLayers);
-            }
-        });
     }
 
     $onDestroy() {
@@ -264,6 +259,7 @@ class ProjectLayersPageController {
         } else {
             this.visible = this.visible.add(id);
         }
+        this.projectEditService.setVisibleProjectLayers(this.visible);
         this.syncMapLayersToVisible();
     }
 
@@ -334,6 +330,7 @@ class ProjectLayersPageController {
                     .all(promises)
                     .then(() => {
                         this.visible = this.visible.subtract(this.selected.keySeq());
+                        this.projectEditService.setVisibleProjectLayers(this.visible);
                         this.selected = new Map();
                     })
                     .catch(e => {
@@ -350,11 +347,13 @@ class ProjectLayersPageController {
 
     showDefaultLayer() {
         this.visible = Set([this.project.defaultLayerId]);
+        this.projectEditService.setVisibleProjectLayers(this.visible);
         this.syncMapLayersToVisible();
     }
 
     showPageLayers() {
         this.visible = this.visible.union(this.layerList.map(l => l.id));
+        this.projectEditService.setVisibleProjectLayers(this.visible);
         this.syncMapLayersToVisible();
     }
 

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -1,11 +1,19 @@
 import _ from 'lodash';
 import tpl from './index.html';
-import {Set, Map} from 'immutable';
+import { Set, Map } from 'immutable';
 
 class ProjectLayersPageController {
     constructor(
-        $rootScope, $state, $q, $log, $scope,
-        projectService, paginationService, modalService, authService, mapService
+        $rootScope,
+        $state,
+        $q,
+        $log,
+        $scope,
+        projectService,
+        paginationService,
+        modalService,
+        authService,
+        mapService
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -16,17 +24,15 @@ class ProjectLayersPageController {
         const visibleLayers = this.projectService.getVisibleProjectLayers();
         this.visible = visibleLayers.size ? visibleLayers : Set([this.project.defaultLayerId]);
         this.syncMapLayersToVisible();
-        this.projectService.getProjectPermissions(this.project, this.user).then(
-            permissions => {
-                this.permissions = permissions.map(p => p.actionType);
-            });
-        this.projectService.getProjectLayerStats(this.project.id).then(
-            layerSceneCounts => {
-                this.layerStats = layerSceneCounts;
-            });
+        this.projectService.getProjectPermissions(this.project, this.user).then(permissions => {
+            this.permissions = permissions.map(p => p.actionType);
+        });
+        this.projectService.getProjectLayerStats(this.project.id).then(layerSceneCounts => {
+            this.layerStats = layerSceneCounts;
+        });
         this.fetchPage();
 
-        this.$scope.$watch('$ctrl.visible', (visibleProjectLayers) => {
+        this.$scope.$watch('$ctrl.visible', visibleProjectLayers => {
             if (visibleProjectLayers) {
                 this.projectService.setVisibleProjectLayers(visibleProjectLayers);
             }
@@ -35,7 +41,7 @@ class ProjectLayersPageController {
 
     $onDestroy() {
         // remove layers from map
-        this.getMap().then((map) => {
+        this.getMap().then(map => {
             map.deleteLayers('Project Layers');
         });
     }
@@ -51,41 +57,46 @@ class ProjectLayersPageController {
     fetchPage(page = this.$state.params.page || 1) {
         this.layerList = [];
         this.layerActions = {};
-        const currentQuery = this.projectService.getProjectLayers(
-            this.project.id,
-            {
+        const currentQuery = this.projectService
+            .getProjectLayers(this.project.id, {
                 pageSize: 30,
                 page: page - 1
-            }
-        ).then((paginatedResponse) => {
-            this.layerList = paginatedResponse.results;
-            this.layerList.forEach((layer) => {
-                layer.subtext = '';
-                if (layer.id === this.project.defaultLayerId) {
-                    layer.subtext += 'Default layer';
+            })
+            .then(
+                paginatedResponse => {
+                    this.layerList = paginatedResponse.results;
+                    this.layerList.forEach(layer => {
+                        layer.subtext = '';
+                        if (layer.id === this.project.defaultLayerId) {
+                            layer.subtext += 'Default layer';
+                        }
+                        if (layer.smartLayerId) {
+                            layer.subtext += layer.subtext.length ? ', Smart layer' : 'Smart Layer';
+                        }
+                    });
+                    const defaultLayer = this.layerList.find(
+                        l => l.id === this.project.defaultLayerId
+                    );
+                    this.layerActions = this.layerList.map(l =>
+                        this.addLayerActions(l, defaultLayer === l)
+                    );
+                    this.pagination = this.paginationService.buildPagination(paginatedResponse);
+                    this.paginationService.updatePageParam(page);
+                    if (this.currentQuery === currentQuery) {
+                        delete this.fetchError;
+                    }
+                },
+                e => {
+                    if (this.currentQuery === currentQuery) {
+                        this.fetchError = e;
+                    }
                 }
-                if (layer.smartLayerId) {
-                    layer.subtext += layer.subtext.length ? ', Smart layer' : 'Smart Layer';
+            )
+            .finally(() => {
+                if (this.currentQuery === currentQuery) {
+                    delete this.currentQuery;
                 }
             });
-            const defaultLayer = this.layerList.find(l => l.id === this.project.defaultLayerId);
-            this.layerActions = this.layerList.map(
-                (l) => this.addLayerActions(l, defaultLayer === l)
-            );
-            this.pagination = this.paginationService.buildPagination(paginatedResponse);
-            this.paginationService.updatePageParam(page);
-            if (this.currentQuery === currentQuery) {
-                delete this.fetchError;
-            }
-        }, (e) => {
-            if (this.currentQuery === currentQuery) {
-                this.fetchError = e;
-            }
-        }).finally(() => {
-            if (this.currentQuery === currentQuery) {
-                delete this.currentQuery;
-            }
-        });
         this.currentQuery = currentQuery;
         return currentQuery;
     }
@@ -111,7 +122,8 @@ class ProjectLayersPageController {
                 {
                     icon: 'icon-eye',
                     isActive: () => this.visible.has(layer.id)
-                }, {
+                },
+                {
                     icon: 'icon-eye-off',
                     isActive: () => !this.visible.has(layer.id)
                 }
@@ -123,10 +135,8 @@ class ProjectLayersPageController {
         };
         const editAction = {
             name: 'Edit',
-            callback: () => this.$state.go(
-                'project.layer',
-                {projectId: this.project.id, layerId: layer.id}
-            ),
+            callback: () =>
+                this.$state.go('project.layer', { projectId: this.project.id, layerId: layer.id }),
             menu: true
         };
         const setDefaultAction = {
@@ -141,44 +151,49 @@ class ProjectLayersPageController {
         };
         const publishAction = {
             name: 'Publishing',
-            callback: () => this.$state.go(
-                'project.layer.settings.publishing',
-                {projectId: this.project.id, layerId: layer.id}
-            ),
+            callback: () =>
+                this.$state.go('project.layer.settings.publishing', {
+                    projectId: this.project.id,
+                    layerId: layer.id
+                }),
             menu: true
         };
         const exportAction = {
             name: 'Export',
-            callback: () => this.$state.go(
-                'project.layer.settings.publishing',
-                {projectId: this.project.id, layerId: layer.id}
-            ),
+            callback: () =>
+                this.$state.go('project.layer.settings.publishing', {
+                    projectId: this.project.id,
+                    layerId: layer.id
+                }),
             menu: true
         };
         const importAction = {
             name: 'Import imagery',
-            callback: () => this.modalService.open({
-                component: 'rfSceneImportModal',
-                resolve: {
-                    project: () => this.project,
-                    layer: () => layer,
-                    origin: () => 'project'
-                }
-            })
+            callback: () =>
+                this.modalService.open({
+                    component: 'rfSceneImportModal',
+                    resolve: {
+                        project: () => this.project,
+                        layer: () => layer,
+                        origin: () => 'project'
+                    }
+                })
         };
         const browseAction = {
             name: 'Browse for imagery',
-            callback: () => this.$state.go(
-                'project.layer.browse',
-                {projectId: this.project.id, layerId: layer.id}
-            )
+            callback: () =>
+                this.$state.go('project.layer.browse', {
+                    projectId: this.project.id,
+                    layerId: layer.id
+                })
         };
         const settingsAction = {
             name: 'Settings',
-            callback: () => this.$state.go(
-                'project.layer.settings',
-                {projectId: this.project.id, layerId: layer.id}
-            ),
+            callback: () =>
+                this.$state.go('project.layer.settings', {
+                    projectId: this.project.id,
+                    layerId: layer.id
+                }),
             menu: true
         };
         const deleteAction = {
@@ -193,14 +208,18 @@ class ProjectLayersPageController {
         // TODO: add implement these when the views are finished:
         // const unimplementedActions = [publishAction, exportAction, settingsAction];
         const layerActions = [
-            previewAction, editAction, editAoiAction, createAnalysisAction,
-            importAction, browseAction
+            previewAction,
+            editAction,
+            editAoiAction,
+            createAnalysisAction,
+            importAction,
+            browseAction
         ];
 
         return [
-            ...!_.get(layer, 'geometry.type') ? [alertAoiAction] : [],
+            ...(!_.get(layer, 'geometry.type') ? [alertAoiAction] : []),
             ...layerActions,
-            ...!isDefaultLayer ? [setDefaultAction, deleteAction] : []
+            ...(!isDefaultLayer ? [setDefaultAction, deleteAction] : [])
         ];
     }
 
@@ -213,9 +232,7 @@ class ProjectLayersPageController {
         if (this.allVisibleSelected()) {
             this.selected = this.selected.clear();
         } else {
-            this.selected = this.selected.merge(
-                new Map(this.layerList.map(i => [i.id, i]))
-            );
+            this.selected = this.selected.merge(new Map(this.layerList.map(i => [i.id, i])));
         }
         this.updateSelectText();
     }
@@ -251,11 +268,15 @@ class ProjectLayersPageController {
     }
 
     setProjectDefaultLayer(layer) {
-        this.projectService.updateProject(Object.assign({}, this.project, {
-            defaultLayerId: layer.id
-        })).then(() => {
-            this.$state.go('.', {}, {inherit: true, reload: true});
-        });
+        this.projectService
+            .updateProject(
+                Object.assign({}, this.project, {
+                    defaultLayerId: layer.id
+                })
+            )
+            .then(() => {
+                this.$state.go('.', {}, { inherit: true, reload: true });
+            });
     }
 
     createAnalysis(layer) {
@@ -263,7 +284,7 @@ class ProjectLayersPageController {
         if (layer) {
             layers = [layer];
         }
-        this.$state.go('project.create-analysis', {layers});
+        this.$state.go('project.create-analysis', { layers });
     }
 
     deleteProjectLayers(layers) {
@@ -276,9 +297,9 @@ class ProjectLayersPageController {
                     title: () => `Really delete ${ids.length} layers?`,
                     subtitle: () => 'Deleting layers cannot be undone',
                     content: () =>
-                        '<h2>Do you wish to continue?</h2>'
-                        + '<p>Future attempts to access these '
-                        + 'layers or associated annotations, tiles, and scenes will fail.',
+                        '<h2>Do you wish to continue?</h2>' +
+                        '<p>Future attempts to access these ' +
+                        'layers or associated annotations, tiles, and scenes will fail.',
                     feedbackIconType: () => 'danger',
                     feedbackIcon: () => 'icon-warning',
                     feedbackBtnType: () => 'btn-danger',
@@ -293,9 +314,9 @@ class ProjectLayersPageController {
                     title: () => 'Really delete layer?',
                     subtitle: () => 'Deleting layers cannot be undone',
                     content: () =>
-                        '<h2>Do you wish to continue?</h2>'
-                        + '<p>Future attempts to access this '
-                        + 'layer or associated annotations, tiles, and scenes will fail.',
+                        '<h2>Do you wish to continue?</h2>' +
+                        '<p>Future attempts to access this ' +
+                        'layer or associated annotations, tiles, and scenes will fail.',
                     feedbackIconType: () => 'danger',
                     feedbackIcon: () => 'icon-warning',
                     feedbackBtnType: () => 'btn-danger',
@@ -304,21 +325,27 @@ class ProjectLayersPageController {
                 }
             }).result;
         }
-        modal.then(() => {
-            const promises = ids.map(
-                id => this.projectService.deleteProjectLayer(this.project.id, id)
-            );
-            this.$q.all(promises).then(() => {
-                this.visible = this.visible.subtract(this.selected.keySeq());
-                this.selected = new Map();
-            }).catch(e => {
-                this.$log.error(e);
-            }).finally(() => {
-                this.fetchPage();
+        modal
+            .then(() => {
+                const promises = ids.map(id =>
+                    this.projectService.deleteProjectLayer(this.project.id, id)
+                );
+                this.$q
+                    .all(promises)
+                    .then(() => {
+                        this.visible = this.visible.subtract(this.selected.keySeq());
+                        this.selected = new Map();
+                    })
+                    .catch(e => {
+                        this.$log.error(e);
+                    })
+                    .finally(() => {
+                        this.fetchPage();
+                    });
+            })
+            .catch(() => {
+                // modal closed
             });
-        }).catch(() => {
-            // modal closed
-        });
     }
 
     showDefaultLayer() {
@@ -357,9 +384,7 @@ class ProjectLayersPageController {
             }
         });
 
-        modal.result
-            .then(() => this.fetchPage())
-            .catch(() => {});
+        modal.result.then(() => this.fetchPage()).catch(() => {});
     }
 
     createItemInfo(layer) {
@@ -374,7 +399,7 @@ class ProjectLayersPageController {
     }
 
     goToAoiDef(id) {
-        this.$state.go('project.layer.aoi', {layerId: id, projectId: this.project.id});
+        this.$state.go('project.layer.aoi', { layerId: id, projectId: this.project.id });
     }
 }
 
@@ -391,5 +416,4 @@ const component = {
 export default angular
     .module('components.pages.projects.layers', [])
     .controller(ProjectLayersPageController.name, ProjectLayersPageController)
-    .component('rfProjectLayersPage', component)
-    .name;
+    .component('rfProjectLayersPage', component).name;

--- a/app-frontend/src/app/components/pages/project/project/index.js
+++ b/app-frontend/src/app/components/pages/project/project/index.js
@@ -3,7 +3,8 @@ import tpl from './index.html';
 
 class ProjectPageController {
     constructor(
-        $rootScope, $state, $location, $transitions, mapService, mapUtilsService,
+        $rootScope, $state, $location, $transitions,
+        mapService, mapUtilsService, projectService
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -22,6 +23,10 @@ class ProjectPageController {
                 }
             });
         });
+    }
+
+    $onDestroy() {
+        this.projectService.setVisibleProjectLayers();
     }
 
     getMap() {

--- a/app-frontend/src/app/components/pages/project/project/index.js
+++ b/app-frontend/src/app/components/pages/project/project/index.js
@@ -1,10 +1,15 @@
-import {Map} from 'immutable';
+import { Map } from 'immutable';
 import tpl from './index.html';
 
 class ProjectPageController {
     constructor(
-        $rootScope, $state, $location, $transitions,
-        mapService, mapUtilsService, projectService
+        $rootScope,
+        $state,
+        $location,
+        $transitions,
+        mapService,
+        mapUtilsService,
+        projectService
     ) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
@@ -14,14 +19,17 @@ class ProjectPageController {
         if (!this.$location.search().bbox) {
             this.fitProjectExtent();
         }
-        this.getMap().then((map) => {
-            this.$transitions.onFinish({
-                to: 'project.*'
-            }, (transition) => {
-                if (!transition.to().name.includes('create-analysis')) {
-                    map.map.invalidateSize();
+        this.getMap().then(map => {
+            this.$transitions.onFinish(
+                {
+                    to: 'project.*'
+                },
+                transition => {
+                    if (!transition.to().name.includes('create-analysis')) {
+                        map.map.invalidateSize();
+                    }
                 }
-            });
+            );
         });
     }
 
@@ -52,5 +60,4 @@ const component = {
 export default angular
     .module('components.pages.project.page', [])
     .controller(ProjectPageController.name, ProjectPageController)
-    .component('rfProjectPage', component)
-    .name;
+    .component('rfProjectPage', component).name;

--- a/app-frontend/src/app/services/projects/edit.service.js
+++ b/app-frontend/src/app/services/projects/edit.service.js
@@ -1,3 +1,5 @@
+import { Set } from 'immutable';
+
 export default (app) => {
     class ProjectEditService {
         constructor(
@@ -16,6 +18,7 @@ export default (app) => {
             this.currentProjectId = null;
             this.currentProject = null;
             this.projectFetchError = null;
+            this.visibleProjectLayers = Set([]);
         }
 
         fetchCurrentProject() {
@@ -69,6 +72,14 @@ export default (app) => {
                     reject({message: 'Error updating project', error});
                 });
             });
+        }
+
+        setVisibleProjectLayers(visibleLayerSet = Set([])) {
+            this.visibleProjectLayers = visibleLayerSet;
+        }
+
+        getVisibleProjectLayers() {
+            return this.visibleProjectLayers;
         }
     }
 

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -1,6 +1,5 @@
 /* globals BUILDCONFIG L*/
 import _ from 'lodash';
-import { Set } from 'immutable';
 
 const availableProcessingOptions = [
     {
@@ -65,7 +64,6 @@ export default app => {
             this.$q = $q;
             this.availableProcessingOptions = availableProcessingOptions;
             this.availableProcessingOptionsThin = this.availableProcessingOptions.slice(0, 2);
-            this.visibleProjectLayers = Set([]);
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
 
@@ -858,14 +856,6 @@ export default app => {
 
         splitLayers(projectId, layerId, splitOptions) {
             return this.Project.splitLayers({ projectId, layerId }, splitOptions).$promise;
-        }
-
-        setVisibleProjectLayers(visibleLayerSet = Set([])) {
-            this.visibleProjectLayers = visibleLayerSet;
-        }
-
-        getVisibleProjectLayers() {
-            return this.visibleProjectLayers;
         }
     }
 

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -1,5 +1,6 @@
 /* globals BUILDCONFIG L*/
 import _ from 'lodash';
+import { Set } from 'immutable';
 
 const availableProcessingOptions = [
     {
@@ -64,6 +65,7 @@ export default app => {
             this.$q = $q;
             this.availableProcessingOptions = availableProcessingOptions;
             this.availableProcessingOptionsThin = this.availableProcessingOptions.slice(0, 2);
+            this.visibleProjectLayers = Set([]);
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
 
@@ -856,6 +858,14 @@ export default app => {
 
         splitLayers(projectId, layerId, splitOptions) {
             return this.Project.splitLayers({ projectId, layerId }, splitOptions).$promise;
+        }
+
+        setVisibleProjectLayers(visibleLayerSet = Set([])) {
+            this.visibleProjectLayers = visibleLayerSet;
+        }
+
+        getVisibleProjectLayers() {
+            return this.visibleProjectLayers;
         }
     }
 


### PR DESCRIPTION
## Overview

This PR preserves the state of visible project layers until the project component is destroyed.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

This feature is implemented in commit `9380542`. Commit `0b69f2d` only contains reformatting changes using `prettier`.


## Testing Instructions

 * Go to V2 project layers list
 * Update layer visibility for one or multiple layers by switching on or off the eye icon
 * Go to project's nested components (like going to analysis list, going to a specific layer, etc), then go back to layers list. Make sure the visibility statuses of layers still persist
 * Navigate away from project UI, or just refresh. Go back to project layers list UI, the visible layer should just be the default layer.

Closes https://github.com/raster-foundry/raster-foundry/issues/4617
