### PR TITLE
Add metadata fields for scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- added `taskId` to annotations and corresponding query paramter [\#5073](https://github.com/raster-foundry/raster-foundry/pull/5073)
+- Added `taskId` to annotations and corresponding query paramter [\#5073](https://github.com/raster-foundry/raster-foundry/pull/5073)
+- Added fields to track metadata for scenes to help with RasterSource construction [\#5103](https://github.com/raster-foundry/raster-foundry/pull/5103)
 
 ### Changed
 - Add support for multiband imagery in WMS responses

--- a/app-backend/db/src/main/resources/migrations/V11__Add_rastersource_metadata.sql
+++ b/app-backend/db/src/main/resources/migrations/V11__Add_rastersource_metadata.sql
@@ -1,0 +1,9 @@
+--- Adds fields to scenes for storing raster source metadata
+ALTER TABLE scenes
+ADD COLUMN data_path text,
+ADD COLUMN crs text,
+ADD COLUMN band_count integer,
+ADD COLUMN cell_type text,
+ADD COLUMN grid_extent jsonb,
+ADD COLUMN resolutions jsonb,
+ADD COLUMN no_data_value double precision;


### PR DESCRIPTION
## Overview

Adds some metadata for scenes to track some information about scenes to help with tile serving

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Run migrations and test tile serving and scenes endpoint by browsing to the data page and one of the development projects

