### PR TITLE
Stop returning 500s for tiles outside project extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Fixed usage of AWS credentials by the GDAL java bindings by using `AWS_DEFAULT_PROFILE` [\#4948](https://github.com/raster-foundry/raster-foundry/pull/4948)
+- Stopped returning internal server errors when requesting tiles outside a project boundary [\#4956](https://github.com/raster-foundry/raster-foundry/pull/4956)
 
 ### Security
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -24,8 +24,7 @@ object BacksplashMosaic extends ToHistogramStoreOps {
             BacksplashImage.getRasterSource(image.uri)
           }, images.head.rasterSource.crs)
         case _ =>
-          throw new MetadataException(
-            "Cannot construct a mosaic with no scenes")
+          throw NoScenesException
       }
     }
   }
@@ -41,7 +40,7 @@ object BacksplashMosaic extends ToHistogramStoreOps {
             .toList
             .distinct
         case _ =>
-          throw new MetadataException("Cannot get crs with no scenes")
+          throw NoScenesException
       }
     }
   }
@@ -109,9 +108,7 @@ object BacksplashMosaic extends ToHistogramStoreOps {
           layerHistogram(filterRelevant(mosaic)) map {
             case Valid(hists) => hists.toList
             case Invalid(e) =>
-              throw MetadataException(
-                s"Could not produce histograms: $e"
-              )
+              throw new MetadataException(s"Could not produce histograms: $e")
           }
         case arrs =>
           val hists = arrs

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -173,8 +173,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                   firstImOption map {
                     _.projectLayerId
                   } getOrElse {
-                    throw MetadataException(
-                      "Cannot produce tiles from empty mosaics")
+                    throw NoScenesException
                   },
                   List(firstImOption flatMap {
                     _.singleBandOptions map { _.band }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
@@ -109,11 +109,11 @@ object ColorRampMosaic extends LazyLogging {
     val singleBandTile = tile.band(0)
     val hist: Histogram[Double] = histogram match {
       case Nil =>
-        throw MetadataException(
+        throw new MetadataException(
           "Received an empty list of histograms for single band color correction")
       case hist +: Nil => hist
       case _ =>
-        throw MetadataException(
+        throw new MetadataException(
           "Received too many histograms for single band color correction")
     }
     val cmap =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Error.scala
@@ -48,6 +48,8 @@ class RollbarReporter[F[_]](implicit M: MonadError[F, BacksplashException])
     case e @ UningestedScenesException(_) =>
       sendError(e)
       throw e
+    case e @ NoScenesException =>
+      throw e
     case e @ MetadataException(_) =>
       sendError(e)
       throw e

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/ProjectStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/ProjectStoreImplicits.scala
@@ -49,7 +49,7 @@ class ProjectStoreImplicits(xa: Transactor[IO])
       )
     }
     val footprint = mosaicDefinition.footprint getOrElse {
-      throw MetadataException(s"Scene ${sceneId} does not have a footprint")
+      throw NoFootprintException
     }
 
     val subsetBands = if (mosaicDefinition.isSingleBand) {
@@ -131,9 +131,7 @@ class ProjectStoreImplicits(xa: Transactor[IO])
             s"Scene ${scene.id} does not have an ingest location")
         }
         val footprint = scene.dataFootprint getOrElse {
-          throw MetadataException(
-            s"Scene ${scene.id} does not have a footprint"
-          )
+          throw NoFootprintException
         }
         val imageBandOverride = bandOverride map { ovr =>
           List(ovr.redBand, ovr.greenBand, ovr.blueBand)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
@@ -98,7 +98,7 @@ class SceneService[ProjStore: ProjectStore, HistStore](
             paintedMosaicExtentReification,
             cs)
           extent = footprint map { _.envelope } getOrElse {
-            throw MetadataException(s"Scene $sceneId does not have a footprint")
+            throw NoFootprintException
           }
           xSize = extent.width / thumbnailSize.width
           ySize = extent.height / thumbnailSize.height

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
@@ -67,7 +67,7 @@ class WmsService[LayerReader: OgcStore](layers: LayerReader, urlPrefix: String)(
                   (LayerExtent.identity(sl),
                    layers.getLayerHistogram(UUID.fromString(title)))
                 case _: MapAlgebraOgcLayer =>
-                  throw MetadataException(
+                  throw new MetadataException(
                     "Arbitrary MAML evaluation is not yet supported by backsplash's OGC endpoints")
               }
               respIO <- (evalExtent(re.extent, re.cellSize), evalHistogram)


### PR DESCRIPTION
## Overview

This PR makes MetadataExceptions less stringy by turning them into a class that other
more specific exceptions can inherit from.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I decided that it made more sense to return a 200 with an empty tile than to return a 404, since 404s
look bad in our monitoring dashboards, but requests outside the imagery extent are going to be
extremely common.

## Testing Instructions

- reassemble backsplash-server
- clear your cache
- fire up your servers
- load a tile layer for a project that's in ok shape
- you should not get 500s