### PR TITLE
Fix Sentinel-2 metadata file download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Convert BacksplashImage to a trait [\#4952](https://github.com/raster-foundry/raster-foundry/pull/4952)
+- Kickoff project layer overview generation reactively [\#4936](https://github.com/raster-foundry/raster-foundry/pull/4936)
 
 ### Changed
 
@@ -16,6 +17,7 @@
 
 - Fixed usage of AWS credentials by the GDAL java bindings by using `AWS_DEFAULT_PROFILE` [\#4948](https://github.com/raster-foundry/raster-foundry/pull/4948)
 - Fixed logging configuration to respect `RF_LOG_LEVEL` environment variable [\#4972](https://github.com/raster-foundry/raster-foundry/pull/4972)
+- Fix Sentinel-2 metadata file download [\#4969](https://github.com/raster-foundry/raster-foundry/pull/4969)
 
 ### Security
 

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -64,3 +64,7 @@ dropbox {
   appSecret = ""
   appSecret = ${?DROPBOX_SECRET}
 }
+
+sentinel2 {
+  datasourceId = "4a50cb75-815d-4fe5-8bc1-144729ce5b42"
+}

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -404,7 +404,6 @@ trait SceneRoutes
     }
   }
 
-  @SuppressWarnings(Array("AsInstanceOf"))
   def getSentinelMetadata(sceneId: UUID, metadataUrl: String): Route =
     authenticate { user =>
       authorizeAsync {

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.api.scene
 
 import java.util.UUID
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
 import cats.data._
 import cats.effect.IO
@@ -100,6 +100,13 @@ trait SceneRoutes
           } ~
           pathPrefix("datasource") {
             pathEndOrSingleSlash { getSceneDatasource(sceneId) }
+          } ~
+          pathPrefix("sentinel-metadata") {
+            pathPrefix(Segment) { metadataUrl =>
+              pathEndOrSingleSlash {
+                get { getSentinelMetadata(sceneId, metadataUrl) }
+              }
+            }
           }
       }
   }
@@ -396,4 +403,35 @@ trait SceneRoutes
       }
     }
   }
