### PR TITLE
Remove project_id from AnnotationGroupCreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Removed superfluous parameter from `POST`s to `/annotation-groups` endpoints [\#5041](https://github.com/raster-foundry/raster-foundry/pull/5041) 
+
 ### Security
 
 ## [1.22.0](https://github.com/raster-foundry/raster-foundry/tree/1.22.0) (2019-06-11)

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -7902,9 +7902,6 @@ definitions:
     properties:
       name:
         type: string
-      projectId:
-        type: string
-        format: uuid
       defaultStyle:
         type: object
 


### PR DESCRIPTION
## Overview

`project_id` is not part of what needs to be posted for correct deserialization,
so this PR removes it from the definition of `AnnotationGroupCreate`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated

## Testing Instructions

- check `Create` in `AnnotationGroup.scala`
- confirm it doesn't have a project id