### PR TITLE
Add analyses to v2 project publish page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- New publish page now lists analyses for selected layers [\4902](https://github.com/raster-foundry/raster-foundry/pull/4902)
 
 ### Changed
 - Improved supported CRS for WMS and WCS Services [\#4875](https://github.com/raster-foundry/raster-foundry/pull/4875)

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -295,13 +295,6 @@ trait ProjectRoutes
                   }
               }
           } ~
-          pathPrefix("analyses") {
-            pathEndOrSingleSlash {
-              get {
-                listProjectAnalyses(projectId)
-              }
-            }
-          } ~
           pathPrefix("project-color-mode") {
             pathEndOrSingleSlash {
               post {
@@ -1165,28 +1158,6 @@ trait ProjectRoutes
       }
     }
   }
-
-  def listProjectAnalyses(projectId: UUID): Route =
-    extractTokenHeader { tokenO =>
-      extractMapTokenParam { mapTokenO =>
-        (projectAuthFromMapTokenO(mapTokenO, projectId) | projectAuthFromTokenO(
-          tokenO,
-          projectId) | projectIsPublic(projectId)) {
-          withPagination { page =>
-            complete {
-              ToolRunDao
-                .listAnalysesWithRelated(
-                  None,
-                  page,
-                  projectId
-                )
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-    }
 
   def processShapefileUpload(matches: Iterator[ScalaFile]): List[String] = {
     // shapefile should have same fields in the property table

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -93,6 +93,7 @@ trait ToolRunRoutes
                           Some(user),
                           page,
                           projectId,
+                          runParams.toolRunParams.projectLayerId,
                           runParams.ownershipTypeParams.ownershipType,
                           runParams.groupQueryParameters.groupType,
                           runParams.groupQueryParameters.groupId
@@ -102,6 +103,7 @@ trait ToolRunRoutes
                       None,
                       page,
                       projectId,
+                      runParams.toolRunParams.projectLayerId,
                       None,
                       None,
                       None

--- a/app-backend/db/src/main/scala/ToolRunDao.scala
+++ b/app-backend/db/src/main/scala/ToolRunDao.scala
@@ -155,6 +155,7 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
   def listAnalysesWithRelated(user: Option[User],
                               pageRequest: PageRequest,
                               projectId: UUID,
+                              layerIdO: Option[UUID] = None,
                               ownershipTypeO: Option[String] = None,
                               groupTypeO: Option[GroupType] = None,
                               groupIdO: Option[UUID] = None)
@@ -172,6 +173,7 @@ object ToolRunDao extends Dao[ToolRun] with ObjectPermissions[ToolRun] {
       """
     val filters: List[Option[Fragment]] = List(
       Some(fr"tr.project_id = ${projectId}"),
+      layerIdO.map(layerId => fr"tr.project_layer_id = ${layerId}"),
       user flatMap {
         queryObjectsF(_,
                       ObjectType.Analysis,

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -67,8 +67,9 @@ class AnalysesListController {
 
     fetchPage(page = this.$state.params.page || 1) {
         this.itemList = [];
-        const currentQuery = this.projectService
-            .getProjectAnalyses(this.project.id, {
+        const currentQuery = this.analysisService
+            .fetchAnalyses({
+                projectId: this.project.id,
                 pageSize: 30,
                 page: page - 1
             })

--- a/app-frontend/src/app/components/pages/project/settings/publishing/index.html
+++ b/app-frontend/src/app/components/pages/project/settings/publishing/index.html
@@ -1,5 +1,8 @@
 <div class="sidebar">
-    <rf-list-item ng-repeat="layer in $ctrl.layerList track by layer.id">
+    <rf-list-item
+        ng-repeat="layer in $ctrl.layerList track by layer.id"
+        ng-click="$ctrl.onSelect(layer)"
+    >
         <item-selector>
             <rf-list-item-selector
                 id="layer.id"
@@ -13,6 +16,22 @@
                 {{ layer.name }}
             </strong>
         </item-title>
+        <item-subtitle ng-if="layer.analysisCount >= 0 || layer.loadingAnalyses">
+            <span
+                ng-show="layer.loadingAnalyses"
+                class="icon-load animate-spin"
+                ng-class="{'stop': !layer.loadingAnalyses}"
+            ></span>
+            <span ng-show="!layer.loadingAnalyses">
+                <ng-pluralize
+                    count="layer.analysisCount"
+                    when="{'0': 'No analyses',
+                            'one': '1 analysis',
+                            'other': '{} analyses'
+                        }"
+                ></ng-pluralize>
+            </span>
+        </item-subtitle>
         <item-date ng-if="layer.rangeStart && layer.rangeEnd">
             {{ layer.rangeStart | date }} - {{ layer.rangeEnd | date }}
         </item-date>
@@ -72,7 +91,7 @@
                     class="radio"
                     ng-repeat="policy in $ctrl.sharePolicies"
                     ng-if="policy.enabled"
-                    ng-click="$ctrl.onPolicyChange(policy)"
+                    ng-click="$ctrl.onPolicyChange(policy, $event)"
                     ng-class="{'active': policy.active}"
                     ng-disabled="!policy.enabled"
                 >
@@ -155,10 +174,20 @@
             </div>
         </div>
     </div>
-    <div class="page-header">
+    <div class="page-header flex-display flex-between">
         <h3>
             Tile layer URLs
         </h3>
+        <button class="btn select-button btn-tiny" ng-click="$ctrl.toggleShowAnalyses()">
+            <label class="checkbox" ng-class="{active: !$ctrl.showAnalyses}">
+                <input
+                    type="checkbox"
+                    ng-checked="!$ctrl.showAnalyses"
+                    ng-click="$ctrl.toggleShowAnalyses()"
+                />
+            </label>
+            <span>Hide Analyses</span>
+        </button>
     </div>
     <div ng-if="!$ctrl.selectedLayers.size" class="page-card">
         <div class="page-card-content center">
@@ -168,84 +197,14 @@
             <p>Select a layer from the list to view its tile layer URLs</p>
         </div>
     </div>
-    <div
+    <rf-map-url-card
         ng-if="$ctrl.selectedLayers.size"
-        class="page-card"
-        ng-repeat="layer in $ctrl.selectedLayers.toArray()"
+        ng-repeat="layer in $ctrl.selectedLayers.toArray() track by layer.id"
+        project="$ctrl.project"
+        layer="layer"
+        map-token="$ctrl.mapToken"
+        share-policy="$ctrl.activePolicy"
+        show-analyses="$ctrl.showAnalyses"
     >
-        <div class="page-card-section">
-            <h4>{{ layer.name }}</h4>
-        </div>
-        <div class="page-card-header">
-            <h5>Base Layer</h5>
-        </div>
-        <div class="form-group">
-            <label for="published-link">ZXY Tile Layer URL</label>
-            <div class="input-group">
-                <input
-                    id="published-link"
-                    type="text"
-                    class="form-control"
-                    value="{{ $ctrl.layerZXYURL(layer) }}"
-                    readonly
-                />
-                <button
-                    class="btn btn-link btn-square btn-icon"
-                    clipboard
-                    text="$ctrl.shareUrl"
-                    ng-click="$ctrl.onCopyClick($event, $ctrl.shareUrl, 'page')"
-                    tooltips
-                    tooltip-size="small"
-                    tooltip-side="top right"
-                    tooltip-template="Copy URL"
-                >
-                    <i
-                        class="icon-copy color-base"
-                        aria-hidden="true"
-                        ng-show="$ctrl.copyType !== 'page'"
-                        ><span class="sr-only">Copy URL</span></i
-                    >
-                    <i
-                        class="icon-check color-green"
-                        aria-hidden="true"
-                        ng-show="$ctrl.copyType === 'page'"
-                    ></i>
-                </button>
-            </div>
-        </div>
-        <div class="form-group">
-            <label for="published-link">ArcGIS Tile Layer URL</label>
-            <div class="input-group">
-                <input
-                    id="published-link"
-                    type="text"
-                    class="form-control"
-                    value="{{ $ctrl.layerArcGISURL(layer) }}"
-                    readonly
-                />
-                <button
-                    class="btn btn-link btn-square btn-icon"
-                    clipboard
-                    text="$ctrl.shareUrl"
-                    ng-click="$ctrl.onCopyClick($event, $ctrl.shareUrl, 'page')"
-                    tooltips
-                    tooltip-size="small"
-                    tooltip-side="top right"
-                    tooltip-template="Copy URL"
-                >
-                    <i
-                        class="icon-copy color-base"
-                        aria-hidden="true"
-                        ng-show="$ctrl.copyType !== 'page'"
-                        ><span class="sr-only">Copy URL</span></i
-                    >
-                    <i
-                        class="icon-check color-green"
-                        aria-hidden="true"
-                        ng-show="$ctrl.copyType === 'page'"
-                    ></i>
-                </button>
-            </div>
-        </div>
-    </div>
+    </rf-map-url-card>
 </div>

--- a/app-frontend/src/app/components/pages/share/analyses/index.js
+++ b/app-frontend/src/app/components/pages/share/analyses/index.js
@@ -45,8 +45,9 @@ class ShareProjectAnalysesController {
 
     fetchPage(page = this.$state.params.page || 1) {
         this.analysisList = [];
-        const currentQuery = this.projectService
-            .getProjectAnalyses(this.project.id, {
+        const currentQuery = this.analysisService
+            .fetchAnalyses(this.project.id, {
+                projectId: this.project.id,
                 pageSize: 10,
                 page: page - 1,
                 mapToken: this.token

--- a/app-frontend/src/app/components/projects/index.js
+++ b/app-frontend/src/app/components/projects/index.js
@@ -9,6 +9,7 @@ import analysisMapItem from './analysisMapItem';
 import projectLayerSelectModal from './projectLayerSelectModal';
 import projectLayerItem from './projectLayerItem';
 import layerSplitModal from './layerSplitModal';
+import mapUrlCard from './mapUrlCard';
 
 export default [
     projectSettingsNavbar,
@@ -21,5 +22,6 @@ export default [
     analysisMapItem,
     projectLayerSelectModal,
     projectLayerItem,
-    layerSplitModal
+    layerSplitModal,
+    mapUrlCard
 ];

--- a/app-frontend/src/app/components/projects/mapUrlCard/index.html
+++ b/app-frontend/src/app/components/projects/mapUrlCard/index.html
@@ -1,0 +1,98 @@
+<div class="page-card">
+    <div class="page-card-section">
+        <h4>{{ $ctrl.layer.name }}</h4>
+    </div>
+    <div class="horizontal-separator page-card-header">
+        <h5>Base Layer</h5>
+    </div>
+    <div class="form-group" ng-repeat="layerUrl in $ctrl.baseLayer.urls track by $index">
+        <label for="published-link">{{ layerUrl.label }}</label>
+        <div class="input-group">
+            <input
+                id="published-link"
+                type="text"
+                class="form-control"
+                value="{{ layerUrl.url }}"
+                readonly
+            />
+            <button
+                class="btn btn-link btn-square btn-icon"
+                clipboard
+                text="layerUrl.url"
+                ng-click="$ctrl.onCopyClick($event, layerUrl.url, layerUrl.label)"
+                tooltips
+                tooltip-size="small"
+                tooltip-side="top right"
+                tooltip-template="Copy URL"
+            >
+                <i
+                    class="icon-copy color-base"
+                    aria-hidden="true"
+                    ng-show="$ctrl.copyType !== layerUrl.label"
+                    ><span class="sr-only">Copy URL</span></i
+                >
+                <i
+                    class="icon-check color-green"
+                    aria-hidden="true"
+                    ng-show="$ctrl.copyType === layerUrl.label"
+                ></i>
+            </button>
+        </div>
+    </div>
+    <div class="horizontal-separator page-card-header" ng-if="$ctrl.analyses && $ctrl.analyses.length">
+        <h5>Analysis Layers</h5>
+    </div>
+    <div ng-if="$ctrl.showAnalyses" ng-repeat="analysis in $ctrl.analyses track by analysis.id">
+        <div class="page-card-header">
+            <h5>{{ analysis.name }} - {{ analysis.date | date }}</h5>
+        </div>
+        <div class="form-group" ng-repeat="analysisUrl in analysis.urls track by analysisUrl.label">
+            <label for="published-link">{{ analysisUrl.label }}</label>
+            <div class="input-group">
+                <input
+                    id="published-link"
+                    type="text"
+                    class="form-control"
+                    value="{{ analysisUrl.url }}"
+                    readonly
+                />
+                <button
+                    class="btn btn-link btn-square btn-icon"
+                    clipboard
+                    text="analysisUrl.url"
+                    ng-click="$ctrl.onCopyClick($event, analysisUrl.url, analysisUrl.label)"
+                    tooltips
+                    tooltip-size="small"
+                    tooltip-side="top right"
+                    tooltip-template="Copy URL"
+                >
+                    <i
+                        class="icon-copy color-base"
+                        aria-hidden="true"
+                        ng-show="$ctrl.copyType !== analysisUrl.label"
+                        ><span class="sr-only">Copy URL</span></i
+                    >
+                    <i
+                        class="icon-check color-green"
+                        aria-hidden="true"
+                        ng-show="$ctrl.copyType === analysisUrl.label"
+                    ></i>
+                </button>
+            </div>
+        </div>
+    </div>
+    <div ng-if="!$ctrl.currentQuery && $ctrl.queryError" class="page-card">
+        <div class="page-card-content center">
+            <span class="modal-icon">
+                <i class="icon-warning color-danger"></i>
+            </span>
+            <p>There was an error fetching analyses</p>
+        </div>
+    </div>
+    <rf-pagination-controls
+        pagination="$ctrl.pagination"
+        is-loading="$ctrl.currentQuery"
+        on-change="$ctrl.fetchPage(undefined, value)"
+        ng-show="$ctrl.showAnalyses"
+    ></rf-pagination-controls>
+</div>

--- a/app-frontend/src/app/components/projects/mapUrlCard/index.js
+++ b/app-frontend/src/app/components/projects/mapUrlCard/index.js
@@ -1,0 +1,225 @@
+import tpl from './index.html';
+import { get } from 'lodash';
+
+const urlMappings = {
+    standard: {
+        label: 'ZXY Tile Layer',
+        z: 'z',
+        x: 'x',
+        y: 'y'
+    },
+    arcGIS: {
+        label: 'ArcGIS',
+        z: 'level',
+        x: 'col',
+        y: 'row'
+    }
+};
+
+class MapUrlCardController {
+    constructor($rootScope, $log, $q, paginationService, projectService, analysisService) {
+        'ngInject';
+        $rootScope.autoInject(this, arguments);
+    }
+
+    $onChanges(changes) {
+        const updatedProject = get(changes, 'project.currentValue');
+        const updatedLayer = get(changes, 'layer.currentValue');
+        const updatedMapToken = get(changes, 'mapToken.currentValue');
+        const updatedSharePolicy = get(changes, 'sharePolicy.currentValue');
+        const updatedShowAnalyses = get(changes, 'showAnalyses.currentValue');
+        const showAnalysesUpdated = typeof updatedShowAnalyses === 'boolean';
+
+        if (updatedProject) {
+            this.project = updatedProject;
+        }
+
+        if (updatedLayer || updatedMapToken || updatedSharePolicy || showAnalysesUpdated) {
+            this.updateLayerUrls(
+                updatedLayer ? updatedLayer : this.layer,
+                updatedMapToken ? updatedMapToken : this.mapToken,
+                updatedSharePolicy ? updatedSharePolicy : this.sharePolicy
+            );
+            this.updateAnalysesUrls(
+                updatedLayer ? updatedLayer : this.layer,
+                updatedMapToken ? updatedMapToken : this.mapToken,
+                updatedSharePolicy ? updatedSharePolicy : this.sharePolicy,
+                showAnalysesUpdated ? updatedShowAnalyses : this.showAnalyses
+            );
+        }
+    }
+
+    mapTileUrl(url, mapping) {
+        return url
+            .replace('{z}', `{${mapping.z}}`)
+            .replace('{x}', `{${mapping.x}}`)
+            .replace('{y}', `{${mapping.y}}`);
+    }
+
+    updateLayerUrls(layer, mapToken, sharePolicy) {
+        if (this.sharePolicy && this.sharePolicy.enum !== 'PRIVATE') {
+            const layerUrl = this.projectService.getProjectLayerTileUrl(
+                this.project,
+                this.layer.id,
+                {
+                    tag: new Date().getTime()
+                },
+                false
+            );
+            this.baseLayer = {
+                urls: [
+                    {
+                        ...urlMappings.standard,
+                        url: this.mapTileUrl(layerUrl, urlMappings.standard)
+                    },
+                    {
+                        ...urlMappings.arcGIS,
+                        url: this.mapTileUrl(layerUrl, urlMappings.arcGIS)
+                    }
+                ],
+                loading: false
+            };
+        } else if (this.mapToken) {
+            const layerUrl = this.projectService.getProjectLayerTileUrl(
+                this.project,
+                this.layer,
+                {
+                    mapToken: this.mapToken.id,
+                    tag: new Date().getTime()
+                },
+                false
+            );
+            this.baseLayer = {
+                urls: [
+                    Object.assign(
+                        {
+                            url: this.mapTileUrl(layerUrl, urlMappings.standard)
+                        },
+                        urlMappings.standard
+                    ),
+                    Object.assign(
+                        {
+                            url: this.mapTileUrl(layerUrl, urlMappings.arcGIS)
+                        },
+                        urlMappings.arcGIS
+                    )
+                ],
+                loading: false
+            };
+        } else {
+            this.baseLayerUrls = {
+                urls: [],
+                loading: true
+            };
+        }
+    }
+
+    updateAnalysesUrls(layer, mapToken, sharePolicy, showAnalyses) {
+        const page = get(this, 'pagination.currentPage', 1);
+        if (!showAnalyses) {
+            this.analyses = [];
+        } else if (sharePolicy.enum === 'PRIVATE') {
+            this.fetchPage(this.layer, page, mapToken);
+        } else {
+            this.fetchPage(this.layer, page, null);
+        }
+    }
+
+    fetchPage(
+        layer = this.layer,
+        page = 1,
+        mapToken = this.sharePolicy === 'PRIVATE' ? this.mapToken : null
+    ) {
+        const currentPage = get(this, 'lastResponse.page');
+        const currentQuery = this.$q((resolve, reject) => {
+            if (currentPage === page - 1 && layer === this.layer && this.lastResponse) {
+                resolve(this.lastResponse);
+            } else {
+                resolve(
+                    this.analysisService.fetchAnalyses({
+                        projectId: this.project.id,
+                        projectLayerId: layer.id,
+                        page: page - 1,
+                        pageSize: 3
+                    })
+                );
+            }
+        })
+            .then(paginatedResponse => {
+                if (this.currentQuery === currentQuery) {
+                    this.lastResponse = paginatedResponse;
+                    this.analyses = paginatedResponse.results.map(analysis => {
+                        const baseUrl = this.analysisToUrl(analysis, mapToken);
+                        return {
+                            id: analysis.id,
+                            name: analysis.name,
+                            date: analysis.modifiedAt,
+                            urls: [
+                                Object.assign(
+                                    {
+                                        url: this.mapTileUrl(baseUrl, urlMappings.standard)
+                                    },
+                                    urlMappings.standard
+                                ),
+                                Object.assign(
+                                    {
+                                        url: this.mapTileUrl(baseUrl, urlMappings.arcGIS)
+                                    },
+                                    urlMappings.arcGIS
+                                )
+                            ]
+                        };
+                    });
+                    this.pagination = this.paginationService.buildPagination(paginatedResponse);
+                    delete this.currentQuery;
+                    delete this.queryError;
+                }
+            })
+            .catch(e => {
+                this.$log.error(e);
+                if (this.currentQuery === currentQuery) {
+                    this.queryError = e;
+                    this.analyses = [];
+                    delete this.currentQuery;
+                }
+            });
+        this.currentQuery = currentQuery;
+        return currentQuery;
+    }
+
+    analysisToUrl(analysis, mapToken) {
+        if (mapToken) {
+            return this.analysisService.getAnalysisTileUrlForProject(
+                this.project.id,
+                analysis.id,
+                {
+                    mapToken: mapToken.id
+                },
+                false
+            );
+        }
+        return this.analysisService.getAnalysisTileUrlForProject(
+            this.project.id,
+            analysis.id,
+            {},
+            false
+        );
+    }
+}
+
+const component = {
+    bindings: {
+        project: '<',
+        layer: '<',
+        mapToken: '<',
+        sharePolicy: '<',
+        showAnalyses: '<'
+    },
+    templateUrl: tpl,
+    controller: MapUrlCardController.name
+};
+
+export default angular
+    .module('components.projects.mapUrlCard', [])
+    .controller(MapUrlCardController.name, MapUrlCardController)
+    .component('rfMapUrlCard', component).name;

--- a/app-frontend/src/app/services/analysis/analysis.service.js
+++ b/app-frontend/src/app/services/analysis/analysis.service.js
@@ -419,13 +419,13 @@ export default app => {
             }).$promise;
         }
 
-        getAnalysisTileUrl(analysisId, params) {
+        getAnalysisTileUrl(analysisId, params, setToken = true) {
             const token = this.authService.token();
             const formattedParams = L.Util.getParamString(
                 _.omitBy(
                     Object.assign(
                         {
-                            token: this.authService.token(),
+                            token: setToken ? this.authService.token() : null,
                             tag: new Date().getTime()
                         },
                         params
@@ -436,13 +436,13 @@ export default app => {
             return `${this.tileServer}/tools/${analysisId}/{z}/{x}/{y}/${formattedParams}`;
         }
 
-        getAnalysisTileUrlForProject(projectId, analysisId, params) {
+        getAnalysisTileUrlForProject(projectId, analysisId, params = {}, setToken = true) {
             const token = this.authService.token();
             const formattedParams = L.Util.getParamString(
                 _.omitBy(
                     Object.assign(
                         {
-                            token: params.mapToken ? null : this.authService.token(),
+                            token: setToken ? this.authService.token() : null,
                             tag: new Date().getTime()
                         },
                         params

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -439,7 +439,7 @@ export default app => {
             throw new Error(
                 'ERROR: Update project.service getProjectCorners to use the ' +
                     'project extent. This function was not updated because ' +
-                    'we don\'t seem to use it anywhere right now.'
+                    "we don't seem to use it anywhere right now."
             );
             // return this.fetchProject(id).then(({project}) => {
 
@@ -869,7 +869,7 @@ export default app => {
         }
 
         getAnnotationsForLayer(projectId, layerId, params) {
-            return this.Project.getAnnotationsForLayer({ projectId, layerId, ...params}).$promise;
+            return this.Project.getAnnotationsForLayer({ projectId, layerId, ...params }).$promise;
         }
     }
 

--- a/app-frontend/src/assets/styles/sass/_shame.scss
+++ b/app-frontend/src/assets/styles/sass/_shame.scss
@@ -3325,6 +3325,7 @@ rf-project-embed-page {
     display: flex;
     flex-direction: column;
     background: #f4f5f7;
+    max-height: 100%;
     .sidebar {
         background: #f4f5f7;
         overflow-y: auto;
@@ -3580,6 +3581,19 @@ rf-list-item {
             border-color: $shade-light;
             color: $brand-primary;
         }
+    }
+}
+
+.filter-light {
+    .btn-toggle {
+        &.active {
+            background: $brand-primary;
+            border-color: $brand-primary;
+            color: $white;
+        }
+        background: $white;
+        border-color: $shade-light;
+        color: $brand-primary;
     }
 }
 
@@ -3990,4 +4004,11 @@ rf-quick-edit-histogram {
 
 rf-list-item item-title a {
     color: inherit;
+}
+
+.horizontal-separator {
+    flex: 1;
+    margin-bottom: 1em;
+    border-radius: 1px;
+    border-bottom: 1px solid $shade-light;
 }

--- a/app-frontend/src/assets/styles/sass/base/_helpers.scss
+++ b/app-frontend/src/assets/styles/sass/base/_helpers.scss
@@ -198,6 +198,9 @@
 .flex-none {
     flex: none !important;
 }
+.flex-between {
+    justify-content: space-between;
+}
 
 .display-i {
     display: inline;

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3224,29 +3224,6 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  /projects/{projectID}/analyses/:
-    get:
-      summary: 'List analyses referencing this project'
-      tags:
-        - Imagery
-      parameters:
-        - $ref: '#/parameters/projectID'
-        - $ref: '#/parameters/pageSize'
-        - $ref: '#/parameters/page'
-      responses:
-        200:
-          description: 'Paginated list of analyses referencing this project'
-          schema:
-            $ref: '#/definitions/ToolRunWithRelatedPaginated'
-        403:
-          description: 'Insufficient permissions for resource or resource does not exist'
-          schema:
-            $ref: '#/definitions/Error'
-        default:
-          description: 'Unexpected error'
-          schema:
-            $ref: '#/definitions/Error'
-
   /areas-of-interest/:
     get:
       summary: 'Get a list of areas of interest'


### PR DESCRIPTION
## Overview
Added analyses to the new project publish page and fixed a bunch of bugs with the url generation and copying.
Fix /tool-runs projectLayerId parameter

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] Swagger specification updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/56811847-aabbb980-6807-11e9-8250-774b547395a0.png)

## Testing Instructions
- Re-assemble your api jar in SBT
- Create a project
- Create three layers on the project
- Create a template which can be used with project layers
- Create 6 analyses on one layer, and 3 analyses on a second
- Verify that when you go to the publish page, each layer lists the number of linked analyses
- Select the layers by clicking anywhere on the list item
- Verify that the urls in the main view make sense, both in the text box and when clicking the copy button and pasting elsewhere
- Make sure the project privacy settings are private
- Verify that the map token is populated and used in all the urls (published page and tile layer urls)
- Verify that the share page works
- Verify that verify that the tile urls work
- Change the project privacy settings to public
- Verify that the map token is no longer in any of the urls or copied text from buttons
- Verify that the share page works
- Verify that the tile urls work

Closes #4860 