### PR TITLE
Add userns_mode to Nexus compose service

### DIFF
--- a/deployment/ansible/roles/raster-foundry.docker/files/daemon.json
+++ b/deployment/ansible/roles/raster-foundry.docker/files/daemon.json
@@ -1,0 +1,3 @@
+{
+    "userns-remap": "jenkins"
+}

--- a/deployment/ansible/roles/raster-foundry.docker/handlers/main.yml
+++ b/deployment/ansible/roles/raster-foundry.docker/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart Docker
+  service: name=docker state=restarted

--- a/deployment/ansible/roles/raster-foundry.docker/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.docker/tasks/main.yml
@@ -7,3 +7,13 @@
         groups=docker
         append=yes
   with_items: "{{ docker_users }}"
+
+- name: Install Docker Daemon configuration
+  copy:
+    src: daemon.json
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Restart Docker

--- a/deployment/ansible/roles/raster-foundry.nexus/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.nexus/tasks/main.yml
@@ -29,12 +29,13 @@
       version: "3"
       services:
         nexus-server:
-          image: sonatype/nexus3:3.13.0
+          image: sonatype/nexus3:3.16.1
           ports:
             - "{{ nexus_http_port }}:8081"
           volumes:
             - "/opt/nexus-data:/nexus-data"
           restart: always
+          userns_mode: "host"
           logging:
             driver: syslog
             options:


### PR DESCRIPTION
## Overview

I already followed rough instructions outlined below to enable user namespace remapping on the Jenkins server:

https://docs.docker.com/engine/security/userns-remap/

This PR resolves permissions issues I encountered with the Nexus service afterwards (because Nexus expects to run as `200:200`).

Closes https://github.com/azavea/raster-foundry-platform/issues/678

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

I already applied these changes via an `ansible-playbook` run to the Jenkins server. See that the Nexus service is working fine and on the latest version:

http://nexus.staging.rasterfoundry.com

See that `develop` is passing:

http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/develop/

