### PR TITLE
Add Metadata Serialization for Scenes and Backfill Command

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.backsplash
 import java.net.URLDecoder
 
 import com.rasterfoundry.common.color._
-import com.rasterfoundry.datamodel.SingleBandOptions
+import com.rasterfoundry.datamodel.{SceneMetadataFields, SingleBandOptions}
 import geotrellis.vector.{io => _, _}
 import geotrellis.raster.{io => _, _}
 import geotrellis.raster.resample.NearestNeighbor
@@ -50,7 +50,7 @@ final case class BacksplashGeotiff(
     singleBandOptions: Option[SingleBandOptions.Params],
     mask: Option[MultiPolygon],
     @cacheKeyExclude footprint: MultiPolygon,
-    noDataValue: Option[Double])
+    metadata: SceneMetadataFields)
     extends LazyLogging
     with BacksplashImage[IO] {
 
@@ -64,7 +64,7 @@ final case class BacksplashGeotiff(
       // Do not bother caching - let GDAL internals worry about that
       val rasterSource = GDALRasterSource(URLDecoder.decode(uri, "UTF-8"))
       IO {
-        noDataValue match {
+        metadata.noDataValue match {
           case Some(nd) =>
             rasterSource.interpretAs(DoubleUserDefinedNoDataCellType(nd))
           case _ =>
@@ -77,7 +77,7 @@ final case class BacksplashGeotiff(
         logger.debug(s"Using GeoTiffRasterSource: ${uri}")
         val rasterSource = new GeoTiffRasterSource(uri)
         IO {
-          noDataValue match {
+          metadata.noDataValue match {
             case Some(nd) =>
               rasterSource.interpretAs(DoubleUserDefinedNoDataCellType(nd))
             case _ =>
@@ -152,7 +152,7 @@ sealed trait BacksplashImage[F[_]] extends LazyLogging {
   val projectId: UUID
   val projectLayerId: UUID
   val mask: Option[MultiPolygon]
-  val noDataValue: Option[Double]
+  val metadata: SceneMetadataFields
 
   val enableGDAL = Config.RasterSource.enableGDAL
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
@@ -89,7 +89,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])
       singleBandOptions,
       mosaicDefinition.mask,
       footprint,
-      mosaicDefinition.noDataValue
+      mosaicDefinition.sceneMetadataFields
     )
   }
 
@@ -132,7 +132,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])
             None, // no single band options ever
             None, // not adding the mask here, since out of functional scope for md to image
             footprint,
-            scene.metadataFields.noDataValue
+            scene.metadataFields
           )
         }
       }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
@@ -63,7 +63,7 @@ class SceneService[RendStore, HistStore](
           None, // no single band options ever
           None, // not adding the mask here, since out of functional scope for md to image
           footprint,
-          scene.metadataFields.noDataValue
+          scene.metadataFields
         )
     }
   }

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -1,7 +1,11 @@
 package com.rasterfoundry.batch
 
 import com.rasterfoundry.batch.aoi.FindAOIProjects
-import com.rasterfoundry.batch.cogMetadata.{HistogramBackfill, OverviewBackfill}
+import com.rasterfoundry.batch.cogMetadata.{
+  HistogramBackfill,
+  OverviewBackfill,
+  RasterSourceMetadataBackfill
+}
 import com.rasterfoundry.batch.export.{CreateExportDef, UpdateExportStatus}
 import com.rasterfoundry.batch.healthcheck.HealthCheck
 import com.rasterfoundry.batch.aoi.UpdateAOIProject
