### PR TITLE
Limit max zoom level for backsplash tiles to 23 on frontend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Limited max zoom level for backsplash tiles to 23 on frontend [\#5013](https://github.com/raster-foundry/raster-foundry/pull/5013)
+
 ### Changed
 
 ### Deprecated

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -323,7 +323,7 @@ module.exports = function (_path) {
                     MAP_ZOOM: 5,
                     PLATFORM_USERS: PLATFORM_USERS,
                     EMBED_URI: JSON.stringify(''),
-                    BACKSPLASH_TILE_MAX_ZOOM: 23
+                    TILES_MAX_ZOOM: 23
                 },
                 'HELPCONFIG': {
                     API_DOCS_URL: JSON.stringify('https://app.swaggerhub.com/apis/raster-foundry/raster-foundry/'),

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -69,7 +69,8 @@ const basemaps = JSON.stringify({
                 attribution: 'Map &copy; 1987-2014 <a href="http://developer.here.com">HERE</a>',
                 subdomains: '1234',
                 'app_id': HERE_APP_ID,
-                'app_code': HERE_APP_CODE
+                'app_code': HERE_APP_CODE,
+                maxZoom: 30
             }
         }
     },
@@ -323,7 +324,8 @@ module.exports = function (_path) {
                     MAP_ZOOM: 5,
                     PLATFORM_USERS: PLATFORM_USERS,
                     EMBED_URI: JSON.stringify(''),
-                    TILES_MAX_ZOOM: 23
+                    TILES_MAX_ZOOM: 23,
+                    VISUAL_MAX_ZOOM: 30
                 },
                 'HELPCONFIG': {
                     API_DOCS_URL: JSON.stringify('https://app.swaggerhub.com/apis/raster-foundry/raster-foundry/'),

--- a/app-frontend/config/webpack/global.js
+++ b/app-frontend/config/webpack/global.js
@@ -322,7 +322,8 @@ module.exports = function (_path) {
                     MAP_CENTER: JSON.stringify([-6.8, 39.2]),
                     MAP_ZOOM: 5,
                     PLATFORM_USERS: PLATFORM_USERS,
-                    EMBED_URI: JSON.stringify('')
+                    EMBED_URI: JSON.stringify(''),
+                    BACKSPLASH_TILE_MAX_ZOOM: 23
                 },
                 'HELPCONFIG': {
                     API_DOCS_URL: JSON.stringify('https://app.swaggerhub.com/apis/raster-foundry/raster-foundry/'),

--- a/app-frontend/src/app/components/map/labMap/labMap.module.js
+++ b/app-frontend/src/app/components/map/labMap/labMap.module.js
@@ -103,7 +103,7 @@ class LabMapController {
             boxZoom: !this.options.static,
             keyboard: !this.options.static,
             tap: !this.options.static,
-            maxZoom: 30
+            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
         }).setView(
             this.initialCenter ? this.initialCenter : [0, 0],
             this.initialZoom ? this.initialZoom : 2

--- a/app-frontend/src/app/components/map/mapContainer/mapContainer.module.js
+++ b/app-frontend/src/app/components/map/mapContainer/mapContainer.module.js
@@ -125,7 +125,7 @@ class MapContainerController {
             boxZoom: !this.options.static,
             keyboard: !this.options.static,
             tap: !this.options.static,
-            maxZoom: 30
+            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
         }).setView(
             this.initialCenter ? this.initialCenter : [0, 0],
             this.initialZoom ? this.initialZoom : 2

--- a/app-frontend/src/app/components/map/staticMap/staticMap.module.js
+++ b/app-frontend/src/app/components/map/staticMap/staticMap.module.js
@@ -1,3 +1,4 @@
+/* globals BUILDCONFIG */
 import angular from 'angular';
 import Map from 'es6-map';
 import staticMapTpl from './staticMap.html';
@@ -38,7 +39,7 @@ class StaticMapController {
             boxZoom: false,
             keyboard: false,
             tap: false,
-            maxZoom: 30
+            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
         }, this.options);
     }
 

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -219,7 +219,10 @@ class AnalysesListController {
             .then(this.autoGenerateRenderDef.bind(this))
             .then(() => {
                 const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
-                return L.tileLayer(tileUrl, { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM });
+                return L.tileLayer(tileUrl, {
+                    maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                    maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+                });
             });
     }
 

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -30,7 +30,6 @@ class AnalysesListController {
         this.visible = new Set();
         this.selected = new Map();
         this.itemActions = new Map();
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.syncMapLayersToVisible();
         this.fetchPage().then(() => {
             if (get(this, 'itemList.length')) {
@@ -220,7 +219,7 @@ class AnalysesListController {
             .then(this.autoGenerateRenderDef.bind(this))
             .then(() => {
                 const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
-                return L.tileLayer(tileUrl, { maxZoom: this.backsplashTileMaxZoom });
+                return L.tileLayer(tileUrl, { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM });
             });
     }
 

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -219,7 +219,7 @@ class AnalysesListController {
             .then(this.autoGenerateRenderDef.bind(this))
             .then(() => {
                 const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
-                return L.tileLayer(tileUrl, { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM });
+                return L.tileLayer(tileUrl, { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM });
             });
     }
 

--- a/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/analyses/index.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 import tpl from './index.html';
 import { colorStopsToRange, createRenderDefinition } from '_redux/histogram-utils';
 import { nodesFromAst, astFromNodes } from '_redux/node-utils';
@@ -29,6 +30,7 @@ class AnalysesListController {
         this.visible = new Set();
         this.selected = new Map();
         this.itemActions = new Map();
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.syncMapLayersToVisible();
         this.fetchPage().then(() => {
             if (get(this, 'itemList.length')) {
@@ -218,7 +220,7 @@ class AnalysesListController {
             .then(this.autoGenerateRenderDef.bind(this))
             .then(() => {
                 const tileUrl = this.analysisService.getAnalysisTileUrl(analysisId);
-                return L.tileLayer(tileUrl, { maxZoom: 30 });
+                return L.tileLayer(tileUrl, { maxZoom: this.backsplashTileMaxZoom });
             });
     }
 

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
@@ -108,7 +108,7 @@ class AnalysesVisualizeController {
                     statistics,
                     analysisTile: {
                         analysis,
-                        mapTile: L.tileLayer(tileUrl, { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM })
+                        mapTile: L.tileLayer(tileUrl, { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM })
                     }
                 };
             })

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
@@ -108,7 +108,10 @@ class AnalysesVisualizeController {
                     statistics,
                     analysisTile: {
                         analysis,
-                        mapTile: L.tileLayer(tileUrl, { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM })
+                        mapTile: L.tileLayer(tileUrl, {
+                            maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+                        })
                     }
                 };
             })

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 import { Map } from 'immutable';
 import { get, min, max } from 'lodash';
 
@@ -28,6 +29,7 @@ class AnalysesVisualizeController {
         this.analysesMap = new Map();
         this.projectId = this.$state.params.projectId;
         this.layerColorHex = {};
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.analyses = this.getAnalysisIds().map(analysisId => {
             // create a trackId for each analysis to enable displaying
             // same analysis multiple times especially for map layers
@@ -107,7 +109,7 @@ class AnalysesVisualizeController {
                     statistics,
                     analysisTile: {
                         analysis,
-                        mapTile: L.tileLayer(tileUrl, { maxZoom: 30 })
+                        mapTile: L.tileLayer(tileUrl, { maxZoom: this.backsplashTileMaxZoom })
                     }
                 };
             })

--- a/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
+++ b/app-frontend/src/app/components/pages/project/analyses/visualize/index.js
@@ -29,7 +29,6 @@ class AnalysesVisualizeController {
         this.analysesMap = new Map();
         this.projectId = this.$state.params.projectId;
         this.layerColorHex = {};
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.analyses = this.getAnalysisIds().map(analysisId => {
             // create a trackId for each analysis to enable displaying
             // same analysis multiple times especially for map layers
@@ -109,7 +108,7 @@ class AnalysesVisualizeController {
                     statistics,
                     analysisTile: {
                         analysis,
-                        mapTile: L.tileLayer(tileUrl, { maxZoom: this.backsplashTileMaxZoom })
+                        mapTile: L.tileLayer(tileUrl, { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM })
                     }
                 };
             })

--- a/app-frontend/src/app/components/pages/share/analyses/index.js
+++ b/app-frontend/src/app/components/pages/share/analyses/index.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 import tpl from './index.html';
 import _ from 'lodash';
 import { Map, Set } from 'immutable';
@@ -21,6 +22,7 @@ class ShareProjectAnalysesController {
         this.visible = new Set();
         this.tileUrls = new Map();
         this.copyTemplate = 'Copy tile URL';
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.$q
             .all({
                 project: this.projectPromise,
@@ -154,7 +156,7 @@ class ShareProjectAnalysesController {
                     mapToken: this.token
                 }
             );
-            return L.tileLayer(tileUrl, { maxZoom: 30 });
+            return L.tileLayer(tileUrl, { maxZoom: this.backsplashTileMaxZoom });
         });
         this.getMap().then(map => {
             map.setLayer('Analyses', mapLayers, true);

--- a/app-frontend/src/app/components/pages/share/analyses/index.js
+++ b/app-frontend/src/app/components/pages/share/analyses/index.js
@@ -22,7 +22,6 @@ class ShareProjectAnalysesController {
         this.visible = new Set();
         this.tileUrls = new Map();
         this.copyTemplate = 'Copy tile URL';
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.$q
             .all({
                 project: this.projectPromise,
@@ -156,7 +155,7 @@ class ShareProjectAnalysesController {
                     mapToken: this.token
                 }
             );
-            return L.tileLayer(tileUrl, { maxZoom: this.backsplashTileMaxZoom });
+            return L.tileLayer(tileUrl, { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM });
         });
         this.getMap().then(map => {
             map.setLayer('Analyses', mapLayers, true);

--- a/app-frontend/src/app/components/pages/share/analyses/index.js
+++ b/app-frontend/src/app/components/pages/share/analyses/index.js
@@ -155,7 +155,10 @@ class ShareProjectAnalysesController {
                     mapToken: this.token
                 }
             );
-            return L.tileLayer(tileUrl, { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM });
+            return L.tileLayer(tileUrl, {
+                maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+            });
         });
         this.getMap().then(map => {
             map.setLayer('Analyses', mapLayers, true);

--- a/app-frontend/src/app/components/pages/share/analyses/index.js
+++ b/app-frontend/src/app/components/pages/share/analyses/index.js
@@ -155,7 +155,7 @@ class ShareProjectAnalysesController {
                     mapToken: this.token
                 }
             );
-            return L.tileLayer(tileUrl, { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM });
+            return L.tileLayer(tileUrl, { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM });
         });
         this.getMap().then(map => {
             map.setLayer('Analyses', mapLayers, true);

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
@@ -43,7 +43,6 @@ class ProjectItemController {
     }
 
     $onInit() {
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.isSelectable = this.$attrs.hasOwnProperty('selectable');
         this.$scope.$watch(
             () => this.selected({ project: this.item }),
@@ -84,7 +83,7 @@ class ProjectItemController {
             this.projectService.getProjectTileURL(this.item, {
                 token: this.authService.token()
             }),
-            {maxZoom: this.backsplashTileMaxZoom}
+            {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM}
         );
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
@@ -83,7 +83,7 @@ class ProjectItemController {
             this.projectService.getProjectTileURL(this.item, {
                 token: this.authService.token()
             }),
-            {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM}
+            {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM}
         );
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
@@ -83,7 +83,10 @@ class ProjectItemController {
             this.projectService.getProjectTileURL(this.item, {
                 token: this.authService.token()
             }),
-            {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM}
+            {
+                maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+            }
         );
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
+++ b/app-frontend/src/app/components/projects/projectItem/projectItem.module.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 import angular from 'angular';
 import { get } from 'lodash';
 
@@ -42,6 +43,7 @@ class ProjectItemController {
     }
 
     $onInit() {
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.isSelectable = this.$attrs.hasOwnProperty('selectable');
         this.$scope.$watch(
             () => this.selected({ project: this.item }),
@@ -81,7 +83,8 @@ class ProjectItemController {
         const layer = L.tileLayer(
             this.projectService.getProjectTileURL(this.item, {
                 token: this.authService.token()
-            })
+            }),
+            {maxZoom: this.backsplashTileMaxZoom}
         );
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -74,7 +74,10 @@ class SceneDetailModalController {
                         greenBand: rgbBands.GREEN,
                         blueBand: rgbBands.BLUE
                     }),
-                    { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM }
+                    {
+                        maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                        maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+                    }
                 ),
                 true
             );

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -1,4 +1,4 @@
-/* global L */
+/* global L, BUILDCONFIG */
 import angular from 'angular';
 import sceneDetailModalTpl from './sceneDetailModal.html';
 require('./sceneDetailModal.scss');
@@ -30,6 +30,7 @@ class SceneDetailModalController {
         });
         this.scene = this.resolve.scene;
         this.repository = this.resolve.repository;
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
     }
 
     $postLink() {
@@ -71,7 +72,7 @@ class SceneDetailModalController {
                         blueBand: rgbBands.BLUE
                     }
                 ),
-                {maxZoom: 30}
+                {maxZoom: this.backsplashTileMaxZoom}
               ),
               true
             );

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -74,7 +74,7 @@ class SceneDetailModalController {
                         greenBand: rgbBands.GREEN,
                         blueBand: rgbBands.BLUE
                     }),
-                    { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM }
+                    { maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM }
                 ),
                 true
             );

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.module.js
@@ -16,8 +16,14 @@ const SceneDetailModalComponent = {
 
 class SceneDetailModalController {
     constructor(
-        $log, $state, modalService, $scope, $rootScope,
-        moment, sceneService, mapService,
+        $log,
+        $state,
+        modalService,
+        $scope,
+        $rootScope,
+        moment,
+        sceneService,
+        mapService,
         authService
     ) {
         'ngInject';
@@ -30,7 +36,6 @@ class SceneDetailModalController {
         });
         this.scene = this.resolve.scene;
         this.repository = this.resolve.repository;
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
     }
 
     $postLink() {
@@ -52,7 +57,7 @@ class SceneDetailModalController {
             if (this.scene.sceneType === 'COG') {
                 this.setCOGThumbnail(mapWrapper);
             } else {
-                mapWrapper.setThumbnail(this.scene, this.repository, {persist: true});
+                mapWrapper.setThumbnail(this.scene, this.repository, { persist: true });
             }
             mapWrapper.map.fitBounds(this.getSceneBounds());
         });
@@ -61,20 +66,17 @@ class SceneDetailModalController {
     setCOGThumbnail(mapWrapper) {
         this.repository.service.getDatasourceBands(this.scene).then(rgbBands => {
             mapWrapper.setLayer(
-              'Browse Scene',
-              L.tileLayer(
-                this.sceneService.getSceneLayerURL(
-                    this.scene,
-                    {
+                'Browse Scene',
+                L.tileLayer(
+                    this.sceneService.getSceneLayerURL(this.scene, {
                         token: this.authService.token(),
                         redBand: rgbBands.RED,
                         greenBand: rgbBands.GREEN,
                         blueBand: rgbBands.BLUE
-                    }
+                    }),
+                    { maxZoom: BUILDCONFIG.TILES_MAX_ZOOM }
                 ),
-                {maxZoom: this.backsplashTileMaxZoom}
-              ),
-              true
+                true
             );
         });
     }
@@ -84,12 +86,14 @@ class SceneDetailModalController {
     }
 
     openDownloadModal() {
-        this.modalService.open({
-            component: 'rfSceneDownloadModal',
-            resolve: {
-                scene: () => this.scene
-            }
-        }).result.catch(() => {});
+        this.modalService
+            .open({
+                component: 'rfSceneDownloadModal',
+                resolve: {
+                    scene: () => this.scene
+                }
+            })
+            .result.catch(() => {});
     }
 
     getSceneBounds() {
@@ -98,7 +102,7 @@ class SceneDetailModalController {
     }
 
     closeWithData(data) {
-        this.close({$value: data});
+        this.close({ $value: data });
     }
 
     cancelEditing() {
@@ -107,14 +111,17 @@ class SceneDetailModalController {
 
     startEditing() {
         if (!this.sources) {
-            this.repository.service.getSources().then((sources) => {
-                this.sources = sources;
-                this.selectedDatasource = this.datasource;
-                this.editingMetadata = true;
-            }, (err) => {
-                this.selectedDatasource = this.datasource;
-                this.datasourceError = err;
-            });
+            this.repository.service.getSources().then(
+                sources => {
+                    this.sources = sources;
+                    this.selectedDatasource = this.datasource;
+                    this.editingMetadata = true;
+                },
+                err => {
+                    this.selectedDatasource = this.datasource;
+                    this.datasourceError = err;
+                }
+            );
         } else {
             this.selectedDatasource = this.datasource;
             this.editingMetadata = true;
@@ -127,9 +134,9 @@ class SceneDetailModalController {
     }
 
     setAccDateDisplay() {
-        return this.scene.filterFields && this.scene.filterFields.acquisitionDate ?
-            this.formatAcqDate(this.scene.filterFields.acquisitionDate) :
-            'MM/DD/YYYY';
+        return this.scene.filterFields && this.scene.filterFields.acquisitionDate
+            ? this.formatAcqDate(this.scene.filterFields.acquisitionDate)
+            : 'MM/DD/YYYY';
     }
 
     updateMetadata() {
@@ -140,10 +147,10 @@ class SceneDetailModalController {
         }
         this.scene = Object.assign(this.scene, {
             datasource: this.selectedDatasource.id,
-            'modifiedAt': this.moment().toISOString(),
-            'modifiedBy': this.scene.owner,
-            'sceneMetadata': this.newSceneMetadata,
-            'filterFields': this.newFilterFields
+            modifiedAt: this.moment().toISOString(),
+            modifiedBy: this.scene.owner,
+            sceneMetadata: this.newSceneMetadata,
+            filterFields: this.newFilterFields
         });
         this.datasource = this.selectedDatasource;
         this.sceneService.update(this.scene).then(
@@ -161,17 +168,24 @@ class SceneDetailModalController {
     }
 
     openDatePickerModal(date) {
-        this.modalService.open({
-            component: 'rfDatePickerModal',
-            windowClass: 'auto-width-modal',
-            resolve: {
-                config: () => Object({
-                    selectedDay: this.moment(date)
-                })
-            }
-        }, false).result.then(selectedDay => {
-            this.updateAcquisitionDate(selectedDay);
-        }).catch(() => {});
+        this.modalService
+            .open(
+                {
+                    component: 'rfDatePickerModal',
+                    windowClass: 'auto-width-modal',
+                    resolve: {
+                        config: () =>
+                            Object({
+                                selectedDay: this.moment(date)
+                            })
+                    }
+                },
+                false
+            )
+            .result.then(selectedDay => {
+                this.updateAcquisitionDate(selectedDay);
+            })
+            .catch(() => {});
     }
 
     updateAcquisitionDate(selectedDay) {
@@ -183,10 +197,14 @@ class SceneDetailModalController {
 
     getMaxBound(field) {
         switch (field) {
-        case 'cloudCover': return 100;
-        case 'sunAzimuth': return 360;
-        case 'sunElevation': return 180;
-        default: throw new Error(`Tried to fetch max bound for invalid field: ${field}`);
+            case 'cloudCover':
+                return 100;
+            case 'sunAzimuth':
+                return 360;
+            case 'sunElevation':
+                return 180;
+            default:
+                throw new Error(`Tried to fetch max bound for invalid field: ${field}`);
         }
     }
 

--- a/app-frontend/src/app/pages/lab/analysis/analysis.js
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.js
@@ -254,7 +254,7 @@ class LabAnalysisController {
     }
 
     createPreviewLayers() {
-        const layerOptions = {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM};
+        const layerOptions = {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM};
         if (this.previewLayers) {
             this.previewLayers.forEach(l => l.remove());
         }

--- a/app-frontend/src/app/pages/lab/analysis/analysis.js
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.js
@@ -28,7 +28,6 @@ class LabAnalysisController {
         this.tileServer = `${this.APP_CONFIG.tileServerLocation}`;
         this.showDiagram = true;
         this.analysisId = this.$state.params.analysisid;
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         let unsubscribe = this.$ngRedux.connect(
             this.mapStateToThis,
             Object.assign({}, LabActions, NodeActions)
@@ -255,7 +254,7 @@ class LabAnalysisController {
     }
 
     createPreviewLayers() {
-        const layerOptions = {maxZoom: this.backsplashTileMaxZoom};
+        const layerOptions = {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM};
         if (this.previewLayers) {
             this.previewLayers.forEach(l => l.remove());
         }

--- a/app-frontend/src/app/pages/lab/analysis/analysis.js
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.js
@@ -1,4 +1,4 @@
-/* global L */
+/* global L, BUILDCONFIG */
 import { FrameView } from '../../../components/map/labMap/frame.module.js';
 import LabActions from '_redux/actions/lab-actions';
 import NodeActions from '_redux/actions/node-actions';
@@ -28,7 +28,7 @@ class LabAnalysisController {
         this.tileServer = `${this.APP_CONFIG.tileServerLocation}`;
         this.showDiagram = true;
         this.analysisId = this.$state.params.analysisid;
-
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         let unsubscribe = this.$ngRedux.connect(
             this.mapStateToThis,
             Object.assign({}, LabActions, NodeActions)
@@ -255,7 +255,7 @@ class LabAnalysisController {
     }
 
     createPreviewLayers() {
-        const layerOptions = {maxZoom: 30};
+        const layerOptions = {maxZoom: this.backsplashTileMaxZoom};
         if (this.previewLayers) {
             this.previewLayers.forEach(l => l.remove());
         }

--- a/app-frontend/src/app/pages/lab/analysis/analysis.js
+++ b/app-frontend/src/app/pages/lab/analysis/analysis.js
@@ -254,7 +254,10 @@ class LabAnalysisController {
     }
 
     createPreviewLayers() {
-        const layerOptions = {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM};
+        const layerOptions = {
+            maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+        };
         if (this.previewLayers) {
             this.previewLayers.forEach(l => l.remove());
         }

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -45,7 +45,7 @@ class ProjectsSceneBrowserController {
         this.sceneCount = null;
         this.planetThumbnailUrls = new Map();
         this.scenesBeingAdded = [];
-
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.setBboxParam = _.debounce((bbox) => {
             this.$location.search('bbox', bbox).replace();
         }, 500);
@@ -232,7 +232,7 @@ class ProjectsSceneBrowserController {
                         blueBand: rgbBands.BLUE
                     }
                 ),
-                {maxZoom: 30})
+                {maxZoom: this.backsplashTileMaxZoom})
             );
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -45,7 +45,6 @@ class ProjectsSceneBrowserController {
         this.sceneCount = null;
         this.planetThumbnailUrls = new Map();
         this.scenesBeingAdded = [];
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
         this.setBboxParam = _.debounce((bbox) => {
             this.$location.search('bbox', bbox).replace();
         }, 500);
@@ -232,7 +231,7 @@ class ProjectsSceneBrowserController {
                         blueBand: rgbBands.BLUE
                     }
                 ),
-                {maxZoom: this.backsplashTileMaxZoom})
+                {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM})
             );
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -231,7 +231,7 @@ class ProjectsSceneBrowserController {
                         blueBand: rgbBands.BLUE
                     }
                 ),
-                {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM})
+                {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM})
             );
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
+++ b/app-frontend/src/app/pages/projects/edit/browse/browse.module.js
@@ -220,18 +220,21 @@ class ProjectsSceneBrowserController {
     setCOGThumbnail(scene, map) {
         this.currentRepository.service.getDatasourceBands(scene).then(rgbBands => {
             map.setLayer(
-              'Hovered Scene',
-              L.tileLayer(
-                this.sceneService.getSceneLayerURL(
-                    scene,
+                'Hovered Scene',
+                L.tileLayer(
+                    this.sceneService.getSceneLayerURL(
+                        scene,
+                        {
+                            token: this.authService.token(),
+                            redBand: rgbBands.RED,
+                            greenBand: rgbBands.GREEN,
+                            blueBand: rgbBands.BLUE
+                        }
+                    ),
                     {
-                        token: this.authService.token(),
-                        redBand: rgbBands.RED,
-                        greenBand: rgbBands.GREEN,
-                        blueBand: rgbBands.BLUE
-                    }
-                ),
-                {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM})
+                        maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                        maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+                    })
             );
         });
     }

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -142,7 +142,8 @@ class ProjectsEditController {
             {token: this.authService.token()}
         );
         let layer = L.tileLayer(url, {
-            maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM
+            maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
         });
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -142,7 +142,7 @@ class ProjectsEditController {
             {token: this.authService.token()}
         );
         let layer = L.tileLayer(url, {
-            maxZoom: BUILDCONFIG.TILES_MAX_ZOOM
+            maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM
         });
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -30,6 +30,7 @@ class ProjectsEditController {
         this.projectId = this.$state.params.projectid;
         this.initialCenter = BUILDCONFIG.MAP_CENTER || [0, 0];
         this.initialZoom = BUILDCONFIG.MAP_ZOOM || 2;
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
         if (!this.project) {
             if (this.projectId) {
@@ -142,7 +143,7 @@ class ProjectsEditController {
             {token: this.authService.token()}
         );
         let layer = L.tileLayer(url, {
-            maxZoom: 30
+            maxZoom: this.backsplashTileMaxZoom
         });
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/pages/projects/edit/edit.module.js
+++ b/app-frontend/src/app/pages/projects/edit/edit.module.js
@@ -30,7 +30,6 @@ class ProjectsEditController {
         this.projectId = this.$state.params.projectid;
         this.initialCenter = BUILDCONFIG.MAP_CENTER || [0, 0];
         this.initialZoom = BUILDCONFIG.MAP_ZOOM || 2;
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
         if (!this.project) {
             if (this.projectId) {
@@ -143,7 +142,7 @@ class ProjectsEditController {
             {token: this.authService.token()}
         );
         let layer = L.tileLayer(url, {
-            maxZoom: this.backsplashTileMaxZoom
+            maxZoom: BUILDCONFIG.TILES_MAX_ZOOM
         });
 
         this.getMap().then(m => {

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -52,7 +52,10 @@ export default class ShareController {
         let token = this.authService.token();
         let queryParameters = token ? {token: token} : null;
         let url = this.projectService.getProjectTileURL(this.project, queryParameters);
-        let layer = L.tileLayer(url, {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM});
+        let layer = L.tileLayer(url, {
+            maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+            maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+        });
 
         this.getMap().then(m => {
             m.addLayer('share-layer', layer);

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -18,7 +18,6 @@ export default class ShareController {
         this.projectId = this.$state.params.projectid;
         this.testNoAuth = false;
         this.sceneList = [];
-        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
         if (this.projectId) {
             this.loadProject();
@@ -53,7 +52,7 @@ export default class ShareController {
         let token = this.authService.token();
         let queryParameters = token ? {token: token} : null;
         let url = this.projectService.getProjectTileURL(this.project, queryParameters);
-        let layer = L.tileLayer(url, {maxZoom: this.backsplashTileMaxZoom});
+        let layer = L.tileLayer(url, {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM});
 
         this.getMap().then(m => {
             m.addLayer('share-layer', layer);

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -52,7 +52,7 @@ export default class ShareController {
         let token = this.authService.token();
         let queryParameters = token ? {token: token} : null;
         let url = this.projectService.getProjectTileURL(this.project, queryParameters);
-        let layer = L.tileLayer(url, {maxZoom: BUILDCONFIG.TILES_MAX_ZOOM});
+        let layer = L.tileLayer(url, {maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM});
 
         this.getMap().then(m => {
             m.addLayer('share-layer', layer);

--- a/app-frontend/src/app/pages/share/share.controller.js
+++ b/app-frontend/src/app/pages/share/share.controller.js
@@ -18,6 +18,7 @@ export default class ShareController {
         this.projectId = this.$state.params.projectid;
         this.testNoAuth = false;
         this.sceneList = [];
+        this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
         if (this.projectId) {
             this.loadProject();
@@ -52,7 +53,7 @@ export default class ShareController {
         let token = this.authService.token();
         let queryParameters = token ? {token: token} : null;
         let url = this.projectService.getProjectTileURL(this.project, queryParameters);
-        let layer = L.tileLayer(url, {maxZoom: 30});
+        let layer = L.tileLayer(url, {maxZoom: this.backsplashTileMaxZoom});
 
         this.getMap().then(m => {
             m.addLayer('share-layer', layer);

--- a/app-frontend/src/app/services/map/layer.service.js
+++ b/app-frontend/src/app/services/map/layer.service.js
@@ -88,7 +88,11 @@ export default (app) => {
                 });
             }
             return this.getMosaicLayerURL().then((url) => {
-                let options = {bounds: this.bounds, maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM};
+                let options = {
+                    bounds: this.bounds,
+                    maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                    maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
+                };
                 this._mosaicTiles = L.tileLayer(url, options);
                 return this._mosaicTiles;
             });

--- a/app-frontend/src/app/services/map/layer.service.js
+++ b/app-frontend/src/app/services/map/layer.service.js
@@ -88,7 +88,7 @@ export default (app) => {
                 });
             }
             return this.getMosaicLayerURL().then((url) => {
-                let options = {bounds: this.bounds, maxZoom: BUILDCONFIG.TILES_MAX_ZOOM};
+                let options = {bounds: this.bounds, maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM};
                 this._mosaicTiles = L.tileLayer(url, options);
                 return this._mosaicTiles;
             });

--- a/app-frontend/src/app/services/map/layer.service.js
+++ b/app-frontend/src/app/services/map/layer.service.js
@@ -41,7 +41,6 @@ export default (app) => {
             this.projectId = projectId;
             this._sceneTiles = null;
             this._mosaicTiles = null;
-            this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
         }
@@ -89,7 +88,7 @@ export default (app) => {
                 });
             }
             return this.getMosaicLayerURL().then((url) => {
-                let options = {bounds: this.bounds, maxZoom: this.backsplashTileMaxZoom};
+                let options = {bounds: this.bounds, maxZoom: BUILDCONFIG.TILES_MAX_ZOOM};
                 this._mosaicTiles = L.tileLayer(url, options);
                 return this._mosaicTiles;
             });

--- a/app-frontend/src/app/services/map/layer.service.js
+++ b/app-frontend/src/app/services/map/layer.service.js
@@ -1,3 +1,4 @@
+/* global BUILDCONFIG */
 export default (app) => {
     /**
      * Represents a layer that can be added to the map
@@ -40,6 +41,7 @@ export default (app) => {
             this.projectId = projectId;
             this._sceneTiles = null;
             this._mosaicTiles = null;
+            this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
         }
@@ -87,7 +89,7 @@ export default (app) => {
                 });
             }
             return this.getMosaicLayerURL().then((url) => {
-                let options = {bounds: this.bounds};
+                let options = {bounds: this.bounds, maxZoom: this.backsplashTileMaxZoom};
                 this._mosaicTiles = L.tileLayer(url, options);
                 return this._mosaicTiles;
             });

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -66,7 +66,6 @@ export default app => {
             this.availableProcessingOptionsThin = this.availableProcessingOptions.slice(0, 2);
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
-            this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
             this.Project = $resource(
                 `${BUILDCONFIG.API_HOST}/api/projects/:id/`,
@@ -849,7 +848,7 @@ export default app => {
         mapLayerFromLayer(project, layer, params) {
             let url = this.getProjectLayerTileUrl(project, layer, params);
             let mapLayer = L.tileLayer(url, {
-                maxZoom: this.backsplashTileMaxZoom
+                maxZoom: BUILDCONFIG.TILES_MAX_ZOOM
             });
             return mapLayer;
         }

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -848,7 +848,7 @@ export default app => {
         mapLayerFromLayer(project, layer, params) {
             let url = this.getProjectLayerTileUrl(project, layer, params);
             let mapLayer = L.tileLayer(url, {
-                maxZoom: BUILDCONFIG.TILES_MAX_ZOOM
+                maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM
             });
             return mapLayer;
         }

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -66,6 +66,7 @@ export default app => {
             this.availableProcessingOptionsThin = this.availableProcessingOptions.slice(0, 2);
 
             this.tileServer = `${APP_CONFIG.tileServerLocation}`;
+            this.backsplashTileMaxZoom = BUILDCONFIG.BACKSPLASH_TILE_MAX_ZOOM;
 
             this.Project = $resource(
                 `${BUILDCONFIG.API_HOST}/api/projects/:id/`,
@@ -848,7 +849,7 @@ export default app => {
         mapLayerFromLayer(project, layer, params) {
             let url = this.getProjectLayerTileUrl(project, layer, params);
             let mapLayer = L.tileLayer(url, {
-                maxZoom: 30
+                maxZoom: this.backsplashTileMaxZoom
             });
             return mapLayer;
         }

--- a/app-frontend/src/app/services/projects/project.service.js
+++ b/app-frontend/src/app/services/projects/project.service.js
@@ -848,7 +848,8 @@ export default app => {
         mapLayerFromLayer(project, layer, params) {
             let url = this.getProjectLayerTileUrl(project, layer, params);
             let mapLayer = L.tileLayer(url, {
-                maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM
+                maxNativeZoom: BUILDCONFIG.TILES_MAX_ZOOM,
+                maxZoom: BUILDCONFIG.VISUAL_MAX_ZOOM
             });
             return mapLayer;
         }


### PR DESCRIPTION
## Overview

~WIP since I need to test the changes. I will work on it later tonight.~

This PR limits max zoom level for backsplash tiles to 23 on frontend.

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Test on frontend map UIs to zoom in to level 23 and higher -- make sure no request is sent when it is higher than 23

Closes #5005 
