### PR TITLE
Cascade layer deletion so that exports are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Deduplicate datasources returned from layer datasource endpoint [\#4885](https://github.com/raster-foundry/raster-foundry/pull/4885)
 - Fixed broken publishing workflow when a user owns too many map tokens [\#4886](https://github.com/raster-foundry/raster-foundry/pull/4886)
+- Cascade layer deletion so that exports are deleted [\#4890](https://github.com/raster-foundry/raster-foundry/pull/4890)
 
 ### Security
 

--- a/app-backend/migrations/src/main/scala/migrations/175.scala
+++ b/app-backend/migrations/src/main/scala/migrations/175.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/175.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -172,4 +172,5 @@ object MigrationSummary {
   M172
   M173
   M174
+  M175
 }

--- a/app-backend/migrations/src_migrations/main/scala/175.scala
+++ b/app-backend/migrations/src_migrations/main/scala/175.scala
@@ -1,0 +1,12 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M175 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(175)(
+    List(
+      sqlu"""
+    ALTER TABLE exports DROP CONSTRAINT exports_project_layer_id_fkey;
+    ALTER TABLE exports ADD CONSTRAINT exports_project_layer_id_fkey FOREIGN KEY (project_layer_id) REFERENCES project_layers(id) ON DELETE CASCADE;
+    """
+    ))
+}


### PR DESCRIPTION
## Overview

This PR adds a migration to cascade the deletion of a project layer so that exports are deleted if any.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- [X] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Run migration
- Spin up server and frontend
- Go to a project's V2 UI
- Create a layer and add a scene to it
- Create an export of this image in this layer
- Go to project layer list and delete this layer. Make sure it succeeds.

Closes https://github.com/raster-foundry/raster-foundry/issues/4859
