### PR TITLE
Backfill project layer overviews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Added job to backfill low-zoom overviews for existing project layers [\#4970](https://github.com/raster-foundry/raster-foundry/pull/4970)
 
 - Convert BacksplashImage to a trait [\#4952](https://github.com/raster-foundry/raster-foundry/pull/4952)
 

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -22,6 +22,8 @@ object Main {
   )
 
   def main(args: Array[String]): Unit = {
+    println(args)
+    println("lol")
     args.headOption match {
       case Some(head) => {
         modules.get(head) match {

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -22,9 +22,6 @@ object Main {
   )
 
   def main(args: Array[String]): Unit = {
-    println(args)
-    println("lol")
-    println("omg")
     args.headOption match {
       case Some(head) => {
         modules.get(head) match {

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.batch
 
 import com.rasterfoundry.batch.aoi.FindAOIProjects
-import com.rasterfoundry.batch.cogMetadata.HistogramBackfill
+import com.rasterfoundry.batch.cogMetadata.{HistogramBackfill, OverviewBackfill}
 import com.rasterfoundry.batch.export.{CreateExportDef, UpdateExportStatus}
 import com.rasterfoundry.batch.healthcheck.HealthCheck
 import com.rasterfoundry.batch.aoi.UpdateAOIProject
@@ -11,13 +11,14 @@ import com.rasterfoundry.batch.notification.NotifyIngestStatus
 object Main {
   val modules = Map[String, Array[String] => Unit](
     CreateExportDef.name -> (CreateExportDef.main(_)),
-    UpdateExportStatus.name -> (UpdateExportStatus.main(_)),
     FindAOIProjects.name -> (FindAOIProjects.main(_)),
     HealthCheck.name -> (HealthCheck.main(_)),
     HistogramBackfill.name -> (HistogramBackfill.main(_)),
     NotifyIngestStatus.name -> (NotifyIngestStatus.main(_)),
+    OverviewBackfill.name -> (OverviewBackfill.main(_)),
     ReadStacFeature.name -> (ReadStacFeature.main(_)),
-    UpdateAOIProject.name -> (UpdateAOIProject.main(_))
+    UpdateAOIProject.name -> (UpdateAOIProject.main(_)),
+    UpdateExportStatus.name -> (UpdateExportStatus.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -24,6 +24,7 @@ object Main {
   def main(args: Array[String]): Unit = {
     println(args)
     println("lol")
+    println("omg")
     args.headOption match {
       case Some(head) => {
         modules.get(head) match {

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -60,7 +60,7 @@ object OverviewBackfill extends Job with RollbarNotifier {
               case (_, n) => n <= 300 && n > 0
             })
             .transact(t)
-            .parEvalMap(10)({
+            .parEvalMap(20)({
               case (projectLayer, _) =>
                 kickoffOverviewGeneration(projectLayer)
             })

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -25,6 +25,7 @@ object OverviewBackfill extends Job with RollbarNotifier {
       .query[Int]
       .stream map { (projectLayer, _) }
 
+  // TODO make sure that this is called synchronously
   def kickoffOverviewGeneration(projectLayer: ProjectLayer): IO[Unit] =
     IO {
       println(s"Kicking off generation for layer ${projectLayer.id}")

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -1,0 +1,39 @@
+package com.rasterfoundry.batch.cogMetadata
+
+import com.rasterfoundry.batch.Job
+import com.rasterfoundry.common.RollbarNotifier
+import com.rasterfoundry.datamodel.ProjectLayer
+
+import cats.effect.IO
+import doobie.{ConnectionIO, Transactor}
+import doobie.implicits._
+import fs2.Stream
+
+object OverviewBackfill extends Job with RollbarNotifier {
+  val name = "backfill-layer-overviews"
+  val xa: Transactor[IO] = ???
+
+  def getProjectLayerSceneCount(projectLayer: ProjectLayer): Stream[ConnectionIO, (ProjectLayer, Int)] =
+    ???
+
+  def kickoffOverviewGeneration(projectLayer: ProjectLayer): IO[Unit] = ???
+
+  val projectLayers: Stream[ConnectionIO, ProjectLayer] = ???
+  val projectLayersWithSceneCounts: Stream[ConnectionIO, (ProjectLayer, Int)] =
+    projectLayers.flatMap(getProjectLayerSceneCount)
+
+  def runJob(args: List[String]): IO[Unit] =
+    projectLayersWithSceneCounts
+      .filter({
+        case (_, n) => n <= 300
+      })
+      .transact(xa)
+      .parEvalMap(15)({
+        case (projectLayer, _) =>
+          kickoffOverviewGeneration(projectLayer)
+      })
+      .fold(())((_: Unit, _: Unit) => ())
+      .compile
+      .to[List]
+      .map { _.head }
+}

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -17,7 +17,6 @@ import scala.concurrent.duration._
 
 object OverviewBackfill extends Job with RollbarNotifier {
   val name = "backfill-layer-overviews"
-  val xa: Transactor[IO] = ???
 
   def getProjectLayerSceneCount(
       projectLayer: ProjectLayer

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -23,6 +23,10 @@ object OverviewBackfill extends Job with RollbarNotifier {
       .query[Int]
       .stream map { (projectLayer, _) }
 
+  /** We know suppressing this warning is fine, because the query for project layers
+    * explicitly filters out any that don't have a project id
+    */
+  @SuppressWarnings(Array("OptionGet"))
   def kickoffOverviewGeneration(
       projectLayer: ProjectLayer
   ): IO[Unit] = IO {

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -3,22 +3,31 @@ package com.rasterfoundry.batch.cogMetadata
 import com.rasterfoundry.batch.Job
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.datamodel.ProjectLayer
+import com.rasterfoundry.database.ProjectLayerDao
 
 import cats.effect.IO
-import doobie.{ConnectionIO, Transactor}
+import doobie._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import fs2.Stream
 
 object OverviewBackfill extends Job with RollbarNotifier {
   val name = "backfill-layer-overviews"
   val xa: Transactor[IO] = ???
 
-  def getProjectLayerSceneCount(projectLayer: ProjectLayer): Stream[ConnectionIO, (ProjectLayer, Int)] =
-    ???
+  def getProjectLayerSceneCount(
+      projectLayer: ProjectLayer
+  ): Stream[ConnectionIO, (ProjectLayer, Int)] =
+    fr"select count(1) from scenes_to_layers where project_layer_id = ${projectLayer.id}"
+      .query[Int]
+      .stream map { (projectLayer, _) }
 
   def kickoffOverviewGeneration(projectLayer: ProjectLayer): IO[Unit] = ???
 
-  val projectLayers: Stream[ConnectionIO, ProjectLayer] = ???
+  // Giant number inside listQ is because listQ needs a limit parameter, but we don't actually
+  // want to limit
+  val projectLayers: Stream[ConnectionIO, ProjectLayer] =
+    ProjectLayerDao.query.listQ(1000000).stream
   val projectLayersWithSceneCounts: Stream[ConnectionIO, (ProjectLayer, Int)] =
     projectLayers.flatMap(getProjectLayerSceneCount)
 
@@ -28,7 +37,7 @@ object OverviewBackfill extends Job with RollbarNotifier {
         case (_, n) => n <= 300
       })
       .transact(xa)
-      .parEvalMap(15)({
+      .parEvalMap(20)({
         case (projectLayer, _) =>
           kickoffOverviewGeneration(projectLayer)
       })

--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -65,7 +65,7 @@ object OverviewBackfill extends Job with RollbarNotifier {
               case (_, n) => n <= 300 && n > 0
             })
             .transact(t)
-            .parEvalMap(30)({
+            .parEvalMap(36)({
               case (projectLayer, _) =>
                 kickoffOverviewGeneration(projectLayer)
             })

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -265,8 +265,6 @@ lazy val lambdaOverviews = project
     ) ++ loggingDependencies
   })
 
-lazy val lambdaOverviewsNoScala = lambdaOverviews.settings()
-
 /**
   * Common Settings
   */


### PR DESCRIPTION
## Overview

This PR adds a job to the batch jar to kickoff project layer overview generation for existing project layers.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests -- one-off job, exercised by these testing instructions

### Notes

Stream concurrency was chosen sort of at random -- because of Lambda and basically constant scene posts I was a little afraid that we'd swamp the db if I went to like 50 so it's pretty conservative. I'll increase and schedule it if the test in staging takes way too long.

## Testing Instructions

- reassemble your batch jar
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main backfill-layer-overviews`
- Check out the output from this batch job for testing it in staging: (forthcoming)
- Confirm that all staging layers with > 0 and <= 300 scenes have project layer overviews set
