### PR TITLE
Don't list all map tokens a user owns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Fixed broken publishing workflow when a user owns too many map tokens [\#4886](https://github.com/raster-foundry/raster-foundry/pull/4886)
+
 ### Security
 
 ## [1.19.0](https://github.com/raster-foundry/raster-foundry/tree/1.19.0) (2019-04-16)

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -92,10 +92,7 @@ object MapTokenDao extends Dao[MapToken] {
       analysesIdsF: Option[Fragment] = (authedAnalyses map { _.id }).toNel map {
         Fragments.in(fr"toolrun_id", _)
       }
-      authFilterF: Fragment = Fragments.orOpt(projIdsF,
-                                              analysesIdsF,
-                                              Some(fr"owner = ${user.id}"))
-      mapTokens <- {
+      authFilterF: Fragment = Fragments.orOpt(projIdsF, analysesIdsF)
         MapTokenDao.query
           .filter(mapTokenParams)
           .filter(authFilterF)

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -93,11 +93,10 @@ object MapTokenDao extends Dao[MapToken] {
         Fragments.in(fr"toolrun_id", _)
       }
       authFilterF: Fragment = Fragments.orOpt(projIdsF, analysesIdsF)
-        MapTokenDao.query
-          .filter(mapTokenParams)
-          .filter(authFilterF)
-          .page(page)
-      }
+      mapTokens <- MapTokenDao.query
+        .filter(mapTokenParams)
+        .filter(authFilterF)
+        .page(page)
     } yield { mapTokens }
   }
 


### PR DESCRIPTION
## Overview

This PR takes out the filter for any  map tokens that happen to be owned by a user.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

There's some other UI bug where we're for some reason firing off two create requests when we try to getOrCreate a map token, but it's in the v1 UI and wasn't immediately obvious, so abandoning.

This might also incidentally fix copying the share url for private projects, or at least locally I was able to visit the share page both with and without a map token (when private / public).

## Testing Instructions

- reassemble your API server
- look at a project
- go to its publish page
- make it private if it's not
- copy its map token
- rejoice
- make it public, then make it private again
- it should still work to copy it
- look at your `GET` requests for map-tokens with the project id filter
- responses should have only the one map token

Closes #4861 
