### PR TITLE
Add owner name and profile URL to the return of annotation GET endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add lambda function for creating project layer overviews and reorganize project [\#4900](https://github.com/raster-foundry/raster-foundry/pull/4900)
+- Add owner name and profile URL to the return of annotation GET endpoint [\#4924](https://github.com/raster-foundry/raster-foundry/pull/4924)
 
 ### Changed
 

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -29,8 +29,9 @@ object AnnotationDao extends Dao[Annotation] {
   def unsafeGetAnnotationById(annotationId: UUID): ConnectionIO[Annotation] =
     query.filter(annotationId).select
 
-  def getAnnotationById(projectId: UUID,
-                        annotationId: UUID): ConnectionIO[Option[AnnotationWithOwnerInfo]] =
+  def getAnnotationById(
+      projectId: UUID,
+      annotationId: UUID): ConnectionIO[Option[AnnotationWithOwnerInfo]] =
     for {
       annotationO <- query
         .filter(fr"project_id = ${projectId}")
@@ -38,33 +39,37 @@ object AnnotationDao extends Dao[Annotation] {
         .selectOption
       ownerIO = annotationO match {
         case Some(annotation) => UserDao.getUserById(annotation.owner)
-        case None => None.pure[ConnectionIO]
+        case None             => None.pure[ConnectionIO]
       }
       ownerO <- ownerIO
-    } yield { (annotationO, ownerO) match {
-      case (Some(annotation), Some(owner)) => Some(AnnotationWithOwnerInfo(
-        annotation.id,
-        annotation.projectId,
-        annotation.createdAt,
-        annotation.createdBy,
-        annotation.modifiedAt,
-        annotation.modifiedBy,
-        annotation.owner,
-        annotation.label,
-        annotation.description,
-        annotation.machineGenerated,
-        annotation.confidence,
-        annotation.quality,
-        annotation.geometry,
-        annotation.annotationGroup,
-        annotation.labeledBy,
-        annotation.verifiedBy,
-        annotation.projectLayerId,
-        owner.name,
-        owner.profileImageUri
-      ))
-      case _ => None
-    } }
+    } yield {
+      (annotationO, ownerO) match {
+        case (Some(annotation), Some(owner)) =>
+          Some(
+            AnnotationWithOwnerInfo(
+              annotation.id,
+              annotation.projectId,
+              annotation.createdAt,
+              annotation.createdBy,
+              annotation.modifiedAt,
+              annotation.modifiedBy,
+              annotation.owner,
+              annotation.label,
+              annotation.description,
+              annotation.machineGenerated,
+              annotation.confidence,
+              annotation.quality,
+              annotation.geometry,
+              annotation.annotationGroup,
+              annotation.labeledBy,
+              annotation.verifiedBy,
+              annotation.projectLayerId,
+              owner.name,
+              owner.profileImageUri
+            ))
+        case _ => None
+      }
+    }
 
   def listAnnotationsForProject(
       projectId: UUID): ConnectionIO[List[Annotation]] = {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -198,14 +198,14 @@ class AnnotationDaoSpec
               updatedAnnotationO match {
                 case Some(updatedAnnotation) =>
                   updatedAnnotation.label == annotationUpdate.label &&
-                  updatedAnnotation.description == annotationUpdate.description &&
-                  updatedAnnotation.machineGenerated == annotationUpdate.machineGenerated &&
-                  updatedAnnotation.confidence == annotationUpdate.confidence &&
-                  updatedAnnotation.quality == annotationUpdate.quality &&
-                  updatedAnnotation.geometry == annotationUpdate.geometry &&
-                  updatedAnnotation.verifiedBy == Some(verifier.id) &&
-                  updatedAnnotation.ownerName == dbUser.name &&
-                  updatedAnnotation.ownerProfileImageUri == dbUser.profileImageUri
+                    updatedAnnotation.description == annotationUpdate.description &&
+                    updatedAnnotation.machineGenerated == annotationUpdate.machineGenerated &&
+                    updatedAnnotation.confidence == annotationUpdate.confidence &&
+                    updatedAnnotation.quality == annotationUpdate.quality &&
+                    updatedAnnotation.geometry == annotationUpdate.geometry &&
+                    updatedAnnotation.verifiedBy == Some(verifier.id) &&
+                    updatedAnnotation.ownerName == dbUser.name &&
+                    updatedAnnotation.ownerProfileImageUri == dbUser.profileImageUri
               }
             )
           }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -182,25 +182,32 @@ class AnnotationDaoSpec
                   dbUser
                 ) flatMap { (affectedRows: Int) =>
                   {
-                    AnnotationDao.unsafeGetAnnotationById(annotationId) map {
-                      (affectedRows, _, verifier)
+                    AnnotationDao.getAnnotationById(dbProject.id, annotationId) map {
+                      (affectedRows, _, verifier, dbUser)
                     }
                   }
                 }
               }
             }
 
