### PR TITLE
Remove scaladoc link

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SigmoidalContrast.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SigmoidalContrast.scala
@@ -50,7 +50,7 @@ object SigmoidalContrast {
   }
 
   /**
-    * Given a singleband [[Tile]] object and the parameters alpha and
+    * Given a singleband [[geotrellis.raster.Tile]] object and the parameters alpha and
     * beta, perform the sigmoidal contrast computation and return the
     * result as a tile.
     *
@@ -71,7 +71,7 @@ object SigmoidalContrast {
     transform(cellType, alpha, beta) _
 
   /**
-    * Given a [[MultibandTile]] object and the parameters alpha and
+    * Given a [[geotrellis.raster.MultibandTile]] object and the parameters alpha and
     * beta, perform the sigmoidal contrast computation on each band
     * and return the result as a multiband tile.
     *

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SigmoidalContrast.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/functions/SigmoidalContrast.scala
@@ -50,7 +50,7 @@ object SigmoidalContrast {
   }
 
   /**
-    * Given a singleband [[geotrellis.raster.Tile]] object and the parameters alpha and
+    * Given a singleband Tile object and the parameters alpha and
     * beta, perform the sigmoidal contrast computation and return the
     * result as a tile.
     *
@@ -71,7 +71,7 @@ object SigmoidalContrast {
     transform(cellType, alpha, beta) _
 
   /**
-    * Given a [[geotrellis.raster.MultibandTile]] object and the parameters alpha and
+    * Given a MultibandTile object and the parameters alpha and
     * beta, perform the sigmoidal contrast computation on each band
     * and return the result as a multiband tile.
     *

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/BacksplashExport.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/BacksplashExport.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
   *
   * To extend this program with a new type (perhaps sourcing raster data in
   *  some way not anticipated here), add a new typeclass instance for the new
-  *  export definition, add the type in question to the [[Exports]] type below,
+  *  export definition, add the type in question to the [[BacksplashExport.Exports]] type below,
   *  and ensure that SerDe behaviors are provided as well
   */
 object BacksplashExport
@@ -37,15 +37,18 @@ object BacksplashExport
       main = {
 
         val exportDefOpt =
-          Opts.option[URI]("definition",
-                           short = "d",
-                           help = "URI of export.ExportDefinition JSON")
+          Opts.option[URI](
+            "definition",
+            short = "d",
+            help = "URI of export.ExportDefinition JSON"
+          )
 
         val compressionLevelOpt = Opts
-          .option[Int]("compression",
-                       short = "c",
-                       help =
-                         "The (deflate) compression level to apply on export")
+          .option[Int](
+            "compression",
+            short = "c",
+            help = "The (deflate) compression level to apply on export"
+          )
           .withDefault(9)
 
         (exportDefOpt, compressionLevelOpt).mapN {
@@ -64,7 +67,8 @@ object BacksplashExport
             decode[Exports](exportDefString) match {
               case Right(exportDef) =>
                 logger.info(
-                  s"Beginning tiff export to ${exportDef.exportDestination}.")
+                  s"Beginning tiff export to ${exportDef.exportDestination}."
+                )
                 val t0 = System.nanoTime()
 
                 val compression = DeflateCompression(compressionLevel)
@@ -81,7 +85,8 @@ object BacksplashExport
                     logger.info(s"Writing tif to file: ${destination.getPath}")
                     FileUtils.writeByteArrayToFile(
                       new File(destination.getPath),
-                      geotiffBytes)
+                      geotiffBytes
+                    )
                   case scheme =>
                     sys.error(s"Unable to upload tif to scheme: $scheme")
                 }

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/BacksplashExport.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/BacksplashExport.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
   *
   * To extend this program with a new type (perhaps sourcing raster data in
   *  some way not anticipated here), add a new typeclass instance for the new
-  *  export definition, add the type in question to the [[BacksplashExport.Exports]] type below,
+  *  export definition, add the type in question to the BacksplashExport.Exports type below,
   *  and ensure that SerDe behaviors are provided as well
   */
 object BacksplashExport

--- a/app-backend/batch/src/main/scala/util/HadoopConfiguration.scala
+++ b/app-backend/batch/src/main/scala/util/HadoopConfiguration.scala
@@ -5,7 +5,7 @@ import org.apache.hadoop.conf.Configuration
 import java.io.{ObjectInputStream, ObjectOutputStream}
 
 /**
-  * Serializable [[Configuration]] wrapper
+  * Serializable Configuration wrapper
   * @param conf Hadoop Configuration
   */
 final case class HadoopConfiguration(var conf: Configuration)

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/SigmoidalContrast.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/SigmoidalContrast.scala
@@ -61,7 +61,7 @@ object SigmoidalContrastOps {
   }
 
   /**
-    * Given a singleband [[Tile]] object and the parameters alpha and
+    * Given a singleband Tile object and the parameters alpha and
     * beta, perform the sigmoidal contrast computation and return the
     * result as a tile.
     *
@@ -82,7 +82,7 @@ object SigmoidalContrastOps {
     transform(cellType, alpha, beta) _
 
   /**
-    * Given a [[MultibandTile]] object and the parameters alpha and
+    * Given a MultibandTile object and the parameters alpha and
     * beta, perform the sigmoidal contrast computation on each band
     * and return the result as a multiband tile.
     *


### PR DESCRIPTION
## Overview

This PR removes a link that doesn't work from cipublish that was making Jenkins sad

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~

## Testing Instructions

- look at the most recent build failure
- confirm this is the right file