### PR TITLE
Update AnnotationDao and TaskDao for STAC export builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ dist/
 /app-tasks/jars/rf-batch.jar
 /data
 
+.vscode
+
 # Patch files
 *.patch
 scratch/

--- a/app-backend/datamodel/src/main/scala/Annotation.scala
+++ b/app-backend/datamodel/src/main/scala/Annotation.scala
@@ -8,6 +8,9 @@ import geotrellis.vector.{Geometry, Projected, io => _}
 import io.circe.generic.JsonCodec
 import io.circe.generic.extras._
 import io.circe.Encoder
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
 
 @JsonCodec
 final case class AnnotationFeatureCollectionCreate(
@@ -351,4 +354,118 @@ object StacLabelItemProperties {
       statName: String,
       value: Double
   )
+}
+
+@JsonCodec
+final case class AnnotationWithClasses(
+    id: UUID,
+    projectId: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    owner: String,
+    description: Option[String],
+    machineGenerated: Option[Boolean],
+    confidence: Option[Float],
+    quality: Option[AnnotationQuality],
+    geometry: Option[Projected[Geometry]],
+    annotationGroup: UUID,
+    labeledBy: Option[String],
+    verifiedBy: Option[String],
+    projectLayerId: UUID,
+    taskId: Option[UUID],
+    classes: Json
+) extends GeoJSONSerializable[AnnotationWithClasses.GeoJSON] {
+  def toGeoJSONFeature = AnnotationWithClasses.GeoJSON(
+    this.id,
+    this.geometry,
+    AnnotationWithClassesProperties(
+      this.projectId,
+      this.createdAt,
+      this.createdBy,
+      this.modifiedAt,
+      this.owner,
+      this.description,
+      this.machineGenerated,
+      this.confidence,
+      this.quality,
+      this.annotationGroup,
+      this.labeledBy,
+      this.verifiedBy,
+      this.projectLayerId,
+      this.taskId,
+      this.classes
+    )
+  )
+}
+
+object AnnotationWithClasses {
+  final case class GeoJSON(
+      id: UUID,
+      geometry: Option[Projected[Geometry]],
+      properties: AnnotationWithClassesProperties,
+      _type: String = "Feature"
+  ) extends GeoJSONFeature
+
+  object GeoJSON {
+    implicit val annoWithClassesGeojonEncoder: Encoder[GeoJSON] =
+      Encoder.forProduct4("id", "geometry", "properties", "type")(
+        geojson => (geojson.id, geojson.geometry, geojson.properties, geojson._type)
+      )
+  }
+}
+
+final case class AnnotationWithClassesProperties(
+  projectId: UUID,
+  createdAt: Timestamp,
+  createdBy: String,
+  modifiedAt: Timestamp,
+  owner: String,
+  description: Option[String],
+  machineGenerated: Option[Boolean],
+  confidence: Option[Float],
+  quality: Option[AnnotationQuality],
+  annotationGroup: UUID,
+  labeledBy: Option[String],
+  verifiedBy: Option[String],
+  projectLayerId: UUID,
+  taskId: Option[UUID],
+  classes: Json
+)
+
+object AnnotationWithClassesProperties {
+  implicit val annotationWithClassesPropertiesEncoder: Encoder[AnnotationWithClassesProperties] =
+    new Encoder[AnnotationWithClassesProperties] {
+      final def apply(properties: AnnotationWithClassesProperties): Json = {
+        val classMap: Map[String, Json] = properties.classes.as[Map[String, Json]].getOrElse(Map.empty)
+        (
+          Map(
+            "projectId" -> properties.projectId.asJson,
+            "createdAt" -> properties.createdAt.asJson,
+            "createdBy" -> properties.createdBy.asJson,
+            "modifiedAt" -> properties.modifiedAt.asJson,
+            "owner" -> properties.owner.asJson,
+            "description" -> properties.description.asJson,
+            "machineGenerated" -> properties.machineGenerated.asJson,
+            "confidence" -> properties.confidence.asJson,
+            "quality" -> properties.quality.asJson,
+            "annotationGroup" -> properties.annotationGroup.asJson,
+            "labeledBy" -> properties.labeledBy.asJson,
+            "verifiedBy" -> properties.verifiedBy.asJson,
+            "projectLayerId" -> properties.projectLayerId.asJson, 
+            "taskId" -> properties.taskId.asJson
+          ) ++ classMap
+        ).asJson
+      }
+    }
+}
+
+final case class AnnotationWithClassesFeatureCollection(
+  features: List[AnnotationWithClasses.GeoJSON],
+  `type`: String = "FeatureCollection"
+)
+
+object AnnotationWithClassesFeatureCollection {
+  implicit val annoWithClassesFCEncoder: Encoder[AnnotationWithClassesFeatureCollection] = 
+    deriveEncoder[AnnotationWithClassesFeatureCollection]
 }

