### PR TITLE
Add more / better zooming actions to project layers and analyses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Preserve state of visible layers [\#4802](https://github.com/raster-foundry/raster-foundry/pull/4802)
 - Display processing imports on layer scenes UI [\#4809](https://github.com/raster-foundry/raster-foundry/pull/4809)
 - Added quick edit functionality for project analyses [\#4804](https://github.com/raster-foundry/raster-foundry/pull/4804)
+- Add zooming, showing, hiding options to multi-select menu on analyses, layers [\4816](https://github.com/raster-foundry/raster-foundry/pull/4816)
 
 ### Changed
 

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.html
@@ -46,12 +46,23 @@
                 Edit
             </button>
         </span>
-        <button
-            class="btn btn-transparent btn-tiny"
-            ng-click="$ctrl.deleteProjectAnalyses($ctrl.selected.valueSeq().toArray())"
-        >
-            Delete
-        </button>
+        <div class="btn btn-tiny btn-transparent" uib-dropdown uib-dropdown-toggle>
+            <span class="icon-menu"></span>
+            <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.zoomToSelected()">Zoom to selected</a>
+                </li>
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.showSelected()">Show on map</a>
+                </li>
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.hideSelected()">Hide on map</a>
+                </li>
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.deleteSelected()" class="color-danger">Delete</a>
+                </li>
+            </ul>
+        </div>
     </rf-selected-actions-bar>
 </div>
 <div class="sidebar-scrollable list-group">

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -498,6 +498,28 @@ class AnalysesListController {
                 this.updateQuickEditState();
             });
     }
+
+    zoomToSelected() {
+        const geoms = this.selected.valueSeq().toArray().map(s => s.layerGeometry);
+        const bounds = L.geoJSON(geoms).getBounds();
+        this.getMap().then(map => {
+            map.map.fitBounds(bounds);
+        });
+    }
+
+    showSelected() {
+        this.visible = this.visible.union(this.selected.keySeq().toArray());
+        this.syncMapLayersToVisible()
+    }
+
+    hideSelected() {
+        this.visible = this.visible.subtract(this.selected.keySeq().toArray());
+        this.syncMapLayersToVisible();
+    }
+
+    deleteSelected() {
+        this.deleteProjectAnalyses(this.selected.valueSeq().toArray());
+    }
 }
 
 const component = {

--- a/app-frontend/src/app/components/pages/project/layer/exports/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/exports/index.html
@@ -1,13 +1,11 @@
 <div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0">
-    <div>
-        <a
-            class="btn btn-small btn-transparent"
-            ui-sref="project.layer.export"
-            ng-if="$ctrl.actionPermissions.export"
-        >
-            <i class="icon-plus"></i>New export
-        </a>
-    </div>
+    <button
+        class="btn btn-small btn-transparent"
+        ui-sref="project.layer.export"
+        ng-if="$ctrl.actionPermissions.export"
+    >
+        <i class="icon-plus"></i>New export
+    </button>
     <div style="flex: 1;"></div>
 </div>
 <div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
@@ -17,7 +15,7 @@
         action-text="$ctrl.selectText"
     >
         <button
-            class="btn btn-transparent"
+            class="btn btn-tiny btn-transparent"
             ng-click="$ctrl.deleteExports($ctrl.selected.valueSeq().toArray())"
         >
             Delete
@@ -26,7 +24,9 @@
 </div>
 <div class="list-group" ng-if="!$ctrl.currentQuery">
     <div class="list-group-item" ng-if="$ctrl.fetchError">
-        <strong class="color-danger"> There was an error fetching exports </strong>
+        <strong class="color-danger">
+            There was an error fetching exports
+        </strong>
         <button type="button" class="btn btn-secondary" ng-click="$ctrl.fetchPage()">
             Try again <i icon="icon-refresh"></i>
         </button>
@@ -39,7 +39,9 @@
             ng-class="{'stop': !$ctrl.currentQuery}"
             ng-show="$ctrl.currentQuery"
         ></i>
-        <strong class="color-dark"> Loading exports... </strong>
+        <strong class="color-dark">
+            Loading exports...
+        </strong>
     </div>
 </div>
 <div
@@ -50,7 +52,9 @@
             !$ctrl.fetchError"
 >
     <div class="list-group-item">
-        <strong class="color-dark"> This layer has no exports in it </strong>
+        <strong class="color-dark">
+            This layer has no exports in it
+        </strong>
     </div>
 </div>
 <div class="sidebar-scrollable list-group">
@@ -64,12 +68,12 @@
             ></rf-list-item-selector
         ></item-selector>
         <item-title>
-            <strong ng-attr-title="{{$ctrl.formatDateDisplay(export.createdAt)}}">
-                {{$ctrl.formatDateDisplay(export.createdAt)}}</strong
+            <strong ng-attr-title="{{ $ctrl.formatDateDisplay(export.createdAt) }}">
+                {{ $ctrl.formatDateDisplay(export.createdAt) }}</strong
             ></item-title
         >
         <item-date>
-            <span class="export-date-subtext">{{export.createdAt | date : 'medium'}}</span>
+            <span class="export-date-subtext">{{ export.createdAt | date: 'medium' }}</span>
             <rf-list-item-status
                 class="export-status export-date-subtext"
                 statuses="$ctrl.exportStatusById[export.id]"

--- a/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.html
+++ b/app-frontend/src/app/components/pages/project/layer/scenes/scenes/index.html
@@ -1,18 +1,12 @@
-<div class="sidebar-actions-group with-padding" ng-show="$ctrl.selected.size === 0">
-    <div uib-dropdown uib-dropdown-toggle>
-        <button class="btn btn-tiny btn-transparent"><i class="icon-plus"></i>Add imagery</button>
+<div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0">
+    <div class="btn btn-small btn-transparent" uib-dropdown uib-dropdown-toggle>
+        <i class="icon-plus"></i>Add imagery
         <ul class="dropdown-menu dropdown-menu-light" uib-dropdown-menu role="menu">
             <li role="menuitem"><a href ng-click="$ctrl.browseScenes()">Browse</a></li>
             <li role="menuitem"><a href ng-click="$ctrl.openImportModal()">Import</a></li>
         </ul>
     </div>
     <div class="flex-fill"></div>
-    <!-- <button class="btn btn-small btn-transparent">Filter...</button> -->
-    <!-- <select class="btn btn-small btn-transparent"> -->
-    <!-- <option value="">Newest</option> -->
-    <!-- <option value="manual">Manual</option> -->
-    <!-- <option value="manual">Ingest date</option> -->
-    <!-- </select> -->
 </div>
 <div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
     <rf-selected-actions-bar

--- a/app-frontend/src/app/components/pages/project/layers/index.html
+++ b/app-frontend/src/app/components/pages/project/layers/index.html
@@ -1,68 +1,86 @@
 <div class="sidebar-actions-group" ng-show="$ctrl.selected.size === 0">
-  <a class="btn btn-small btn-transparent" ng-click="$ctrl.showNewLayerModal()">
-    <i class="icon-plus"></i> New Layer
-  </a>
-  <div style="flex: 1;"></div>
-  <div class="btn btn-small btn-transparent" uib-dropdown uib-dropdown-toggle>
-    Layer Visibility
-    <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
-      <li role="menuitem">
-        <a href ng-click="$ctrl.showDefaultLayer()">Show only default</a></li>
-      <li role="menuitem">
-        <a href ng-click="$ctrl.showPageLayers()">Show all on page</a></li>
-    </ul>
-  </div>
+    <a class="btn btn-tiny btn-transparent" ng-click="$ctrl.showNewLayerModal()">
+        <i class="icon-plus"></i> New Layer
+    </a>
+    <div style="flex: 1;"></div>
+    <div class="btn btn-small btn-transparent" uib-dropdown uib-dropdown-toggle>
+        Layer Visibility
+        <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+            <li role="menuitem">
+                <a href ng-click="$ctrl.showDefaultLayer()">Show only default</a>
+            </li>
+            <li role="menuitem">
+                <a href ng-click="$ctrl.showPageLayers()">Show all on page</a>
+            </li>
+            <li role="menuitem">
+                <a href ng-click="$ctrl.hideAll()">Hide all</a>
+            </li>
+        </ul>
+    </div>
 </div>
 <div class="selected-actions-group" ng-show="$ctrl.selected.size > 0">
-  <rf-selected-actions-bar
-      checked="$ctrl.allVisibleSelected()"
-      on-click="$ctrl.selectAll()"
-      action-text="$ctrl.selectText"
-  >
-    <button class="btn btn-transparent"
-            ng-click="$ctrl.createAnalysis()">
-      Create Analysis
-    </button>
-    <button class="btn btn-transparent"
-            ng-click="$ctrl.deleteProjectLayers($ctrl.selected.valueSeq().toArray())"
-            ng-disabled="$ctrl.selected.has($ctrl.project.defaultLayerId)">
-      Delete
-    </button>
-  </rf-selected-actions-bar>
+    <rf-selected-actions-bar
+        checked="$ctrl.allVisibleSelected()"
+        on-click="$ctrl.selectAll()"
+        action-text="$ctrl.selectText"
+    >
+        <button class="btn btn-tiny btn-transparent" ng-click="$ctrl.createAnalysis()">
+            Create Analysis
+        </button>
+        <div class="btn btn-tiny btn-transparent" uib-dropdown uib-dropdown-toggle>
+            <span class="icon-menu"></span>
+            <ul class="dropdown-menu dropdown-menu-light drop-left" uib-dropdown-menu role="menu">
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.zoomToSelected()">Zoom to selected</a>
+                </li>
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.showSelected()">Show on map</a>
+                </li>
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.hideSelected()">Hide on map</a>
+                </li>
+                <li role="menuitem">
+                    <a href ng-click="$ctrl.deleteSelected()" class="color-danger">Delete</a>
+                </li>
+            </ul>
+        </div>
+    </rf-selected-actions-bar>
 </div>
 <div class="sidebar-scrollable list-group">
-  <rf-list-item ng-repeat="layer in $ctrl.layerList track by layer.id">
-    <item-selector>
-      <rf-list-item-selector
-          id="layer.id"
-          selected="$ctrl.isSelected(layer.id)"
-          on-select="$ctrl.onSelect(id)"
-          color="layer.colorGroupHex"
-      ></rf-list-item-selector></item-selector>
-    <item-title><strong ng-attr-title="{{layer.name}}">{{layer.name}}</strong></item-title>
-    <item-subtitle><span>{{layer.subtext}}</span></item-subtitle>
-    <item-date>
-      <span class="export-date-subtext">{{layer.createdAt | date}}</span>
-      <rf-list-item-status
-          class="export-status export-date-subtext"
-          has-count="true"
-          statuses="$ctrl.uploadStatusByLayer[layer.id]"
-          status-map="$ctrl.uploadStatusMap"
-      >
-      </rf-list-item-status>
-    </item-date>
-    <item-actions>
-      <rf-list-item-actions actions="$ctrl.layerActions[$index]"></rf-list-item-actions>
-    </item-actions>
-    <item-statistics>
-      <rf-layer-stats scene-count="$ctrl.getSceneCount(layer.id)">
-      </rf-layer-stats">
-    </item-statistics>
-  </rf-list-item>
-  <rf-pagination-controls
-      pagination="$ctrl.pagination"
-      is-loading="$ctrl.currentQuery"
-      on-change="$ctrl.fetchPage(value)"
-      ng-show="!$ctrl.currentQuery && !$ctrl.fetchError"
-  ></rf-pagination-controls>
+    <rf-list-item ng-repeat="layer in $ctrl.layerList track by layer.id">
+        <item-selector>
+            <rf-list-item-selector
+                id="layer.id"
+                selected="$ctrl.isSelected(layer.id)"
+                on-select="$ctrl.onSelect(id)"
+                color="layer.colorGroupHex"
+            ></rf-list-item-selector
+        ></item-selector>
+        <item-title
+            ><strong ng-attr-title="{{ layer.name }}">{{ layer.name }}</strong></item-title
+        >
+        <item-subtitle><span>{{ layer.subtext }}</span></item-subtitle>
+        <item-date>
+          <span class="export-date-subtext">{{ layer.createdAt | date }}</span>
+          <rf-list-item-status
+              class="export-status export-date-subtext"
+              has-count="true"
+              statuses="$ctrl.uploadStatusByLayer[layer.id]"
+              status-map="$ctrl.uploadStatusMap"
+          >
+          </rf-list-item-status>
+        </item-date>
+        <item-actions>
+            <rf-list-item-actions actions="$ctrl.layerActions[$index]"></rf-list-item-actions>
+        </item-actions>
+        <item-statistics>
+            <rf-layer-stats scene-count="$ctrl.getSceneCount(layer.id)"></rf-layer-stats>
+        </item-statistics>
+    </rf-list-item>
+    <rf-pagination-controls
+        pagination="$ctrl.pagination"
+        is-loading="$ctrl.currentQuery"
+        on-change="$ctrl.fetchPage(value)"
+        ng-show="!$ctrl.currentQuery && !$ctrl.fetchError"
+    ></rf-pagination-controls>
 </div>

--- a/app-frontend/src/app/components/pages/project/layers/index.js
+++ b/app-frontend/src/app/components/pages/project/layers/index.js
@@ -238,6 +238,39 @@ class ProjectLayersPageController {
         });
     }
 
