### PR TITLE
Capture X-Amzn-Trace-Id in Nginx access logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Capture X-Amzn-Trace-Id in Nginx access logs [\#5068](https://github.com/raster-foundry/raster-foundry/pull/5068)
 
 ### Changed
 - Upgraded version of GeoTrellis Server and MAML [\#5046](https://github.com/raster-foundry/raster-foundry/pull/5046), [\#5063](https://github.com/raster-foundry/raster-foundry/pull/5063)

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -16,6 +16,7 @@ http {
     log_format timed_combined '$remote_addr - $remote_user '
                               '"$request" $status $body_bytes_sent $gzip_ratio '
                               '"$http_referer" "$http_user_agent" '
+                              '"$http_x_amzn_trace_id" '
                               '$request_time $upstream_response_time';
 
     access_log /var/log/nginx/access.log timed_combined;


### PR DESCRIPTION
## Overview

Capture `X-Amzn-Trace-Id` in Nginx access logs to help connect request and response timings between the application load balancer and Nginx.

Resolves #5065 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Run `./scripts/server`
- Make a request using a [mock trace identifier](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html#request-tracing-syntax):
```bash
http GET 'http://localhost:8081/healthcheck' \
    'X-Amzn-Trace-Id':'Self=1-67891234-12456789abcdef012345678;Root=1-67891233-abcdef012345678912345678;CalledFrom=app'
```
- See that the trace identifier is captured in the Nginx access logs:
```bash
nginx-backsplash_1        | 172.28.0.1 - - "GET /healthcheck HTTP/1.1" 200 60 0.59 "-" "HTTPie/1.0.2" "Self=1-67891234-12456789abcdef012345678;Root=1-67891233-abcdef012345678912345678;CalledFrom=app" 5.113 5.114
```