### PR TITLE
Add STAC async export endpoints and export builder in batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ dist/
 /app-tasks/jars/rf-batch.jar
 /data
 
+.vscode
+
 # Patch files
 *.patch
 scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add STAC async export endpoint [\#5061](https://github.com/raster-foundry/raster-foundry/pull/5061)
+- Added STAC async export endpoints and export builder in batch [\#5018](https://github.com/raster-foundry/raster-foundry/pull/5018)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Add STAC async export endpoint [\#5061](https://github.com/raster-foundry/raster-foundry/pull/5061)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+
 - Add STAC async export endpoint [\#5061](https://github.com/raster-foundry/raster-foundry/pull/5061)
 
 ### Changed
@@ -23,6 +24,7 @@
 - Added fields to track metadata for scenes to help with RasterSource construction [\#5103](https://github.com/raster-foundry/raster-foundry/pull/5103)
 
 ### Changed
+
 - Add support for multiband imagery in WMS responses
   [\#5082](https://github.com/raster-foundry/raster-foundry/pull/5082)
 

--- a/app-backend/.vscode/tasks.json
+++ b/app-backend/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "format",
+            "type": "shell",
+            "command": "./sbt scalafmt",
+            "problemMatcher": []
+        }
+    ]
+}

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -22,6 +22,7 @@ import com.rasterfoundry.api.user.UserRoutes
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.api.license.LicenseRoutes
 import com.rasterfoundry.api.team.TeamRoutes
+import com.rasterfoundry.api.stac.StacRoutes
 
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
 import ch.megard.akka.http.cors.scaladsl.settings._
@@ -57,7 +58,8 @@ trait Router
     with ShapeRoutes
     with LicenseRoutes
     with TeamRoutes
-    with PlatformRoutes {
+    with PlatformRoutes
+    with StacRoutes {
 
   val settings = CorsSettings.defaultSettings.copy(
     allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE))
@@ -120,6 +122,9 @@ trait Router
           } ~
           pathPrefix("teams") {
             teamRoutes
+          } ~
+          pathPrefix("stac") {
+            stacRoutes
           }
       } ~
       pathPrefix("config") {

--- a/app-backend/api/src/main/scala/stac/Routes.scala
+++ b/app-backend/api/src/main/scala/stac/Routes.scala
@@ -96,7 +96,7 @@ trait StacRoutes
       entity(as[StacExport]) { updateStacExport =>
         onSuccess(
           StacExportDao
-            .update(updateStacExport, id, user)
+            .update(updateStacExport, id)
             .transact(xa)
             .unsafeToFuture) {
           completeSingleOrNotFound

--- a/app-backend/api/src/main/scala/stac/Routes.scala
+++ b/app-backend/api/src/main/scala/stac/Routes.scala
@@ -1,0 +1,124 @@
+package com.rasterfoundry.api.stac
+
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
+
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.StatusCodes
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import cats.effect.IO
+
+import java.util.UUID
+import doobie._
+import doobie.implicits._
+
+trait StacRoutes
+    extends Authentication
+    with PaginationDirectives
+    with UserErrorHandler
+    with CommonHandlers
+    with QueryParametersCommon {
+  val xa: Transactor[IO]
+
+  val stacRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listStacExports } ~
+        post { createStacExport }
+    } ~
+      pathPrefix(JavaUUID) { stacExportId =>
+        pathEndOrSingleSlash {
+          get { getStacExport(stacExportId) } ~
+            put { updateStacExport(stacExportId) } ~
+            delete { deleteStacExport(stacExportId) }
+        }
+      }
+  }
+
+  def listStacExports: Route = authenticate { user =>
+    (withPagination & stacExportQueryParameters) {
+      (page: PageRequest, params: StacExportQueryParameters) =>
+        complete {
+          StacExportDao
+            .list(page, params, user)
+            .transact(xa)
+            .unsafeToFuture
+        }
+    }
+  }
+
+  def createStacExport: Route = authenticate { user =>
+    entity(as[StacExport.Create]) { newStacExport =>
+      authorizeAsync {
+        StacExportDao
+          .hasProjectViewAccess(newStacExport.layerDefinitions, user)
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        onSuccess(
+          StacExportDao
+            .create(newStacExport, user)
+            .transact(xa)
+            .unsafeToFuture) { stacExport =>
+          // To be implemented: kickoffStacExport(stacExport.id)
+          complete((StatusCodes.Created, stacExport))
+        }
+      }
+    }
+  }
+
+  def getStacExport(id: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      StacExportDao
+        .isOwnerOrSuperUser(user, id)
+        .transact(xa)
+        .unsafeToFuture
+    } {
+      rejectEmptyResponse {
+        complete {
+          StacExportDao
+            .getById(id)
+            .transact(xa)
+            .unsafeToFuture
+        }
+      }
+    }
+  }
+
+  def updateStacExport(id: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      StacExportDao
+        .isOwnerOrSuperUser(user, id)
+        .transact(xa)
+        .unsafeToFuture
+    } {
+      entity(as[StacExport]) { updateStacExport =>
+        onSuccess(
+          StacExportDao
+            .update(updateStacExport, id, user)
+            .transact(xa)
+            .unsafeToFuture) {
+          completeSingleOrNotFound
+        }
+      }
+    }
+  }
+
+  def deleteStacExport(id: UUID): Route = authenticate { user =>
+    authorizeAsync {
+      StacExportDao
+        .isOwnerOrSuperUser(user, id)
+        .transact(xa)
+        .unsafeToFuture
+    } {
+      onSuccess(
+        StacExportDao
+          .delete(id)
+          .transact(xa)
+          .unsafeToFuture) { count: Int =>
+        complete((StatusCodes.NoContent, s"$count stac export deleted"))
+      }
+    }
+  }
+}

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -184,4 +184,14 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
       'actionEndTime.as(deserializerTimestamp).?,
       'actionUser.as[String].?
     ).as(UserTaskActivityParameters.apply _)
+
+  def stacExportQueryParameters =
+    (
+      userAuditQueryParameters &
+        ownerQueryParameters &
+        searchParams &
+        parameters(
+          'exportStatus.as[String].?
+        )
+    ).as(StacExportQueryParameters.apply _)
 }

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -5,7 +5,8 @@ import com.rasterfoundry.batch.cogMetadata.{HistogramBackfill, OverviewBackfill}
 import com.rasterfoundry.batch.export.{CreateExportDef, UpdateExportStatus}
 import com.rasterfoundry.batch.healthcheck.HealthCheck
 import com.rasterfoundry.batch.aoi.UpdateAOIProject
