### PR TITLE
Make tile server threadpool configuration more sane

### DIFF
--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -48,7 +48,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
     case _                  => "http://localhost:8081"
   }
 
-  override protected implicit def contextShift: ContextShift[IO] =
+  override protected implicit val contextShift: ContextShift[IO] =
     IO.contextShift(
       ExecutionContext.fromExecutor(
         Executors.newFixedThreadPool(

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -54,24 +54,19 @@ object RFTransactor {
       new HikariDataSource(hikariConfig)
     }
 
-    val connectionEC =
+    val connectionEC: ExecutionContext =
       ExecutionContext.fromExecutor(
-        ExecutionContext.fromExecutor(
-          Executors.newFixedThreadPool(
-            Properties.envOrElse("HIKARI_CONNECTION_THREADS", "8").toInt,
-            new ThreadFactoryBuilder().setNameFormat("db-connection-%d").build()
-          )
+        Executors.newFixedThreadPool(
+          Properties.envOrElse("HIKARI_CONNECTION_THREADS", "8").toInt,
+          new ThreadFactoryBuilder().setNameFormat("db-connection-%d").build()
         )
       )
 
-    val transactionEC =
+    val transactionEC: ExecutionContext =
       ExecutionContext.fromExecutor(
-        ExecutionContext.fromExecutor(
-          Executors.newCachedThreadPool(
-            new ThreadFactoryBuilder()
-              .setNameFormat("db-transaction-%d")
-              .build()
-          )
+        Executors.newFixedThreadPool(
+          Properties.envOrElse("HIKARI_TRANSACTION_THREADS", "8").toInt,
+          new ThreadFactoryBuilder().setNameFormat("db-transaction-%d").build()
         )
       )
   }


### PR DESCRIPTION
## Overview

This PR addresses two problems that were causing a proliferation of JVM threads. The first it addresses is that the Hikari configuration wasn't using fixed thread pools for transactions. In practice this meant that under heavy load (e.g. at zoom level 30), the number of transactions it needed to run exceeded the number of cached threads available, so it would increase them basically without bound until it got really angry. The second it addresses is that the implicit context shift in the `Main` for backsplash was a `def` instead of a `val`. What this meant is that we frequently created new context shfits. Testing instructions will provide evidence for both of these claims.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

# Notes

We still explode on overzoomed Landsat 8 imagery (and presumably overzoomed Sentinel-2? I don't know, I haven't tested that yet). There's at least a specific symptom now, which is that the `FutureNotifyListener` thread enters a `Running` state and then camps out. I _think_ that means that there's some other work that's getting stuck, but I haven't found what work that is yet. (#5064)

## Testing Instructions

- assemble backsplash on develop
- bring up your servers and frontend on your host
- (I can help with these steps if you haven't done it before) start visual vm
- add a jmx connection to localhost:9030, if you're on your host, otherwise, make sure :9030 is forwarded from your vm to your host
- sort the threads by name
- navigate to one of the two naip projects
- set browser zoom to 30%
- zoom in so the tiles fill most of the screen
- switch to single band, switch the visualization a few times (band or colors, whatever), and watch the `http4s-%d` and `db-transaction-%d` threads proliferate, and note that they're not doing anything
- checkout this branch
- assemble backsplash
- remove and re-add the jmx connection and sort threads by name
- refresh the rf page (to clear cached leaflet stuff) and repeat the single band variations
- threads should not proliferate

Closes #5036 