-            val (affectedRows, updatedAnnotation, verifier) =
+            val (affectedRows, updatedAnnotationO, verifier, dbUser) =
               annotationsUpdateWithAnnotationIO.transact(xa).unsafeRunSync
 
             affectedRows == 1 &&
-            updatedAnnotation.label == annotationUpdate.label &&
-            updatedAnnotation.description == annotationUpdate.description &&
-            updatedAnnotation.machineGenerated == annotationUpdate.machineGenerated &&
-            updatedAnnotation.confidence == annotationUpdate.confidence &&
-            updatedAnnotation.quality == annotationUpdate.quality &&
-            updatedAnnotation.geometry == annotationUpdate.geometry &&
-            updatedAnnotation.verifiedBy == Some(verifier.id)
+            (
+              updatedAnnotationO match {
+                case Some(updatedAnnotation) =>
+                  updatedAnnotation.label == annotationUpdate.label &&
+                  updatedAnnotation.description == annotationUpdate.description &&
+                  updatedAnnotation.machineGenerated == annotationUpdate.machineGenerated &&
+                  updatedAnnotation.confidence == annotationUpdate.confidence &&
+                  updatedAnnotation.quality == annotationUpdate.quality &&
+                  updatedAnnotation.geometry == annotationUpdate.geometry &&
+                  updatedAnnotation.verifiedBy == Some(verifier.id) &&
+                  updatedAnnotation.ownerName == dbUser.name &&
+                  updatedAnnotation.ownerProfileImageUri == dbUser.profileImageUri
+              }
+            )
           }
       }
     }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1914,7 +1914,7 @@ paths:
         200:
           description: 'GeoJSON feature containing one annotation from this project default layer'
           schema:
-            $ref: '#/definitions/AnnotationFeature'
+            $ref: '#/definitions/AnnotationFeatureWithOwnerInfo'
         403:
           description: 'Insufficient permissions for resource or resource does not exist'
           schema:
@@ -3019,7 +3019,7 @@ paths:
         200:
           description: 'GeoJSON feature containing one annotation from this project layer'
           schema:
-            $ref: '#/definitions/AnnotationFeature'
+            $ref: '#/definitions/AnnotationFeatureWithOwnerInfo'
         403:
           description: 'Insufficient permissions for resource or resource does not exist'
           schema:
@@ -7232,6 +7232,47 @@ definitions:
           annotationGroup:
             type: string
             format: uuid
+      geometry:
+        $ref: "#/definitions/Geometry"
+
+  AnnotationFeatureWithOwnerInfo:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        allOf:
+        - $ref: '#/definitions/BaseModel'
+        - $ref: '#/definitions/TimeModelMixin'
+        - $ref: '#/definitions/UserTrackingMixin'
+        - type: object
+        properties:
+          label:
+            type: string
+          description:
+            type: string
+          machineGenerated:
+            type: boolean
+          confidence:
+            type: number
+            format: float
+          quality:
+            type: string
+            enum:
+              - 'YES'
+              - 'NO'
+              - 'MISS'
+              - 'MATCH'
+          projectId:
+            type: string
+            format: uuid
+          annotationGroup:
+            type: string
+            format: uuid
+          ownerName:
+            type: string
+          ownerProfileImageUri:
+            type: string
       geometry:
         $ref: "#/definitions/Geometry"
 


### PR DESCRIPTION
## Overview

This PR updates the single annotation `GET` endpoint so that it includes owner name and profile picture url.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] Swagger specification updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (Updated the test)

## Testing Instructions

- CI for `AnnotationDaoSpec` should pass
- Reassemble the api jar
- Spin up server and frontend
- Go to a project and create some annotations, grab project ID and one of annotations' ID
- `GET` to `/api/project/<project ID>/annotations/<annotation ID>` should give you owner name and profile url along with annotation info

Closes #4922 
