### PR TITLE
Add single band options from project layer to OgcStyles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Switched general single band options out for configured single band options from RF database [\#4888](https://github.com/raster-foundry/raster-foundry/pull/4888)
+
 ### Deprecated
 
 ### Fixed

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/OgcStyles.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/OgcStyles.scala
@@ -39,18 +39,28 @@ object OgcStyles {
     }
 
   def fromSingleBandOptions(singleBandParams: SingleBandOptions.Params,
-                            layerName: String): OgcStyle = new OgcStyle {
-    val name = s"$layerName - ${singleBandParams.band}"
-    val title = s"$layerName - ${singleBandParams.band}"
-    def renderImage(mbtile: MultibandTile,
-                    format: OutputFormat,
-                    hists: List[Histogram[Double]]): Array[Byte] = {
-      val tile = mbtile.subsetBands(singleBandParams.band)
-      val hist = List(hists(singleBandParams.band))
-      val colored = ColorRampMosaic.colorTile(tile, hist, singleBandParams)
-      toBytes(colored, format)
-    }
+                            layerName: String,
+                            indexBand: Boolean = true): OgcStyle =
+    new OgcStyle {
+      val name = if (indexBand) {
+        s"$layerName - ${singleBandParams.band}"
+      } else {
+        layerName
+      }
+      val title = if (indexBand) {
+        s"$layerName - ${singleBandParams.band}"
+      } else {
+        layerName
+      }
+      def renderImage(mbtile: MultibandTile,
+                      format: OutputFormat,
+                      hists: List[Histogram[Double]]): Array[Byte] = {
+        val tile = mbtile.subsetBands(singleBandParams.band)
+        val hist = List(hists(singleBandParams.band))
+        val colored = ColorRampMosaic.colorTile(tile, hist, singleBandParams)
+        toBytes(colored, format)
+      }
 
-    def legends = Nil
-  }
+      def legends = Nil
+    }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
@@ -1,18 +1,9 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash.{BacksplashMosaic, OgcStore, ProjectStore}
-import com.rasterfoundry.backsplash.color.{
-  BandDataType,
-  OgcStyles,
-  SingleBandOptions
-}
+import com.rasterfoundry.backsplash.color.{OgcStyles, SingleBandOptions}
 import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
-import com.rasterfoundry.common.datamodel.{
-  Band,
-  ColorComposite,
-  Datasource,
-  ProjectLayer
-}
+import com.rasterfoundry.common.datamodel.{ColorComposite, ProjectLayer}
 import com.rasterfoundry.database.{
   LayerAttributeDao,
   ProjectDao,
@@ -26,7 +17,6 @@ import doobie.Transactor
 import doobie.implicits._
 import geotrellis.proj4.{LatLng, WebMercator}
 import geotrellis.raster.histogram.Histogram
-import geotrellis.raster.render.ColorRamps.Viridis
 import geotrellis.server.ogc.{OgcSource, SimpleSource, OgcStyle}
 import geotrellis.server.ogc.ows._
 import geotrellis.server.ogc.wcs.WcsModel
@@ -44,32 +34,6 @@ class OgcImplicits[P: ProjectStore](layers: P, xa: Transactor[IO])
       composites: Map[String, ColorComposite]): List[OgcStyle] =
     composites.values map { OgcStyles.fromColorComposite _ } toList
 
-  private def datasourcesToOgcStyles(
-      datasources: List[Datasource]): List[OgcStyle] = {
-    val bands: List[List[Band.Create]] = datasources map { datasource =>
-      {
-        val decoded = datasource.bands.as[List[Band.Create]]
-        decoded getOrElse Nil
-      }
-    }
-
-    val shortest = bands.minBy(_.length)
-    shortest map { band =>
-      OgcStyles.fromSingleBandOptions(
-        SingleBandOptions.Params(
-          band.number,
-          BandDataType.Sequential,
-          0,
-          Viridis.colors map { color =>
-            s"#${color.toHexString.take(6)}"
-          } asJson,
-          "left"
-        ),
-        s"Single band - ${band.name}"
-      )
-    }
-  }
-
   private def getStyles(projectLayerId: UUID): IO[List[OgcStyle]] =
     for {
       configured <- ProjectLayerDatasourcesDao
@@ -77,16 +41,14 @@ class OgcImplicits[P: ProjectStore](layers: P, xa: Transactor[IO])
         .transact(xa) map { datasources =>
         (datasources flatMap { datasource =>
           compositesToOgcStyles(datasource.composites)
-        }) ++ datasourcesToOgcStyles(datasources)
+        })
       }
       rf <- ProjectLayerDao
         .unsafeGetProjectLayerById(projectLayerId)
         .transact(xa) map { projectLayer =>
         (projectLayer.singleBandOptions asJson)
           .as[SingleBandOptions.Params] map {
-          OgcStyles.fromSingleBandOptions(_,
-                                          "Raster Foundry",
-                                          indexBand = false)
+          OgcStyles.fromSingleBandOptions(_, "Single Band", indexBand = false)
         } toList
       }
     } yield { configured ++ rf }


### PR DESCRIPTION
## Overview

This PR adds a "Raster Foundry" style to OGC layers. It's whatever the database single band options for the project layer happen to be at the time you send a `GetCapabilities` request.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- find a nice project layer with a scene that visualizes well (not MODIS or Sentinel-2)
- add it as a WMS layer to QGIS
- look at the last style available -- it's called Raster Foundry
- look at it
- it should look pretty familiar

Helps with azavea/raster-foundry-platform#682