### PR TITLE
Rewrite user task activity summary endpoint and add more test cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Upgraded version of GeoTrellis Server and MAML [\#5046](https://github.com/raster-foundry/raster-foundry/pull/5046), [\#5063](https://github.com/raster-foundry/raster-foundry/pull/5063)
+- Updated user task activity endpoint [\#5078](https://github.com/raster-foundry/raster-foundry/pull/5078)
 
 ### Deprecated
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -206,9 +206,10 @@ final case class TaskUserSummary(
     userId: String,
     name: String,
     profileImageUri: String,
-    labelTaskCount: Int,
-    validateTaskCount: Int,
-    avgTimeSpentSecond: Float
+    labeledTaskCount: Int,
+    labeledTaskAvgTimeSecond: Float,
+    validatedTaskCount: Int,
+    validatedTaskAvgTimeSecond: Float
 )
 
 object TaskUserSummary {

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -8127,10 +8127,13 @@ definitions:
         type: string
       profileImageUri:
         type: string
-      labelTaskCount:
+      labeledTaskCount:
         type: integer
-      validateTaskCount:
+      labeledTaskAvgTimeSecond:
+        type: number
+        format: float
+      validatedTaskCount:
         type: integer
-      avgTimeSpentSecond:
+      validatedTaskAvgTimeSecond:
         type: number
         format: float


### PR DESCRIPTION
## Overview

This PR rewrites functions behind the user task activity summary endpoint and adds more test cases.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- [x] Swagger specification updated
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

## Testing Instructions

- New property tests in CI should pass
- Reassemble jars
- Spin up servers
- Point annotate to this branch
- Create a project in annotate (it is suggested to update team IDs in local env before hand)
- Add user A and B to both label and validate teams
- Log in to annotate with user A. Label some tasks
- Log in to annotate with user B. Validate some tasks.
- Log in to annotate with an admin account
- Go to this project's dashboard. Dashboard's collaborators display should be broken, but will be fixed very soon. Open up network traffic and filter to `summary` endpoint. Make sure you see both user A and user B activities.

Closes https://github.com/raster-foundry/annotate/issues/277
