### PR TITLE
Add ability to persist container service core dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Added
 - Added job to backfill low-zoom overviews for existing project layers [\#4970](https://github.com/raster-foundry/raster-foundry/pull/4970)
-
 - Convert BacksplashImage to a trait [\#4952](https://github.com/raster-foundry/raster-foundry/pull/4952)
 - Kickoff project layer overview generation reactively [\#4936](https://github.com/raster-foundry/raster-foundry/pull/4936)
+- Added ability to persist container service core dumps [\#4955](https://github.com/raster-foundry/raster-foundry/pull/4955)
 
 ### Changed
 

--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -6,7 +6,6 @@ docker_compose_version: "1.23.*"
 
 shellcheck_version: "0.3.*"
 
-docker_users:
-  - "vagrant"
+docker_user: "vagrant"
 
 pyyaml_version: "3.13"

--- a/deployment/ansible/group_vars/jenkins.yml
+++ b/deployment/ansible/group_vars/jenkins.yml
@@ -1,7 +1,5 @@
 ---
-docker_users:
-  - "vagrant"
-  - "jenkins"
+docker_user: "jenkins"
 
 java_version: "8u191*"
 java_major_version: "8"

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -32,3 +32,11 @@
     - name: Set Environment variable for host user (used to namespace jars and other artifacts in development)
       lineinfile: dest=/etc/environment regexp=^RF_HOST_USER line="RF_HOST_USER={{ host_user }}"
       when: host_user is defined
+
+    - name: Create script to handle core dumps
+      copy: content="#!/bin/sh\nexec /bin/gzip -1 > /tmp/core.$1.$2.gz\n"
+            dest=/usr/local/sbin/handle_core owner=root group=root mode=0755
+
+    - name: Set pattern for core dump handler
+      sysctl: name="kernel.core_pattern" value="|/usr/local/sbin/handle_core %E %p"
+              sysctl_set=yes state=present reload=yes

--- a/deployment/ansible/raster-foundry.yml
+++ b/deployment/ansible/raster-foundry.yml
@@ -38,5 +38,5 @@
             dest=/usr/local/sbin/handle_core owner=root group=root mode=0755
 
     - name: Set pattern for core dump handler
-      sysctl: name="kernel.core_pattern" value="|/usr/local/sbin/handle_core %E %p"
+      sysctl: name="kernel.core_pattern" value="|/usr/local/sbin/handle_core %t %e"
               sysctl_set=yes state=present reload=yes

--- a/deployment/ansible/roles/raster-foundry.docker/files/daemon.json
+++ b/deployment/ansible/roles/raster-foundry.docker/files/daemon.json
@@ -1,3 +1,0 @@
-{
-    "userns-remap": "jenkins"
-}

--- a/deployment/ansible/roles/raster-foundry.docker/tasks/main.yml
+++ b/deployment/ansible/roles/raster-foundry.docker/tasks/main.yml
@@ -1,16 +1,18 @@
 ---
 - name: Install Docker Compose
-  pip: name=docker-compose version={{ docker_compose_version }}
+  pip:
+    name: docker-compose
+    version: "{{ docker_compose_version }}"
 
 - name: Add Ansible user to Docker group
-  user: name="{{ item }}"
-        groups=docker
-        append=yes
-  with_items: "{{ docker_users }}"
+  user:
+    name: "{{ docker_user }}"
+    groups: docker
+    append: yes
 
-- name: Install Docker Daemon configuration
-  copy:
-    src: daemon.json
+- name: Configure Docker daemon
+  template:
+    src: daemon.json.j2
     dest: /etc/docker/daemon.json
     owner: root
     group: root

--- a/deployment/ansible/roles/raster-foundry.docker/templates/daemon.json.j2
+++ b/deployment/ansible/roles/raster-foundry.docker/templates/daemon.json.j2
@@ -1,0 +1,15 @@
+{
+    "userns-remap": "{{ '' if docker_user == 'vagrant' else 'jenkins' }}",
+    "default-ulimits": {
+        "nofile": {
+            "Name": "nofile",
+            "Hard": 64000,
+            "Soft": 64000
+        },
+        "core": {
+            "Name": "core",
+            "Hard": -1,
+            "Soft": -1
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Configure the Docker daemon to support core file sizes of `unlimited` via `daemon.json` configuration overrides. Then, set the `sysctl` `kernel.core_pattern` to a path within `/tmp` on the Docker host.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated~
~- [ ] Symlinks from new migrations present or corrected for any new migrations~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Notes

This PR is omitting the ability to upload a core dump to S3. Locally, core dumps are centralized in `/tmp` on the Docker host. https://github.com/azavea/raster-foundry-deployment/pull/209 handles centralizing core dumps to S3 in non-local environments (AWS).

## Testing Instructions

- Execute `setup` to ensure that the Ansible changes in this PR get applied to the local development virtual machine
- SSH into the virtual machine and check for the `sysctl` configuration changes

```console
vagrant@vagrant:/opt/raster-foundry$ sudo cat /proc/sys/kernel/core_pattern
|/usr/local/sbin/handle_core %E %p
vagrant@vagrant:/opt/raster-foundry$ cat /usr/local/sbin/handle_core
#!/bin/sh
exec /bin/gzip -1 > /tmp/core.$1.$2.gz
```

- Launch a container and attempt to generate a core dump

```console
vagrant@vagrant:/opt/raster-foundry$ docker run -ti --rm quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim /bin/bash
root@655f74798856:/usr/local# ulimit -c
unlimited
root@655f74798856:/usr/local# sleep 10 &
[1] 6
root@655f74798856:/usr/local# ps
  PID TTY          TIME CMD
    1 pts/0    00:00:00 bash
    6 pts/0    00:00:00 sleep
    7 pts/0    00:00:00 ps
root@655f74798856:/usr/local# kill -ABRT 6
[1]+  Aborted                 (core dumped) sleep 10
```

Fixes https://github.com/azavea/raster-foundry-platform/issues/716