--- a/app-backend/db/src/main/scala/StacExportDao.scala
+++ b/app-backend/db/src/main/scala/StacExportDao.scala
@@ -66,8 +66,7 @@ object StacExportDao extends Dao[StacExport] {
     )
   }
 
-  def update(stacExport: StacExport,
-             id: UUID): ConnectionIO[Int] = {
+  def update(stacExport: StacExport, id: UUID): ConnectionIO[Int] = {
     val now = new Timestamp(new Date().getTime)
     (fr"UPDATE" ++ this.tableF ++ fr"SET" ++ fr"""
       modified_at = ${now},

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -434,4 +434,21 @@ object TaskDao extends Dao[Task] {
     ON
       team_users.user_id = user_validated_tasks.user_id
   """).query[TaskUserSummary].to[List]
+
+  def listLayerTasksByStatus(
+      projectId: UUID,
+      layerId: UUID,
+      taskStatuses: List[String]
+  ): ConnectionIO[List[Task]] = {
+    val taskStatusF: Fragment =
+      taskStatuses.map(TaskStatus.fromString(_)).toNel match {
+        case Some(taskStatusNel) => Fragments.in(fr"status", taskStatusNel)
+        case _                   => fr""
+      }
+    query
+      .filter(fr"project_id = $projectId")
+      .filter(fr"project_layer_id = $layerId")
+      .filter(taskStatusF)
+      .list
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -8,6 +8,8 @@ import org.scalacheck.Prop.forAll
 import org.scalatest._
 import org.scalatestplus.scalacheck.Checkers
 import com.rasterfoundry.datamodel.PageRequest
+import java.util.UUID
+import io.circe.syntax._
 
 class AnnotationDaoSpec
     extends FunSuite
@@ -311,6 +313,198 @@ class AnnotationDaoSpec
                 )
               })
               .toSet == annotationsForProject.results.toSet
