### PR TITLE
Fix Missing Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixed missing logs from scala services [\#5094](https://github.com/raster-foundry/raster-foundry/pull/5094)
+
 ### Security
 
 ## [1.25.0](https://github.com/raster-foundry/raster-foundry/tree/1.25.0)

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -24,7 +24,7 @@ object Main extends App with Config with Router {
   val xa = RFTransactor.buildTransactor()
 
   val canSelect = sql"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync
-  println(s"Server Started (${canSelect})")
+  logger.info(s"Server Started (${canSelect})")
 
   def terminate(): Future[Terminated] = {
     system.terminate()

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -58,7 +58,8 @@ lazy val sharedSettings = Seq(
   // Try to keep logging sane and make sure to use slf4j + logback
   excludeDependencies ++= Seq(
     "log4j" % "log4j",
-    "org.slf4j" % "slf4j-log4j12"
+    "org.slf4j" % "slf4j-log4j12",
+    "org.slf4j" % "slf4j-nop"
   ),
   scalacOptions := scalaOptions,
   // https://github.com/sbt/sbt/issues/3570

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 


### PR DESCRIPTION
## Overview

We were missing _any_ logs from the scala backend because `slf4j-nop` was being included in dependencies which seemed to be nooping any logging we had configured. This PR makes sure that `slf4j-nop` is excluded from our dependencies.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Assemble Jars
- Start server and make sure that the backsplash banner prints and `Server Started` prints for the API server