### PR TITLE
Handle scene ingest errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Removed
 
 ### Fixed
+- Better error handling for ingests, no longer always fail the batch job [/#5070](https://github.com/raster-foundry/raster-foundry/pull/5070)
 
 ### Security
 

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -1,5 +1,7 @@
 import logging
 import subprocess
+import sys
+import copy
 
 import click
 
@@ -8,6 +10,16 @@ from ..ingest import io
 from ..utils.exception_reporting import wrap_rollbar
 
 logger = logging.getLogger(__name__)
+
+
+def execute(cmd):
+    popen = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+    for stdout_line in iter(popen.stdout.readline, ""):
+        yield stdout_line
+    popen.stdout.close()
+    return_code = popen.wait()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, cmd)
 
 
 @click.command(name='ingest-scene')
@@ -24,18 +36,62 @@ def ingest_scene(scene_id):
 
 def ingest(scene_id):
     """Separated into another function because the Click annotation messes with calling it from other tasks"""
-    logger.info("Converting scene to COG: %s", scene_id)
-    scene = Scene.from_id(scene_id)
-    if scene.ingestStatus != 'INGESTED':
-        scene.ingestStatus = 'INGESTING'
-        scene.update()
-    image_locations = [(x.sourceUri, x.filename) for x in sorted(
-        scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
-    io.create_cog(image_locations, scene)
-    logger.info('Cog created, writing histogram to attribute store')
-    metadata_to_postgres(scene.id)
-    logger.info('Histogram added to attribute store, notifying interested parties')
-    notify_for_scene_ingest_status(scene.id)
+    originalScene = None
+    try:
+        logger.info("Converting scene to COG: %s", scene_id)
+        try:
+            scene = Scene.from_id(scene_id)
+            originalScene = copy.deepcopy(scene)
+            # updates status
+            if scene.ingestStatus != 'INGESTED':
+                scene.ingestStatus = 'INGESTING'
+                scene.update()
+        except Exception:
+            logger.error('Error while setting scene up for ingestion')
+            raise
+        else:
+            logger.info('Fetched and set ingest status on scene to INGESTING')
+
+        image_locations = [(x.sourceUri, x.filename) for x in sorted(
+            scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
+
+        try:
+            io.create_cog(image_locations, scene).update()
+        except Exception:
+            logger.error('There as an error converting the scene to a COG')
+            raise
+
+        logger.info('Cog created, writing histogram to attribute store')
+        try:
+            metadata_to_postgres(scene.id)
+        except Exception:
+            logger.error('error while writing metadata to postgres')
+            raise
+
+        logger.info('Histogram added to attribute store, updating scene ingest status')
+        try:
+            scene.ingestStatus = 'INGESTED'
+            scene.update()
+        except Exception as e:
+            logger.error('Error updating scene status after ingestion:\n%s', e)
+            raise
+
+        logger.info('Scene finished ingesting. Notifying interested parties')
+        try:
+            notify_for_scene_ingest_status(scene.id)
+        except subprocess.CalledProcessError as e:
+            logger.error('There was error while notifying users of ingest status, but the ingest succeeded:\n%s', e)
+
+    except Exception as e:
+        logger.error('There was an unrecoverable error during the ingest:\n%s', e)
+        if originalScene is not None:
+            try:
+                logger.info('Attempting to revert scene state')
+                originalScene.update()
+                logger.info('reverted scene state')
+            except Exception as e:
+                logger.error('Unable to revert scene to original state:\n%s', e)
+        sys.exit('There was an unrecoverable error during scene ingestion: %s' % e)
 
 
 def metadata_to_postgres(scene_id):
@@ -52,10 +108,9 @@ def metadata_to_postgres(scene_id):
     ]
 
     logger.debug('Bash command to store histogram: %s', ' '.join(bash_cmd))
-    running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
-    while running_process.poll() is None:
-        logger.info(running_process.stdout.readline())
-    logger.info(running_process.stdout.read())
+    for output in execute(bash_cmd):
+        logger.info(output)
+
     logger.info('Successfully completed metadata postgres write for scene %s',
                 scene_id)
     return True
@@ -73,12 +128,7 @@ def notify_for_scene_ingest_status(scene_id):
         'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
         'com.rasterfoundry.batch.Main', 'notify_ingest_status', scene_id
     ]
-    try:
-        running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
-        while running_process.poll() is None:
-            logger.info(running_process.stdout.readline())
-        logger.info(running_process.stdout.read())
-    except subprocess.CalledProcessError as e:
-        logger.error('Error notifying users about ingest status:\n', e.output)
 
+    for output in execute(bash_cmd):
+        logger.info(output)
     return True

--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -19,6 +19,17 @@ logger = logging.getLogger(__name__)
 
 
 def create_cog(image_locations, scene, same_path=False):
+    """
+    Args:
+      image_locations (List[(uri, filename)]): Used to fetch source imagery for the scene for processing
+      scene (Scene): Scene to create COG from
+      same_path (boolean): Output to the same path that it was downloaded from
+
+    Returns:
+      Scene: The mutated scene. Must call update() on it to be reflected on the API
+    Raises:
+      Exception: Any exceptions here are unrecoverable.
+    """
     with get_tempdir() as local_dir:
         dsts = [os.path.join(local_dir, fname) for _, fname in image_locations]
         cog.fetch_imagery(image_locations, local_dir)
@@ -34,8 +45,8 @@ def create_cog(image_locations, scene, same_path=False):
             )
         else:
             updated_scene = upload_tif(cog_path, scene)
-        updated_scene.update()
         os.remove(cog_path)
+        return updated_scene
 
 
 def upload_tif(tif_path, scene, key='', ingest_location=''):
@@ -50,7 +61,6 @@ def upload_tif(tif_path, scene, key='', ingest_location=''):
     logger.info('Tif uploaded successfully')
     scene.ingestLocation = s3uri if len(ingest_location) == 0 else ingestUri
     scene.sceneType = 'COG'
-    scene.ingestStatus = 'INGESTED'
     return scene
 
 

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -21,6 +21,11 @@ class BaseModel(object):
 
     @classmethod
     def from_id(cls, id):
+        """ Fetch a resource with the specified ID
+
+        Raises:
+            requests.exceptions.HTTPError
+        """
         url = '{HOST}{URL_PATH}{id}'.format(HOST=cls.HOST, URL_PATH=cls.URL_PATH, id=id)
         session = get_session()
         response = session.get(url)

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -69,6 +69,11 @@ def fetch_imagery(image_locations, local_dir):
 
 
 def fetch_image(location, filename, local_dir):
+    """Fetch an image an write it to a local directory
+
+    Raises:
+      ValueError: Invalid URL schema in location
+    """
     bucket, key = s3_bucket_and_key_from_url(location)
     if bucket.startswith('sentinel'):
         extra_kwargs = {'RequestPayer': 'requester'}

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -34,6 +34,10 @@ def get_tempdir(debug=False):
 
 
 def s3_bucket_and_key_from_url(s3_url):
+    """
+    Raises:
+      ValueError
+    """
     parts = urlparse(s3_url)
     # parts.path[1:] drops the leading slash that urlparse includes
     return (parts.netloc, parts.path[1:])

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -50,6 +50,7 @@ function load_database_backup() {
     # gosu postgres pg_dump -Fc rasterfoundry > database.pgdump
     docker-compose \
         exec -T postgres pg_restore -U rasterfoundry -Fc -d rasterfoundry /tmp/data/database.pgdump
+    ./scripts/migrate migrate
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]


### PR DESCRIPTION
## Overview
Handle errors during scene ingests and roll back scene changes if the ingest fails.
Add a little bit of documentation in the python scripts
Run migrations when loading development data


### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/61144949-4920f800-a4a4-11e9-9ebf-d09caa0b92c1.png)

### Notes
The ingest might fail due to available database connections. Fixing that is a separate issue, and it's actually a good sign that this PR is handling the fail correctly if that returns a non-zero exit code

## Testing Instructions

- Rebuild your batch jar
- Rebuild your batch container with `docker-compose build batch`
- start your API server
- Create a new project, add an uningested scene to it
- Open a shell on your batch container with `./scripts/console batch bash`
- run `rf ingest-scene ${scene-id}` using the uningested scene 
- verify that it completes with an exit code of 0 by typing `echo $?` after it finishes
- Edit `ingest_scene.py` by raising an exception on line 66 `raise Exception("This is a test")` .. or kill your API server while it's ingesting. 
- Re-build your batch container if you updated the script, and restart the shell
- Run an ingest on another scene and verify that it fails with an exit code >0 using `echo $?` after the script executes and raises an exception

Closes #5062 
