### PR TITLE
Make './scripts/console sbt' run with dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Enabled inserting annotations in bulk in one `INSERT INTO` command [\#4777](https://github.com/raster-foundry/raster-foundry/pull/4777)
 - Started using swaggerhub for documentation [\#4818](https://github.com/raster-foundry/raster-foundry/pull/4818)
 - Made various UI improvements [\#4801](https://github.com/raster-foundry/raster-foundry/pull/4801)
+- Make `./scripts/console sbt` run with docker dependencies [\#4865](https://github.com/raster-foundry/raster-foundry/pull/4865)
 
 ### Deprecated
 

--- a/scripts/console
+++ b/scripts/console
@@ -20,7 +20,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     elif [ "${1:-}" = "sbt" ]; then
         docker-compose \
-            run --rm --no-deps sbt
+            run --rm sbt
     else
         docker-compose \
             run --rm --no-deps --service-ports \


### PR DESCRIPTION
## Overview

Self-explanatory

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Run `./scripts/console sbt` and notice that the postgres and memcached containers start up
