### PR TITLE
Make scripts/update use flyway migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 - Fixed usage of AWS credentials by the GDAL java bindings by using `AWS_DEFAULT_PROFILE` [\#4948](https://github.com/raster-foundry/raster-foundry/pull/4948)
 - Fix Sentinel-2 metadata file download [\#4969](https://github.com/raster-foundry/raster-foundry/pull/4969)
+- Fix scripts/update so that it uses flyway for migrations [\#5032](https://github.com/raster-foundry/raster-foundry/pull/5032)
 
 ### Security
 

--- a/scripts/update
+++ b/scripts/update
@@ -11,33 +11,9 @@ function usage() {
     echo -n \
 "Usage: $(basename "$0")
 
-Update project dependencies, build assembly JARs, run database migrations, 
+Update project dependencies, build assembly JARs, run database migrations,
 and build static asset bundle.
 "
-}
-
-function run_database_migrations() {
-    # Check if database migrations have already been initialized
-    set +e
-    docker-compose \
-        exec -T postgres \
-        psql -U rasterfoundry -d rasterfoundry -c 'select 1 from __migrations__'
-    status_check=$?
-    set -e
-    if [ $status_check == 0 ]; then
-        echo "Migrations already initialized"
-    else
-        # Initialize the database for migrations.
-        docker-compose \
-            run --rm sbt \
-            "migrations/run init"
-    fi
-
-    # Run database migrations. The way scala-forklift works requires this to be called twice:
-    # the first run figures out the migrations to run and the second run applies them.
-    docker-compose \
-        run --rm sbt \
-        ";migrations/run update;migrations/run apply"
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
@@ -55,7 +31,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             ";api/assembly;backsplash-server/assembly"
 
         echo "Running application database migrations"
-        run_database_migrations
+        ./scripts/migrate migrate
 
         echo "Updating frontend dependencies"
         docker-compose \


### PR DESCRIPTION
## Overview

Removes usage of forklift migrations in `scripts/update`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Run `./scripts/update`

Closes #4654 
