### PR TITLE
Increase tile service timeouts, upgrade Nginx, and enable TCP_NODELAY

### DIFF
--- a/app-backend/backsplash-server/src/main/resources/application.conf
+++ b/app-backend/backsplash-server/src/main/resources/application.conf
@@ -19,8 +19,11 @@ parallelism {
 }
 
 server {
-  timeoutSeconds = 15
-  timeoutSeconds = ${?BACKSPLASH_SERVER_TIMEOUT}
+  idleTimeoutSeconds = 63
+  idleTimeoutSeconds = ${?BACKSPLASH_IDLE_TIMEOUT}
+
+  responseHeaderTimeoutSeconds = 60
+  responseHeaderTimeoutSeconds = ${?BACKSPLASH_RESPONSE_HEADER_TIMEOUT}
 
   requestLimit = 3000
   requestLimit = ${?BACKSPLASH_SERVER_REQUEST_LIMIT}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -16,7 +16,9 @@ object Config {
 
   object server {
     private val serverConfig = config.getConfig("server")
-    val timeoutSeconds = serverConfig.getInt("timeoutSeconds")
+    val idleTimeoutSeconds = serverConfig.getInt("idleTimeoutSeconds")
+    val responseHeaderTimeoutSeconds =
+      serverConfig.getInt("responseHeaderTimeoutSeconds")
     val requestLimit = serverConfig.getInt("requestLimit")
   }
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -13,6 +13,7 @@ import com.rasterfoundry.database.util.RFTransactor
 import cats.effect._
 import com.olegpy.meow.hierarchy._
 import org.http4s._
+import org.http4s.blaze.channel.{ChannelOptions, OptionValue}
 import org.http4s.server.middleware.{AutoSlash, CORS, CORSConfig}
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.Router
@@ -216,6 +217,9 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
       .enableHttp2(false)
       .withHttpApp(router.orNotFound)
       .withBanner(startupBanner)
+      .withChannelOptions(ChannelOptions(OptionValue[java.lang.Boolean](
+        java.net.StandardSocketOptions.TCP_NODELAY,
+        true)))
       .serve
 
   val canSelect = sql"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync

--- a/docker-compose.swagger.yml
+++ b/docker-compose.swagger.yml
@@ -6,7 +6,7 @@ services:
       - "8888:8080"
 
   swagger-ui:
-    image: nginx:1.14
+    image: nginx:1.16
     volumes:
       - ./docs/swagger/:/usr/share/nginx/html:ro
     ports:

--- a/nginx/Dockerfile.api
+++ b/nginx/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM nginx:1.14
+FROM nginx:1.16
 
 RUN mkdir -p /etc/nginx/includes
 

--- a/nginx/Dockerfile.backsplash
+++ b/nginx/Dockerfile.backsplash
@@ -1,4 +1,4 @@
-FROM nginx:1.14
+FROM nginx:1.16
 
 RUN mkdir -p /etc/nginx/includes
 

--- a/nginx/etc/nginx/nginx.conf
+++ b/nginx/etc/nginx/nginx.conf
@@ -21,7 +21,12 @@ http {
 
     access_log /var/log/nginx/access.log timed_combined;
 
-    keepalive_timeout 65;
+    keepalive_disable msie6;
+    keepalive_timeout 65s;
+    keepalive_requests 100;
+
+    client_header_timeout 65s;
+    client_body_timeout 65s;
 
     server_tokens off;
 


### PR DESCRIPTION
## Overview

As clients pan on the map, recently initiated tile requests that fall off of the viewport get cancelled. Request cancellations between the client and the ALB lead to HTTP 460s (in the logs), but cancellations are also propagated upstream (to Nginx, and the tile service).

The AWS ALB has a configurable idle timeout of 60 seconds. When upstream timeouts are shorter than the ALB idle timeout, connections between the ALB and the upstream get mixed up. In some cases, the ALB reuses a connection to send a message to the upstream, but the upstream's end of the connection is already closed. This injects latency into the request/response cycle because the ALB has to figure out the connection is closed and retry sending the request through another connection. The timeout increases in this PR aim to mitigate this behavior.

In addition:

- Nginx was upgraded to its most recent stable release
- `TCP_NODELAY` was added to http4s in an effort to align with the Nginx configuration and reduce latency by sending data as soon as it is available

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Styleguide updated, if necessary~
~- [ ] Swagger specification updated~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

TBD

Closes https://github.com/azavea/raster-foundry-platform/issues/786
