### PR TITLE
Write STAC export to S3

### DIFF
--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -107,3 +107,9 @@ dropbox {
 auth0 {
   systemUser = ${?AUTH0_SYSTEM_USER}
 }
+
+s3 {
+  region = "us-east-1"
+  region = ${?AWS_REGION}
+  dataBucket = ${?DATA_BUCKET}
+}

--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -203,7 +203,7 @@ class LabelCollectionBuilder[
         Some("Label Collection")
       ),
       StacLink(
-        "../rootPath",
+        s"../${rootPath}",
         StacRoot,
         Some(`application/json`),
         Some("Root")

--- a/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
@@ -186,7 +186,7 @@ class LayerCollectionBuilder[
         Some(s"Scene Collection ${sceneCollectionId}")
       ),
       StacLink(
-        rootPath,
+        sceneCollectionRootPath,
         StacRoot,
         Some(`application/json`),
         Some("Root")
@@ -232,7 +232,7 @@ class LayerCollectionBuilder[
         Some(s"Label Collection ${labelCollectionId}")
       ),
       StacLink(
-        rootPath,
+        labelCollectionRootPath,
         StacRoot,
         Some(`application/json`),
         Some("Root")

--- a/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
@@ -120,8 +120,8 @@ class StacCatalogBuilder[
     ev.unused
     // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>
     val absPath: String = stacCatalog.parentPath.get
-    // ../catalog.json
-    val rootPath = "../catalog.json"
+    // catalog.json
+    val rootPath = "catalog.json"
 
     val layerCollectionList: List[
       (
@@ -147,18 +147,18 @@ class StacCatalogBuilder[
           new LayerCollectionBuilder[
             LayerCollectionBuilder.CollectionBuilder.EmptyCollection
           ]()
-        val layerSelfAbsLink = s"${absPath}/catalog.json"
+        val layerSelfAbsLink = s"${layerCollectionAbsPath}/collection.json"
         val layerOwnLinks = List(
           StacLink(
             // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
-            layerSelfAbsLink,
+            s"${absPath}/catalog.json",
             Parent,
             Some(`application/json`),
             Some(s"Catalog ${stacCatalog.id.get}")
           ),
           StacLink(
             // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/collection.json
-            s"${layerCollectionAbsPath}/collection.json",
+            layerSelfAbsLink,
             Self,
             Some(`application/json`),
             Some(s"Layer Collection ${layerId}")

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -33,6 +33,7 @@ final case class WriteStacCatalog(exportId: UUID)(
 
   protected def s3Client = S3()
 
+  @SuppressWarnings(Array("CatchThrowable"))
   protected def putObjectToS3(selfLink: String,
                               data: String,
                               contentType: String) = {
@@ -57,6 +58,7 @@ final case class WriteStacCatalog(exportId: UUID)(
     }
   }
 
+  @SuppressWarnings(Array("OptionGet"))
   protected def getStacSelfLink(stacLinks: List[StacLink]): String =
     stacLinks.find(_.rel == Self).map(_.href).get
 

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -230,8 +230,43 @@ final case class WriteStacCatalog(exportId: UUID)(
       .withContents(contentBundle)
       .build()
 
-    println(catalog.asJson)
-    println(layerSceneLabelCollectionsItemsAssets)
+    
+    layerSceneLabelCollectionsItemsAssets.map {
+      case (layerCollection, (sceneCollection, sceneItemList), (labelCollection, labelItem, (_, labelDataLink))) =>
+        val catalogSelfLink: String = catalog.links.find(_.rel == Self).map(_.href).getOrElse("")
+        println("catalogSelfLink")
+        println(catalogSelfLink)
+        println(catalog.asJson)
+
+        val layerCollectionSelfLink: String = layerCollection.links.find(_.rel == Self).map(_.href).getOrElse("")
+        println("layerCollectionSelfLink")
+        println(layerCollectionSelfLink)
+        println(layerCollection.asJson)
+        
+        val sceneCollectionSelfLink: String = sceneCollection.links.find(_.rel == Self).map(_.href).getOrElse("")
+        println("sceneCollectionSelfLink")
+        println(sceneCollectionSelfLink)
+        println(sceneCollection.asJson)
+
+        val sceneItemSelfLink: String = sceneItemList(0).links.find(_.rel == Self).map(_.href).getOrElse("")
+        println("sceneItemSelfLink")
+        println(sceneItemSelfLink)
+        println(sceneItemList(0).asJson)
+
+        val labelCollectionSelfLink: String = labelCollection.links.find(_.rel == Self).map(_.href).getOrElse("")
+        println("labelCollectionSelfLink")
+        println(labelCollectionSelfLink)
+        println(labelCollection.asJson)
+
+        val labelItemSelfLink: String = labelItem.links.find(_.rel == Self).map(_.href).head
+        println("labelItemSelfLink")
+        println(labelItemSelfLink)
+        println(labelItem.asJson)
+        
+
+        println("labelDataLink")
+        println(labelDataLink)
+    }
 
     // TODO: Write STAC catalog etc to s3
     // writeToS3(catalog, layerSceneLabelCollectionsItemsAssets)

--- a/app-backend/batch/src/main/scala/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/util/conf/Config.scala
@@ -122,7 +122,7 @@ trait Config {
   protected lazy val dropboxConfig: Dropbox = config.as[Dropbox]("dropbox")
   val jarPath =
     "s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar"
-  
+
   protected lazy val s3Config = config.getConfig("s3")
   protected lazy val region = s3Config.getString("region")
   protected lazy val dataBucket = s3Config.getString("dataBucket")

--- a/app-backend/batch/src/main/scala/util/conf/Config.scala
+++ b/app-backend/batch/src/main/scala/util/conf/Config.scala
@@ -122,4 +122,8 @@ trait Config {
   protected lazy val dropboxConfig: Dropbox = config.as[Dropbox]("dropbox")
   val jarPath =
     "s3://us-east-1.elasticmapreduce/libs/script-runner/script-runner.jar"
+  
+  protected lazy val s3Config = config.getConfig("s3")
+  protected lazy val region = s3Config.getString("region")
+  protected lazy val dataBucket = s3Config.getString("dataBucket")
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -465,7 +465,7 @@ object TaskDao extends Dao[Task] {
       }
     (fr"""
       SELECT
-        ST_Transform(ST_Collect(geometry), 4326) AS geometry,
+        ST_Transform(ST_Buffer(ST_Union(ST_Buffer(geometry, 1)), -1), 4326) AS geometry,
         ST_XMin(ST_Extent(ST_Transform(geometry, 4326))) AS x_min,
         ST_YMin(ST_Extent(ST_Transform(geometry, 4326))) AS y_min,
         ST_XMax(ST_Extent(ST_Transform(geometry, 4326))) AS x_max,


### PR DESCRIPTION
## Overview

This PR enables writing STAC export to RF S3 data bucket that respects the internal structure of the catalog.

```
Exported Catalog:
     |-> Layer collection
     |   |-> Scene Collection
     |   |   |-> Scene Item
     |   |   |-> Scene Item
     |   |   |-> (One or more scene items)
     |   |-> Label Collection
     |   |   |-> Label Item (Only one)
     |   |   |-> Label Data in GeoJSON Feature Collection
     |-> (One or more Layer Collections)
```

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions
- `./scripts/load_development_data --download`
- `./scripts/console`:
   * `api/assembly`
   * `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "AL Project Test 1",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID>`
- Check on S3 development data bucket -> `stac-exports`, there should be a new folder containing your exported catalog

Closes https://github.com/raster-foundry/raster-foundry/issues/5087
