### PR TITLE
Replace docs site with swaggerhub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Made tools reference licenses by id [\#4701](https://github.com/raster-foundry/raster-foundry/pull/4701)
 - Support map tokens on /projects/{} get route, /tool-runs/ get route [\#4768](https://github.com/raster-foundry/raster-foundry/pull/4768)
 - Enabled inserting annotations in bulk in one `INSERT INTO` command [\#4777](https://github.com/raster-foundry/raster-foundry/pull/4777)
+- Started using swaggerhub for documentation [\#4818](https://github.com/raster-foundry/raster-foundry/pull/4818)
 
 ### Deprecated
 

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -325,7 +325,7 @@ module.exports = function (_path) {
                     EMBED_URI: JSON.stringify('')
                 },
                 'HELPCONFIG': {
-                    API_DOCS_URL: JSON.stringify('https://docs.rasterfoundry.com/'),
+                    API_DOCS_URL: JSON.stringify('https://app.swaggerhub.com/apis/raster-foundry/raster-foundry/'),
                     HELP_HOME: JSON.stringify('https://help.rasterfoundry.com/'),
                     GETTING_STARTED_WITH_PROJECTS: JSON.stringify(
                         'https://help.rasterfoundry.com/creating-projects'


### PR DESCRIPTION
## Overview

Switches to using the Raster Foundry swaggerhub

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
![swaggerhub](https://user-images.githubusercontent.com/898060/55252467-67325780-5229-11e9-92b3-d33a2c54111d.gif)

## Testing Instructions

 * Load the main page, click on "API Documentation"