### PR TITLE
Pad tiles to avoid QGIS stretching

### DIFF
--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/WmsService.scala
@@ -74,10 +74,13 @@ class WmsService[LayerReader: OgcStore](layers: LayerReader, urlPrefix: String)(
                 .parMapN {
                   case (Valid(mbTile), hists) =>
                     logger.debug(s"Style: ${layer.style}, hists are: ${hists}")
+                    val invisiTile =
+                      mbTile.prototype(params.width, params.height)
+                    val fullTile = invisiTile merge mbTile
                     val tileResp = layer.style map {
-                      _.renderImage(mbTile, params.format, hists)
+                      _.renderImage(fullTile, params.format, hists)
                     } getOrElse {
-                      Render(mbTile, layer.style, params.format, hists)
+                      Render(fullTile, layer.style, params.format, hists)
                     }
                     Ok(tileResp)
                   // at least one is invalid, we don't care which, and we want all the errors


### PR DESCRIPTION
## Overview

Tiles are currently being cropped to remove NoData areas. The result is that partially colored tiles can sometimes get stretched by clients (like QGIS) which expect returned images to range over the entire extent being requested. This is why the tiled view is susceptible to stretching and the regular view isn't (i.e. the regular view expects imagery for *just* the requested extent whereas the tiled view requests extents along a predefined grid that may/may not be backed by imagery).

This PR simply ensures that tiles are always padded out to the appropriate size for the given request. It is likely a bandage rather than an ideal solution, but it should suffice to move us beyond the artifacts currently being seen.

The correct imagery is on top. Note the stretching on the right side and on the bottom:
![image](https://user-images.githubusercontent.com/1977405/61410899-3bf47680-a8b3-11e9-96c0-090e78d85976.png)

## Testing Instructions

Local testing of this PR appears to not be possible at the moment (there are issues on develop which seem cause 500s on the relevant code paths). Instead, we should extensively test WMS layers on staging once this PR is accepted. It touches a small enough area and is simple enough that testing-on-staging is likely not to give us problems in this case.

Closes #4965
