### PR TITLE
Fix typo in actionType QP for task list endpoint

### DIFF
--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -181,7 +181,7 @@ object Filters {
         fr"task_actions.user_id = $qp"
       },
       taskQP.actionType map { qp =>
-        fr"task_actions.to_status = $qp OR task_actions.from_status = $qp"
+        fr"(task_actions.to_status = $qp OR task_actions.from_status = $qp)"
       },
       taskQP.actionStartTime map { qp =>
         fr"task_actions.timestamp >= $qp"


### PR DESCRIPTION
## Overview

This PR fixes a typo in the `actionType` QP in the task list endpoint. It surfaced itself when developing collaborators table and activity graphs in Annotate. Going to 🤠 this one once CI is happen.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- We need those parentheses
- 🤠 
