### PR TITLE
Tune proxy_connect_timeout to make Nginx fail faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Upgrade doobie to 0.7.0 [\#5130](https://github.com/raster-foundry/raster-foundry/pull/5130)
 - Updated STAC export location to use the S3 prefix [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Updated values for label:task, label:property, and label:classes of the STAC label item [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
+- Tune proxy_connect_timeout to make Nginx fail faster [\#5133](https://github.com/raster-foundry/raster-foundry/pull/5133)
 
 ### Deprecated
 

--- a/nginx/etc/nginx/includes/proxy-settings.conf
+++ b/nginx/etc/nginx/includes/proxy-settings.conf
@@ -5,5 +5,5 @@
 proxy_set_header Host $http_host;
 proxy_set_header X-Forwarded-For $remote_addr;
 proxy_connect_timeout 5s;
-proxy_read_timeout 15s;
+proxy_read_timeout 10s;
 proxy_redirect off;

--- a/nginx/etc/nginx/includes/proxy-settings.conf
+++ b/nginx/etc/nginx/includes/proxy-settings.conf
@@ -5,5 +5,5 @@
 proxy_set_header Host $http_host;
 proxy_set_header X-Forwarded-For $remote_addr;
 proxy_connect_timeout 5s;
-proxy_read_timeout 20s;
+proxy_read_timeout 5s;
 proxy_redirect off;

--- a/nginx/etc/nginx/includes/proxy-settings.conf
+++ b/nginx/etc/nginx/includes/proxy-settings.conf
@@ -5,5 +5,5 @@
 proxy_set_header Host $http_host;
 proxy_set_header X-Forwarded-For $remote_addr;
 proxy_connect_timeout 5s;
-proxy_read_timeout 5s;
+proxy_read_timeout 15s;
 proxy_redirect off;

--- a/nginx/etc/nginx/includes/proxy-settings.conf
+++ b/nginx/etc/nginx/includes/proxy-settings.conf
@@ -4,5 +4,6 @@
 
 proxy_set_header Host $http_host;
 proxy_set_header X-Forwarded-For $remote_addr;
+proxy_connect_timeout 5s;
 proxy_read_timeout 20s;
 proxy_redirect off;


### PR DESCRIPTION
## Overview

Requests to Backsplash, without tuning `proxy_connect_timeout`, get killed when the `proxy_read_timeout` threshold trips:

![no connect timeout](https://user-images.githubusercontent.com/1774125/63621443-ec941b00-c5c1-11e9-80ff-5ff1ae6b964a.png)

With `proxy_connect_timeout` tuned to `5s`:

![with connect timeout](https://user-images.githubusercontent.com/1774125/63621446-f289fc00-c5c1-11e9-84f7-ed179e839c1b.png)

I think this is a step in the right direction. However, the [timeouts](https://github.com/azavea/raster-foundry-deployment/blob/26efbcf83d6080ee0b1ff29fba3243eb71d338bc/core/terraform/backsplash.tf#L48) for the Backsplash target groups are `3s` (HTTP) and `5s` (HTTPS), so this shouldn't impact how quickly an ECS health check fails.

Connects https://github.com/azavea/raster-foundry-platform/issues/802

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

## Testing Instructions

- Checkout `develop`
- Bring up a local instance of Raster Foundry:
```
export AWS_PROFILE=raster-foundry
export RF_SETTINGS_BUCKET=rasterfoundry-development-config-us-east-1
./scripts/bootstrap
./scripts/update
./scripts/load_development_data --download
./scripts/server
```
- In another pane, kill Backsplash:
```bash
docker kill raster-foundry_backsplash_1
```
- Navigate to a project; observe tile requests throw a 502 after ~20s
- Checkout `feature/jrb/make-nginx-fail-faster`
- Restart `./scripts/server`
- Kill Backsplash
- Navigate to a project; observe tile requests throw a 504 after ~5s
