### PR TITLE
Set layerId to null when deleting upload records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,8 @@
 - Users that have edit permissions on an analysis can now share the analysis from within the lab interface [\#4797](https://github.com/raster-foundry/raster-foundry/pull/4797)
 - Fixed dependency conflict for circe between geotrellis-server, maml, and Raster Foundry [\#4703](https://github.com/raster-foundry/raster-foundry/pull/4703)
 - Attached ACL policy to exports uploaded to external buckets to allow owner control [\#4825](https://github.com/raster-foundry/raster-foundry/pull/4825)
-- Fix annotation shapefile import and export[\#4829](https://github.com/raster-foundry/raster-foundry/pull/4829)
+- Fix annotation shapefile import and export [\#4829](https://github.com/raster-foundry/raster-foundry/pull/4829)
+- Set layerId to null when deleting upload records [\#4844](https://github.com/raster-foundry/raster-foundry/pull/4844)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-backend/migrations/src/main/scala/migrations/173.scala
+++ b/app-backend/migrations/src/main/scala/migrations/173.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/173.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -170,4 +170,5 @@ object MigrationSummary {
   M170
   M171
   M172
+  M173
 }

--- a/app-backend/migrations/src_migrations/main/scala/173.scala
+++ b/app-backend/migrations/src_migrations/main/scala/173.scala
@@ -1,0 +1,12 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M173 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(173)(
+    List(
+      sqlu"""
+    ALTER TABLE uploads DROP CONSTRAINT uploads_layer_id_fkey;
+    ALTER TABLE uploads ADD CONSTRAINT uploads_layer_id_fkey FOREIGN KEY (layer_id) REFERENCES project_layers(id) ON DELETE SET NULL;
+    """
+    ))
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,10 @@
-version: '2.3'
+version: "2.3"
 services:
   postgres:
     image: quay.io/azavea/postgis:2.3-postgres9.6-slim
     volumes:
       - ./data/:/tmp/data/
     env_file: .env
-    ports:
-      - 5434:5432
     expose:
       - "5432"
     healthcheck:


### PR DESCRIPTION
## Overview

This PR updates the foreign key `layer_id`'s constraint in `uploads` table so that it sets the field to `NULL` when layers are deleted.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- [X] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

 * Before running the migration, on V2 UI, upload an image to a layer, then delete this layer. The deletion should fail.
 * Go to imported raster data list on frontend. Make sure there is a new import in progress reflected in the status bar.
 * Run the migration.
 * On V2 UI, delete the layer you uploaded an image to in step 1. Make sure the layer deletion succeeds.
 * Go to imported raster data list on frontend. Make sure the import status bar looks the same as step 2.

Closes #4833 