+
+  @SuppressWarnings(Array("AsInstanceOf"))
+  def getSentinelMetadata(sceneId: UUID, metadataUrl: String): Route =
+    authenticate { user =>
+      authorizeAsync {
+        val authorizedIO = for {
+          auth <- SceneDao.authorized(user,
+                                      ObjectType.Scene,
+                                      sceneId,
+                                      ActionType.View)
+          datasource <- SceneDao.getSceneDatasource(sceneId)
+        } yield {
+          auth && datasource.id == UUID.fromString(
+            "4a50cb75-815d-4fe5-8bc1-144729ce5b42")
+        }
+        authorizedIO.transact(xa).unsafeToFuture
+      } {
+        onSuccess(
+          SceneDao
+            .getSentinelMetadata(metadataUrl)
+            .transact(xa)
+            .unsafeToFuture) { (s3Object, metaData) =>
+          val s3MediaType = metaData.getContentType() match {
+            case "application/json" => ContentTypes.`application/json`
+            case "application/xml"  => ContentTypes.`text/xml(UTF-8)`
+            case _                  => throw new Exception("Unsupported media type")
+          }
+          complete(HttpResponse(entity = HttpEntity(s3MediaType, s3Object)))
+        }
+      }
+    }
 }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -425,9 +425,11 @@ trait SceneRoutes
             .unsafeToFuture) { (s3Object, metaData) =>
           metaData.getContentType() match {
             case "application/json" =>
-              complete(HttpResponse(entity = HttpEntity(ContentTypes.`application/json`, s3Object)))
-            case "application/xml"  =>
-              complete(HttpResponse(entity = HttpEntity(ContentTypes.`text/xml(UTF-8)`, s3Object)))
+              complete(HttpResponse(
+                entity = HttpEntity(ContentTypes.`application/json`, s3Object)))
+            case "application/xml" =>
+              complete(HttpResponse(
+                entity = HttpEntity(ContentTypes.`text/xml(UTF-8)`, s3Object)))
             case _ =>
               complete(StatusCodes.UnsupportedMediaType)
           }

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -12,6 +12,7 @@ trait Config {
   private val s3Config = config.getConfig("s3")
   private val tileServerConfig = config.getConfig("tileServer")
   private val dropboxConfig = config.getConfig("dropbox")
+  private val sentinel2Config = config.getConfig("sentinel2")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
@@ -36,4 +37,6 @@ trait Config {
   val dropboxClientId = dropboxConfig.getString("appKey")
 
   val scopedUploadRoleArn = s3Config.getString("scopedUploadRoleArn")
+
+  val sentinel2DatasourceId = sentinel2Config.getString("datasourceId")
 }

--- a/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.html
@@ -1,124 +1,147 @@
 <div class="modal-header">
-	<button type="button" class="close" aria-label="Close"
-          ng-click="$ctrl.dismiss()">
-    <span aria-hidden="true">&times;</span>
-  </button>
-  <span class="badge"><i class="icon-download"></i></span>
-  <h4 class="modal-title">
-    Download scenes
-  </h4>
+    <button type="button" class="close" aria-label="Close" ng-click="$ctrl.dismiss()">
+        <span aria-hidden="true">&times;</span>
+    </button>
+    <span class="badge"><i class="icon-download"></i></span>
+    <h4 class="modal-title"> Download scenes </h4>
 </div>
 <div class="modal-body" ng-if="!$ctrl.rejectionMessage">
-  <div class="list-group" ng-show="$ctrl.isLoading">
-    <span class="list-placeholder">
-      <i class="icon-load animate-spin"></i>
-    </span>
-  </div>
-  <div class="list-group" ng-if="!$ctrl.isLoading" ng-repeat="downloadSet in $ctrl.downloads">
-    <div class="list-group-item">
-      <div class="list-group-overflow">
-        <strong class="color-dark">{{downloadSet.label}}</strong>
-      </div>
+    <div class="list-group" ng-show="$ctrl.isLoading">
+        <span class="list-placeholder"> <i class="icon-load animate-spin"></i> </span>
     </div>
-    <div ng-init="show = false">
-      <div class="list-group-item selectable"
-           ng-click="show = !show">
-        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
-        <strong class="color-dark">Images</strong>
-        <ng-pluralize count="downloadSet.images.length"
-                      when="{'0': 'No images',
+    <div class="list-group" ng-if="!$ctrl.isLoading" ng-repeat="downloadSet in $ctrl.downloads">
+        <div class="list-group-item">
+            <div class="list-group-overflow">
+                <strong class="color-dark">{{downloadSet.label}}</strong>
+            </div>
+        </div>
+        <div ng-init="show = false">
+            <div class="list-group-item selectable" ng-click="show = !show">
+                <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
+                <strong class="color-dark">Images</strong>
+                <ng-pluralize
+                    count="downloadSet.images.length"
+                    when="{'0': 'No images',
                             'one': 'One image&nbsp',
-                            'other': '{} images&nbsp'}">
-        </ng-pluralize>
-        available
-      </div>
-      <div ng-show="show"
-           class="list-group-subitem"
-           ng-repeat-start="image in downloadSet.images"
-           ng-init="showImageDownloads = false">
-        <a class="color-dark"
-           ng-attr-href="{{image.uri}}"
-           ng-if="image.uri.startsWith('http')"
-           download>
-          <span class="badge"><i class="icon-download"></i></span>
-        </a>
-        <a class="color-dark"
-           ng-if="image.uri.startsWith('s3://')"
-           tooltips tooltip-template="
+                            'other': '{} images&nbsp'}"
+                >
+                </ng-pluralize>
+                available
+            </div>
+            <div
+                ng-show="show"
+                class="list-group-subitem"
+                ng-repeat-start="image in downloadSet.images"
+                ng-init="showImageDownloads = false"
+            >
+                <a
+                    class="color-dark"
+                    ng-attr-href="{{image.uri}}"
+                    ng-if="image.uri.startsWith('http')"
+                    download
+                >
+                    <span class="badge"><i class="icon-download"></i></span>
+                </a>
+                <a
+                    class="color-dark"
+                    ng-if="image.uri.startsWith('s3://')"
+                    tooltips
+                    tooltip-template="
                   S3 resources must be downloaded using a command line or library AWS client.
                   Click to read about the AWS command line client.
                   "
