### PR TITLE
Fix Analysis Exports, Add Layer Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 ### Removed
 
 - Removed layer re-ordering, layer sorting, layer type selection from UI [\#4616](https://github.com/raster-foundry/raster-foundry/pull/4616)
-- Removed lingering database assocation of scenes and projects (in deference to scenes to layers to projects) [\#4764](https://github.com/raster-foundry/raster-foundry/pull/4764)
+- Removed lingering database assocation of scenes and projects (in deference to scenes to layers to projects) [\#4764](https://github.com/raster-foundry/raster-foundry/pull/4764) [\#4867](https://github.com/raster-foundry/raster-foundry/pull/4867)
 - Removed tool categories and tags [\#4779](https://github.com/raster-foundry/raster-foundry/pull/4779)
 
 ### Fixed

--- a/app-backend/common/src/main/scala/datamodel/ExportOptions.scala
+++ b/app-backend/common/src/main/scala/datamodel/ExportOptions.scala
@@ -4,7 +4,9 @@ import java.net.URI
 
 import geotrellis.proj4.CRS
 import geotrellis.vector.{MultiPolygon, Projected}
+import io.circe.{Decoder, ObjectEncoder}
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
+import io.circe.generic.semiauto._
 
 @ConfiguredJsonCodec
 final case class ExportOptions(mask: Option[Projected[MultiPolygon]],
@@ -22,4 +24,7 @@ final case class ExportOptions(mask: Option[Projected[MultiPolygon]],
 
 object ExportOptions {
   implicit val config: Configuration = Configuration.default.withDefaults
+
+  implicit val encoder: ObjectEncoder[ExportOptions] =
+    deriveEncoder[ExportOptions]
 }

--- a/app-backend/common/src/main/scala/datamodel/ExportOptions.scala
+++ b/app-backend/common/src/main/scala/datamodel/ExportOptions.scala
@@ -4,9 +4,7 @@ import java.net.URI
 
 import geotrellis.proj4.CRS
 import geotrellis.vector.{MultiPolygon, Projected}
-import io.circe.{Decoder, ObjectEncoder}
 import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
-import io.circe.generic.semiauto._
 
 @ConfiguredJsonCodec
 final case class ExportOptions(mask: Option[Projected[MultiPolygon]],
@@ -24,7 +22,4 @@ final case class ExportOptions(mask: Option[Projected[MultiPolygon]],
 
 object ExportOptions {
   implicit val config: Configuration = Configuration.default.withDefaults
-
-  implicit val encoder: ObjectEncoder[ExportOptions] =
-    deriveEncoder[ExportOptions]
 }

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -784,14 +784,14 @@ object Generators extends ArbitraryInstances {
       operation <- arbitrary[String]
     } yield
       ExportOptions(mask,
-        resolution,
-                          crop,
-                          raw,
-                          bands,
-                          rasterSize,
-                          Some(3857),
-                          new URI(""),
-                          operation)
+                    resolution,
+                    crop,
+                    raw,
+                    bands,
+                    rasterSize,
+                    Some(3857),
+                    new URI(""),
+                    operation)
 
   private def exportCreateGen: Gen[Export.Create] =
     for {

--- a/app-backend/db/src/main/scala/ExportDao.scala
+++ b/app-backend/db/src/main/scala/ExportDao.scala
@@ -6,7 +6,6 @@ import com.rasterfoundry.common.ast._
 import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.common.datamodel.export._
 import com.rasterfoundry.database.Implicits._
-
 import geotrellis.raster._
 import geotrellis.vector.reproject.Implicits._
 import geotrellis.proj4._
@@ -17,8 +16,9 @@ import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-
 import java.util.UUID
+
+import cats.data.NonEmptyList
 
 object ExportDao extends Dao[Export] {
 
@@ -130,8 +130,7 @@ object ExportDao extends Dao[Export] {
         case (Some(projectId), None, None) =>
           for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            mosaicExportSourceList <- mosaicInput(project.defaultLayerId,
-                                                  exportOptions).map(_.asJson)
+            mosaicExportSourceList <- mosaicInput(project.defaultLayerId, exportOptions).map(_.asJson)
           } yield { mosaicExportSourceList }
         case (None, Some(projectLayerId), None) =>
           throw new Exception(
@@ -178,7 +177,7 @@ object ExportDao extends Dao[Export] {
         }
       }.pure[ConnectionIO]
       _ <- logger.debug("Fetched ast").pure[ConnectionIO]
-      projectLocs <- projectIngestLocs(oldAST)
+      exportParameters <- getExportParameters(oldAST)
       _ <- logger
         .debug("Found ingest locations for projects")
         .pure[ConnectionIO]
@@ -190,7 +189,7 @@ object ExportDao extends Dao[Export] {
             exportOptions.resolution,
             mask,
             mamlExpression,
-            projectLocs
+            exportParameters
           )
         case None =>
           throw new Exception("Exports are required to provide a mask")
@@ -233,95 +232,173 @@ object ExportDao extends Dao[Export] {
       ast.withMetadata(NodeMetadata()).withArgs(args)
   }
 
+  private def getProjectLocations(projects: NonEmptyList[UUID])
+    : ConnectionIO[Map[UUID, (List[UUID], List[String])]] = {
+    val q =
+      sql"""SELECT projects.id, array_agg(stl.scene_id), array_agg(scenes.ingest_location)
+    FROM
+    projects
+    LEFT JOIN
+    scenes_to_layers as stl
+    ON
+    projects.default_layer_id = stl.project_layer_id
+    LEFT JOIN
+    scenes
+    ON
+    stl.scene_id = scenes.id
+    """ ++ Fragments.whereAndOpt(
+        Some(Fragments.in(fr"projects.id", projects)),
+        Some(fr"scenes.ingest_location IS NOT null")) ++
+        fr"GROUP BY projects.id"
+    for {
+      projectSceneLocations <- q
+        .query[(UUID, List[UUID], List[String])]
+        .to[List]
+    } yield {
+      projectSceneLocations.map {
+        case (projectId, sceneIds, locations) =>
+          (projectId, (sceneIds, locations))
+      }.toMap
+    }
+  }
+
+  private def getLayerLocations(layers: NonEmptyList[UUID])
+    : ConnectionIO[Map[UUID, (List[UUID], List[String])]] = {
+    val q: Fragment =
+      sql"""SELECT stl.project_layer_id, array_agg(stl.scene_id), array_agg(scenes.ingest_location)
+    FROM
+    scenes_to_layers as stl
+    LEFT JOIN
+    scenes
+    ON
+    stl.scene_id = scenes.id
+    """ ++ Fragments.whereAndOpt(
+        Some(Fragments.in(fr"stl.project_layer_id", layers)),
+        Some(fr"scenes.ingest_location IS NOT null")) ++
+        fr"GROUP BY stl.project_layer_id"
+    for {
+      projectLayerSceneLocations <- q
+        .query[(UUID, List[UUID], List[String])]
+        .to[List]
+    } yield {
+      projectLayerSceneLocations.map {
+        case (layerId, sceneIds, locations) =>
+          (layerId, (sceneIds, locations))
+      }.toMap
+    }
+  }
+
+  sealed trait SourceType
+  final case object ProjectSrc extends SourceType
+  final case object LayerSrc extends SourceType
+
+  final case class Parameters(id: UUID,
+                              sourceType: SourceType,
+                              band: Int,
+                              nodataOverride: Option[Double])
+
   // Returns ID as string and a list of location/band/ndoverride
-  private def projectIngestLocs(ast: MapAlgebraAST)
+  private def getExportParameters(ast: MapAlgebraAST)
     : ConnectionIO[Map[String, List[(String, Int, Option[Double])]]] = {
 
-    final case class Parameters(projectId: UUID,
-                                band: Int,
-                                nodataOverride: Option[Double])
+    // This really, really needs to be fixed upstream.
+    def setNoDataOverride(cellType: CellType): Option[Double] = {
+      cellType match {
+        case BitCellType                         => None
+        case ByteCellType                        => None
+        case UByteCellType                       => None
+        case ShortCellType                       => None
+        case UShortCellType                      => None
+        case IntCellType                         => None
+        case FloatCellType                       => None
+        case DoubleCellType                      => None
+        case ByteConstantNoDataCellType          => Some(Byte.MinValue.toDouble)
+        case UByteConstantNoDataCellType         => Some(0.toDouble)
+        case ShortConstantNoDataCellType         => Some(Short.MinValue.toDouble)
+        case UShortConstantNoDataCellType        => Some(0.toDouble)
+        case IntConstantNoDataCellType           => Some(Int.MinValue.toDouble)
+        case FloatConstantNoDataCellType         => Some(Double.NaN)
+        case DoubleConstantNoDataCellType        => Some(Double.NaN)
+        case ByteUserDefinedNoDataCellType(nd)   => Some(nd.toDouble)
+        case UByteUserDefinedNoDataCellType(nd)  => Some(nd.toDouble)
+        case ShortUserDefinedNoDataCellType(nd)  => Some(nd.toDouble)
+        case UShortUserDefinedNoDataCellType(nd) => Some(nd.toDouble)
+        case IntUserDefinedNoDataCellType(nd)    => Some(nd.toDouble)
+        case FloatUserDefinedNoDataCellType(nd)  => Some(nd.toDouble)
+        case DoubleUserDefinedNoDataCellType(nd) => Some(nd)
+      }
+    }
 
-    val projToIngestLoc: Set[Parameters] = {
+    val parameters: Set[Parameters] = {
       logger.debug(s"AST TILE SOURCES: ${ast.tileSources}")
       logger.debug(s"AST ${ast.asJson}")
+
       ast.tileSources.flatMap { s =>
-        logger.debug(s"RFML RASTER: ${s}")
         s match {
           case s: ProjectRaster =>
             val projectId = s.projId
             val band = s.band.getOrElse(1)
-            // This really, really needs to be fixed upstream.
-            val ndOverride = s.celltype.flatMap {
-              case BitCellType                         => None
-              case ByteCellType                        => None
-              case UByteCellType                       => None
-              case ShortCellType                       => None
-              case UShortCellType                      => None
-              case IntCellType                         => None
-              case FloatCellType                       => None
-              case DoubleCellType                      => None
-              case ByteConstantNoDataCellType          => Some(Byte.MinValue.toDouble)
-              case UByteConstantNoDataCellType         => Some(0.toDouble)
-              case ShortConstantNoDataCellType         => Some(Short.MinValue.toDouble)
-              case UShortConstantNoDataCellType        => Some(0.toDouble)
-              case IntConstantNoDataCellType           => Some(Int.MinValue.toDouble)
-              case FloatConstantNoDataCellType         => Some(Double.NaN)
-              case DoubleConstantNoDataCellType        => Some(Double.NaN)
-              case ByteUserDefinedNoDataCellType(nd)   => Some(nd.toDouble)
-              case UByteUserDefinedNoDataCellType(nd)  => Some(nd.toDouble)
-              case ShortUserDefinedNoDataCellType(nd)  => Some(nd.toDouble)
-              case UShortUserDefinedNoDataCellType(nd) => Some(nd.toDouble)
-              case IntUserDefinedNoDataCellType(nd)    => Some(nd.toDouble)
-              case FloatUserDefinedNoDataCellType(nd)  => Some(nd.toDouble)
-              case DoubleUserDefinedNoDataCellType(nd) => Some(nd)
-            }
-            Some(Parameters(projectId, band, ndOverride))
+            val ndOverride = s.celltype.flatMap(setNoDataOverride)
+            Some(Parameters(projectId, ProjectSrc, band, ndOverride))
+          case s: LayerRaster =>
+            val layerId = s.layerId
+            val band = s.band.getOrElse(1)
+            val ndOverride = s.celltype.flatMap(setNoDataOverride)
+            Some(Parameters(layerId, LayerSrc, band, ndOverride))
           case _ =>
             None
         }
       }
     }
-    logger.debug(s"Project Ingest Locations: ${projToIngestLoc}")
-    logger.debug(s"Working with this many projects: ${projToIngestLoc.size}")
+    logger.debug(s"Parameters: ${parameters}")
+    logger.debug(s"Working with this many parameters: ${parameters.size}")
 
-    val sceneProjectSelect = fr"""
-    SELECT stl.project_layer_id, array_agg(stl.scene_id), array_agg(scenes.ingest_location)
-    FROM
-      scenes_to_layers as stl
-    LEFT JOIN
-      scenes
-    ON
-      stl.scene_id = scenes.id
-    """ ++ Fragments.whereAndOpt(
-      projToIngestLoc.toList
-        .map(_.projectId)
+    val projectIds =
+      parameters
+        .filter(_.sourceType.isInstanceOf[ProjectSrc.type])
+        .map(_.id)
+        .toList
         .toNel
-        .map(ids => Fragments.in(fr"stp.project_id", ids))
-    ) ++ fr"GROUP BY stp.project_id"
-    val projectSceneLocs = for {
-      stps <- sceneProjectSelect
-        .query[(UUID, List[UUID], List[String])]
-        .to[List]
-    } yield {
-      val projectSources = stps.map {
-        case (projectId, sceneIds, locations) =>
-          (projectId, (sceneIds, locations))
-      }.toMap
+    val layerIds =
+      parameters
+        .filter(_.sourceType.isInstanceOf[LayerSrc.type])
+        .map(_.id)
+        .toList
+        .toNel
 
-      projToIngestLoc.flatMap {
-        case parameters =>
-          val projectId = parameters.projectId
-          val band = parameters.band
-          val key = s"${projectId}_${band}"
-          projectSources.get(projectId) match {
-            case Some((sceneIds, locations)) => {
-              val value = locations.map((_, band, parameters.nodataOverride))
+    val sceneLocations = for {
+      projectLocations <- {
+        projectIds match {
+          case Some(ids) => getProjectLocations(ids)
+          case _         => Map[UUID, (List[UUID], List[String])]().pure[ConnectionIO]
+        }
+      }
+      layerLocations <- {
+        layerIds match {
+          case Some(ids) => getLayerLocations(ids)
+          case _         => Map[UUID, (List[UUID], List[String])]().pure[ConnectionIO]
+        }
+      }
+    } yield {
+      parameters.flatMap {
+        case Parameters(id, ProjectSrc, band, nodataOverride) =>
+          val key = s"${id}_${band}"
+          projectLocations.get(id) match {
+            case Some((_, locations)) =>
+              val value = locations.map((_, band, nodataOverride))
               Some(key -> value)
-            }
+            case _ => None
+          }
+        case Parameters(id, LayerSrc, band, nodataOverride) =>
+          val key = s"${id}_${band}"
+          layerLocations.get(id) match {
+            case Some((_, locations)) =>
+              val value = locations.map((_, band, nodataOverride))
+              Some(key -> value)
             case _ => None
           }
       }.toMap
     }
-    projectSceneLocs
+    sceneLocations
   }
 }

--- a/app-backend/db/src/main/scala/ExportDao.scala
+++ b/app-backend/db/src/main/scala/ExportDao.scala
@@ -130,7 +130,8 @@ object ExportDao extends Dao[Export] {
         case (Some(projectId), None, None) =>
           for {
             project <- ProjectDao.unsafeGetProjectById(projectId)
-            mosaicExportSourceList <- mosaicInput(project.defaultLayerId, exportOptions).map(_.asJson)
+            mosaicExportSourceList <- mosaicInput(project.defaultLayerId,
+                                                  exportOptions).map(_.asJson)
           } yield { mosaicExportSourceList }
         case (None, Some(projectLayerId), None) =>
           throw new Exception(

--- a/app-backend/db/src/main/scala/ExportDao.scala
+++ b/app-backend/db/src/main/scala/ExportDao.scala
@@ -205,13 +205,13 @@ object ExportDao extends Dao[Export] {
     SceneToLayerDao.getMosaicDefinition(layerId).compile.toList map { mds =>
       // we definitely need NoData but it isn't obviously available :(
       val ndOverride: Option[Double] = None
-      val layers = mds.map { md =>
+      val layers = mds.flatMap { md =>
         md.ingestLocation.map { location =>
           (location,
            exportOptions.bands.map(_.toList).getOrElse(List()),
            ndOverride)
         }
-      }.flatten
+      }
       exportOptions.mask.map(_.geom.reproject(WebMercator, LatLng)) match {
         case Some(mask) =>
           MosaicExportSource(

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -43,15 +43,16 @@ object UploadDao extends Dao[Upload] {
       // Use posted Upload.Create without modifications in other cases
       projectO <- (newUpload.projectId, newUpload.layerId) match {
         case (Some(projectId), None) => ProjectDao.getProjectById(projectId)
-        case _ => None.pure[ConnectionIO]
+        case _                       => None.pure[ConnectionIO]
       }
       updatedUpload = projectO match {
-        case Some(project) => newUpload.copy(layerId = Some(project.defaultLayerId))
+        case Some(project) =>
+          newUpload.copy(layerId = Some(project.defaultLayerId))
         case _ => newUpload
       }
       upload = updatedUpload.toUpload(user,
-                                  (userPlatform.id, userPlatformAdmin),
-                                  ownerPlatform)
+                                      (userPlatform.id, userPlatformAdmin),
+                                      ownerPlatform)
       insertedUpload <- (
         sql"""
        INSERT INTO uploads

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
@@ -66,8 +66,7 @@ class ExportDaoSpec
               }
             } yield exportDefinition
 
-            val testExportDefinition =
-              xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
+            xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
             true
           }
       }
@@ -110,8 +109,7 @@ class ExportDaoSpec
               }
             } yield exportDefinition
 
-            val testExportDefinition =
-              xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
+            xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
             true
           }
       }
@@ -145,19 +143,23 @@ class ExportDaoSpec
                                                  dbProject.id,
                                                  dbProject.defaultLayerId)
               dbToolRun <- {
-                val projectRaster: ProjectRaster = ProjectRaster(UUID.randomUUID(),
-                                                     dbProject.id,
-                                                     Some(2),
-                                                     None,
-                                                     None)
-                val layerRaster: LayerRaster = LayerRaster(UUID.randomUUID(),
-                                                 dbProject.defaultLayerId,
-                                                 Some(1),
-                                                 None,
-                                                 None)
+                val projectRaster: ProjectRaster =
+                  ProjectRaster(UUID.randomUUID(),
+                                dbProject.id,
+                                Some(2),
+                                None,
+                                None)
+                val layerRaster: LayerRaster =
+                  LayerRaster(UUID.randomUUID(),
+                              dbProject.defaultLayerId,
+                              Some(1),
+                              None,
+                              None)
                 val ast =
                   MapAlgebraAST
-                    .Addition(List(projectRaster, layerRaster), UUID.randomUUID(), None)
+                    .Addition(List(projectRaster, layerRaster),
+                              UUID.randomUUID(),
+                              None)
 
                 val toolRun =
                   toolRunCreate.copy(executionParameters = ast.asJson)
@@ -169,11 +171,11 @@ class ExportDaoSpec
                 ExportDao.insert(export.copy(toolRunId = Some(dbToolRun.id)),
                                  dbUser)
               }
-              exportDefinition <- ExportDao.getExportDefinition(dbExport, dbUser)
+              exportDefinition <- ExportDao.getExportDefinition(dbExport,
+                                                                dbUser)
             } yield exportDefinition
 
-            val testExportDefinition =
-              xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
+            xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
             true
           }
       }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ExportDaoSpec.scala
@@ -1,9 +1,26 @@
 package com.rasterfoundry.database
 
+import java.util.UUID
+
+import com.rasterfoundry.common.ast.MapAlgebraAST
+import com.rasterfoundry.common.ast.MapAlgebraAST.{LayerRaster, ProjectRaster}
+import com.rasterfoundry.common.ast.codec.MapAlgebraCodec
+import com.rasterfoundry.common.datamodel._
+import com.rasterfoundry.common.datamodel.Generators.Implicits._
+import com.rasterfoundry.database.Implicits._
+import io.circe.syntax._
 import doobie.implicits._
 import org.scalatest._
+import org.scalatest.prop.Checkers
+import org.scalacheck.Prop.forAll
 
-class ExportDaoSpec extends FunSuite with Matchers with DBTestConfig {
+class ExportDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers
+    with MapAlgebraCodec {
 
   test("types") {
     xa.use(
@@ -13,5 +30,153 @@ class ExportDaoSpec extends FunSuite with Matchers with DBTestConfig {
       )
       .unsafeRunSync
       .length should be >= 0
+  }
+
+  test("can create an export definition for project export") {
+    check {
+      forAll {
+        (user: User.Create,
+         org: Organization.Create,
+         platform: Platform,
+         projCreate: Project.Create,
+         sceneCreate: Scene.Create,
+         exportCreate: Export.Create) =>
+          {
+            val projectInsertIO = for {
+              (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(user,
+                                                                    org,
+                                                                    platform,
+                                                                    projCreate)
+              randomDatasource <- unsafeGetRandomDatasource
+              dbScene <- {
+                val scene =
+                  fixupSceneCreate(dbUser, randomDatasource, sceneCreate)
+                SceneDao.insert(scene, dbUser)
+              }
+              _ <- ProjectDao.addScenesToProject(List(dbScene.id),
+                                                 dbProject.id,
+                                                 dbProject.defaultLayerId)
+              dbExport <- {
+                val export = exportCreate.toExport(dbUser)
+                ExportDao.insert(export.copy(projectId = Some(dbProject.id)),
+                                 dbUser)
+              }
+              exportDefinition <- {
+                ExportDao.getExportDefinition(dbExport, dbUser)
+              }
+            } yield exportDefinition
+
+            val testExportDefinition =
+              xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
+            true
+          }
+      }
+    }
+  }
+
+  test("can create an export definition for project _layer_ export") {
+    check {
+      forAll {
+        (user: User.Create,
+         org: Organization.Create,
+         platform: Platform,
+         projCreate: Project.Create,
+         sceneCreate: Scene.Create,
+         exportCreate: Export.Create) =>
+          {
+            val projectInsertIO = for {
+              (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(user,
+                                                                    org,
+                                                                    platform,
+                                                                    projCreate)
+              randomDatasource <- unsafeGetRandomDatasource
+              dbScene <- {
+                val scene =
+                  fixupSceneCreate(dbUser, randomDatasource, sceneCreate)
+                SceneDao.insert(scene, dbUser)
+              }
+              _ <- ProjectDao.addScenesToProject(List(dbScene.id),
+                                                 dbProject.id,
+                                                 dbProject.defaultLayerId)
+              dbExport <- {
+                val export = exportCreate.toExport(dbUser)
+                ExportDao.insert(export.copy(projectId = Some(dbProject.id),
+                                             projectLayerId =
+                                               Some(dbProject.defaultLayerId)),
+                                 dbUser)
+              }
+              exportDefinition <- {
+                ExportDao.getExportDefinition(dbExport, dbUser)
+              }
+            } yield exportDefinition
+
+            val testExportDefinition =
+              xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
+            true
+          }
+      }
+    }
+  }
+
+  test(
+    "can create an export definition for tool run with layer and project sources") {
+    check {
+      forAll {
+        (user: User.Create,
+         org: Organization.Create,
+         platform: Platform,
+         projCreate: Project.Create,
+         sceneCreate: Scene.Create,
+         exportCreate: Export.Create,
+         toolRunCreate: ToolRun.Create) =>
+          {
+            val projectInsertIO = for {
+              (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(user,
+                                                                    org,
+                                                                    platform,
+                                                                    projCreate)
+              randomDatasource <- unsafeGetRandomDatasource
+              dbScene <- {
+                val scene =
+                  fixupSceneCreate(dbUser, randomDatasource, sceneCreate)
+                SceneDao.insert(scene, dbUser)
+              }
+              _ <- ProjectDao.addScenesToProject(List(dbScene.id),
+                                                 dbProject.id,
+                                                 dbProject.defaultLayerId)
+              dbToolRun <- {
+                val projectRaster: ProjectRaster = ProjectRaster(UUID.randomUUID(),
+                                                     dbProject.id,
+                                                     Some(2),
+                                                     None,
+                                                     None)
+                val layerRaster: LayerRaster = LayerRaster(UUID.randomUUID(),
+                                                 dbProject.defaultLayerId,
+                                                 Some(1),
+                                                 None,
+                                                 None)
+                val ast =
+                  MapAlgebraAST
+                    .Addition(List(projectRaster, layerRaster), UUID.randomUUID(), None)
+
+                val toolRun =
+                  toolRunCreate.copy(executionParameters = ast.asJson)
+                ToolRunDao.insertToolRun(toolRun, dbUser)
+
+              }
+              dbExport <- {
+                val export = exportCreate.toExport(dbUser)
+                ExportDao.insert(export.copy(toolRunId = Some(dbToolRun.id)),
+                                 dbUser)
+              }
+              exportDefinition <- ExportDao.getExportDefinition(dbExport, dbUser)
+            } yield exportDefinition
+
+            val testExportDefinition =
+              xa.use(t => projectInsertIO.transact(t)).unsafeRunSync
+            true
+          }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Overview

Creating export definitions still relied on the scenes to projects relationship and didn't fully support layer sources in analyses. This PR adds that support and adds tests that will help us catch future problems hopefully when the underlying database changes.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

- In an existing project, create an export - note the the export ID in the server logs
- After rebuilding `batch` and `backsplash-export` run `./scripts/console batch "rf export <export-id>"`
- Create an export for a new analysis and select a layer or something, run an export job

Closes #4851