### PR TITLE
Add metrics dao and migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
-- New publish page now lists analyses for selected layers [\4902](https://github.com/raster-foundry/raster-foundry/pull/4902)
-
 - Included tests for project layer split behavior [\#4901](https://github.com/raster-foundry/raster-foundry/pull/4901)
+- New publish page now lists analyses for selected layers [\4902](https://github.com/raster-foundry/raster-foundry/pull/4902)
+- Created metrics table and MetricDao for incrementing request counts [\#4916](https://github.com/raster-foundry/raster-foundry/pull/4916)
 
 ### Changed
 - Improved supported CRS for WMS and WCS Services [\#4875](https://github.com/raster-foundry/raster-foundry/pull/4875)

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -1,13 +1,12 @@
 package com.rasterfoundry.backsplash
 
 import geotrellis.contrib.vlm.MosaicRasterSource
-import geotrellis.proj4.{WebMercator, CRS}
+import geotrellis.proj4.CRS
 import geotrellis.vector._
 import geotrellis.raster.histogram._
 import geotrellis.server._
 
 import cats.implicits._
-import cats.data.{NonEmptyList => NEL}
 import cats.data.Validated._
 import cats.effect._
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -230,7 +230,8 @@ lazy val common = project
       Dependencies.rollbar,
       Dependencies.apacheCommonsEmail,
       Dependencies.scalaCheck,
-      Dependencies.akkaHttpExtensions % "test"
+      Dependencies.catsScalacheck,
+      Dependencies.akkaHttpExtensions % "test",
     )
   })
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -230,6 +230,7 @@ lazy val common = project
       Dependencies.rollbar,
       Dependencies.apacheCommonsEmail,
       Dependencies.scalaCheck,
+      Dependencies.catsScalacheck,
       Dependencies.akkaHttpExtensions % "test",
     )
   })

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -230,7 +230,6 @@ lazy val common = project
       Dependencies.rollbar,
       Dependencies.apacheCommonsEmail,
       Dependencies.scalaCheck,
-      Dependencies.catsScalacheck,
       Dependencies.akkaHttpExtensions % "test",
     )
   })

--- a/app-backend/common/src/main/scala/datamodel/Metric.scala
+++ b/app-backend/common/src/main/scala/datamodel/Metric.scala
@@ -1,11 +1,11 @@
 package com.rasterfoundry.common.datamodel
 
-import io.circe.generic.JsonCodec
+import io.circe._
+import io.circe.generic.semiauto._
 
 import java.time.{Instant, LocalDateTime, LocalDate, ZoneOffset}
 import java.util.UUID
 
