### PR TITLE
Allow toggling annotation display on share page

### DIFF
--- a/app-frontend/src/app/components/common/listItemWidgets/listItemActions/index.html
+++ b/app-frontend/src/app/components/common/listItemWidgets/listItemActions/index.html
@@ -1,37 +1,46 @@
-<div class="btn btn-text btn-transparent"
-     ng-repeat="action in $ctrl.actions | filter: {menu: false}"
-     ng-attr-title="{{action.name}}"
-     ng-click="action.callback($event)"
-     tooltips
-     tooltip-template="{{action.tooltip}}"
-     tooltip-size="small"
-     tooltip-class="layer-item-tooltip"
-     tooltip-side="left"
-     tooltip-hidden="!action.tooltip"
+<div
+    class="display-i"
+    ng-repeat="action in $ctrl.actions | filter: {menu: false}"
+    ng-attr-title="{{ action.name }}"
+    tooltips
+    tooltip-template="{{ action.tooltip }}"
+    tooltip-size="small"
+    tooltip-class="layer-item-tooltip"
+    tooltip-side="left"
+    tooltip-hidden="!action.tooltip"
 >
-  <span ng-if="action.icon"
-        ng-attr-class="{{action.icon}}"
-  ></span>
-  <span ng-repeat="icon in action.icons"
-        ng-attr-class="{{icon.icon}}"
-        ng-if="icon.isActive()"
-  ></span>
+    <button
+        class="btn btn-text btn-transparent"
+        ng-click="action.callback($event)"
+        ng-disabled="action.disabled()"
+    >
+        <i ng-if="action.icon" ng-attr-class="{{ action.icon }}"></i>
+        <i
+            ng-repeat="icon in action.icons"
+            ng-attr-class="{{ icon.icon }}"
+            ng-if="icon.isActive()"
+        ></i>
+    </button>
 </div>
 <div uib-dropdown class="display-ib">
-  <button class="btn btn-text btn-transparent"
-          ng-if="($ctrl.actions | filter: {menu: true}).length > 0"
-          uib-dropdown-toggle
-  >
-    <i class="icon-menu"></i>
-    <span class="sr-only">More actions</span>
-  </button>
+    <button
+        class="btn btn-text btn-transparent"
+        ng-if="($ctrl.actions | filter: {menu: true}).length > 0"
+        uib-dropdown-toggle
+    >
+        <i class="icon-menu"></i>
+        <span class="sr-only">More actions</span>
+    </button>
     <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
-      <li role="menuitem"
-          ng-repeat="action in $ctrl.actions | filter: {menu: true}">
-        <a href ng-click="action.callback($event)"
-          ng-show="action.name"
-          ng-attr-title="{{action.title}}">{{action.name}}</a>
-        <span class="menu-separator" ng-show="action.separator"></span>
-      </li>
+        <li role="menuitem" ng-repeat="action in $ctrl.actions | filter: {menu: true}">
+            <a
+                href
+                ng-click="action.callback($event)"
+                ng-show="action.name"
+                ng-attr-title="{{ action.title }}"
+                >{{ action.name }}</a
+            >
+            <span class="menu-separator" ng-show="action.separator"></span>
+        </li>
     </ul>
 </div>

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.html
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.html
@@ -165,5 +165,5 @@
     >
         <i class="icon-borders"></i>
     </button>
-    <ng-transclude><h1>Blah</h1></ng-transclude>
+    <ng-transclude></ng-transclude>
 </div>

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.html
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.html
@@ -1,120 +1,169 @@
 <div class="map-container"></div>
 <div class="map-container-draw-controls" ng-if="$ctrl.drawing">
-  <div class="map-draw-title">
-    <div ng-if="!$ctrl.editingStage"><strong>Draw a shape</strong></div>
-    <div ng-if="$ctrl.editingStage === 'select'"><strong>Select a shape to edit</strong></div>
-    <div ng-if="$ctrl.editingStage === 'modify'"><strong>Edit shape</strong></div>
-  </div>
-  <div class="map-draw-actions">
-    <button class="btn"
+    <div class="map-draw-title">
+        <div ng-if="!$ctrl.editingStage"><strong>Draw a shape</strong></div>
+        <div ng-if="$ctrl.editingStage === 'select'"><strong>Select a shape to edit</strong></div>
+        <div ng-if="$ctrl.editingStage === 'modify'"><strong>Edit shape</strong></div>
+    </div>
+    <div class="map-draw-actions">
+        <button
+            class="btn"
             ng-class="{
                    'btn-transparent': !$ctrl.shapeInProgress && !$ctrl.editingStage,
                    'btn-light': $ctrl.shapeInProgress || $ctrl.editingStage
                    }"
