### PR TITLE
Fix project layer task delete endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed bugs in task list and delete endpoints [\#5026](https://github.com/raster-foundry/raster-foundry/pull/5026) [\#5034](https://github.com/raster-foundry/raster-foundry/pull/5034) [\#5042](https://github.com/raster-foundry/raster-foundry/pull/5042) [\#5038](https://github.com/raster-foundry/raster-foundry/pull/5038) [\#5048](https://github.com/raster-foundry/raster-foundry/pull/5048)
+
 ### Security
 
 ## [1.22.0](https://github.com/raster-foundry/raster-foundry/tree/1.22.0) (2019-06-11)
@@ -48,6 +50,7 @@
 ## [1.21.3](https://github.com/raster-foundry/raster-foundry/tree/1.21.3) (2019-06-06)
 
 ### Added
+
 - Updated healthcheck to include loading tile metadata [\#5017](https://github.com/raster-foundry/raster-foundry/pull/5017)
 
 ## [1.21.2](https://github.com/raster-foundry/raster-foundry/tree/1.21.2) (2019-05-23)

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -125,12 +125,10 @@ trait ProjectLayerTaskRoutes
         } {
           complete {
             TaskDao
-              .tasksForProjectAndLayerQB(
-                TaskQueryParameters(),
+              .deleteLayerTasks(
                 projectId,
                 layerId
               )
-              .delete
               .transact(xa)
               .unsafeToFuture map { _ =>
               HttpResponse(StatusCodes.NoContent)

--- a/app-backend/db/src/main/resources/migrations/V8__Cascade_delete_task_action.sql
+++ b/app-backend/db/src/main/resources/migrations/V8__Cascade_delete_task_action.sql
@@ -1,0 +1,5 @@
+-- Cascade the deletion of task actions when tasks are deleted
+
+ALTER TABLE public.task_actions
+DROP CONSTRAINT "task_actions_task_id_fkey",
+ADD CONSTRAINT "task_actions_task_id_fkey" FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE CASCADE;

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -290,4 +290,8 @@ object TaskDao extends Dao[Task] {
 
   def unlockTask(taskId: UUID): ConnectionIO[Option[Task.TaskFeature]] =
     deleteLockF(taskId).update.run *> getTaskWithActions(taskId)
+
+  def deleteLayerTasks(projectId: UUID, layerId: UUID): ConnectionIO[Int] = {
+    (fr"DELETE FROM " ++ this.tableF ++ fr"WHERE project_id = ${projectId} and project_layer_id = ${layerId}").update.run
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -374,7 +374,6 @@ class TaskDaoSpec
 
   }
 
-
   test("delete all tasks in a project layer") {
     check {
       forAll {
@@ -410,9 +409,10 @@ class TaskDaoSpec
                 )
               } yield { (fetched, deletedRowCount) }
 
-            val (tasks, deletedTaskCount) = fetchedAndDeletedIO.transact(xa).unsafeRunSync
+            val (tasks, deletedtaskCount) =
+              fetchedAndDeletedIO.transact(xa).unsafeRunSync
             assert(
-              tasks.count  == deletedTaskCount,
+              tasks.count == deletedtaskCount,
               "Retrieved and deleted tasks should be the same"
             )
             true


### PR DESCRIPTION
## Overview

This PR fixes the project layer task delete endpoint and adds a property test for it. It also adds a migration to cascade the deletion of task action records when tasks are deleted.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [X] Any new SQL strings have tests

## Testing Instructions

- CI
- Run migrations
- Point the`feature/asu/use-task-delete-endpoint` branch of Annotate frontend to this branch
- Create a project in annotate
- Label or validate some tasks
- Delete this project from Annotate
- It should work

Closes #5044 