-           tooltip-size="small"
-           tooltip-class="rf-tooltip"
-           tooltip-side="bottom"
-           href="https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html"
-           target="_blank">
-          <span class="badge"><i class="icon-help"></i></span>
-        </a>
-        <div class="form-group all-in-one"
-             style="width: 100%"
-             ng-if="image.uri.startsWith('s3://')"
-        >
-          <input type="text"
-                 class="form-control"
-                 ng-attr-title="{{image.filename}}"
-                 ng-value="image.uri"
-                 readonly />
-          <button class="btn btn-link btn-copy-modal-first"
-                  clipboard text="image.uri"
-                  ng-click="$ctrl.onCopyClick($event, image.uri, 'page')">
-            <span ng-show="$ctrl.copyType !== 'page'">Copy</span>
-            <span class="icon-check copy-confirmation" ng-show="$ctrl.copyType === 'page'"></span>
-          </button>
+                    tooltip-size="small"
+                    tooltip-class="rf-tooltip"
+                    tooltip-side="bottom"
+                    href="https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-welcome.html"
+                    target="_blank"
+                >
+                    <span class="badge"><i class="icon-help"></i></span>
+                </a>
+                <div
+                    class="form-group all-in-one"
+                    style="width: 100%"
+                    ng-if="image.uri.startsWith('s3://')"
+                >
+                    <input
+                        type="text"
+                        class="form-control"
+                        ng-attr-title="{{image.filename}}"
+                        ng-value="image.uri"
+                        readonly
+                    />
+                    <button
+                        class="btn btn-link btn-copy-modal-first"
+                        clipboard
+                        text="image.uri"
+                        ng-click="$ctrl.onCopyClick($event, image.uri, 'page')"
+                    >
+                        <span ng-show="$ctrl.copyType !== 'page'">Copy</span>
+                        <span
+                            class="icon-check copy-confirmation"
+                            ng-show="$ctrl.copyType === 'page'"
+                        ></span>
+                    </button>
+                </div>
+                <a ng-attr-href="{{image.uri}}" ng-if="image.uri.startsWith('http')" download
+                    >{{image.filename}}</a
+                >
+            </div>
+            <div
+                ng-repeat-end
+                ng-show="show"
+                class="list-group-subitem download"
+                ng-repeat="file in image.metadata"
+            >
+                <a class="color-dark" ng-attr-href="{{file}}" download>
+                    <span class="badge"><i class="icon-download"></i></span>
+                </a>
+                <a class="color-dark" ng-attr-href="{{file}}" download> {{file}} </a>
+            </div>
         </div>
-        <a ng-attr-href="{{image.uri}}"
-           ng-if="image.uri.startsWith('http')"
-           download>{{image.filename}}</a>
-      </div>
-      <div ng-repeat-end
-           ng-show="show"
-           class="list-group-subitem download"
-           ng-repeat="file in image.metadata">
-        <a class="color-dark" ng-attr-href="{{file}}" download>
-          <span class="badge"><i class="icon-download"></i></span>
-        </a>
-        <a class="color-dark" ng-attr-href="{{file}}" download>
-          {{file}}
-        </a>
-      </div>
-    </div>
-    <div ng-init="show = false" ng-if="downloadSet.metadata.length">
-      <div class="list-group-item selectable"
-           ng-click="show = !show">
-        <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
-        <strong class="color-dark">Metadata</strong>
-        <ng-pluralize count="downloadSet.metadata.length"
-                      when="{'0': 'No metadata files',
+        <div ng-init="show = false" ng-if="downloadSet.metadata.length">
+            <div class="list-group-item selectable" ng-click="show = !show">
+                <span class="badge color-dark selectable"><i class="icon-plus"></i></span>
+                <strong class="color-dark">Metadata</strong>
+                <ng-pluralize
+                    count="downloadSet.metadata.length"
+                    when="{'0': 'No metadata files',
                             'one': 'One metadata file&nbsp',
