### PR TITLE
Correctly mosaic tiles which have a no-data value other than 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Correctly mosaic tiles which have a no-data value other than 0 [\#5131](https://github.com/raster-foundry/raster-foundry/pull/5131)
+
 ### Security
 
 ## [1.27.0](https://github.com/raster-foundry/raster-foundry/compare/1.26.0...1.27.0)

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -5,6 +5,7 @@ import geotrellis.raster.{ArrayTile, MultibandTile, isData}
 import io.circe.generic.JsonCodec
 import org.apache.commons.math3.util.FastMath
 import spire.syntax.cfor.cfor
+import geotrellis.raster.UByteConstantNoDataCellType
 
 /**
   * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
@@ -119,10 +120,11 @@ object ColorCorrect extends LazyLogging {
   ): MultibandTile = {
     val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
     val (gr, gg, gb) = (gammas(0), gammas(1), gammas(2))
+    val tileCellType = UByteConstantNoDataCellType
     val (nred, ngreen, nblue) = (
-      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
-      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows),
-      ArrayTile.alloc(rgbTile.cellType, rgbTile.cols, rgbTile.rows)
+      ArrayTile.alloc(tileCellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(tileCellType, rgbTile.cols, rgbTile.rows),
+      ArrayTile.alloc(tileCellType, rgbTile.cols, rgbTile.rows)
     )
 
     val ClipBounds(rmin, rmax) = layerNormalizeArgs(0)


### PR DESCRIPTION
## Overview
Use uByteConstantNoDataCellType for color corrected imagery instead of the original tile's celltype

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![test](https://user-images.githubusercontent.com/4392704/63614308-b0a48a00-c5b0-11e9-847f-d9f2782aa61a.jpg)


## Testing Instructions

- assemble backsplash-server
- Create a project and import two scenes which a) overlap and b) have a nodata value other than 0
https://github.com/azavea/raster-foundry-platform/issues/822 lists a project with two such scenes
- Verify that the project mosaics the two scenes without a gap or transparency where there should be data
- Verify that all the other development scenes mosaic / render correctly

Closes https://github.com/azavea/raster-foundry-platform/issues/822