### PR TITLE
Enable listing annotations with owner info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Add zooming, showing, hiding options to multi-select menu on analyses, layers [\4816](https://github.com/raster-foundry/raster-foundry/pull/4816)
 - Added API specifications back to core repository [\#4819](https://github.com/raster-foundry/raster-foundry/pull/4819)
 - Added `overviewsLocation` and `minZoomLevel` to `projectLayers` [\#4857](https://github.com/raster-foundry/raster-foundry/pull/4857)
+- Enable listing annotations with owner info [\#4864](https://github.com/raster-foundry/raster-foundry/pull/4864)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -34,18 +34,34 @@ trait ProjectAnnotationRoutes
         (withPagination & annotationQueryParams) {
           (page: PageRequest, queryParams: AnnotationQueryParameters) =>
             complete {
-              AnnotationDao
-                .listByLayer(projectId, page, queryParams)
-                .transact(xa)
-                .unsafeToFuture
-                .map { p =>
-                  {
-                    fromPaginatedResponseToGeoJson[
-                      Annotation,
-                      Annotation.GeoJSON
-                    ](p)
-                  }
-                }
+              (queryParams.withOwnerInfo match {
+                case Some(true) =>
+                  AnnotationDao
+                    .listByLayerWithOwnerInfo(projectId, page, queryParams)
+                    .transact(xa)
+                      .unsafeToFuture
+                      .map { p =>
+                        {
+                          fromPaginatedResponseToGeoJson[
+                            AnnotationWithOwnerInfo,
+                            AnnotationWithOwnerInfo.GeoJSON
+                          ](p)
+                        }
+                      }
+                case _ =>
+                  AnnotationDao
+                    .listByLayer(projectId, page, queryParams)
+                    .transact(xa)
+                      .unsafeToFuture
+                      .map { p =>
+                        {
+                          fromPaginatedResponseToGeoJson[
+                            Annotation,
+                            Annotation.GeoJSON
+                          ](p)
+                        }
+                      }
+              })
             }
         }
       }

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -39,28 +39,28 @@ trait ProjectAnnotationRoutes
                   AnnotationDao
                     .listByLayerWithOwnerInfo(projectId, page, queryParams)
                     .transact(xa)
-                      .unsafeToFuture
-                      .map { p =>
-                        {
-                          fromPaginatedResponseToGeoJson[
-                            AnnotationWithOwnerInfo,
-                            AnnotationWithOwnerInfo.GeoJSON
-                          ](p)
-                        }
+                    .unsafeToFuture
+                    .map { p =>
+                      {
+                        fromPaginatedResponseToGeoJson[
+                          AnnotationWithOwnerInfo,
+                          AnnotationWithOwnerInfo.GeoJSON
+                        ](p)
                       }
+                    }
                 case _ =>
                   AnnotationDao
                     .listByLayer(projectId, page, queryParams)
                     .transact(xa)
-                      .unsafeToFuture
-                      .map { p =>
-                        {
-                          fromPaginatedResponseToGeoJson[
-                            Annotation,
-                            Annotation.GeoJSON
-                          ](p)
-                        }
+                    .unsafeToFuture
+                    .map { p =>
+                      {
+                        fromPaginatedResponseToGeoJson[
+                          Annotation,
+                          Annotation.GeoJSON
+                        ](p)
                       }
+                    }
               })
             }
         }

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -55,17 +55,20 @@ trait ProjectLayerAnnotationRoutes
                 (queryParams.withOwnerInfo match {
                   case Some(true) =>
                     AnnotationDao
-                      .listByLayerWithOwnerInfo(projectId, page, queryParams, Some(layerId))
+                      .listByLayerWithOwnerInfo(projectId,
+                                                page,
+                                                queryParams,
+                                                Some(layerId))
                       .transact(xa)
-                        .unsafeToFuture
-                        .map { p =>
-                          {
-                            fromPaginatedResponseToGeoJson[
-                              AnnotationWithOwnerInfo,
-                              AnnotationWithOwnerInfo.GeoJSON
-                            ](p)
-                          }
+                      .unsafeToFuture
+                      .map { p =>
+                        {
+                          fromPaginatedResponseToGeoJson[
+                            AnnotationWithOwnerInfo,
+                            AnnotationWithOwnerInfo.GeoJSON
+                          ](p)
                         }
+                      }
                   case _ =>
                     AnnotationDao
                       .listByLayer(projectId, page, queryParams, Some(layerId))

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -52,18 +52,34 @@ trait ProjectLayerAnnotationRoutes
           (withPagination & annotationQueryParams) {
             (page: PageRequest, queryParams: AnnotationQueryParameters) =>
               complete {
-                AnnotationDao
-                  .listByLayer(projectId, page, queryParams, Some(layerId))
-                  .transact(xa)
-                  .unsafeToFuture
-                  .map { p =>
-                    {
-                      fromPaginatedResponseToGeoJson[
-                        Annotation,
-                        Annotation.GeoJSON
-                      ](p)
-                    }
-                  }
+                (queryParams.withOwnerInfo match {
+                  case Some(true) =>
+                    AnnotationDao
+                      .listByLayerWithOwnerInfo(projectId, page, queryParams, Some(layerId))
+                      .transact(xa)
+                        .unsafeToFuture
+                        .map { p =>
+                          {
+                            fromPaginatedResponseToGeoJson[
+                              AnnotationWithOwnerInfo,
+                              AnnotationWithOwnerInfo.GeoJSON
+                            ](p)
+                          }
+                        }
+                  case _ =>
+                    AnnotationDao
+                      .listByLayer(projectId, page, queryParams, Some(layerId))
+                      .transact(xa)
+                      .unsafeToFuture
+                      .map { p =>
+                        {
+                          fromPaginatedResponseToGeoJson[
+                            Annotation,
+                            Annotation.GeoJSON
+                          ](p)
+                        }
+                      }
+                })
               }
           }
         }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -109,7 +109,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
           'maxConfidence.as[Double].?,
           'quality.as[String].?,
           'annotationGroup.as[UUID].?,
-          'bbox.as[String].*
+          'bbox.as[String].*,
+          'withOwnerInfo.as[Boolean].?
         ))).as(AnnotationQueryParameters.apply _)
 
   def shapeQueryParams =

