### PR TITLE
Bump GDAL warp bindings

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -500,7 +500,7 @@ lazy val backsplashServer =
     })
     .settings({
       dependencyOverrides ++= Seq(
-        "com.azavea.gdal" % "gdal-warp-bindings" % "33.5523882"
+        "com.azavea.gdal" % "gdal-warp-bindings" % "33.92f1773"
       )
     })
     .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))


### PR DESCRIPTION
## Overview

Uses a patched version of the gdal warp bindings to enable automatically capturing core dumps when the tile service is stopped.