-            ng-click="$ctrl.onCancelDrawing()">
-      <span ng-if="!$ctrl.shapes.features.length || $ctrl.shapeInProgress || $ctrl.editingStage">Cancel</span>
-      <span ng-if="$ctrl.shapes.features.length && !$ctrl.shapeInProgress && !$ctrl.editingStage">Reset</span>
-    </button>
-    <button class="btn btn-light"
+            ng-click="$ctrl.onCancelDrawing()"
+        >
+            <span
+                ng-if="!$ctrl.shapes.features.length || $ctrl.shapeInProgress || $ctrl.editingStage"
+                >Cancel</span
+            >
+            <span
+                ng-if="$ctrl.shapes.features.length && !$ctrl.shapeInProgress && !$ctrl.editingStage"
+                >Reset</span
+            >
+        </button>
+        <button
+            class="btn btn-light"
             ng-if="$ctrl.shapes.features.length && !$ctrl.shapeInProgress && !$ctrl.editingStage"
-            ng-click="$ctrl.onEditStart()">Edit</button>
-    <button class="btn"
+            ng-click="$ctrl.onEditStart()"
+        >
+            Edit
+        </button>
+        <button
+            class="btn"
             ng-class="{
                    'btn-default': !ctrl.shapes.features.length,
                    'btn-light': $ctrl.shapes.features.length
                    }"
             ng-click="$ctrl.startDrawingShape()"
             ng-if="!$ctrl.shapeInProgress && !$ctrl.editingStage"
-    >
-      <span ng-if="!$ctrl.shapes.features.length">Start Drawing</span>
-      <span ng-if="$ctrl.shapes.features.length">Draw More</span>
-    </button>
-    <button class="btn btn-danger"
+        >
+            <span ng-if="!$ctrl.shapes.features.length">Start Drawing</span>
+            <span ng-if="$ctrl.shapes.features.length">Draw More</span>
+        </button>
+        <button
+            class="btn btn-danger"
             ng-if="$ctrl.editingStage === 'modify'"
-            ng-click="$ctrl.onEditDelete()">
-      Delete
-    </button>
-    <button class="btn btn-default"
+            ng-click="$ctrl.onEditDelete()"
+        >
+            Delete
+        </button>
+        <button
+            class="btn btn-default"
             ng-if="$ctrl.editingStage === 'modify'"
-            ng-click="$ctrl.onEditFinish()">
+            ng-click="$ctrl.onEditFinish()"
+        >
             Save
-    </button>
-    <button class="btn btn-default"
+        </button>
+        <button
+            class="btn btn-default"
             ng-if="$ctrl.shapes.features.length && !$ctrl.shapeInProgress && !$ctrl.editingStage"
-            ng-click="$ctrl.onFinishDrawing()">Finish</button>
-  </div>
+            ng-click="$ctrl.onFinishDrawing()"
+        >
+            Finish
+        </button>
+    </div>
 </div>
 <div class="map-container-controls">