--- a/app-backend/common/src/main/scala/datamodel/Annotation.scala
+++ b/app-backend/common/src/main/scala/datamodel/Annotation.scala
@@ -276,3 +276,83 @@ object Annotation extends LazyLogging {
     }
   }
 }
+
+@JsonCodec
+final case class AnnotationWithOwnerInfo(id: UUID,
+                                         projectId: UUID,
+                                         createdAt: Timestamp,
+                                         createdBy: String,
+                                         modifiedAt: Timestamp,
+                                         modifiedBy: String,
+                                         owner: String,
+                                         label: String,
+                                         description: Option[String],
+                                         machineGenerated: Option[Boolean],
+                                         confidence: Option[Float],
+                                         quality: Option[AnnotationQuality],
+                                         geometry: Option[Projected[Geometry]],
+                                         annotationGroup: UUID,
+                                         labeledBy: Option[String],
+                                         verifiedBy: Option[String],
+                                         projectLayerId: UUID,
+                                         ownerName: String,
+                                         ownerProfileImageUri: String)
+  extends GeoJSONSerializable[AnnotationWithOwnerInfo.GeoJSON] {
+    def toGeoJSONFeature = AnnotationWithOwnerInfo.GeoJSON(
+      this.id,
+      this.geometry,
+        AnnotationWithOwnerInfoProperties(
+         this.projectId,
+         this.createdAt,
+         this.createdBy,
+         this.modifiedAt,
+         this.modifiedBy,
+         this.owner,
+         this.label,
+         this.description,
+         this.machineGenerated,
+         this.confidence,
+         this.quality,
+         this.annotationGroup,
+         this.labeledBy,
+         this.verifiedBy,
+         this.projectLayerId,
+         this.ownerName,
+         this.ownerProfileImageUri
+        )
+      )
+  }
+
+object AnnotationWithOwnerInfo {
+
+  implicit val config: Configuration =
+    Configuration.default.copy(transformMemberNames = {
+      case "_type" => "type"
+      case other   => other
+    })
+
+  @ConfiguredJsonCodec
+  final case class GeoJSON(id: UUID,
+                           geometry: Option[Projected[Geometry]],
+                           properties: AnnotationWithOwnerInfoProperties,
+                           _type: String = "Feature") extends GeoJSONFeature
+}
+
+@JsonCodec
+final case class AnnotationWithOwnerInfoProperties(projectId: UUID,
+                                      createdAt: Timestamp,
+                                      createdBy: String,
+                                      modifiedAt: Timestamp,
+                                      modifiedBy: String,
+                                      owner: String,
+                                      label: String,
+                                      description: Option[String],
+                                      machineGenerated: Option[Boolean],
+                                      confidence: Option[Float],
+                                      quality: Option[AnnotationQuality],
+                                      annotationGroup: UUID,
+                                      labeledBy: Option[String] = None,
+                                      verifiedBy: Option[String] = None,
+                                      projectLayerId: UUID,
+                                      ownerName: String,
+                                      ownerProfileImageUri: String)

