### PR TITLE
Decrease duplicated queries for tile rendering for thumbnails and mosaic TMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- Eliminated superfluous scene queries in thumbnail rendering [\#5139](https://github.com/raster-foundry/raster-foundry/pull/5139)
+
 ### Security
 
 ## [1.28.0](https://github.com/raster-foundry/raster-foundry/compare/1.27.0...1.28.0)

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -9,7 +9,7 @@ import com.rasterfoundry.database.util.RFTransactor
 
 import doobie.implicits._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 object AkkaSystem {
   implicit val system = ActorSystem("rf-system")
@@ -22,6 +22,7 @@ object Main extends App with Config with Router {
   implicit val materializer = AkkaSystem.materializer
 
   val xa = RFTransactor.buildTransactor()
+  implicit val ec = ExecutionContext.Implicits.global
 
   val canSelect = sql"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync
   logger.info(s"Server Started (${canSelect})")

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -19,7 +19,7 @@ import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.circe._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Success
 
@@ -33,6 +33,8 @@ trait ExportRoutes
     with AWSBatch {
 
   val xa: Transactor[IO]
+
+  implicit val ec: ExecutionContext
 
   val exportRoutes: Route = handleExceptions(userExceptionHandler) {
     pathEndOrSingleSlash {

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -12,7 +12,7 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.Transactor
 import doobie.implicits._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import java.util.UUID
 
 trait ProjectAnnotationRoutes
@@ -23,6 +23,7 @@ trait ProjectAnnotationRoutes
     with QueryParametersCommon {
 
   implicit val xa: Transactor[IO]
+  implicit val ec: ExecutionContext
 
   def listAnnotations(projectId: UUID): Route = extractTokenHeader { tokenO =>
     extractMapTokenParam { mapTokenO =>
@@ -66,7 +67,7 @@ trait ProjectAnnotationRoutes
   }
 
   def createAnnotation(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
         .transact(xa)
@@ -93,7 +94,7 @@ trait ProjectAnnotationRoutes
 
   def exportAnnotationShapefile(projectId: UUID): Route = authenticate { user =>
     (annotationExportQueryParameters) { annotationExportQP =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.View)
           .transact(xa)
@@ -124,7 +125,7 @@ trait ProjectAnnotationRoutes
 
   def getAnnotation(projectId: UUID, annotationId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.View)
           .transact(xa)
@@ -146,7 +147,7 @@ trait ProjectAnnotationRoutes
 
   def updateAnnotation(projectId: UUID): Route =
     authenticate { user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
           .transact(xa)
@@ -168,7 +169,7 @@ trait ProjectAnnotationRoutes
 
   def deleteAnnotation(projectId: UUID, annotationId: UUID): Route =
     authenticate { user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
           .transact(xa)
@@ -186,7 +187,7 @@ trait ProjectAnnotationRoutes
     }
 
   def deleteProjectAnnotations(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
         .transact(xa)
@@ -204,7 +205,7 @@ trait ProjectAnnotationRoutes
   }
 
   def listAnnotationGroups(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -220,7 +221,7 @@ trait ProjectAnnotationRoutes
   }
 
   def createAnnotationGroup(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
         .transact(xa)
@@ -239,7 +240,7 @@ trait ProjectAnnotationRoutes
 
   def getAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.View)
           .transact(xa)
@@ -258,7 +259,7 @@ trait ProjectAnnotationRoutes
       projectId: UUID,
       annotationGroupId: UUID
   ): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -275,7 +276,7 @@ trait ProjectAnnotationRoutes
 
   def updateAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
           .transact(xa)
@@ -294,7 +295,7 @@ trait ProjectAnnotationRoutes
 
   def deleteAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
           .transact(xa)

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -13,7 +13,7 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.Transactor
 import doobie.implicits._
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 import java.util.UUID
 
@@ -25,6 +25,8 @@ trait ProjectLayerAnnotationRoutes
     with QueryParametersCommon {
 
   implicit val xa: Transactor[IO]
+
+  implicit val ec: ExecutionContext
 
   def listLayerLabels(projectId: UUID, layerId: UUID): Route = authenticate {
     user =>

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -13,8 +13,7 @@ import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.{ConnectionIO, Transactor}
 import doobie.implicits._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
+import scala.concurrent.ExecutionContext
 import java.util.UUID
 
 trait ProjectLayerTaskRoutes
@@ -25,6 +24,7 @@ trait ProjectLayerTaskRoutes
     with QueryParametersCommon {
 
   implicit val xa: Transactor[IO]
+  implicit val ec: ExecutionContext
 
   def listLayerTasks(projectId: UUID, layerId: UUID): Route = authenticate {
     user =>

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
 import better.files.{File => ScalaFile}
+import cats.Applicative
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
@@ -580,7 +581,7 @@ trait ProjectRoutes
   }
 
   def updateProject(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)
@@ -599,7 +600,7 @@ trait ProjectRoutes
   }
 
   def deleteProject(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Delete)
         .transact(xa)
@@ -612,7 +613,7 @@ trait ProjectRoutes
   }
 
   def listLabels(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -625,7 +626,7 @@ trait ProjectRoutes
   }
 
   def listAOIs(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -640,7 +641,7 @@ trait ProjectRoutes
   }
 
   def createAOI(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)
@@ -660,7 +661,7 @@ trait ProjectRoutes
 
   def acceptScene(projectId: UUID, sceneId: UUID): Route = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
           .transact(xa)
@@ -679,7 +680,7 @@ trait ProjectRoutes
   }
 
   def acceptScenes(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)
@@ -704,7 +705,7 @@ trait ProjectRoutes
   }
 
   def listProjectScenes(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -735,10 +736,10 @@ trait ProjectRoutes
                                                projectId,
                                                ActionType.View)
           authResult <- (authProject, projectQueryParams.analysisId) match {
-            case (false, Some(analysisId: UUID)) =>
+            case (AuthFailure(), Some(analysisId: UUID)) =>
               ToolRunDao
                 .authorizeReferencedProject(user, analysisId, projectId)
-            case (_, _) => authProject.pure[ConnectionIO]
+            case (_, _) => Applicative[ConnectionIO].pure(authProject.toBoolean)
           }
         } yield authResult
         authorized.transact(xa).unsafeToFuture
@@ -759,7 +760,7 @@ trait ProjectRoutes
 
   /** Set the manually defined z-ordering for scenes within a given project */
   def setProjectSceneOrder(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)
@@ -787,7 +788,7 @@ trait ProjectRoutes
   /** Get the color correction paramters for a project/scene pairing */
   def getProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) =
     authenticate { user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.View)
           .transact(xa)
@@ -809,7 +810,7 @@ trait ProjectRoutes
   /** Set color correction parameters for a project/scene pairing */
   def setProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) =
     authenticate { user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
           .transact(xa)
@@ -831,7 +832,7 @@ trait ProjectRoutes
     }
 
   def setProjectColorMode(projectId: UUID) = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)
@@ -854,7 +855,7 @@ trait ProjectRoutes
   /** Set color correction parameters for a list of scenes */
   def setProjectScenesColorCorrectParams(projectId: UUID) = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
           .transact(xa)
@@ -877,7 +878,7 @@ trait ProjectRoutes
 
   /** Get the information which defines mosaicing behavior for each scene in a given project */
   def getProjectMosaicDefinition(projectId: UUID) = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -903,7 +904,7 @@ trait ProjectRoutes
 
   def addProjectScenes(projectId: UUID, layerIdO: Option[UUID] = None): Route =
     authenticate { user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
           .transact(xa)
@@ -931,7 +932,7 @@ trait ProjectRoutes
   def updateProjectScenes(projectId: UUID,
                           layerIdO: Option[UUID] = None): Route =
     authenticate { user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
           .transact(xa)
@@ -964,7 +965,7 @@ trait ProjectRoutes
   def deleteProjectScenes(projectId: UUID,
                           layerIdO: Option[UUID] = None): Route = authenticate {
     user =>
-      authorizeAsync {
+      authorizeAuthResultAsync {
         ProjectDao
           .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
           .transact(xa)
@@ -990,7 +991,7 @@ trait ProjectRoutes
   }
 
   def listProjectPermissions(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)
@@ -1011,7 +1012,7 @@ trait ProjectRoutes
         (ProjectDao.authorized(user,
                                ObjectType.Project,
                                projectId,
-                               ActionType.Edit),
+                               ActionType.Edit) map { _.toBoolean },
          acrList traverse { acr =>
            ProjectDao.isValidPermission(acr, user)
          } map { _.foldLeft(true)(_ && _) }).tupled
@@ -1037,7 +1038,7 @@ trait ProjectRoutes
         (ProjectDao.authorized(user,
                                ObjectType.Project,
                                projectId,
-                               ActionType.Edit),
+                               ActionType.Edit) map { _.toBoolean },
          ProjectDao.isValidPermission(acr, user)).tupled
           .map({ authTup =>
             authTup._1 && authTup._2
@@ -1056,7 +1057,7 @@ trait ProjectRoutes
   }
 
   def listUserProjectActions(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
@@ -1087,7 +1088,7 @@ trait ProjectRoutes
   }
 
   def deleteProjectPermissions(projectId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
         .transact(xa)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -397,7 +397,7 @@ trait SceneRoutes
         .unsafeToFuture
     } {
       onSuccess(
-        SceneDao.getSceneDatasource(sceneId).transact(xa).unsafeToFuture) {
+        DatasourceDao.getSceneDatasource(sceneId).transact(xa).unsafeToFuture) {
         datasourceO =>
           complete { datasourceO }
       }
@@ -412,9 +412,11 @@ trait SceneRoutes
                                       ObjectType.Scene,
                                       sceneId,
                                       ActionType.View)
-          datasource <- SceneDao.getSceneDatasource(sceneId)
+          datasource <- DatasourceDao.getSceneDatasource(sceneId)
         } yield {
-          auth && datasource.id == UUID.fromString(sentinel2DatasourceId)
+          auth && (datasource map { (ds: Datasource) =>
+            ds.id == Some(UUID.fromString(sentinel2DatasourceId))
+          } getOrElse { false })
         }
         authorizedIO.transact(xa).unsafeToFuture
       } {

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -30,7 +30,7 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 import com.rasterfoundry.common.LayerAttribute
 
 trait SceneRoutes
@@ -42,6 +42,8 @@ trait SceneRoutes
     with AWSBatch
     with UserErrorHandler
     with HistogramJsonFormats {
+
+  implicit val ec: ExecutionContext
 
   val xa: Transactor[IO]
 
@@ -213,7 +215,7 @@ trait SceneRoutes
   }
 
   def updateScene(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       SceneDao
         .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
         .transact(xa)
@@ -232,7 +234,7 @@ trait SceneRoutes
   }
 
   def deleteScene(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       SceneDao
         .authorized(user, ObjectType.Scene, sceneId, ActionType.Delete)
         .transact(xa)
@@ -246,7 +248,7 @@ trait SceneRoutes
   }
 
   def getDownloadUrl(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       SceneWithRelatedDao
         .authorized(user, ObjectType.Scene, sceneId, ActionType.Download)
         .transact(xa)
@@ -285,7 +287,7 @@ trait SceneRoutes
   }
 
   def listScenePermissions(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       SceneDao
         .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
         .transact(xa)
@@ -303,7 +305,10 @@ trait SceneRoutes
   def replaceScenePermissions(sceneId: UUID): Route = authenticate { user =>
     entity(as[List[ObjectAccessControlRule]]) { acrList =>
       authorizeAsync {
-        (SceneDao.authorized(user, ObjectType.Scene, sceneId, ActionType.Edit),
+        (SceneDao
+           .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit) map {
+           _.toBoolean
+         },
          acrList traverse { acr =>
            SceneDao.isValidPermission(acr, user)
          } map { _.foldLeft(true)(_ && _) }).tupled
@@ -326,7 +331,10 @@ trait SceneRoutes
   def addScenePermission(sceneId: UUID): Route = authenticate { user =>
     entity(as[ObjectAccessControlRule]) { acr =>
       authorizeAsync {
-        (SceneDao.authorized(user, ObjectType.Scene, sceneId, ActionType.Edit),
+        (SceneDao
+           .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit) map {
+           _.toBoolean
+         },
          SceneDao.isValidPermission(acr, user)).tupled
           .map(authTup => authTup._1 && authTup._2)
           .transact(xa)
@@ -372,7 +380,7 @@ trait SceneRoutes
   }
 
   def deleteScenePermissions(sceneId: UUID): Route = authenticate { user =>
-    authorizeAsync {
+    authorizeAuthResultAsync {
       SceneDao
         .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
         .transact(xa)
@@ -411,7 +419,7 @@ trait SceneRoutes
           auth <- SceneDao.authorized(user,
                                       ObjectType.Scene,
                                       sceneId,
-                                      ActionType.View)
+                                      ActionType.View) map { _.toBoolean }
           datasource <- DatasourceDao.getSceneDatasource(sceneId)
         } yield {
           auth && (datasource map { (ds: Datasource) =>

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -423,7 +423,7 @@ trait SceneRoutes
           datasource <- DatasourceDao.getSceneDatasource(sceneId)
         } yield {
           auth && (datasource map { (ds: Datasource) =>
-            ds.id == Some(UUID.fromString(sentinel2DatasourceId))
+            Some(ds.id) == Some(UUID.fromString(sentinel2DatasourceId))
           } getOrElse { false })
         }
         authorizedIO.transact(xa).unsafeToFuture

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -17,21 +17,21 @@ import cats.Semigroup
 import scalacache._
 import scalacache.memoization._
 import scalacache.CatsEffect.modes._
-import ProjectStore._
+import RenderableStore._
 import ToolStore._
 import ExtentReification._
 import HasRasterExtents._
 import TmsReification._
 import com.typesafe.scalalogging.LazyLogging
 
-class MosaicImplicits[HistStore: HistogramStore, ProjStore: ProjectStore](
+class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
     histStore: HistStore,
-    projStore: ProjStore
+    rendStore: RendStore
 ) extends ToTmsReificationOps
     with ToExtentReificationOps
     with ToHasRasterExtentsOps
     with ToHistogramStoreOps
-    with ToProjectStoreOps
+    with ToRenderableStoreOps
     with ToToolStoreOps
     with LazyLogging {
 
@@ -273,9 +273,8 @@ class MosaicImplicits[HistStore: HistogramStore, ProjStore: ProjectStore](
           }
           stream = self zip {
             self flatMap { (backsplashIm: BacksplashImage[IO]) =>
-              fs2.Stream.eval(
-                projStore.getOverviewConfig(backsplashIm.projectLayerId)
-              )
+              fs2.Stream.eval( // kicks off project layer query
+                rendStore.getOverviewConfig(backsplashIm.projectLayerId))
             }
           } take (1) flatMap {
             case (baseBacksplashImage, overviewConfig) =>

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
@@ -8,10 +8,13 @@ import simulacrum._
 
 import java.util.UUID
 
-@typeclass trait ProjectStore[A] {
+// RenderableStore
+// currently scenes and layers
+//
+@typeclass trait RenderableStore[A] {
   @op("read") def read(
       self: A,
-      projId: UUID,
+      renderableId: UUID,
       window: Option[Projected[Polygon]],
       bandOverride: Option[BandOverride],
       imageSubset: Option[NEL[UUID]]
@@ -19,6 +22,6 @@ import java.util.UUID
 
   @op("getOverviewConfig") def getOverviewConfig(
       self: A,
-      projId: UUID
+      renderableId: UUID
   ): IO[OverviewConfig]
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -40,7 +40,7 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
   private def checkProjectAuthCached(user: User,
                                      projectId: UUID): IO[AuthResult[Project]] =
-    memoizeF[IO, AuthResult[Project]](Some(60.seconds)) {
+    memoizeF[IO, AuthResult[Project]](Some(60 seconds)) {
       logger.debug(
         s"Checking Project Auth User: ${user.id} => Project: ${projectId} with DB")
       ProjectDao
@@ -50,7 +50,7 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
   private def checkSceneAuthCached(user: User,
                                    sceneId: UUID): IO[AuthResult[Scene]] =
-    memoizeF[IO, AuthResult[Scene]](Some(60.seconds)) {
+    memoizeF[IO, AuthResult[Scene]](Some(60 seconds)) {
       logger.debug(
         s"Checking Scene Auth User: ${user.id} => Scene: ${sceneId} with DB"
       )
@@ -61,7 +61,7 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
   private def checkToolRunAuth(user: User,
                                toolRunId: UUID): IO[AuthResult[ToolRun]] =
-    memoizeF[IO, AuthResult[ToolRun]](Some(10.seconds)) {
+    memoizeF[IO, AuthResult[ToolRun]](Some(10 seconds)) {
       logger.debug(
         s"Checking Tool Run Auth User: ${user.id} => Project: ${toolRunId} with DB")
       ToolRunDao
@@ -71,7 +71,7 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
   private def checkProjectLayerCached(projectID: UUID,
                                       layerID: UUID): IO[Boolean] =
-    memoizeF[IO, Boolean](Some(10.seconds)) {
+    memoizeF[IO, Boolean](Some(10 seconds)) {
       logger.debug(
         s"Checking whether layer ${layerID} is in project ${projectID}")
       ProjectLayerDao.layerIsInProject(layerID, projectID).transact(xa)
@@ -79,7 +79,7 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
   private def checkProjectAnalysisCached(projectId: UUID,
                                          analysisId: UUID): IO[Boolean] =
-    memoizeF[IO, Boolean](Some(10.seconds)) {
+    memoizeF[IO, Boolean](Some(10 seconds)) {
       logger.debug(
         s"Checking whether analysis $analysisId references project $projectId")
       ToolRunDao.analysisReferencesProject(analysisId, projectId).transact(xa)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
-import com.rasterfoundry.datamodel.User
+import com.rasterfoundry.datamodel.{Scene, User}
 import com.rasterfoundry.http4s.{Cache => Http4sUtilCache}
 
 import com.typesafe.scalalogging.LazyLogging
@@ -17,6 +17,9 @@ object Cache extends LazyLogging {
     CaffeineCache[Boolean]
   logger.info(
     s"Authorization Cache Status (read/write) ${authorizationCacheFlags}")
+
+  val caffeineSceneCache: Cache[Scene] =
+    CaffeineCache[Scene]
 
   val authenticationCacheFlags = Http4sUtilCache.authenticationCacheFlags
   val caffeineAuthenticationCache: Cache[Option[User]] =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
-import com.rasterfoundry.datamodel.{Scene, User}
+import com.rasterfoundry.datamodel.{AuthResult, Project, Scene, ToolRun, User}
 import com.rasterfoundry.http4s.{Cache => Http4sUtilCache}
 
 import com.typesafe.scalalogging.LazyLogging
@@ -26,5 +26,14 @@ object Cache extends LazyLogging {
     CaffeineCache[Option[User]]
   logger.info(
     s"Authentication Cache Status, backsplash: ${authenticationCacheFlags}")
+
+  val sceneAuthCache: Cache[AuthResult[Scene]] =
+    CaffeineCache[AuthResult[Scene]]
+
+  val projectAuthCache: Cache[AuthResult[Project]] =
+    CaffeineCache[AuthResult[Project]]
+
+  val toolRunAuthCache: Cache[AuthResult[ToolRun]] =
+    CaffeineCache[AuthResult[ToolRun]]
 
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -1,6 +1,13 @@
 package com.rasterfoundry.backsplash.server
 
-import com.rasterfoundry.datamodel.{AuthResult, Project, Scene, ToolRun, User}
+import com.rasterfoundry.datamodel.{
+  AuthResult,
+  Project,
+  ProjectLayer,
+  Scene,
+  ToolRun,
+  User
+}
 import com.rasterfoundry.http4s.{Cache => Http4sUtilCache}
 
 import com.typesafe.scalalogging.LazyLogging
@@ -21,6 +28,9 @@ object Cache extends LazyLogging {
   val caffeineSceneCache: Cache[Scene] =
     CaffeineCache[Scene]
 
+  val caffeineProjectLayerCache: Cache[ProjectLayer] =
+    CaffeineCache[ProjectLayer]
+
   val authenticationCacheFlags = Http4sUtilCache.authenticationCacheFlags
   val caffeineAuthenticationCache: Cache[Option[User]] =
     CaffeineCache[Option[User]]
@@ -35,5 +45,4 @@ object Cache extends LazyLogging {
 
   val toolRunAuthCache: Cache[AuthResult[ToolRun]] =
     CaffeineCache[AuthResult[ToolRun]]
-
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
@@ -1,8 +1,8 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash.error.NoDataInRegionException
-import com.rasterfoundry.datamodel.Scene
-import com.rasterfoundry.database.SceneDao
+import com.rasterfoundry.datamodel.{ProjectLayer, Scene}
+import com.rasterfoundry.database.{ProjectLayerDao, SceneDao}
 import com.rasterfoundry.database.Implicits._
 
 import cats.effect.IO
@@ -27,6 +27,19 @@ object Cacheable {
       SceneDao.getSceneById(sceneId, window).transact(xa) flatMap {
         case Some(scene) => IO.pure { scene }
         case None        => IO.raiseError(NoDataInRegionException)
+      }
+    }
+
+  def getProjectLayerById(projectLayerId: UUID,
+                          @cacheKeyExclude xa: Transactor[IO])(
+      implicit cache: Cache[ProjectLayer]): IO[ProjectLayer] =
+    memoizeF(Some(60 seconds)) {
+      ProjectLayerDao.getProjectLayerById(projectLayerId).transact(xa) flatMap {
+        case Some(projectLayer) => IO.pure { projectLayer }
+        // Not finding a project layer is like not finding scenes, in that
+        // the user asked for data somewhere for a project layer, and we
+        // definitely don't have it
+        case None => IO.raiseError(NoDataInRegionException)
       }
     }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
@@ -1,11 +1,14 @@
 package com.rasterfoundry.backsplash.server
 
+import com.rasterfoundry.backsplash.error.NoDataInRegionException
 import com.rasterfoundry.datamodel.Scene
 import com.rasterfoundry.database.SceneDao
+import com.rasterfoundry.database.Implicits._
 
 import cats.effect.IO
 import doobie._
 import doobie.implicits._
+import geotrellis.vector.{Projected, Polygon}
 import scalacache._
 import scalacache.CatsEffect.modes._
 import scalacache.memoization._
@@ -13,17 +16,17 @@ import scalacache.memoization._
 import scala.concurrent.duration._
 
 import java.util.UUID
+import com.rasterfoundry.backsplash.error.NoDataInRegionException
 
 object Cacheable {
-  def getSceneById(ttl: Option[FiniteDuration])(
-      sceneId: UUID,
-      xa: Transactor[IO])(implicit cache: Cache[Scene]): IO[Scene] =
-    memoizeF[IO, Scene](ttl) {
-      SceneDao.unsafeGetSceneById(sceneId).transact(xa)
-    }
-
-  def getSceneById(sceneId: UUID, xa: Transactor[IO])(
+  def getSceneById(sceneId: UUID,
+                   window: Option[Projected[Polygon]],
+                   @cacheKeyExclude xa: Transactor[IO])(
       implicit cache: Cache[Scene]): IO[Scene] =
-    getSceneById(Some(3 seconds))(sceneId, xa)
-
+    memoizeF(Some(3 seconds)) {
+      SceneDao.getSceneById(sceneId, window).transact(xa) flatMap {
+        case Some(scene) => IO.pure { scene }
+        case None        => IO.raiseError(NoDataInRegionException)
+      }
+    }
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
@@ -23,7 +23,7 @@ object Cacheable {
                    window: Option[Projected[Polygon]],
                    @cacheKeyExclude xa: Transactor[IO])(
       implicit cache: Cache[Scene]): IO[Scene] =
-    memoizeF(Some(3 seconds)) {
+    memoizeF(Some(60 seconds)) {
       SceneDao.getSceneById(sceneId, window).transact(xa) flatMap {
         case Some(scene) => IO.pure { scene }
         case None        => IO.raiseError(NoDataInRegionException)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cacheable.scala
@@ -1,0 +1,29 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.datamodel.Scene
+import com.rasterfoundry.database.SceneDao
+
+import cats.effect.IO
+import doobie._
+import doobie.implicits._
+import scalacache._
+import scalacache.CatsEffect.modes._
+import scalacache.memoization._
+
+import scala.concurrent.duration._
+
+import java.util.UUID
+
+object Cacheable {
+  def getSceneById(ttl: Option[FiniteDuration])(
+      sceneId: UUID,
+      xa: Transactor[IO])(implicit cache: Cache[Scene]): IO[Scene] =
+    memoizeF[IO, Scene](ttl) {
+      SceneDao.unsafeGetSceneById(sceneId).transact(xa)
+    }
+
+  def getSceneById(sceneId: UUID, xa: Transactor[IO])(
+      implicit cache: Cache[Scene]): IO[Scene] =
+    getSceneById(Some(3 seconds))(sceneId, xa)
+
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -161,7 +161,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
   val sceneMosaicService: HttpRoutes[IO] =
     authenticators.tokensAuthMiddleware(
       AuthedAutoSlash(
-        new SceneService(SceneDao(), sceneMosaicImplicits, xa).routes
+        new SceneService(sceneMosaicImplicits, xa).routes
       )
     )
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -113,7 +113,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
 
   val authenticators = new Authenticators(xa)
 
-  val projectStoreImplicits = new ProjectStoreImplicits(xa)
+  val projectStoreImplicits = new RenderableStoreImplicits(xa)
   import projectStoreImplicits._
 
   val projectLayerMosaicImplicits =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -15,7 +15,7 @@ import cats.effect.IO
 import doobie.Transactor
 import doobie.implicits._
 
-class BacksplashMamlAdapter[HistStore, LayerStore: ProjectStore](
+class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
     mosaicImplicits: MosaicImplicits[HistStore, LayerStore],
     layerStore: LayerStore,
     xa: Transactor[IO]) {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
@@ -1,8 +1,12 @@
 package com.rasterfoundry.backsplash.server
 
-import com.rasterfoundry.backsplash.{BacksplashMosaic, OgcStore, ProjectStore}
+import com.rasterfoundry.backsplash.{
+  BacksplashMosaic,
+  OgcStore,
+  RenderableStore
+}
 import com.rasterfoundry.backsplash.color.OgcStyles
-import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
+import com.rasterfoundry.backsplash.RenderableStore.ToRenderableStoreOps
 import com.rasterfoundry.datamodel.{
   ColorComposite,
   ProjectLayer,
@@ -32,9 +36,9 @@ import opengis.wms.{Name, OnlineResource, Service}
 
 import java.util.UUID
 
-class OgcImplicits[P: ProjectStore](layers: P, xa: Transactor[IO])(
+class OgcImplicits[R: RenderableStore](layers: R, xa: Transactor[IO])(
     implicit contextShift: ContextShift[IO]
-) extends ToProjectStoreOps {
+) extends ToRenderableStoreOps {
 
   private def compositesToOgcStyles(
       composites: Map[String, ColorComposite]

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/ToolStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/ToolStoreImplicits.scala
@@ -19,7 +19,7 @@ import java.util.UUID
 class ToolStoreImplicits[HistStore](
     mosaicImplicits: MosaicImplicits[HistStore, SceneToLayerDao],
     xa: Transactor[IO])
-    extends ProjectStoreImplicits(xa)
+    extends RenderableStoreImplicits(xa)
     with LazyLogging {
 
   import mosaicImplicits._

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
@@ -3,7 +3,7 @@ package com.rasterfoundry.backsplash.server
 import com.rasterfoundry.backsplash._
 import com.rasterfoundry.common.color.ColorCorrect
 import com.rasterfoundry.backsplash.Parameters._
-import com.rasterfoundry.backsplash.ProjectStore.ToProjectStoreOps
+import com.rasterfoundry.backsplash.RenderableStore.ToRenderableStoreOps
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.datamodel.{BandOverride, Datasource, Scene, User}
 import com.rasterfoundry.database.DatasourceDao
@@ -23,10 +23,10 @@ import org.http4s.headers._
 
 import java.util.UUID
 
-class SceneService[ProjStore, HistStore](
-    mosaicImplicits: MosaicImplicits[HistStore, ProjStore],
+class SceneService[RendStore, HistStore](
+    mosaicImplicits: MosaicImplicits[HistStore, RendStore],
     xa: Transactor[IO])(implicit cs: ContextShift[IO])
-    extends ToProjectStoreOps {
+    extends ToRenderableStoreOps {
 
   import mosaicImplicits._
   implicit val tmsReification = paintedMosaicTmsReification

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
@@ -23,7 +23,7 @@ import org.http4s.headers._
 
 import java.util.UUID
 
-class SceneService[ProjStore: ProjectStore, HistStore](
+class SceneService[ProjStore, HistStore](
     mosaicImplicits: MosaicImplicits[HistStore, ProjStore],
     xa: Transactor[IO])(implicit cs: ContextShift[IO])
     extends ToProjectStoreOps {

--- a/app-backend/datamodel/src/main/scala/AuthResult.scala
+++ b/app-backend/datamodel/src/main/scala/AuthResult.scala
@@ -1,0 +1,22 @@
+package com.rasterfoundry.datamodel
+
+sealed trait AuthResult[T] {
+  def toBoolean: Boolean
+}
+
+case class AuthSuccess[T](
+    value: T
+) extends AuthResult[T] {
+  def toBoolean: Boolean = true
+}
+
+case class AuthFailure[T]() extends AuthResult[T] {
+  def toBoolean: Boolean = false
+}
+
+object AuthResult {
+  def fromOption[T](src: Option[T]): AuthResult[T] = src match {
+    case Some(v) => AuthSuccess(v)
+    case _       => AuthFailure()
+  }
+}

--- a/app-backend/db/src/main/scala/AnnotationGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationGroupDao.scala
@@ -197,5 +197,5 @@ object AnnotationGroupDao extends Dao[AnnotationGroup] {
         layerId,
         annotationGroupId
       )
-    } yield { authProject && layerExists && authAnnotationGroup }
+    } yield { authProject.toBoolean && layerExists && authAnnotationGroup }
 }

--- a/app-backend/db/src/main/scala/AoiDao.scala
+++ b/app-backend/db/src/main/scala/AoiDao.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.database
 
 import java.util.UUID
 
+import cats.Applicative
 import cats.implicits._
 import com.rasterfoundry.database.util._
 import com.rasterfoundry.datamodel._
@@ -117,7 +118,7 @@ object AoiDao extends Dao[AOI] {
       projectAuthed <- aoiO map { _.projectId } match {
         case Some(projectId) =>
           ProjectDao.authorized(user, ObjectType.Project, projectId, actionType)
-        case _ => false.pure[ConnectionIO]
+        case _ => Applicative[ConnectionIO].pure(AuthFailure[Project]())
       }
-    } yield { projectAuthed }
+    } yield { projectAuthed.toBoolean }
 }

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -41,7 +41,8 @@ object Dao extends LazyLogging {
                  a: List[Any],
                  e1: FiniteDuration,
                  e2: FiniteDuration) =>
-      val queryString = s.lines.dropWhile(_.trim.isEmpty).mkString("\n  ")
+      val queryString =
+        s.lines.dropWhile(_.trim.isEmpty).toArray.mkString("\n  ")
       val logString = queryString
         .split("\\?", -1)
         .zip(a.map(s => "'" + s + "'"))
@@ -56,7 +57,8 @@ object Dao extends LazyLogging {
       """.stripMargin)
 
     case ProcessingFailure(s, a, e1, e2, t) =>
-      val queryString = s.lines.dropWhile(_.trim.isEmpty).mkString("\n  ")
+      val queryString =
+        s.lines.dropWhile(_.trim.isEmpty).toArray.mkString("\n  ")
       val logString = queryString
         .split("\\?", -1)
         .zip(a.map(s => "'" + s + "'"))
@@ -72,11 +74,13 @@ object Dao extends LazyLogging {
       """.stripMargin)
 
     case ExecFailure(s, a, e1, t) =>
-      val queryString = s.lines.dropWhile(_.trim.isEmpty).mkString("\n  ")
+      val queryString =
+        s.lines.dropWhile(_.trim.isEmpty).toArray.mkString("\n  ")
       val logString = queryString
         .split("\\?", -1)
         .zip(a.map(s => "'" + s + "'"))
         .flatMap({ case (t1, t2) => List(t1, t2) })
+        .toList
         .mkString("")
       logger.error(s"""Failed Statement Execution:
         |

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -48,7 +48,7 @@ object Dao extends LazyLogging {
         .zip(a.map(s => "'" + s + "'"))
         .flatMap({ case (t1, t2) => List(t1, t2) })
         .mkString("")
-      logger.debug(s"""Successful Statement Execution:
+      logger.info(s"""Successful Statement Execution:
         |
         |  ${logString}
         |

--- a/app-backend/db/src/main/scala/DatasourceDao.scala
+++ b/app-backend/db/src/main/scala/DatasourceDao.scala
@@ -183,9 +183,10 @@ object DatasourceDao
       objectType: ObjectType,
       objectId: UUID,
       actionType: ActionType
-  ): ConnectionIO[Boolean] =
+  ): ConnectionIO[AuthResult[Datasource]] =
     this.query
       .filter(authorizedF(user, objectType, actionType))
       .filter(objectId)
-      .exists
+      .selectOption
+      .map(AuthResult.fromOption _)
 }

--- a/app-backend/db/src/main/scala/MapTokenDao.scala
+++ b/app-backend/db/src/main/scala/MapTokenDao.scala
@@ -1,8 +1,9 @@
 package com.rasterfoundry.database
 
+import com.rasterfoundry.datamodel.{AuthFailure, PageRequest, Project, ToolRun}
 import com.rasterfoundry.datamodel._
 
-import com.rasterfoundry.datamodel.PageRequest
+import cats.Applicative
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
@@ -67,7 +68,7 @@ object MapTokenDao extends Dao[MapToken] {
             )
           }
         }
-      ).getOrElse(false.pure[ConnectionIO])
+      ).getOrElse(Applicative[ConnectionIO].pure(AuthFailure[Project]()))
       toolRunAuthed = (
         mapTokenO flatMap { _.toolRun } map { (toolRunId: UUID) =>
           {
@@ -79,9 +80,9 @@ object MapTokenDao extends Dao[MapToken] {
             )
           }
         }
-      ).getOrElse(false.pure[ConnectionIO])
+      ).getOrElse(Applicative[ConnectionIO].pure(AuthFailure[ToolRun]()))
       authTuple <- (projAuthed, toolRunAuthed).tupled
-    } yield { authTuple._1 || authTuple._2 }
+    } yield { authTuple._1.toBoolean || authTuple._2.toBoolean }
 
   def listAuthorizedMapTokens(
       user: User,

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -20,7 +20,7 @@ trait ObjectPermissions[Model] {
   def authorized(user: User,
                  objectType: ObjectType,
                  objectId: UUID,
-                 actionType: ActionType): ConnectionIO[Boolean]
+                 actionType: ActionType): ConnectionIO[AuthResult[Model]]
 
   def isValidObject(id: UUID): ConnectionIO[Boolean] =
     (tableName match {

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -388,9 +388,10 @@ object SceneDao
       objectType: ObjectType,
       objectId: UUID,
       actionType: ActionType
-  ): ConnectionIO[Boolean] =
+  ): ConnectionIO[AuthResult[Scene]] =
     this.query
       .filter(authorizedF(user, objectType, actionType))
       .filter(objectId)
-      .exists
+      .selectOption
+      .map(AuthResult.fromOption _)
 }

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -63,11 +63,6 @@ object SceneDao
   def unsafeGetSceneById(id: UUID): ConnectionIO[Scene] =
     query.filter(id).select
 
-  def getSceneDatasource(sceneId: UUID): ConnectionIO[Datasource] =
-    unsafeGetSceneById(sceneId) flatMap { scene: Scene =>
-      DatasourceDao.unsafeGetDatasourceById(scene.datasource)
-    }
-
   @SuppressWarnings(Array("CollectionIndexOnNonIndexedSeq"))
   def insert(
       sceneCreate: Scene.Create,

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -51,14 +51,14 @@ object SceneDao
   def getSceneById(id: UUID): ConnectionIO[Option[Scene]] =
     query.filter(id).selectOption
 
-  def streamSceneById(sceneId: UUID, footprint: Option[Projected[Polygon]])(
+  def getSceneById(sceneId: UUID, footprint: Option[Projected[Polygon]])(
       implicit Filter: Filterable[Any, Projected[Geometry]]
-  ): fs2.Stream[ConnectionIO, Scene] =
+  ): ConnectionIO[Option[Scene]] =
     (selectF ++ Fragments.whereAndOpt(
       (Some(fr"id = ${sceneId}") +: (footprint map {
         Filter.toFilters(_)
       } getOrElse { List.empty })): _*
-    )).query[Scene].stream
+    )).query[Scene].option
 
   def unsafeGetSceneById(id: UUID): ConnectionIO[Scene] =
     query.filter(id).select

--- a/app-backend/db/src/main/scala/ShapeDao.scala
+++ b/app-backend/db/src/main/scala/ShapeDao.scala
@@ -6,7 +6,8 @@ import com.rasterfoundry.datamodel.{
   User,
   ObjectType,
   GroupType,
-  ActionType
+  ActionType,
+  AuthResult
 }
 
 import doobie._
@@ -139,9 +140,10 @@ object ShapeDao extends Dao[Shape] with ObjectPermissions[Shape] {
       objectType: ObjectType,
       objectId: UUID,
       actionType: ActionType
-  ): ConnectionIO[Boolean] =
+  ): ConnectionIO[AuthResult[Shape]] =
     this.query
       .filter(authorizedF(user, objectType, actionType))
       .filter(objectId)
-      .exists
+      .selectOption
+      .map(AuthResult.fromOption _)
 }

--- a/app-backend/db/src/main/scala/ToolDao.scala
+++ b/app-backend/db/src/main/scala/ToolDao.scala
@@ -6,7 +6,8 @@ import com.rasterfoundry.datamodel.{
   User,
   ObjectType,
   GroupType,
-  ActionType
+  ActionType,
+  AuthResult
 }
 
 import doobie._
@@ -110,9 +111,10 @@ object ToolDao extends Dao[Tool] with ObjectPermissions[Tool] {
       objectType: ObjectType,
       objectId: UUID,
       actionType: ActionType
-  ): ConnectionIO[Boolean] =
+  ): ConnectionIO[AuthResult[Tool]] =
     this.query
       .filter(authorizedF(user, objectType, actionType))
       .filter(objectId)
-      .exists
+      .selectOption
+      .map(AuthResult.fromOption _)
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AuthorizationSpec.scala
@@ -58,7 +58,7 @@ class AuthorizationSpec
                                                        ObjectType.Project,
                                                        project.id,
                                                        ActionType.View)
-            } yield (user1Authorized, user2Authorized)
+            } yield (user1Authorized.toBoolean, user2Authorized.toBoolean)
 
             val (user1Authed, user2Authed) =
               usersAuthedIO.transact(xa).unsafeRunSync
@@ -117,7 +117,7 @@ class AuthorizationSpec
                                                        ObjectType.Project,
                                                        project.id,
                                                        ActionType.View)
-            } yield { (user1Authorized, user2Authorized) }
+            } yield { (user1Authorized.toBoolean, user2Authorized.toBoolean) }
 
             val (user1Authed, user2Authed) =
               usersAuthedIO.transact(xa).unsafeRunSync
@@ -172,7 +172,7 @@ class AuthorizationSpec
                                                        ObjectType.Project,
                                                        project.id,
                                                        ActionType.View)
-            } yield { (user1Authorized, user2Authorized) }
+            } yield { (user1Authorized.toBoolean, user2Authorized.toBoolean) }
 
             val (user1Authed, user2Authed) =
               usersAuthedIO.transact(xa).unsafeRunSync

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -558,7 +558,12 @@ class ProjectDaoSpec
                                                     ObjectType.Project,
                                                     projectInsert2.id,
                                                     action)
-            } yield { (action, projectInsert2, isPermitted1, isPermitted2) }
+            } yield {
+              (action,
+               projectInsert2,
+               isPermitted1.toBoolean,
+               isPermitted2.toBoolean)
+            }
 
             val (action, projectInsert2, isPermitted1, isPermitted2) =
               isUserPermittedIO.transact(xa).unsafeRunSync


### PR DESCRIPTION
## Overview

This PR reduces the number of scene by id queries in the thumbnail rendering process from four to one. It also _just about_ removes the need to have `ProjectStoreImplicits` for `SceneDao` at all, but they're still used in `MosaicImplicits`, so they can't _quite_ be removed yet.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

~While I'm working on this and #5119 simultaneously, it seemed worth it to break this out, since the change to the return type of `authorized` had far-reaching consequences~ now they're combined

It will probably be easiest to focus on the [last four commits](https://github.com/raster-foundry/raster-foundry/pull/5139/files/be68aed8b22aba0770eeafefb587a16397e3b19d..464fcc4bd94b1712215ec228a150b2f936590338) for the first change, then the [next two commits](https://github.com/raster-foundry/raster-foundry/pull/5139/files/9d65c53828e77cbb5300932166293de15404b349..310530fbfbdd58cf9d55c012745e70a3b9ebb661) for the second change

Here are timings from `develop` in its current state / without this PR:

https://s3.amazonaws.com/rasterfoundry-staging-it-us-east-1/gatling/341/index.html

The staging cluster scaled to its maximum number of task instances after the load test on `develop`, from starting at the minimum.

And here are timings from `test/js/dedupe-queries`, which is in the same state as this branch:

https://s3.amazonaws.com/rasterfoundry-staging-it-us-east-1/gatling/342/index.html

The staging cluster also scaled to its maximum number of instances after this load test was over, from starting at its minimum.

The two noticeable differences for me were:

- in the response time distribution, the right tail is considerably shorter on this branch than it is on develop
- in the response time percentiles over time, the mid-percentiles (50, 75, 80, 85, 90) stay far lower on this branch than on develop

To verify this, I scrolled to the same page position (thanks, standard reporting layout) and tabbed back and forth in the browser. It's not super scientific, but the differences are stark enough that they're noticeable even without a more careful reading.

## Testing Instructions

- enable database logging in the way you prefer (probably use the postgres container command option, since #5129 is still wip -- add `command: postgres -c log_statement=all` to your `postgres` service in docker-compose.yml)
- reassemble tile and api servers
- bring up your servers and frontend
- get a bearer token from the frontend
- request a thumbnail for the `Local File Single Scene` project:

```bash
$ http 'http://localhost:8081/scenes/533fdfa0-0f76-49d8-8114-e9326d6c91ad/thumbnail?floor=25&height=128&token=<YOUR TOKEN>'`
```

- confirm in your postgres logs that you only have one select from the `scenes` table
- request a tms tile for the planet project:

```bash
$ http 'http://localhost:8081/94bb99c1-c8da-4321-a03b-fce884009a90/15/6600/12846/?tag=1567026023147&token=<YOUR TOKEN>'
```

- confirm in your postgres logs that you have no more than two database queries for getting a project layer by id (you can end up with two because of parallelism / the cache not being populated at the time the second call occurs)
- confirm that you only have a single read from `scene_to_layers`

Closes #5119 

Closes #5122 
