### PR TITLE
Don't include all tool run tokens with map tokens for a project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Fixed
 
+- Fixed query parameter handling that listed all tool run map tokens with project map tokens [\#4928](https://github.com/raster-foundry/raster-foundry/pull/4928)
+
 ### Security
 
 ## [1.20.0](https://github.com/raster-foundry/raster-foundry/tree/1.20.0) (2019-05-01)

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.common
 import com.rasterfoundry.datamodel._
 import java.net.URI
 
+import cats.data.{NonEmptyList => NEL}
 import cats.implicits._
 import com.rasterfoundry.datamodel.{Order, PageRequest}
 import geotrellis.vector.testkit.Rectangle
@@ -1133,6 +1134,13 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbMetric: Arbitrary[Metric] = Arbitrary {
       metricGen
+    }
+
+    implicit def arbNEL[T: Arbitrary]: Arbitrary[NEL[T]] = Arbitrary {
+      for {
+        h <- arbitrary[T]
+        t <- arbitrary[List[T]]
+      } yield { NEL(h, t) }
     }
   }
 }

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -92,7 +92,7 @@ object MapTokenDao extends Dao[MapToken] {
       analysesIdsF: Option[Fragment] = (authedAnalyses map { _.id }).toNel map {
         Fragments.in(fr"toolrun_id", _)
       }
-      authFilterF: Fragment = Fragments.orOpt(projIdsF, analysesIdsF)
+      authFilterF: Fragment = projIdsF orElse analysesIdsF getOrElse Fragment.empty
       mapTokens <- MapTokenDao.query
         .filter(mapTokenParams)
         .filter(authFilterF)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MapTokenDaoSpec.scala
@@ -3,6 +3,8 @@ package com.rasterfoundry.database
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.common.Generators.Implicits._
 
+import cats.data.{NonEmptyList => NEL}
+import cats.implicits._
 import doobie.implicits._
 import org.scalatest._
 import org.scalacheck.Prop.forAll
@@ -24,25 +26,35 @@ class MapTokenDaoSpec
   test("Retrieve a map token for a project") {
     check {
       forAll {
-        (mapTokenCreate: MapToken.Create,
-         user: User.Create,
-         project: Project.Create) =>
+        (tokensAndProjects: NEL[(MapToken.Create, Project.Create)],
+         user: User.Create) =>
           {
             val retrievedMapTokensIO =
               for {
                 dbUser <- UserDao.create(user)
-                dbProject <- ProjectDao.insertProject(project, dbUser)
-                dbMapToken <- MapTokenDao.insert(
-                  fixupMapToken(mapTokenCreate, dbUser, Some(dbProject), None),
-                  dbUser
-                )
-                retrievedGood <- MapTokenDao.checkProject(dbProject.id)(
-                  dbMapToken.id)
+                dbMapToken <- tokensAndProjects traverse {
+                  case (token, project) =>
+                    ProjectDao.insertProject(project, dbUser) flatMap {
+                      dbProject =>
+                        MapTokenDao.insert(
+                          fixupMapToken(token, dbUser, Some(dbProject), None),
+                          dbUser
+                        )
+                    }
+                } map { _.head }
+                retrievedGood <- MapTokenDao.checkProject(
+                  dbMapToken.project.get)(dbMapToken.id)
                 retrievedBad <- MapTokenDao.checkProject(UUID.randomUUID)(
                   dbMapToken.id)
-              } yield { (dbMapToken, retrievedGood, retrievedBad) }
+                listed <- MapTokenDao.listAuthorizedMapTokens(
+                  dbUser,
+                  CombinedMapTokenQueryParameters(
+                    mapTokenParams =
+                      MapTokenQueryParameters(projectId = dbMapToken.project)),
+                  PageRequest(0, 10, Map.empty))
+              } yield { (dbMapToken, retrievedGood, retrievedBad, listed) }
 
-            val (mapToken, shouldBeSome, shouldBeNone) =
+            val (mapToken, shouldBeSome, shouldBeNone, listed) =
               retrievedMapTokensIO.transact(xa).unsafeRunSync
 
             assert(
@@ -52,6 +64,10 @@ class MapTokenDaoSpec
             assert(
               shouldBeNone == None,
               "; Bogus IDs should not return a map token"
+            )
+            assert(
+              listed.results.length == 1,
+              "; Only one map token should have come back for a project"
             )
 
             true


### PR DESCRIPTION
## Overview

This PR introduces a test to make sure that when we list map tokens for a project we only get one back. It also makes changes necessary to get that to happen, now that I figured out what the problem is in real life.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

- look at tests
- share a tool run with a map token
- list map tokens for a project in the frontend
- observe that you don't get extras from tool runs

Closes #4861, again