### PR TITLE
Use JDK11 in contexts where we're running a JAR

### DIFF
--- a/app-backend/Dockerfile
+++ b/app-backend/Dockerfile
@@ -1,9 +1,0 @@
-FROM openjdk:8-jre
-
-COPY ./ /opt/raster-foundry
-WORKDIR /opt/raster-foundry
-
-RUN ./sbt migrations/update && \
-    ./sbt migrations/compile
-
-CMD ["./sbt"]

--- a/app-backend/Dockerfile.build
+++ b/app-backend/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
 
 RUN set -ex && \
 	apt-get update && \

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-alpine
+FROM openjdk:11-slim
 
 RUN \
       addgroup -S rf \

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-slim
 
 RUN \
-    adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf
+    adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf
 
 COPY ./target/scala-2.12/api-assembly.jar /var/lib/rf/
 

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:11-slim
 
 RUN \
-    adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf
+    adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf
 
 COPY ./target/scala-2.12/api-assembly.jar /var/lib/rf/
 

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,8 +1,7 @@
 FROM openjdk:11-slim
 
 RUN \
-      addgroup -S rf \
-      && adduser -D -S -h /var/lib/rf -s /sbin/nologin -G rf rf
+    adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf
 
 COPY ./target/scala-2.12/api-assembly.jar /var/lib/rf/
 

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -135,7 +135,7 @@ trait UserRoutes
   def getUserByEncodedAuthId(authIdEncoded: String): Route = authenticate {
     user =>
       rejectEmptyResponse {
-        val authId = URLDecoder.decode(authIdEncoded, "US-ASCII")
+        val authId = URLDecoder.decode(authIdEncoded, "UTF-8")
         if (user.id == authId) {
           complete(
             UserDao.unsafeGetUserById(authId).transact(xa).unsafeToFuture())

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -135,7 +135,7 @@ trait UserRoutes
   def getUserByEncodedAuthId(authIdEncoded: String): Route = authenticate {
     user =>
       rejectEmptyResponse {
-        val authId = URLDecoder.decode(authIdEncoded, "US_ASCII")
+        val authId = URLDecoder.decode(authIdEncoded, "US-ASCII")
         if (user.id == authId) {
           complete(
             UserDao.unsafeGetUserById(authId).transact(xa).unsafeToFuture())

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
 
 RUN \
-    adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf
+    adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf
 
 COPY ./target/scala-2.12/backsplash-assembly.jar /var/lib/rf/
 

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
 
 RUN \
     adduser --home /var/lib/rf --shell /sbin/nologin --disabled-password --gecos "" rf

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:2.3-jdk8-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
 
 COPY rf/requirements.txt /tmp/
 RUN set -ex \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - ./nginx/etc/nginx/conf.d/backsplash.conf:/etc/nginx/conf.d/default.conf
 
   api-server:
-    image: openjdk:8-jre
+    image: openjdk:11-slim
     links:
       - postgres:database.service.rasterfoundry.internal
       - memcached:tile-cache.service.rasterfoundry.internal
@@ -116,7 +116,7 @@ services:
       - postgres:database.service.rasterfoundry.internal
 
   backsplash:
-    image: quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
+    image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       - "backsplash-assembly.jar"
 
   sbt:
-    image: quay.io/azavea/openjdk-gdal:2.3.2-jdk8-slim
+    image: quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Overview

- Use JDK11 in contexts where we're running a JAR
- Update GDAL `2.3.2` references to `2.4`(we were using `2.4` images for `backsplash`)
- Modify `api/Dockerfile` to be Debian based as there are [no Alpine JDK11 images](https://github.com/docker-library/openjdk/issues/272)
- `US_ASCII` -> `US-ASCII` to resolve `java.io.UnsupportedEncodingException: US_ASCII`

It's worth mentioning that, as there aren't any OpenJDK-sanctioned Alpine images for JDK11, the sizes of the containers we build are going to increase. There are [Alpine images](https://github.com/adoptopenjdk/openjdk-docker) maintained by the AdoptOpenJDK group, although they state that they are not yet [TCK compliant](https://en.wikipedia.org/wiki/Technology_Compatibility_Kit).

It's also worth mentioning that they are no longer maintaining Alpine images for JDK8:

>no more OpenJDK 8 Alpine images (Alpine/musl is not officially supported by the OpenJDK project, so this reflects that -- see "Project Portola" for the Alpine porting efforts which I understand are still in need of help)

https://github.com/docker-library/openjdk/pull/322

Also, `URLDecoder.decode(String s, String enc)` uses `Charset.forName(String charsetName)` to translate `enc` into a valid `Charset`. 

I'm not exactly sure how this is working as it stands, because `US_ASCII` is not a valid alias for the `US-ASCII` charset, even in JDK8 (I tested `Charset.forName` on JDK8 and I looked at the [source code](https://github.com/AdoptOpenJDK/openjdk-jdk8u/blob/aa318070b27849f1fe00d14684b2a40f7b29bf79/jdk/src/share/classes/sun/nio/cs/standard-charsets#L42-L54)). 

Resolves https://github.com/azavea/raster-foundry-platform/issues/743

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Styleguide updated, if necessary
- [ ] Swagger specification updated
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

Resolves https://github.com/azavea/raster-foundry-platform/issues/743

## Testing Instructions

I cycled this onto staging via [`test/jrb/jdk11`](https://github.com/raster-foundry/raster-foundry/compare/test/jrb/jdk11), and I am able to load tiles:

![image](https://user-images.githubusercontent.com/1774125/59707723-33841f80-91d1-11e9-84c6-a361a1eff03e.png)

There was some [discussion](https://azavea.slack.com/archives/C089LBS6S/p1560538097256100) in Slack, I'm not sure if slow tile loading is an issue with the JDK bump, or is normal behavior for the application.