-@JsonCodec
 case class Metric(
     id: UUID,
     period: (LocalDate, LocalDate),
@@ -15,6 +15,9 @@ case class Metric(
 )
 
 object Metric {
+
+  implicit val encMetric: Encoder[Metric] = deriveEncoder[Metric]
+
   def apply(id: UUID,
             metricEvent: MetricEvent,
             occurredAt: Instant,

--- a/app-backend/common/src/main/scala/datamodel/Metric.scala
+++ b/app-backend/common/src/main/scala/datamodel/Metric.scala
@@ -1,0 +1,36 @@
+package com.rasterfoundry.common.datamodel
+
+import io.circe.generic.JsonCodec
+
+import java.time.{Instant, LocalDateTime, LocalDate, ZoneOffset}
+import java.util.UUID
+
+@JsonCodec
+case class Metric(
+    id: UUID,
+    period: (LocalDate, LocalDate),
+    metricEvent: MetricEvent,
+    value: Int,
+    requester: String
+)
+
+object Metric {
+  def apply(id: UUID,
+            metricEvent: MetricEvent,
+            occurredAt: Instant,
+            value: Int,
+            requester: String): Metric =
+    Metric(
+      id,
+      rangeForInstant(occurredAt),
+      metricEvent,
+      value,
+      requester
+    )
+
+  def rangeForInstant(instant: Instant): (LocalDate, LocalDate) = {
+    val dayStart =
+      LocalDateTime.ofInstant(instant, ZoneOffset.UTC).toLocalDate
+    (dayStart, dayStart.plusDays(1))
+  }
+}

--- a/app-backend/common/src/main/scala/datamodel/MetricEvent.scala
+++ b/app-backend/common/src/main/scala/datamodel/MetricEvent.scala
@@ -1,0 +1,63 @@
+package com.rasterfoundry.common.datamodel
+
+import cats.implicits._
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+
+import java.util.UUID
+
+sealed trait MetricEvent {
+  def toQueryParams: MetricQueryParameters
+}
+
+object MetricEvent {
+  import ProjectLayerMosaicEvent._
+  import AnalysisEvent._
+  implicit val encMetricEvent: Encoder[MetricEvent] = new Encoder[MetricEvent] {
+    def apply(event: MetricEvent) = event match {
+      case plm: ProjectLayerMosaicEvent => plm.asJson
+      case analysis: AnalysisEvent      => analysis.asJson
+    }
+  }
+  implicit val decMetricEvent: Decoder[MetricEvent] = Decoder[
+    ProjectLayerMosaicEvent].widen or Decoder[AnalysisEvent].widen
+}
+
+case class ProjectLayerMosaicEvent(
+    projectId: UUID,
+    projectLayerId: UUID,
+    projectOwner: String
+) extends MetricEvent {
+  def toQueryParams = MetricQueryParameters(
+    projectId = Some(projectId),
+    projectLayerId = Some(projectLayerId),
+    requestType = MetricRequestType.ProjectMosaicRequest
+  )
+}
+
+object ProjectLayerMosaicEvent {
+  implicit val decProjectLayerMosaicEvent: Decoder[ProjectLayerMosaicEvent] =
+    deriveDecoder
+  implicit val encProjectLayerMosaicEvent: Encoder[ProjectLayerMosaicEvent] =
+    deriveEncoder
+}
+
+case class AnalysisEvent(
+    projectId: Option[UUID],
+    projectLayerId: Option[UUID],
+    analysisId: UUID,
+    nodeId: Option[UUID],
+    analysisOwner: String
+) extends MetricEvent {
+  def toQueryParams = MetricQueryParameters(
+    analysisId = Some(analysisId),
+    nodeId = nodeId,
+    requestType = MetricRequestType.AnalysisRequest
+  )
+}
+
+object AnalysisEvent {
+  implicit val decAnalysisEvent: Decoder[AnalysisEvent] = deriveDecoder
+  implicit val encAnalysisEvent: Encoder[AnalysisEvent] = deriveEncoder
+}

--- a/app-backend/common/src/main/scala/datamodel/MetricEvent.scala
+++ b/app-backend/common/src/main/scala/datamodel/MetricEvent.scala
@@ -27,7 +27,8 @@ object MetricEvent {
 case class ProjectLayerMosaicEvent(
     projectId: UUID,
     projectLayerId: UUID,
-    projectOwner: String
+    projectOwner: String,
+    isAnalysis: Boolean = false
 ) extends MetricEvent {
   def toQueryParams = MetricQueryParameters(
     projectId = Some(projectId),
@@ -48,7 +49,8 @@ case class AnalysisEvent(
     projectLayerId: Option[UUID],
     analysisId: UUID,
     nodeId: Option[UUID],
-    analysisOwner: String
+    analysisOwner: String,
+    isAnalysis: Boolean = true
 ) extends MetricEvent {
   def toQueryParams = MetricQueryParameters(
     analysisId = Some(analysisId),

--- a/app-backend/common/src/main/scala/datamodel/MetricRequestType.scala
+++ b/app-backend/common/src/main/scala/datamodel/MetricRequestType.scala
@@ -1,0 +1,8 @@
+package com.rasterfoundry.common.datamodel
+
+sealed trait MetricRequestType
+
+object MetricRequestType {
+  case object ProjectMosaicRequest extends MetricRequestType
+  case object AnalysisRequest extends MetricRequestType
+}

--- a/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
+++ b/app-backend/common/src/main/scala/datamodel/QueryParameters.scala
@@ -636,4 +636,13 @@ object BboxUtil {
           "Four comma separated coordinates must be given for bbox"
         ).initCause(e)
     }
+
 }
+
+final case class MetricQueryParameters(
+    projectId: Option[UUID] = None,
+    projectLayerId: Option[UUID] = None,
+    analysisId: Option[UUID] = None,
+    nodeId: Option[UUID] = None,
+    requestType: MetricRequestType
+)

--- a/app-backend/common/src/main/scala/datamodel/package.scala
+++ b/app-backend/common/src/main/scala/datamodel/package.scala
@@ -79,8 +79,6 @@ trait JsonCodecs {
     new Decoder[(LocalDate, LocalDate)] {
       def apply(c: HCursor): Decoder.Result[(LocalDate, LocalDate)] = {
         val intervalString = c.focus map { _.noSpaces } getOrElse { "\"[,)\"" }
-        println(s"Original focus was: ${c.focus}")
-        println(s"Interval string is: ${intervalString}")
         val (s1, s2) = intervalString
           .replace(" 00:00", "")
           .replace("[", "")

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -1125,6 +1125,7 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbSplitOptions: Arbitrary[SplitOptions] = Arbitrary {
       splitOptionsGen
+    }
 
     implicit def arbMetric: Arbitrary[Metric] = Arbitrary {
       metricGen

--- a/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/azavea/rf/datamodel/implicits/Generators.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.common.datamodel
 
 import java.net.URI
 
+import cats.implicits._
 import com.lonelyplanet.akka.http.extensions.{Order, PageRequest}
 import geotrellis.vector.testkit.Rectangle
 import geotrellis.vector.{MultiPolygon, Point, Polygon, Projected}
@@ -9,6 +10,8 @@ import io.circe.syntax._
 import io.circe.testing.ArbitraryInstances
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
+import org.scalacheck.cats.implicits._
+
 import java.sql.Timestamp
 import java.time.LocalDate
 import java.util.UUID
@@ -166,6 +169,16 @@ object Generators extends ArbitraryInstances {
 
   private def fileTypeGen: Gen[FileType] =
     Gen.oneOf(FileType.Geotiff, FileType.GeotiffWithMetadata)
+
+  private def timeRangeGen: Gen[(LocalDate, LocalDate)] =
+    for {
+      year <- Gen.choose(2005, 2019)
+      month <- Gen.choose(1, 12)
+      day <- Gen.choose(1, 28)
+    } yield {
+      val start = LocalDate.of(year, month, day)
+      (start, start.plusDays(1))
+    }
 
   private def timestampIn2016Gen: Gen[Timestamp] =
     for {
@@ -879,6 +892,48 @@ object Generators extends ArbitraryInstances {
       }
     }
 
+  private def metricEventGen: Gen[MetricEvent] = Gen.oneOf(
+    projectMosaicEventGen.widen,
+    analysisEventGen.widen
+  )
+
+  private def projectMosaicEventGen: Gen[ProjectLayerMosaicEvent] =
+    for {
+      projectId <- uuidGen
+      projectLayerId <- uuidGen
+      projectOwner <- nonEmptyStringGen
+    } yield ProjectLayerMosaicEvent(projectId, projectLayerId, projectOwner)
+
+  private def analysisEventGen: Gen[AnalysisEvent] =
+    for {
+      (projectId, projectLayerId) <- Gen.oneOf(
+        (uuidGen map { Some(_) }, uuidGen map {
+          Some(_)
+        }).tupled,
+        Gen.const((None, None))
+      )
+      analysisId <- uuidGen
+      nodeId <- Gen.oneOf(
+        Gen.const(None),
+        uuidGen map { Some(_) }
+      )
+      analysisOwner <- nonEmptyStringGen
+    } yield
+      AnalysisEvent(projectId,
+                    projectLayerId,
+                    analysisId,
+                    nodeId,
+                    analysisOwner)
+
+  private def metricGen: Gen[Metric] =
+    for {
+      id <- uuidGen
+      period <- timeRangeGen
+      metricEvent <- metricEventGen
+      value <- Gen.const(1)
+      requester <- nonEmptyStringGen
+    } yield { Metric(id, period, metricEvent, value, requester) }
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
       credentialGen
@@ -1070,6 +1125,9 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbSplitOptions: Arbitrary[SplitOptions] = Arbitrary {
       splitOptionsGen
+
+    implicit def arbMetric: Arbitrary[Metric] = Arbitrary {
+      metricGen
     }
   }
 }

--- a/app-backend/db/src/main/scala/MetricDao.scala
+++ b/app-backend/db/src/main/scala/MetricDao.scala
@@ -4,70 +4,59 @@ import com.rasterfoundry.common.datamodel._
 import com.rasterfoundry.database.filter._
 import com.rasterfoundry.database.Implicits._
 
-import cats.implicits._
 import doobie._
 import doobie.postgres.implicits._
 import doobie.implicits._
 
-import java.time.LocalDate
+import java.util.UUID
 
 object MetricDao extends Dao[Metric] {
   val tableName = "metrics"
-  val selectF = sql"""
-    SELECT metrics.id, period, metric_event, value, requester
-  """
+  val selectF = sql"""SELECT
+    id, period, metric_event, metric_value, requester
+  FROM """ ++ tableF
 
-  def uniquenessFilters(metric: Metric) =
+  def unsafeGetMetricById(metricId: UUID): ConnectionIO[Metric] =
+    query.filter(fr"id  = $metricId").select
+
+  // See raster-foundry/raster-foundry #4914 for the beginnings of a plan for
+  // querying and aggregating metrics
+
+  def uniquenessFilters(metric: Metric) = {
+    val periodStart = metric.period._1.toString ++ "T00:00:00Z"
     List(
       Some(fr"requester = ${metric.requester}"),
-      Some(fr"period @> '${metric.period._1}T00:00:00 :: timestamp'")
+      Some(fr"""period @> $periodStart :: timestamp""")
     ) ++ Filters.metricQP(metric.metricEvent.toQueryParams)
+  }
 
   def increment(metric: Metric): ConnectionIO[Int] = {
-    query
+    println(s"Filters are ${uniquenessFilters(metric)}")
+    val q = query
       .filter(uniquenessFilters(metric))
-      .selectOption flatMap {
-      case None =>
+    q.exists flatMap {
+      case false =>
         insert(metric)
-      case Some(s) =>
+      case true =>
         update(metric)
     }
   }
 
-  def sumForRange(range: (LocalDate, LocalDate),
-                  groupBy: String = "requester",
-                  user: User,
-                  params: MetricQueryParameters,
-                  groupByF: Fragment): ConnectionIO[List[Metric]] =
-    for {
-      platform <- UserDao.unsafeGetUserPlatform(user.id)
-      ugrsFiltered = Fragment.const(
-        """
-        (SELECT * FROM user_group_roles
-         WHERE
-           is_active=true and group_type='PLATFORM' and group_id='${platform.id}'
-        ) filt_ugrs""")
-      userScopedTableF = fr"metrics inner join " ++
-        ugrsFiltered ++
-        fr" ON filt_ugrs.user_id = metrics.requester"
-      metrics <- List(selectF,
-                      userScopedTableF,
-                      Fragments.whereAndOpt(Filters.metricQP(params): _*),
-                      groupByF)
-        .intercalate(Fragment.empty)
-        .query[Metric]
-        .to[List]
-    } yield metrics
-
-  def insert(metric: Metric): ConnectionIO[Int] =
-    (fr"""
-      INSERT INTO metrics (id, period, metric_event, value, requester)
+  def insert(metric: Metric): ConnectionIO[Int] = {
+    val baseCount = 1
+    val frag = (fr"""
+      INSERT INTO metrics (id, period, metric_event, metric_value, requester)
       VALUES (
-        ${metric.id}, ${metric.period}, ${metric.metricEvent}, ${metric.value}, ${metric.requester}
+        ${metric.id}, ${metric.period}, ${metric.metricEvent}, $baseCount, ${metric.requester}
       );
-      """).query[Int].unique
+      """)
+    frag.update.run
+  }
 
-  def update(metric: Metric): ConnectionIO[Int] =
-    (fr"UPDATE metrics SET value = value + 1" ++ Fragments.whereAndOpt(
-      uniquenessFilters(metric): _*)).query[Int].unique
+  def update(metric: Metric): ConnectionIO[Int] = {
+    val frag = (Fragment.const(
+      "UPDATE metrics SET metric_value = (metric_value + 1)") ++ Fragments
+      .whereAndOpt(uniquenessFilters(metric): _*))
+    frag.update.run
+  }
 }

--- a/app-backend/db/src/main/scala/MetricDao.scala
+++ b/app-backend/db/src/main/scala/MetricDao.scala
@@ -31,7 +31,6 @@ object MetricDao extends Dao[Metric] {
   }
 
   def increment(metric: Metric): ConnectionIO[Int] = {
-    println(s"Filters are ${uniquenessFilters(metric)}")
     val q = query
       .filter(uniquenessFilters(metric))
     q.exists flatMap {

--- a/app-backend/db/src/main/scala/MetricDao.scala
+++ b/app-backend/db/src/main/scala/MetricDao.scala
@@ -1,0 +1,73 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.common.datamodel._
+import com.rasterfoundry.database.filter._
+import com.rasterfoundry.database.Implicits._
+
+import cats.implicits._
+import doobie._
+import doobie.postgres.implicits._
+import doobie.implicits._
+
+import java.time.LocalDate
+
+object MetricDao extends Dao[Metric] {
+  val tableName = "metrics"
+  val selectF = sql"""
+    SELECT metrics.id, period, metric_event, value, requester
+  """
+
+  def uniquenessFilters(metric: Metric) =
+    List(
+      Some(fr"requester = ${metric.requester}"),
+      Some(fr"period @> '${metric.period._1}T00:00:00 :: timestamp'")
+    ) ++ Filters.metricQP(metric.metricEvent.toQueryParams)
+
+  def increment(metric: Metric): ConnectionIO[Int] = {
+    query
+      .filter(uniquenessFilters(metric))
+      .selectOption flatMap {
+      case None =>
+        insert(metric)
+      case Some(s) =>
+        update(metric)
+    }
+  }
+
+  def sumForRange(range: (LocalDate, LocalDate),
+                  groupBy: String = "requester",
+                  user: User,
+                  params: MetricQueryParameters,
+                  groupByF: Fragment): ConnectionIO[List[Metric]] =
+    for {
+      platform <- UserDao.unsafeGetUserPlatform(user.id)
+      ugrsFiltered = Fragment.const(
+        """
+        (SELECT * FROM user_group_roles
+         WHERE
+           is_active=true and group_type='PLATFORM' and group_id='${platform.id}'
+        ) filt_ugrs""")
+      userScopedTableF = fr"metrics inner join " ++
+        ugrsFiltered ++
+        fr" ON filt_ugrs.user_id = metrics.requester"
+      metrics <- List(selectF,
+                      userScopedTableF,
+                      Fragments.whereAndOpt(Filters.metricQP(params): _*),
+                      groupByF)
+        .intercalate(Fragment.empty)
+        .query[Metric]
+        .to[List]
+    } yield metrics
+
+  def insert(metric: Metric): ConnectionIO[Int] =
+    (fr"""
+      INSERT INTO metrics (id, period, metric_event, value, requester)
+      VALUES (
+        ${metric.id}, ${metric.period}, ${metric.metricEvent}, ${metric.value}, ${metric.requester}
+      );
+      """).query[Int].unique
+
+  def update(metric: Metric): ConnectionIO[Int] =
+    (fr"UPDATE metrics SET value = value + 1" ++ Fragments.whereAndOpt(
+      uniquenessFilters(metric): _*)).query[Int].unique
+}

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -377,6 +377,11 @@ trait Filterables extends RFMeta with LazyLogging {
           Filters.platformIdQP(params.platformIdParams)
     }
 
+  implicit def metricQueryParamsFilter: Filterable[Any, MetricQueryParameters] =
+    Filterable[Any, MetricQueryParameters] { params =>
+      Filters.metricQP(params)
+    }
+
   implicit val orgSearchQueryParamsFilter
     : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
@@ -400,7 +405,6 @@ trait Filterables extends RFMeta with LazyLogging {
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
-
 }
 
 object Filterables extends Filterables

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -111,4 +111,28 @@ object Filters {
     List(platformIdParams.platformId.map(platformId =>
       fr"platform_id = ${platformId}"))
   }
+
+  def metricQP(
+      metricQueryParams: MetricQueryParameters): List[Option[Fragment]] = {
+    List(
+      metricQueryParams.projectId map { projId =>
+        fr"""metric_event @> '{"projectId": "$projId"}'"""
+      },
+      metricQueryParams.projectLayerId map { projLayerId =>
+        fr"""metric_event @> '{"projectLayerId": "$projLayerId"}'"""
+      },
+      metricQueryParams.analysisId map { analysisId =>
+        fr"""metric_event @> '{"analysisId": "$analysisId"}'"""
+      },
+      metricQueryParams.nodeId map { nodeId =>
+        fr"""metric_event @> '{"nodeId": "$nodeId"}'"""
+      },
+      metricQueryParams.requestType match {
+        case MetricRequestType.ProjectMosaicRequest =>
+          Some(fr"""metric_event ? 'projectOwner'""")
+        case MetricRequestType.AnalysisRequest =>
+          Some(fr"""metric_event ? 'analysisOwner'""")
+      }
+    )
+  }
 }

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -10,7 +10,6 @@ import io.circe.syntax._
 
 import scala.reflect.runtime.universe.TypeTag
 import java.net.URI
-import java.time.LocalDate
 
 object CirceJsonbMeta {
   def apply[Type: TypeTag: Encoder: Decoder] = {
@@ -56,9 +55,6 @@ trait CirceJsonbMeta {
 
   implicit val jsonMeta: Meta[Json] =
     CirceJsonbMeta[Json]
-
-  implicit val timeRangeMeta: Meta[(LocalDate, LocalDate)] =
-    CirceJsonbMeta[(LocalDate, LocalDate)]
 
   implicit val metricEventMeta: Meta[MetricEvent] =
     CirceJsonbMeta[MetricEvent]

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -10,6 +10,7 @@ import io.circe.syntax._
 
 import scala.reflect.runtime.universe.TypeTag
 import java.net.URI
+import java.time.LocalDate
 
 object CirceJsonbMeta {
   def apply[Type: TypeTag: Encoder: Decoder] = {
@@ -55,4 +56,10 @@ trait CirceJsonbMeta {
 
   implicit val jsonMeta: Meta[Json] =
     CirceJsonbMeta[Json]
+
+  implicit val timeRangeMeta: Meta[(LocalDate, LocalDate)] =
+    CirceJsonbMeta[(LocalDate, LocalDate)]
+
+  implicit val metricEventMeta: Meta[MetricEvent] =
+    CirceJsonbMeta[MetricEvent]
 }

--- a/app-backend/db/src/main/scala/meta/package.scala
+++ b/app-backend/db/src/main/scala/meta/package.scala
@@ -23,7 +23,6 @@ package object meta {
           // We can't piggy-back on json here, since the format of the interval string makes
           // circe _extremely angry_ and we can't even construct an HCursor to write a
           // custom decoder.
-          println(s"Value to start is: ${intervalString.getValue}")
           val (s1, s2) = intervalString.getValue
             .replace("\"", "")
             .replace(" 00:00:00", "")
@@ -45,7 +44,6 @@ package object meta {
             val o = new PGobject
             o.setType("tsrange")
             o.setValue(a.asJson.noSpaces.replace("\"", ""))
-            println(o)
             o
           }
         )

--- a/app-backend/db/src/main/scala/meta/package.scala
+++ b/app-backend/db/src/main/scala/meta/package.scala
@@ -1,9 +1,53 @@
 package com.rasterfoundry.database
 
+import com.rasterfoundry.common.datamodel._
+
+import cats.syntax.either._
+import doobie._
+import io.circe.syntax._
+import org.postgresql.util.PGobject
+
+import java.time.LocalDate
+
 package object meta {
   trait RFMeta
       extends GtWktMeta
       with CirceJsonbMeta
       with EnumMeta
-      with PermissionsMeta
+      with PermissionsMeta {
+
+    implicit val timeRangeMeta: Meta[(LocalDate, LocalDate)] =
+      Meta.Advanced
+        .other[PGobject]("tsrange")
+        .timap[(LocalDate, LocalDate)](intervalString => {
+          // We can't piggy-back on json here, since the format of the interval string makes
+          // circe _extremely angry_ and we can't even construct an HCursor to write a
+          // custom decoder.
+          println(s"Value to start is: ${intervalString.getValue}")
+          val (s1, s2) = intervalString.getValue
+            .replace("\"", "")
+            .replace(" 00:00:00", "")
+            .replace("[", "")
+            .replace(")", "")
+            .split(",")
+            .toList match {
+            case h :: t :: Nil =>
+              (h, t)
+            case _ =>
+              ("", "")
+          }
+          Either
+            .catchNonFatal((LocalDate.parse(s1), LocalDate.parse(s2)))
+            .leftMap[(LocalDate, LocalDate)](e => throw e)
+            .merge
+        })(
+          a => {
+            val o = new PGobject
+            o.setType("tsrange")
+            o.setValue(a.asJson.noSpaces.replace("\"", ""))
+            println(o)
+            o
+          }
+        )
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MetricDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MetricDaoSpec.scala
@@ -27,7 +27,8 @@ class MetricDaoSpec
         {
           val repetitions = getRepetitionAttempts(0)
           val metricIO = for {
-            _ <- MetricDao.increment(metric)            countOnce <- MetricDao.unsafeGetMetricById(metric.id)
+            _ <- MetricDao.increment(metric)
+            countOnce <- MetricDao.unsafeGetMetricById(metric.id)
             _ <- List.fill(repetitions)(()) traverse { _ =>
               MetricDao.increment(metric)
             }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MetricDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MetricDaoSpec.scala
@@ -27,11 +27,7 @@ class MetricDaoSpec
         {
           val repetitions = getRepetitionAttempts(0)
           val metricIO = for {
-            _ <- MetricDao.increment(metric) map { result =>
-              println(s"Result is: $result")
-              result
-            }
-            countOnce <- MetricDao.unsafeGetMetricById(metric.id)
+            _ <- MetricDao.increment(metric)            countOnce <- MetricDao.unsafeGetMetricById(metric.id)
             _ <- List.fill(repetitions)(()) traverse { _ =>
               MetricDao.increment(metric)
             }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MetricDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MetricDaoSpec.scala
@@ -1,0 +1,52 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.common.datamodel._
+import com.rasterfoundry.common.datamodel.Generators.Implicits._
+
+import doobie.implicits._
+import cats.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatest.prop.Checkers
+
+import scala.util.Random
+
+class MetricDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+  // 0.8 cutoff means it's about 50/50 whether we get three repetitions
+  // 3 seemed like a nice number to expect on average
+  def getRepetitionAttempts(init: Int): Int =
+    if (Random.nextFloat > 0.8) init else getRepetitionAttempts(init + 1)
+  test("insert and update a metric") {
+    check {
+      forAll { (metric: Metric) =>
+        {
+          val repetitions = getRepetitionAttempts(0)
+          val metricIO = for {
+            _ <- MetricDao.increment(metric) map { result =>
+              println(s"Result is: $result")
+              result
+            }
+            countOnce <- MetricDao.unsafeGetMetricById(metric.id)
+            _ <- List.fill(repetitions)(()) traverse { _ =>
+              MetricDao.increment(metric)
+            }
+            countAgain <- MetricDao.unsafeGetMetricById(metric.id)
+          } yield { (countOnce, countAgain) }
+
+          val (initial, afterUpdate) = metricIO.transact(xa).unsafeRunSync
+          assert(initial.value == 1,
+                 "On insert, the count for this metric should be 1")
+          assert(
+            afterUpdate.value == 1 + repetitions,
+            "After updating, the count for this metric should be 1 + the number of updates")
+          true
+        }
+      }
+    }
+  }
+}

--- a/app-backend/migrations/src/main/scala/migrations/176.scala
+++ b/app-backend/migrations/src/main/scala/migrations/176.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/176.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -173,4 +173,5 @@ object MigrationSummary {
   M173
   M174
   M175
+  M176
 }

--- a/app-backend/migrations/src_migrations/main/scala/176.scala
+++ b/app-backend/migrations/src_migrations/main/scala/176.scala
@@ -1,0 +1,20 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M176 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(176)(
+    List(
+      sqlu"""
+CREATE TABLE metrics (
+    id           UUID PRIMARY KEY NOT NULL,
+    period       tsrange NOT NULL,
+    metric_event jsonb NOT NULL,
+    value        int NOT NULL,
+    requester    varchar(255) REFERENCES users(id) NOT NULL
+);
+
+CREATE INDEX metrics_period_idx ON metrics(period);
+CREATE INDEX metrics_metric_event_idx ON metrics USING GIN (metric_event);
+"""
+    ))
+}

--- a/app-backend/migrations/src_migrations/main/scala/176.scala
+++ b/app-backend/migrations/src_migrations/main/scala/176.scala
@@ -5,12 +5,14 @@ object M176 {
   RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(176)(
     List(
       sqlu"""
+-- requester doesn't reference users for auditability reasons,
+-- so we can keep metrics after deleting users, if that ever happens
 CREATE TABLE metrics (
-    id           UUID PRIMARY KEY NOT NULL,
+    id           uuid PRIMARY KEY NOT NULL,
     period       tsrange NOT NULL,
     metric_event jsonb NOT NULL,
-    value        int NOT NULL,
-    requester    varchar(255) REFERENCES users(id) NOT NULL
+    metric_value int NOT NULL,
+    requester    varchar(255) NOT NULL
 );
 
 CREATE INDEX metrics_period_idx ON metrics(period);

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Version {
   val cats = "1.4.0"
   val catsEffect = "1.0.0"
   val catsMeow = "0.2.0"
+  val catsScalacheck = "0.1.1"
   val chill = "0.9.2"
   val circe = "0.11.1"
   val circeOptics = "0.11.0"
@@ -75,6 +76,7 @@ object Dependencies {
   val catsCore = "org.typelevel" %% "cats-core" % Version.cats
   val catsEffect = "org.typelevel" %% "cats-effect" % Version.catsEffect
   val catsMeow = "com.olegpy" %% "meow-mtl" % Version.catsMeow
+  val catsScalacheck = "io.chrisdavenport" %% "cats-scalacheck" % Version.catsScalacheck % "test"
   val chill = "com.twitter" %% "chill" % Version.chill
   val circeCore = "io.circe" %% "circe-core" % Version.circe
   val circeGeneric = "io.circe" %% "circe-generic" % Version.circe

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -18,7 +18,6 @@ object Version {
   val cats = "1.4.0"
   val catsEffect = "1.0.0"
   val catsMeow = "0.2.0"
-  val catsScalacheck = "0.1.1"
   val chill = "0.9.2"
   val circe = "0.11.1"
   val circeOptics = "0.11.0"
@@ -76,7 +75,6 @@ object Dependencies {
   val catsCore = "org.typelevel" %% "cats-core" % Version.cats
   val catsEffect = "org.typelevel" %% "cats-effect" % Version.catsEffect
   val catsMeow = "com.olegpy" %% "meow-mtl" % Version.catsMeow
-  val catsScalacheck = "io.chrisdavenport" %% "cats-scalacheck" % Version.catsScalacheck % "test"
   val chill = "com.twitter" %% "chill" % Version.chill
   val circeCore = "io.circe" %% "circe-core" % Version.circe
   val circeGeneric = "io.circe" %% "circe-generic" % Version.circe


### PR DESCRIPTION
## Overview

This PR adds a MetricDao and migration to add a metrics table. Metrics are currently insert only, though you can get one by id if you really want to.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests (my god was this unpleasant)

### Notes

There are a few things I learned in this process that hurt a lot:

1. you basically can't use the `?` or `?|` json operators from doobie, since it thinks you want to fill in parameters, but you don't
2. if you want to use json filters in doobie, you have to _first_ create the json filter (e.g. `'{"projectId":"$projId"}` and _then_ interpolate that into your fragment
3. postgres's string representation of intervals plays terribly with circe, doobie wants to map database json into an array or object, so starting with a `[` is a real disaster
4. `ParsingFailure` is a terrible name for an exception, and getting a `ParsingFailure` out of Postgres interaction was a terrible red herring that it took me a few hours to figure out was actually a problem with decoding in circe.

All of that hurt a lot, but at last, look upon the MetricDao and ~despair~ rejoice

## Testing Instructions

- confirm the tests make sense
- `db/testOnly *MetricDaoSpec` from sbt
- ci

Closes #4906
