### PR TITLE
Deduplicate datasources returned from layer datasource endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Deduplicate datasources returned from layer datasource endpoint [\#4885](https://github.com/raster-foundry/raster-foundry/pull/4885)
+
 ### Security
 
 ## [1.19.0](https://github.com/raster-foundry/raster-foundry/tree/1.19.0) (2019-04-16)

--- a/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDatasourcesDao.scala
@@ -14,7 +14,7 @@ object ProjectLayerDatasourcesDao extends Dao[Datasource] {
                      INNER JOIN scenes s ON sl.scene_id = s.id
                      INNER JOIN datasources d on s.datasource = d.id"""
   val selectF = fr"""
-      SELECT
+      SELECT DISTINCT ON (d.id)
         d.id, d.created_at, d.created_by, d.modified_at, d.modified_by, d.owner,
         d.name, d.visibility, d.composites, d.extras, d.bands, d.license_name
           FROM""" ++ tableF

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -60,7 +60,7 @@ class ProjectLayerDatasourceDaoSpec
               "Listed datasources should be the same as that of scenes in this layer")
             assert(
               insertedDatasourceIds.toSet.size == listedDatasourceIds.length,
-              "Listed datasources length should be the same of deduplicated list of scene datasources")
+              "Listed datasources length should be the same as deduplicated list of scene datasources")
             true
           }
       }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectLayerDatasourceDaoSpec.scala
@@ -30,56 +30,38 @@ class ProjectLayerDatasourceDaoSpec
             page: PageRequest
         ) =>
           {
-            val scenesInsertWithUserProjectIO = for {
+            val datasourcesIO = for {
               (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(user,
                                                                     org,
                                                                     platform,
                                                                     project)
-              datasource <- DatasourceDao.create(
-                dsCreate.toDatasource(dbUser),
-                dbUser
-              )
-              scenesInsert <- (scenes map {
+              datasource <- fixupDatasource(dsCreate, dbUser)
+              dbScenes <- (scenes map {
                 fixupSceneCreate(dbUser, datasource, _)
               }).traverse(
                 (scene: Scene.Create) => SceneDao.insert(scene, dbUser)
               )
-            } yield (scenesInsert, dbUser, dbProject, datasource)
-
-            val datasourceListIO = scenesInsertWithUserProjectIO flatMap {
-              case (
-                  dbScenes: List[Scene.WithRelated],
-                  dbUser: User,
-                  dbProject: Project,
-                  datasource: Datasource
-                  ) => {
-                ProjectDao.addScenesToProject(
-                  dbScenes map { _.id },
-                  dbProject.id,
+              _ <- ProjectDao.addScenesToProject(
+                dbScenes map { _.id },
+                dbProject.id,
+                dbProject.defaultLayerId
+              )
+              layerDatsources <- ProjectLayerDatasourcesDao
+                .listProjectLayerDatasources(
                   dbProject.defaultLayerId
-                ) flatMap { _ =>
-                  {
-                    ProjectLayerDatasourcesDao.listProjectLayerDatasources(
-                      dbProject.defaultLayerId
-                    ) map { datasources: List[Datasource] =>
-                      (dbScenes.map { _.datasource }, datasources)
-                    }
-                  }
-                }
-              }
-            }
+                )
+            } yield (dbScenes.map(_.datasource.id), layerDatsources.map(_.id))
 
-            val (insertedDatasources, listedDatasources) =
-              xa.use(t => datasourceListIO.transact(t)).unsafeRunSync
-            val insertedIds = insertedDatasources.toSet map {
-              (datasource: Datasource.Thin) =>
-                datasource.id
-            }
-            val listedIds = listedDatasources.toSet map {
-              (datasource: Datasource) =>
-                datasource.id
-            }
-            insertedIds == listedIds
+            val (insertedDatasourceIds, listedDatasourceIds) =
+              xa.use(t => datasourcesIO.transact(t)).unsafeRunSync
+
+            assert(
+              insertedDatasourceIds.toSet == listedDatasourceIds.toSet,
+              "Listed datasources should be the same as that of scenes in this layer")
+            assert(
+              insertedDatasourceIds.toSet.size == listedDatasourceIds.length,
+              "Listed datasources length should be the same of deduplicated list of scene datasources")
+            true
           }
       }
     }

--- a/app-frontend/src/app/components/projects/layerSplitModal/index.js
+++ b/app-frontend/src/app/components/projects/layerSplitModal/index.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import { get } from 'lodash';
+import { get, uniqBy } from 'lodash';
 
 import tpl from './index.html';
 
@@ -129,7 +129,7 @@ class LayerSplitModalController {
         this.projectService
             .getProjectLayerDatasources(this.projectId, this.layerId)
             .then(datasources => {
-                this.hasMultipleDatasources = datasources.length > 1;
+                this.hasMultipleDatasources = get(uniqBy(datasources, 'id'), 'length') > 1;
             });
     }
 


### PR DESCRIPTION
## Overview

This PR:
- `SELECT DISTINCT ON (datasource.id)` when pulling datasources of scenes in a layer for layer datasource list endpoint
- updates the property test to test that the resulted datasource list is deduplicated for a layer
- adds an extra check on frontend to deduplicate datasources returned from the api for layer split modal

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (tests exist and are updated in this pr)

## Testing Instructions

- Make sure `db/testOnly *ProjectLayerDatasourceDaoSpec` pass
- Reassemble the `jar`s
- Spin up server and frontend
- Go to a project layer with scenes from multiple datasources (V2 frontend), and bring up the layer split modal, check that the modal warns about multiple datasources in layer
- Go to a project layer with scenes from the same datasource (V2 frontend), and bring up the layer split modal, check that the modal does not warn about multiple datasources in layer

Closes https://github.com/raster-foundry/raster-foundry/issues/4858