--- a/app-backend/common/src/main/scala/datamodel/Annotation.scala
+++ b/app-backend/common/src/main/scala/datamodel/Annotation.scala
@@ -297,31 +297,31 @@ final case class AnnotationWithOwnerInfo(id: UUID,
                                          projectLayerId: UUID,
                                          ownerName: String,
                                          ownerProfileImageUri: String)
-  extends GeoJSONSerializable[AnnotationWithOwnerInfo.GeoJSON] {
-    def toGeoJSONFeature = AnnotationWithOwnerInfo.GeoJSON(
-      this.id,
-      this.geometry,
-        AnnotationWithOwnerInfoProperties(
-         this.projectId,
-         this.createdAt,
-         this.createdBy,
-         this.modifiedAt,
-         this.modifiedBy,
-         this.owner,
-         this.label,
-         this.description,
-         this.machineGenerated,
-         this.confidence,
-         this.quality,
-         this.annotationGroup,
-         this.labeledBy,
-         this.verifiedBy,
-         this.projectLayerId,
-         this.ownerName,
-         this.ownerProfileImageUri
-        )
-      )
-  }
+    extends GeoJSONSerializable[AnnotationWithOwnerInfo.GeoJSON] {
+  def toGeoJSONFeature = AnnotationWithOwnerInfo.GeoJSON(
+    this.id,
+    this.geometry,
+    AnnotationWithOwnerInfoProperties(
+      this.projectId,
+      this.createdAt,
+      this.createdBy,
+      this.modifiedAt,
+      this.modifiedBy,
+      this.owner,
+      this.label,
+      this.description,
+      this.machineGenerated,
+      this.confidence,
+      this.quality,
+      this.annotationGroup,
+      this.labeledBy,
+      this.verifiedBy,
+      this.projectLayerId,
+      this.ownerName,
+      this.ownerProfileImageUri
+    )
+  )
+}
 
 object AnnotationWithOwnerInfo {
 
@@ -335,24 +335,26 @@ object AnnotationWithOwnerInfo {
   final case class GeoJSON(id: UUID,
                            geometry: Option[Projected[Geometry]],
                            properties: AnnotationWithOwnerInfoProperties,
-                           _type: String = "Feature") extends GeoJSONFeature
+                           _type: String = "Feature")
+      extends GeoJSONFeature
 }
 
 @JsonCodec
-final case class AnnotationWithOwnerInfoProperties(projectId: UUID,
-                                      createdAt: Timestamp,
-                                      createdBy: String,
-                                      modifiedAt: Timestamp,
-                                      modifiedBy: String,
-                                      owner: String,
-                                      label: String,
-                                      description: Option[String],
-                                      machineGenerated: Option[Boolean],
-                                      confidence: Option[Float],
-                                      quality: Option[AnnotationQuality],
-                                      annotationGroup: UUID,
-                                      labeledBy: Option[String] = None,
-                                      verifiedBy: Option[String] = None,
-                                      projectLayerId: UUID,
-                                      ownerName: String,
-                                      ownerProfileImageUri: String)
+final case class AnnotationWithOwnerInfoProperties(
+    projectId: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    modifiedBy: String,
+    owner: String,
+    label: String,
+    description: Option[String],
+    machineGenerated: Option[Boolean],
+    confidence: Option[Float],
+    quality: Option[AnnotationQuality],
+    annotationGroup: UUID,
+    labeledBy: Option[String] = None,
+    verifiedBy: Option[String] = None,
+    projectLayerId: UUID,
+    ownerName: String,
+    ownerProfileImageUri: String)

