### PR TITLE
Don't throw away string cache keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Fixed query parameter handling that listed all tool run map tokens with project map tokens [\#4928](https://github.com/raster-foundry/raster-foundry/pull/4928)
+- Fixed a bug that caused tile server interaction with the cache to be unsuccessful for reads and writes [\#4939](https://github.com/raster-foundry/raster-foundry/pull/4939)
 
 ### Security
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -43,7 +43,7 @@ object Cache extends LazyLogging {
       strs.mkString(":")
     }
 
-    def stringToCacheKey(key: String) = ""
+    def stringToCacheKey(key: String) = key
   }
 
   val tileCache: Cache[Option[MultibandTile]] = {


### PR DESCRIPTION
## Overview

This PR prevents us from throwing string cache keys in the garbage in backsplash.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

This is a pretty big oops on my part. I think I just forgot to implement the string cache key method when I updated the cache key builder for handling optional multipolygons.
 
## Testing Instructions

- fire up your existing tile server
- make some requests
- observe the warning for `Failed to write to cache. Key = `
- reassemble
- kill and revive the tile server
- make requests again
- note that the warning is gone and that the cache is actually working

Closes #4937 