@@ -15,6 +19,7 @@ object Main {
     FindAOIProjects.name -> (FindAOIProjects.main(_)),
     HealthCheck.name -> (HealthCheck.main(_)),
     HistogramBackfill.name -> (HistogramBackfill.main(_)),
+    RasterSourceMetadataBackfill.name -> (RasterSourceMetadataBackfill.main(_)),
     NotifyIngestStatus.name -> (NotifyIngestStatus.main(_)),
     OverviewBackfill.name -> (OverviewBackfill.main(_)),
     ReadStacFeature.name -> (ReadStacFeature.main(_)),

--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -1,0 +1,79 @@
+package com.rasterfoundry.batch.cogMetadata
+
+import java.net.URLDecoder
+import java.util.UUID
+
+import cats.effect.IO
+import cats.implicits._
+import com.rasterfoundry.batch.Job
+import com.rasterfoundry.common.RollbarNotifier
+import com.rasterfoundry.database.RasterSourceMetadataDao
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.datamodel.RasterSourceMetadata
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+import geotrellis.contrib.vlm.gdal.GDALRasterSource
+
+object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
+
+  type CogTuple = (UUID, String)
+
+  val name = "rastersource-metadata-backfill"
+
+  def getScenesToBackfill(
+      implicit xa: Transactor[IO]): IO[List[(UUID, String)]] = {
+    logger.info("Finding COG scenes without metadata in layer_attributes")
+    fr"""select
+           id, ingest_location
+         from
+           scenes
+         where
+           scene_type = 'COG' and
+           ingest_location is not null and
+           crs is null;
+       """.query[(UUID, String)].to[List].transact(xa) map { tuples =>
+      {
+        logger.info(s"Found ${tuples.length} scenes to get metadata for")
+        tuples
+      }
+    }
+  }
+
+  // presence of the ingest location is guaranteed by the filter in the sql string
+  @SuppressWarnings(Array("OptionGet"))
+  def insertRasterSourceMetadata(cogTuple: CogTuple)(
+      implicit xa: Transactor[IO]): IO[RasterSourceMetadata] = {
+    println(s"Getting Raster Source: ${cogTuple._1}")
+    val rasterSource = GDALRasterSource(URLDecoder.decode(cogTuple._2, "UTF-8"))
+    println(s"Getting Metadata: ${cogTuple._1}")
+    val rasterSourceMetadata = RasterSourceMetadata(
+      rasterSource.dataPath,
+      rasterSource.crs,
+      rasterSource.bandCount,
+      rasterSource.cellType,
+      rasterSource.noDataValue,
+      rasterSource.gridExtent,
+      rasterSource.resolutions
+    )
+    println(s"Inserting Metadata: ${cogTuple._1}")
+    val md = RasterSourceMetadataDao
+      .update(cogTuple._1, rasterSourceMetadata)
+      .transact(xa)
+      .map(_ => rasterSourceMetadata)
+    println(s"Done: ${cogTuple._1}")
+    md
+  }
+
+  def runJob(args: List[String]) =
+    RFTransactor.xaResource.use { transactor =>
+      implicit val xa = transactor
+      for {
+        scenes <- getScenesToBackfill(xa)
+        metadata <- scenes.map(t => insertRasterSourceMetadata(t)).parSequence
+      } yield {
+        metadata
+          .foreach(rsm => println(s"Inserted metadata for ${rsm.dataPath}"))
+      }
+    }
+}

