### PR TITLE
Prevent splitting polygons which cross the Meridian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed broken publishing workflow when a user owns too many map tokens [\#4886](https://github.com/raster-foundry/raster-foundry/pull/4886)
 - Void tile cache when project layer mask changes [\#4889](https://github.com/raster-foundry/raster-foundry/pulls)
 - Cascade layer deletion so that exports are deleted [\#4890](https://github.com/raster-foundry/raster-foundry/pull/4890)
+- Fix anti-meridian splitting logic also splitting prime-meridian scenes [\#4904](https://github.com/raster-foundry/raster-foundry/pull/4904)
 
 ### Security
 

--- a/app-lambda/rflambda/fields.py
+++ b/app-lambda/rflambda/fields.py
@@ -2,35 +2,94 @@ from typing import List, Optional, Tuple
 
 from pyproj import Proj, transform  # type: ignore
 from shapely.geometry import MultiPolygon, Polygon, mapping  # type: ignore
+from enum import Enum
 
 
-def shift_footprint(footprint: List[Tuple[float, float]]) -> MultiPolygon:
-    """Split a footprint into eastern and western hemisphere components
+class Side(Enum):
+    LEFT = -1
+    RIGHT = 1
 
-    This function splits footprint polygons that cross the anti-meridian into
-    a piece intersecting the Western hemisphere and a piece intersecting the Eastern
-    hemisphere. The reason for this is that if we don't split them, we end up with
-    terrible footprint spanning basically the entire globe, which wreaks havoc on
-    logic that uses the data / tile footprints.
+
+def shift_point(
+        point: Tuple[float, float], split: float, side: Side,
+        inclusive: bool, degrees: float) -> Tuple[float, float]:
     """
-    intersects = len(
-        [x for (x, _) in footprint if x > 0]) not in (len(footprint), 0)
+
+    Args:
+      point - point which will be shifted
+      split - Shift points which are to the left of the split longitude
+      side - Shift points on the specified side of the split
+      inclusive - Shift points on the split line
+      degrees - Degrees longitude to shift a point (positive and negative allowed)
+    """
+    x, y = point[0], point[1]
+    if inclusive:
+        if x * side.value <= split * side.value:
+            return (x + degrees, y)
+        else:
+            return point
+    else:
+        if x * side.value < split * side.value:
+            return (x + degrees, y)
+        else:
+            return point
+
+
+def intersects_antimeridian(footprint: List[Tuple[float, float]]) -> bool:
+    """
+    This does a very simple check:
+    Reproject the polygon to LatLng
+    Shift points in the polygon which have negative values by adding 360 to them so the projection
+        is now on a 0 to 360 degrees projection instead of -180 to 180
+    If the resulting polygon is smaller, then we assume the polygon crosses the antimeridian.
+    We can make this assumption because Landsat and Sentinel do not record imagery in sections which
+    span a large enough portion of the globe to break the assumption
+    We define the anti-meridian as Line(Point(180, -90), Point(180, 90)) because
+        in LatLng, it's Line(Point(-180, -90), Point(-180, 90)) and we add 360 to it
+
+    Eg: A polygon with a left bound of Point(-179, 1) and a right bound of Point(179, 1)
+        would stretch across the entire map. The shifted bounds of Point(179, 1) and Point(181, 1)
+        have a smaller area, so we split the polygon and shift the half which is > 180
+        backward 360 degrees
+
+        A polygon with bounds Point(-1, 1) and Point(1, 1) when shifted will be Point(1, 1)
+        and Point(359, 1). This crosses the anti-meridian, but creates a shape which is larger
+        than the original. We therefore conclude that it does not need splitting.
+    """
+    shifted_footprint = [shift_point(p, 0, Side.RIGHT, False, 360) for p in footprint]
+    return Polygon(footprint).area - 1 > Polygon(shifted_footprint).area
+
+
+def normalize_footprint(footprint: List[Tuple[float, float]]) -> MultiPolygon:
+    """Split footprints which cross the anti-meridian
+
+    Most applications, including RasterFoundry, cannot handle a single polygon representation
+    of anti-meridian crossing footprint.
+    Normalizing footprints by splitting them over the anti-meridian fixes cases where
+    scenes appear to span all longitudes outside their actual footprint.
+    If a footprint covers the anti-meridian, the shape is shifted 360 degrees, split,
+    then the split section is moved back.
+    """
+    intersects = intersects_antimeridian(footprint)
     if not intersects:
         return MultiPolygon([Polygon(footprint)])
     else:
-        west_hemisphere = Polygon([(180, -90), (360, -90), (360, 90),
-                                   (180, 90), (180, -90)])
-        east_hemisphere = Polygon([(0, -90), (180, -90), (180, 90), (0, 90),
-                                   (0, -90)])
-        new_poly = Polygon(
-            [(x if x > 0 else x + 360, y) for x, y in footprint])
-        western = Polygon([
-            (x - 360, y)
-            for x, y in new_poly.intersection(west_hemisphere).exterior.coords
+        shifted_footprint = Polygon([shift_point(p, 0, Side.RIGHT, False, 360) for p in footprint])
+        left_hemisphere_mask = Polygon([(0, -90), (180, -90), (180, 90), (0, 90), (0, -90)])
+        left_split = shifted_footprint.intersection(left_hemisphere_mask)
+        right_split = Polygon([
+            shift_point((x, y), 180, Side.LEFT, True, -360)
+            for x, y
+            in shifted_footprint.difference(left_hemisphere_mask).exterior.coords
         ])
-        eastern = Polygon(
-            new_poly.intersection(east_hemisphere).exterior.coords)
-        return MultiPolygon([western, eastern])
+        if left_split.area > 0 and right_split.area > 0:
+            return MultiPolygon([left_split, right_split])
+        elif left_split.area > 0:
+            return MultiPolygon([left_split])
+        elif right_split.area > 0:
+            return MultiPolygon([right_split])
+        else:
+            return MultiPolygon([])
 
 
 class FilterFields(object):
@@ -57,7 +116,7 @@ class Footprints(object):
         Points are assumed to be in ll, lr, ur, ul order
         """
 
-        data_poly = shift_footprint(data_footprint + [data_footprint[0]])
+        data_poly = normalize_footprint(data_footprint + [data_footprint[0]])
         tile_poly = MultiPolygon([x.envelope for x in data_poly])
         data_polygon = mapping(data_poly)
         tile_polygon = mapping(tile_poly)

--- a/app-lambda/tests/test_footprints.py
+++ b/app-lambda/tests/test_footprints.py
@@ -25,3 +25,14 @@ def test_no_footprint_shift():
     assert shape(footprints.data_polygon).area == good_poly.area
     # Since the shape is rectangular, these should be the same
     assert shape(footprints.tile_polygon).area == shape(footprints.data_polygon).area
+
+
+def test_prime_meridian_footprint():
+    bbox = [(-20, 0), (20, 0), (20, 5), (-20, 5)]
+    good_poly = MultiPolygon(
+        [Polygon(bbox + [bbox[0]])]
+    )
+    footprints = Footprints(bbox)
+    assert shape(footprints.data_polygon).area == good_poly.area
+    # Since the shape is rectangular, these should be the same
+    assert shape(footprints.tile_polygon).area == shape(footprints.data_polygon).area


### PR DESCRIPTION
## Overview
Fix the import lambda splitting footprints that it shouldn't
Add test case for footprints that cross the prime meridian


### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests **_no sql, but updated lambda tests_**

### Demo
![image](https://user-images.githubusercontent.com/4392704/56831352-d0ac8280-6836-11e9-9617-9335f895653a.png)


### Notes
This will not fix existing scenes, I'm going to work on a migration to fix them which will be run separately. Rather get this on staging and tested ASAP.

## Testing Instructions

- Review code
- Run `./scripts/test` and verify that the lambda tests run / pass

Closes #4903 
