### PR TITLE
Add overviewsLocation and minZoomLevel to projectLayers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Added quick edit functionality for project analyses [\#4804](https://github.com/raster-foundry/raster-foundry/pull/4804)
 - Add zooming, showing, hiding options to multi-select menu on analyses, layers [\4816](https://github.com/raster-foundry/raster-foundry/pull/4816)
 - Added API specifications back to core repository [\#4819](https://github.com/raster-foundry/raster-foundry/pull/4819)
+- Added `overviewsLocation` and `minZoomLevel` to `projectLayers` [\#4857](https://github.com/raster-foundry/raster-foundry/pull/4857)
 
 ### Changed
 

--- a/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
+++ b/app-backend/common/src/main/scala/datamodel/ProjectLayer.scala
@@ -24,8 +24,10 @@ final case class ProjectLayer(
     rangeEnd: Option[Timestamp],
     geometry: Option[Projected[Geometry]],
     isSingleBand: Boolean,
-    singleBandOptions: Option[SingleBandOptions.Params])
-    extends GeoJSONSerializable[ProjectLayer.GeoJSON] {
+    singleBandOptions: Option[SingleBandOptions.Params],
+    overviewsLocation: Option[String],
+    minZoomLevel: Option[Int]
+) extends GeoJSONSerializable[ProjectLayer.GeoJSON] {
   def toGeoJSONFeature: ProjectLayer.GeoJSON = ProjectLayer.GeoJSON(
     this.id,
     this.geometry,
@@ -39,7 +41,9 @@ final case class ProjectLayer(
       this.rangeStart,
       this.rangeEnd,
       this.isSingleBand,
-      this.singleBandOptions
+      this.singleBandOptions,
+      this.overviewsLocation,
+      this.minZoomLevel
     )
   )
 }
@@ -55,7 +59,10 @@ final case class ProjectLayerProperties(
     rangeStart: Option[Timestamp],
     rangeEnd: Option[Timestamp],
     isSingleBand: Boolean,
-    singleBandOptions: Option[SingleBandOptions.Params])
+    singleBandOptions: Option[SingleBandOptions.Params],
+    overviewsLocation: Option[String],
+    minZoomLevel: Option[Int]
+)
 
 object ProjectLayer extends LazyLogging with JsonCodecs {
 
@@ -67,7 +74,9 @@ object ProjectLayer extends LazyLogging with JsonCodecs {
                           rangeEnd: Option[Timestamp],
                           geometry: Option[Projected[Geometry]],
                           isSingleBand: Boolean,
-                          singleBandOptions: Option[SingleBandOptions.Params]) {
+                          singleBandOptions: Option[SingleBandOptions.Params],
+                          overviewsLocation: Option[String],
+                          minZoomLevel: Option[Int]) {
     def toProjectLayer: ProjectLayer = {
       val now = new Timestamp(new java.util.Date().getTime)
       ProjectLayer(
@@ -82,7 +91,9 @@ object ProjectLayer extends LazyLogging with JsonCodecs {
         this.rangeEnd,
         this.geometry,
         this.isSingleBand,
-        this.singleBandOptions
+        this.singleBandOptions,
+        this.overviewsLocation,
+        this.minZoomLevel
       )
     }
   }
@@ -114,9 +125,11 @@ object ProjectLayer extends LazyLogging with JsonCodecs {
           rangeEnd,
           geometry,
           false,
+          None,
+          None,
           None
         )
-      }) or Decoder.forProduct9(
+      }) or Decoder.forProduct11(
       "name",
       "projectId",
       "colorGroupHex",
@@ -125,7 +138,9 @@ object ProjectLayer extends LazyLogging with JsonCodecs {
       "rangeEnd",
       "geometry",
       "isSingleBand",
-      "singleBandOptions"
+      "singleBandOptions",
+      "overviewsLocation",
+      "minZoomLevel"
     )(Create.apply _)
   }
 
@@ -147,7 +162,9 @@ object ProjectLayer extends LazyLogging with JsonCodecs {
         properties.rangeEnd,
         geometry,
         properties.isSingleBand,
-        properties.singleBandOptions
+        properties.singleBandOptions,
+        properties.overviewsLocation,
+        properties.minZoomLevel
       )
     }
   }

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -771,6 +771,8 @@ object Generators extends ArbitraryInstances {
       geometry <- Gen.const(None)
       isSingleBand <- Gen.const(false)
       singleBandOptions <- Gen.const(None)
+      overviewsLocation <- Gen.const(None)
+      minZoomLevel <- Gen.const(None)
     } yield {
       ProjectLayer.Create(name,
                           projectId,
@@ -780,7 +782,9 @@ object Generators extends ArbitraryInstances {
                           rangeEnd,
                           geometry,
                           isSingleBand,
-                          singleBandOptions)
+                          singleBandOptions,
+                          overviewsLocation,
+                          minZoomLevel)
     }
 
   object Implicits {

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -95,6 +95,8 @@ object ProjectDao
                      None,
                      None,
                      false,
+                     None,
+                     None,
                      None)
       )
       project <- (fr"INSERT INTO" ++ tableF ++ fr"""

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -18,8 +18,12 @@ import java.util.UUID
 object ProjectLayerDao extends Dao[ProjectLayer] {
   val tableName = "project_layers"
 
-  val selectAllColsF: Fragment =
-    fr"SELECT id, created_at, modified_at, name, project_id, color_group_hex, smart_layer_id, range_start, range_end, geometry, is_single_band, single_band_options"
+  val selectAllColsF: Fragment = fr"""
+    SELECT
+      id, created_at, modified_at, name, project_id, color_group_hex,
+      smart_layer_id, range_start, range_end, geometry, is_single_band,
+      single_band_options, overviews_location, min_zoom_level
+    """
 
   val selectF: Fragment =
     selectAllColsF ++ fr"from" ++ tableF
@@ -56,11 +60,14 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
   ): ConnectionIO[ProjectLayer] = {
     (fr"INSERT INTO" ++ tableF ++ fr"""
     (id, created_at, modified_at, name, project_id, color_group_hex,
-    smart_layer_id, range_start, range_end, geometry, is_single_band, single_band_options)
+    smart_layer_id, range_start, range_end, geometry, is_single_band, single_band_options,
+    overviews_location, min_zoom_level
+    )
     VALUES
       (${pl.id}, ${pl.createdAt}, ${pl.modifiedAt}, ${pl.name}, ${pl.projectId},
       ${pl.colorGroupHex}, ${pl.smartLayerId}, ${pl.rangeStart}, ${pl.rangeEnd},
-      ${pl.geometry}, ${pl.isSingleBand}, ${pl.singleBandOptions})
+      ${pl.geometry}, ${pl.isSingleBand}, ${pl.singleBandOptions}, ${pl.overviewsLocation},
+      ${pl.minZoomLevel})
     """).update.withUniqueGeneratedKeys[ProjectLayer](
       "id",
       "created_at",
@@ -73,7 +80,9 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
       "range_end",
       "geometry",
       "is_single_band",
-      "single_band_options"
+      "single_band_options",
+      "overviews_location",
+      "min_zoom_level"
     )
   }
 
@@ -87,7 +96,9 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
       geometry = ${projectLayer.geometry},
       project_id = ${projectLayer.projectId},
       is_single_band = ${projectLayer.isSingleBand},
-      single_band_options = ${projectLayer.singleBandOptions}
+      single_band_options = ${projectLayer.singleBandOptions},
+      overviews_location=${projectLayer.overviewsLocation},
+      min_zoom_level=${projectLayer.minZoomLevel}
     """ ++ Fragments.whereAndOpt(Some(idFilter))).update
     query
   }