-import com.rasterfoundry.batch.stac.{ReadStacFeature}
+import com.rasterfoundry.batch.stacImport.{ReadStacFeature}
+import com.rasterfoundry.batch.stacExport.{WriteStacCatalog}
 import com.rasterfoundry.batch.notification.NotifyIngestStatus
 
 object Main {
@@ -17,8 +18,9 @@ object Main {
     NotifyIngestStatus.name -> (NotifyIngestStatus.main(_)),
     OverviewBackfill.name -> (OverviewBackfill.main(_)),
     ReadStacFeature.name -> (ReadStacFeature.main(_)),
+    WriteStacCatalog.name -> (WriteStacCatalog.main(_)),
     UpdateAOIProject.name -> (UpdateAOIProject.main(_)),
-    UpdateExportStatus.name -> (UpdateExportStatus.main(_))
+    UpdateExportStatus.name -> (UpdateExportStatus.main(_)),
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/package.scala
+++ b/app-backend/batch/src/main/scala/package.scala
@@ -22,6 +22,11 @@ import scala.util.Either
 
 package object batch {
 
+  @SuppressWarnings(Array("all"))
+  implicit class IdOps[A](a: A) {
+    def unused: Unit = ()
+  }
+
   implicit class HasCellSize[A <: {
     def rows: Int; def cols: Int; def extent: Extent
   }](obj: A) {

--- a/app-backend/batch/src/main/scala/stacExport/ContentBundle.scala
+++ b/app-backend/batch/src/main/scala/stacExport/ContentBundle.scala
@@ -1,0 +1,17 @@
+package com.rasterfoundry.batch.stacExport
+
+import java.util.UUID
+import io.circe._
+
+import com.rasterfoundry.datamodel._
+
+case class ContentBundle(
+    export: StacExport,
+    layerToSceneTaskAnnotation: Map[UUID,
+                                    (List[Scene],
+                                     Option[UnionedGeomExtent],
+                                     List[Task],
+                                     Option[UnionedGeomExtent],
+                                     Option[Json],
+                                     Option[StacLabelItemPropertiesThin])]
+)

--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -1,0 +1,287 @@
+package com.rasterfoundry.batch.stacExport
+
+import geotrellis.server.stac._
+import io.circe._
+import com.rasterfoundry.datamodel._
+import geotrellis.server.stac.{StacExtent => _}
+import com.rasterfoundry.batch.stacExport.{StacExtent => BatchStacExtent}
+import io.circe._
+import io.circe.syntax._
+import io.circe.syntax._
+import java.util.UUID
+import java.sql.Timestamp
+import java.time.Instant
+
+object LabelCollectionBuilder {
+  sealed trait CollectionRequirements
+  object CollectionBuilder {
+    trait EmptyCollection extends CollectionRequirements
+    trait CollectionStacVersion extends CollectionRequirements
+    trait CollectionId extends CollectionRequirements
+    trait CollectionTitle extends CollectionRequirements
+    trait CollectionExtent extends CollectionRequirements
+    trait CollectionLinks extends CollectionRequirements
+    trait CollectionDescription extends CollectionRequirements
+    trait CollectionParentPath extends CollectionRequirements
+    trait CollectionTasksGeomExtent extends CollectionRequirements
+    trait CollectionItemInfoThin extends CollectionRequirements
+    trait CollectionSceneItemLinks extends CollectionRequirements
+    type CompleteCollection =
+      EmptyCollection
+        with CollectionStacVersion
+        with CollectionId
+        with CollectionTitle
+        with CollectionExtent
+        with CollectionLinks
+        with CollectionDescription
+        with CollectionParentPath
+        with CollectionTasksGeomExtent
+        with CollectionItemInfoThin
+        with CollectionSceneItemLinks
+  }
+}
+
+case class IncompleteLabelCollection(
+    stacVersion: Option[String] = None,
+    id: Option[String] = None,
+    title: Option[String] = None,
+    description: Option[String] = None,
+    keywords: Option[List[String]] = None,
+    version: String = "1", // always 1, we aren't versioning exports
+    license: Option[String] = None,
+    providers: List[StacProvider] = List(),
+    extent: Option[BatchStacExtent] = None,
+    properties: Option[JsonObject] = None,
+    links: List[StacLink] = List(), // builders?
+    parentPath: Option[String] = None,
+    rootPath: Option[String] = None,
+    tasks: List[Task] = List(),
+    tasksGeomExtent: Option[UnionedGeomExtent] = None,
+    itemPropsThin: StacLabelItemPropertiesThin = StacLabelItemPropertiesThin(),
+    sceneItemLinks: List[(String, String)] = List()
+) {
+  @SuppressWarnings(Array("OptionGet"))
+  def toStacCollection(): StacCollection = {
+    val extent: Json = this.extent match {
+      case Some(ext) => ext.asJson
+      case None      => Json.Null
+    }
+    StacCollection(
+      this.stacVersion.get,
+      this.id.get,
+      this.title,
+      this.description.get,
+      this.keywords.getOrElse(List()), // not required
+      this.version,
+      this.license.getOrElse(""), // required but not clear yet
+      this.providers, // not required
+      extent,
+      JsonObject.empty, // properties, free-form json, not required
+      this.links
+    )
+  }
+}
+
+class LabelCollectionBuilder[
+    CollectionRequirements <: LabelCollectionBuilder.CollectionRequirements
+](labelCollection: IncompleteLabelCollection = IncompleteLabelCollection()) {
+  import LabelCollectionBuilder.CollectionBuilder._
+
+  def withVersion(
+      version: String
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionStacVersion] =
+    new LabelCollectionBuilder(
+      labelCollection.copy(stacVersion = Some(version))
+    )
+
+  def withId(
+      id: String
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionId] =
+    new LabelCollectionBuilder(labelCollection.copy(id = Some(id)))
+
+  def withTitle(
+      title: String
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionTitle] =
+    new LabelCollectionBuilder(labelCollection.copy(title = Some(title)))
+
+  def withDescription(
+      description: String
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionDescription] =
+    new LabelCollectionBuilder(
+      labelCollection.copy(description = Some(description))
+    )
+
+  def withLinks(
+      links: List[StacLink]
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionLinks] =
+    new LabelCollectionBuilder(
+      labelCollection.copy(links = labelCollection.links ++ links)
+    )
+
+  def withExtent(
+      extent: StacExtent
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionExtent] =
+    new LabelCollectionBuilder(labelCollection.copy(extent = Some(extent)))
+
+  def withParentPath(
+      parentPath: String,
+      rootPath: String
+  ): LabelCollectionBuilder[CollectionRequirements with CollectionParentPath] =
+    new LabelCollectionBuilder(
+      labelCollection
+        .copy(parentPath = Some(parentPath), rootPath = Some(rootPath))
+    )
+
+  def withTasksGeomExtent(
+      tasks: List[Task],
+      tasksGeomExtent: Option[UnionedGeomExtent]
+  ): LabelCollectionBuilder[
+    CollectionRequirements with CollectionTasksGeomExtent] =
+    new LabelCollectionBuilder(
+      labelCollection.copy(tasks = labelCollection.tasks ++ tasks,
+                           tasksGeomExtent = tasksGeomExtent)
+    )
+
+  def withItemPropInfo(
+      itemPropsThin: StacLabelItemPropertiesThin
+  ): LabelCollectionBuilder[
+    CollectionRequirements with CollectionItemInfoThin
+  ] =
+    new LabelCollectionBuilder(
+      labelCollection.copy(itemPropsThin = itemPropsThin)
+    )
+
+  def withSceneItemLinks(
+      sceneItemLinks: List[(String, String)]
+  ): LabelCollectionBuilder[
+    CollectionRequirements with CollectionSceneItemLinks
+  ] =
+    new LabelCollectionBuilder(
+      labelCollection.copy(
+        sceneItemLinks = labelCollection.sceneItemLinks ++ sceneItemLinks
+      )
+    )
+
+  @SuppressWarnings(Array("OptionGet"))
+  def build()(
+      implicit ev: CollectionRequirements =:= CompleteCollection
+  ): (StacCollection, StacItem, String) = {
+    // Silence unused warning because scalac warns about phantom types
+    ev.unused
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>
+    val absPath = labelCollection.parentPath.get
+    // ../../../catalog.json
+    val rootPath = labelCollection.rootPath.get
+
+    val itemBuilder =
+      new StacItemBuilder[StacItemBuilder.ItemBuilder.EmptyItem]()
+    val labelItemId = UUID.randomUUID().toString()
+    val labelItemGeomExtent = labelCollection.tasksGeomExtent.get
+    val labelItemFootprint = labelItemGeomExtent.geometry
+    val labelItemBbox = ItemBbox(
+      labelItemGeomExtent.xMin,
+      labelItemGeomExtent.yMin,
+      labelItemGeomExtent.xMax,
+      labelItemGeomExtent.yMax
+    )
+
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>
+    val labelItemSelfAbsPath = s"${absPath}/${labelItemId}"
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>/item.json
+    val labelItemSelfAbsLink = s"${labelItemSelfAbsPath}/item.json"
+    val labelItemLinks = List(
+      StacLink(
+        labelItemSelfAbsLink,
+        Self,
+        Some(`application/json`),
+        Some(s"Label item ${labelItemId}")
+      ),
+      StacLink(
+        s"${absPath}/collection.json",
+        Parent,
+        Some(`application/json`),
+        Some("Label Collection")
+      ),
+      StacLink(
+        "../rootPath",
+        StacRoot,
+        Some(`application/json`),
+        Some("Root")
+      )
+    ) ++ labelCollection.sceneItemLinks.map(link => {
+      // TODO: For the rel (the second argumetn), we need a Source type,
+      // which needs to be added in gt-server
+      StacLink(
+        link._1,
+        VendorLinkType("Source"),
+        Some(`image/cog`),
+        Some("Source image STAC item for the label item")
+      )
+    })
+    val dateTime = labelCollection.extent.get.temporal(0) match {
+      case Some(dt) => Timestamp.from(Instant.parse(s"${dt}Z"))
+      case _        => new Timestamp(new java.util.Date().getTime)
+    }
+    val labelItemProperties = StacLabelItemProperties(
+      labelCollection.itemPropsThin.property,
+      labelCollection.itemPropsThin.classes,
+      "Labels in layer",
+      labelCollection.itemPropsThin._type,
+      Some(List(labelCollection.itemPropsThin.task)),
+      Some(List("manual")),
+      None,
+      dateTime
+    )
+    val labelItemPropertiesJsonObj = JsonObject.fromMap(
+      Map(
+        "label:property" -> labelItemProperties.property.asJson,
+        "label:classes" -> labelItemProperties.classes.asJson,
+        "label:description" -> labelItemProperties.description.asJson,
+        "label:type" -> labelItemProperties._type.asJson,
+        "label:task" -> labelItemProperties.task.asJson,
+        "label:method" -> labelItemProperties.method.asJson,
+        "label:overview" -> labelItemProperties.overview.asJson,
+        "datetime" -> labelItemProperties.datetime.asJson
+      )
+    )
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>/data.geojson
+    val labelDataS3AbsLink: String = s"${labelItemSelfAbsPath}/data.geojson"
+    // TODO: below should actually be `application/geo+json`
+    // but StacItem from gt-server only accepts `image/cog`
+    // or it will throw an exception
+    val labelAsset = Map(
+      labelItemId ->
+        StacAsset(
+          labelDataS3AbsLink,
+          Some("Label Data Feature Collection"),
+          Some(`image/cog`)
+        )
+    )
+    val labelItem: StacItem = itemBuilder
+      .withId(labelItemId)
+      .withGeometries(labelItemFootprint, labelItemBbox)
+      .withLinks(labelItemLinks)
+      .withCollection(labelCollection.id.get)
+      .withProperties(labelItemPropertiesJsonObj)
+      .withParentPath(absPath, rootPath)
+      .withAssets(labelAsset)
+      .build()
+
+    (
+      labelCollection
+        .copy(
+          links = labelCollection.links ++ List(
+            StacLink(
+              labelItemSelfAbsLink,
+              Item,
+              Some(`application/json`),
+              Some("STAC label item link")
+            )
+          )
+        )
+        .toStacCollection(),
+      labelItem,
+      labelDataS3AbsLink
+    )
+  }
+}

--- a/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
@@ -1,0 +1,320 @@
+package com.rasterfoundry.batch.stacExport
+
+import geotrellis.server.stac._
+import geotrellis.server.stac.{StacExtent => _}
+import geotrellis.vector.reproject.Reproject
+import geotrellis.proj4.CRS
+import java.util.UUID
+import io.circe._
+import io.circe.syntax._
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.batch.stacExport.{StacExtent => BatchStacExtent}
+
+object LayerCollectionBuilder {
+  sealed trait CollectionRequirements
+  object CollectionBuilder {
+    trait EmptyCollection extends CollectionRequirements
+    trait CollectionStacVersion extends CollectionRequirements
+    trait CollectionId extends CollectionRequirements
+    trait CollectionTitle extends CollectionRequirements
+    trait CollectionExtent extends CollectionRequirements
+    trait CollectionLinks extends CollectionRequirements
+    trait CollectionDescription extends CollectionRequirements
+    trait CollectionParentPath extends CollectionRequirements
+    trait CollectionSceneTaskAnnotations extends CollectionRequirements
+    type CompleteCollection =
+      EmptyCollection
+        with CollectionStacVersion
+        with CollectionId
+        with CollectionTitle
+        with CollectionExtent
+        with CollectionLinks
+        with CollectionDescription
+        with CollectionParentPath
+        with CollectionSceneTaskAnnotations
+  }
+}
+
+case class IncompleteLayerCollection(
+    stacVersion: Option[String] = None, // required
+    id: Option[String] = None, // required
+    title: Option[String] = None,
+    description: Option[String] = None, // required
+    keywords: Option[List[String]] = None,
+    version: String = "1", // always 1, we aren't versioning exports
+    license: Option[String] = None, // required
+    providers: Option[List[StacProvider]] = None,
+    extent: Option[BatchStacExtent] = None, // required
+    properties: Option[JsonObject] = None,
+    links: List[StacLink] = List(), // builders?  // required
+    parentPath: Option[String] = None,
+    rootPath: Option[String] = None,
+    layersToScenes: Map[UUID, List[Scene]] = Map(),
+    sceneTaskAnnotations: Option[
+      (
+          List[Scene],
+          Option[UnionedGeomExtent],
+          List[Task],
+          Option[UnionedGeomExtent],
+          Option[Json],
+          Option[StacLabelItemPropertiesThin]
+      )
+    ] = None
+) {
+  @SuppressWarnings(Array("OptionGet"))
+  def toStacCollection(): StacCollection = {
+    val extent: Json = this.extent match {
+      case Some(ext) => ext.asJson
+      case None      => Json.Null
+    }
+    StacCollection(
+      this.stacVersion.get,
+      this.id.get,
+      this.title,
+      this.description.get,
+      this.keywords.getOrElse(List()), // not required
+      this.version,
+      this.license.getOrElse(""), // required but not clear yet
+      this.providers.getOrElse(List()), // not required
+      extent,
+      JsonObject.empty, // properties, free-form json, not required
+      this.links
+    )
+  }
+}
+
+class LayerCollectionBuilder[
+    CollectionRequirements <: LayerCollectionBuilder.CollectionRequirements
+](layerCollection: IncompleteLayerCollection = IncompleteLayerCollection()) {
+  import LayerCollectionBuilder.CollectionBuilder._
+
+  def withVersion(
+      stacVersion: String
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionStacVersion] =
+    new LayerCollectionBuilder(
+      layerCollection.copy(stacVersion = Some(stacVersion))
+    )
+
+  def withId(
+      id: String
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionId] =
+    new LayerCollectionBuilder(layerCollection.copy(id = Some(id)))
+
+  def withTitle(
+      title: String
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionTitle] =
+    new LayerCollectionBuilder(layerCollection.copy(title = Some(title)))
+
+  def withDescription(
+      description: String
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionDescription] =
+    new LayerCollectionBuilder(
+      layerCollection.copy(description = Some(description))
+    )
+
+  def withLinks(
+      links: List[StacLink]
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionLinks] =
+    new LayerCollectionBuilder(
+      layerCollection.copy(links = layerCollection.links ++ links)
+    )
+
+  def withExtent(
+      extent: BatchStacExtent
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionExtent] =
+    new LayerCollectionBuilder(layerCollection.copy(extent = Some(extent)))
+
+  def withParentPath(
+      parentPath: String,
+      rootPath: String
+  ): LayerCollectionBuilder[CollectionRequirements with CollectionParentPath] =
+    new LayerCollectionBuilder(
+      layerCollection
+        .copy(parentPath = Some(parentPath), rootPath = Some(rootPath))
+    )
+
+  def withSceneTaskAnnotations(
+      sceneTaskAnnotations: (
+          List[Scene],
+          Option[UnionedGeomExtent],
+          List[Task],
+          Option[UnionedGeomExtent],
+          Option[Json],
+          Option[StacLabelItemPropertiesThin]
+      )
+  ): LayerCollectionBuilder[
+    CollectionRequirements with CollectionSceneTaskAnnotations
+  ] =
+    new LayerCollectionBuilder(
+      layerCollection.copy(
+        sceneTaskAnnotations = Some(sceneTaskAnnotations)
+      )
+    )
+
+  def inspect: IncompleteLayerCollection = layerCollection
+
+  @SuppressWarnings(Array("OptionGet"))
+  def build()(
+      implicit ev: CollectionRequirements =:= CompleteCollection
+  ): (
+      StacCollection, // layer collection
+      (StacCollection, List[StacItem]), // scene collection and scene items
+      (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+  ) = {
+    ev.unused
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>
+    val absPath = layerCollection.parentPath.get
+    // ../../<catalogId>
+    val rootPath = layerCollection.rootPath.get
+
+    // Build a scene collection and a list of scene items
+    val sceneCollectionId = UUID.randomUUID().toString()
+    val sceneList = layerCollection.sceneTaskAnnotations.get._1
+    val sceneCollectionBuilder = new SceneCollectionBuilder[
+      SceneCollectionBuilder.CollectionBuilder.EmptyCollection
+    ]()
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<sceneCollectionID>
+    val sceneCollectionAbsPath = s"${absPath}/${sceneCollectionId}"
+    // ../../../catalog.json
+    val sceneCollectionRootPath = s"../${rootPath}"
+    val sceneCollectionAbsLink = s"${sceneCollectionAbsPath}/collection.json"
+    val sceneCollectionOwnLinks = List(
+      StacLink(
+        sceneCollectionAbsLink,
+        Self,
+        Some(`application/json`),
+        Some(s"Scene Collection ${sceneCollectionId}")
+      ),
+      StacLink(
+        rootPath,
+        StacRoot,
+        Some(`application/json`),
+        Some("Root")
+      ),
+      StacLink(
+        s"${absPath}/collection.json",
+        Parent,
+        Some(`application/json`),
+        Some("Layer Collection")
+      )
+    )
+    val (sceneCollection, sceneItems, sceneItemLinks): (
+        StacCollection,
+        List[StacItem],
+        List[(String, String)]
+    ) = sceneCollectionBuilder
+      .withVersion(layerCollection.stacVersion.get)
+      .withId(sceneCollectionId)
+      .withTitle("Scene collection")
+      .withDescription(s"Scene collection in layer ${layerCollection.id.get}")
+      .withExtent(layerCollection.extent.get)
+      .withSceneList(sceneList)
+      .withLinks(sceneCollectionOwnLinks)
+      .withParentPath(sceneCollectionAbsPath, sceneCollectionRootPath)
+      .build()
+
+    // Build a lable collection and a list of label items
+    val labelCollectionId = UUID.randomUUID().toString()
+    val labelGeomExtent = layerCollection.sceneTaskAnnotations.get._4
+    val labelCollectionBuilder = new LabelCollectionBuilder[
+      LabelCollectionBuilder.CollectionBuilder.EmptyCollection
+    ]()
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>
+    val labelCollectionAbsPath = s"${absPath}/${labelCollectionId}"
+    // ../../../catalog.json
+    val labelCollectionRootPath = s"../${rootPath}"
+    val labelCollectionAbsLink = s"${labelCollectionAbsPath}/collection.json"
+    val labelCollectionOwnLinks = List(
+      StacLink(
+        labelCollectionAbsLink,
+        Self,
+        Some(`application/json`),
+        Some(s"Label Collection ${labelCollectionId}")
+      ),
+      StacLink(
+        rootPath,
+        StacRoot,
+        Some(`application/json`),
+        Some("Root")
+      ),
+      StacLink(
+        s"${absPath}/collection.json",
+        Parent,
+        Some(`application/json`),
+        Some("Layer Collection")
+      )
+    )
+    val tasks = layerCollection.sceneTaskAnnotations.get._3
+    val tasksGeomExtent = layerCollection.sceneTaskAnnotations.get._4
+    val itemPropsThin = layerCollection.sceneTaskAnnotations.get._6
+    val labelSpatialExtent: List[Double] = labelGeomExtent match {
+      case Some(extent) =>
+        List(extent.xMin, extent.yMin, extent.xMax, extent.yMax)
+      case None =>
+        val ext = tasks
+          .map(_.geometry)
+          .map(
+            geom =>
+              Reproject(
+                geom.geom,
+                CRS.fromEpsgCode(3857),
+                CRS.fromEpsgCode(4326)
+            )
+          )
+          .map(_.envelope)
+          .reduce((e1, e2) => {
+            e1.combine(e2)
+          })
+        List(ext.xmin, ext.ymin, ext.xmax, ext.ymax)
+    }
+
+    val labelExtent: BatchStacExtent = layerCollection.extent.get.copy(
+      spatial = labelSpatialExtent
+    )
+    val (labelCollection, labelItem, labelDataS3AbsLink): (
+        StacCollection,
+        StacItem,
+        String
+    ) =
+      labelCollectionBuilder
+        .withVersion(layerCollection.stacVersion.get)
+        .withId(labelCollectionId)
+        .withTitle("Label collection")
+        .withDescription(s"Label collection in layer ${layerCollection.id.get}")
+        .withExtent(labelExtent)
+        .withLinks(labelCollectionOwnLinks)
+        .withParentPath(labelCollectionAbsPath, labelCollectionRootPath)
+        .withTasksGeomExtent(tasks, tasksGeomExtent)
+        .withItemPropInfo(itemPropsThin.get)
+        .withSceneItemLinks(sceneItemLinks)
+        .build()
+
+    val updatedLayerCollection: StacCollection = layerCollection
+      .copy(
+        links = layerCollection.links ++ List(
+          StacLink(
+            labelCollectionAbsLink,
+            Child,
+            Some(`application/json`),
+            Some("Label Collection")
+          ),
+          StacLink(
+            sceneCollectionAbsLink,
+            Child,
+            Some(`application/json`),
+            Some("Scene Collection")
+          )
+        )
+      )
+      .toStacCollection()
+    (
+      updatedLayerCollection,
+      (sceneCollection, sceneItems),
+      (
+        labelCollection,
+        labelItem,
+        (layerCollection.sceneTaskAnnotations.get._5, labelDataS3AbsLink)
+      )
+    )
+  }
+}

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -1,0 +1,234 @@
+package com.rasterfoundry.batch.stacExport
+
+import geotrellis.vector.reproject.Reproject
+import geotrellis.proj4.CRS
+import com.rasterfoundry.datamodel._
+import io.circe._
+import io.circe.syntax._
+import io.circe.parser._
+import geotrellis.server.stac._
+import geotrellis.server.stac.{StacExtent => _}
+import com.rasterfoundry.batch.stacExport.{StacExtent => BatchStacExtent}
+
+object SceneCollectionBuilder {
+  sealed trait CollectionRequirements
+  object CollectionBuilder {
+    trait EmptyCollection extends CollectionRequirements
+    trait CollectionStacVersion extends CollectionRequirements
+    trait CollectionId extends CollectionRequirements
+    trait CollectionTitle extends CollectionRequirements
+    trait CollectionExtent extends CollectionRequirements
+    trait CollectionLinks extends CollectionRequirements
+    trait CollectionDescription extends CollectionRequirements
+    trait CollectionParentPath extends CollectionRequirements
+    trait CollectionSceneList extends CollectionRequirements
+    type CompleteCollection =
+      EmptyCollection
+        with CollectionStacVersion
+        with CollectionId
+        with CollectionTitle
+        with CollectionExtent
+        with CollectionLinks
+        with CollectionDescription
+        with CollectionParentPath
+        with CollectionSceneList
+  }
+}
+
+final case class IncompleteSceneCollection(
+    stacVersion: Option[String] = None, // required
+    id: Option[String] = None, // required
+    title: Option[String] = None,
+    description: Option[String] = None, // required
+    keywords: Option[List[String]] = None,
+    version: String = "1", // always 1, we aren't versioning exports
+    license: Option[String] = None, // required
+    providers: Option[List[StacProvider]] = None,
+    extent: Option[BatchStacExtent] = None, // required
+    properties: Option[Json] = None,
+    links: List[StacLink] = List(), // builders?  // required
+    parentPath: Option[String] = None,
+    rootPath: Option[String] = None,
+    sceneList: List[Scene] = List()
+) {
+  @SuppressWarnings(Array("OptionGet"))
+  def toStacCollection: StacCollection = {
+    val extent: Json = this.extent match {
+      case Some(ext) => ext.asJson
+      case None      => Json.Null
+    }
+    StacCollection(
+      this.stacVersion.get,
+      this.id.get,
+      this.title,
+      this.description.get,
+      this.keywords.getOrElse(List()), // not required
+      this.version,
+      this.license.getOrElse(""), // required but not clear yet
+      this.providers.getOrElse(List[StacProvider]()), // not required
+      extent,
+      JsonObject.empty, // properties, free-form json, not required
+      this.links
+    )
+  }
+}
+
+class SceneCollectionBuilder[
+    CollectionRequirements <: SceneCollectionBuilder.CollectionRequirements
+](sceneCollection: IncompleteSceneCollection = IncompleteSceneCollection()) {
+  import SceneCollectionBuilder.CollectionBuilder._
+
+  def withVersion(
+      version: String
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionStacVersion] =
+    new SceneCollectionBuilder(
+      sceneCollection.copy(stacVersion = Some(version)))
+
+  def withId(
+      id: String
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionId] =
+    new SceneCollectionBuilder(sceneCollection.copy(id = Some(id)))
+
+  def withTitle(
+      title: String
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionTitle] =
+    new SceneCollectionBuilder(sceneCollection.copy(title = Some(title)))
+
+  def withDescription(
+      description: String
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionDescription] =
+    new SceneCollectionBuilder(
+      sceneCollection.copy(description = Some(description))
+    )
+
+  def withLinks(
+      links: List[StacLink]
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionLinks] =
+    new SceneCollectionBuilder(
+      sceneCollection.copy(links = sceneCollection.links ++ links)
+    )
+
+  def withExtent(
+      extent: StacExtent
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionExtent] =
+    new SceneCollectionBuilder(sceneCollection.copy(extent = Some(extent)))
+
+  def withParentPath(
+      parentPath: String,
+      rootPath: String
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionParentPath] =
+    new SceneCollectionBuilder(
+      sceneCollection
+        .copy(parentPath = Some(parentPath), rootPath = Some(rootPath))
+    )
+
+  def withSceneList(
+      sceneList: List[Scene]
+  ): SceneCollectionBuilder[CollectionRequirements with CollectionSceneList] =
+    new SceneCollectionBuilder(
+      sceneCollection
+        .copy(sceneList = sceneCollection.sceneList ++ sceneList)
+    )
+
+  @SuppressWarnings(Array("OptionGet"))
+  def build()(
+      implicit ev: CollectionRequirements =:= CompleteCollection
+  ): (StacCollection, List[StacItem], List[(String, String)]) = {
+    ev.unused
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<sceneCollectionID>
+    val absPath = sceneCollection.parentPath.get
+    // ../../../catalog.json
+    val rootPath = sceneCollection.rootPath.get
+
+    val sceneItemsAndLinks: List[(StacItem, (String, String))] =
+      sceneCollection.sceneList
+        .map(scene => {
+          val itemBuilder =
+            new StacItemBuilder[StacItemBuilder.ItemBuilder.EmptyItem]()
+          val sceneFootprint = Reproject(
+            scene.dataFootprint.get.geom,
+            CRS.fromEpsgCode(3857),
+            CRS.fromEpsgCode(4326)
+          )
+          val sceneBbox = ItemBbox(
+            sceneFootprint.envelope.xmin,
+            sceneFootprint.envelope.ymin,
+            sceneFootprint.envelope.xmax,
+            sceneFootprint.envelope.ymax
+          )
+          // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<sceneCollectionID>/<sceneId>
+          val sceneAbsPath = s"${absPath}/${scene.id}"
+          // ../../../../catalog.json
+          val sceneRootPath = s"../${rootPath}"
+          val itemLinkAndTitle: (String, String) =
+            (s"${sceneAbsPath}/item.json", s"Scene Item ${scene.id.toString}")
+          val sceneLinks = List(
+            StacLink(
+              itemLinkAndTitle._1,
+              Self,
+              Some(`application/json`),
+              Some(itemLinkAndTitle._2)
+            ),
+            StacLink(
+              s"${absPath}/collection.json",
+              Parent,
+              Some(`application/json`),
+              Some("Scene Collection")
+            ),
+            StacLink(
+              sceneRootPath,
+              StacRoot,
+              Some(`application/json`),
+              Some("Root")
+            )
+          )
+          val sceneProperties = JsonObject(
+            (
+              "datetime",
+              parse(
+                scene.filterFields.acquisitionDate.get.toLocalDateTime.toString
+              ).getOrElse(Json.Null)
+            )
+          )
+          val sceneAsset = Map(
+            scene.id.toString ->
+              StacAsset(
+                scene.ingestLocation.get,
+                Some("scene"),
+                Some(`image/cog`)
+              )
+          )
+          (
+            itemBuilder
+              .withId(scene.id.toString)
+              .withGeometries(sceneFootprint, sceneBbox)
+              .withLinks(sceneLinks)
+              .withCollection(sceneCollection.id.get)
+              .withProperties(sceneProperties)
+              .withParentPath(absPath, rootPath)
+              .withAssets(sceneAsset)
+              .build(),
+            itemLinkAndTitle
+          )
+        })
+
+    val sceneLinks: List[(String, String)] = sceneItemsAndLinks.map(_._2)
+
+    (
+      sceneCollection
+        .copy(
+          links = sceneCollection.links ++ sceneLinks.map(link => {
+            StacLink(
+              link._1,
+              Item,
+              Some(`application/json`),
+              Some(link._2)
+            )
+          })
+        )
+        .toStacCollection, // the scene collection
+      sceneItemsAndLinks.map(_._1), // a list of scene items
+      sceneLinks // a list of (sceneItemAbsLink, sceneItemTitle)
+    )
+  }
+}

--- a/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
@@ -1,0 +1,250 @@
+package com.rasterfoundry.batch.stacExport
+
+import geotrellis.server.stac._
+
+import com.rasterfoundry.datamodel._
+import geotrellis.proj4.CRS
+import geotrellis.vector.reproject.Reproject
+import cats.implicits._
+import io.circe._
+import java.sql.Timestamp
+
+object StacCatalogBuilder {
+  sealed trait CatalogRequirements
+  object CatalogBuilder {
+    trait EmptyCatalog extends CatalogRequirements
+    trait CatalogVersion extends CatalogRequirements
+    trait CatalogParentPath extends CatalogRequirements
+    trait CatalogId extends CatalogRequirements
+    trait CatalogTitle extends CatalogRequirements
+    trait CatalogDescription extends CatalogRequirements
+    trait CatalogLinks extends CatalogRequirements
+    trait CatalogContents extends CatalogRequirements
+    type CompleteCatalog =
+      EmptyCatalog
+        with CatalogVersion
+        with CatalogParentPath
+        with CatalogId
+        with CatalogTitle
+        with CatalogDescription
+        with CatalogLinks
+        with CatalogContents
+  }
+}
+
+case class IncompleteStacCatalog(
+    stacVersion: Option[String] = None,
+    parentPath: Option[String] = None,
+    rootPath: Option[String] = None,
+    isRoot: Boolean = false,
+    id: Option[String] = None,
+    title: Option[String] = None,
+    description: Option[String] = None,
+    links: List[StacLink] = List(),
+    contents: Option[ContentBundle] = None
+) {
+  @SuppressWarnings(Array("OptionGet"))
+  def toStacCatalog(): StacCatalog = {
+    StacCatalog(
+      stacVersion.get,
+      id.get,
+      title,
+      description.get,
+      links
+    )
+  }
+}
+
+class StacCatalogBuilder[
+    CatalogRequirements <: StacCatalogBuilder.CatalogRequirements
+](stacCatalog: IncompleteStacCatalog = IncompleteStacCatalog()) {
+  import StacCatalogBuilder.CatalogBuilder._
+
+  def withVersion(
+      stacVersion: String
+  ): StacCatalogBuilder[CatalogRequirements with CatalogVersion] =
+    new StacCatalogBuilder(stacCatalog.copy(stacVersion = Some(stacVersion)))
+
+  def withParentPath(
+      parentPath: String,
+      isRoot: Boolean = false,
+      rootPath: String = ""
+  ): StacCatalogBuilder[CatalogRequirements with CatalogParentPath] =
+    new StacCatalogBuilder(
+      stacCatalog.copy(
+        parentPath = Some(parentPath),
+        rootPath = Some(rootPath),
+        isRoot = isRoot
+      )
+    )
+
+  def withId(
+      id: String
+  ): StacCatalogBuilder[CatalogRequirements with CatalogId] =
+    new StacCatalogBuilder(stacCatalog.copy(id = Some(id)))
+
+  def withTitle(
+      title: String
+  ): StacCatalogBuilder[CatalogRequirements with CatalogTitle] =
+    new StacCatalogBuilder(stacCatalog.copy(title = Some(title)))
+
+  def withDescription(
+      description: String
+  ): StacCatalogBuilder[CatalogRequirements with CatalogDescription] =
+    new StacCatalogBuilder(stacCatalog.copy(description = Some(description)))
+
+  def withLinks(
+      links: List[StacLink]
+  ): StacCatalogBuilder[CatalogRequirements with CatalogLinks] =
+    new StacCatalogBuilder(stacCatalog.copy(links = links))
+
+  def withContents(
+      contents: ContentBundle
+  ): StacCatalogBuilder[CatalogRequirements with CatalogContents] =
+    new StacCatalogBuilder(stacCatalog.copy(contents = Some(contents)))
+
+  @SuppressWarnings(Array("OptionGet"))
+  def build()(
+      implicit ev: CatalogRequirements =:= CompleteCatalog
+  ): (
+      StacCatalog, // catalog
+      List[
+        (
+            StacCollection, // layer collection
+            (StacCollection, List[StacItem]), // scene collection and scene items
+            (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+        )
+      ]
+  ) = {
+    // Silence unused warning because scalac warns about phantom types
+    ev.unused
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>
+    val absPath: String = stacCatalog.parentPath.get
+    // ../catalog.json
+    val rootPath = "../catalog.json"
+
+    val layerCollectionList: List[
+      (
+          StacCollection, // layer collection
+          (StacCollection, List[StacItem]), // scene collection and scene items
+          (StacCollection, StacItem, (Option[Json], String)), // label collection, label item, label data, and s3 location
+          String //layerSelfAbsLink
+      )
+    ] = stacCatalog.contents.get.layerToSceneTaskAnnotation
+      .map {
+        case (layerId, sceneTaskAnnotation) => (layerId, sceneTaskAnnotation)
+      }
+      .toList
+      .map(layerInfo => {
+        val layerId: String = layerInfo._1.toString
+        val sceneList: List[Scene] = layerInfo._2._1
+        val sceneGeomExtent: Option[UnionedGeomExtent] = layerInfo._2._2
+        // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerId>
+        val layerCollectionAbsPath = s"${absPath}/${layerId}"
+        // ../../catalog.json
+        val layerRootPath = s"../${rootPath}"
+        val layerCollectionBuilder =
+          new LayerCollectionBuilder[
+            LayerCollectionBuilder.CollectionBuilder.EmptyCollection
+          ]()
+        val layerSelfAbsLink = s"${absPath}/catalog.json"
+        val layerOwnLinks = List(
+          StacLink(
+            // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
+            layerSelfAbsLink,
+            Parent,
+            Some(`application/json`),
+            Some(s"Catalog ${stacCatalog.id.get}")
+          ),
+          StacLink(
+            // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/collection.json
+            s"${layerCollectionAbsPath}/collection.json",
+            Self,
+            Some(`application/json`),
+            Some(s"Layer Collection ${layerId}")
+          ),
+          StacLink(
+            // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<catalogId>.json
+            layerRootPath,
+            StacRoot,
+            Some(`application/json`),
+            Some("Root")
+          )
+        )
+        val layerSceneSpatialExtent: List[Double] = sceneGeomExtent match {
+          case Some(geomExt) =>
+            List(geomExt.xMin, geomExt.yMin, geomExt.xMax, geomExt.yMax)
+          case None =>
+            val extent = sceneList
+              .map(_.dataFootprint.get)
+              .map(
+                geom =>
+                  Reproject(
+                    geom.geom,
+                    CRS.fromEpsgCode(3857),
+                    CRS.fromEpsgCode(4326)
+                )
+              )
+              .map(_.envelope)
+              .reduce((e1, e2) => {
+                e1.combine(e2)
+              })
+            List(extent.xmin, extent.ymin, extent.xmax, extent.ymax)
+        }
+        val layerSceneAqcTime: List[Timestamp] =
+          sceneList map { scene =>
+            scene.filterFields.acquisitionDate.getOrElse(scene.createdAt)
+          }
+        val layerSceneTemporalExtent: List[Option[String]] = List(
+          Some(layerSceneAqcTime.minBy(_.getTime).toLocalDateTime.toString),
+          Some(layerSceneAqcTime.maxBy(_.getTime).toLocalDateTime.toString)
+        )
+        val layerExtent = StacExtent(
+          layerSceneSpatialExtent,
+          layerSceneTemporalExtent
+        )
+        val (
+          layerCollection,
+          (sceneCollection, sceneItems),
+          (labelCollection, labelItem, (labelDataJson, labelDataS3AbsLink))
+        ): (
+            StacCollection,
+            (StacCollection, List[StacItem]),
+            (StacCollection, StacItem, (Option[Json], String))
+        ) = layerCollectionBuilder
+          .withVersion(stacCatalog.stacVersion.get)
+          .withId(layerId)
+          .withTitle("Layers")
+          .withDescription("Project layer collection")
+          .withLinks(layerOwnLinks)
+          .withParentPath(layerCollectionAbsPath, layerRootPath)
+          .withExtent(layerExtent)
+          .withSceneTaskAnnotations(layerInfo._2)
+          .build()
+        (
+          layerCollection,
+          (sceneCollection, sceneItems),
+          (labelCollection, labelItem, (labelDataJson, labelDataS3AbsLink)),
+          layerSelfAbsLink
+        )
+      })
+
+    val udpatedStacCatalog = stacCatalog
+      .copy(
+        links = stacCatalog.links ++ layerCollectionList.map {
+          case (_, _, _, layerSelfLink) =>
+            StacLink(
+              layerSelfLink,
+              Child,
+              Some(`application/json`),
+              Some("Layer Collection")
+            )
+        }
+      )
+      .toStacCatalog()
+    val layerInfoList = layerCollectionList.map(layerInfo =>
+      (layerInfo._1, layerInfo._2, layerInfo._3))
+
+    (udpatedStacCatalog, layerInfoList)
+  }
+}

--- a/app-backend/batch/src/main/scala/stacExport/StacExtent.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacExtent.scala
@@ -1,0 +1,17 @@
+package com.rasterfoundry.batch.stacExport
+
+import io.circe.Encoder
+
+// Spatial = bbox[lowerleftx, lowerlefty, upperrightx, upperrighty]
+// temportal = ["start date isostring"||null, "end date isostring"||null]
+// https://github.com/radiantearth/stac-spec/blob/dev/collection-spec/collection-spec.md#extent-object
+case class StacExtent(spatial: List[Double], temporal: List[Option[String]])
+
+object StacExtent {
+  implicit val encStacExtent: Encoder[StacExtent] =
+    Encoder.forProduct2("spatial", "temporal")(ext => {
+      val spatial: List[Double] = ext.spatial
+      val temporal: List[String] = ext.temporal.map(_.getOrElse("null"))
+      (spatial, temporal)
+    })
+}

--- a/app-backend/batch/src/main/scala/stacExport/StacItemBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacItemBuilder.scala
@@ -1,0 +1,109 @@
+package com.rasterfoundry.batch.stacExport
+
+import geotrellis.server.stac._
+import io.circe._
+import geotrellis.vector.{io => _, _}
+
+case class ItemBbox(
+    lowerLeftLng: Double,
+    lowerLeftLat: Double,
+    upperRightLng: Double,
+    upperRightLat: Double
+)
+
+object StacItemBuilder {
+  sealed trait ItemRequirements
+  object ItemBuilder {
+    trait EmptyItem extends ItemRequirements
+    trait ItemId extends ItemRequirements
+    trait ItemGeometries extends ItemRequirements
+    trait ItemLinks extends ItemRequirements
+    trait ItemCollection extends ItemRequirements
+    trait ItemProperties extends ItemRequirements
+    trait ItemParentPath extends ItemRequirements
+    trait ItemAssets extends ItemRequirements
+    type CompleteItem =
+      EmptyItem
+        with ItemId
+        with ItemGeometries
+        with ItemLinks
+        with ItemCollection
+        with ItemProperties
+        with ItemParentPath
+        with ItemAssets
+  }
+}
+
+case class IncompleteStacItem(
+    id: Option[String] = None,
+    _type: String = "feature",
+    geometry: Option[Geometry] = None,
+    bbox: Option[ItemBbox] = None,
+    links: List[StacLink] = List(), // builders? ids? build function of parent needs to provide. relative links
+    assets: Map[String, StacAsset] = Map(), // relative links to collection, catalog
+    collection: Option[String] = None, // id of collection
+    properties: Option[JsonObject] = None,
+    parentPath: Option[String] = None,
+    rootPath: Option[String] = None,
+) {
+  @SuppressWarnings(Array("OptionGet"))
+  def toStacItem(): StacItem = {
+    val itemBbox = this.bbox.get
+    StacItem(
+      id = this.id.get,
+      geometry = this.geometry.get,
+      bbox = TwoDimBbox(
+        itemBbox.lowerLeftLng,
+        itemBbox.lowerLeftLat,
+        itemBbox.upperRightLng,
+        itemBbox.upperRightLat
+      ),
+      links = this.links,
+      assets = this.assets,
+      collection = this.collection,
+      properties = this.properties.get
+    )
+  }
+}
+
+class StacItemBuilder[ItemRequirements <: StacItemBuilder.ItemRequirements](
+    stacItem: IncompleteStacItem = IncompleteStacItem()) {
+  import StacItemBuilder.ItemBuilder._
+
+  def withId(id: String): StacItemBuilder[ItemRequirements with ItemId] =
+    new StacItemBuilder(stacItem.copy(id = Some(id)))
+
+  def withGeometries(
+      geometry: Geometry,
+      bbox: ItemBbox): StacItemBuilder[ItemRequirements with ItemGeometries] =
+    new StacItemBuilder(
+      stacItem.copy(geometry = Some(geometry), bbox = Some(bbox)))
+
+  def withLinks(
+      links: List[StacLink]): StacItemBuilder[ItemRequirements with ItemLinks] =
+    new StacItemBuilder(stacItem.copy(links = stacItem.links ++ links))
+
+  def withCollection(collectionId: String)
+    : StacItemBuilder[ItemRequirements with ItemCollection] =
+    new StacItemBuilder(stacItem.copy(collection = Some(collectionId)))
+
+  def withProperties(properties: JsonObject)
+    : StacItemBuilder[ItemRequirements with ItemProperties] =
+    new StacItemBuilder(stacItem.copy(properties = Some(properties)))
+
+  def withParentPath(
+      path: String,
+      rootPath: String): StacItemBuilder[ItemRequirements with ItemParentPath] =
+    new StacItemBuilder(
+      stacItem.copy(parentPath = Some(path), rootPath = Some(rootPath)))
+
+  def withAssets(assets: Map[String, StacAsset])
+    : StacItemBuilder[ItemRequirements with ItemAssets] =
+    new StacItemBuilder(stacItem.copy(assets = stacItem.assets ++ assets))
+
+  @SuppressWarnings(Array("OptionGet"))
+  def build()(implicit ev: ItemRequirements =:= CompleteItem): StacItem = {
+    ev.unused // Silence unused warning because scalac warns about phantom types
+    stacItem.toStacItem
+  }
+}

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -1,0 +1,264 @@
+package com.rasterfoundry.batch.stacExport
+
+import com.rasterfoundry.batch.Job
+import com.rasterfoundry.batch.util.conf.Config
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.common.RollbarNotifier
+
+import geotrellis.server.stac._
+
+import java.sql.Timestamp
+import java.util.Date;
+import java.util.UUID
+import doobie._
+import doobie.implicits._
+import io.circe._
+import io.circe.syntax._
+import cats.implicits._
+import cats.effect.IO
+
+final case class WriteStacCatalog(exportId: UUID)(
+    implicit val xa: Transactor[IO])
+    extends Config
+    with RollbarNotifier {
+
+  val name = WriteStacCatalog.name
+
+  def runJob(args: List[String]) = ???
+
+  // Use the SELF type link on each object to upload it to the correct place
+  // label items are accopanied by a geojson asset, which should be uploaded relative
+  // to the item itself
+  protected def writeToS3(
+      catalog: StacCatalog,
+      layerSceneLabelCollectionsItemsAssets: List[
+        (
+            StacCollection, // layer collection
+            (StacCollection, List[StacItem]), // scene collection and scene items
+            (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+        )
+      ]
+  ) = ???
+
+  protected def setExportStatus(
+      export: StacExport,
+      status: ExportStatus
+  ): ConnectionIO[Int] = {
+    for {
+      count <- StacExportDao.update(
+        export.copy(exportStatus = status),
+        export.id
+      )
+    } yield count
+  }
+
+  protected def sceneTaskAnnotationforLayers(
+      layerDefinitions: List[StacExport.LayerDefinition],
+      taskStatuses: List[String]
+  ): ConnectionIO[Map[
+    UUID,
+    (List[Scene],
+     Option[UnionedGeomExtent],
+     List[Task],
+     Option[UnionedGeomExtent],
+     Option[Json],
+     Option[StacLabelItemPropertiesThin])
+  ]] = {
+    (layerDefinitions traverse {
+      case StacExport.LayerDefinition(projectId, layerId) =>
+        for {
+          projectTypeO <- ProjectDao.getAnnotationProjectType(projectId)
+          infoOption <- projectTypeO match {
+            case Some(projectType) =>
+              createLayerInfoMap(projectId, layerId, taskStatuses, projectType)
+            case _ => Option.empty.pure[ConnectionIO]
+          }
+        } yield {
+          infoOption match {
+            case Some(info) => Some((layerId, info))
+            case _          => None
+          }
+        }
+    }) map { _.flatten.toMap }
+  }
+
+  protected def createLayerInfoMap(
+      projectId: UUID,
+      layerId: UUID,
+      taskStatuses: List[String],
+      projectType: String
+  ): ConnectionIO[Option[
+    (List[Scene],
+     Option[UnionedGeomExtent],
+     List[Task],
+     Option[UnionedGeomExtent],
+     Option[Json],
+     Option[StacLabelItemPropertiesThin])
+  ]] =
+    for {
+      scenes <- ProjectLayerScenesDao.listLayerScenesRaw(layerId)
+      scenesGeomExtent <- ProjectLayerScenesDao.createUnionedGeomExtent(layerId)
+      tasks <- TaskDao.listLayerTasksByStatus(projectId, layerId, taskStatuses)
+      tasksGeomExtent <- TaskDao.createUnionedGeomExtent(projectId,
+                                                         layerId,
+                                                         taskStatuses)
+      annotations <- AnnotationDao.getLayerAnnotationJsonByTaskStatus(
+        projectId,
+        layerId,
+        taskStatuses,
+        projectType
+      )
+      labelItemPropsThin <- ProjectDao.getAnnotationProjectStacInfo(projectId)
+    } yield {
+      Some(
+        (scenes,
+         scenesGeomExtent,
+         tasks,
+         tasksGeomExtent,
+         annotations,
+         labelItemPropsThin))
+    }
+
+  @SuppressWarnings(Array("all"))
+  def run(): Unit = {
+
+    logger.info(s"Exporting STAC export for record ${exportId}...")
+
+    /*
+      For project:
+      get the project extras field
+
+      For each project layer:
+      fetch scenes
+      fetch tasks, filter by exportDefinition.taskStatuses
+      fetch the annotations filtered by task statuses
+      save the annotations as a geojson feature collection
+      (map the labels of annotations according the project extras field, setting properties etc) -> already done in Daos
+
+      returns:
+      Map[
+        UUID, // layer ID
+        (
+          List[Scene],
+          List[Task],
+          Option[Json], // STAC-compliant annotation data in a geojson feature collection
+          Option[StacLabelItemPropertiesThin] // project label and class definition, will be used to populate label STAC item properties
+        )
+      ]
+     */
+
+    // Fetch data
+    val dbIO = for {
+      exportDefinition <- StacExportDao.unsafeGetById(exportId)
+      _ <- setExportStatus(exportDefinition, ExportStatus.Exporting)
+      layerSceneTaskAnnotation <- sceneTaskAnnotationforLayers(
+        exportDefinition.layerDefinitions,
+        exportDefinition.taskStatuses
+      )
+    } yield (exportDefinition, layerSceneTaskAnnotation)
+
+    logger.info(s"Creating content bundle with layers, scenes, and labels...")
+    val (exportDef, layerInfo) = dbIO.transact(xa).unsafeRunSync
+    val contentBundle = ContentBundle(
+      exportDef,
+      layerInfo
+    )
+
+    logger.info(s"Buidling a catalog...")
+    // Construct STAC datamodel
+    /*
+     Exported Catalog:
+     |-> Layer collection
+     |   |-> Scene Collection
+     |   |   |-> Scene Item
+     |   |   |-> Scene Item
+     |   |   |-> (One or more scene items)
+     |   |-> Label Collection
+     |   |   |-> Label Item (Only one)
+     |   |   |-> Label Data in GeoJSON Feature Collection
+     |-> (One or more Layer Collections)
+
+     Final structure is going to be on s3
+     */
+    val catalogBuilder =
+      new StacCatalogBuilder[StacCatalogBuilder.CatalogBuilder.EmptyCatalog]()
+    val stacVersion = "0.7.0"
+    val currentPath =
+      contentBundle.export.exportLocation
+        .getOrElse("s3://rasterfoundry-production-data-us-east-1/stac-exports")
+    val catalogId = contentBundle.export.id.toString
+    val catalogParentPath = s"${currentPath}/${catalogId}"
+    val catalogDescription =
+      s"Exported from Raster Foundry ${(new Timestamp((new Date()).getTime())).toString()}"
+    val catalogOwnLinks = List(
+      StacLink(
+        // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
+        s"${catalogParentPath}/catalog.json",
+        Self,
+        Some(`application/json`),
+        Some(s"Catalog ${catalogId}")
+      ),
+      // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
+      StacLink(
+        s"${catalogParentPath}/catalog.json",
+        StacRoot,
+        Some(`application/json`),
+        Some(s"Catalog ${catalogId}")
+      )
+    )
+    val (
+      catalog,
+      layerSceneLabelCollectionsItemsAssets
+    ): (
+        StacCatalog, // catalog
+        List[
+          (
+              StacCollection, // layer collection
+              (StacCollection, List[StacItem]), // scene collection and scene items
+              (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+          )
+        ]
+    ) = catalogBuilder
+      .withVersion(stacVersion)
+      .withParentPath(catalogParentPath, true)
+      .withId(contentBundle.export.id.toString)
+      .withTitle(contentBundle.export.name)
+      .withDescription(catalogDescription)
+      .withLinks(catalogOwnLinks)
+      .withContents(contentBundle)
+      .build()
+
+    println(catalog.asJson)
+    println(layerSceneLabelCollectionsItemsAssets)
+
+    // TODO: Write STAC catalog etc to s3
+    // writeToS3(catalog, layerSceneLabelCollectionsItemsAssets)
+
+    // Update StacExport in database with location of export and finished status
+    val exportStatusUpdateIO =
+      setExportStatus(contentBundle.export, ExportStatus.Exported)
+
+    val exportRecordCount = exportStatusUpdateIO.transact(xa).unsafeRunSync
+
+    logger
+      .info(
+        s"${exportRecordCount} STAC export record for ${exportId} is updated")
+  }
+}
+
+object WriteStacCatalog extends Job {
+  val name = "write_stac_catalog"
+
+  def runJob(args: List[String]): IO[Unit] = {
+    RFTransactor.xaResource.use(transactor => {
+      implicit val xa = transactor
+      val job = args.toList match {
+        case List(id: String) => WriteStacCatalog(UUID.fromString(id))
+      }
+
+      IO { job.run }
+    })
+  }
+}

--- a/app-backend/batch/src/main/scala/stacImport/ReadStacFeature.scala
+++ b/app-backend/batch/src/main/scala/stacImport/ReadStacFeature.scala
@@ -1,4 +1,4 @@
-package com.rasterfoundry.batch.stac
+package com.rasterfoundry.batch.stacImport
 
 import com.rasterfoundry.batch.util._
 import com.rasterfoundry.batch.util.conf.Config

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -357,6 +357,7 @@ lazy val batch = project
       Dependencies.geotrellisS3,
       Dependencies.geotrellisUtil,
       Dependencies.geotrellisRaster,
+      Dependencies.geotrellisServerStac,
       Dependencies.sparkCore,
       Dependencies.ficus,
       Dependencies.dropbox,

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1012,14 +1012,12 @@ object Generators extends ArbitraryInstances {
       name <- nonEmptyStringGen
       owner <- Gen.const(None)
       layerDefinition <- layerDefinitionGen
-      isUnion <- Gen.oneOf(true, false)
       taskStatuses <- taskStatusListGen
     } yield {
       StacExport.Create(
         name,
         owner,
         List(layerDefinition),
-        isUnion,
         taskStatuses
       )
     }

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -996,6 +996,37 @@ object Generators extends ArbitraryInstances {
       Task.TaskGridFeatureCreate(properties, geometry)
     }
 
+  private def taskStatusListGen: Gen[List[TaskStatus]] =
+    Gen.oneOf(0, 5) flatMap { Gen.listOfN(_, taskStatusGen) }
+
+  private def layerDefinitionGen: Gen[StacExport.LayerDefinition] =
+    for {
+      projectId <- uuidGen
+      layerId <- uuidGen
+    } yield {
+      StacExport.LayerDefinition(projectId, layerId)
+    }
+
+  private def stacExportCreateGen: Gen[StacExport.Create] =
+    for {
+      name <- nonEmptyStringGen
+      owner <- Gen.const(None)
+      layerDefinition <- layerDefinitionGen
+      isUnion <- Gen.oneOf(true, false)
+      taskStatuses <- taskStatusListGen
+    } yield {
+      StacExport.Create(
+        name,
+        owner,
+        List(layerDefinition),
+        isUnion,
+        taskStatuses
+      )
+    }
+
+  private def stacExportQueryParametersGen: Gen[StacExportQueryParameters] =
+    Gen.const(StacExportQueryParameters())
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
       credentialGen
@@ -1220,6 +1251,16 @@ object Generators extends ArbitraryInstances {
     implicit def arbTaskPropertiesCreate: Arbitrary[Task.TaskPropertiesCreate] =
       Arbitrary {
         taskPropertiesCreateGen
+      }
+
+    implicit def arbStacExportCreate: Arbitrary[StacExport.Create] =
+      Arbitrary {
+        stacExportCreateGen
+      }
+
+    implicit def arbStacExportQueryParameters: Arbitrary[StacExportQueryParameters] =
+      Arbitrary {
+        stacExportQueryParametersGen
       }
   }
 }

--- a/app-backend/datamodel/src/main/scala/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/Annotation.scala
@@ -291,71 +291,6 @@ final case class AnnotationWithOwnerInfoProperties(
     ownerName: String,
     ownerProfileImageUri: String)
 
-final case class StacLabelItemProperties(
-    property: List[String],
-    classes: StacLabelItemProperties.StacLabelItemClasses,
-    description: String,
-    _type: String,
-    datetime: Timestamp,
-    title: Option[String] = None,
-    task: Option[List[String]] = None,
-    method: Option[List[String]] = None,
-    version: Option[String] = None,
-    summary: Option[StacLabelItemProperties.StacLabelSummary] = None
-)
-
-object StacLabelItemProperties {
-  implicit val encodeStacLabelItemProperties: Encoder[StacLabelItemProperties] =
-    Encoder.forProduct10(
-      "label:property",
-      "label:classes",
-      "label:description",
-      "label:type",
-      "datetime",
-      "title",
-      "label:task",
-      "label:method",
-      "label:version",
-      "label:summary"
-    )(
-      item =>
-        (item.property,
-         item.classes,
-         item.description,
-         item._type,
-         item.datetime,
-         item.title,
-         item.task,
-         item.method,
-         item.version,
-         item.summary))
-
-  @JsonCodec
-  final case class StacLabelItemClasses(
-      name: String,
-      classes: List[String]
-  )
-
-  @JsonCodec
-  final case class StacLabelSummary(
-      propertyKey: String,
-      counts: Option[List[Count]] = None,
-      statistics: Option[List[Statistics]] = None
-  )
-
-  @JsonCodec
-  final case class Count(
-      className: String,
-      count: Int
-  )
-
-  @JsonCodec
-  final case class Statistics(
-      statName: String,
-      value: Double
-  )
-}
-
 @JsonCodec
 final case class AnnotationWithClasses(
     id: UUID,
@@ -410,34 +345,37 @@ object AnnotationWithClasses {
   object GeoJSON {
     implicit val annoWithClassesGeojonEncoder: Encoder[GeoJSON] =
       Encoder.forProduct4("id", "geometry", "properties", "type")(
-        geojson => (geojson.id, geojson.geometry, geojson.properties, geojson._type)
+        geojson =>
+          (geojson.id, geojson.geometry, geojson.properties, geojson._type)
       )
   }
 }
 
 final case class AnnotationWithClassesProperties(
-  projectId: UUID,
-  createdAt: Timestamp,
-  createdBy: String,
-  modifiedAt: Timestamp,
-  owner: String,
-  description: Option[String],
-  machineGenerated: Option[Boolean],
-  confidence: Option[Float],
-  quality: Option[AnnotationQuality],
-  annotationGroup: UUID,
-  labeledBy: Option[String],
-  verifiedBy: Option[String],
-  projectLayerId: UUID,
-  taskId: Option[UUID],
-  classes: Json
+    projectId: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    owner: String,
+    description: Option[String],
+    machineGenerated: Option[Boolean],
+    confidence: Option[Float],
+    quality: Option[AnnotationQuality],
+    annotationGroup: UUID,
+    labeledBy: Option[String],
+    verifiedBy: Option[String],
+    projectLayerId: UUID,
+    taskId: Option[UUID],
+    classes: Json
 )
 
 object AnnotationWithClassesProperties {
-  implicit val annotationWithClassesPropertiesEncoder: Encoder[AnnotationWithClassesProperties] =
+  implicit val annotationWithClassesPropertiesEncoder
+    : Encoder[AnnotationWithClassesProperties] =
     new Encoder[AnnotationWithClassesProperties] {
       final def apply(properties: AnnotationWithClassesProperties): Json = {
-        val classMap: Map[String, Json] = properties.classes.as[Map[String, Json]].getOrElse(Map.empty)
+        val classMap: Map[String, Json] =
+          properties.classes.as[Map[String, Json]].getOrElse(Map.empty)
         (
           Map(
             "projectId" -> properties.projectId.asJson,
@@ -452,7 +390,7 @@ object AnnotationWithClassesProperties {
             "annotationGroup" -> properties.annotationGroup.asJson,
             "labeledBy" -> properties.labeledBy.asJson,
             "verifiedBy" -> properties.verifiedBy.asJson,
-            "projectLayerId" -> properties.projectLayerId.asJson, 
+            "projectLayerId" -> properties.projectLayerId.asJson,
             "taskId" -> properties.taskId.asJson
           ) ++ classMap
         ).asJson
@@ -461,11 +399,18 @@ object AnnotationWithClassesProperties {
 }
 
 final case class AnnotationWithClassesFeatureCollection(
-  features: List[AnnotationWithClasses.GeoJSON],
-  `type`: String = "FeatureCollection"
+    features: List[AnnotationWithClasses.GeoJSON],
+    `type`: String = "FeatureCollection"
 )
 
 object AnnotationWithClassesFeatureCollection {
-  implicit val annoWithClassesFCEncoder: Encoder[AnnotationWithClassesFeatureCollection] = 
+  implicit val annoWithClassesFCEncoder
+    : Encoder[AnnotationWithClassesFeatureCollection] =
     deriveEncoder[AnnotationWithClassesFeatureCollection]
 }
+
+@JsonCodec
+final case class AnnotationFeatureCollection(
+    features: List[Annotation.GeoJSON],
+    `type`: String = "FeatureCollection"
+)

--- a/app-backend/datamodel/src/main/scala/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/Annotation.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import geotrellis.vector.{Geometry, Projected, io => _}
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras._
+import io.circe.Encoder
 
 @JsonCodec
 final case class AnnotationFeatureCollectionCreate(
@@ -285,5 +286,69 @@ final case class AnnotationWithOwnerInfoProperties(
     projectLayerId: UUID,
     taskId: Option[UUID] = None,
     ownerName: String,
-    ownerProfileImageUri: String
+    ownerProfileImageUri: String)
+
+final case class StacLabelItemProperties(
+    property: List[String],
+    classes: StacLabelItemProperties.StacLabelItemClasses,
+    description: String,
+    _type: String,
+    datetime: Timestamp,
+    title: Option[String] = None,
+    task: Option[List[String]] = None,
+    method: Option[List[String]] = None,
+    version: Option[String] = None,
+    summary: Option[StacLabelItemProperties.StacLabelSummary] = None
 )
+
+object StacLabelItemProperties {
+  implicit val encodeStacLabelItemProperties: Encoder[StacLabelItemProperties] =
+    Encoder.forProduct10(
+      "label:property",
+      "label:classes",
+      "label:description",
+      "label:type",
+      "datetime",
+      "title",
+      "label:task",
+      "label:method",
+      "label:version",
+      "label:summary"
+    )(
+      item =>
+        (item.property,
+         item.classes,
+         item.description,
+         item._type,
+         item.datetime,
+         item.title,
+         item.task,
+         item.method,
+         item.version,
+         item.summary))
+
+  @JsonCodec
+  final case class StacLabelItemClasses(
+      name: String,
+      classes: List[String]
+  )
+
+  @JsonCodec
+  final case class StacLabelSummary(
+      propertyKey: String,
+      counts: Option[List[Count]] = None,
+      statistics: Option[List[Statistics]] = None
+  )
+
+  @JsonCodec
+  final case class Count(
+      className: String,
+      count: Int
+  )
+
+  @JsonCodec
+  final case class Statistics(
+      statName: String,
+      value: Double
+  )
+}

--- a/app-backend/datamodel/src/main/scala/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/Annotation.scala
@@ -8,6 +8,9 @@ import geotrellis.vector.{Geometry, Projected, io => _}
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras._
 import io.circe.Encoder
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
 
 @JsonCodec
 final case class AnnotationFeatureCollectionCreate(
@@ -351,4 +354,118 @@ object StacLabelItemProperties {
       statName: String,
       value: Double
   )
+}
+
+@JsonCodec
+final case class AnnotationWithClasses(
+    id: UUID,
+    projectId: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    owner: String,
+    description: Option[String],
+    machineGenerated: Option[Boolean],
+    confidence: Option[Float],
+    quality: Option[AnnotationQuality],
+    geometry: Option[Projected[Geometry]],
+    annotationGroup: UUID,
+    labeledBy: Option[String],
+    verifiedBy: Option[String],
+    projectLayerId: UUID,
+    taskId: Option[UUID],
+    classes: Json
+) extends GeoJSONSerializable[AnnotationWithClasses.GeoJSON] {
+  def toGeoJSONFeature = AnnotationWithClasses.GeoJSON(
+    this.id,
+    this.geometry,
+    AnnotationWithClassesProperties(
+      this.projectId,
+      this.createdAt,
+      this.createdBy,
+      this.modifiedAt,
+      this.owner,
+      this.description,
+      this.machineGenerated,
+      this.confidence,
+      this.quality,
+      this.annotationGroup,
+      this.labeledBy,
+      this.verifiedBy,
+      this.projectLayerId,
+      this.taskId,
+      this.classes
+    )
+  )
+}
+
+object AnnotationWithClasses {
+  final case class GeoJSON(
+      id: UUID,
+      geometry: Option[Projected[Geometry]],
+      properties: AnnotationWithClassesProperties,
+      _type: String = "Feature"
+  ) extends GeoJSONFeature
+
+  object GeoJSON {
+    implicit val annoWithClassesGeojonEncoder: Encoder[GeoJSON] =
+      Encoder.forProduct4("id", "geometry", "properties", "type")(
+        geojson => (geojson.id, geojson.geometry, geojson.properties, geojson._type)
+      )
+  }
+}
+
+final case class AnnotationWithClassesProperties(
+  projectId: UUID,
+  createdAt: Timestamp,
+  createdBy: String,
+  modifiedAt: Timestamp,
+  owner: String,
+  description: Option[String],
+  machineGenerated: Option[Boolean],
+  confidence: Option[Float],
+  quality: Option[AnnotationQuality],
+  annotationGroup: UUID,
+  labeledBy: Option[String],
+  verifiedBy: Option[String],
+  projectLayerId: UUID,
+  taskId: Option[UUID],
+  classes: Json
+)
+
+object AnnotationWithClassesProperties {
+  implicit val annotationWithClassesPropertiesEncoder: Encoder[AnnotationWithClassesProperties] =
+    new Encoder[AnnotationWithClassesProperties] {
+      final def apply(properties: AnnotationWithClassesProperties): Json = {
+        val classMap: Map[String, Json] = properties.classes.as[Map[String, Json]].getOrElse(Map.empty)
+        (
+          Map(
+            "projectId" -> properties.projectId.asJson,
+            "createdAt" -> properties.createdAt.asJson,
+            "createdBy" -> properties.createdBy.asJson,
+            "modifiedAt" -> properties.modifiedAt.asJson,
+            "owner" -> properties.owner.asJson,
+            "description" -> properties.description.asJson,
+            "machineGenerated" -> properties.machineGenerated.asJson,
+            "confidence" -> properties.confidence.asJson,
+            "quality" -> properties.quality.asJson,
+            "annotationGroup" -> properties.annotationGroup.asJson,
+            "labeledBy" -> properties.labeledBy.asJson,
+            "verifiedBy" -> properties.verifiedBy.asJson,
+            "projectLayerId" -> properties.projectLayerId.asJson, 
+            "taskId" -> properties.taskId.asJson
+          ) ++ classMap
+        ).asJson
+      }
+    }
+}
+
+final case class AnnotationWithClassesFeatureCollection(
+  features: List[AnnotationWithClasses.GeoJSON],
+  `type`: String = "FeatureCollection"
+)
+
+object AnnotationWithClassesFeatureCollection {
+  implicit val annoWithClassesFCEncoder: Encoder[AnnotationWithClassesFeatureCollection] = 
+    deriveEncoder[AnnotationWithClassesFeatureCollection]
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -679,3 +679,19 @@ object UserTaskActivityParameters {
     : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
+
+final case class StacExportQueryParameters(
+    userParams: UserAuditQueryParameters = UserAuditQueryParameters(),
+    ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
+    searchParams: SearchQueryParameters = SearchQueryParameters(),
+    exportStatus: Option[String] = None
+)
+
+object StacExportQueryParameters {
+  implicit def encStacExportQueryParameters
+    : Encoder[StacExportQueryParameters] =
+    deriveEncoder[StacExportQueryParameters]
+  implicit def decStacExportQueryParameters
+    : Decoder[StacExportQueryParameters] =
+    deriveDecoder[StacExportQueryParameters]
+}

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -15,7 +15,6 @@ final case class StacExport(id: UUID,
                             exportLocation: Option[String],
                             exportStatus: ExportStatus,
                             layerDefinitions: List[StacExport.LayerDefinition],
-                            unionAois: Boolean,
                             taskStatuses: List[String])
 
 object StacExport {
@@ -29,7 +28,6 @@ object StacExport {
   final case class Create(name: String,
                           owner: Option[String],
                           layerDefinitions: List[StacExport.LayerDefinition],
-                          unionAois: Boolean,
                           taskStatuses: List[TaskStatus])
       extends OwnerCheck {
     def toStacExport(user: User): StacExport = {
@@ -47,7 +45,6 @@ object StacExport {
         None,
         ExportStatus.NotExported,
         this.layerDefinitions,
-        this.unionAois,
         this.taskStatuses.map(_.toString)
       )
     }

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -1,0 +1,57 @@
+package com.rasterfoundry.datamodel
+
+import java.sql.Timestamp
+import java.util.{UUID, Date}
+
+import io.circe.generic.JsonCodec
+
+@JsonCodec
+final case class StacExport(id: UUID,
+                            createdAt: Timestamp,
+                            createdBy: String,
+                            modifiedAt: Timestamp,
+                            modifiedBy: Option[String],
+                            owner: String,
+                            name: String,
+                            exportLocation: Option[String],
+                            exportStatus: ExportStatus,
+                            layerDefinitions: List[StacExport.LayerDefinition],
+                            unionAois: Boolean,
+                            taskStatuses: List[String])
+
+object StacExport {
+
+  def tupled = (StacExport.apply _).tupled
+
+  @JsonCodec
+  final case class LayerDefinition(projectId: UUID, layerId: UUID)
+
+  @JsonCodec
+  final case class Create(name: String,
+                          owner: Option[String],
+                          layerDefinitions: List[StacExport.LayerDefinition],
+                          unionAois: Boolean,
+                          taskStatuses: List[TaskStatus])
+      extends OwnerCheck {
+    def toStacExport(user: User): StacExport = {
+      val id = UUID.randomUUID()
+      val now = new Timestamp(new Date().getTime)
+      val ownerId = checkOwner(user, this.owner)
+
+      StacExport(
+        id,
+        now, // createdAt
+        user.id, // createdBy
+        now, // modifiedAt
+        Some(user.id), // modifiedBy
+        ownerId, // owner
+        this.name,
+        None,
+        ExportStatus.NotExported,
+        this.layerDefinitions,
+        this.unionAois,
+        this.taskStatuses.map(_.toString)
+      )
+    }
+  }
+}

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -10,7 +10,6 @@ final case class StacExport(id: UUID,
                             createdAt: Timestamp,
                             createdBy: String,
                             modifiedAt: Timestamp,
-                            modifiedBy: Option[String],
                             owner: String,
                             name: String,
                             exportLocation: Option[String],
@@ -43,7 +42,6 @@ object StacExport {
         now, // createdAt
         user.id, // createdBy
         now, // modifiedAt
-        Some(user.id), // modifiedBy
         ownerId, // owner
         this.name,
         None,

--- a/app-backend/datamodel/src/main/scala/StacLabelItemProperties.scala
+++ b/app-backend/datamodel/src/main/scala/StacLabelItemProperties.scala
@@ -1,0 +1,80 @@
+package com.rasterfoundry.datamodel
+
+import java.sql.Timestamp
+import io.circe.generic.JsonCodec
+import io.circe.Encoder
+import io.circe._
+
+final case class StacLabelItemProperties(
+    property: List[String], // required
+    classes: List[StacLabelItemProperties.StacLabelItemClasses], // required
+    description: String, // required
+    _type: String, // required
+    task: Option[List[String]] = None,
+    method: Option[List[String]] = None,
+    overview: Option[StacLabelItemProperties.StacLabelOverview] = None,
+    datetime: Timestamp // required
+)
+
+object StacLabelItemProperties {
+  implicit val encodeStacLabelItemProperties: Encoder[StacLabelItemProperties] =
+    Encoder.forProduct8(
+      "label:property",
+      "label:classes",
+      "label:description",
+      "label:type",
+      "label:task",
+      "label:method",
+      "label:overview",
+      "datetime"
+    )(
+      item =>
+        (
+          item.property,
+          item.classes,
+          item.description,
+          item._type,
+          item.task,
+          item.method,
+          item.overview,
+          item.datetime
+      )
+    )
+
+  @JsonCodec
+  final case class StacLabelItemClasses(
+      name: String,
+      classes: List[String]
+  )
+
+  @JsonCodec
+  final case class StacLabelOverview(
+      propertyKey: String,
+      counts: Option[List[Count]] = None,
+      statistics: Option[List[Statistics]] = None
+  )
+
+  @JsonCodec
+  final case class Count(
+      className: String,
+      count: Int
+  )
+
+  @JsonCodec
+  final case class Statistics(
+      statName: String,
+      value: Double
+  )
+}
+
+final case class StacLabelItemPropertiesThin(
+    property: List[String] = List(),
+    classes: List[StacLabelItemProperties.StacLabelItemClasses] = List(),
+    _type: String = "",
+    task: String = ""
+)
+
+final case class ProjectStacInfo(
+    labelName: Option[String],
+    labelGroupName: Option[String]
+)

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.datamodel
 import geotrellis.vector.{Geometry, Projected}
 import io.circe._
 import io.circe.generic.semiauto.{deriveEncoder, deriveDecoder}
+import io.circe.generic.JsonCodec
 
 import java.time.Instant
 import java.util.UUID
@@ -213,3 +214,12 @@ object TaskUserSummary {
   implicit val taskUserSummaryEncoder: Encoder[TaskUserSummary] =
     deriveEncoder[TaskUserSummary]
 }
+
+@JsonCodec
+final case class UnionedGeomExtent(
+    geometry: Projected[Geometry],
+    xMin: Double,
+    yMin: Double,
+    xMax: Double,
+    yMax: Double
+)

--- a/app-backend/db/src/main/resources/migrations/V12__Add_stac_export_table.sql
+++ b/app-backend/db/src/main/resources/migrations/V12__Add_stac_export_table.sql
@@ -5,7 +5,6 @@ CREATE TABLE public.stac_exports (
     created_at timestamp without time zone NOT NULL,
     created_by character varying(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
     modified_at timestamp without time zone NOT NULL,
-    modified_by character varying(255) REFERENCES public.users(id) ON DELETE SET NULL,
     owner character varying(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
     name character varying(255) NOT NULL,
     export_location text,

--- a/app-backend/db/src/main/resources/migrations/V12__Add_stac_export_table.sql
+++ b/app-backend/db/src/main/resources/migrations/V12__Add_stac_export_table.sql
@@ -1,7 +1,7 @@
 -- Add a table for label stac export
 
 CREATE TABLE public.stac_exports (
-    id uuid NOT NULL,
+    id uuid primary key,
     created_at timestamp without time zone NOT NULL,
     created_by character varying(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
     modified_at timestamp without time zone NOT NULL,
@@ -10,6 +10,11 @@ CREATE TABLE public.stac_exports (
     export_location text,
     export_status public.export_status NOT NULL,
     layer_definitions jsonb NOT NULL,
-    union_aois boolean NOT NULL DEFAULT false,
     task_statuses text[] NOT NULL DEFAULT ARRAY['VALIDATED']::text[]
 );
+
+CREATE INDEX stac_export_owner_idx ON public.stac_exports USING btree(owner);
+
+CREATE INDEX stac_export_created_by_idx ON public.stac_exports USING btree(created_by);
+
+CREATE INDEX stac_export_status_idx ON public.stac_exports USING btree(export_status);

--- a/app-backend/db/src/main/resources/migrations/V12__Add_stac_export_table.sql
+++ b/app-backend/db/src/main/resources/migrations/V12__Add_stac_export_table.sql
@@ -1,0 +1,16 @@
+-- Add a table for label stac export
+
+CREATE TABLE public.stac_exports (
+    id uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    created_by character varying(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    modified_at timestamp without time zone NOT NULL,
+    modified_by character varying(255) REFERENCES public.users(id) ON DELETE SET NULL,
+    owner character varying(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    name character varying(255) NOT NULL,
+    export_location text,
+    export_status public.export_status NOT NULL,
+    layer_definitions jsonb NOT NULL,
+    union_aois boolean NOT NULL DEFAULT false,
+    task_statuses text[] NOT NULL DEFAULT ARRAY['VALIDATED']::text[]
+);

--- a/app-backend/db/src/main/scala/ProjectLayerDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerDao.scala
@@ -255,7 +255,9 @@ object ProjectLayerDao extends Dao[ProjectLayer] {
       splitOptions: SplitOptions): ConnectionIO[List[ProjectLayer]] = {
     for {
       layer <- unsafeGetProjectLayerById(layerId)
-      scenes <- ProjectLayerScenesDao.listLayerScenesRaw(layerId, splitOptions)
+      scenes <- ProjectLayerScenesDao
+        .listLayerScenesRaw(layerId, Some(splitOptions))
+        .flatMap(ProjectLayerScenesDao.scenesToProjectScenes(_, layerId))
       groupedScenes = scenes.groupBy(groupScenesBySplitOptions(splitOptions))
       newLayers <- batchCreateLayers(groupedScenes, layer, splitOptions)
       _ <- splitOptions.removeFromLayer match {

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -42,19 +42,21 @@ object ProjectLayerScenesDao extends Dao[Scene] {
 
   def listLayerScenesRaw(
       layerId: UUID,
-      splitOptions: SplitOptions
-  ): ConnectionIO[List[Scene.ProjectScene]] = {
-    val sceneParams = CombinedSceneQueryParams(
-      sceneParams = SceneQueryParameters(
-        minAcquisitionDatetime = Some(splitOptions.rangeStart),
-        maxAcquisitionDatetime = Some(splitOptions.rangeEnd)
-      )
-    )
+      splitOptionsO: Option[SplitOptions] = None): ConnectionIO[List[Scene]] = {
+    val sceneParams = splitOptionsO match {
+      case Some(splitOptions: SplitOptions) =>
+        CombinedSceneQueryParams(
+          sceneParams = SceneQueryParameters(
+            minAcquisitionDatetime = Some(splitOptions.rangeStart),
+            maxAcquisitionDatetime = Some(splitOptions.rangeEnd)
+          )
+        )
+      case _ => CombinedSceneQueryParams()
+    }
     query
       .filter(fr"project_layer_id = ${layerId}")
       .filter(sceneParams)
       .list
-      .flatMap(scenesToProjectScenes(_, layerId))
   }
 
   def listLayerScenes(
@@ -136,4 +138,19 @@ object ProjectLayerScenesDao extends Dao[Scene] {
     }
   }
 
+  def createUnionedGeomExtent(
+      layerId: UUID
+  ): ConnectionIO[Option[UnionedGeomExtent]] =
+    (fr"""
+    SELECT
+      ST_Transform(ST_Collect(s.data_footprint), 4326) AS geometry,
+      ST_XMin(ST_Extent(ST_Transform(s.data_footprint, 4326))) AS x_min,
+      ST_YMin(ST_Extent(ST_Transform(s.data_footprint, 4326))) AS y_min,
+      ST_XMax(ST_Extent(ST_Transform(s.data_footprint, 4326))) AS x_max,
+      ST_YMax(ST_Extent(ST_Transform(s.data_footprint, 4326))) AS y_max
+    FROM scenes s
+    JOIN scenes_to_layers stl
+    ON s.id = stl.scene_id
+    WHERE stl.project_layer_id = ${layerId}
+  """).query[UnionedGeomExtent].option
 }

--- a/app-backend/db/src/main/scala/StacExportDao.scala
+++ b/app-backend/db/src/main/scala/StacExportDao.scala
@@ -1,0 +1,107 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.datamodel.PageRequest
+
+import java.sql.Timestamp
+import java.util.{UUID, Date}
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+
+object StacExportDao extends Dao[StacExport] {
+  val tableName = "stac_exports"
+
+  val selectF: Fragment = sql"""
+      SELECT
+        id, created_at, created_by, modified_at, modified_by, owner,
+        name, export_location, export_status, layer_definitions, union_aois,
+        task_statuses
+      FROM
+    """ ++ tableF
+
+  def unsafeGetById(id: UUID): ConnectionIO[StacExport] =
+    query.filter(id).select
+
+  def getById(id: UUID): ConnectionIO[Option[StacExport]] =
+    query.filter(id).selectOption
+
+  def list(page: PageRequest,
+           params: StacExportQueryParameters,
+           user: User): ConnectionIO[PaginatedResponse[StacExport]] =
+    query
+      .filter(params)
+      .filter(user.isSuperuser && user.isActive match {
+        case true  => fr""
+        case false => fr"owner = ${user.id}"
+      })
+      .page(page)
+
+  def create(newStacExport: StacExport.Create,
+             user: User): ConnectionIO[StacExport] = {
+    val newExport = newStacExport.toStacExport(user)
+    (fr"INSERT INTO" ++ tableF ++ fr"""
+      (id, created_at, created_by, modified_at, modified_by, owner,
+      name, export_location, export_status, layer_definitions, union_aois,
+      task_statuses)
+    VALUES
+      (${newExport.id}, ${newExport.createdAt}, ${newExport.createdBy}, ${newExport.modifiedAt},
+      ${newExport.modifiedBy}, ${newExport.owner}, ${newExport.name}, ${newExport.exportLocation},
+      ${newExport.exportStatus}, ${newExport.layerDefinitions}, ${newExport.unionAois},
+      ${newExport.taskStatuses})
+    """).update.withUniqueGeneratedKeys[StacExport](
+      "id",
+      "created_at",
+      "created_by",
+      "modified_at",
+      "modified_by",
+      "owner",
+      "name",
+      "export_location",
+      "export_status",
+      "layer_definitions",
+      "union_aois",
+      "task_statuses"
+    )
+  }
+
+  def update(stacExport: StacExport,
+             id: UUID,
+             user: User): ConnectionIO[Int] = {
+    val now = new Timestamp(new Date().getTime)
+    (fr"UPDATE" ++ this.tableF ++ fr"SET" ++ fr"""
+      modified_at = ${now},
+      modified_by = ${user.id},
+      name = ${stacExport.name},
+      export_location = ${stacExport.exportLocation},
+      export_status = ${stacExport.exportStatus}
+      where id = ${id}
+      """).update.run
+  }
+
+  def delete(id: UUID): ConnectionIO[Int] = {
+    (fr"DELETE FROM " ++ this.tableF ++ fr"WHERE id = ${id}").update.run
+  }
+
+  def isOwnerOrSuperUser(user: User, id: UUID): ConnectionIO[Boolean] =
+    for {
+      exportO <- getById(id)
+      isSuperuser = user.isSuperuser && user.isActive
+    } yield {
+      exportO match {
+        case Some(export) => export.owner == user.id || isSuperuser
+        case _            => isSuperuser
+      }
+    }
+
+  def hasProjectViewAccess(layerDefinitions: List[StacExport.LayerDefinition],
+                           user: User): ConnectionIO[Boolean] =
+    layerDefinitions traverse { ld =>
+      ProjectDao.authProjectLayerExist(ld.projectId,
+                                       ld.layerId,
+                                       user,
+                                       ActionType.View)
+    } map { _.foldLeft(true)(_ && _) }
+}

--- a/app-backend/db/src/main/scala/StacExportDao.scala
+++ b/app-backend/db/src/main/scala/StacExportDao.scala
@@ -17,7 +17,7 @@ object StacExportDao extends Dao[StacExport] {
   val selectF: Fragment = sql"""
       SELECT
         id, created_at, created_by, modified_at, owner,
-        name, export_location, export_status, layer_definitions, union_aois,
+        name, export_location, export_status, layer_definitions,
         task_statuses
       FROM
     """ ++ tableF
@@ -44,13 +44,12 @@ object StacExportDao extends Dao[StacExport] {
     val newExport = newStacExport.toStacExport(user)
     (fr"INSERT INTO" ++ tableF ++ fr"""
       (id, created_at, created_by, modified_at, owner,
-      name, export_location, export_status, layer_definitions, union_aois,
+      name, export_location, export_status, layer_definitions,
       task_statuses)
     VALUES
       (${newExport.id}, ${newExport.createdAt}, ${newExport.createdBy}, ${newExport.modifiedAt},
       ${newExport.owner}, ${newExport.name}, ${newExport.exportLocation},${newExport.exportStatus},
-      ${newExport.layerDefinitions}, ${newExport.unionAois},
-      ${newExport.taskStatuses})
+      ${newExport.layerDefinitions}, ${newExport.taskStatuses})
     """).update.withUniqueGeneratedKeys[StacExport](
       "id",
       "created_at",
@@ -61,7 +60,6 @@ object StacExportDao extends Dao[StacExport] {
       "export_location",
       "export_status",
       "layer_definitions",
-      "union_aois",
       "task_statuses"
     )
   }

--- a/app-backend/db/src/main/scala/StacExportDao.scala
+++ b/app-backend/db/src/main/scala/StacExportDao.scala
@@ -16,7 +16,7 @@ object StacExportDao extends Dao[StacExport] {
 
   val selectF: Fragment = sql"""
       SELECT
-        id, created_at, created_by, modified_at, modified_by, owner,
+        id, created_at, created_by, modified_at, owner,
         name, export_location, export_status, layer_definitions, union_aois,
         task_statuses
       FROM
@@ -43,20 +43,19 @@ object StacExportDao extends Dao[StacExport] {
              user: User): ConnectionIO[StacExport] = {
     val newExport = newStacExport.toStacExport(user)
     (fr"INSERT INTO" ++ tableF ++ fr"""
-      (id, created_at, created_by, modified_at, modified_by, owner,
+      (id, created_at, created_by, modified_at, owner,
       name, export_location, export_status, layer_definitions, union_aois,
       task_statuses)
     VALUES
       (${newExport.id}, ${newExport.createdAt}, ${newExport.createdBy}, ${newExport.modifiedAt},
-      ${newExport.modifiedBy}, ${newExport.owner}, ${newExport.name}, ${newExport.exportLocation},
-      ${newExport.exportStatus}, ${newExport.layerDefinitions}, ${newExport.unionAois},
+      ${newExport.owner}, ${newExport.name}, ${newExport.exportLocation},${newExport.exportStatus},
+      ${newExport.layerDefinitions}, ${newExport.unionAois},
       ${newExport.taskStatuses})
     """).update.withUniqueGeneratedKeys[StacExport](
       "id",
       "created_at",
       "created_by",
       "modified_at",
-      "modified_by",
       "owner",
       "name",
       "export_location",
@@ -67,13 +66,10 @@ object StacExportDao extends Dao[StacExport] {
     )
   }
 
-  def update(stacExport: StacExport,
-             id: UUID,
-             user: User): ConnectionIO[Int] = {
+  def update(stacExport: StacExport, id: UUID): ConnectionIO[Int] = {
     val now = new Timestamp(new Date().getTime)
     (fr"UPDATE" ++ this.tableF ++ fr"SET" ++ fr"""
       modified_at = ${now},
-      modified_by = ${user.id},
       name = ${stacExport.name},
       export_location = ${stacExport.exportLocation},
       export_status = ${stacExport.exportStatus}

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -434,4 +434,21 @@ object TaskDao extends Dao[Task] {
     ON
       team_users.user_id = user_validated_tasks.user_id
   """).query[TaskUserSummary].to[List]
+
+  def listLayerTasksByStatus(
+      projectId: UUID,
+      layerId: UUID,
+      taskStatuses: List[String]
+  ): ConnectionIO[List[Task]] = {
+    val taskStatusF: Fragment =
+      taskStatuses.map(TaskStatus.fromString(_)).toNel match {
+        case Some(taskStatusNel) => Fragments.in(fr"status", taskStatusNel)
+        case _                   => fr""
+      }
+    query
+      .filter(fr"project_id = $projectId")
+      .filter(fr"project_layer_id = $layerId")
+      .filter(taskStatusF)
+      .list
+  }
 }

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -412,6 +412,20 @@ trait Filterables extends RFMeta with LazyLogging {
     Filterable[Any, TaskQueryParameters] { qp =>
       Filters.taskQP(qp)
     }
+
+  implicit val labelStacExportQPFilter
+    : Filterable[Any, StacExportQueryParameters] =
+    Filterable[Any, StacExportQueryParameters] {
+      params: StacExportQueryParameters =>
+        Filters.onlyUserQP(params.userParams) ++
+          Filters.ownerQP(params.ownerParams) ++
+          Filters.searchQP(params.searchParams, List("name")) ++
+          List(
+            params.exportStatus map { qp =>
+              fr"export_status = UPPER($qp)::public.export_status"
+            },
+          )
+    }
 }
 
 object Filterables extends Filterables

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -68,4 +68,11 @@ trait CirceJsonbMeta {
 
   implicit val userScopeMeta: Meta[Map[ObjectType, List[ActionType]]] =
     CirceJsonbMeta[Map[ObjectType, List[ActionType]]]
+
+  implicit val stacExportLayerDefinitionsMeta
+    : Meta[List[StacExport.LayerDefinition]] =
+    CirceJsonbMeta[List[StacExport.LayerDefinition]]
+
+  implicit val taskStatusListMeta: Meta[List[TaskStatus]] =
+    CirceJsonbMeta[List[TaskStatus]]
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -8,6 +8,8 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatestplus.scalacheck.Checkers
 import com.rasterfoundry.datamodel.PageRequest
+import java.util.UUID
+import io.circe.syntax._
 
 class AnnotationDaoSpec
     extends FunSuite
@@ -311,6 +313,198 @@ class AnnotationDaoSpec
                 )
               })
               .toSet == annotationsForProject.results.toSet
+          }
+      }
+    }
+  }
+
+  test("list detection annotations from a layer by task status") {
+    check {
+      forAll {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            annoAndTaskFeatureCreate: (Task.TaskFeatureCreate,
+                                       List[Annotation.Create]),
+            labelValidateTeamCreate: (Team.Create, Team.Create),
+            labelValidateTeamUgrCreate: (UserGroupRole.Create,
+                                         UserGroupRole.Create)
+        ) =>
+          {
+            val (taskFeatureCreate, annotationsCreate) =
+              annoAndTaskFeatureCreate
+            val labelName = "Car"
+            val labelId = UUID.randomUUID()
+            val labelGroupId = UUID.randomUUID()
+            val connIO = for {
+              (dbUser, dbOrg, dbPlatform, dbProject) <- insertUserOrgPlatProject(
+                userCreate,
+                orgCreate,
+                platform,
+                projectCreate
+              )
+              updatedDbProject <- fixupProjectExtrasUpdate(
+                labelValidateTeamCreate,
+                labelValidateTeamUgrCreate,
+                dbOrg,
+                dbUser,
+                dbPlatform,
+                dbProject,
+                Some(List((labelId, labelName, labelGroupId))),
+                Some(Map(labelGroupId -> "Car Group"))
+              )
+              collection <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreate, updatedDbProject)
+                      .withStatus(TaskStatus.Labeled)
+                  )
+                ),
+                dbUser
+              )
+              feature = collection.features.head
+              updatedAnnotationsCreate = annotationsCreate.map(annoCreate => {
+                annoCreate.copy(
+                  label = labelId.toString(),
+                  geometry = Some(feature.geometry),
+                  taskId = Some(feature.id)
+                )
+              })
+              insertedAnnotations <- AnnotationDao.insertAnnotations(
+                updatedAnnotationsCreate,
+                dbProject.id,
+                dbUser
+              )
+              listedAnnotations <- AnnotationDao
+                .listDetectionLayerAnnotationsByTaskStatus(
+                  dbProject.id,
+                  dbProject.defaultLayerId,
+                  List("LABELED")
+                )
+            } yield { (insertedAnnotations, listedAnnotations) }
+
+            val (dbAnnotations, listed) = connIO.transact(xa).unsafeRunSync
+            dbAnnotations.length == listed.length &&
+            listed.map(_.label).toSet == Set(labelName) &&
+            true
+          }
+      }
+    }
+  }
+
+  test("list classification annotations from a layer by task status") {
+    check {
+      forAll {
+        (
+            userOrgPlat: (User.Create, Organization.Create, Platform),
+            projectCreate: Project.Create,
+            annotationCreates: (Annotation.Create, Annotation.Create),
+            taskFeatureCreates: (Task.TaskFeatureCreate, Task.TaskFeatureCreate),
+            labelValidateTeamCreate: (Team.Create, Team.Create),
+            labelValidateTeamUgrCreate: (UserGroupRole.Create,
+                                         UserGroupRole.Create)
+        ) =>
+          {
+            val (userCreate, orgCreate, platform) = userOrgPlat
+            val (taskFeatureCreateOne, taskFeatureCreateTwo) =
+              taskFeatureCreates
+            val (annotationCreateOne, annotationCreateTwo) = annotationCreates
+            val labelNameOne = "Finished"
+            val labelIdOne = UUID.randomUUID()
+            val labelNameTwo = "Partial"
+            val labelIdTwo = UUID.randomUUID()
+            val labelGroupIdOne = UUID.randomUUID()
+            val labelGroupNameOne = "Building"
+            val labelGroupIdTwo = UUID.randomUUID()
+            val labelGroupNameTwo = "Road"
+
+            val connIO = for {
+              (dbUser, dbOrg, dbPlatform, dbProject) <- insertUserOrgPlatProject(
+                userCreate,
+                orgCreate,
+                platform,
+                projectCreate
+              )
+              updatedDbProject <- fixupProjectExtrasUpdate(
+                labelValidateTeamCreate,
+                labelValidateTeamUgrCreate,
+                dbOrg,
+                dbUser,
+                dbPlatform,
+                dbProject,
+                Some(
+                  List(
+                    (labelIdOne, labelNameOne, labelGroupIdOne),
+                    (labelIdTwo, labelNameTwo, labelGroupIdTwo),
+                  )),
+                Some(
+                  Map(
+                    labelGroupIdOne -> labelGroupNameOne,
+                    labelGroupIdTwo -> labelGroupNameTwo
+                  ))
+              )
+              taskCollectionOne <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreateOne,
+                                           updatedDbProject)
+                      .withStatus(TaskStatus.Labeled)
+                  )
+                ),
+                dbUser
+              )
+              taskCollectionTwo <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreateTwo,
+                                           updatedDbProject)
+                      .withStatus(TaskStatus.Validated)
+                  )
+                ),
+                dbUser
+              )
+              taskOne = taskCollectionOne.features.head
+              taskTwo = taskCollectionTwo.features.head
+              _ <- AnnotationDao.insertAnnotations(
+                List(
+                  annotationCreateOne.copy(
+                    label = s"${labelIdOne} ${labelIdTwo}",
+                    geometry = Some(taskOne.geometry),
+                    taskId = Some(taskOne.id)
+                  ),
+                  annotationCreateTwo.copy(
+                    label = s"${labelIdOne} ${labelIdTwo}",
+                    geometry = Some(taskTwo.geometry),
+                    taskId = Some(taskTwo.id)
+                  )
+                ),
+                dbProject.id,
+                dbUser
+              )
+              listedAnnotationsFC <- AnnotationDao
+                .listClassificationLayerAnnotationsByTaskStatus(
+                  dbProject.id,
+                  dbProject.defaultLayerId,
+                  List("LABELED", "VALIDATED")
+                )
+            } yield { listedAnnotationsFC }
+
+            val listed = connIO.transact(xa).unsafeRunSync
+
+            listed.features.length == 2 &&
+            listed.`type` == "FeatureCollection" &&
+            listed.features.foldLeft(true)((acc, feature) => {
+              acc &&
+              feature.properties.asJson.hcursor
+                .get[String](labelGroupNameOne)
+                .toOption == Some(labelNameOne) &&
+              feature.properties.asJson.hcursor
+                .get[String](labelGroupNameTwo)
+                .toOption == Some(labelNameTwo)
+            }) &&
+            true
           }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -381,4 +381,16 @@ trait PropTestHelpers {
       updatedDbProject <- ProjectDao.unsafeGetProjectById(dbProject.id)
     } yield updatedDbProject
   }
+
+  def fixupStacExportCreate(
+      stacExportCreate: StacExport.Create,
+      user: User,
+      project: Project
+  ): StacExport.Create =
+    stacExportCreate.copy(
+      layerDefinitions = List(
+        StacExport.LayerDefinition(project.id, project.defaultLayerId)
+      ),
+      owner = Some(user.id)
+    )
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -18,7 +18,24 @@ import java.util.UUID
 case class ProjectExtras(annotate: ProjectExtrasAnnotate)
 
 @JsonCodec
-case class ProjectExtrasAnnotate(labelers: UUID, validators: UUID)
+case class ProjectExtrasAnnotate(
+    labelers: UUID,
+    validators: UUID,
+    labels: List[ProjectExtrasAnnotateLabel],
+    projectType: String,
+    preexistingTeams: Boolean,
+    overlayUrl: Option[String] = None,
+    labelGroups: Map[UUID, String]
+)
+
+@JsonCodec
+case class ProjectExtrasAnnotateLabel(
+    name: String,
+    id: UUID,
+    colorHexCode: String,
+    labelGroup: UUID,
+    default: Boolean
+)
 
 trait PropTestHelpers {
 
@@ -305,26 +322,34 @@ trait PropTestHelpers {
 
   def fixupTaskFeaturesCollection(
       tfc: Task.TaskFeatureCollectionCreate,
-      project: Project
+      project: Project,
+      statusOption: Option[TaskStatus] = None
   ) =
     tfc.copy(
       features =
-        tfc.features map { fixupTaskFeatureCreate(_, project) }
+        tfc.features map { fixupTaskFeatureCreate(_, project, statusOption) }
     )
 
   def fixupTaskFeatureCreate(
       tfc: Task.TaskFeatureCreate,
-      project: Project
+      project: Project,
+      statusOption: Option[TaskStatus] = None
   ): Task.TaskFeatureCreate =
     tfc.copy(
-      properties = fixupTaskPropertiesCreate(tfc.properties, project)
+      properties =
+        fixupTaskPropertiesCreate(tfc.properties, project, statusOption)
     )
 
   def fixupTaskPropertiesCreate(
       tpc: Task.TaskPropertiesCreate,
-      project: Project
+      project: Project,
+      statusOption: Option[TaskStatus] = None
   ): Task.TaskPropertiesCreate =
-    tpc.copy(projectId = project.id, projectLayerId = project.defaultLayerId)
+    tpc.copy(
+      projectId = project.id,
+      projectLayerId = project.defaultLayerId,
+      status = statusOption.getOrElse(tpc.status)
+    )
 
   def fixupProjectExtrasUpdate(
       labelValidateTeamCreate: (Team.Create, Team.Create),
@@ -332,7 +357,9 @@ trait PropTestHelpers {
       dbOrg: Organization,
       dbUser: User,
       dbPlatform: Platform,
-      dbProject: Project
+      dbProject: Project,
+      labelsOption: Option[List[(UUID, String, UUID)]] = None,
+      labelGroupsOption: Option[Map[UUID, String]] = None
   ): ConnectionIO[Project] = {
     val (labelTeamCreate, validateTeamCreate) = labelValidateTeamCreate
     val (labelTeamUgrCreate, validateTeamUgrCreate) = labelValidateTeamUgrCreate
@@ -368,11 +395,11 @@ trait PropTestHelpers {
       _ <- ProjectDao.updateProject(
         dbProject.copy(
           extras = Some(
-            ProjectExtras(
-              ProjectExtrasAnnotate(
-                dbLabelTeam.id,
-                dbValidateTeam.id
-              )
+            fixupProjectExtrasAnnotate(
+              dbLabelTeam.id,
+              dbValidateTeam.id,
+              labelsOption,
+              labelGroupsOption
             ).asJson
           )
         ),
@@ -380,6 +407,56 @@ trait PropTestHelpers {
       )
       updatedDbProject <- ProjectDao.unsafeGetProjectById(dbProject.id)
     } yield updatedDbProject
+  }
+
+  def fixupProjectExtrasAnnotate(
+      labelTeamId: UUID,
+      validateTeamId: UUID,
+      labelsOption: Option[List[(UUID, String, UUID)]] = None,
+      labelGroupsOption: Option[Map[UUID, String]] = None
+  ): ProjectExtras = (labelsOption, labelGroupsOption) match {
+    case (Some(labels), Some(labelGroups)) =>
+      val createdLabels = labels.map(label => {
+        ProjectExtrasAnnotateLabel(
+          label._2,
+          label._1,
+          "red",
+          label._3,
+          false
+        )
+      })
+      ProjectExtras(
+        ProjectExtrasAnnotate(
+          labelTeamId,
+          validateTeamId,
+          createdLabels,
+          "detection",
+          true,
+          None,
+          labelGroups
+        ))
+    case _ =>
+      val defaultLabelId = UUID.randomUUID()
+      val defaultLayerGroupId = UUID.randomUUID()
+      val defaultLabels = List(
+        ProjectExtrasAnnotateLabel(
+          "Test",
+          defaultLabelId,
+          "red",
+          defaultLayerGroupId,
+          false
+        )
+      )
+      ProjectExtras(
+        ProjectExtrasAnnotate(
+          labelTeamId,
+          validateTeamId,
+          defaultLabels,
+          "detection",
+          true,
+          None,
+          Map(defaultLayerGroupId -> "Test Group")
+        ))
   }
 
   def fixupStacExportCreate(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -1,0 +1,315 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.common.Generators.Implicits._
+
+import doobie.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatestplus.scalacheck.Checkers
+
+class StacExportDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+
+  test("inserting a Stac Export") {
+    check {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform,
+         projectCreate: Project.Create,
+         stacExportCreate: StacExport.Create) => {
+          val createStacExportIO = for {
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
+                                                                  orgCreate,
+                                                                  platform,
+                                                                  projectCreate)
+            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
+                                                          dbUser,
+                                                          dbProject)
+            dbStacExport <- StacExportDao.create(
+              fixedStacExportCreate,
+              dbUser
+            )
+          } yield { (dbUser, fixedStacExportCreate, dbStacExport) }
+          val (user, seCreate, se) =
+            createStacExportIO.transact(xa).unsafeRunSync
+
+          assert(
+            user.id == se.owner,
+            "Inserted StacExport owner should be the same as user"
+          )
+          assert(
+            seCreate.name == se.name,
+            "Sent and inserted StacExport name should be the same"
+          )
+          assert(
+            se.exportLocation == None,
+            "Inserted StacExport export location should be empty"
+          )
+          assert(
+            se.exportStatus == ExportStatus.NotExported,
+            "Inserted StacExport status should be NotExported"
+          )
+          assert(
+            se.layerDefinitions == seCreate.layerDefinitions,
+            "Sent and inserted StacExport layer definition should be the same"
+          )
+          assert(
+            se.unionAois == seCreate.unionAois,
+            "Sent and inserted StacExport unionAois should be the same"
+          )
+          assert(
+            se.taskStatuses.toSet == seCreate.taskStatuses
+              .map(_.toString)
+              .toSet,
+            "Sent and inserted StacExport taskStatuses should be the same"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("getting a Stac Export by id") {
+    check {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform,
+         projectCreate: Project.Create,
+         stacExportCreate: StacExport.Create) => {
+          val selectStacExportIO = for {
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
+                                                                  orgCreate,
+                                                                  platform,
+                                                                  projectCreate)
+            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
+                                                          dbUser,
+                                                          dbProject)
+            dbStacExport <- StacExportDao.create(
+              fixedStacExportCreate,
+              dbUser
+            )
+            selectedStacExport <- StacExportDao
+              .getById(dbStacExport.id)
+          } yield { (dbUser, dbStacExport, selectedStacExport) }
+
+          val (user, se, selectedSeO) =
+            selectStacExportIO.transact(xa).unsafeRunSync
+
+          selectedSeO match {
+            case Some(selectedSe) =>
+              assert(
+                se.id == selectedSe.id,
+                "Inserted and selected StacExport id should be the same"
+              )
+              assert(
+                user.id == selectedSe.owner,
+                "Selected StacExport owner should be the same as user"
+              )
+              assert(
+                se.name == selectedSe.name,
+                "Inserted and selected StacExport name should be the same"
+              )
+              assert(
+                selectedSe.exportLocation == None,
+                "Selected StacExport export location should be empty"
+              )
+              assert(
+                selectedSe.exportStatus == ExportStatus.NotExported,
+                "Selected StacExport status should be NotExported"
+              )
+              assert(
+                se.layerDefinitions == selectedSe.layerDefinitions,
+                "Inserted and selected StacExport layer definition should be the same"
+              )
+              assert(
+                se.unionAois == selectedSe.unionAois,
+                "Inserted and selected StacExport unionAois should be the same"
+              )
+              assert(
+                se.taskStatuses.toSet == selectedSe.taskStatuses.toSet,
+                "Inserted and selected StacExport taskStatuses should be the same"
+              )
+              true
+            case _ => false
+          }
+        }
+      )
+    }
+  }
+
+  test("updating a Stac Export") {
+    check {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform,
+         projectCreate: Project.Create,
+         stacExportCreate: StacExport.Create) => {
+          val updatetStacExportIO = for {
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
+                                                                  orgCreate,
+                                                                  platform,
+                                                                  projectCreate)
+            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
+                                                          dbUser,
+                                                          dbProject)
+            dbStacExport <- StacExportDao.create(
+              fixedStacExportCreate,
+              dbUser
+            )
+            updatedRowCount <- StacExportDao.update(
+              dbStacExport.copy(
+                exportStatus = ExportStatus.Exported,
+                exportLocation = Some(""),
+                taskStatuses = List()
+              ),
+              dbStacExport.id,
+              dbUser
+            )
+            selectedStacExport <- StacExportDao
+              .unsafeGetById(dbStacExport.id)
+          } yield {
+            (dbUser, dbStacExport, updatedRowCount, selectedStacExport)
+          }
+
+          val (user, se, rowCount, selectedSe) =
+            updatetStacExportIO.transact(xa).unsafeRunSync
+
+          assert(
+            rowCount == 1,
+            "Should have one record updated"
+          )
+          assert(
+            se.id == selectedSe.id,
+            "Inserted and selected StacExport id should be the same"
+          )
+          assert(
+            user.id == selectedSe.owner,
+            "Selected StacExport owner should be the same as user"
+          )
+          assert(
+            se.name == selectedSe.name,
+            "Inserted and selected StacExport name should be the same"
+          )
+          assert(
+            selectedSe.exportLocation == Some(""),
+            "Selected StacExport export location should be updated"
+          )
+          assert(
+            selectedSe.exportStatus == ExportStatus.Exported,
+            "Selected StacExport status should be updated"
+          )
+          assert(
+            se.layerDefinitions == selectedSe.layerDefinitions,
+            "Inserted and selected StacExport layer definition should be the same"
+          )
+          assert(
+            se.unionAois == selectedSe.unionAois,
+            "Inserted and selected StacExport unionAois should be the same"
+          )
+          assert(
+            se.taskStatuses.toSet == selectedSe.taskStatuses.toSet,
+            "Updating task statuses should not change the record in DB"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("deleting a Stac Export") {
+    check {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform,
+         projectCreate: Project.Create,
+         stacExportCreate: StacExport.Create) => {
+          val deletetStacExportIO = for {
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
+                                                                  orgCreate,
+                                                                  platform,
+                                                                  projectCreate)
+            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
+                                                          dbUser,
+                                                          dbProject)
+            dbStacExport <- StacExportDao.create(fixedStacExportCreate, dbUser)
+            deletedRowCount <- StacExportDao
+              .delete(dbStacExport.id)
+            selectedStacExport <- StacExportDao
+              .getById(dbStacExport.id)
+          } yield { (deletedRowCount, selectedStacExport) }
+
+          val (rowCount, selectedSe) =
+            deletetStacExportIO.transact(xa).unsafeRunSync
+
+          assert(
+            rowCount == 1,
+            "Should have one record deleted"
+          )
+          assert(
+            selectedSe == None,
+            "Inserted StacExport should be deleted from DB"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("listing Stac Export") {
+    check {
+      forAll(
+        (userCreate: User.Create,
+         orgCreate: Organization.Create,
+         platform: Platform,
+         projectCreate: Project.Create,
+         stacExportCreate1: StacExport.Create,
+         stacExportCreate2: StacExport.Create,
+         page: PageRequest,
+         queryParams: StacExportQueryParameters) => {
+          val updatetStacExportIO = for {
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
+                                                                  orgCreate,
+                                                                  platform,
+                                                                  projectCreate)
+            fixedStacExportCreate1 = fixupStacExportCreate(stacExportCreate1,
+                                                          dbUser,
+                                                          dbProject)
+            fixedStacExportCreate2 = fixupStacExportCreate(stacExportCreate2,
+                                                           dbUser,
+                                                           dbProject)
+            dbStacExport1 <- StacExportDao.create(fixedStacExportCreate1,
+                                                  dbUser)
+            _ <- StacExportDao.create(fixedStacExportCreate2, dbUser)
+            _ <- StacExportDao.update(
+              dbStacExport1.copy(
+                exportStatus = ExportStatus.Exported
+              ),
+              dbStacExport1.id,
+              dbUser
+            )
+            paginatedStacExport <- StacExportDao
+              .list(page, queryParams.copy(exportStatus = Some("Exported")), dbUser)
+          } yield paginatedStacExport
+
+          val paginatedResp =
+            updatetStacExportIO.transact(xa).unsafeRunSync
+
+          assert(
+            paginatedResp.count == 1,
+            "Should have one record matching the export status filter"
+          )
+          true
+        }
+      )
+    }
+  }
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -170,8 +170,7 @@ class StacExportDaoSpec
                 exportLocation = Some(""),
                 taskStatuses = List()
               ),
-              dbStacExport.id,
-              dbUser
+              dbStacExport.id
             )
             selectedStacExport <- StacExportDao
               .unsafeGetById(dbStacExport.id)
@@ -281,8 +280,8 @@ class StacExportDaoSpec
                                                                   platform,
                                                                   projectCreate)
             fixedStacExportCreate1 = fixupStacExportCreate(stacExportCreate1,
-                                                          dbUser,
-                                                          dbProject)
+                                                           dbUser,
+                                                           dbProject)
             fixedStacExportCreate2 = fixupStacExportCreate(stacExportCreate2,
                                                            dbUser,
                                                            dbProject)
@@ -293,11 +292,12 @@ class StacExportDaoSpec
               dbStacExport1.copy(
                 exportStatus = ExportStatus.Exported
               ),
-              dbStacExport1.id,
-              dbUser
+              dbStacExport1.id
             )
             paginatedStacExport <- StacExportDao
-              .list(page, queryParams.copy(exportStatus = Some("Exported")), dbUser)
+              .list(page,
+                    queryParams.copy(exportStatus = Some("Exported")),
+                    dbUser)
           } yield paginatedStacExport
 
           val paginatedResp =

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -60,10 +60,6 @@ class StacExportDaoSpec
             "Sent and inserted StacExport layer definition should be the same"
           )
           assert(
-            se.unionAois == seCreate.unionAois,
-            "Sent and inserted StacExport unionAois should be the same"
-          )
-          assert(
             se.taskStatuses.toSet == seCreate.taskStatuses
               .map(_.toString)
               .toSet,
@@ -127,10 +123,6 @@ class StacExportDaoSpec
               assert(
                 se.layerDefinitions == selectedSe.layerDefinitions,
                 "Inserted and selected StacExport layer definition should be the same"
-              )
-              assert(
-                se.unionAois == selectedSe.unionAois,
-                "Inserted and selected StacExport unionAois should be the same"
               )
               assert(
                 se.taskStatuses.toSet == selectedSe.taskStatuses.toSet,
@@ -208,10 +200,6 @@ class StacExportDaoSpec
           assert(
             se.layerDefinitions == selectedSe.layerDefinitions,
             "Inserted and selected StacExport layer definition should be the same"
-          )
-          assert(
-            se.unionAois == selectedSe.unionAois,
-            "Inserted and selected StacExport unionAois should be the same"
           )
           assert(
             se.taskStatuses.toSet == selectedSe.taskStatuses.toSet,

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -108,6 +108,7 @@ object Dependencies {
   val geotrellisServer = "com.azavea" %% "geotrellis-server-core" % Version.geotrellisServer
   val geotrellisProj4 = "org.locationtech.geotrellis" %% "geotrellis-proj4" % Version.geotrellis
   val geotrellisServerOgc = "com.azavea" %% "geotrellis-server-ogc" % Version.geotrellisServer
+  val geotrellisServerStac = "com.azavea" %% "geotrellis-server-stac" % Version.geotrellisServer
   val geotrellisShapefile = "org.locationtech.geotrellis" %% "geotrellis-shapefile" % Version.geotrellis
   val geotrellisSpark = "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.geotrellis
   val geotrellisUtil = "org.locationtech.geotrellis" %% "geotrellis-util" % Version.geotrellis

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -101,7 +101,9 @@ x-resources:
   - name: Admin
     description: |
       Platforms, Organizations, and Teams can be used to manage users and visibility of projects, analyses, and scenes. Most of these functions will only be available to uses who are administrating groups.
-
+  - name: STAC
+    description: |
+      SpatioTemporal Asset Catalog
 tags:
   - name: Users
     description: 'Operations involving users and organizations'
@@ -117,6 +119,8 @@ tags:
     description: 'Resources relating to object-level access'
   - name: Admin
     description: 'Resources related to administration'
+  - name: STAC
+    description: 'Resources related to STAC catalog'
 
 paths:
   /users/dropbox-setup/:
@@ -4795,6 +4799,119 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /stac/:
+    x-resource: STAC
+    get:
+      summary: 'Get a paginated list of STAC export records'
+      description: |
+        Get a paginated list of all the STAC export records a user owns. Super users will get a full list of all records
+      tags:
+        - STAC
+      parameters:
+        - $ref: '#/parameters/orderingBase'
+        - $ref: '#/parameters/pageSize'
+        - $ref: '#/parameters/page'
+        - $ref: '#/parameters/owner'
+        - $ref: '#/parameters/createdBy'
+        - $ref: '#/parameters/modifiedBy'
+        - $ref: '#/parameters/search'
+        - $ref: '#/parameters/exportStatus'
+      responses:
+        200:
+          description: 'Paginated list of STAC export records'
+          schema:
+            $ref: '#/definitions/StacExportPaginated'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      summary: 'Kick off an async STAC export task'
+      tags:
+        - STAC
+      parameters:
+        - name: stacExport
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/StacExportCreate'
+      responses:
+        201:
+          description: 'STAC export creation successful'
+          schema:
+            $ref: '#/definitions/StacExport'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+  /stac/{stacExportID}/:
+    x-resource: STAC
+    get:
+      summary: 'Get a STAC export record details'
+      tags:
+        - STAC
+      parameters:
+        - $ref: '#/parameters/stacExportID'
+      responses:
+        200:
+          description: 'STAC export record found'
+          schema:
+            $ref: '#/definitions/StacExport'
+        404:
+          description: 'Resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: 'Insufficient permissions for resource'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    put:
+      summary: 'Perform a complete update of a STAC export record.'
+      tags:
+        - STAC
+      parameters:
+        - name: stacExport
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/StacExport'
+        - $ref: '#/parameters/stacExportID'
+      responses:
+        204:
+          description: 'Update successful (no further processing needed)'
+        404:
+          description: 'Resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        403:
+          description: 'Insufficient permissions for resource'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: 'Delete a STAC export record'
+      tags:
+        - STAC
+      parameters:
+        - $ref: '#/parameters/stacExportID'
+      responses:
+        204:
+          description: 'Deletion successful (no content)'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
 
 parameters:
   projectLayer:
@@ -5540,6 +5657,12 @@ parameters:
     in: query
     type: string
     required: false
+  stacExportID:
+    name: stacExportID
+    in: path
+    required: true
+    type: string
+    format: uuid
 
 definitions:
   ActionTypeArray:
@@ -8120,3 +8243,76 @@ definitions:
       validatedTaskAvgTimeSecond:
         type: number
         format: float
+  LayerDefinitionItem:
+    type: object
+    properties:
+      projectId:
+        type: string
+        format: uuid
+        description: 'UUID of a project'
+      layerId:
+        type: string
+        format: uuid
+        description: "UUID of this project's layer"
+  LayerDefinitions:
+    type: array
+    items:
+      $ref: '#/definitions/LayerDefinitionItem'
+  StacExportCreate:
+    type: object
+    required:
+      - name
+      - layerDefinitions
+      - isUnion
+      - taskStatuses
+    properties:
+      name:
+        type: string
+        description: 'The display name of the STAC export record'
+      owner:
+        type: string
+        description: 'Owner of of the STAC export record'
+      layerDefinitions:
+        description: 'List of project and layers to be exported'
+        $ref: '#/definitions/LayerDefinitions'
+      isUnion:
+        type: boolean
+        description: 'Union the AOIs or not'
+      taskStatuses:
+        type: array
+        items:
+          $ref: '#/definitions/TaskStatus'
+  StacExport:
+    allOf:
+      - $ref: '#/definitions/TimeModelMixin'
+      - $ref: '#/definitions/UserTrackingMixin'
+      - $ref: '#/definitions/StacExportCreate'
+      - type: object
+        properties:
+          id:
+            type: string
+            description: 'STAC export Id'
+          exportLocation:
+            type: string
+            description: 'The url of the exported STAC catalog'
+          exportStatus:
+            type: string
+            description: 'The url of the exported STAC catalog'
+            enum:
+              - 'CREATED'
+              - 'EXPORTING'
+              - 'EXPORTED'
+              - 'QUEUED'
+              - 'PROCESSING'
+              - 'COMPLETE'
+              - 'FAILED'
+              - 'ABORTED'
+  StacExportPaginated:
+    allOf:
+      - $ref: '#/definitions/PaginatedResponse'
+      - type: object
+        properties:
+          results:
+            type: array
+            items:
+              $ref: '#/definitions/StacExport'

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -4813,7 +4813,6 @@ paths:
         - $ref: '#/parameters/page'
         - $ref: '#/parameters/owner'
         - $ref: '#/parameters/createdBy'
-        - $ref: '#/parameters/modifiedBy'
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/exportStatus'
       responses:


### PR DESCRIPTION
## Overview

This PR adds CRUD endpoints for exporting STAC catalog with label data asynchronously. It also adds a STAC export builder that builds catalog in the below structure.

```
Exported Catalog:
     |-> Layer collection
     |   |-> Scene Collection
     |   |   |-> Scene Item
     |   |   |-> Scene Item
     |   |   |-> (One or more scene items)
     |   |-> Label Collection
     |   |   |-> Label Item (Only one)
     |   |   |-> Label Data in GeoJSON Feature Collection
     |-> (One or more Layer Collections)
```

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [X] Swagger specification updated
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes:

Some to-dos after this is merged:
- Write exported catalog to S3 ([PR](https://github.com/raster-foundry/raster-foundry/pull/5110))
- Kick off the export batch job once a record is created
- Create task definition for this export job

## Testing Instructions

- `./scripts/load_development_data --download`
- `./scripts/console`:
   * `api/assembly`
   * `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "AL Project Test 1",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID>`