### PR TITLE
Add an endpoint for listing user activity summary on tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added an endpoint for listing user activity summary on tasks [\#5051](https://github.com/raster-foundry/raster-foundry/pull/5051)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -240,4 +240,28 @@ trait ProjectLayerTaskRoutes
         }
       }
     }
+
+  def getTaskUserSummary(projectId: UUID, layerId: UUID): Route = authenticate {
+    user =>
+      {
+        authorizeAsync {
+          ProjectDao
+            .authProjectLayerExist(
+              projectId,
+              layerId,
+              user,
+              ActionType.Annotate
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            TaskDao
+              .getTaskUserSummary(projectId, layerId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+  }
 }

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -255,11 +255,13 @@ trait ProjectLayerTaskRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          complete {
-            TaskDao
-              .getTaskUserSummary(projectId, layerId)
-              .transact(xa)
-              .unsafeToFuture
+          (userTaskActivityParameters) { userTaskActivityParams =>
+            complete {
+              TaskDao
+                .getTaskUserSummary(projectId, layerId, userTaskActivityParams)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
       }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -302,6 +302,11 @@ trait ProjectRoutes
                           createLayerTaskGrid(projectId, layerId)
                         }
                       } ~
+                      pathPrefix("summary") {
+                        get {
+                          getTaskUserSummary(projectId, layerId)
+                        }
+                      } ~
                       pathPrefix(JavaUUID) { taskId =>
                         pathEndOrSingleSlash {
                           get {

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -177,4 +177,11 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
       'actionMinCount.as[Int].?,
       'actionMaxCount.as[Int].?
     ).as(TaskQueryParameters.apply _)
+
+  def userTaskActivityParameters =
+    parameters(
+      'actionStartTime.as(deserializerTimestamp).?,
+      'actionEndTime.as(deserializerTimestamp).?,
+      'actionUser.as[String].?
+    ).as(UserTaskActivityParameters.apply _)
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -664,3 +664,18 @@ final case class TaskQueryParameters(
   val bboxPolygon: Option[Seq[Projected[Polygon]]] =
     BboxUtil.toBboxPolygon(bbox)
 }
+
+final case class UserTaskActivityParameters(
+    actionStartTime: Option[Timestamp] = None,
+    actionEndTime: Option[Timestamp] = None,
+    actionUser: Option[String] = None
+)
+
+object UserTaskActivityParameters {
+  implicit def encUserTaskActivityParameters
+    : Encoder[UserTaskActivityParameters] =
+    deriveEncoder[UserTaskActivityParameters]
+  implicit def decUserTaskActivityParameters
+    : Decoder[UserTaskActivityParameters] =
+    deriveDecoder[UserTaskActivityParameters]
+}

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -201,3 +201,17 @@ object Task {
       )
   }
 }
+
+final case class TaskUserSummary(
+    userId: String,
+    name: String,
+    profileImageUri: String,
+    labelTaskCount: Int,
+    validateTaskCount: Int,
+    avgTimeSpentSecond: Float
+)
+
+object TaskUserSummary {
+  implicit val taskUserSummrayEncoder: Encoder[TaskUserSummary] =
+    deriveEncoder[TaskUserSummary]
+}

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -212,6 +212,6 @@ final case class TaskUserSummary(
 )
 
 object TaskUserSummary {
-  implicit val taskUserSummrayEncoder: Encoder[TaskUserSummary] =
+  implicit val taskUserSummaryEncoder: Encoder[TaskUserSummary] =
     deriveEncoder[TaskUserSummary]
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -294,4 +294,86 @@ object TaskDao extends Dao[Task] {
   def deleteLayerTasks(projectId: UUID, layerId: UUID): ConnectionIO[Int] = {
     (fr"DELETE FROM " ++ this.tableF ++ fr"WHERE project_id = ${projectId} and project_layer_id = ${layerId}").update.run
   }
+
+  def getTaskActionTimeF(projectId: UUID,
+                         layerId: UUID,
+                         fromStatus: TaskStatus,
+                         toStatus: TaskStatus): Fragment = fr"""
+    (SELECT task_actions.user_id, tasks.id as task_id, MAX(task_actions.timestamp) AS timestamp
+    FROM tasks
+    LEFT JOIN task_actions
+    ON task_actions.task_id = tasks.id
+    WHERE
+      project_id = uuid($projectId)
+      AND project_layer_id = uuid($layerId)
+      AND task_actions.FROM_status = $fromStatus
+      AND task_actions.to_status = $toStatus
+    GROUP BY (task_actions.user_id, tasks.id, task_actions.FROM_status, task_actions.to_status))
+  """
+
+  def getTaskCountAndTimeSpentByActionF(projectId: UUID,
+                                        layerId: UUID,
+                                        action: String): Fragment = {
+    val taskSelectF = fr"""
+      SELECT
+        a.user_id,
+        count(a.task_id) AS task_count,
+        sum(EXTRACT(EPOCH FROM (b.timestamp - a.timestamp))) / count(a.task_id) AS avg_time
+      FROM
+    """
+    val joinAndGroupF = fr"""
+      ON a.user_id = b.user_id AND a.task_id = b.task_id
+      GROUP BY a.user_id
+    """
+    action match {
+      case "label" =>
+        fr"(" ++ taskSelectF ++
+          getTaskActionTimeF(projectId,
+                             layerId,
+                             TaskStatus.Unlabeled,
+                             TaskStatus.LabelingInProgress) ++
+          fr"AS a INNER JOIN " ++
+          getTaskActionTimeF(projectId,
+                             layerId,
+                             TaskStatus.LabelingInProgress,
+                             TaskStatus.Labeled) ++
+          fr"AS b" ++
+          joinAndGroupF ++ fr")"
+      case "validate" =>
+        fr"(" ++ taskSelectF ++
+          getTaskActionTimeF(projectId,
+                             layerId,
+                             TaskStatus.Labeled,
+                             TaskStatus.ValidationInProgress) ++
+          fr"AS a INNER JOIN " ++
+          getTaskActionTimeF(projectId,
+                             layerId,
+                             TaskStatus.ValidationInProgress,
+                             TaskStatus.Validated) ++
+          fr"AS b" ++
+          joinAndGroupF ++ fr")"
+    }
+  }
+
+  def getTaskUserSummary(projectId: UUID,
+                         layerId: UUID): ConnectionIO[List[TaskUserSummary]] =
+    (
+      fr"""
+      SELECT
+        aa.user_id,
+        users.name,
+        users.profile_image_uri,
+        COALESCE(aa.task_count, 0),
+        COALESCE(bb.task_count, 0),
+        CASE COALESCE(aa.task_count, 0) + COALESCE(bb.task_count, 0)
+           WHEN 0 THEN 0
+           ELSE (COALESCE(aa.task_count, 0) * COALESCE(aa.avg_time, 0) + COALESCE(bb.task_count, 0) * COALESCE(bb.avg_time, 0)) / (COALESCE(aa.task_count, 0) + COALESCE(bb.task_count, 0))
+        END AS avg_time_spent_second
+      FROM
+    """ ++
+        getTaskCountAndTimeSpentByActionF(projectId, layerId, "label") ++
+        fr"AS aa FULL OUTER JOIN" ++
+        getTaskCountAndTimeSpentByActionF(projectId, layerId, "validate") ++
+        fr"AS bb ON aa.user_id = bb.user_id INNER JOIN users ON users.id = aa.user_id"
+    ).query[TaskUserSummary].to[List]
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -308,7 +308,7 @@ object TaskDao extends Dao[Task] {
       .whereAndOpt(
         Some(fr"project_id = uuid($projectId)"),
         Some(fr"project_layer_id = uuid($layerId)"),
-        Some(fr"task_actions.FROM_status = $fromStatus"),
+        Some(fr"task_actions.from_status = $fromStatus"),
         Some(fr"task_actions.to_status = $toStatus"),
         params.actionStartTime map { start =>
           fr"task_actions.timestamp >= $start"

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3524,6 +3524,32 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /projects/{projectID}/layers/{layerID}/tasks/summary:
+    get:
+      summary: "Get the summary of user activities on tasks"
+      tags:
+        - Imagery
+      parameters:
+        - $ref: "#/parameters/projectID"
+        - $ref: "#/parameters/layerID"
+        - $ref: "#/parameters/actionUser"
+        - $ref: "#/parameters/actionStartTime"
+        - $ref: "#/parameters/actionEndTime"
+      responses:
+        200:
+          description: "A list of user activity summaries on tasks"
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/UserTaskActivity'
+        403:
+          description: "Insufficient permissions for resource or resource does not exist"
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: "Unexpected error"
+          schema:
+            $ref: "#/definitions/Error"
   /areas-of-interest/:
     get:
       summary: 'Get a list of areas of interest'
@@ -8095,3 +8121,19 @@ definitions:
             description: length of task along the y-axis in meters
       geometry:
         $ref: '#/definitions/Geometry'
+  UserTaskActivity:
+    type: object
+    properties:
+      userId:
+        type: string
+      name:
+        type: string
+      profileImageUri:
+        type: string
+      labelTaskCount:
+        type: integer
+      validateTaskCount:
+        type: integer
+      avgTimeSpentSecond:
+        type: number
+        format: float


### PR DESCRIPTION
## Overview

This PR adds an endpoint to list user activities on tasks for a project layer.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] Swagger specification updated
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

### Demo

![Screen Shot 2019-07-02 at 5 10 12 PM](https://user-images.githubusercontent.com/16109558/60546887-5132a800-9cec-11e9-893d-afa735e73bde.png)


## Testing Instructions

- CI should pass
- Test this endpoint by using the frontend support in here: https://github.com/raster-foundry/annotate/pull/271

Closes https://github.com/raster-foundry/annotate/issues/253
