### PR TITLE
[wip] Simplify cogification

### DIFF
--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -22,16 +22,15 @@ def create_cog(image_locations, scene, same_path=False):
     with get_tempdir() as local_dir:
         dsts = [os.path.join(local_dir, fname) for _, fname in image_locations]
         cog.fetch_imagery(image_locations, local_dir)
-        warped_paths = cog.warp_tifs(dsts, local_dir)
-        merged_tif = cog.merge_tifs(warped_paths, local_dir)
-        cog.add_overviews(merged_tif)
-        cog_path = cog.convert_to_cog(merged_tif, local_dir)
+        cog_path = cog.merge_tifs(dsts, local_dir)
+        cog.add_overviews(cog_path)
         if same_path:
             updated_scene = upload_tif(
                 cog_path, scene,
-                os.path.join('user-uploads', scene.owner, '{}_COG.tif'.format(scene.id)),
-                os.path.join('user-uploads', urllib.quote_plus(scene.owner), '{}_COG.tif'.format(scene.id))
-            )
+                os.path.join('user-uploads', scene.owner, '{}_COG.tif'.format(
+                    scene.id)),
+                os.path.join('user-uploads', urllib.quote_plus(scene.owner),
+                             '{}_COG.tif'.format(scene.id)))
         else:
             updated_scene = upload_tif(cog_path, scene)
         updated_scene.update()

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -127,10 +127,8 @@ def process_to_cog(prefix, gcs_prefix, landsat_id, config):
         'STACKED': os.path.join(prefix, stacked_fname)
     }
     local_paths = sorted(glob.glob('{}/{}*.TIF'.format(prefix, landsat_id)))
-    warped_paths = cog.warp_tifs(local_paths, prefix)
-    merged = cog.merge_tifs(warped_paths, prefix)
-    cog.add_overviews(merged)
-    cog_path = cog.convert_to_cog(merged, prefix)
+    cog_path = cog.merge_tifs(local_paths, prefix)
+    cog.add_overviews(cog_path)
     shutil.move(cog_path, filenames['COG'])
     return (filenames['COG'], cog_fname)
 

--- a/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
+++ b/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
@@ -71,15 +71,11 @@ def create_geotiffs(modis_path, local_dir):
 
     tifs = sorted(hdf_to_geotiffs(modis_path, local_dir))
     logger.info('Tifs: %s', '\n'.join(tifs))
-    warped_paths = cog.warp_tifs(tifs, local_dir)
-    merged_tif = cog.merge_tifs(warped_paths, local_dir)
+    merged_tif = cog.merge_tifs(tifs, local_dir)
     warp_tif(merged_tif, post_web_mercator_path)
     with rasterio.open(post_web_mercator_path, 'r') as src:
         logger.info('Nodata before adding overviews: %s', src.meta['nodata'])
     cog.add_overviews(post_web_mercator_path)
     with rasterio.open(post_web_mercator_path, 'r') as src:
         logger.info('Nodata after adding overviews: %s', src.meta['nodata'])
-    cog_path = cog.convert_to_cog(post_web_mercator_path, local_dir)
-    with rasterio.open(cog_path, 'r') as src:
-        logger.info('Nodata after cog conversion: %s', src.meta['nodata'])
-    return [cog_path]
+    return [post_web_mercator_path]


### PR DESCRIPTION
## Overview

This PR simplifies cogification by removing the steps where we manually resample and throw tiling in at the end. It was supposed to fix nodata issues as well, but doesn't seem to do so for datasources where the bands have different data types, which is a drag, because that's gonna be just about all the multispectral/hyperspectral imagery we have.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

This might become "fix MODIS nodata / single band issues" if I can figure out how to get gdal to do what I want it to do, but if we go the have-multi-tif scenes route, this step is still useful, so leaving it here for now as a checkpoint.

## Testing Instructions

- create a MODIS upload or add a Sentinel-2 or Landsat 8 scene to a project
- run `process-upload` or `ingest-scene`
- observe that there are like a trillion fewer steps

Closes #XXX
