### PR TITLE
Pull all project layers to list in overview backfill

### DIFF
--- a/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/OverviewBackfill.scala
@@ -71,10 +71,10 @@ object OverviewBackfill extends Job with RollbarNotifier {
           projectLayersWithSceneCounts
             .transact(t)
             .flatMap { layers =>
-              layers parTraverse {
+              layers.parTraverse({
                 case (layer, _) =>
-                  kickoffOverviewGeneration(layer)
-              }
+                  kickoffOverviewGeneration(layer).attempt
+              })
           }
       )
       .map { results =>


### PR DESCRIPTION
## Overview

This PR pulls the whole stream of project layers to add overviews to and adds better error-handling
so the whole traversal won't fail if one does. It's an effort to prevent failures due to socket read
timeouts that I encountered once it was actually time to backfill the layers. This PR and
`test/js/pull-whole-stream-of-layers` have the same code.

Update:

This "worked" in the sense that the processing didn't die from socket timeouts. It's possible that our staging projects are in general too degenerate to be much use as an indication of how robust the overview generation is, but a _huge_ percentage (92%) of the invocations failed. A lot of these were "the server doesn't support ranged byte reads," which I'm assuming is COGs we've cleaned up. A number of others were running out of memory.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~

## Testing Instructions

- testing from the results of the `test/` branch