### PR TITLE
Add migration to fix split prime meridian scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Cascade layer deletion so that exports are deleted [\#4890](https://github.com/raster-foundry/raster-foundry/pull/4890)
 - Filtered out MODIS and Landsat 7 images from less than 24 hours ago when browsing NASA CMR [\#4896](https://github.com/raster-foundry/raster-foundry/pull/4896)
 - Fix anti-meridian splitting logic also splitting prime-meridian scenes [\#4904](https://github.com/raster-foundry/raster-foundry/pull/4904)
+- Fix prime meridian scenes which were split accidentally [\#4921](https://github.com/raster-foundry/raster-foundry/pull/4921)
 
 ### Security
 

--- a/app-backend/migrations/src/main/scala/migrations/177.scala
+++ b/app-backend/migrations/src/main/scala/migrations/177.scala
@@ -1,0 +1,1 @@
+../../../../src_migrations/main/scala/177.scala

--- a/app-backend/migrations/src/main/scala/migrations/Summary.scala
+++ b/app-backend/migrations/src/main/scala/migrations/Summary.scala
@@ -174,4 +174,5 @@ object MigrationSummary {
   M174
   M175
   M176
+  M177
 }

--- a/app-backend/migrations/src_migrations/main/scala/177.scala
+++ b/app-backend/migrations/src_migrations/main/scala/177.scala
@@ -1,0 +1,65 @@
+import slick.jdbc.PostgresProfile.api._
+import com.liyaos.forklift.slick.SqlMigration
+
+object M177 {
+  RFMigrations.migrations = RFMigrations.migrations :+ SqlMigration(177)(
+    List(
+      sqlu"""
+-- Fix scenes on the prime meridian that were split by a faulty lambda script
+
+UPDATE scenes
+   SET data_footprint = (
+     SELECT
+       ST_TRANSFORM(
+         ST_SHIFTLONGITUDE(
+           ST_MULTI(
+             ST_REMOVEREPEATEDPOINTS(
+               ST_MAKEPOLYGON(
+                 ST_ADDPOINT(geom.line, st_startpoint(geom.line))
+               )
+             )
+           )
+         ),
+         3857
+       )
+       from (
+         select
+           ST_MAKELINE(
+             Array(
+               SELECT pts.geom
+                 FROM
+                     ST_DUMPPOINTS(
+                       ST_UNARYUNION(
+                         ST_SHIFTLONGITUDE(
+                           ST_TRANSFORM(scenes.data_footprint, 4326))))
+                     AS pts
+                WHERE NOT ST_INTERSECTS(
+                  pts.geom,
+                  ST_SETSRID(
+                    ST_MAKELINE(
+                      ST_MAKEPOINT(180,90),
+                      ST_MAKEPOINT(180, -90)
+                    ),
+                    4326)
+                )
+             )
+           ) line
+       ) geom
+   )
+       FROM
+       ST_TRANSFORM('SRID=4326;POLYGON((-180 -78, -180 78, -170 78, -170 -78, -180 -78))'::geometry, 3857) AS negative_antimeridian,
+       ST_TRANSFORM('SRID=4326;POLYGON((-5 -78, -5 78, -10 78, -10 -78, -5 -78))'::geometry, 3857) AS offset_prime_antimeridian,
+       ST_TRANSFORM(ST_SetSRID(ST_MAKELINE(ST_MAKEPOINT(0, -89), ST_MAKEPOINT(0,89)), 4326), 3857) AS primemeridian
+ WHERE
+  (
+    ST_INTERSECTS(scenes.data_footprint, negative_antimeridian) AND
+    ST_INTERSECTS(scenes.data_footprint, offset_prime_antimeridian) AND
+    NOT ST_INTERSECTS(scenes.data_footprint, primemeridian)
+  ) and
+  scenes.datasource IN (
+    '697a0b91-b7a8-446e-842c-97cda155554d', '4a50cb75-815d-4fe5-8bc1-144729ce5b42',
+    '55735945-9da5-47c3-8ae4-572b5e11205b', 'eb34ce6d-acf5-49a3-ae43-5b4480a3ff7a'
+  );
+"""
+    ))
+}


### PR DESCRIPTION
## Overview
This migration fixes scenes which were corrupted before the lambda function in https://github.com/raster-foundry/raster-foundry/pull/4904 was fixed

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~ Swagger specification updated~
- [x] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
Scene footprints after being fixed on staging
![image](https://user-images.githubusercontent.com/4392704/57026670-54d08280-6c08-11e9-9e95-e74e9a85ce8f.png)


### Notes
Migration was tested on staging and all fixed scene data_footprints were visually verified in qgis

## Testing Instructions

- Run migration locally and verify that it succeeds without errors

Closes #4909
