### PR TITLE
Fix task list endpoint's returned count field

### DIFF
--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -94,7 +94,8 @@ object Dao extends LazyLogging {
       filters: List[Option[Fragment]],
       countFragment: Option[Fragment] = None) {
 
-    val countF: Fragment = countFragment.getOrElse(fr"SELECT count(id) FROM" ++ tableF)
+    val countF: Fragment =
+      countFragment.getOrElse(fr"SELECT count(id) FROM" ++ tableF)
     val deleteF: Fragment = fr"DELETE FROM" ++ tableF
     val existF: Fragment = fr"SELECT 1 FROM" ++ tableF
 

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -91,9 +91,10 @@ object Dao extends LazyLogging {
   final case class QueryBuilder[Model: Read: Write](
       selectF: Fragment,
       tableF: Fragment,
-      filters: List[Option[Fragment]]) {
+      filters: List[Option[Fragment]],
+      countFragment: Option[Fragment] = None) {
 
-    val countF: Fragment = fr"SELECT count(id) FROM" ++ tableF
+    val countF: Fragment = countFragment.getOrElse(fr"SELECT count(id) FROM" ++ tableF)
     val deleteF: Fragment = fr"DELETE FROM" ++ tableF
     val existF: Fragment = fr"SELECT 1 FROM" ++ tableF
 

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -17,7 +17,8 @@ object TaskDao extends Dao[Task] {
 
   val tableName = "tasks"
   val joinTableF =
-    Fragment.const("tasks left join task_actions on tasks.id = task_actions.task_id")
+    Fragment.const(
+      "tasks left join task_actions on tasks.id = task_actions.task_id")
 
   val cols =
     fr"""
@@ -153,7 +154,11 @@ object TaskDao extends Dao[Task] {
       layerId: UUID
   ): Dao.QueryBuilder[Task] =
     Dao
-      .QueryBuilder[Task](listF, joinTableF, Nil, Some(fr"SELECT count(distinct id) FROM" ++ joinTableF))
+      .QueryBuilder[Task](
+        listF,
+        joinTableF,
+        Nil,
+        Some(fr"SELECT count(distinct id) FROM" ++ joinTableF))
       .filter(queryParams)
       .filter(fr"project_id = $projectId")
       .filter(fr"project_layer_id = $layerId")

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -153,7 +153,7 @@ object TaskDao extends Dao[Task] {
       layerId: UUID
   ): Dao.QueryBuilder[Task] =
     Dao
-      .QueryBuilder[Task](listF, joinTableF, Nil)
+      .QueryBuilder[Task](listF, joinTableF, Nil, Some(fr"SELECT count(distinct id) FROM" ++ joinTableF))
       .filter(queryParams)
       .filter(fr"project_id = $projectId")
       .filter(fr"project_layer_id = $layerId")


### PR DESCRIPTION
## Overview

This PR fixes the count field returned by the task list endpoint so that it reflects the count in the DB.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- `api/assembly`
- Spin up servers and grab a token
- Choose a project layer that has small scene footprint so that task creation is fast
- `POST` to `api/projects/<project ID>/layers/<layer ID>/tasks/grid` with below json:
```json
{
  "type": "Feature",
  "properties": {
    "xSizeMeters": 500,
    "ySizeMeters": 500
  },
  "geometry": "<use_the_extent_field_of_this_project>"
}
```
- `GET` to `api/projects/<project ID>/layers/<layer ID>/tasks` should list tasks. Make sure that the value of the `count` field matches the length of the value in `features` field.
- Grab some tasks, and send `PUT` to `api/projects/<project ID>/layers/<layer ID>/tasks/<task ID>` with a task feature, and with updated status field like `LABELING_IN_PROGRESS`, `LABELED`, etc. 
- Try out QPs like `bbox=<bbox string>`, `status=<One of task statuses>, `locked=false`, `actionType=LABELING_IN_PROGRESS`, etc and make sure they work as expected, and check the `count` and the length of `features`.
