### PR TITLE
Fix annotation shapefile import and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 - Users that have edit permissions on an analysis can now share the analysis from within the lab interface [\#4797](https://github.com/raster-foundry/raster-foundry/pull/4797)
 - Fixed dependency conflict for circe between geotrellis-server, maml, and Raster Foundry [\#4703](https://github.com/raster-foundry/raster-foundry/pull/4703)
 - Attached ACL policy to exports uploaded to external buckets to allow owner control [\#4825](https://github.com/raster-foundry/raster-foundry/pull/4825)
+- Fix annotation shapefile import and export[\#4829](https://github.com/raster-foundry/raster-foundry/pull/4829)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-backend/api/src/main/scala/project/AnnotationShapefileService.scala
+++ b/app-backend/api/src/main/scala/project/AnnotationShapefileService.scala
@@ -5,7 +5,7 @@ import com.rasterfoundry.common.S3
 import com.rasterfoundry.api.utils.Config
 
 import com.typesafe.scalalogging.LazyLogging
-import com.vividsolutions.jts.{geom => jts}
+import org.locationtech.jts.{geom => jts}
 import com.amazonaws.services.s3.AmazonS3URI
 import geotrellis.geotools._
 import geotrellis.proj4.CRS

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -57,7 +57,7 @@ object Dependencies {
   val http4sCirce = "org.http4s" %% "http4s-circe" % Version.http4s
   val http4sDSL = "org.http4s" %% "http4s-dsl" % Version.http4s
   val http4sServer = "org.http4s" %% "http4s-server" % Version.http4s
-  val jts = "com.vividsolutions" % "jts" % Version.jts
+  val jts = "org.locationtech.jts" % "jts-core" % Version.jts
   val mamlJvm = "com.azavea" %% "maml-jvm" % Version.maml
   val mamlSpark = "com.azavea" %% "maml-spark" % Version.maml
   val nimbusJose = "com.guizmaii" %% "scala-nimbus-jose-jwt" % Version.nimbusJose

--- a/app-backend/project/Version.scala
+++ b/app-backend/project/Version.scala
@@ -31,7 +31,7 @@ object Version {
   val hikariCP = "3.2.0"
   val http4s = "0.20.0-M6"
   val json4s = "3.5.0"
-  val jts = "1.13"
+  val jts = "1.16.0"
   val maml = "0.2.1"
   val nimbusJose = "0.6.0"
   val postgres = "42.1.1"


### PR DESCRIPTION
## Overview

This PR updates `jts` dependency to keep it inline with what is used in `geotrellis 2.2.0` to make annotation shapefile import and export work again.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * `api/assembly`
 * Spin up the server and frontend
 * Go to a project and go under annotation tab
 * Draw some annotations
 * Click on `...` on top right of sidebar and select `Export`
 * In dev tool, make sure `GET api/projects/<project ID>/annotations/shapefile` is successful
 * Choose `Shapefile` from the `Export format` dropdown, and click on `Export` -- make sure it downloads correctly
 * Go back to annotation list. Delete annotations. Click on `...` on top right of sidebar and select `Import`
 * Upload the downloaded zipped shapefile. Make sure it lets you select data columns. Make sure it displays the annotations after confirming data columns.

Closes #2967 
Closes #4557 
Closes #4827 
