### PR TITLE
Add spec for user scopes CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added ability to persist container service core dumps [\#4955](https://github.com/raster-foundry/raster-foundry/pull/4955)
 - Added database support for tasks on projects + project layers [\#4996](https://github.com/raster-foundry/raster-foundry/pull/4996)
 - Support storing processed uploads in source bucket [\#4997](https://github.com/raster-foundry/raster-foundry/pull/4997)
+- Add spec for user scopes CRUD [\#5002](https://github.com/raster-foundry/raster-foundry/pull/5002)
 
 ### Changed
 

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -206,7 +206,7 @@ paths:
   /users/me/scopes:
     x-resource: Users
     get:
-      summary: 'Get actions on objects a logged-in user can operate'
+      summary: 'Get object action scopes for a logged-in user'
       tags:
         - Users
       responses:
@@ -284,7 +284,7 @@ paths:
   /users/{userID}/scopes:
     x-resource: Users
     get:
-      summary: 'Get actions on objects an user can operate'
+      summary: 'Get object action scopes for a user'
       tags:
         - Users
       parameters:
@@ -303,7 +303,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: 'Create actions on objects an user can operate'
+      summary: 'Create object action scopes for a user'
       tags:
         - Users
       parameters:
@@ -315,7 +315,7 @@ paths:
             $ref: '#/definitions/UserScopes'
       responses:
         200:
-          description: 'Actions on objects an user can operate'
+          description: 'Actions on objects a user can operate'
           schema:
             $ref: '#/definitions/UserScopes'
         default:
@@ -323,7 +323,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: 'Update actions on objects an user can operate'
+      summary: 'Update object action scopes for a user'
       tags:
         - Users
       parameters:
@@ -345,7 +345,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: 'Remove all actions on objects an user can operate'
+      summary: 'Remove all object action scopes for a user'
       tags:
         - Users
       parameters:
@@ -355,7 +355,7 @@ paths:
           description: 'Deletion Successful (no content)'
         404:
           description: |
-            The UUID parameter does not refer to an user or the user does not have permission to perform this action
+            The UUID parameter does not refer to a user or the user does not have permission to perform this action
           schema:
             $ref: '#/definitions/Error'
   /organizations/search/:
@@ -6092,7 +6092,7 @@ definitions:
             type: string
 
   UserScopes:
-    description: A map from API resource/object types to allowed actions for an user
+    description: A map from API resource/object types to allowed actions for a user
     type: object
     additionalProperties:
       $ref: '#/definitions/ActionTypeArray'

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -262,6 +262,83 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /users/{userID}/scopes:
+    x-resource: Users
+    get:
+      summary: 'Get actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/userID'
+      responses:
+        200:
+          description: 'User scopes found'
+          schema:
+            $ref: '#/definitions/UserScopes'
+        404:
+          description: 'User scopes not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: 'Create actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/userID'
+        - name: UserScopes
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UserScopes'
+      responses:
+        200:
+          description: 'Actions on objects a user can operate'
+          schema:
+            $ref: '#/definitions/UserScopes'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Update actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/userID'
+        - name: UserScopes
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/UserScopes'
+      responses:
+        204:
+          description: 'Update successful (No Content)'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Remove all actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      tags:
+        - Users
+      parameters:
+        - $ref: '#/parameters/userID'
+      responses:
+        204:
+          description: 'Deletion Successful (no content)'
+        404:
+          description: |
+            The UUID parameter does not refer to a user or the user does not have permission to perform this action
+          schema:
+            $ref: '#/definitions/Error'
   /organizations/search/:
     x-resource: Organizations
     get:
@@ -5402,6 +5479,47 @@ parameters:
     required: false
 
 definitions:
+  ActionTypeArray:
+    type: array
+    items:
+      $ref: '#/definitions/ActionType'
+    example:
+      - 'VIEW'
+      - 'EDIT'
+      - 'CREATE'
+  ActionType:
+    type: string
+    enum:
+      - 'VIEW'
+      - 'EDIT'
+      - 'DEACTIVATE'
+      - 'DELETE'
+      - 'ANNOTATE'
+      - 'EXPORT'
+      - 'DOWNLOAD'
+      - 'CREATE'
+  ObjectType:
+    type: string
+    enum:
+      - 'PROJECT'
+      - 'SCENE'
+      - 'DATASOURCE'
+      - 'SHAPE'
+      - 'WORKSPACE'
+      - 'TEMPLATE'
+      - 'ANALYSIS'
+      - 'PLATFORM'
+      - 'ORGANIZATION'
+      - 'TEAM'
+      - 'USER'
+      - 'UPLOAD'
+      - 'EXPORT'
+      - 'FEED'
+      - 'MAPTOKEN'
+      - 'LICENSE'
+      - 'TOOLTAG'
+      - 'TOOLCATEGORY'
+      - 'AOI'
   LayerSplitOptions:
     type: object
     properties:
@@ -5953,6 +6071,12 @@ definitions:
         properties:
           email:
             type: string
+
+  UserScopes:
+    description: a Map(ObjectType, Array[ActionType])
+    type: object
+    additionalProperties:
+      $ref: '#/definitions/ActionTypeArray'
 
   UserWithRole:
     allOf:

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -203,6 +203,25 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /users/me/scopes:
+    x-resource: Users
+    get:
+      summary: 'Get actions on objects a logged-in user can operate'
+      tags:
+        - Users
+      responses:
+        200:
+          description: 'User scopes found'
+          schema:
+            $ref: '#/definitions/UserScopes'
+        404:
+          description: 'User scopes not found'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /users/search/:
     x-resource: Users
     get:
@@ -265,7 +284,7 @@ paths:
   /users/{userID}/scopes:
     x-resource: Users
     get:
-      summary: 'Get actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      summary: 'Get actions on objects an user can operate'
       tags:
         - Users
       parameters:
@@ -284,7 +303,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     post:
-      summary: 'Create actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      summary: 'Create actions on objects an user can operate'
       tags:
         - Users
       parameters:
@@ -296,7 +315,7 @@ paths:
             $ref: '#/definitions/UserScopes'
       responses:
         200:
-          description: 'Actions on objects a user can operate'
+          description: 'Actions on objects an user can operate'
           schema:
             $ref: '#/definitions/UserScopes'
         default:
@@ -304,7 +323,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     put:
-      summary: 'Update actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      summary: 'Update actions on objects an user can operate'
       tags:
         - Users
       parameters:
@@ -326,7 +345,7 @@ paths:
           schema:
             $ref: '#/definitions/Error'
     delete:
-      summary: 'Remove all actions on objects a user can operate (a Map(ObjectType, Array[ActionType]))'
+      summary: 'Remove all actions on objects an user can operate'
       tags:
         - Users
       parameters:
@@ -336,7 +355,7 @@ paths:
           description: 'Deletion Successful (no content)'
         404:
           description: |
-            The UUID parameter does not refer to a user or the user does not have permission to perform this action
+            The UUID parameter does not refer to an user or the user does not have permission to perform this action
           schema:
             $ref: '#/definitions/Error'
   /organizations/search/:
@@ -6073,7 +6092,7 @@ definitions:
             type: string
 
   UserScopes:
-    description: a Map(ObjectType, Array[ActionType])
+    description: A map from API resource/object types to allowed actions for an user
     type: object
     additionalProperties:
       $ref: '#/definitions/ActionTypeArray'


### PR DESCRIPTION
## Overview

This PR adds spec for user scopes CRUD.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [X] Swagger specification updated
- ~Symlinks from new migrations present or corrected for any new migrations~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


### Notes

Per offline discussions with @notthatbreezy and based on my understanding, we support endpoints to get, create, update, delete user scopes in a `Map(ObjectType, Array[ActionType])`.

Per limitations of swagger 2.0, to model Map or Dictionary properties, the choice we have seems to be using `additionalProperties `: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#model-with-mapdictionary-properties . 

## Testing Instructions

- Not sure if CI runs spec check. If not, paste it in swagger editor and make sure it passes checks.
- Make sure it reflects the essence of the usr scope ADR and the issue

Closes https://github.com/raster-foundry/raster-foundry/issues/4968