@@ -133,7 +144,9 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
            Some(end),
            layer.geometry,
            layer.isSingleBand,
-           layer.singleBandOptions
+           layer.singleBandOptions,
+           layer.overviewsLocation,
+           layer.minZoomLevel
          ),
          scenes)
       case ((_, datasourceO), scenes) =>
@@ -152,7 +165,9 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
            None,
            layer.geometry,
            layer.isSingleBand,
-           layer.singleBandOptions
+           layer.singleBandOptions,
+           layer.overviewsLocation,
+           layer.minZoomLevel
          ),
          scenes)
     }

--- a/app-backend/migrations/src/main/scala/migrations/174.scala
+++ b/app-backend/migrations/src/main/scala/migrations/174.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/174.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -171,4 +171,5 @@ object MigrationSummary {
   M171
   M172
   M173
+  M174
 }

--- a/app-backend/migrations/src_migrations/main/scala/174.scala
+++ b/app-backend/migrations/src_migrations/main/scala/174.scala
@@ -1,0 +1,13 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M174 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(174)(
+    List(
+      sqlu"""
+      ALTER TABLE project_layers
+        ADD COLUMN overviews_location TEXT,
+        ADD COLUMN min_zoom_level INTEGER;
+      """
+    ))
+}


### PR DESCRIPTION
## Overview

This PR adds `overviews_location` and `min_zoom_level` to `project_layers` table, updates `projectLayer` data model, and updates `ProjectLayerDao`, `ProjectDao`, and affected generators for property tests.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Make sure both `mg update` and `mg apply` work
- Make sure property tests pass
- `api/assembly`, `backsplash-server/assembly` and then spin up server and frontend
- Make sure creating a new project still works and it creates a default project layer under the hood as usual
- Go to a project's V2 UI, make sure creating a new project layer still works
- Add scenes from different dates and datasources to a layer in V2 UI, and split this layer afterwards, make sure the layer split still works as usual

Closes https://github.com/raster-foundry/raster-foundry/issues/4836
