### PR TITLE
Update gt-server for rgb(a) WMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Changed
+- Add support for multiband imagery in WMS responses
+  [\#5082](https://github.com/raster-foundry/raster-foundry/pull/5082)
 
 ### Deprecated
 

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Version {
   val geotools = "17.1"
   val geotrellisContrib = "3.16.0"
   val geotrellis = "3.0.0-M3"
-  val geotrellisServer = "3.3.8"
+  val geotrellisServer = "3.4.0"
   val hadoop = "2.8.4"
   val http4s = "0.20.0"
   val json4s = "3.5.0"


### PR DESCRIPTION
## Overview

Users of RF WMS will generally just use the default parent layer. This is problematic as things currently stand because most imagery that will be viewed via WMS is multiband and the current default behavior is to display the first band in greyscale. This PR adds a bit of logic to examine the bandcount and select the appropriate behavior. RGB (3 bands), RGBA (4 bands), and greyscale (any other number of bands, of which only the first will be displayed) should now be supported by default in `GetMap` requests.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Styleguide updated, if necessary

## Testing Instructions

- Select any 3 band or 4 band image sources in RF
- Access the default 'parent' layer via a WMS client
- Are the cones in your eyes excited or just the rods?
- Cones are the ones that see color

Closes #5075
