### PR TITLE
Make flake8 and pytest ignore deps in ./opt of app-lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 - Set layerId to null when deleting upload records [\#4844](https://github.com/raster-foundry/raster-foundry/pull/4844)
 - Project analyses Visualize view conditionally overwrites render def instead of always [\#4848](https://github.com/raster-foundry/raster-foundry/pull/4848)
 - Moved legacy filters over to new styling [\#4855](https://github.com/raster-foundry/raster-foundry/pull/4848)
+- Make flake8 and pytest ignore dependencies in `opt` directory of `app-lambda` [\#4853](https://github.com/raster-foundry/raster-foundry/pull/4853)
 
 ## [1.18.1](https://github.com/raster-foundry/raster-foundry/tree/1.18.0) (2019-02-20)
 

--- a/app-lambda/setup.cfg
+++ b/app-lambda/setup.cfg
@@ -19,5 +19,5 @@ universal = 1
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
+collect_ignore = ['setup.py', 'opt']
 norecursedirs = opt

--- a/app-lambda/setup.cfg
+++ b/app-lambda/setup.cfg
@@ -20,4 +20,4 @@ test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-
+norecursedirs = opt

--- a/app-lambda/tox.ini
+++ b/app-lambda/tox.ini
@@ -19,6 +19,6 @@ commands =
     {envpython} setup.py test
 
 [flake8]
-exclude = .tox,*.egg,build,data,venv
+exclude = .tox,*.egg,build,data,venv,opt
 select = E,W,F
 max-line-length = 100


### PR DESCRIPTION
## Overview

This PR updates setups in `app-lambda` so that `flake8` and `pytest` ignores styling checks and tests in dependency code.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- The instructions here are mocking what will happen during the lambda-related parts of `./script/test` and `./script/cipublish`
- Note: if you are testing in a VM, I would suggest deleting the `app-lambda` directory in the VM, and `vagrant rsync` to make sure `app-lambda` directory is up to date
- Build the lambda functions from the root of the directory
```bash
docker-compose -f "docker-compose.test.yml" \
               run --rm --no-deps lambda \
               pip install -t opt/ ./
docker-compose -f "docker-compose.test.yml" \
               run --rm --no-deps lambda \
               cp -r "/opt/raster-foundry/app-lambda/rflambda/" "/opt/raster-foundry/app-lambda/opt/"
pushd "./app-lambda/opt/"
  zip -9 -r ../package.zip ./*
popd
```
- Run lambda test suite from the root of the directory
```bash
docker-compose \
            -f docker-compose.test.yml \
            run --rm \
            --entrypoint tox \
            lambda
```

Closes #4852 
