### PR TITLE
Log exceeding tile server request quota

### DIFF
--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -177,9 +177,9 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
     )
   )
 
-  // jitter the request limit by +/- 500
+  // jitter the request limit by +/- 1500
   val requestLimitJitter =
-    scala.util.Random.nextInt % 500
+    scala.util.Random.nextInt % 1500
 
   def router =
     errorHandling {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
@@ -44,7 +44,7 @@ class HealthcheckService(xa: Transactor[IO], quota: Int)(
                 case (Right(r)) => HealthResult(r)
                 case (Left(l))  => HealthResult(l)
               }
-          }
+        }
       )
 
   private def gdalHealth = timeoutToSick(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
@@ -44,7 +44,7 @@ class HealthcheckService(xa: Transactor[IO], quota: Int)(
                 case (Right(r)) => HealthResult(r)
                 case (Left(l))  => HealthResult(l)
               }
-        }
+          }
       )
 
   private def gdalHealth = timeoutToSick(
@@ -103,8 +103,11 @@ class HealthcheckService(xa: Transactor[IO], quota: Int)(
         HealthCheck.liftF[IO, Tagged[String, ?]] {
           IO {
             if (served >= quota) {
+              val message =
+                s"Request quota exceeded -- limit: $quota, counted: $served"
+              logger.warn(message)
               HealthResult.tagged(
-                s"Request count too high -- limit: $quota, counted: $served",
+                message,
                 Health.sick
               )
             } else {

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -62,6 +62,11 @@ lazy val sharedSettings = Seq(
   ),
   scalacOptions := scalaOptions,
   // https://github.com/sbt/sbt/issues/3570
+  scalacOptions in (Compile, console) ~= (_.filterNot(
+    _ == "-Ywarn-unused-import")
+    .filterNot(_ == "-Xfatal-warnings")
+    .filterNot(_ == "-Ywarn-unused")
+    .filterNot(_ == "-Ywarn-unused-import")),
   updateOptions := updateOptions.value.withGigahorse(false),
   externalResolvers := Seq(
     "Geotoolkit Repo" at "http://maven.geotoolkit.org",
@@ -500,7 +505,7 @@ lazy val backsplashServer =
     })
     .settings({
       dependencyOverrides ++= Seq(
-        "com.azavea.gdal" % "gdal-warp-bindings" % "33.6cc58d3"
+        "com.azavea.gdal" % "gdal-warp-bindings" % "33.58d4965"
       )
     })
     .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -142,7 +142,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-          )
+        )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -159,12 +159,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-        : Decoder[TaskFeatureCollectionCreate] =
+      : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-        : Encoder[TaskFeatureCollectionCreate] =
+      : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -177,10 +177,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-        : Encoder[TaskGridCreateProperties] =
+      : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-        : Decoder[TaskGridCreateProperties] =
+      : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     env_file: .env
     expose:
       - "5432"
-    ports:
-      - 5432:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
       interval: 5s
@@ -141,10 +139,10 @@ services:
       - AWS_DEFAULT_PROFILE=raster-foundry
       - BACKSPLASH_AUTHORIZATION_CACHE_ENABLE=true
       - BACKSPLASH_RASTERSOURCE_CACHE_ENABLE=true
-      - BACKSPLASH_ENABLE_GDAL=false
+      - BACKSPLASH_ENABLE_GDAL=true
       - BACKSPLASH_CORE_STREAM_CONCURRENCY=16
       - BACKSPLASH_ENABLE_REQUEST_METRICS=false
-      - BACKSPLASH_SERVER_REQUEST_LIMIT=500
+      - BACKSPLASH_SERVER_REQUEST_LIMIT
     ports:
       - "8080:8080"
       - "9030:9030"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     env_file: .env
     expose:
       - "5432"
+    ports:
+      - 5432:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
       interval: 5s
@@ -139,10 +141,10 @@ services:
       - AWS_DEFAULT_PROFILE=raster-foundry
       - BACKSPLASH_AUTHORIZATION_CACHE_ENABLE=true
       - BACKSPLASH_RASTERSOURCE_CACHE_ENABLE=true
-      - BACKSPLASH_ENABLE_GDAL=true
+      - BACKSPLASH_ENABLE_GDAL=false
       - BACKSPLASH_CORE_STREAM_CONCURRENCY=16
       - BACKSPLASH_ENABLE_REQUEST_METRICS=false
-      - BACKSPLASH_SERVER_REQUEST_LIMIT
+      - BACKSPLASH_SERVER_REQUEST_LIMIT=500
     ports:
       - "8080:8080"
       - "9030:9030"


### PR DESCRIPTION
## Overview

It's difficult to tell the difference between service health degradation because we opted into it and service health degradation because something is actually wrong. The reason for this is that we can't actually see the healthcheck responses in anything that monitors service health. This PR adds a log when we voluntarily mark a backsplash service as sick due to its exceeding its request quota.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ internal facing

## Testing Instructions

- set BACKSPLASH_SERVER_REQUEST_LIMIT to something small, like 50, and kill the jitter (set [this](https://github.com/raster-foundry/raster-foundry/pull/5031/files#diff-53eeaa79292eff98ee110b8ba5f67993R182) to 0)
- assemble tile server
- bring up tile server
- make some tile requests until the healthcheck reports unhealthy
- observe that it also logged a warning
- kill the server
- `console` in a subproject, doesn't matter which
- import something
- observe that you're not warned about unused imports
- import something random in a scala file
- compile
- observe that you're still warned about unused imports