+          }
+      }
+    }
+  }
+
+  test("list detection annotations from a layer by task status") {
+    check {
+      forAll {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            annoAndTaskFeatureCreate: (Task.TaskFeatureCreate,
+                                       List[Annotation.Create]),
+            labelValidateTeamCreate: (Team.Create, Team.Create),
+            labelValidateTeamUgrCreate: (UserGroupRole.Create,
+                                         UserGroupRole.Create)
+        ) =>
+          {
+            val (taskFeatureCreate, annotationsCreate) =
+              annoAndTaskFeatureCreate
+            val labelName = "Car"
+            val labelId = UUID.randomUUID()
+            val labelGroupId = UUID.randomUUID()
+            val connIO = for {
+              (dbUser, dbOrg, dbPlatform, dbProject) <- insertUserOrgPlatProject(
+                userCreate,
+                orgCreate,
+                platform,
+                projectCreate
+              )
+              updatedDbProject <- fixupProjectExtrasUpdate(
+                labelValidateTeamCreate,
+                labelValidateTeamUgrCreate,
+                dbOrg,
+                dbUser,
+                dbPlatform,
+                dbProject,
+                Some(List((labelId, labelName, labelGroupId))),
+                Some(Map(labelGroupId -> "Car Group"))
+              )
+              collection <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreate, updatedDbProject)
+                      .withStatus(TaskStatus.Labeled)
+                  )
+                ),
+                dbUser
+              )
+              feature = collection.features.head
+              updatedAnnotationsCreate = annotationsCreate.map(annoCreate => {
+                annoCreate.copy(
+                  label = labelId.toString(),
+                  geometry = Some(feature.geometry),
+                  taskId = Some(feature.id)
+                )
+              })
+              insertedAnnotations <- AnnotationDao.insertAnnotations(
+                updatedAnnotationsCreate,
+                dbProject.id,
+                dbUser
+              )
+              listedAnnotations <- AnnotationDao
+                .listDetectionLayerAnnotationsByTaskStatus(
+                  dbProject.id,
+                  dbProject.defaultLayerId,
+                  List("LABELED")
+                )
+            } yield { (insertedAnnotations, listedAnnotations) }
+
+            val (dbAnnotations, listed) = connIO.transact(xa).unsafeRunSync
+            dbAnnotations.length == listed.length &&
+            listed.map(_.label).toSet == Set(labelName) &&
+            true
+          }
+      }
+    }
+  }
+
+  test("list classification annotations from a layer by task status") {
+    check {
+      forAll {
+        (
+            userOrgPlat: (User.Create, Organization.Create, Platform),
+            projectCreate: Project.Create,
+            annotationCreates: (Annotation.Create, Annotation.Create),
+            taskFeatureCreates: (Task.TaskFeatureCreate, Task.TaskFeatureCreate),
+            labelValidateTeamCreate: (Team.Create, Team.Create),
+            labelValidateTeamUgrCreate: (UserGroupRole.Create,
+                                         UserGroupRole.Create)
+        ) =>
+          {
+            val (userCreate, orgCreate, platform) = userOrgPlat
+            val (taskFeatureCreateOne, taskFeatureCreateTwo) =
+              taskFeatureCreates
+            val (annotationCreateOne, annotationCreateTwo) = annotationCreates
+            val labelNameOne = "Finished"
+            val labelIdOne = UUID.randomUUID()
+            val labelNameTwo = "Partial"
+            val labelIdTwo = UUID.randomUUID()
+            val labelGroupIdOne = UUID.randomUUID()
+            val labelGroupNameOne = "Building"
+            val labelGroupIdTwo = UUID.randomUUID()
+            val labelGroupNameTwo = "Road"
+
+            val connIO = for {
+              (dbUser, dbOrg, dbPlatform, dbProject) <- insertUserOrgPlatProject(
+                userCreate,
+                orgCreate,
+                platform,
+                projectCreate
+              )
+              updatedDbProject <- fixupProjectExtrasUpdate(
+                labelValidateTeamCreate,
+                labelValidateTeamUgrCreate,
+                dbOrg,
+                dbUser,
+                dbPlatform,
+                dbProject,
+                Some(
+                  List(
+                    (labelIdOne, labelNameOne, labelGroupIdOne),
+                    (labelIdTwo, labelNameTwo, labelGroupIdTwo),
+                  )),
+                Some(
+                  Map(
+                    labelGroupIdOne -> labelGroupNameOne,
+                    labelGroupIdTwo -> labelGroupNameTwo
+                  ))
+              )
+              taskCollectionOne <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreateOne,
+                                           updatedDbProject)
+                      .withStatus(TaskStatus.Labeled)
+                  )
+                ),
+                dbUser
+              )
+              taskCollectionTwo <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreateTwo,
+                                           updatedDbProject)
+                      .withStatus(TaskStatus.Validated)
+                  )
+                ),
+                dbUser
+              )
+              taskOne = taskCollectionOne.features.head
+              taskTwo = taskCollectionTwo.features.head
+              _ <- AnnotationDao.insertAnnotations(
+                List(
+                  annotationCreateOne.copy(
+                    label = s"${labelIdOne} ${labelIdTwo}",
+                    geometry = Some(taskOne.geometry),
+                    taskId = Some(taskOne.id)
+                  ),
+                  annotationCreateTwo.copy(
+                    label = s"${labelIdOne} ${labelIdTwo}",
+                    geometry = Some(taskTwo.geometry),
+                    taskId = Some(taskTwo.id)
+                  )
+                ),
+                dbProject.id,
+                dbUser
+              )
+              listedAnnotationsFC <- AnnotationDao
+                .listClassificationLayerAnnotationsByTaskStatus(
+                  dbProject.id,
+                  dbProject.defaultLayerId,
+                  List("LABELED", "VALIDATED")
+                )
+            } yield { listedAnnotationsFC }
+
+            val listed = connIO.transact(xa).unsafeRunSync
+
+            listed.features.length == 2 &&
+            listed.`type` == "FeatureCollection" &&
+            listed.features.foldLeft(true)((acc, feature) => {
+              acc &&
+              feature.properties.asJson.hcursor
+                .get[String](labelGroupNameOne)
+                .toOption == Some(labelNameOne) &&
+              feature.properties.asJson.hcursor
+                .get[String](labelGroupNameTwo)
+                .toOption == Some(labelNameTwo)
+            }) &&
+            true
           }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -18,7 +18,24 @@ import java.util.UUID
 case class ProjectExtras(annotate: ProjectExtrasAnnotate)
 
 @JsonCodec
