### PR TITLE
Support storing processed uploads in source bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Convert BacksplashImage to a trait [\#4952](https://github.com/raster-foundry/raster-foundry/pull/4952)
 - Kickoff project layer overview generation reactively [\#4936](https://github.com/raster-foundry/raster-foundry/pull/4936)
 - Added ability to persist container service core dumps [\#4955](https://github.com/raster-foundry/raster-foundry/pull/4955)
-
+- Support storing processed uploads in source bucket [\#4997](https://github.com/raster-foundry/raster-foundry/pull/4997)
 
 ### Changed
 

--- a/app-backend/common/src/test/scala/com/UploadSpec.scala
+++ b/app-backend/common/src/test/scala/com/UploadSpec.scala
@@ -20,6 +20,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       Visibility.Private,
       None,
       None,
+      None,
       None
     )
     // note the id is not "foo"
@@ -43,6 +44,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       ().asJson,
       Some("foo"), // proposed owner
       Visibility.Private,
+      None,
       None,
       None,
       None
@@ -69,6 +71,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       Visibility.Private,
       None,
       None,
+      None,
       None
     )
     // note the id is not "foo"
@@ -91,6 +94,7 @@ class UploadTestSuite extends FunSuite with Matchers {
       ().asJson,
       Some("foo"), // proposed owner
       Visibility.Private,
+      None,
       None,
       None,
       None

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -596,6 +596,7 @@ object Generators extends ArbitraryInstances {
       projectId <- Gen.const(None)
       layerId <- Gen.const(None)
       source <- Gen.oneOf(nonEmptyStringGen map { Some(_) }, Gen.const(None))
+      keepInSourceBucket <- Gen.const(None)
     } yield {
       Upload.Create(
         uploadStatus,
@@ -608,7 +609,8 @@ object Generators extends ArbitraryInstances {
         visibility,
         projectId,
         layerId,
-        source
+        source,
+        keepInSourceBucket
       )
     }
 

--- a/app-backend/datamodel/src/main/scala/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/Upload.scala
@@ -22,7 +22,8 @@ final case class Upload(id: UUID,
                         visibility: Visibility,
                         projectId: Option[UUID],
                         layerId: Option[UUID],
-                        source: Option[String])
+                        source: Option[String],
+                        keepInSourceBucket: Boolean)
 
 object Upload {
 
@@ -41,7 +42,8 @@ object Upload {
                           visibility: Visibility,
                           projectId: Option[UUID],
                           layerId: Option[UUID],
-                          source: Option[String]) {
+                          source: Option[String],
+                          keepInSourceBucket: Option[Boolean]) {
     def toUpload(user: User,
                  userPlatformAdmin: (UUID, Boolean),
                  ownerPlatform: Option[UUID]): Upload = {
@@ -94,7 +96,8 @@ object Upload {
         this.visibility,
         this.projectId,
         this.layerId,
-        this.source
+        this.source,
+        this.keepInSourceBucket.getOrElse(false)
       )
     }
   }

--- a/app-backend/db/src/main/resources/migrations/V3__Add_keepInSourceBucket_to_uploads.sql
+++ b/app-backend/db/src/main/resources/migrations/V3__Add_keepInSourceBucket_to_uploads.sql
@@ -1,0 +1,4 @@
+-- Add a keepInSourceBucket boolean field to uploads table
+-- to indicate whether to use source tif bucket or not
+
+ALTER TABLE uploads ADD COLUMN keep_in_source_bucket BOOLEAN DEFAULT false NOT NULL;

--- a/app-backend/db/src/main/resources/migrations/V4__Add_keepInSourceBucket_to_uploads.sql
+++ b/app-backend/db/src/main/resources/migrations/V4__Add_keepInSourceBucket_to_uploads.sql
@@ -1,4 +1,4 @@
 -- Add a keepInSourceBucket boolean field to uploads table
 -- to indicate whether to use source tif bucket or not
 
-ALTER TABLE uploads ADD COLUMN keep_in_source_bucket BOOLEAN DEFAULT false NOT NULL;
+ALTER TABLE public.uploads ADD COLUMN keep_in_source_bucket BOOLEAN DEFAULT false NOT NULL;

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -21,7 +21,7 @@ object UploadDao extends Dao[Upload] {
        id, created_at, created_by, modified_at, modified_by,
        owner, upload_status, file_type, upload_type,
        files, datasource, metadata, visibility, project_id,
-       layer_id, source
+       layer_id, source, keep_in_source_bucket
     FROM
   """ ++ tableF
 
@@ -59,12 +59,12 @@ object UploadDao extends Dao[Upload] {
          (id, created_at, created_by, modified_at, modified_by,
           owner, upload_status, file_type, upload_type,
           files, datasource, metadata, visibility, project_id,
-          layer_id, source)
+          layer_id, source, keep_in_source_bucket)
        VALUES (
          ${upload.id}, ${upload.createdAt}, ${upload.createdBy}, ${upload.modifiedAt}, ${upload.modifiedBy},
          ${upload.owner}, ${upload.uploadStatus}, ${upload.fileType}, ${upload.uploadType},
          ${upload.files}, ${upload.datasource}, ${upload.metadata}, ${upload.visibility}, ${upload.projectId},
-         ${upload.layerId}, ${upload.source}
+         ${upload.layerId}, ${upload.source}, ${upload.keepInSourceBucket}
        )
       """.update.withUniqueGeneratedKeys[Upload](
           "id",
@@ -82,7 +82,8 @@ object UploadDao extends Dao[Upload] {
           "visibility",
           "project_id",
           "layer_id",
-          "source"
+          "source",
+          "keep_in_source_bucket"
         )
       )
     } yield insertedUpload
@@ -104,7 +105,8 @@ object UploadDao extends Dao[Upload] {
           visibility = ${upload.visibility},
           project_id = ${upload.projectId},
           layer_id = ${upload.layerId},
-          source = ${upload.source}
+          source = ${upload.source},
+          keep_in_source_bucket = ${upload.keepInSourceBucket}
      """ ++ Fragments.whereAndOpt(Some(idFilter))).update.run
     (for {
       oldUpload <- oldUploadIO

--- a/app-tasks/rf/src/rf/models/upload.py
+++ b/app-tasks/rf/src/rf/models/upload.py
@@ -7,7 +7,7 @@ class Upload(BaseModel):
     def __init__(self, uploadStatus, fileType, uploadType, files,
                  datasource, metadata, visibility, id=None, createdAt=None,
                  createdBy=None, modifiedAt=None, modifiedBy=None, owner=None,
-                 projectId=None, layerId=None):
+                 projectId=None, layerId=None, keepInSourceBucket=None):
         self.id = id
         self.createdAt = createdAt
         self.createdBy = createdBy
@@ -23,6 +23,7 @@ class Upload(BaseModel):
         self.visibility = visibility
         self.projectId = projectId
         self.layerId = layerId
+        self.keepInSourceBucket = keepInSourceBucket
 
     def to_dict(self):
         return dict(
@@ -40,7 +41,8 @@ class Upload(BaseModel):
             visibility=self.visibility,
             owner=self.owner,
             projectId=self.projectId,
-            layerId=self.layerId
+            layerId=self.layerId,
+            keepInSourceBucket=self.keepInSourceBucket
         )
 
     def update_upload_status(self, status):
@@ -64,7 +66,8 @@ class Upload(BaseModel):
             modifiedBy=d.get('modifiedBy'),
             owner=d.get('owner'),
             projectId=d.get('projectId'),
-            layerId=d.get('layerId')
+            layerId=d.get('layerId'),
+            keepInSourceBucket=d.get('keepInSourceBucket')
         )
 
     @classmethod

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -49,6 +49,7 @@ class GeoTiffS3SceneFactory(object):
         self.acquisitionDate = self._upload.metadata.get('acquisitionDate')
         self.cloudCover = self._upload.metadata.get('cloudCover', 0)
         self.tags = self._upload.metadata.get('tags') or ['']
+        self.keep_in_source_bucket = self._upload.keepInSourceBucket
 
     def generate_scenes(self):
         """Create a Scene and associated Image for each GeoTiff in self.s3_path
@@ -70,7 +71,10 @@ class GeoTiffS3SceneFactory(object):
                 cog.add_overviews(tmp_fname)
                 cog_path = cog.convert_to_cog(tmp_fname, tempdir)
                 scene = self.create_geotiff_scene(tmp_fname, os.path.splitext(filename)[0])
-                scene.ingestLocation = upload_tifs([cog_path], self.owner, scene.id)[0]
+                if self.keep_in_source_bucket:
+                    scene.ingestLocation = upload_tifs([cog_path], self.owner, scene.id, bucket_name)[0]
+                else:
+                    scene.ingestLocation = upload_tifs([cog_path], self.owner, scene.id)[0]
                 images = [self.create_geotiff_image(
                     tmp_fname, urllib.unquote(scene.ingestLocation), scene, cog_path
                 )]

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -164,7 +164,7 @@ def get_session():
     return session
 
 
-def upload_tifs(tifs, user_id, scene_id):
+def upload_tifs(tifs, user_id, scene_id, bucket_name=None):
     """Upload tifs to S3
 
     Args:
@@ -175,7 +175,7 @@ def upload_tifs(tifs, user_id, scene_id):
     Returns:
         list[str]: list of s3 URIs for tiffs
     """
-    bucket = os.getenv('DATA_BUCKET')
+    bucket = bucket_name or os.getenv('DATA_BUCKET')
     s3_directory = os.path.join('user-uploads', user_id, scene_id)
     s3_client = boto3.client('s3')
     s3_uris = []

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -7101,6 +7101,11 @@ definitions:
             description: 'for uploads of type S3 and Dropbox, the location of the files to import. If files are specified, this field is ignored'
           metadata:
             $ref: '#/definitions/UploadMetadata'
+          keepInSourceBucket:
+            type: boolean
+            description: 'For S3 upload(s), use the same data bucket as source files for scene ingest location if set to true; use RF data bucket if set to false. It is false by default'
+            example: false
+
   Upload:
     allOf:
       - $ref: '#/definitions/BaseModel'

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -58,14 +58,14 @@ then
     then
         usage
     else
-        # API server won't start until Postgres is passing Health Checks
-        docker-compose up -d api-server
         if [ "${1:-}" = "--download" ] || [ ! -f data/database.pgdump ]; then
             download_database_backup
             download_development_images
         fi
-        load_database_backup
+        # API server won't start until Postgres is passing Health Checks
+        docker-compose up -d api-server
         docker-compose rm -sf api-server
+        load_database_backup
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

This PR adds a new field `keepInSourceBucket` to the `uploads` table with `false` value by default so that the processed uploaded scene will live in where the `DATA_BUCKET` env variable specifies. If set `true` on upload creation, the processed upload will live within the source bucket as the unprocessed file. (We already name the resulting scene's key as `<user id>/<scene id>/<cog.tif>`.)

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [X] Swagger specification updated
- [X] Symlinks from new migrations present or corrected for any new migrations
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (generator and tests are updated)

## Testing Instructions

- `./scripts/migrate migrate`
- Create two upload records in DB with `files` field containing tif in S3 that is not in the dev data bucket. Set one of them `keep_in_source_bucket` field to true
- Assemble the batch jar. `docker-compose build batch`
- In a batch shell, run `rf process-upload <upload id>` to process these two uploads
- Make sure one of the processed COG is in the source file bucket, and the other one is in the dev data bucket

Closes https://github.com/raster-foundry/raster-foundry/issues/4913
