### PR TITLE
Update PR template to include checking for needing indices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,8 +5,8 @@ Brief description of what this PR does, and why it is needed.
 ### Checklist
 
 - [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
-- [ ] Styleguide updated, if necessary
 - [ ] Swagger specification updated
+- [ ] New tables and queries have appropriate indices added
 - [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
 - [ ] Any new SQL strings have tests
 


### PR DESCRIPTION
## Overview

We have missed adding indices to tables a few times when they are queries a lot. This updates the PR template to remove reference to the style guide (not maintained) and adds a checkbox for updating indices on new tables and queries if necessary.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

