### PR TITLE
Use zoom level in OverviewInput for lambda function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added database support for tasks on projects + project layers [\#4996](https://github.com/raster-foundry/raster-foundry/pull/4996)
 - Support storing processed uploads in source bucket [\#4997](https://github.com/raster-foundry/raster-foundry/pull/4997)
 - Add spec for user scopes CRUD [\#5002](https://github.com/raster-foundry/raster-foundry/pull/5002)
+- Use zoom level in OverviewInput for lambda function to generate layer overviews [\#4998](https://github.com/raster-foundry/raster-foundry/pull/4998)
 
 ### Changed
 

--- a/app-backend/common/src/main/scala/AWSLambda.scala
+++ b/app-backend/common/src/main/scala/AWSLambda.scala
@@ -84,13 +84,13 @@ trait AWSLambda extends RollbarNotifier with LazyLogging {
       s"s3://${s3Config.dataBucket}/lambdaOverviews/projects/${projectId
         .toString()}/${layerId.toString()}-overview.tif"
     val refreshToken: String = auth0Config.systemRefreshToken
-    val pixelSizeMeters: Int = 2444
+    val minZoomLevel: Int = 6
     val payloadcs: OverviewInput = OverviewInput(
       outputLocation,
       projectId,
       layerId,
       refreshToken,
-      pixelSizeMeters
+      minZoomLevel
     )
     val payload: String = payloadcs.asJson.noSpaces
     val payloadObfuscated: String =

--- a/app-backend/datamodel/src/main/scala/OverviewInput.scala
+++ b/app-backend/datamodel/src/main/scala/OverviewInput.scala
@@ -9,5 +9,5 @@ final case class OverviewInput(
     projectId: UUID,
     projectLayerId: UUID,
     refreshToken: String,
-    pixelSizeMeters: Int
+    minZoomLevel: Int
 )

--- a/app-backend/lambda-overviews/src/main/scala/com/rasterfoundry/lambda/overviews/HttpClient.scala
+++ b/app-backend/lambda-overviews/src/main/scala/com/rasterfoundry/lambda/overviews/HttpClient.scala
@@ -55,11 +55,9 @@ object HttpClient {
   }
 
   def updateProjectWithOverview(authToken: String,
-                                projectId: UUID,
-                                layerId: UUID,
-                                overviewLocation: String): Int = {
+                                overviewInput: OverviewInput): Int = {
     val projectLayerUri =
-      uri"$rfApiServer/api/projects/$projectId/layers/$layerId"
+      uri"$rfApiServer/api/projects/${overviewInput.projectId}/layers/${overviewInput.projectLayerId}"
     println("Getting project layer by ID")
     val projectLayerResponse = client
       .headers(Map("Authorization" -> s"Bearer $authToken"))
@@ -71,16 +69,20 @@ object HttpClient {
       case Right(pl) => pl
     }
     println("Updating project layer with new overview location")
-    val layerUpdateStatus = client
-      .headers(Map("Authorization" -> s"Bearer $authToken"))
-      .put(projectLayerUri)
-      .body(projectLayer.copy(overviewsLocation = Some(overviewLocation)))
-      .send()
-      .code match {
-      case StatusCodes.NoContent => 204
-      case StatusCodes.NotFound  => 404
-      case _                     => 0
-    }
+    val layerUpdateStatus =
+      client
+        .headers(Map("Authorization" -> s"Bearer $authToken"))
+        .put(projectLayerUri)
+        .body(
+          projectLayer.copy(overviewsLocation =
+                              Some(overviewInput.outputLocation),
+                            minZoomLevel = Some(overviewInput.minZoomLevel)))
+        .send()
+        .code match {
+        case StatusCodes.NoContent => 204
+        case StatusCodes.NotFound  => 404
+        case _                     => 0
+      }
     layerUpdateStatus
   }
 

--- a/app-backend/lambda-overviews/src/main/scala/com/rasterfoundry/lambda/overviews/OverviewGenerator.scala
+++ b/app-backend/lambda-overviews/src/main/scala/com/rasterfoundry/lambda/overviews/OverviewGenerator.scala
@@ -82,6 +82,9 @@ object OverviewGenerator extends LazyLogging {
     )
 
     println("Creating project overview")
+    // James figured out the formula by fitting the plot of
+    // zoom level versus pixel size in meters
+    // 156412 is the pixel size on zoom level 0
     val projectOverviewOption =
       OverviewGenerator.createProjectOverview(
         initialProjectScenes,


### PR DESCRIPTION
## Overview

This PR updates the `OverviewInput` case class to take a `minZoomLevel` instead of `pixelSizeMeters`, transforms the zoom level to pixel size in the overview generation function in lambda, and updates the project layer with this zoom level.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Assemble servers and start them
- Open an `sbt` shell and run the following command to generate a jar for overview generation:
```
project lambdaOverviews
set assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = true)
assembly
```
- Get a refresh token from the UI, and update the following `json` with your refresh token:
```
{"outputLocation" : "s3://rasterfoundry-development-data-us-east-1/lambdaOverviews/projects/<project-id>/<layer-id>-overview.tif","projectId" : "<project-id>","projectLayerId" : "<layer-id>","refreshToken" : "<refresh-token>","minZoomLevel" : 6}
```
- Navigate to the assembly jar location and run the following:
```
AWS_PROFILE=raster-foundry java -jar lambda-overviews-assembly.jar '<overviewInputJson>'
```
- Once complete, in the same shell, download the tif and open it in QGIS:
```
AWS_PROFILE=raster-foundry aws s3 cp s3://rasterfoundry-development-data-us-east-1/lambdaOverviews/projects/<project-id>/<layer-id>-overview.tif .
```

Closes https://github.com/raster-foundry/raster-foundry/issues/4985
