### PR TITLE
Use subprocess.check_call instead of Popen

### DIFF
--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -54,8 +54,8 @@ def metadata_to_postgres(scene_id):
     logger.debug('Bash command to store histogram: %s', ' '.join(bash_cmd))
     running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
     while running_process.poll() is None:
-        print(running_process.stdout.readline())
-    print(running_process.stdout.read())
+        logger.info(running_process.stdout.readline())
+    logger.info(running_process.stdout.read())
     logger.info('Successfully completed metadata postgres write for scene %s',
                 scene_id)
     return True
@@ -76,9 +76,9 @@ def notify_for_scene_ingest_status(scene_id):
     try:
         running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
         while running_process.poll() is None:
-            print(running_process.stdout.readline())
-            print(running_process.stdout.read())
+            logger.info(running_process.stdout.readline())
+        logger.info(running_process.stdout.read())
     except subprocess.CalledProcessError as e:
-        print('Error notifying users about ingest status:\n', e.output)
+        logger.error('Error notifying users about ingest status:\n', e.output)
 
     return True

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -52,8 +52,10 @@ def metadata_to_postgres(scene_id):
     ]
 
     logger.debug('Bash command to store histogram: %s', ' '.join(bash_cmd))
-    running_cmd = subprocess.Popen(bash_cmd)
-    running_cmd.communicate()
+    running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
+    while running_process.poll() is None:
+        print(running_process.stdout.readline())
+    print(running_process.stdout.read())
     logger.info('Successfully completed metadata postgres write for scene %s',
                 scene_id)
     return True
@@ -71,6 +73,12 @@ def notify_for_scene_ingest_status(scene_id):
         'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
         'com.rasterfoundry.batch.Main', 'notify_ingest_status', scene_id
     ]
-    running_process = subprocess.Popen(bash_cmd)
-    running_process.communicate()
+    try:
+        running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
+        while running_process.poll() is None:
+            print(running_process.stdout.readline())
+            print(running_process.stdout.read())
+    except subprocess.CalledProcessError as e:
+        print('Error notifying users about ingest status:\n', e.output)
+
     return True


### PR DESCRIPTION
## Overview
The metadata generation subprocess can fail if we don't have enough connections in the hikari pool.
This should prevent failures from resulting in a successful ingest job

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes
We still need to figure out what's causing the database issues.
This should cause the ingests to fail, and they can be tried again

## Testing Instructions
- Deploy to staging and see if database errors which occur during metadata generation result in a failing status.
- Can probably test by kicking off a bunch of ingests at once, or limiting the staging database connections. Any idea how to do the latter?

Closes https://github.com/azavea/raster-foundry-platform/issues/769
Closes #4951 
