### PR TITLE
Conditionally overwrite render def on visualize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Attached ACL policy to exports uploaded to external buckets to allow owner control [\#4825](https://github.com/raster-foundry/raster-foundry/pull/4825)
 - Fix annotation shapefile import and export [\#4829](https://github.com/raster-foundry/raster-foundry/pull/4829)
 - Set layerId to null when deleting upload records [\#4844](https://github.com/raster-foundry/raster-foundry/pull/4844)
+- Project analyses Visualize view conditionally overwrites render def instead of always [\#4848](https://github.com/raster-foundry/raster-foundry/pull/4848)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
@@ -3,67 +3,75 @@
         <h3>Key metrics</h3>
     </div>
     <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.loadingAnalysis">
-      <h3>Loading histograms and maps<i class="icon-load animate-spin"></i></h3>
+        <h3>Loading histograms and maps<i class="icon-load animate-spin"></i></h3>
     </div>
     <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.errorLoadingAnalysis">
-      <h3 class="color-danger"><i class="icon-warning"></i>Failed to load histograms and maps. Please try again later.</h3>
+        <h3 class="color-danger">
+            <i class="icon-warning"></i>Failed to load histograms and maps. Please try again later.
+        </h3>
     </div>
     <div class="page-card analysis-maps-card" ng-if="!$ctrl.loadingAnalysis">
-      <div class="row">
-        <div class="column-4 flex-display" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId">
-          <rf-analysis-map-item
-              class="panel panel-off-white project-item"
-              analysis-id="analysis.trackId"
-              analysis-tile="analysis.analysisTile">
-              <item-selector>
+        <div class="row">
+            <div
+                class="column-4 flex-display"
+                ng-repeat="analysis in $ctrl.analyses track by analysis.trackId"
+            >
+                <rf-analysis-map-item
+                    class="panel panel-off-white project-item"
+                    analysis-id="analysis.trackId"
+                    analysis-tile="analysis.analysisTile"
+                >
+                    <item-selector>
+                        <rf-list-item-selector
+                            id="analysis.trackId"
+                            selected="$ctrl.selected.has(analysis.trackId)"
+                            color="$ctrl.layerColorHex[analysis.id]"
+                        ></rf-list-item-selector>
+                    </item-selector>
+                </rf-analysis-map-item>
+            </div>
+        </div>
+    </div>
+    <div
+        class="page-card analysis-histogram-card"
+        ng-repeat="analysis in $ctrl.analyses track by analysis.trackId"
+        ng-if="!$ctrl.loadingAnalysis"
+    >
+        <div class="row">
+            <div class="column-3 flex-display">
                 <rf-list-item-selector
                     id="analysis.trackId"
-                    selected="$ctrl.selected.has(analysis.trackId)"
                     color="$ctrl.layerColorHex[analysis.id]"
                 ></rf-list-item-selector>
-              </item-selector>
-          </rf-analysis-map-item>
-        </div>
-      </div>
-    </div>
-    <div class="page-card analysis-histogram-card" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId" ng-if="!$ctrl.loadingAnalysis">
-      <div class="row">
-        <div class="column-3 flex-display">
-          <rf-list-item-selector
-              id="analysis.trackId"
-              color="$ctrl.layerColorHex[analysis.id]"
-          ></rf-list-item-selector>
-          <div class="list-group-overflow">
-            <div class="text-overflow-ellipsis">
-              <strong>{{$ctrl.analysesMap.get(analysis.trackId).name}}</strong>
+                <div class="list-group-overflow">
+                    <div class="text-overflow-ellipsis">
+                        <strong>{{ $ctrl.analysesMap.get(analysis.trackId).name }}</strong>
+                    </div>
+                    <div class="text-overflow-ellipsis">
+                        {{ $ctrl.analysesMap.get(analysis.trackId).modifiedAt | date: 'medium' }}
+                    </div>
+                </div>
             </div>
-            <div class="text-overflow-ellipsis">
-              {{$ctrl.analysesMap.get(analysis.trackId).modifiedAt | date: 'medium'}}
+            <div class="column-9 flex-display">
+                <rf-data-viz-histogram
+                    id="analysis.trackId"
+                    histogram-promise="analysis.histogram"
+                    bounds-promise="$ctrl.histogramBounds"
+                >
+                    <rf-histogram-bar
+                        statistics="analysis.statistics"
+                        bounds-promise="$ctrl.histogramBounds"
+                        histogram-promise="analysis.histogram"
+                    >
+                    </rf-histogram-bar>
+                </rf-data-viz-histogram>
             </div>
-          </div>
         </div>
-        <div class="column-9 flex-display">
-          <rf-data-viz-histogram
-              id="analysis.trackId"
-              histogram-promise="analysis.histogram"
-              bounds-promise="$ctrl.histogramBounds"
-          >
-              <rf-histogram-bar
-                  statistics="analysis.statistics"
-                  bounds-promise="$ctrl.histogramBounds"
-                  histogram-promise="analysis.histogram"
-              >
-              </rf-histogram-bar>
-          </rf-data-viz-histogram>
+        <div class="row">
+            <div class="column-3 flex-display no-padding"></div>
+            <div class="column-9 flex-display no-padding">
+                <rf-data-viz-statistics statistics="analysis.statistics"> </rf-data-viz-statistics>
+            </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="column-3 flex-display no-padding">
-        </div>
-        <div class="column-9 flex-display no-padding">
-          <rf-data-viz-statistics statistics="analysis.statistics">
-          </rf-data-viz-statistics>
-        </div>
-      </div>
     </div>
 </div>

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.html
@@ -2,13 +2,13 @@
     <div class="page-header wide">
         <h3>Key metrics</h3>
     </div>
-    <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.isLoadingAnalysis">
+    <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.loadingAnalysis">
       <h3>Loading histograms and maps<i class="icon-load animate-spin"></i></h3>
     </div>
-    <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.isLoadingAnalysisError">
+    <div class="page-card analysis-histogram-card text-center" ng-if="$ctrl.errorLoadingAnalysis">
       <h3 class="color-danger"><i class="icon-warning"></i>Failed to load histograms and maps. Please try again later.</h3>
     </div>
-    <div class="page-card analysis-maps-card" ng-if="!$ctrl.isLoadingAnalysis">
+    <div class="page-card analysis-maps-card" ng-if="!$ctrl.loadingAnalysis">
       <div class="row">
         <div class="column-4 flex-display" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId">
           <rf-analysis-map-item
@@ -26,7 +26,7 @@
         </div>
       </div>
     </div>
-    <div class="page-card analysis-histogram-card" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId" ng-if="!$ctrl.isLoadingAnalysis">
+    <div class="page-card analysis-histogram-card" ng-repeat="analysis in $ctrl.analyses track by analysis.trackId" ng-if="!$ctrl.loadingAnalysis">
       <div class="row">
         <div class="column-3 flex-display">
           <rf-list-item-selector


### PR DESCRIPTION
## Overview
Don't overwrite render def if quickedit manual render def flag is set

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~[Swagger specification](https://github.com/raster-foundry/raster-foundry-api-spec) updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/55646206-95271700-57a8-11e9-97f7-d7dc515d4b7e.png)


## Testing Instructions

 * Change the render def of a project analysis to something noticeably different, select it, and click visualize
* Verify that the color map is preserved and not overwritten
* Verify that if you create a new analysis from a project layer and don't preview it or change parameters, you can still visualize it (it should show as a solid color, since it has invalid parameters)

Closes #4835
