### PR TITLE
Add Upload Processing for Non-Spatial Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Changed
 
 - Use flyway for running migrations and publish image for flyway migrations [\#4987](https://github.com/raster-foundry/raster-foundry/pull/4987)
-- Added enum value for `NON_SPATIAL` file types to uploads [\#4993]](https://github.com/raster-foundry/raster-foundry/pull/4993)
+- Added support for uploading non-spatial data [\#4993]](https://github.com/raster-foundry/raster-foundry/pull/4993)[\#5001]](https://github.com/raster-foundry/raster-foundry/pull/5001)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -79,9 +79,11 @@ trait UploadRoutes
 
   def createUpload: Route = authenticate { user =>
     entity(as[Upload.Create]) { newUpload =>
+      logger.debug(
+        s"newUpload: ${newUpload.uploadType}, ${newUpload.source}, ${newUpload.fileType}")
       val uploadToInsert =
         (newUpload.uploadType, newUpload.source, newUpload.fileType) match {
-          case (UploadType.S3, None, FileType.NonSpatial) => {
+          case (UploadType.S3, _, FileType.NonSpatial) => {
             if (newUpload.files.nonEmpty) newUpload
             else
               throw new IllegalStateException(

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -48,6 +48,7 @@ class GeoTiffS3SceneFactory(object):
         self.datasource = self._upload.datasource
         self.acquisitionDate = self._upload.metadata.get('acquisitionDate')
         self.cloudCover = self._upload.metadata.get('cloudCover', 0)
+        self.fileType = upload.fileType
         self.tags = self._upload.metadata.get('tags') or ['']
         self.keep_in_source_bucket = self._upload.keepInSourceBucket
 
@@ -68,6 +69,10 @@ class GeoTiffS3SceneFactory(object):
             with get_tempdir() as tempdir:
                 tmp_fname = os.path.join(tempdir, filename)
                 bucket.download_file(key, tmp_fname)
+
+                if self.fileType == 'NON_SPATIAL':
+                    tmp_fname = cog.georeference_file(tmp_fname)
+
                 cog.add_overviews(tmp_fname)
                 cog_path = cog.convert_to_cog(tmp_fname, tempdir)
                 scene = self.create_geotiff_scene(tmp_fname, os.path.splitext(filename)[0])

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -26,14 +26,14 @@ def georeference_file(file_path):
         height = ds.height
 
     output_dir, source_filename = os.path.split(file_path)
-    translated_tiff = '{}.tif'.format(source_filename.split('.')[0])
+    translated_tiff = os.path.join(output_dir, '{}.tif'.format(source_filename.split('.')[0]))
     translate_command = [
         'gdal_translate',
         '-a_ullr', '0', str(height), str(width), '0',
         '-a_srs', 'epsg:3857',
-        file_path, os.path.join(output_dir, translated_tiff)
+        file_path, translated_tiff
     ]
-    logger.debug('Running translate command: %s', translate_command))
+    logger.debug('Running translate command: %s', translate_command)
     subprocess.check_call(translate_command)
     return translated_tiff
 

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -26,7 +26,7 @@ def georeference_file(file_path):
         height = ds.height
 
     output_dir, source_filename = os.path.split(file_path)
-    translated_tiff = os.path.join(output_dir, '{}.tif'.format(source_filename.split('.')[0]))
+    translated_tiff = os.path.join(output_dir, '{}-referenced.tif'.format(source_filename.split('.')[0]))
     translate_command = [
         'gdal_translate',
         '-a_ullr', '0', str(height), str(width), '0',

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -29,11 +29,11 @@ def georeference_file(file_path):
     translated_tiff = '{}.tif'.format(source_filename.split('.')[0])
     translate_command = [
         'gdal_translate',
-        '-a_ullr', 0, height, width, 0,
+        '-a_ullr', '0', str(height), str(width), '0',
         '-a_srs', 'epsg:3857',
         file_path, os.path.join(output_dir, translated_tiff)
     ]
-    logger.debug('Running translate command: %s', ' '.join(translate_command))
+    logger.debug('Running translate command: %s', translate_command))
     subprocess.check_call(translate_command)
     return translated_tiff
 


### PR DESCRIPTION
## Overview

Brief description of what this PR does, and why it is needed.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated (updated in previous PR)

## Testing Instructions

- Rebuild api server and batch containers
```
docker-compose build batch
./scripts/console sbt
api/assembly
```
- Create Project - note project id
```
echo '{"name":"NonSpatialDemo","description":"","visibility":"PRIVATE","tileVisibility":"PRIVATE","tags":[],"isAOIProject":false}' | http --auth-type=JWT :9091/api/projects
```
- Create Upload - note upload id, pass in project ID
```
echo '{"files":["s3://rasterfoundry-development-data-us-east-1/TgMEFKAG_400x400.jpg"],"datasource":"b4ca6661-27fa-497e-a85a-2a5632d5fe7c","fileType":"NON_SPATIAL","uploadStatus":"UPLOADING","visibility":"PRIVATE","metadata":{"acquisitionDate":"2019-05-20T20:49:26.348Z","cloudCover":0},"uploadType":"S3","source": null,"projectId":"1e299e13-3abe-44e8-8986-7477fa77e6be"}' | http --auth-type=JWT :9091/api/uploads
```
- Process Upload (note api server needs to be running)
```
docker-compose run batch "rf process-upload <upload-id>"
```
- Switch to project once successfully done, you'll have to mess with coloring since this image only has 3 bands, but the datasource specifies 4

Closes #4976
