### PR TITLE
Get and write group roles from JWT claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+
 - Add lambda function for creating project layer overviews and reorganize project [\#4900](https://github.com/raster-foundry/raster-foundry/pull/4900)
 - Add owner name and profile URL to the return of annotation GET endpoint [\#4924](https://github.com/raster-foundry/raster-foundry/pull/4924)
-
 - Added request counting middleware to backsplash-server [\#4919](https://github.com/raster-foundry/raster-foundry/pull/4919)
+- Enabled getting and writing user group roles from JWT [\#4931](https://github.com/raster-foundry/raster-foundry/pull/4931)
 
 ### Changed
 
@@ -21,11 +22,13 @@
 ## [1.20.0](https://github.com/raster-foundry/raster-foundry/tree/1.20.0) (2019-05-01)
 
 ### Added
+
 - Included tests for project layer split behavior [\#4901](https://github.com/raster-foundry/raster-foundry/pull/4901)
 - New publish page now lists analyses for selected layers [\4902](https://github.com/raster-foundry/raster-foundry/pull/4902)
 - Created metrics table and MetricDao for incrementing request counts [\#4916](https://github.com/raster-foundry/raster-foundry/pull/4916)
 
 ### Changed
+
 - Improved supported CRS for WMS and WCS Services [\#4875](https://github.com/raster-foundry/raster-foundry/pull/4875)
 - Switched general single band options out for configured single band options from RF database [\#4888](https://github.com/raster-foundry/raster-foundry/pull/4888)
 - Add gitSnapshots prefix to Maven Central release command [\#4874](https://github.com/raster-foundry/raster-foundry/pull/4874)

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -237,6 +237,13 @@ trait Authentication extends Directives with LazyLogging {
       }
     )
 
+    val userRole = getStringClaimOrBlank(
+      jwtClaims,
+      "https://app.rasterfoundry.com;platformRole").toUpperCase match {
+      case "ADMIN" => GroupRole.Admin
+      case _       => GroupRole.Member
+    }
+
     for {
       platform <- PlatformDao.getPlatformById(platformId)
       systemUserO <- UserDao.getUserById(auth0SystemUser)
@@ -263,7 +270,7 @@ trait Authentication extends Directives with LazyLogging {
         orgID
       )
       newUserWithRoles <- {
-        UserDao.createUserWithJWT(systemUser, jwtUser)
+        UserDao.createUserWithJWT(systemUser, jwtUser, userRole)
       }
     } yield newUserWithRoles
   }

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -804,7 +804,7 @@ object Generators extends ArbitraryInstances {
       crop <- arbitrary[Boolean]
       raw <- arbitrary[Boolean]
       bands <- arbitrary[Option[Seq[Int]]]
-      operation <- arbitrary[String]
+      operation <- nonEmptyStringGen
     } yield
       ExportOptions(mask,
                     resolution,

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -76,7 +76,8 @@ object UserDao extends Dao[User] with Sanitization {
 
   def createUserWithJWT(
       creatingUser: User,
-      jwtUser: User.JwtFields): ConnectionIO[(User, List[UserGroupRole])] = {
+      jwtUser: User.JwtFields,
+      userRole: GroupRole): ConnectionIO[(User, List[UserGroupRole])] = {
     for {
       organization <- OrganizationDao.query
         .filter(jwtUser.organizationId)
@@ -104,7 +105,7 @@ object UserDao extends Dao[User] with Sanitization {
             createdUser.id,
             GroupType.Platform,
             jwtUser.platformId,
-            GroupRole.Member
+            userRole
           )
           .toUserGroupRole(creatingUser, MembershipStatus.Approved)
       )
@@ -119,7 +120,7 @@ object UserDao extends Dao[User] with Sanitization {
                   "Tried to create a user role using a non-existent organization ID")
               )
               .id,
-            GroupRole.Member
+            userRole
           )
           .toUserGroupRole(creatingUser, MembershipStatus.Approved)
       )

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -55,7 +55,9 @@ class UserDaoSpec
               val newUserFields =
                 jwtFields.copy(platformId = insertedPlatform.id,
                                organizationId = insertedOrg.id)
-              UserDao.createUserWithJWT(creatingUser, newUserFields)
+              UserDao.createUserWithJWT(creatingUser,
+                                        newUserFields,
+                                        GroupRole.Member)
             }
             userRoles <- UserGroupRoleDao.listByUser(newUser)
           } yield (newUser, userRoles)


### PR DESCRIPTION
## Overview

This PR enables getting and writing user group roles from JWT claim.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Get an access token from you know where with or without a role
- Send a request to any RF endpoint, e.g. `/api/projects`
- Make sure this user is added to the `users` table, and corresponding user group roles are added correctly to the `user_group_roles` table

Closes https://github.com/azavea/raster-foundry-platform/issues/700
