### PR TITLE
Fix RasterSource caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed usage of AWS credentials by the GDAL java bindings by using `AWS_DEFAULT_PROFILE` [\#4948](https://github.com/raster-foundry/raster-foundry/pull/4948)
 - Fixed logging configuration to respect `RF_LOG_LEVEL` environment variable [\#4972](https://github.com/raster-foundry/raster-foundry/pull/4972)
 - Fix Sentinel-2 metadata file download [\#4969](https://github.com/raster-foundry/raster-foundry/pull/4969)
+- Fixed a bug causing all raster sources to share a cache location [\#5003](https://github.com/raster-foundry/raster-foundry/pull/5003)
 
 ### Security
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -53,10 +53,10 @@ final case class BacksplashGeotiff(
     with BacksplashImage[IO] {
 
   implicit val tileCache = Cache.tileCache
-  implicit val flags = Cache.tileCacheFlags
   implicit val rasterSourceCache = Cache.rasterSourceCache
 
   def getRasterSource: IO[RasterSource] = {
+    implicit val rasterSourceCacheFlags = Cache.rasterSourceCacheFlags
     if (enableGDAL) {
       logger.debug(s"Using GDAL Raster Source: ${uri}")
       // Do not bother caching - let GDAL internals worry about that
@@ -142,6 +142,8 @@ sealed trait BacksplashImage[F[_]] extends LazyLogging {
 
   /** Read ZXY tile - defers to a private method to enable disable/enabling of cache **/
   def read(z: Int, x: Int, y: Int): F[Option[MultibandTile]] = {
+    implicit val flags =
+      Flags(Config.cache.tileCacheEnable, Config.cache.tileCacheEnable)
     readWithCache(z, x, y)
   }
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -73,8 +73,14 @@ object Cache extends LazyLogging {
     Flags(Config.cache.histogramCacheEnable, Config.cache.histogramCacheEnable)
   logger.info(s"Histogram Cache Status: ${histCacheFlags}")
 
-  val rasterSourceCache: Cache[GeoTiffRasterSource] =
+  val rasterSourceCache: Cache[GeoTiffRasterSource] = {
+    implicit val cacheConfig: CacheConfig = CacheConfig(
+      memoization = MemoizationConfig(
+        MethodCallToStringConverter.includeClassConstructorParams)
+    )
     CaffeineCache[GeoTiffRasterSource]
+  }
+
   val rasterSourceCacheFlags: Flags = Flags(
     Config.cache.rasterSourceCacheEnable,
     Config.cache.rasterSourceCacheEnable)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -498,6 +498,11 @@ lazy val backsplashServer =
         Dependencies.scalacacheCaffeine
       ) ++ loggingDependencies
     })
+    .settings({
+      dependencyOverrides ++= Seq(
+        "com.azavea.gdal" % "gdal-warp-bindings" % "33.5523882"
+      )
+    })
     .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))
     .settings(assemblyJarName in assembly := "backsplash-assembly.jar")
     .settings(test in assembly := {})


### PR DESCRIPTION
## Overview

This PR modifies the raster source cache config to include class constructor arguments. The move to `getRasterSource` with no arguments made it so that all raster sources were cached under the same key, with hilarious (from a certain dark perspective) results.

It also bumps the gdalwarp bindings dependency to a version that doesn't fail in a particular way.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- disable gdal
- view a layer
- view a different layer
- it should work

Closes #5000 