-  <div class="zoom-level" title="Current Zoom">
-    {{$ctrl.zoomLevel}}
-  </div>
-  <button class="map-control-btn"
-          title="Zoom In"
-          ng-click="$ctrl.zoomIn()"
-          tooltips tooltip-template="Zoom in" tooltip-size="small" tooltip-class="map-control-tooltip" tooltip-side="left">
-    <i class="icon-plus"></i>
-  </button>
-  <button class="map-control-btn"
-          title="Zoom Out"
-          ng-click="$ctrl.zoomOut()"
-          tooltips tooltip-template="Zoom out" tooltip-size="small" tooltip-class="map-control-tooltip" tooltip-side="left">
-    <i class="icon-minus"></i>
-  </button>
+    <div class="zoom-level" title="Current Zoom">
+        {{ $ctrl.zoomLevel }}
+    </div>
+    <button
+        class="map-control-btn"
+        title="Zoom In"
+        ng-click="$ctrl.zoomIn()"
+        tooltips
+        tooltip-template="Zoom in"
+        tooltip-size="small"
+        tooltip-class="map-control-tooltip"
+        tooltip-side="left"
+    >
+        <i class="icon-plus"></i>
+    </button>
+    <button
+        class="map-control-btn"
+        title="Zoom Out"
+        ng-click="$ctrl.zoomOut()"
+        tooltips
+        tooltip-template="Zoom out"
+        tooltip-size="small"
+        tooltip-class="map-control-tooltip"
+        tooltip-side="left"
+    >
+        <i class="icon-minus"></i>
+    </button>
 
-  <button class="map-control-btn"
-          title="Geolocation search"
-          ng-show="!$ctrl.modalService.activeModal"
-          ng-click="$ctrl.openMapSearchModal()"
-          tooltips tooltip-template="Search places" 
-          tooltip-size="small" 
-          tooltip-class="map-control-tooltip"
-          tooltip-side="left"
-          tooltip-show="true">
-    <i class="icon-search"></i>
-  </button>
+    <button
+        class="map-control-btn"
+        title="Geolocation search"
+        ng-show="!$ctrl.modalService.activeModal"
+        ng-click="$ctrl.openMapSearchModal()"
+        tooltips
+        tooltip-template="Search places"
+        tooltip-size="small"
+        tooltip-class="map-control-tooltip"
+        tooltip-side="left"
+        tooltip-show="true"
+    >
+        <i class="icon-search"></i>
+    </button>
 
-  <div class="map-control-popup-container">
-    <button class="map-control-btn"
+    <div class="map-control-popup-container">
+        <button
+            class="map-control-btn"
             title="Basemap and layers"
             ng-class="{'active': $ctrl.layerPickerOpen}"
             ng-click="$ctrl.toggleLayerPicker($event)"
-            tooltips tooltip-template="Basemap and layers" 
-            tooltip-size="small" 
+            tooltips
+            tooltip-template="Basemap and layers"
+            tooltip-size="small"
             tooltip-class="map-control-tooltip"
-            tooltip-side="left">
-      <i class="icon-project"></i>
-    </button>
-    <div class="map-control-popup layer-popup"
-          ng-show="$ctrl.layerPickerOpen"
-          ng-click="$ctrl.cancelPropagation($event)">
-      <div class="map-control-popup-body">
-        <div class="layer-picker-option"
-             ng-repeat="layer in $ctrl.basemapKeys"
-             ng-style="$ctrl.getBasemapStyle(layer)"
-             ng-click="$ctrl.setBasemap(layer)"
-             ng-attr-title="{{layer}}"
-             ng-class="{'active': $ctrl.mapWrapper.currentBasemap == layer}">
-          <div class="layer-picker-label sr-only">{{layer}}</div>
+            tooltip-side="left"
+        >
+            <i class="icon-project"></i>
+        </button>
+        <div
+            class="map-control-popup layer-popup"
+            ng-show="$ctrl.layerPickerOpen"
+            ng-click="$ctrl.cancelPropagation($event)"
+        >
+            <div class="map-control-popup-body">
+                <div
+                    class="layer-picker-option"
+                    ng-repeat="layer in $ctrl.basemapKeys"
+                    ng-style="$ctrl.getBasemapStyle(layer)"
+                    ng-click="$ctrl.setBasemap(layer)"
+                    ng-attr-title="{{ layer }}"
+                    ng-class="{'active': $ctrl.mapWrapper.currentBasemap == layer}"
+                >
+                    <div class="layer-picker-label sr-only">{{ layer }}</div>
+                </div>
+                <hr />
+                <div
+                    class="layer-picker-toggle"
+                    ng-click="$ctrl.toggleLayer(layerId)"
+                    ng-repeat="layerId in $ctrl.toggleableLayers()"
+                    ng-class="{'active': $ctrl.layerEnabled(layerId)}"
+                >
+                    <div class="layer-picker-label">{{ layerId }}</div>
+                    <div class="toggle"></div>
+                </div>
+            </div>
         </div>
