### PR TITLE
Add RasterSource Healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Use zoom level in OverviewInput for lambda function to generate layer overviews [\#4998](https://github.com/raster-foundry/raster-foundry/pull/4998)
 - Added endpoints for project layer "tasks" [\#5008](https://github.com/raster-foundry/raster-foundry/pull/5008)
 - Add user scope migration and data model [\#5009](https://github.com/raster-foundry/raster-foundry/pull/5009)
+- Updated healthcheck to include loading tile metadata [\#5017](https://github.com/raster-foundry/raster-foundry/pull/5017)
 
 ### Changed
 

--- a/app-backend/backsplash-server/src/main/resources/application.conf
+++ b/app-backend/backsplash-server/src/main/resources/application.conf
@@ -41,3 +41,11 @@ metrics {
   enableMetrics = false
   enableMetrics = ${?BACKSPLASH_ENABLE_REQUEST_METRICS}
 }
+
+healthcheck {
+  tiffBucket = "rasterfoundry-global-artifacts-us-east-1"
+  tiffBucket = ${?BACKSPLASH_HEALTHCHECK_TIFF_BUCKET}
+
+  tiffKey = "healthcheck-image.tif"
+  tiffKey = ${?BACKSPLASH_HEALTHCHECK_TIFF_KEY}
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -31,4 +31,10 @@ object Config {
     private val metricsConfig = config.getConfig("metrics")
     val enableMetrics = metricsConfig.getBoolean("enableMetrics")
   }
+
+  object healthcheck {
+    private val healthcheckConfig = config.getConfig("healthcheck")
+    val tiffBucket = healthcheckConfig.getString("tiffBucket")
+    val tiffKey = healthcheckConfig.getString("tiffKey")
+  }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
@@ -1,12 +1,14 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash.Cache.tileCache
-
 import cats._
 import cats.effect._
 import cats.implicits._
+import com.typesafe.scalalogging.LazyLogging
 import doobie._
 import doobie.implicits._
+import geotrellis.contrib.vlm.gdal.GDALRasterSource
+import geotrellis.spark.io.s3.S3Client
 import org.http4s._
 import org.http4s.dsl._
 import scalacache.modes.sync._
@@ -16,7 +18,8 @@ import scala.concurrent.duration._
 
 class HealthcheckService(xa: Transactor[IO])(implicit timer: Timer[IO],
                                              contextShift: ContextShift[IO])
-    extends Http4sDsl[IO] {
+    extends Http4sDsl[IO]
+    with LazyLogging {
 
   private def timeoutToSick(check: HealthCheck[IO, Id]): HealthCheck[IO, Id] =
     HealthCheck
@@ -36,6 +39,28 @@ class HealthcheckService(xa: Transactor[IO])(implicit timer: Timer[IO],
               case (Left(l))  => HealthResult.one(l)
             }
       })
+
+  private def gdalHealth = timeoutToSick(
+    HealthCheck.liftF[IO, Id] {
+      val s3Client = S3Client.DEFAULT
+      val bucket = Config.healthcheck.tiffBucket
+      val key = Config.healthcheck.tiffKey
+      val s3Path = s"s3://${bucket}/${key}"
+      s3Client.doesObjectExist(bucket, key) match {
+        case false =>
+          logger.warn(s"${s3Path} does not exist - not failing health check")
+          IO(HealthResult.one(Health.healthy))
+        case true =>
+          val rs = GDALRasterSource(s"$s3Path")
+          // Read some metadata with GDAL
+          val crs = rs.crs
+          val bandCount = rs.bandCount
+          logger.debug(
+            s"Read metadata for ${s3Path} (CRS: ${crs}, Band Count: ${bandCount})")
+          IO(HealthResult.one(Health.healthy))
+      }
+    }
+  )
 
   private def dbHealth =
     timeoutToSick(
@@ -62,12 +87,13 @@ class HealthcheckService(xa: Transactor[IO])(implicit timer: Timer[IO],
   val routes: HttpRoutes[IO] =
     HttpRoutes.of {
       case GET -> Root =>
-        val healthcheck = (dbHealth |+| cacheHealth)
+        val healthcheck = (dbHealth |+| cacheHealth |+| gdalHealth)
           .through(mods.recoverToSick)
         healthcheck.check flatMap { check =>
           if (check.value.reduce.isHealthy) Ok("A-ok")
           else {
-            ServiceUnavailable("Postgres or memcached unavailable")
+            logger.warn("Healthcheck Failed (postres, memcached, or gdal)")
+            ServiceUnavailable("Postgres, memcached, or gdal unavailable")
           }
         }
     }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -500,7 +500,7 @@ lazy val backsplashServer =
     })
     .settings({
       dependencyOverrides ++= Seq(
-        "com.azavea.gdal" % "gdal-warp-bindings" % "33.92f1773"
+        "com.azavea.gdal" % "gdal-warp-bindings" % "33.6cc58d3"
       )
     })
     .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -500,7 +500,7 @@ lazy val backsplashServer =
     })
     .settings({
       dependencyOverrides ++= Seq(
-        "com.azavea.gdal" % "gdal-warp-bindings" % "33.5523882"
+        "com.azavea.gdal" % "gdal-warp-bindings" % "33.92f1773"
       )
     })
     .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))


### PR DESCRIPTION
## Overview

Adds a healthcheck that loads some metadata about a tiff. If the tiff location has moved, the healthcheck throws a warning, but does not error out (in case the image is accidentally moved).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

This screenshot is a demo of what the logs look like when the image has moved:

![image](https://user-images.githubusercontent.com/898060/59031582-11ce8400-8832-11e9-831f-f860cc0939c4.png)


### Notes

It is unclear if this is going to work as far as making sure that servers that pass healthchecks but can't serve tiles no longer do that. It is not possible to reproduce this in development so the only way to test I think is to push it out and test.

## Testing Instructions

- Rebuild servers, start server, go to `localhost:8080/healthcheck`

Closes #4945