-                            'other': '{} metadata files&nbsp'}">
-        </ng-pluralize>
-        available
-      </div>
-      <div ng-show="show"
-           class="list-group-subitem"
-           ng-repeat="download in downloadSet.metadata">
-        <a class="color-dark" ng-attr-href="{{download}}" download>
-          <span class="badge"><i class="icon-download"></i></span>
-        </a>
-        <div class="list-group-overflow">
-          <a ng-attr-href="{{download}}" download>{{download | shortenUrl}}</a>
+                            'other': '{} metadata files&nbsp'}"
+                >
+                </ng-pluralize>
+                available
+            </div>
+            <div
+                ng-show="show"
+                class="list-group-subitem"
+                ng-repeat="download in downloadSet.metadata"
+            >
+                <a class="color-dark" ng-attr-href="{{download}}" download>
+                    <span class="badge"><i class="icon-download"></i></span>
+                </a>
+                <div class="list-group-overflow">
+                    <a
+                        ng-attr-href="{{download}}"
+                        download
+                        ng-if="$ctrl.resolve.scene.datasource.name !== 'Sentinel-2'"
+                        >{{download | shortenUrl}}</a
+                    >
+                    <a
+                        ng-click="$ctrl.onDownloadSentinelMetadata(download)"
+                        ng-if="$ctrl.resolve.scene.datasource.name === 'Sentinel-2'"
+                        >{{download | shortenUrl}}</a
+                    >
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
 </div>
 
-<div class="modal-body" ng-if="$ctrl.rejectionMessage">
-    <p>{{ $ctrl.rejectionMessage }}</p>
-</div>
+<div class="modal-body" ng-if="$ctrl.rejectionMessage"> <p>{{ $ctrl.rejectionMessage }}</p> </div>
 
 <div class="modal-footer">
-  <div class="footer-section left">
-    <button type="button" class="btn" ng-click="$ctrl.dismiss()">Close</button>
-  </div>
+    <div class="footer-section left">
+        <button type="button" class="btn" ng-click="$ctrl.dismiss()">Close</button>
+    </div>
 </div>

--- a/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDownloadModal/sceneDownloadModal.module.js
@@ -13,12 +13,13 @@ const SceneDownloadModalComponent = {
 };
 
 class SceneDownloadModalController {
-    constructor(sceneService, $timeout, $log, $window) {
+    constructor(sceneService, $timeout, $log, $window, $document) {
         'ngInject';
         this.sceneService = sceneService;
         this.$timeout = $timeout;
         this.$log = $log;
         this.$window = $window;
+        this.$document = $document;
     }
 
     $onInit() {
@@ -75,9 +76,8 @@ class SceneDownloadModalController {
             .replace('https://', '')
             .split('/')
             .join('-');
-        this.sceneService
-            .getSentinelMetadata(this.resolve.scene.id, url)
-            .then(resp => {
+        this.sceneService.getSentinelMetadata(this.resolve.scene.id, url).then(
+            resp => {
                 let data = [];
                 let option = {};
                 if (isXml) {
@@ -94,12 +94,14 @@ class SceneDownloadModalController {
                 const downloadLink = angular.element('<a></a>');
                 downloadLink.attr('href', this.$window.URL.createObjectURL(blob));
                 downloadLink.attr('download', fileName);
+                this.$document[0].body.appendChild(downloadLink[0]);
                 downloadLink[0].click();
-            })
-            .catch(err => {
+            },
+            err => {
                 this.$log.error(err);
                 this.$window.alert('There was an error downloading this metadata file');
-            });
+            }
+        );
     }
 }
 


### PR DESCRIPTION
## Overview

This PR adds backend and frontend supports to enable downloading sentinel-2 scene metadata files from a requester pays bucket.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Assemble the api jar
- Spin up servers and frontend
- Add a sentinel scene to a project layer
- Bring up the scene download modal through clicking on the cloud button on scene sidebar item
- Under the metadata section, make sure all files listed can be downloaded (json and xml)
- Look at network traffic, there should be `GET` requests when you click on those download links
- Add a landsat scene to a project layer
- Bring up scene download modal and download metadata files. There should not be extra `GET` requests to get the metadata files/objects.
