### PR TITLE
Update version of gt-server and maml used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Upgraded version of GeoTrellis Server and MAML [\#5046](https://github.com/raster-foundry/raster-foundry/pull/5046)
 
 ### Deprecated
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/PaintableTool.scala
@@ -2,10 +2,9 @@ package com.rasterfoundry.backsplash
 
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.backsplash.color.{Implicits => ColorImplicits}
-
 import com.azavea.maml.ast.Expression
 import com.azavea.maml.error.Interpreted
-import com.azavea.maml.eval.BufferingInterpreter
+import com.azavea.maml.eval.ConcurrentInterpreter
 import geotrellis.raster.histogram.Histogram
 import geotrellis.raster._
 import geotrellis.vector._
@@ -28,25 +27,26 @@ object PaintableTool {
   def apply[Param: TmsReification: ExtentReification: HasRasterExtents](
       expr: Expression,
       paramMap: Map[String, Param],
-      renderDef: Option[RenderDefinition],
-      interpreter: BufferingInterpreter = BufferingInterpreter.DEFAULT
+      renderDef: Option[RenderDefinition]
   ): PaintableTool = new PaintableTool {
 
     def tms(z: Int, x: Int, y: Int)(
         implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
+      val interpreter = ConcurrentInterpreter.DEFAULT[IO]
       val eval = LayerTms(IO.pure(expr), IO.pure(paramMap), interpreter)
       eval(z, x, y)
     }
 
     def extent(extent: Extent, cellsize: CellSize)(
         implicit cs: ContextShift[IO]): IO[Interpreted[MultibandTile]] = {
+      val interpreter = ConcurrentInterpreter.DEFAULT[IO]
       val eval = LayerExtent(IO.pure(expr), IO.pure(paramMap), interpreter)
       eval(extent, cellsize)
     }
 
     def histogram(maxCellsSampled: Int)(implicit cs: ContextShift[IO])
       : IO[Interpreted[List[Histogram[Double]]]] = {
-
+      val interpreter = ConcurrentInterpreter.DEFAULT[IO]
       logger.debug(s"Cells to sample: $maxCellsSampled")
       LayerHistogram(IO.pure(expr), IO.pure(paramMap), interpreter, 2000000)
     }

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportableInstances.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/ExportableInstances.scala
@@ -32,7 +32,7 @@ trait ExportableInstances extends LazyLogging {
           val eval =
             LayerTms.apply(IO.pure(self.source.ast),
                            IO.pure(self.source.params),
-                           BufferingInterpreter.DEFAULT)
+                           ConcurrentInterpreter.DEFAULT[IO])
 
           def next() = {
             val (x, y) = allTiles.head

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/MosaicService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/MosaicService.scala
@@ -5,11 +5,10 @@ import com.rasterfoundry.backsplash._
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.common.utils.TileUtils
 import com.rasterfoundry.database.ProjectLayerDao
-
 import cats.data.Validated._
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
-import com.azavea.maml.eval.BufferingInterpreter
+import com.azavea.maml.eval.ConcurrentInterpreter
 import com.azavea.maml.ast.{GeomLit, Masking, RasterVar}
 import doobie.implicits._
 import geotrellis.proj4.{LatLng, WebMercator}
@@ -24,7 +23,6 @@ import org.http4s.headers._
 import org.http4s.util.CaseInsensitiveString
 import doobie.util.transactor.Transactor
 import geotrellis.vector.{MultiPolygon, Polygon, Projected}
-
 import java.util.UUID
 
 class MosaicService[LayerStore: ProjectStore, HistStore, ToolStore](
@@ -63,7 +61,7 @@ class MosaicService[LayerStore: ProjectStore, HistStore, ToolStore](
                 layers.read(layerId, Some(polygonBbox), bandOverride, None)
               LayerTms(IO.pure(expression),
                        IO.pure(Map("mosaic" -> param)),
-                       BufferingInterpreter.DEFAULT)
+                       ConcurrentInterpreter.DEFAULT[IO])
             case _ =>
               LayerTms.identity(
                 layers.read(layerId, Some(polygonBbox), bandOverride, None)

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Version {
   val geotools = "17.1"
   val geotrellisContrib = "3.13.0"
   val geotrellis = "3.0.0-M3"
-  val geotrellisServer = "3.3.6"
+  val geotrellisServer = "3.3.7"
   val hadoop = "2.8.4"
   val http4s = "0.20.0"
   val json4s = "3.5.0"

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Version {
   val geotools = "17.1"
   val geotrellisContrib = "3.13.0"
   val geotrellis = "3.0.0-M3"
-  val geotrellisServer = "3.3.5"
+  val geotrellisServer = "3.3.6"
   val hadoop = "2.8.4"
   val http4s = "0.20.0"
   val json4s = "3.5.0"

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,13 +33,13 @@ object Version {
   val geotools = "17.1"
   val geotrellisContrib = "3.13.0"
   val geotrellis = "3.0.0-M3"
-  val geotrellisServer = "3.3.3"
+  val geotrellisServer = "3.3.5"
   val hadoop = "2.8.4"
   val http4s = "0.20.0"
   val json4s = "3.5.0"
   val jts = "1.16.0"
   val logback = "1.2.3"
-  val maml = "0.3.3"
+  val maml = "0.4.0"
   val nimbusJose = "0.6.0"
   val postgis = "2.2.1"
   val rollbar = "1.4.0"
@@ -120,7 +120,7 @@ object Dependencies {
   val http4sServer = "org.http4s" %% "http4s-server" % Version.http4s
   val http4sXml = "org.http4s" %% "http4s-scala-xml" % Version.http4s
   val logbackClassic = "ch.qos.logback" % "logback-classic" % Version.logback
-  val mamlJvm = "com.azavea" %% "maml-jvm" % Version.maml
+  val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % Version.maml
   val monocleCore = "com.github.julien-truffaut" %% "monocle-core" % "1.5.1-cats"
   val nimbusJose = "com.guizmaii" %% "scala-nimbus-jose-jwt" % Version.nimbusJose
   val postgis = "net.postgis" % "postgis-jdbc" % Version.postgis


### PR DESCRIPTION
## Overview

Upgrades version of geotrellis-server and fixes the organization id used for maml + upgrades it.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Rebuild servers and interact with a project/layer + tool
