### PR TITLE
Fix analysis list on share page for public projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - Project analyses Visualize view conditionally overwrites render def instead of always [\#4848](https://github.com/raster-foundry/raster-foundry/pull/4848)
 - Moved legacy filters over to new styling [\#4855](https://github.com/raster-foundry/raster-foundry/pull/4848)
 - Make flake8 and pytest ignore dependencies in `opt` directory of `app-lambda` [\#4853](https://github.com/raster-foundry/raster-foundry/pull/4853)
+- Fix v2 share page using the wrong endpoint to fetch analyses, fix error states [\#4845](https://github.com/raster-foundry/raster-foundry/pull/4845)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-frontend/src/app/components/pages/share/analyses/index.html
+++ b/app-frontend/src/app/components/pages/share/analyses/index.html
@@ -41,7 +41,8 @@
     </div>
     <div
         class="modal-inner-container small text-center sidebar-top-margin"
-        ng-if="$ctrl.analysisList && !$ctrl.analysisList.length && !$ctrl.currentQuery"
+        ng-if="$ctrl.analysisList && !$ctrl.analysisList.length &&
+               !$ctrl.currentQuery && !$ctrl.fetchError"
     >
         <span class="modal-icon"><i class="icon-info"></i></span>
         <div>

--- a/app-frontend/src/app/components/pages/share/analyses/index.js
+++ b/app-frontend/src/app/components/pages/share/analyses/index.js
@@ -45,12 +45,11 @@ class ShareProjectAnalysesController {
 
     fetchPage(page = this.$state.params.page || 1) {
         this.analysisList = [];
-        const currentQuery = this.analysisService
-            .fetchAnalyses({
+        const currentQuery = this.projectService
+            .getProjectAnalyses(this.project.id, {
                 pageSize: 10,
                 page: page - 1,
-                mapToken: this.token,
-                projectId: this.project.id
+                mapToken: this.token
             })
             .then(
                 paginatedResponse => {

--- a/app-frontend/src/app/components/pages/share/layers/index.html
+++ b/app-frontend/src/app/components/pages/share/layers/index.html
@@ -37,7 +37,8 @@
     </div>
     <div
         class="modal-inner-container small text-center sidebar-top-margin"
-        ng-if="$ctrl.layerList && !$ctrl.layerList.length && !$ctrl.currentQuery"
+        ng-if="$ctrl.layerList && !$ctrl.layerList.length &&
+               !$ctrl.currentQuery && !$ctrl.fetchError"
     >
         <span class="modal-icon"><i class="icon-info"></i></span>
         <div>


### PR DESCRIPTION
## Overview
Fix analysis listing on project share page

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/55640333-5e95d000-5799-11e9-8f0d-d0ff6e9824ed.png)
![image](https://user-images.githubusercontent.com/4392704/55640532-d237dd00-5799-11e9-8a9e-ffea49d94c71.png)


## Testing Instructions
* Make a project public, then go to its v2 share page in an incognito browser
 * Verify that you can now load the project analysis list
* Verify that if you put the browser in offline mode when navigating from the layer list view to the analyses list view, the only the error message shows, instead of both the error message and the "no analyses" message
* Do the above with the layer list view as well
* Go through other share page interactivity like annotations and make sure it works as expected

Closes #4770
