### PR TITLE
Add taskId to annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Upgraded version of GeoTrellis Server and MAML [\#5046](https://github.com/raster-foundry/raster-foundry/pull/5046), [\#5063](https://github.com/raster-foundry/raster-foundry/pull/5063)
+- Updated user task activity endpoint [\#5078](https://github.com/raster-foundry/raster-foundry/pull/5078)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Removed
 
 ### Fixed
+- Better error handling for ingests, no longer always fail the batch job [/#5070](https://github.com/raster-foundry/raster-foundry/pull/5070)
 
 ### Security
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -115,7 +115,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
           'quality.as[String].?,
           'annotationGroup.as[UUID].?,
           'bbox.as[String].*,
-          'withOwnerInfo.as[Boolean].?
+          'withOwnerInfo.as[Boolean].?,
+          'taskId.as[UUID].?
         )
       )).as(AnnotationQueryParameters.apply _)
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
@@ -74,10 +74,13 @@ class WmsService[LayerReader: OgcStore](layers: LayerReader, urlPrefix: String)(
                 .parMapN {
                   case (Valid(mbTile), hists) =>
                     logger.debug(s"Style: ${layer.style}, hists are: ${hists}")
+                    val invisiTile =
+                      mbTile.prototype(params.width, params.height)
+                    val fullTile = invisiTile merge mbTile
                     val tileResp = layer.style map {
-                      _.renderImage(mbTile, params.format, hists)
+                      _.renderImage(fullTile, params.format, hists)
                     } getOrElse {
-                      Render(mbTile, layer.style, params.format, hists)
+                      Render(fullTile, layer.style, params.format, hists)
                     }
                     Ok(tileResp)
                   // at least one is invalid, we don't care which, and we want all the errors

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -190,10 +190,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -218,10 +218,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -274,10 +274,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -350,10 +350,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -367,10 +367,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -394,10 +394,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -434,10 +434,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -451,7 +451,8 @@ final case class AnnotationQueryParameters(
     quality: Option[String] = None,
     annotationGroup: Option[UUID] = None,
     bbox: Iterable[String] = Seq.empty[String],
-    withOwnerInfo: Option[Boolean] = None
+    withOwnerInfo: Option[Boolean] = None,
+    taskId: Option[UUID] = None
 ) {
   val bboxPolygon: Option[Seq[Projected[Polygon]]] =
     BboxUtil.toBboxPolygon(bbox)
@@ -459,10 +460,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -472,10 +473,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -518,10 +519,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -558,10 +559,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -574,10 +575,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -593,10 +594,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -673,9 +674,9 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -206,9 +206,10 @@ final case class TaskUserSummary(
     userId: String,
     name: String,
     profileImageUri: String,
-    labelTaskCount: Int,
-    validateTaskCount: Int,
-    avgTimeSpentSecond: Float
+    labeledTaskCount: Int,
+    labeledTaskAvgTimeSecond: Float,
+    validatedTaskCount: Int,
+    validatedTaskAvgTimeSecond: Float
 )
 
 object TaskUserSummary {

--- a/app-backend/db/src/main/resources/migrations/V9__Add_taskId_to_annotations.sql
+++ b/app-backend/db/src/main/resources/migrations/V9__Add_taskId_to_annotations.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE annotations
+ADD COLUMN task_id uuid;
+
+ALTER TABLE ONLY annotations
+ADD CONSTRAINT annotations_task_id_fkey FOREIGN KEY (task_id) REFERENCES public.tasks(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -22,7 +22,7 @@ object AnnotationDao extends Dao[Annotation] {
         id, project_id, created_at, created_by, modified_at, modified_by, owner,
         label, description, machine_generated, confidence,
         quality, geometry, annotation_group, labeled_by, verified_by,
-        project_layer_id
+        project_layer_id, task_id
       FROM
     """ ++ tableF
 
@@ -64,6 +64,7 @@ object AnnotationDao extends Dao[Annotation] {
               annotation.labeledBy,
               annotation.verifiedBy,
               annotation.projectLayerId,
+              annotation.taskId,
               owner.name,
               owner.profileImageUri
             ))
@@ -135,7 +136,7 @@ object AnnotationDao extends Dao[Annotation] {
       id, project_id, created_at, created_by, modified_at, modified_by, owner,
       label, description, machine_generated, confidence,
       quality, geometry, annotation_group, labeled_by, verified_by,
-      project_layer_id
+      project_layer_id, task_id
     ) VALUES"""
     for {
       project <- ProjectDao.unsafeGetProjectById(projectId)
@@ -174,7 +175,7 @@ object AnnotationDao extends Dao[Annotation] {
           ${annotation.modifiedAt}, ${annotation.modifiedBy}, ${annotation.owner}, ${annotation.label},
           ${annotation.description}, ${annotation.machineGenerated}, ${annotation.confidence}, ${annotation.quality},
           ${annotation.geometry}, ${annotation.annotationGroup}, ${annotation.labeledBy}, ${annotation.verifiedBy},
-          ${annotation.projectLayerId}
+          ${annotation.projectLayerId}, ${annotation.taskId}
         )"""
         })
       insertedAnnotations <- annotationFragments.toNel
@@ -198,7 +199,8 @@ object AnnotationDao extends Dao[Annotation] {
                 "annotation_group",
                 "labeled_by",
                 "verified_by",
-                "project_layer_id"
+                "project_layer_id",
+                "task_id"
               )
               .compile
               .toList)
@@ -221,7 +223,8 @@ object AnnotationDao extends Dao[Annotation] {
         annotation_group = ${annotation.annotationGroup},
         labeled_by = ${annotation.labeledBy},
         verified_by = ${annotation.verifiedBy},
-        project_layer_id = ${annotation.projectLayerId}
+        project_layer_id = ${annotation.projectLayerId},
+        task_id = ${annotation.taskId}
       WHERE
         id = ${annotation.id} AND project_id = ${projectId}
     """).update.run
@@ -282,6 +285,9 @@ object AnnotationDao extends Dao[Annotation] {
         queryParams.annotationGroup.map({ ag =>
           fr"a.annotation_group = $ag"
         }),
+        queryParams.taskId.map({ tid =>
+          fr"a.task_id = $tid"
+        }),
         queryParams.bboxPolygon match {
           case Some(bboxPolygons) =>
             val fragments = bboxPolygons.map(
@@ -303,7 +309,7 @@ object AnnotationDao extends Dao[Annotation] {
       SELECT a.id, a.project_id, a.created_at, a.created_by, a.modified_at,
         a.modified_by, a.owner, a.label, a.description, a.machine_generated,
         a.confidence, a.quality, a.geometry, a.annotation_group, a.labeled_by,
-        a.verified_by, a.project_layer_id, u.name owner_name,
+        a.verified_by, a.project_layer_id, a.task_id, u.name owner_name,
         u.profile_image_uri owner_profile_image_uri
     """
 

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -47,7 +47,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-    : Filterable[Any, TimestampQueryParameters] =
+      : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -59,7 +59,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-    : Filterable[Any, ProjectQueryParameters] =
+      : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -88,7 +88,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-    : Filterable[Any, CombinedToolQueryParameters] =
+      : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -101,7 +101,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-    : Filterable[Any, AnnotationQueryParameters] =
+      : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -124,6 +124,9 @@ trait Filterables extends RFMeta with LazyLogging {
             annotParams.annotationGroup.map({ ag =>
               fr"annotation_group = $ag"
             }),
+            annotParams.taskId.map({ tid =>
+              fr"task_id = $tid"
+            }),
             annotParams.bboxPolygon match {
               case Some(bboxPolygons) =>
                 val fragments = bboxPolygons.map(
@@ -137,7 +140,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-    : Filterable[Any, CombinedSceneQueryParams] =
+      : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -185,8 +188,8 @@ trait Filterables extends RFMeta with LazyLogging {
               case _    => fr"ingest_status != 'INGESTED'"
             }),
             sceneParams.ingestStatus.toList.toNel.map({ statuses =>
-              Fragments.in(fr"ingest_status",
-                           statuses.map(IngestStatus.fromString(_)))
+              Fragments
+                .in(fr"ingest_status", statuses.map(IngestStatus.fromString(_)))
             }),
             (sceneParams.bboxPolygon, sceneParams.shape) match {
               case (Some(bboxPolygons), _) =>
@@ -201,7 +204,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-    : Filterable[Any, ProjectSceneQueryParameters] =
+      : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -209,14 +212,14 @@ trait Filterables extends RFMeta with LazyLogging {
           case _    => fr"ingest_status != 'INGESTED'"
         }),
         params.ingestStatus.toList.toNel.map({ statuses =>
-          Fragments.in(fr"ingest_status",
-                       statuses.map(IngestStatus.fromString(_)))
+          Fragments
+            .in(fr"ingest_status", statuses.map(IngestStatus.fromString(_)))
         })
       )
     }
 
   implicit val mapTokenQueryParametersFilter
-    : Filterable[Any, CombinedMapTokenQueryParameters] =
+      : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -224,7 +227,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-    : Filterable[Any, CombinedToolRunQueryParameters] =
+      : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -271,7 +274,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-    : Filterable[Any, DatasourceQueryParameters] =
+      : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -342,7 +345,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-    : Filterable[Any, ThumbnailQueryParameters] =
+      : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -357,7 +360,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-    : Filterable[Any, PlatformQueryParameters] =
+      : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -367,7 +370,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-    : Filterable[Any, OrganizationQueryParameters] =
+      : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -382,14 +385,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-    : Filterable[Organization, SearchQueryParameters] =
+      : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-    : Filterable[User, SearchQueryParameters] =
+      : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -400,7 +403,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-    : Filterable[Any, Projected[MultiPolygon]] =
+      : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -307,6 +307,7 @@ class AnnotationDaoSpec
                   annotation.labeledBy,
                   annotation.verifiedBy,
                   annotation.projectLayerId,
+                  annotation.taskId,
                   dbUser.name,
                   dbUser.profileImageUri
                 )

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -86,11 +86,12 @@ def ingest(scene_id):
         logger.error('There was an unrecoverable error during the ingest:\n%s', e)
         if originalScene is not None:
             try:
-                logger.info('Attempting to revert scene state')
+                logger.info('Reverting scene and setting status to failed.')
+                originalScene.ingestStatus = 'FAILED'
                 originalScene.update()
-                logger.info('reverted scene state')
+                logger.info('Scene status set to failed.')
             except Exception as e:
-                logger.error('Unable to revert scene to original state:\n%s', e)
+                logger.error('Unable to revert scene to original state with failed status:\n%s', e)
         sys.exit('There was an unrecoverable error during scene ingestion: %s' % e)
 
 

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -1,5 +1,7 @@
 import logging
 import subprocess
+import sys
+import copy
 
 import click
 
@@ -8,6 +10,16 @@ from ..ingest import io
 from ..utils.exception_reporting import wrap_rollbar
 
 logger = logging.getLogger(__name__)
+
+
+def execute(cmd):
+    popen = subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True)
+    for stdout_line in iter(popen.stdout.readline, ""):
+        yield stdout_line
+    popen.stdout.close()
+    return_code = popen.wait()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, cmd)
 
 
 @click.command(name='ingest-scene')
@@ -24,18 +36,62 @@ def ingest_scene(scene_id):
 
 def ingest(scene_id):
     """Separated into another function because the Click annotation messes with calling it from other tasks"""
-    logger.info("Converting scene to COG: %s", scene_id)
-    scene = Scene.from_id(scene_id)
-    if scene.ingestStatus != 'INGESTED':
-        scene.ingestStatus = 'INGESTING'
-        scene.update()
-    image_locations = [(x.sourceUri, x.filename) for x in sorted(
-        scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
-    io.create_cog(image_locations, scene)
-    logger.info('Cog created, writing histogram to attribute store')
-    metadata_to_postgres(scene.id)
-    logger.info('Histogram added to attribute store, notifying interested parties')
-    notify_for_scene_ingest_status(scene.id)
+    originalScene = None
+    try:
+        logger.info("Converting scene to COG: %s", scene_id)
+        try:
+            scene = Scene.from_id(scene_id)
+            originalScene = copy.deepcopy(scene)
+            # updates status
+            if scene.ingestStatus != 'INGESTED':
+                scene.ingestStatus = 'INGESTING'
+                scene.update()
+        except Exception:
+            logger.error('Error while setting scene up for ingestion')
+            raise
+        else:
+            logger.info('Fetched and set ingest status on scene to INGESTING')
+
+        image_locations = [(x.sourceUri, x.filename) for x in sorted(
+            scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
+
+        try:
+            io.create_cog(image_locations, scene).update()
+        except Exception:
+            logger.error('There as an error converting the scene to a COG')
+            raise
+
+        logger.info('Cog created, writing histogram to attribute store')
+        try:
+            metadata_to_postgres(scene.id)
+        except Exception:
+            logger.error('error while writing metadata to postgres')
+            raise
+
+        logger.info('Histogram added to attribute store, updating scene ingest status')
+        try:
+            scene.ingestStatus = 'INGESTED'
+            scene.update()
+        except Exception as e:
+            logger.error('Error updating scene status after ingestion:\n%s', e)
+            raise
+
+        logger.info('Scene finished ingesting. Notifying interested parties')
+        try:
+            notify_for_scene_ingest_status(scene.id)
+        except subprocess.CalledProcessError as e:
+            logger.error('There was error while notifying users of ingest status, but the ingest succeeded:\n%s', e)
+
+    except Exception as e:
+        logger.error('There was an unrecoverable error during the ingest:\n%s', e)
+        if originalScene is not None:
+            try:
+                logger.info('Attempting to revert scene state')
+                originalScene.update()
+                logger.info('reverted scene state')
+            except Exception as e:
+                logger.error('Unable to revert scene to original state:\n%s', e)
+        sys.exit('There was an unrecoverable error during scene ingestion: %s' % e)
 
 
 def metadata_to_postgres(scene_id):
@@ -52,10 +108,9 @@ def metadata_to_postgres(scene_id):
     ]
 
     logger.debug('Bash command to store histogram: %s', ' '.join(bash_cmd))
-    running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
-    while running_process.poll() is None:
-        logger.info(running_process.stdout.readline())
-    logger.info(running_process.stdout.read())
+    for output in execute(bash_cmd):
+        logger.info(output)
+
     logger.info('Successfully completed metadata postgres write for scene %s',
                 scene_id)
     return True
@@ -73,12 +128,7 @@ def notify_for_scene_ingest_status(scene_id):
         'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
         'com.rasterfoundry.batch.Main', 'notify_ingest_status', scene_id
     ]
-    try:
-        running_process = subprocess.check_call(bash_cmd, stdout=subprocess.PIPE)
-        while running_process.poll() is None:
-            logger.info(running_process.stdout.readline())
-        logger.info(running_process.stdout.read())
-    except subprocess.CalledProcessError as e:
-        logger.error('Error notifying users about ingest status:\n', e.output)
 
+    for output in execute(bash_cmd):
+        logger.info(output)
     return True

--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -19,6 +19,17 @@ logger = logging.getLogger(__name__)
 
 
 def create_cog(image_locations, scene, same_path=False):
+    """
+    Args:
+      image_locations (List[(uri, filename)]): Used to fetch source imagery for the scene for processing
+      scene (Scene): Scene to create COG from
+      same_path (boolean): Output to the same path that it was downloaded from
+
+    Returns:
+      Scene: The mutated scene. Must call update() on it to be reflected on the API
+    Raises:
+      Exception: Any exceptions here are unrecoverable.
+    """
     with get_tempdir() as local_dir:
         dsts = [os.path.join(local_dir, fname) for _, fname in image_locations]
         cog.fetch_imagery(image_locations, local_dir)
@@ -34,8 +45,8 @@ def create_cog(image_locations, scene, same_path=False):
             )
         else:
             updated_scene = upload_tif(cog_path, scene)
-        updated_scene.update()
         os.remove(cog_path)
+        return updated_scene
 
 
 def upload_tif(tif_path, scene, key='', ingest_location=''):
@@ -50,7 +61,6 @@ def upload_tif(tif_path, scene, key='', ingest_location=''):
     logger.info('Tif uploaded successfully')
     scene.ingestLocation = s3uri if len(ingest_location) == 0 else ingestUri
     scene.sceneType = 'COG'
-    scene.ingestStatus = 'INGESTED'
     return scene
 
 

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -21,6 +21,11 @@ class BaseModel(object):
 
     @classmethod
     def from_id(cls, id):
+        """ Fetch a resource with the specified ID
+
+        Raises:
+            requests.exceptions.HTTPError
+        """
         url = '{HOST}{URL_PATH}{id}'.format(HOST=cls.HOST, URL_PATH=cls.URL_PATH, id=id)
         session = get_session()
         response = session.get(url)

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -69,6 +69,11 @@ def fetch_imagery(image_locations, local_dir):
 
 
 def fetch_image(location, filename, local_dir):
+    """Fetch an image an write it to a local directory
+
+    Raises:
+      ValueError: Invalid URL schema in location
+    """
     bucket, key = s3_bucket_and_key_from_url(location)
     if bucket.startswith('sentinel'):
         extra_kwargs = {'RequestPayer': 'requester'}

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -34,6 +34,10 @@ def get_tempdir(debug=False):
 
 
 def s3_bucket_and_key_from_url(s3_url):
+    """
+    Raises:
+      ValueError
+    """
     parts = urlparse(s3_url)
     # parts.path[1:] drops the leading slash that urlparse includes
     return (parts.netloc, parts.path[1:])

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1888,6 +1888,7 @@ paths:
         - $ref: '#/parameters/bbox'
         - $ref: '#/parameters/withOwnerInfo'
         - $ref: '#/parameters/annotationGroup'
+        - $ref: '#/parameters/taskID'
       responses:
         200:
           description: 'GeoJSON feature collection containing paginated annotations of this project default layer'

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -8127,10 +8127,13 @@ definitions:
         type: string
       profileImageUri:
         type: string
-      labelTaskCount:
+      labeledTaskCount:
         type: integer
-      validateTaskCount:
+      labeledTaskAvgTimeSecond:
+        type: number
+        format: float
+      validatedTaskCount:
         type: integer
-      avgTimeSpentSecond:
+      validatedTaskAvgTimeSecond:
         type: number
         format: float

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1888,7 +1888,7 @@ paths:
         - $ref: '#/parameters/bbox'
         - $ref: '#/parameters/withOwnerInfo'
         - $ref: '#/parameters/annotationGroup'
-        - $ref: '#/parameters/taskID'
+        - $ref: '#/parameters/taskId'
       responses:
         200:
           description: 'GeoJSON feature collection containing paginated annotations of this project default layer'
@@ -2987,7 +2987,7 @@ paths:
         - $ref: '#/parameters/bbox'
         - $ref: '#/parameters/withOwnerInfo'
         - $ref: '#/parameters/annotationGroup'
-        - $ref: '#/parameters/task'
+        - $ref: '#/parameters/taskId'
       responses:
         200:
           description: 'GeoJSON feature collection containing paginated annotations of this project layer'
@@ -5542,8 +5542,8 @@ parameters:
     in: query
     type: integer
     required: false
-  task:
-    name: task
+  taskId:
+    name: taskId
     description: 'Filter to annotations belonging to the specified task'
     in: query
     type: string

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -50,6 +50,7 @@ function load_database_backup() {
     # gosu postgres pg_dump -Fc rasterfoundry > database.pgdump
     docker-compose \
         exec -T postgres pg_restore -U rasterfoundry -Fc -d rasterfoundry /tmp/data/database.pgdump
+    ./scripts/migrate migrate
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]


### PR DESCRIPTION
## Overview

This PR adds `taskId` to annotations so that they can be explicitly linked to tasks. This also adds `taskId` as a query parameter.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated

### Notes

There was a `task` QP in the spec that wasn't implemented so I updated it to reflect the new name of the QP.

## Testing Instructions

- If you have tasks in your dev db, grab an id from one.
- If you don't have tasks in your dev db, drop the foreign key constraint: `alter table annotations drop constraint "annotations_task_id_fkey";`
- Create some annotations if you don't have any in your db
- Update annotations with the task id from a task
- Send some requests with the `taskId` param (test with non-existent IDs too) and see that it returns what you'd expect

Closes #5072 
