### PR TITLE
Use left join to list tasks

### DIFF
--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -17,7 +17,7 @@ object TaskDao extends Dao[Task] {
 
   val tableName = "tasks"
   val joinTableF =
-    Fragment.const("tasks join task_actions on tasks.id = task_actions.task_id")
+    Fragment.const("tasks left join task_actions on tasks.id = task_actions.task_id")
 
   val cols =
     fr"""


### PR DESCRIPTION
## Overview

This PR updates the list endpoint for tasks so that it uses left join instead (so it will return results if the `task_actions` table does not have matching records).

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

It is weird that the task endpoints are not on staging. Let's hope this build will add the endpoints in, so that they are accessible to annotate development work.

## Testing Instructions

- `api/assembly`
- Spin up servers and grab a token
- Choose a project layer that has small scene footprint so that task creation is fast
- `GET` to `api/projects/<project ID>/layers/<layer ID>/tasks` should give you results but with 0 count.
- `POST` to `api/projects/<project ID>/layers/<layer ID>/tasks/grid` with below json:
```json
{
  "type": "Feature",
  "properties": {
    "xSizeMeters": 500,
    "ySizeMeters": 500
  },
  "geometry": "<use_the_extent_field_of_this_project>"
}
```
- `GET` to `api/projects/<project ID>/layers/<layer ID>/tasks` should list tasks. Try out QPs like `bbox=<bbox string>`, `status=UNLABELED`, `locked=false`, `actionType=LABELING_IN_PROGRESS`, etc and make sure they work as expected
