### PR TITLE
Fix warning for in split modal for projects with a single datasource

### DIFF
--- a/app-frontend/src/app/components/projects/layerSplitModal/index.js
+++ b/app-frontend/src/app/components/projects/layerSplitModal/index.js
@@ -129,7 +129,7 @@ class LayerSplitModalController {
         this.projectService
             .getProjectLayerDatasources(this.projectId, this.layerId)
             .then(datasources => {
-                this.hasMultipleDatasources = datasources.length;
+                this.hasMultipleDatasources = datasources.length > 1;
             });
     }
 


### PR DESCRIPTION
## Overview
See title

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible **(no change, same release)**
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Split a layer with a single datasource and verify that the warning doesn't show up.

Closes https://github.com/raster-foundry/raster-foundry/issues/4858
