### PR TITLE
Add all entities as object types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
-- Added job to backfill low-zoom overviews for existing project layers [\#4970](https://github.com/raster-foundry/raster-foundry/pull/4970)
 
+- Added `ActionType` for `CREATE` [\#4992](https://github.com/raster-foundry/raster-foundry/pull/4992)
+- Added `ObjectType` for all entities [\#4992](https://github.com/raster-foundry/raster-foundry/pull/4992)
+- Added job to backfill low-zoom overviews for existing project layers [\#4970](https://github.com/raster-foundry/raster-foundry/pull/4970)
 - Convert BacksplashImage to a trait [\#4952](https://github.com/raster-foundry/raster-foundry/pull/4952)
 - Kickoff project layer overview generation reactively [\#4936](https://github.com/raster-foundry/raster-foundry/pull/4936)
 

--- a/app-backend/datamodel/src/main/scala/ActionType.scala
+++ b/app-backend/datamodel/src/main/scala/ActionType.scala
@@ -15,6 +15,7 @@ object ActionType {
   case object Annotate extends ActionType("ANNOTATE")
   case object Export extends ActionType("EXPORT")
   case object Download extends ActionType("DOWNLOAD")
+  case object Create extends ActionType("CREATE")
 
   def fromString(s: String): ActionType = s.toUpperCase match {
     case "VIEW"       => View
@@ -24,6 +25,7 @@ object ActionType {
     case "ANNOTATE"   => Annotate
     case "EXPORT"     => Export
     case "DOWNLOAD"   => Download
+    case "CREATE"     => Create
     case _            => throw new Exception(s"Invalid ActionType: ${s}")
   }
 

--- a/app-backend/datamodel/src/main/scala/ObjectType.scala
+++ b/app-backend/datamodel/src/main/scala/ObjectType.scala
@@ -15,16 +15,40 @@ object ObjectType {
   case object Workspace extends ObjectType("WORKSPACE")
   case object Template extends ObjectType("TEMPLATE")
   case object Analysis extends ObjectType("ANALYSIS")
+  case object Platform extends ObjectType("PLATFORM")
+  case object Organization extends ObjectType("ORGANIZATION")
+  case object Team extends ObjectType("TEAM")
+  case object User extends ObjectType("USER")
+  case object Upload extends ObjectType("UPLOAD")
+  case object Export extends ObjectType("EXPORT")
+  case object Feed extends ObjectType("FEED")
+  case object MapToken extends ObjectType("MAPTOKEN")
+  case object License extends ObjectType("LICENSE")
+  case object ToolTag extends ObjectType("TOOLTAG")
+  case object ToolCategory extends ObjectType("TOOLCATEGORY")
+  case object AOI extends ObjectType("AOI")
 
   def fromString(s: String): ObjectType = s.toUpperCase match {
-    case "PROJECT"    => Project
-    case "SCENE"      => Scene
-    case "DATASOURCE" => Datasource
-    case "SHAPE"      => Shape
-    case "WORKSPACE"  => Workspace
-    case "TEMPLATE"   => Template
-    case "ANALYSIS"   => Analysis
-    case _            => throw new Exception(s"Invalid ObjectType: ${s}")
+    case "PROJECT"      => Project
+    case "SCENE"        => Scene
+    case "DATASOURCE"   => Datasource
+    case "SHAPE"        => Shape
+    case "WORKSPACE"    => Workspace
+    case "TEMPLATE"     => Template
+    case "ANALYSIS"     => Analysis
+    case "PLATFORM"     => Platform
+    case "ORGANIZATION" => Organization
+    case "TEAM"         => Team
+    case "USER"         => User
+    case "UPLOAD"       => Upload
+    case "EXPORT"       => Export
+    case "FEED"         => Feed
+    case "MAPTOKEN"     => MapToken
+    case "LICENSE"      => License
+    case "TOOLTAG"      => ToolTag
+    case "TOOLCATEGORY" => ToolCategory
+    case "AOI"          => AOI
+    case _              => throw new Exception(s"Invalid ObjectType: ${s}")
   }
 
   implicit val ObjectTypeEncoder: Encoder[ObjectType] =

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -5583,6 +5583,9 @@ definitions:
           - 'DEACTIVATE'
           - 'DELETE'
           - 'ANNOTATE'
+          - 'EXPORT'
+          - 'DOWNLOAD'
+          - 'CREATE'
   ObjectAccessControlRule:
     $ref: '#/definitions/AccessControlRule'
   AccessControlRuleCreate:
@@ -5619,6 +5622,18 @@ definitions:
               - 'WORKSPACE'
               - 'TEMPLATE'
               - 'ANALYSIS'
+              - 'PLATFORM'
+              - 'ORGANIZATION'
+              - 'TEAM'
+              - 'USER'
+              - 'UPLOAD'
+              - 'EXPORT'
+              - 'FEED'
+              - 'MAPTOKEN'
+              - 'LICENSE'
+              - 'TOOLTAG'
+              - 'TOOLCATEGORY'
+              - 'AOI'
           objectId:
             type: string
             description: 'Id of the object this access control rule applies to'


### PR DESCRIPTION
## Overview

This PR adds case objects to `ObjectType` to cover all API accessible entities. This includes the addition of members for:
- platform
- organization
- team
- user
- upload
- export
- feed
- maptoken
- license
- tooltag
- toolcategory
- aoi

This PR also adds a `CREATE` member to `ActionType`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated

### Notes

I was going to update the database enums for `object_type` and `action_type` but since we moved ACRs to a column on entities, they haven't been used. I've created https://github.com/raster-foundry/raster-foundry/issues/4994 to address this issue.

## Testing Instructions

- CI