-case class ProjectExtrasAnnotate(labelers: UUID, validators: UUID)
+case class ProjectExtrasAnnotate(
+    labelers: UUID,
+    validators: UUID,
+    labels: List[ProjectExtrasAnnotateLabel],
+    projectType: String,
+    preexistingTeams: Boolean,
+    overlayUrl: Option[String] = None,
+    labelGroups: Map[UUID, String]
+)
+
+@JsonCodec
+case class ProjectExtrasAnnotateLabel(
+    name: String,
+    id: UUID,
+    colorHexCode: String,
+    labelGroup: UUID,
+    default: Boolean
+)
 
 trait PropTestHelpers {
 
@@ -305,26 +322,34 @@ trait PropTestHelpers {
 
   def fixupTaskFeaturesCollection(
       tfc: Task.TaskFeatureCollectionCreate,
-      project: Project
+      project: Project,
+      statusOption: Option[TaskStatus] = None
   ) =
     tfc.copy(
       features =
-        tfc.features map { fixupTaskFeatureCreate(_, project) }
+        tfc.features map { fixupTaskFeatureCreate(_, project, statusOption) }
     )
 
   def fixupTaskFeatureCreate(
       tfc: Task.TaskFeatureCreate,
-      project: Project
+      project: Project,
+      statusOption: Option[TaskStatus] = None
   ): Task.TaskFeatureCreate =
     tfc.copy(
-      properties = fixupTaskPropertiesCreate(tfc.properties, project)
+      properties =
+        fixupTaskPropertiesCreate(tfc.properties, project, statusOption)
     )
 
   def fixupTaskPropertiesCreate(
       tpc: Task.TaskPropertiesCreate,
-      project: Project
+      project: Project,
+      statusOption: Option[TaskStatus] = None
   ): Task.TaskPropertiesCreate =
-    tpc.copy(projectId = project.id, projectLayerId = project.defaultLayerId)
+    tpc.copy(
+      projectId = project.id,
+      projectLayerId = project.defaultLayerId,
+      status = statusOption.getOrElse(tpc.status)
+    )
 
   def fixupProjectExtrasUpdate(
       labelValidateTeamCreate: (Team.Create, Team.Create),
@@ -332,7 +357,9 @@ trait PropTestHelpers {
       dbOrg: Organization,
       dbUser: User,
       dbPlatform: Platform,
-      dbProject: Project
+      dbProject: Project,
+      labelsOption: Option[List[(UUID, String, UUID)]] = None,
+      labelGroupsOption: Option[Map[UUID, String]] = None
   ): ConnectionIO[Project] = {
     val (labelTeamCreate, validateTeamCreate) = labelValidateTeamCreate
     val (labelTeamUgrCreate, validateTeamUgrCreate) = labelValidateTeamUgrCreate
@@ -368,11 +395,11 @@ trait PropTestHelpers {
       _ <- ProjectDao.updateProject(
         dbProject.copy(
           extras = Some(
-            ProjectExtras(
-              ProjectExtrasAnnotate(
-                dbLabelTeam.id,
-                dbValidateTeam.id
-              )
+            fixupProjectExtrasAnnotate(
+              dbLabelTeam.id,
+              dbValidateTeam.id,
+              labelsOption,
+              labelGroupsOption
             ).asJson
           )
         ),
@@ -380,6 +407,56 @@ trait PropTestHelpers {
       )
       updatedDbProject <- ProjectDao.unsafeGetProjectById(dbProject.id)
     } yield updatedDbProject
+  }
+
+  def fixupProjectExtrasAnnotate(
+      labelTeamId: UUID,
+      validateTeamId: UUID,
+      labelsOption: Option[List[(UUID, String, UUID)]] = None,
+      labelGroupsOption: Option[Map[UUID, String]] = None
+  ): ProjectExtras = (labelsOption, labelGroupsOption) match {
+    case (Some(labels), Some(labelGroups)) =>
+      val createdLabels = labels.map(label => {
+        ProjectExtrasAnnotateLabel(
+          label._2,
+          label._1,
+          "red",
+          label._3,
+          false
+        )
+      })
+      ProjectExtras(
+        ProjectExtrasAnnotate(
+          labelTeamId,
+          validateTeamId,
+          createdLabels,
+          "detection",
+          true,
+          None,
+          labelGroups
+        ))
+    case _ =>
+      val defaultLabelId = UUID.randomUUID()
+      val defaultLayerGroupId = UUID.randomUUID()
+      val defaultLabels = List(
+        ProjectExtrasAnnotateLabel(
+          "Test",
+          defaultLabelId,
+          "red",
+          defaultLayerGroupId,
+          false
+        )
+      )
+      ProjectExtras(
+        ProjectExtrasAnnotate(
+          labelTeamId,
+          validateTeamId,
+          defaultLabels,
+          "detection",
+          true,
+          None,
+          Map(defaultLayerGroupId -> "Test Group")
+        ))
   }
 
   def fixupStacExportCreate(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -280,8 +280,8 @@ class StacExportDaoSpec
                                                                   platform,
                                                                   projectCreate)
             fixedStacExportCreate1 = fixupStacExportCreate(stacExportCreate1,
-                                                          dbUser,
-                                                          dbProject)
+                                                           dbUser,
+                                                           dbProject)
             fixedStacExportCreate2 = fixupStacExportCreate(stacExportCreate2,
                                                            dbUser,
                                                            dbProject)
@@ -295,7 +295,9 @@ class StacExportDaoSpec
               dbStacExport1.id
             )
             paginatedStacExport <- StacExportDao
-              .list(page, queryParams.copy(exportStatus = Some("Exported")), dbUser)
+              .list(page,
+                    queryParams.copy(exportStatus = Some("Exported")),
+                    dbUser)
           } yield paginatedStacExport
 
           val paginatedResp =


### PR DESCRIPTION
## Overview

This PR:
- adds a method in `TaskDao` to select tasks filtered by a list of statuses from a project layer, so that their geometries can be combined to create the AOI of the the Label STAC **Item**
- adds two method in `AnnotationDao`:
    * one for generating STAC compliant label **data** for detection project, by spatially filter annotations by tasks with specified statuses (legacy detection projects' annotations don't have `task_id` field populated)
    * one for generating STAC compliant label **data** feature collection for single or multi-class classification project, by selecting annotations by task IDs with specified statuses and transforming the resulted classes to key-value pairs in the properties field in each GeoJSON Feature

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Styleguide updated, if necessary~
- ~Swagger specification updated~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests

## Testing Instructions

- Make sure the new tests make sense (the classification project's test case, with name `list classification annotations from a layer by task status`, also tests encoding GeoJSON Feature and FeatureCollection)
- CI

Closes https://github.com/azavea/raster-foundry-platform/issues/797