--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -44,9 +44,9 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
   @SuppressWarnings(Array("OptionGet"))
   def insertRasterSourceMetadata(cogTuple: CogTuple)(
       implicit xa: Transactor[IO]): IO[RasterSourceMetadata] = {
-    println(s"Getting Raster Source: ${cogTuple._1}")
+    logger.info(s"Getting Raster Source: ${cogTuple._1}")
     val rasterSource = GDALRasterSource(URLDecoder.decode(cogTuple._2, "UTF-8"))
-    println(s"Getting Metadata: ${cogTuple._1}")
+    logger.info(s"Getting Metadata: ${cogTuple._1}")
     val rasterSourceMetadata = RasterSourceMetadata(
       rasterSource.dataPath,
       rasterSource.crs,
@@ -56,7 +56,7 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
       rasterSource.gridExtent,
       rasterSource.resolutions
     )
-    println(s"Inserting Metadata: ${cogTuple._1}")
+    logger.info(s"Inserting Metadata: ${cogTuple._1}")
     val md = RasterSourceMetadataDao
       .update(cogTuple._1, rasterSourceMetadata)
       .transact(xa)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -310,6 +310,7 @@ lazy val datamodel = project
       Dependencies.geotrellisRaster,
       Dependencies.geotrellisVector,
       Dependencies.geotrellisProj4,
+      Dependencies.geotrellisContribGDAL,
       Dependencies.geotrellisVectorTestkit,
       Dependencies.circeCore,
       Dependencies.circeParser,
@@ -332,6 +333,9 @@ lazy val db = project
       Dependencies.scalatest,
       Dependencies.doobieCore,
       Dependencies.doobieHikari,
+      Dependencies.scalaCheck,
+      Dependencies.geotrellisContribGDAL,
+      Dependencies.geotrellisRaster,
       Dependencies.doobiePostgres,
       Dependencies.doobiePostgresCirce,
       Dependencies.scalaCheck,
@@ -422,7 +426,7 @@ lazy val akkautil = project
   * Backsplash Core Settings
   */
 lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
-  .dependsOn(common)
+  .dependsOn(common, db)
   .settings(sharedSettings: _*)
   .settings(
     fork in run := true,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -190,9 +190,7 @@ lazy val root = project
              lambdaOverviews)
 
 lazy val loggingDependencies = Seq(
-  Dependencies.scalaLogging % Runtime,
-  Dependencies.slf4j % Runtime,
-  Dependencies.log4jOverslf4j % Runtime, // for any java classes looking for this
+  Dependencies.scalaLogging,
   Dependencies.logbackClassic % Runtime
 )
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -424,7 +424,7 @@ lazy val akkautil = project
   * Backsplash Core Settings
   */
 lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
-  .dependsOn(common, db)
+  .dependsOn(common)
   .settings(sharedSettings: _*)
   .settings(
     fork in run := true,

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/MosaicDefinition.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/MosaicDefinition.scala
@@ -19,5 +19,5 @@ final case class MosaicDefinition(
     isSingleBand: Boolean,
     singleBandOptions: Option[Json],
     mask: Option[MultiPolygon],
-    noDataValue: Option[Double]
+    sceneMetadataFields: SceneMetadataFields
 )

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/SceneToLayer.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/SceneToLayer.scala
@@ -6,7 +6,7 @@ import io.circe.Json
 import java.util.UUID
 
 import com.rasterfoundry.common.color._
-import com.rasterfoundry.datamodel.SceneType
+import com.rasterfoundry.datamodel.{SceneMetadataFields, SceneType}
 
 final case class SceneToLayer(sceneId: UUID,
                               projectLayerId: UUID,
@@ -35,7 +35,7 @@ final case class SceneToLayerWithSceneType(
     isSingleBand: Boolean,
     singleBandOptions: Option[Json],
     mask: Option[Projected[Geometry]],
-    noDataValue: Option[Double]
+    metadataFields: SceneMetadataFields
 )
 
 @JsonCodec

--- a/app-backend/datamodel/src/main/scala/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/Scene.scala
@@ -3,6 +3,8 @@ package com.rasterfoundry.datamodel
 import java.sql.Timestamp
 import java.util.UUID
 
+import geotrellis.proj4.CRS
+import geotrellis.raster.{CellType, GridExtent}
 import geotrellis.vector.{MultiPolygon, Projected}
 import io.circe._
 import io.circe.generic.JsonCodec
@@ -32,11 +34,11 @@ final case class SceneStatusFields(
 @JsonCodec
 final case class SceneMetadataFields(
     dataPath: Option[String] = None,
-    crs: Option[String] = None,
+    crs: Option[CRS] = None,
     bandCount: Option[Int] = None,
-    cellType: Option[String] = None,
-    gridExtent: Option[Json] = None,
-    resolutions: Option[Json] = None,
+    cellType: Option[CellType] = None,
+    gridExtent: Option[GridExtent[Long]] = None,
+    resolutions: Option[List[GridExtent[Long]]] = None,
     noDataValue: Option[Double] = None
 )
 

--- a/app-backend/datamodel/src/main/scala/com/rasterfoundry/datamodel/RasterSourceMetadata.scala
+++ b/app-backend/datamodel/src/main/scala/com/rasterfoundry/datamodel/RasterSourceMetadata.scala
@@ -1,0 +1,25 @@
+package com.rasterfoundry.datamodel
+
+import geotrellis.contrib.vlm.gdal.GDALDataPath
+import geotrellis.proj4.CRS
+import geotrellis.raster.{CellType, GridExtent}
+
+/** Metadata used in the RasterSourceWithMetadata source
+  * so that the information supplied here can be used instead
+  * of reading metadata from the source
+  *
+  * @param dataPath
+  * @param crs
+  * @param bandCount
+  * @param cellType
+  * @param noDataValue
+  * @param gridExtent
+  * @param resolutions
+  */
+final case class RasterSourceMetadata(dataPath: GDALDataPath,
+                                      crs: CRS,
+                                      bandCount: Int,
+                                      cellType: CellType,
+                                      noDataValue: Option[Double],
+                                      gridExtent: GridExtent[Long],
+                                      resolutions: List[GridExtent[Long]])

--- a/app-backend/db/src/main/scala/RasterSourceMetadataDao.scala
+++ b/app-backend/db/src/main/scala/RasterSourceMetadataDao.scala
@@ -1,0 +1,61 @@
+package com.rasterfoundry.database
+
+import java.util.UUID
+
+import com.rasterfoundry.database.meta.CirceJsonbMeta
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+import com.rasterfoundry.datamodel._
+import geotrellis.contrib.vlm.gdal.GDALDataPath
+import geotrellis.proj4.CRS
+import geotrellis.raster.CellType
+import geotrellis.vector.Extent
+
+object RasterSourceMetadataDao extends CirceJsonbMeta {
+
+  implicit val dataPathMeta: Meta[GDALDataPath] =
+    Meta[String].timap(GDALDataPath.apply)(_.path)
+
+  implicit val crsMeta: Meta[CRS] =
+    Meta[String].timap(CRS.fromString)(_.toProj4String)
+
+  implicit val cellTypeMeta: Meta[CellType] =
+    Meta[String].timap(CellType.fromName)(CellType.toName)
+
+  implicit val extentMeta: Meta[Extent] =
+    Meta[Array[Double]].timap { array =>
+      Extent(array(0), array(1), array(2), array(3))
+    } { e =>
+      Array(e.xmin, e.ymin, e.xmax, e.ymax)
+    }
+
+  val selectF: Fragment =
+    fr"""
+    SELECT
+      data_path, crs, band_count, cell_type,
+      no_data_value, grid_extent, resolutions
+    FROM
+      scenes
+  """
+
+  def select(id: UUID): ConnectionIO[RasterSourceMetadata] = {
+    println(s"Getting RS: ${id}")
+    (selectF ++ Fragments.whereAnd(fr"id = ${id}"))
+      .query[RasterSourceMetadata]
+      .unique
+  }
+
+  def update(id: UUID, rsm: RasterSourceMetadata): ConnectionIO[Int] = {
+    fr"""UPDATE scenes SET
+        data_path = ${rsm.dataPath},
+        crs = ${rsm.crs},
+        band_count = ${rsm.bandCount},
+        cell_type = ${rsm.cellType},
+        grid_extent = ${rsm.gridExtent},
+        resolutions = ${rsm.resolutions},
+        no_data_value = ${rsm.noDataValue}
+        where id = ${id}
+      """.update.run
+  }
+}

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -333,7 +333,7 @@ object SceneDao
             false,
             Some(().asJson),
             None,
-            scene.metadataFields.noDataValue
+            scene.metadataFields
           )
         )
       } getOrElse { Seq.empty }

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -134,7 +134,8 @@ object SceneToLayerDao
     val select = fr"""
     SELECT
       scene_id, project_id, project_layer_id, accepted, scene_order, mosaic_definition, scene_type, ingest_location,
-      data_footprint, is_single_band, single_band_options, geometry, no_data_value
+      data_footprint, is_single_band, single_band_options, geometry, data_path, crs, band_count,
+         cell_type, grid_extent, resolutions, no_data_value
     FROM (
       scenes_to_layers
     LEFT JOIN
@@ -166,7 +167,7 @@ object SceneToLayerDao
               stp.isSingleBand,
               stp.singleBandOptions,
               stp.mask flatMap { _.geom.as[MultiPolygon] },
-              stp.noDataValue
+              stp.metadataFields
             )
         } getOrElse {
           MosaicDefinition(
@@ -179,7 +180,7 @@ object SceneToLayerDao
             stp.isSingleBand,
             stp.singleBandOptions,
             stp.mask flatMap { _.as[MultiPolygon] },
-            stp.noDataValue
+            stp.metadataFields
           )
         }
       }

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -2,15 +2,16 @@ package com.rasterfoundry.database.meta
 
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.common.color._
-
 import doobie._
 import doobie.postgres.circe.jsonb.implicits._
-import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
+import cats.implicits._
 
 import scala.reflect.runtime.universe.TypeTag
 import java.net.URI
+
+import geotrellis.raster.{CellSize, GridExtent}
 
 object CirceJsonbMeta {
   def apply[Type: TypeTag: Encoder: Decoder] = {
@@ -21,8 +22,35 @@ object CirceJsonbMeta {
 }
 
 trait CirceJsonbMeta {
+
+  implicit val cellSizeEncoder: Encoder[CellSize] =
+    (a: CellSize) =>
+      Json.obj(
+        ("width", a.width.asJson),
+        ("height", a.height.asJson)
+    )
+
+  implicit val cellSizeDecoder: Decoder[CellSize] = (c: HCursor) =>
+    for {
+      width <- c.downField("width").as[Double]
+      height <- c.downField("height").as[Double]
+    } yield {
+      new CellSize(width, height)
+  }
+
+  implicit val gridExtentMeta: Meta[GridExtent[Long]] =
+    CirceJsonbMeta[GridExtent[Long]]
+  implicit val gridExtentListMeta: Meta[List[GridExtent[Long]]] =
+    CirceJsonbMeta[List[GridExtent[Long]]]
+
+  implicit val mapMeta: Meta[Map[String, String]] =
+    CirceJsonbMeta[Map[String, String]]
+
   implicit val compositeMeta: Meta[Map[String, ColorComposite]] =
     CirceJsonbMeta[Map[String, ColorComposite]]
+
+  implicit val cellSizeMeta: Meta[List[CellSize]] =
+    CirceJsonbMeta[List[CellSize]]
 
   implicit val credentialMeta: Meta[Credential] =
     CirceJsonbMeta[Credential]

--- a/app-backend/db/src/main/scala/meta/package.scala
+++ b/app-backend/db/src/main/scala/meta/package.scala
@@ -1,13 +1,14 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.datamodel._
-
-import cats.syntax.either._
+import cats.implicits._
 import doobie._
 import io.circe.syntax._
 import org.postgresql.util.PGobject
-
 import java.time.LocalDate
+
+import geotrellis.proj4.CRS
+import geotrellis.raster.CellType
 
 package object meta {
   trait RFMeta
@@ -15,6 +16,12 @@ package object meta {
       with CirceJsonbMeta
       with EnumMeta
       with PermissionsMeta {
+
+    implicit val crsMeta: Meta[CRS] =
+      Meta[String].timap(CRS.fromString)(_.toProj4String)
+
+    implicit val cellTypeMeta: Meta[CellType] =
+      Meta[String].timap(CellType.fromName)(CellType.toName)
 
     implicit val timeRangeMeta: Meta[(LocalDate, LocalDate)] =
       Meta.Advanced


### PR DESCRIPTION
## Overview

This PR was more important when we thought storing metadata on scenes was going
to be super important for improving WMS performance. This started with creating
a new `RasterSourceWithMetadata`; however, adding a new type of `RasterSource`
and verifying its correctness was a quite a bit of work and there are two reasons
why this PR stops short of implementing `RastersourceWithMetadata`:

  1. [Two](https://github.com/raster-foundry/raster-foundry/issues/5142) [bugs](https://github.com/raster-foundry/raster-foundry/issues/5141) in the current WMS implementation made it really difficult to verify
  the correctness of `RasterSourceWithMetadata` as far as memory consumption and rendering
  different CRSes (implementing the `reproject` correctly in this new `RasterSource` was
  especially difficult with lots of edge cases and I think it makes more sense to hold off
  on this change when the current WMS implementation seems broken in some cases
  
  2. The need for quickly generating `GetCapabilities` responses is less urgent at the time
  
So why even include this PR? There are still a few things in this PR that I think are 
useful and do not represent too much additional risk. First, the addition of `NoDataValue` on
scenes (and additional metadata fields) did not include encoders/decoders for the new options
on `Scene` - which was a bug waiting to happen. This PR includes encoders/decoders for
these types to be able to serialize to/from the database/json in an expected manner. Second,
a new command for backfilling metadata on existing imagery is included - which should be useful,
but we had deferred as it wasn't deemed as necessary to fix `nodata` rendering.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

For completeness - here is the implementation of `RasterSourceWithMetadata` that is excluded from this PR:

```scala
package com.rasterfoundry.backsplash

import com.rasterfoundry.datamodel.RasterSourceMetadata
import com.typesafe.scalalogging.LazyLogging
import geotrellis.contrib.vlm.Implicits._
import geotrellis.contrib.vlm.gdal.{
  GDALDataPath,
  GDALRasterSource,
  GDALWarpOptions
}
import geotrellis.contrib.vlm.{RasterSource, ResampleGrid, TargetCellType}
import geotrellis.proj4.CRS
import geotrellis.raster.io.geotiff.OverviewStrategy
import geotrellis.raster.reproject.Reproject
import geotrellis.raster.resample.ResampleMethod
import geotrellis.raster.{
  CellType,
  GridBounds,
  GridExtent,
  MultibandTile,
  Raster
}
import geotrellis.vector.Extent

/** Rastersource that populates its metadata with information supplied
  * from outside the source imagery -- this is to avoid metadata reads
  * from sources when used in the context of a MosaicRasterSource
  *
  * @param rsm
  * @param rasterSource
  * @param targetCellType
  */
case class RasterSourceWithMetadata(original: RasterSourceMetadata,
                                    rasterSource: GDALRasterSource,
                                    targetCellType: Option[TargetCellType] =
                                      None,
                                    rsm: Option[RasterSourceMetadata] = None)
    extends RasterSource
    with LazyLogging {

  logger.info(
    s"GridExtents: RSM: ${rsm.map(_.gridExtent)}, rastersource: ${rasterSource.gridExtent}, original: ${original.gridExtent}")
  val dataPath: GDALDataPath = rasterSource.dataPath
  val path: String = dataPath.path

  override val crs: CRS = rsm.getOrElse(original).crs
  override val bandCount: Int = rsm.getOrElse(original).bandCount
  override val cellType: CellType = rsm.getOrElse(original).cellType
  override val gridExtent: GridExtent[Long] = {
    val ge = rsm.getOrElse(original).gridExtent
    logger.info(s"Retrieving Grid Extent: ${ge}")
    ge
  }

  override def resolutions: List[GridExtent[Long]] =
    rsm.getOrElse(original).resolutions

  override def reproject(targetCRS: CRS,
                         reprojectOptions: Reproject.Options,
                         strategy: OverviewStrategy): RasterSource = {
    logger.info(s"Reproject Options: ${reprojectOptions}")
    val reprojectedGridExtent =
      original.gridExtent.reproject(original.crs, targetCRS, reprojectOptions)

    logger.info(s"Reprojected Cell Size: ${reprojectedGridExtent.cellSize}")

    val updatedResolutions =
      original.resolutions.map(_.reproject(original.crs, targetCRS))

    val options: GDALWarpOptions = rasterSource.options.copy(
      cellSize = Some(reprojectedGridExtent.cellSize),
      sourceCRS = Some(original.crs),
      targetCRS = Some(targetCRS),
      resampleMethod = Some(reprojectOptions.method)
    )

    RasterSourceWithMetadata(
      original,
      GDALRasterSource(dataPath, options),
      targetCellType,
      Some(
        original.copy(crs = targetCRS,
                      gridExtent = reprojectedGridExtent,
                      resolutions = updatedResolutions))
    )

  }

  override def resample(resampleGrid: ResampleGrid[Long],
                        method: ResampleMethod,
                        strategy: OverviewStrategy): RasterSource = {
    RasterSourceWithMetadata(
      original,
      GDALRasterSource(dataPath,
                       rasterSource.options.resample(gridExtent, resampleGrid)),
      targetCellType,
      Some(original.copy(gridExtent = resampleGrid(gridExtent)))
    )
  }

  override def read(extent: Extent,
                    bands: Seq[Int]): Option[Raster[MultibandTile]] = {
    println(s"Read with Extent $extent and Bands")
    logger.info(
      s"Cell Sizes At Read: rsm: ${rsm.get.gridExtent.cellSize} rastersource: ${rasterSource.gridExtent.cellSize}")
    logger.info(s"Rastersource Extent: ${rasterSource.extent}")
    logger.info(
      s"Rastersource Metadata: crs ${rasterSource.crs}, grid extent ${rasterSource.gridExtent}, datapath ${rasterSource.dataPath}")
    val gb = rasterSource.gridExtent.gridBoundsFor(extent)
    logger.info(
      s"Grid Bounds ${gb.size} cols: ${gb.colMax - gb.colMin} rows: ${gb.rowMax - gb.rowMin}")
    this.rasterSource.read(extent, bands)
  }

  override def read(bounds: GridBounds[Long],
                    bands: Seq[Int]): Option[Raster[MultibandTile]] = {
    println(s"Read with GridBounds $bounds and Bands")
    rasterSource.read(bounds, bands)
  }

  override def readBounds(bounds: Traversable[GridBounds[Long]],
                          bands: Seq[Int]): Iterator[Raster[MultibandTile]] = {
    println(s"Ready with Traversable Bounds $bounds")
    rasterSource.readBounds(bounds, bands)

  }

  override def convert(targetCellType: TargetCellType): RasterSource = {
    RasterSourceWithMetadata(
      original,
      GDALRasterSource(
        dataPath,
        rasterSource.options.convert(targetCellType,
                                     rsm.getOrElse(original).noDataValue,
                                     Some(cols.toInt -> rows.toInt)),
        Some(targetCellType)),
      Some(targetCellType),
      Some(original.copy(cellType = targetCellType.cellType))
    )
  }
}
```

## Testing Instructions

- Re-assemble the batch subproject
- Run `./scripts/console/ batch bash`
- Run `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main rastersource-metadata-backfill`
- Assemble API server and start
- After exporting JWT auth token make the following `http` request:
`http --auth-type=jwt :9100/api/scenes/71758023-abb6-47df-ba8b-996358e2fc2e`
- Inspect the JSON metadata fields are filled in with values that look correc (e.g. a `proj4` string for `CRS`, a `gridExtent`, etc.)

Closes https://github.com/azavea/raster-foundry-platform/issues/810