--- a/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
+++ b/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
@@ -449,7 +449,8 @@ final case class AnnotationQueryParameters(
     maxConfidence: Option[Double] = None,
     quality: Option[String] = None,
     annotationGroup: Option[UUID] = None,
-    bbox: Iterable[String] = Seq.empty[String]
+    bbox: Iterable[String] = Seq.empty[String],
+    withOwnerInfo: Option[Boolean] = None
 ) {
   val bboxPolygon: Option[Seq[Projected[Polygon]]] =
     BboxUtil.toBboxPolygon(bbox)

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -604,6 +604,9 @@ object Generators extends ArbitraryInstances {
   private def combinedSceneQueryParamsGen: Gen[CombinedSceneQueryParams] =
     Gen.const(CombinedSceneQueryParams())
 
+  private def annotationQueryParametersGen: Gen[AnnotationQueryParameters] =
+    Gen.const(AnnotationQueryParameters())
+
   private def projectSceneQueryParametersGen: Gen[ProjectSceneQueryParameters] =
     Gen.const(ProjectSceneQueryParameters())
 
@@ -965,6 +968,11 @@ object Generators extends ArbitraryInstances {
         sceneCreates <- arbitrary[List[Scene.Create]]
       } yield { (projectLayerCreate, sceneCreates) }
       Arbitrary { Gen.listOfN(5, tupGen) }
+    }
+
+    implicit def arbAnnotationQueryParameters
+      : Arbitrary[AnnotationQueryParameters] = Arbitrary {
+      annotationQueryParametersGen
     }
   }
 }

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -227,9 +227,9 @@ object AnnotationDao extends Dao[Annotation] {
     query.filter(fr"project_id = ${projectId}").filter(annotationId).delete
 
   def createAnnotateWithOwnerInfoFilters(
-    projectId: UUID,
-    projectLayerId: UUID,
-    queryParams: AnnotationQueryParameters
+      projectId: UUID,
+      projectLayerId: UUID,
+      queryParams: AnnotationQueryParameters
   ): List[Option[Fragment]] =
     Filters.userQP(queryParams.userParams) ++
       List(
@@ -256,13 +256,13 @@ object AnnotationDao extends Dao[Annotation] {
             Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
           case _ => None
         }
-    )
+      )
 
   def listByLayerWithOwnerInfo(
-    projectId: UUID,
-    pageRequest: PageRequest,
-    queryParams: AnnotationQueryParameters,
-    projectLayerIdO: Option[UUID] = None
+      projectId: UUID,
+      pageRequest: PageRequest,
+      queryParams: AnnotationQueryParameters,
+      projectLayerIdO: Option[UUID] = None
   ): ConnectionIO[PaginatedResponse[AnnotationWithOwnerInfo]] = {
     val selectF: Fragment = fr"""
       SELECT a.id, a.project_id, a.created_at, a.created_by, a.modified_at,
@@ -282,7 +282,9 @@ object AnnotationDao extends Dao[Annotation] {
     for {
       project <- ProjectDao.unsafeGetProjectById(projectId)
       projectLayerId = ProjectDao.getProjectLayerId(projectLayerIdO, project)
-      filters = createAnnotateWithOwnerInfoFilters(projectId, projectLayerId, queryParams)
+      filters = createAnnotateWithOwnerInfoFilters(projectId,
+                                                   projectLayerId,
+                                                   queryParams)
       page <- (selectF ++ fromF ++ Fragments.whereAndOpt(filters: _*) ++ Page(
         pageRequest.copy(
           sort = pageRequest.sort ++ Map("a.modified_at" -> Order.Desc,
@@ -297,11 +299,11 @@ object AnnotationDao extends Dao[Annotation] {
       val hasNext = (pageRequest.offset * pageRequest.limit) + 1 < count
 
       PaginatedResponse[AnnotationWithOwnerInfo](count,
-                                            hasPrevious,
-                                            hasNext,
-                                            pageRequest.offset,
-                                            pageRequest.limit,
-                                            page)
+                                                 hasPrevious,
+                                                 hasNext,
+                                                 pageRequest.offset,
+                                                 pageRequest.limit,
+                                                 page)
     }
   }
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1787,11 +1787,14 @@ paths:
         - Imagery
       parameters:
         - $ref: '#/parameters/projectID'
-        - $ref: '#/parameters/AnnotationLabel'
+        - $ref: '#/parameters/annotationLabel'
         - $ref: '#/parameters/annotationQualityCheck'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/pageSize'
         - $ref: '#/parameters/queryMapToken'
+        - $ref: '#/parameters/bbox'
+        - $ref: '#/parameters/withOwnerInfo'
+        - $ref: '#/parameters/annotationGroup'
       responses:
         200:
           description: 'GeoJSON feature collection containing paginated annotations of this project default layer'
@@ -2888,10 +2891,13 @@ paths:
       parameters:
         - $ref: '#/parameters/projectID'
         - $ref: '#/parameters/layerID'
-        - $ref: '#/parameters/AnnotationLabel'
+        - $ref: '#/parameters/annotationLabel'
         - $ref: '#/parameters/annotationQualityCheck'
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/bbox'
+        - $ref: '#/parameters/withOwnerInfo'
+        - $ref: '#/parameters/annotationGroup'
       responses:
         200:
           description: 'GeoJSON feature collection containing paginated annotations of this project layer'
@@ -4568,7 +4574,7 @@ parameters:
         - 'modifiedAt,desc'
         - 'modifiedAt,asc'
   annotationQualityCheck:
-    name: annotationQualityCheck
+    name: quality
     description: 'Quality check on annotations'
     in: query
     type: string
@@ -4576,10 +4582,10 @@ parameters:
       - 'PASS'
       - 'FAIL'
       - 'NEUTRAL'
-  AnnotationLabel:
-    name: AnnotationLabel
+  annotationLabel:
+    name: label
     in: query
-    description: 'name of a label'
+    description: 'Name of an annotation label'
     type: string
   name:
     name: name
@@ -5046,6 +5052,19 @@ parameters:
     description: 'Bounding box of the form "bbox=southwest_lng,southwest_lat,northeast_lng,northeast_lat". Delimit multiple with semicolons.'
     in: query
     type: string
+    required: false
+  withOwnerInfo:
+    name: withOwnerInfo
+    description: 'Boolean value indicating if to return annotations with owner name and profile picture uri.'
+    in: query
+    type: boolean
+    required: false
+  annotationGroup:
+    name: annotationGroup
+    description: 'UUID of an annotation group'
+    in: query
+    type: string
+    format: uuid
     required: false
   project:
     name: project


### PR DESCRIPTION
## Overview

This PR:
- adds an optional `withOwnerInfo` query parameter to annotation query parameters
- enables listing project annotations and project layer annotations with more owner info `ownerName` and `ownerProfileImageUri` if `withOwnerInfo = true`
- adds property tests for the new sql

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] Swagger specification updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

## Testing Instructions

- Make sure that tests in `AnnotationDaoSpec` pass
- `api/assembly` and then spin up server and frontend
- In the UI, go to a project and create some annotations
- `GET` to `.../api/projects/<project id>/annotations?withOwnerInfo=true` should give you a paginated response of annotations, and for each annotation, it should have `ownerName` and `ownerProfileImageUri` fields
- `GET` to `.../api/projects/<project id>/layers/<project default layer id>/annotations?withOwnerInfo=true` should give you a paginated response of annotations, and for each annotation, it should have `ownerName` and `ownerProfileImageUri` fields
- Update the above two requests to exclude `withOwnerInfo` QP or set it to `false`, they should just return annotations without extra owner info
- Create annotations in other layers of this project, and test step 5 again, and make sure it still works
- Try out the below QPs and make sure they work as expected:
   * `label` -- filter by the name of annotations
   * `annotationGroup` -- filter by uuid of an annotation group
   * `bbox` -- filter by bounding box
- Paste the responded GeoJSON feature collection to any tool/software as you like and make sure they can be visualized

Closes #https://github.com/raster-foundry/raster-foundry/issues/4765
