### PR TITLE
Task grid endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Use zoom level in OverviewInput for lambda function to generate layer overviews [\#4998](https://github.com/raster-foundry/raster-foundry/pull/4998)
 - Added endpoints for project layer "tasks" [\#5008](https://github.com/raster-foundry/raster-foundry/pull/5008)
 - Add user scope migration and data model [\#5009](https://github.com/raster-foundry/raster-foundry/pull/5009)
-
+- Added task grid endpoint [\#5021](https://github.com/raster-foundry/raster-foundry/pull/5021)
 ### Changed
 
 - Use flyway for running migrations and publish image for flyway migrations [\#4987](https://github.com/raster-foundry/raster-foundry/pull/4987)

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -79,6 +79,36 @@ trait ProjectLayerTaskRoutes
       }
   }
 
+  def createLayerTaskGrid(projectId: UUID, layerId: UUID): Route =
+    authenticate { user =>
+      {
+        authorizeAsync {
+          ProjectDao
+            .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[Task.TaskGridFeatureCreate]) { tgf =>
+            complete(
+              StatusCodes.Created,
+              TaskDao
+                .insertTasksByGrid(
+                  Task.TaskPropertiesCreate(
+                    projectId,
+                    layerId,
+                    TaskStatus.Unlabeled
+                  ),
+                  tgf,
+                  user
+                )
+                .transact(xa)
+                .unsafeToFuture
+            )
+          }
+        }
+      }
+    }
+
   def deleteLayerTasks(projectId: UUID, layerId: UUID): Route =
     authenticate { user =>
       {

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -297,6 +297,11 @@ trait ProjectRoutes
                         deleteLayerTasks(projectId, layerId)
                       }
                     } ~
+                      pathPrefix("grid") {
+                        post {
+                          createLayerTaskGrid(projectId, layerId)
+                        }
+                      } ~
                       pathPrefix(JavaUUID) { taskId =>
                         pathEndOrSingleSlash {
                           get {

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -81,11 +81,13 @@ object Generators extends ArbitraryInstances {
     Gen.oneOf(Visibility.Public, Visibility.Organization, Visibility.Private)
 
   private def taskStatusGen: Gen[TaskStatus] =
-    Gen.oneOf(TaskStatus.Unlabeled,
-              TaskStatus.LabelingInProgress,
-              TaskStatus.Labeled,
-              TaskStatus.ValidationInProgress,
-              TaskStatus.Validated)
+    Gen.oneOf(
+      TaskStatus.Unlabeled,
+      TaskStatus.LabelingInProgress,
+      TaskStatus.Labeled,
+      TaskStatus.ValidationInProgress,
+      TaskStatus.Validated
+    )
 
   private def userVisibilityGen: Gen[UserVisibility] =
     Gen.oneOf(UserVisibility.Public, UserVisibility.Private)
@@ -94,11 +96,13 @@ object Generators extends ArbitraryInstances {
     Gen.oneOf(OrgStatus.Requested, OrgStatus.Active, OrgStatus.Inactive)
 
   private def exportStatusGen: Gen[ExportStatus] =
-    Gen.oneOf(ExportStatus.Exported,
-              ExportStatus.Exporting,
-              ExportStatus.Failed,
-              ExportStatus.ToBeExported,
-              ExportStatus.NotExported)
+    Gen.oneOf(
+      ExportStatus.Exported,
+      ExportStatus.Exporting,
+      ExportStatus.Failed,
+      ExportStatus.ToBeExported,
+      ExportStatus.NotExported
+    )
 
   private def sceneTypeGen: Gen[SceneType] =
     Gen.oneOf(SceneType.Avro, SceneType.COG)
@@ -723,7 +727,7 @@ object Generators extends ArbitraryInstances {
     }
 
   private def userOrgPlatformGen
-    : Gen[(User.Create, Organization.Create, Platform)] =
+      : Gen[(User.Create, Organization.Create, Platform)] =
     for {
       platform <- platformGen
       orgCreate <- organizationCreateGen map {
@@ -814,15 +818,17 @@ object Generators extends ArbitraryInstances {
       bands <- arbitrary[Option[Seq[Int]]]
       operation <- nonEmptyStringGen
     } yield
-      ExportOptions(mask,
-                    resolution,
-                    crop,
-                    raw,
-                    bands,
-                    rasterSize,
-                    Some(3857),
-                    new URI(""),
-                    operation)
+      ExportOptions(
+        mask,
+        resolution,
+        crop,
+        raw,
+        bands,
+        rasterSize,
+        Some(3857),
+        new URI(""),
+        operation
+      )
 
   private def exportCreateGen: Gen[Export.Create] =
     for {
@@ -860,17 +866,19 @@ object Generators extends ArbitraryInstances {
       overviewsLocation <- Gen.const(None)
       minZoomLevel <- Gen.const(None)
     } yield {
-      ProjectLayer.Create(name,
-                          projectId,
-                          colorGroupHex,
-                          smartLayerId,
-                          rangeStart,
-                          rangeEnd,
-                          geometry,
-                          isSingleBand,
-                          singleBandOptions,
-                          overviewsLocation,
-                          minZoomLevel)
+      ProjectLayer.Create(
+        name,
+        projectId,
+        colorGroupHex,
+        smartLayerId,
+        rangeStart,
+        rangeEnd,
+        geometry,
+        isSingleBand,
+        singleBandOptions,
+        overviewsLocation,
+        minZoomLevel
+      )
     }
 
   private def splitOptionsGen: Gen[SplitOptions] =
@@ -884,21 +892,25 @@ object Generators extends ArbitraryInstances {
       removeFromLayer <- arbitrary[Option[Boolean]]
     } yield {
       if (t1.before(t2)) {
-        SplitOptions(name,
-                     colorGroupHex,
-                     t1,
-                     t2,
-                     period,
-                     onDatasource,
-                     removeFromLayer)
+        SplitOptions(
+          name,
+          colorGroupHex,
+          t1,
+          t2,
+          period,
+          onDatasource,
+          removeFromLayer
+        )
       } else {
-        SplitOptions(name,
-                     colorGroupHex,
-                     t2,
-                     t1,
-                     period,
-                     onDatasource,
-                     removeFromLayer)
+        SplitOptions(
+          name,
+          colorGroupHex,
+          t2,
+          t1,
+          period,
+          onDatasource,
+          removeFromLayer
+        )
       }
     }
 
@@ -932,12 +944,14 @@ object Generators extends ArbitraryInstances {
       analysisOwner <- nonEmptyStringGen
       referer <- nonEmptyStringGen
     } yield
-      AnalysisEvent(projectId,
-                    projectLayerId,
-                    analysisId,
-                    nodeId,
-                    analysisOwner,
-                    referer)
+      AnalysisEvent(
+        projectId,
+        projectLayerId,
+        analysisId,
+        nodeId,
+        analysisOwner,
+        referer
+      )
 
   private def metricGen: Gen[Metric] =
     for {
@@ -961,11 +975,27 @@ object Generators extends ArbitraryInstances {
     } yield { Task.TaskFeatureCreate(properties, geometry) }
 
   private def taskFeatureCollectionCreateGen
-    : Gen[Task.TaskFeatureCollectionCreate] =
+      : Gen[Task.TaskFeatureCollectionCreate] =
     for {
       features <- Gen.nonEmptyListOf(taskFeatureCreateGen)
     } yield {
       Task.TaskFeatureCollectionCreate(features = features)
+    }
+
+  private def taskGridCreatePropertiesGen: Gen[Task.TaskGridCreateProperties] =
+    for {
+      xSizeMeters <- Gen.const(100000)
+      ySizeMeters <- Gen.const(100000)
+    } yield {
+      Task.TaskGridCreateProperties(xSizeMeters, ySizeMeters)
+    }
+
+  private def taskGridFeatureCreateGen: Gen[Task.TaskGridFeatureCreate] =
+    for {
+      properties <- taskGridCreatePropertiesGen
+      geometry <- projectedMultiPolygonGen3857
+    } yield {
+      Task.TaskGridFeatureCreate(properties, geometry)
     }
 
   object Implicits {
@@ -978,12 +1008,12 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbCombinedSceneQueryParams
-      : Arbitrary[CombinedSceneQueryParams] = Arbitrary {
+        : Arbitrary[CombinedSceneQueryParams] = Arbitrary {
       combinedSceneQueryParamsGen
     }
 
     implicit def arbProjectsceneQueryParameters
-      : Arbitrary[ProjectSceneQueryParameters] =
+        : Arbitrary[ProjectSceneQueryParameters] =
       Arbitrary { projectSceneQueryParametersGen }
 
     implicit def arbAnnotationCreate: Arbitrary[Annotation.Create] = Arbitrary {
@@ -1096,7 +1126,7 @@ object Generators extends ArbitraryInstances {
     implicit def arbPlatform: Arbitrary[Platform] = Arbitrary { platformGen }
 
     implicit def arbUserOrgPlatform
-      : Arbitrary[(User.Create, Organization.Create, Platform)] = Arbitrary {
+        : Arbitrary[(User.Create, Organization.Create, Platform)] = Arbitrary {
       userOrgPlatformGen
     }
 
@@ -1112,11 +1142,11 @@ object Generators extends ArbitraryInstances {
       Arbitrary { searchQueryParametersGen }
 
     implicit def arbObjectAccessControlRule
-      : Arbitrary[ObjectAccessControlRule] =
+        : Arbitrary[ObjectAccessControlRule] =
       Arbitrary { objectAccessControlRuleGen }
 
     implicit def arbListObjectAccessControlRule
-      : Arbitrary[List[ObjectAccessControlRule]] =
+        : Arbitrary[List[ObjectAccessControlRule]] =
       Arbitrary {
         Gen.nonEmptyListOf[ObjectAccessControlRule](
           arbitrary[ObjectAccessControlRule]
@@ -1144,7 +1174,7 @@ object Generators extends ArbitraryInstances {
       Arbitrary { projectLayerCreateGen }
 
     implicit def arbProjectLayerCreateWithScenes
-      : Arbitrary[List[(ProjectLayer.Create, List[Scene.Create])]] = {
+        : Arbitrary[List[(ProjectLayer.Create, List[Scene.Create])]] = {
       val tupGen = for {
         projectLayerCreate <- arbitrary[ProjectLayer.Create]
         sceneCreates <- arbitrary[List[Scene.Create]]
@@ -1153,7 +1183,7 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbAnnotationQueryParameters
-      : Arbitrary[AnnotationQueryParameters] = Arbitrary {
+        : Arbitrary[AnnotationQueryParameters] = Arbitrary {
       annotationQueryParametersGen
     }
 
@@ -1178,9 +1208,21 @@ object Generators extends ArbitraryInstances {
       }
 
     implicit def arbTaskFeatureCollectionCreate
-      : Arbitrary[Task.TaskFeatureCollectionCreate] =
+        : Arbitrary[Task.TaskFeatureCollectionCreate] =
       Arbitrary {
         taskFeatureCollectionCreateGen
+      }
+
+    implicit def arbTaskGridFeatureCreate
+        : Arbitrary[Task.TaskGridFeatureCreate] =
+      Arbitrary {
+        taskGridFeatureCreateGen
+      }
+
+    implicit def arbTaskPropertiesCreate
+        : Arbitrary[Task.TaskPropertiesCreate] =
+      Arbitrary {
+        taskPropertiesCreateGen
       }
   }
 }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -129,7 +129,7 @@ object Task {
 
   case class TaskFeatureCollection(
       _type: String = "FeatureCollection",
-      features: List[TaskFeature],
+      features: List[TaskFeature]
   )
 
   object TaskFeatureCollection {
@@ -142,7 +142,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-        )
+          )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -159,15 +159,45 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-      : Decoder[TaskFeatureCollectionCreate] =
+        : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-      : Encoder[TaskFeatureCollectionCreate] =
+        : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
   }
 
+  final case class TaskGridCreateProperties(
+      xSizeMeters: Int,
+      ySizeMeters: Int
+  )
+
+  object TaskGridCreateProperties {
+    implicit val encTaskGridCreateProperties
+        : Encoder[TaskGridCreateProperties] =
+      deriveEncoder
+    implicit val decTaskGridCreateProperties
+        : Decoder[TaskGridCreateProperties] =
+      deriveDecoder
+  }
+
+  case class TaskGridFeatureCreate(
+      properties: TaskGridCreateProperties,
+      geometry: Projected[Geometry],
+      _type: String = "Feature"
+  )
+
+  object TaskGridFeatureCreate {
+    implicit val decTaskGridFeatureCreate: Decoder[TaskGridFeatureCreate] =
+      Decoder.forProduct3("properties", "geometry", "type")(
+        TaskGridFeatureCreate.apply _
+      )
+    implicit val encTaskGridFeatureCreate: Encoder[TaskGridFeatureCreate] =
+      Encoder.forProduct3("properties", "geometry", "type")(
+        tfc => (tfc.properties, tfc.geometry, tfc._type)
+      )
+  }
 }

--- a/app-backend/db/src/main/resources/migrations/V7__Add_ST_MakeGrid_Function.sql
+++ b/app-backend/db/src/main/resources/migrations/V7__Add_ST_MakeGrid_Function.sql
@@ -1,0 +1,60 @@
+CREATE OR REPLACE FUNCTION public.ST_MakeGrid (
+  bound_polygon public.geometry,
+  width_step integer,
+  height_step integer
+)
+RETURNS public.geometry AS
+$body$
+DECLARE
+  Xmin DOUBLE PRECISION;
+  Xmax DOUBLE PRECISION;
+  Ymax DOUBLE PRECISION;
+  X DOUBLE PRECISION;
+  Y DOUBLE PRECISION;
+  NextX DOUBLE PRECISION;
+  NextY DOUBLE PRECISION;
+  CPoint public.geometry;
+  sectors public.geometry[];
+  newSector public.geometry;
+  i INTEGER;
+  SRID INTEGER;
+  source_srid INTEGER;
+BEGIN
+  source_srid := ST_SRID(bound_polygon);
+  bound_polygon := ST_Transform(bound_polygon, 4326);
+  Xmin := ST_XMin(bound_polygon);
+  Xmax := ST_XMax(bound_polygon);
+  Ymax := ST_YMax(bound_polygon);
+  SRID := 4326;
+  Y := ST_YMin(bound_polygon); --current sector's corner coordinate
+  i := -1;
+  <<yloop>>
+  LOOP
+    IF (Y > Ymax) THEN
+        EXIT;
+    END IF;
+    X := Xmin;
+    <<xloop>>
+    LOOP
+      IF (X > Xmax) THEN
+          EXIT;
+      END IF;
+      CPoint := ST_SetSRID(ST_MakePoint(X, Y), SRID);
+      NextX := ST_X(ST_Project(CPoint, $2, radians(90))::geometry);
+      NextY := ST_Y(ST_Project(CPoint, $3, radians(0))::geometry);
+      i := i + 1;
+      newSector := ST_MakeEnvelope(X, Y, NextX, NextY, SRID);
+      IF (ST_Intersects(newSector, bound_polygon)) THEN
+        sectors[i] := ST_Transform(newSector, source_srid);
+      END IF;
+      X := NextX;
+    END LOOP xloop;
+    CPoint := ST_SetSRID(ST_MakePoint(X, Y), SRID);
+    NextY := ST_Y(ST_Project(CPoint, $3, radians(0))::geometry);
+    Y := NextY;
+  END LOOP yloop;
+
+  RETURN ST_Collect(sectors);
+END;
+$body$
+LANGUAGE 'plpgsql';

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -310,7 +310,12 @@ trait PropTestHelpers {
       project: Project
   ): Task.TaskFeatureCreate =
     tfc.copy(
-      properties = tfc.properties
-        .copy(projectId = project.id, projectLayerId = project.defaultLayerId)
+      properties = fixupTaskPropertiesCreate(tfc.properties, project)
     )
+
+  def fixupTaskPropertiesCreate(
+      tpc: Task.TaskPropertiesCreate,
+      project: Project
+  ): Task.TaskPropertiesCreate =
+    tpc.copy(projectId = project.id, projectLayerId = project.defaultLayerId)
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3497,7 +3497,30 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
-
+  /projects/{projectID}/layers/{layerID}/tasks/grid:
+    post:
+      summary: 'Create a task grid for the specified project layer. Does not overwrite existing tasks.'
+      tags:
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/projectID'
+        - $ref: '#/parameters/layerID'
+        - name: taskGridCreate
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/TaskGridCreate'
+      responses:
+        204:
+          description: 'Task grid was successfully created'
+        400:
+          description: 'Task grid could not be created. The provided parameters were likely invalid'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /areas-of-interest/:
     get:
       summary: 'Get a list of areas of interest'
@@ -8054,3 +8077,18 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/TaskFeatureCreate'
+  TaskGridCreate:
+    type: object
+    properties:
+      type:
+        type: string
+      properties:
+        properties:
+          xSizeMeters:
+            type: integer
+            description: length of task along the x-axis in meters
+          ySizeMeters:
+            type: integer
+            description: length of task along the y-axis in meters
+      geometry:
+        $ref: '#/definitions/Geometry'

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3511,8 +3511,11 @@ paths:
           schema:
             $ref: '#/definitions/TaskGridCreate'
       responses:
-        204:
+        201:
           description: 'Task grid was successfully created'
+          schema:
+            type: integer
+            description: Number of tasks created
         400:
           description: 'Task grid could not be created. The provided parameters were likely invalid'
           schema:


### PR DESCRIPTION
## Overview

This PR adds an endpoint that generates a grid of tasks for a project layer based on a polygon mask and grid cell size (x and y).

A migration is included that adds a function `ST_MakeGrid`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

### Demo

![image](https://user-images.githubusercontent.com/2442245/59126092-314cd600-8932-11e9-86a4-984d29a020ed.png)


![image](https://user-images.githubusercontent.com/2442245/59126073-24c87d80-8932-11e9-894e-cf37c9453db8.png)


### Notes

The scalacheck parameters (10000m cell size) were chosen to make the test probably take less than 10 seconds with an arbitrary multi-polygon. It's possible that it could take longer but I haven't seen that yet.

## Testing Instructions

- Pick a project layer that has no tasks
- Create a geojson feature with `xSizeMeters` and `ySizeMeters` properties (geojson.io is handy for this) of at least 10000m initially, depending on your polygon size. It's possible to time out the endpoint if the cell size is too small and the polygon is too large.
- `POST /projects/{projectId}/layers/{layerId}/tasks/grid` with the geojson
- Should get an integer response back that indicates the number of tasks that were created
- You can hit the DB with a query to list the tasks for that project layer and verify they match
- You could also `SELECT ST_AsGeoJSON(ST_Transform(ST_Collect(geometry), 4326)) from tasks where...` to get back a geojson object that you can visualize with geojson.io
- Check out the spec additions and ensure it matches the implementation