-        <hr>
-        <div class="layer-picker-toggle"
-             ng-click="$ctrl.toggleLayer(layerId)"
-             ng-repeat="layerId in $ctrl.toggleableLayers()"
-             ng-class="{'active': $ctrl.layerEnabled(layerId)}">
-          <div class="layer-picker-label">{{layerId}}</div>
-          <div class="toggle"></div>
-        </div>
-      </div>
     </div>
-  </div>
-  <button class="map-control-btn last-of-type"
-          title="Selection Polygon"
-          ng-class="{'active': $ctrl.geojsonEnabled()}"
-          ng-click="$ctrl.toggleGeojson()"
-          tooltips tooltip-template="Toggle scene footprints" 
-          tooltip-size="small" 
-          tooltip-class="map-control-tooltip"
-          tooltip-side="left">
-    <i class="icon-borders"></i>
-  </button>
+    <button
+        class="map-control-btn"
+        title="Selection Polygon"
+        ng-class="{'active': $ctrl.geojsonEnabled()}"
+        ng-click="$ctrl.toggleGeojson()"
+        tooltips
+        tooltip-template="Toggle scene footprints"
+        tooltip-size="small"
+        tooltip-class="map-control-tooltip"
+        tooltip-side="left"
+    >
+        <i class="icon-borders"></i>
+    </button>
+    <ng-transclude><h1>Blah</h1></ng-transclude>
 </div>

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.module.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.module.js
@@ -16,6 +16,7 @@ const GREEN = '#81C784';
 const MapContainerComponent = {
     templateUrl: mapTpl,
     controller: 'MapContainerController',
+    transclude: true,
     bindings: {
         mapId: '@',
         options: '<?',

--- a/app-frontend/src/app/components/pages/share/layers/index.html
+++ b/app-frontend/src/app/components/pages/share/layers/index.html
@@ -8,10 +8,6 @@
     >
     </rf-pagination-count>
     <rf-list-item ng-repeat="layer in $ctrl.layerList track by layer.id">
-        <item-selector>
-            <rf-list-item-selector id="layer.id" color="layer.colorGroupHex">
-            </rf-list-item-selector>
-        </item-selector>
         <item-title>
             <strong ng-attr-title="{{ layer.name }}">{{ layer.name }}</strong>
         </item-title>

--- a/app-frontend/src/app/components/pages/share/project/index.html
+++ b/app-frontend/src/app/components/pages/share/project/index.html
@@ -87,6 +87,20 @@
 <div class="container column-stretch container-not-scrollable with-secondary-navbar">
     <div class="sidebar" ui-view></div>
     <div class="main">
-        <rf-map-container map-id="share"></rf-map-container>
+        <rf-map-container map-id="share">
+            <button
+                class="map-control-btn"
+                title="Show annotations"
+                ng-class="{'active': $ctrl.shareService.showingAnnotations}"
+                ng-click="$ctrl.shareService.toggleShowingAnnotations()"
+                tooltips
+                tooltip-template="Toggle layer annotations"
+                tooltip-size="small"
+                tooltip-class="map-control-tooltip"
+                tooltip-side="left"
+            >
+                <i class="icon-polygon"></i>
+            </button>
+        </rf-map-container>
     </div>
 </div>

--- a/app-frontend/src/app/components/pages/share/project/index.js
+++ b/app-frontend/src/app/components/pages/share/project/index.js
@@ -7,7 +7,7 @@ let assetLogo = BUILDCONFIG.LOGOFILE
     : require('_assets/images/raster-foundry-logo.svg');
 
 class ShareProjectController {
-    constructor($rootScope, $log, $q, $state, authService, mapService) {
+    constructor($rootScope, $log, $q, $state, authService, mapService, shareService) {
         'ngInject';
         $rootScope.autoInject(this, arguments);
     }

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -294,6 +294,16 @@ export default app => {
                             layerId: '@layerId'
                         },
                         isArray: true
+                    },
+                    getAnnotationsForLayer: {
+                        method: 'GET',
+                        url:
+                            `${BUILDCONFIG.API_HOST}/api/projects/:projectId/` +
+                            'layers/:layerId/annotations',
+                        params: {
+                            projectId: '@projectId',
+                            layerId: '@layerId'
+                        }
                     }
                 }
             );
@@ -765,7 +775,7 @@ export default app => {
         }
 
         updateSceneOrder(projectId, sceneIds) {
-            return this.Project.updateSceneOrder({ projectId: projectId }, sceneIds).$promise;
+            return this.Project.updateSceneOrder({ projectId }, sceneIds).$promise;
         }
 
         getAnnotationShapefile(projectId) {
@@ -856,6 +866,10 @@ export default app => {
 
         splitLayers(projectId, layerId, splitOptions) {
             return this.Project.splitLayers({ projectId, layerId }, splitOptions).$promise;
+        }
+
+        getAnnotationsForLayer(projectId, layerId, params) {
+            return this.Project.getAnnotationsForLayer({ projectId, layerId, ...params}).$promise;
         }
     }
 

--- a/app-frontend/src/app/services/projects/share.service.js
+++ b/app-frontend/src/app/services/projects/share.service.js
@@ -1,0 +1,27 @@
+export default (app) => {
+    class ShareService {
+        constructor() {
+            this.showingAnnotations = false;
+            this.callbacks = {
+                toggleShowingAnnotations: {}
+            };
+        }
+
+        toggleShowingAnnotations(value = !this.showingAnnotations) {
+            this.showingAnnotations = value;
+            Object.values(this.callbacks.toggleShowingAnnotations).forEach(c => c(value));
+        }
+
+        addCallback(key, callback) {
+            const id = new Date().getTime();
+            this.callbacks[key][id] = callback;
+            return id;
+        }
+
+        removeCallback(key, id) {
+            delete this.callbacks[key][id];
+        }
+    }
+
+    app.service('shareService', ShareService);
+};

--- a/app-frontend/src/app/services/services.module.js
+++ b/app-frontend/src/app/services/services.module.js
@@ -43,6 +43,7 @@ require('./projects/export.service').default(shared);
 require('./projects/histogram.service').default(shared);
 require('./projects/export.service').default(shared);
 require('./projects/aoi.service').default(shared);
+require('./projects/share.service').default(shared);
 
 // scenes
 require('./scenes/scene.service').default(shared);

--- a/app-frontend/src/assets/styles/sass/components/_map-controls.scss
+++ b/app-frontend/src/assets/styles/sass/components/_map-controls.scss
@@ -1,225 +1,225 @@
 .map-container-controls {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: $shade-dark;
-  border-radius: $border-radius-base;
-  z-index: 1025;
-  display: flex;
-  flex-direction: column;
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: $shade-dark;
+    border-radius: $border-radius-base;
+    z-index: 1025;
+    display: flex;
+    flex-direction: column;
 
-  &.is-dragging {
-    pointer-events: none;
-    
-    * {
-      pointer-events: none;
+    &.is-dragging {
+        pointer-events: none;
+
+        * {
+            pointer-events: none;
+        }
     }
-  }
 
-  &.align-left {
-    left: 5px;
-    right: auto; // ie11 fix
-    right: initial;
-  }
+    &.align-left {
+        left: 5px;
+        right: auto; // ie11 fix
+        right: initial;
+    }
 }
 
 .zoom-level {
-  padding: .6rem 0;
-  color: $white;
-  font-weight: bold;
-  font-size: 1.2rem;
-  text-align: center;
-  cursor: auto;
-  user-select: none;
-  background-color: $shade-normal;
-  border-radius: $border-radius-base $border-radius-base 0 0;
+    padding: 0.6rem 0;
+    color: $white;
+    font-weight: bold;
+    font-size: 1.2rem;
+    text-align: center;
+    cursor: auto;
+    user-select: none;
+    background-color: $shade-normal;
+    border-radius: $border-radius-base $border-radius-base 0 0;
 }
 
 .map-control-btn {
-  appearance: none;
-  width: 100%;
-  display: block;
-  border: none;
-  border-bottom: 1px solid $shade-normal;
-  padding: 1.1rem 1.6rem;
-  background: none;
-  color: $white;
+    appearance: none;
+    width: 100%;
+    display: block;
+    border: none;
+    border-bottom: 1px solid $shade-normal;
+    padding: 1.1rem 1.6rem;
+    background: none;
+    color: $white;
 
-  &:hover,
-  &.active:not(.disabled,:disabled) {
-    color: $brand-primary;
-    background-color: $shade-normal;
-  }
+    &:hover,
+    &.active:not(.disabled, :disabled) {
+        color: $brand-primary;
+        background-color: $shade-normal;
+    }
 
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba($brand-primary, .3);
-    z-index: 1;
-  }
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba($brand-primary, 0.3);
+        z-index: 1;
+    }
 
-  &.disabled, &:disabled {
-    cursor: not-allowed;
-    background: none !important;
+    &.disabled,
+    &:disabled {
+        cursor: not-allowed;
+        background: none !important;
+
+        > i {
+            color: $white;
+            opacity: 0.5;
+        }
+    }
+
+    &:last-of-type {
+        border-radius: 0 0 $border-radius-base $border-radius-base;
+        border-bottom: none;
+    }
 
     > i {
-      color: $white;
-      opacity: .5;
+        font-size: 1.4rem;
     }
-  }
-
-  &.last-of-type {
-    border-radius: 0 0 $border-radius-base $border-radius-base;
-    border-bottom: none;
-  }
-
-  > i {
-    font-size: 1.4rem;
-  }
 }
 
 .map-control-tooltip {
-  white-space: nowrap;
-  min-width: initial;
+    white-space: nowrap;
+    min-width: initial;
 }
 
 .map-control-popup-container {
-  position: relative;
+    position: relative;
 }
 
 .map-control-popup {
-  position: absolute;
-  transform: translateX(-100%);
-  left: -.8rem;
-  top: -1rem;
-  background: $white;
-  font-size: 1.2rem;
-  z-index: 1025;
-  user-select: none;
-  border-radius: $border-radius-base;
-  box-shadow: 0 0 10px 0 rgba($shade-dark, .25);
-
-  &:focus {
-    outline: transparent;
-  }
-
-  &:before {
-    content: '';
-    display: block;
     position: absolute;
-    right: -1.7rem;
-    top: 2rem;
-    border: 10px solid transparent;
-    border-left-color: $white;
-    z-index: 0;
-  }
-
-  p {
-    margin: 0 0 5px;
-    font-weight: 600;
+    transform: translateX(-100%);
+    left: -0.8rem;
+    top: -1rem;
+    background: $white;
     font-size: 1.2rem;
-    color: $gray-darker;
-  }
+    z-index: 1025;
+    user-select: none;
+    border-radius: $border-radius-base;
+    box-shadow: 0 0 10px 0 rgba($shade-dark, 0.25);
+
+    &:focus {
+        outline: transparent;
+    }
+
+    &:before {
+        content: '';
+        display: block;
+        position: absolute;
+        right: -1.7rem;
+        top: 2rem;
+        border: 10px solid transparent;
+        border-left-color: $white;
+        z-index: 0;
+    }
+
+    p {
+        margin: 0 0 5px;
+        font-weight: 600;
+        font-size: 1.2rem;
+        color: $gray-darker;
+    }
 }
 
 .map-control-popup-body {
-  padding: 1.5rem;
+    padding: 1.5rem;
 }
 
 .layer-picker-option {
-  display: flex;
-  width: 100%;
-  height: 3rem;
-  border-radius: $border-radius-base;
-  border: 1px solid $gray-lightest;
-  align-items: center;
-  cursor: pointer;
+    display: flex;
+    width: 100%;
+    height: 3rem;
+    border-radius: $border-radius-base;
+    border: 1px solid $gray-lightest;
+    align-items: center;
+    cursor: pointer;
 
-  &.active {
-    border: 2px solid $brand-primary;
-  }
+    &.active {
+        border: 2px solid $brand-primary;
+    }
 
-  &:focus {
-    outline: none;
-    box-shadow: 0 0 0 3px rgba($brand-primary, .3);
-  }
+    &:focus {
+        outline: none;
+        box-shadow: 0 0 0 3px rgba($brand-primary, 0.3);
+    }
 
-  &:hover:not(.active),
-  &:focus:not(.active) {
-    outline: none;
-    border: 1px solid $shade-normal;
-    box-shadow: 0 0 0 3px rgba($brand-primary, .3);
-  }
+    &:hover:not(.active),
+    &:focus:not(.active) {
+        outline: none;
+        border: 1px solid $shade-normal;
+        box-shadow: 0 0 0 3px rgba($brand-primary, 0.3);
+    }
 
-  + .layer-picker-option {
-    margin-top: 1rem;
-  }
+    + .layer-picker-option {
+        margin-top: 1rem;
+    }
 }
 
 .layer-picker-toggle {
-  @extend .layer-picker-option;
-  padding: 0 1rem;
-
-  .layer-picker-label {
-    opacity: .5;
-  }
-
-  .toggle {
-    position: relative;
-    background-color: $gray-lightest;
-    border: 1px solid $gray-lightest;
-    width: 20px;
-    height: 10px;
-    border-radius: 20px;
-
-    &:after {
-      content: '';
-      display: block;
-      width: 8px;
-      height: 8px;
-      background: $brand-primary;
-      background: $shade-light;
-      border-radius: 10px;
-      position: relative;
-      left: 0;
-      transition: .2s ease all;
-    }
-  }
-
-  &.active {
+    @extend .layer-picker-option;
+    padding: 0 1rem;
 
     .layer-picker-label {
-      opacity: 1;
+        opacity: 0.5;
     }
 
     .toggle {
-      background: $gray;
-      border-color: $gray;
+        position: relative;
+        background-color: $gray-lightest;
+        border: 1px solid $gray-lightest;
+        width: 20px;
+        height: 10px;
+        border-radius: 20px;
+
+        &:after {
+            content: '';
+            display: block;
+            width: 8px;
+            height: 8px;
+            background: $brand-primary;
+            background: $shade-light;
+            border-radius: 10px;
+            position: relative;
+            left: 0;
+            transition: 0.2s ease all;
+        }
     }
 
-    .toggle:after {
-      background: $brand-primary;
-      left: 10px;
+    &.active {
+        .layer-picker-label {
+            opacity: 1;
+        }
+
+        .toggle {
+            background: $gray;
+            border-color: $gray;
+        }
+
+        .toggle:after {
+            background: $brand-primary;
+            left: 10px;
+        }
     }
-  }
 }
 
 .layer-picker-label {
-  flex: 1;
-  font-size: 1.2rem;
-  font-weight: 600;
-  color: $gray;
-  margin-right: 1rem;
-  white-space: nowrap;
+    flex: 1;
+    font-size: 1.2rem;
+    font-weight: 600;
+    color: $gray;
+    margin-right: 1rem;
+    white-space: nowrap;
 }
 
 .layer-popup {
-  min-width: 20rem;
+    min-width: 20rem;
 }
 
 .measure-popup {
-  min-width: 17rem;
+    min-width: 17rem;
 }
 
 .export-popup {
-  min-width: 30rem;
+    min-width: 30rem;
 }


### PR DESCRIPTION
## Overview

This PR adds a map control to the share page that allows the user to toggle annotations on and off for all visible layers.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/2442245/55163077-805ed980-513f-11e9-8812-6f3356bd4ed1.png)

![image](https://user-images.githubusercontent.com/2442245/55163118-9371a980-513f-11e9-992c-ae4603699e59.png)

### Notes

This sets the page size at 100 for annotations. This may need some tuning but I don't have a good sense for what a good default is.

## Testing Instructions

 * Create/use a project that has multiple layers and multiple layers with annotations. Make sure the default layer has annotations. It helps if all of the annotations are around the same area.
 * Go to the settings for the project and copy the share page URL (keep the project as private so a mapToken is appended to the URL since public projects aren't fully supported for the new share page yet, see #4770)
* Go to the share page and verify that the annotation toggle control is present and not 'on' by default
* Toggle the map annotation control and try making different layers visible/not visible and make sure that only annotations from visible layers are shown.
* Switch to the analysis tab and see that annotations are no longer on the map, but the control should still be there
* Toggle the annotation control from the analysis tab and see that when you re-enter the layers tab that the annotations are displayed/hidden in accordance with the state of the annotation toggle control

Closes #4774