+    zoomToSelected() {
+        // get geometries
+        const geoms = this.selected
+            .valueSeq()
+            .toArray()
+            .map(s => s.geometry);
+        const bounds = L.geoJSON(geoms).getBounds();
+
+        // go to bounds
+        this.getMap().then(map => {
+            map.map.fitBounds(bounds);
+        });
+    }
+
+    showSelected() {
+        this.visible = this.visible.union(this.selected.keySeq().toArray());
+        this.syncMapLayersToVisible();
+    }
+
+    hideSelected() {
+        this.visible = this.visible.subtract(this.selected.keySeq().toArray());
+        this.syncMapLayersToVisible();
+    }
+
+    deleteSelected() {
+        this.deleteProjectLayers(this.selected.valueSeq().toArray());
+    }
+
+    hideAll() {
+        this.visible = new Set();
+        this.syncMapLayersToVisible();
+    }
+
     allVisibleSelected() {
         let layerSet = Set(this.layerList.map(l => l.id));
         return layerSet.intersect(this.selected.keySeq()).size === layerSet.size;
@@ -256,7 +289,7 @@ class ProjectLayersPageController {
         if (this.allVisibleSelected()) {
             this.selectText = `Clear selected (${this.selected.size})`;
         } else {
-            this.selectText = `Select all listed (${this.selected.size})`;
+            this.selectText = `Select visible (${this.selected.size})`;
         }
     }
 
@@ -267,6 +300,7 @@ class ProjectLayersPageController {
             const layer = this.layerList.find(l => l.id === id);
             this.selected = this.selected.set(id, layer);
         }
+        this.updateSelectText();
     }
 
     isSelected(layerId) {
@@ -354,9 +388,10 @@ class ProjectLayersPageController {
                 this.$q
                     .all(promises)
                     .then(() => {
-                        this.visible = this.visible.subtract(this.selected.keySeq());
+                        this.visible = this.visible.subtract(this.selected.keySeq().toArray());
                         this.projectEditService.setVisibleProjectLayers(this.visible);
                         this.selected = new Map();
+                        this.syncMapLayersToVisible();
                     })
                     .catch(e => {
                         this.$log.error(e);

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -144,8 +144,6 @@ rf-selected-actions-bar {
 
     a {
         box-shadow: initial;
-        // padding: 1.25rem 1rem;
-        // margin: 0.1rem;
         display: flex;
         flex-direction: row;
         align-items: center;

--- a/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
+++ b/app-frontend/src/assets/styles/sass/layout/_sidebar.scss
@@ -125,6 +125,16 @@
     }
 }
 
+.sidebar-actions-group {
+    a,.btn {
+        box-shadow: initial;
+        padding: 1.15rem 1rem;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+    }
+}
+
 .sidebar-actions-group,
 rf-selected-actions-bar {
     display: flex;
@@ -134,8 +144,8 @@ rf-selected-actions-bar {
 
     a {
         box-shadow: initial;
-        padding: 1.25rem 1rem;
-        margin: 0.25rem;
+        // padding: 1.25rem 1rem;
+        // margin: 0.1rem;
         display: flex;
         flex-direction: row;
         align-items: center;


### PR DESCRIPTION
## Overview
Allow zooming to project layers / analyses
Allow selecting multiple layers / analyses and zooming to them as a group
Allow showing / hiding stuff on the map as a selected group

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~ny new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/55186116-26283d80-516c-11e9-83a1-07b5e94536e3.png)
![image](https://user-images.githubusercontent.com/4392704/55186136-3213ff80-516c-11e9-90b9-42fc5148f90c.png)

### Notes
~Depends on changes in https://github.com/raster-foundry/raster-foundry/pull/4804~ _merged_
~Only the last commit is relevant for this PR~

## Testing Instructions

 * Verify that you can select layers, show / hide them, and zoom to the group
* Verify that you can do the same to analyses

Closes #4703
