### PR TITLE
Add projectId and layerId QPs to STAC export list endpoint and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Added
 
 - Added trace ID to exception logging for backsplash [\#5134](https://github.com/raster-foundry/raster-foundry/pull/5134)
+- Added projectId and layerId QPs to STAC export list endpoint [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 
 ### Changed
 
 - Upgrade doobie to 0.7.0 [\#5130](https://github.com/raster-foundry/raster-foundry/pull/5130)
+- Updated STAC export location to use the S3 prefix [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
+- Updated values for label:task, label:property, and label:classes of the STAC label item [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -191,7 +191,9 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         ownerQueryParameters &
         searchParams &
         parameters(
-          'exportStatus.as[String].?
+          'exportStatus.as[String].?,
+          'projectId.as[UUID].?,
+          'layerId.as[UUID].?
         )
     ).as(StacExportQueryParameters.apply _)
 }

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -113,7 +113,7 @@ final case class WriteStacCatalog(exportId: UUID)(
               unsafeGetStacSelfLink(sceneItem.links),
               sceneItem.asJson.noSpaces,
               "application/json"
-            )
+          )
         )
         // label collection
         putObjectToS3(

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -684,7 +684,9 @@ final case class StacExportQueryParameters(
     userParams: UserAuditQueryParameters = UserAuditQueryParameters(),
     ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
     searchParams: SearchQueryParameters = SearchQueryParameters(),
-    exportStatus: Option[String] = None
+    exportStatus: Option[String] = None,
+    projectId: Option[UUID] = None,
+    layerId: Option[UUID] = None,
 )
 
 object StacExportQueryParameters {

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -634,15 +634,15 @@ object ProjectDao
               infoList
                 .traverse(_.labelGroupName)
                 .map(groupNames => groupNames.filter(_.nonEmpty)) match {
-                case Some(groupNameList) if groupNameList.length != 0 =>
+                case Some(groupNameList) if groupNameList.nonEmpty =>
                   (groupNameList.distinct, "classification")
                 case _ => (List("label"), "detection")
               }
             val stacClasses
-              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
-                case Some(groupName) if groupName.length != 0 => groupName
-                case _                                        => "label"
+                case Some(groupName) if groupName.nonEmpty => groupName
+                case _                                     => "label"
               })
               .map {
                 case (propName, info) =>

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -631,14 +631,19 @@ object ProjectDao
           case 0 => None
           case _ =>
             val (property, taskType): (List[String], String) =
-              infoList.traverse(_.labelGroupName) match {
-                case Some(groupNameList) =>
+              infoList
+                .traverse(_.labelGroupName)
+                .map(groupNames => groupNames.filter(_.nonEmpty)) match {
+                case Some(groupNameList) if groupNameList.length != 0 =>
                   (groupNameList.distinct, "classification")
                 case _ => (List("label"), "detection")
               }
             val stacClasses
-              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
-              .groupBy(_.labelGroupName.getOrElse("label"))
+                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+              .groupBy(_.labelGroupName match {
+                case Some(groupName) if groupName.length != 0 => groupName
+                case _                                        => "label"
+              })
               .map {
                 case (propName, info) =>
                   StacLabelItemProperties.StacLabelItemClasses(

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -639,7 +639,7 @@ object ProjectDao
                 case _ => (List("label"), "detection")
               }
             val stacClasses
-                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
                 case Some(groupName) if groupName.length != 0 => groupName
                 case _                                        => "label"

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -631,7 +631,7 @@ object ProjectDao
           case 0 => None
           case _ =>
             val stacClasses
-                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
                 case Some(groupName) if groupName.nonEmpty => groupName
                 case _                                     => "label"

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -630,16 +630,8 @@ object ProjectDao
         infoList.length match {
           case 0 => None
           case _ =>
-            val (property, taskType): (List[String], String) =
-              infoList
-                .traverse(_.labelGroupName)
-                .map(groupNames => groupNames.filter(_.nonEmpty)) match {
-                case Some(groupNameList) if groupNameList.nonEmpty =>
-                  (groupNameList.distinct, "classification")
-                case _ => (List("label"), "detection")
-              }
             val stacClasses
-              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
                 case Some(groupName) if groupName.nonEmpty => groupName
                 case _                                     => "label"
@@ -651,6 +643,12 @@ object ProjectDao
                     info.traverse(_.labelName).getOrElse(List())
                 )
             } toList)
+            val groupNamesDry = stacClasses.map(_.name).toSet
+            val (property, taskType) =
+              groupNamesDry.size match {
+                case 1 => (List("label"), "detection")
+                case _ => (groupNamesDry.toList, "classification")
+              }
             Some(
               StacLabelItemPropertiesThin(
                 property,

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -639,7 +639,7 @@ object ProjectDao
                 case _ => (List("label"), "detection")
               }
             val stacClasses
-                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
                 case Some(groupName) if groupName.nonEmpty => groupName
                 case _                                     => "label"

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -433,7 +433,6 @@ trait Filterables extends RFMeta with LazyLogging {
                       .LayerDefinition(projectId, layerId)
                       .asJson
                       .noSpaces
-                      .toString()
                   ) ++ fr"]'::jsonb"
                 )
               case _ => None

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -48,7 +48,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-      : Filterable[Any, TimestampQueryParameters] =
+    : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -60,7 +60,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-      : Filterable[Any, ProjectQueryParameters] =
+    : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -89,7 +89,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-      : Filterable[Any, CombinedToolQueryParameters] =
+    : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -102,7 +102,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-      : Filterable[Any, AnnotationQueryParameters] =
+    : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -141,7 +141,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-      : Filterable[Any, CombinedSceneQueryParams] =
+    : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -205,7 +205,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-      : Filterable[Any, ProjectSceneQueryParameters] =
+    : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -220,7 +220,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-      : Filterable[Any, CombinedMapTokenQueryParameters] =
+    : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -228,7 +228,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-      : Filterable[Any, CombinedToolRunQueryParameters] =
+    : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -275,7 +275,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-      : Filterable[Any, DatasourceQueryParameters] =
+    : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -346,7 +346,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-      : Filterable[Any, ThumbnailQueryParameters] =
+    : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -361,7 +361,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-      : Filterable[Any, PlatformQueryParameters] =
+    : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -371,7 +371,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-      : Filterable[Any, OrganizationQueryParameters] =
+    : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -386,14 +386,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-      : Filterable[Organization, SearchQueryParameters] =
+    : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-      : Filterable[User, SearchQueryParameters] =
+    : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -404,7 +404,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-      : Filterable[Any, Projected[MultiPolygon]] =
+    : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -415,7 +415,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-      : Filterable[Any, StacExportQueryParameters] =
+    : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -4,6 +4,7 @@ import com.rasterfoundry.database.Filterable
 import com.rasterfoundry.database.meta.RFMeta
 import com.rasterfoundry.datamodel._
 
+import io.circe.syntax._
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import doobie.Fragments.in
@@ -47,7 +48,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-    : Filterable[Any, TimestampQueryParameters] =
+      : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -59,7 +60,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-    : Filterable[Any, ProjectQueryParameters] =
+      : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -88,7 +89,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-    : Filterable[Any, CombinedToolQueryParameters] =
+      : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -101,7 +102,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-    : Filterable[Any, AnnotationQueryParameters] =
+      : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -140,7 +141,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-    : Filterable[Any, CombinedSceneQueryParams] =
+      : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -204,7 +205,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-    : Filterable[Any, ProjectSceneQueryParameters] =
+      : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -219,7 +220,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-    : Filterable[Any, CombinedMapTokenQueryParameters] =
+      : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -227,7 +228,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-    : Filterable[Any, CombinedToolRunQueryParameters] =
+      : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -274,7 +275,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-    : Filterable[Any, DatasourceQueryParameters] =
+      : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -345,7 +346,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-    : Filterable[Any, ThumbnailQueryParameters] =
+      : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -360,7 +361,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-    : Filterable[Any, PlatformQueryParameters] =
+      : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -370,7 +371,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-    : Filterable[Any, OrganizationQueryParameters] =
+      : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -385,14 +386,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-    : Filterable[Organization, SearchQueryParameters] =
+      : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-    : Filterable[User, SearchQueryParameters] =
+      : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -403,7 +404,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-    : Filterable[Any, Projected[MultiPolygon]] =
+      : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -414,7 +415,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-    : Filterable[Any, StacExportQueryParameters] =
+      : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -424,6 +425,19 @@ trait Filterables extends RFMeta with LazyLogging {
             params.exportStatus map { qp =>
               fr"export_status = UPPER($qp)::public.export_status"
             },
+            (params.projectId, params.layerId) match {
+              case (Some(projectId), Some(layerId)) =>
+                Some(
+                  fr"layer_definitions @> '[" ++ Fragment.const(
+                    StacExport
+                      .LayerDefinition(projectId, layerId)
+                      .asJson
+                      .noSpaces
+                      .toString()
+                  ) ++ fr"]'::jsonb"
+                )
+              case _ => None
+            }
           )
     }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -18,19 +18,25 @@ class StacExportDaoSpec
   test("inserting a Stac Export") {
     check {
       forAll(
-        (userCreate: User.Create,
-         orgCreate: Organization.Create,
-         platform: Platform,
-         projectCreate: Project.Create,
-         stacExportCreate: StacExport.Create) => {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            stacExportCreate: StacExport.Create
+        ) => {
           val createStacExportIO = for {
-            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
-                                                                  orgCreate,
-                                                                  platform,
-                                                                  projectCreate)
-            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
-                                                          dbUser,
-                                                          dbProject)
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(
+              userCreate,
+              orgCreate,
+              platform,
+              projectCreate
+            )
+            fixedStacExportCreate = fixupStacExportCreate(
+              stacExportCreate,
+              dbUser,
+              dbProject
+            )
             dbStacExport <- StacExportDao.create(
               fixedStacExportCreate,
               dbUser
@@ -74,19 +80,25 @@ class StacExportDaoSpec
   test("getting a Stac Export by id") {
     check {
       forAll(
-        (userCreate: User.Create,
-         orgCreate: Organization.Create,
-         platform: Platform,
-         projectCreate: Project.Create,
-         stacExportCreate: StacExport.Create) => {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            stacExportCreate: StacExport.Create
+        ) => {
           val selectStacExportIO = for {
-            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
-                                                                  orgCreate,
-                                                                  platform,
-                                                                  projectCreate)
-            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
-                                                          dbUser,
-                                                          dbProject)
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(
+              userCreate,
+              orgCreate,
+              platform,
+              projectCreate
+            )
+            fixedStacExportCreate = fixupStacExportCreate(
+              stacExportCreate,
+              dbUser,
+              dbProject
+            )
             dbStacExport <- StacExportDao.create(
               fixedStacExportCreate,
               dbUser
@@ -139,19 +151,25 @@ class StacExportDaoSpec
   test("updating a Stac Export") {
     check {
       forAll(
-        (userCreate: User.Create,
-         orgCreate: Organization.Create,
-         platform: Platform,
-         projectCreate: Project.Create,
-         stacExportCreate: StacExport.Create) => {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            stacExportCreate: StacExport.Create
+        ) => {
           val updatetStacExportIO = for {
-            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
-                                                                  orgCreate,
-                                                                  platform,
-                                                                  projectCreate)
-            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
-                                                          dbUser,
-                                                          dbProject)
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(
+              userCreate,
+              orgCreate,
+              platform,
+              projectCreate
+            )
+            fixedStacExportCreate = fixupStacExportCreate(
+              stacExportCreate,
+              dbUser,
+              dbProject
+            )
             dbStacExport <- StacExportDao.create(
               fixedStacExportCreate,
               dbUser
@@ -214,19 +232,25 @@ class StacExportDaoSpec
   test("deleting a Stac Export") {
     check {
       forAll(
-        (userCreate: User.Create,
-         orgCreate: Organization.Create,
-         platform: Platform,
-         projectCreate: Project.Create,
-         stacExportCreate: StacExport.Create) => {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            stacExportCreate: StacExport.Create
+        ) => {
           val deletetStacExportIO = for {
-            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
-                                                                  orgCreate,
-                                                                  platform,
-                                                                  projectCreate)
-            fixedStacExportCreate = fixupStacExportCreate(stacExportCreate,
-                                                          dbUser,
-                                                          dbProject)
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(
+              userCreate,
+              orgCreate,
+              platform,
+              projectCreate
+            )
+            fixedStacExportCreate = fixupStacExportCreate(
+              stacExportCreate,
+              dbUser,
+              dbProject
+            )
             dbStacExport <- StacExportDao.create(fixedStacExportCreate, dbUser)
             deletedRowCount <- StacExportDao
               .delete(dbStacExport.id)
@@ -254,27 +278,35 @@ class StacExportDaoSpec
   test("listing Stac Export") {
     check {
       forAll(
-        (userCreate: User.Create,
-         orgCreate: Organization.Create,
-         platform: Platform,
-         projectCreate: Project.Create,
-         stacExportCreate1: StacExport.Create,
-         stacExportCreate2: StacExport.Create,
-         page: PageRequest,
-         queryParams: StacExportQueryParameters) => {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create,
+            stacExportCreate1: StacExport.Create,
+            stacExportCreate2: StacExport.Create,
+            page: PageRequest,
+            queryParams: StacExportQueryParameters
+        ) => {
           val updatetStacExportIO = for {
-            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(userCreate,
-                                                                  orgCreate,
-                                                                  platform,
-                                                                  projectCreate)
-            fixedStacExportCreate1 = fixupStacExportCreate(stacExportCreate1,
-                                                           dbUser,
-                                                           dbProject)
-            fixedStacExportCreate2 = fixupStacExportCreate(stacExportCreate2,
-                                                           dbUser,
-                                                           dbProject)
-            dbStacExport1 <- StacExportDao.create(fixedStacExportCreate1,
-                                                  dbUser)
+            (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(
+              userCreate,
+              orgCreate,
+              platform,
+              projectCreate
+            )
+            fixedStacExportCreate1 = fixupStacExportCreate(
+              stacExportCreate1,
+              dbUser,
+              dbProject
+            )
+            fixedStacExportCreate2 = fixupStacExportCreate(
+              stacExportCreate2,
+              dbUser,
+              dbProject
+            )
+            dbStacExport1 <- StacExportDao
+              .create(fixedStacExportCreate1, dbUser)
             _ <- StacExportDao.create(fixedStacExportCreate2, dbUser)
             _ <- StacExportDao.update(
               dbStacExport1.copy(
@@ -283,9 +315,15 @@ class StacExportDaoSpec
               dbStacExport1.id
             )
             paginatedStacExport <- StacExportDao
-              .list(page,
-                    queryParams.copy(exportStatus = Some("Exported")),
-                    dbUser)
+              .list(
+                page,
+                queryParams.copy(
+                  exportStatus = Some("Exported"),
+                  projectId = Some(dbProject.id),
+                  layerId = Some(dbProject.defaultLayerId)
+                ),
+                dbUser
+              )
           } yield paginatedStacExport
 
           val paginatedResp =

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -4815,6 +4815,8 @@ paths:
         - $ref: '#/parameters/createdBy'
         - $ref: '#/parameters/search'
         - $ref: '#/parameters/exportStatus'
+        - $ref: '#/parameters/projectId'
+        - $ref: '#/parameters/layerId'
       responses:
         200:
           description: 'Paginated list of STAC export records'
@@ -5019,6 +5021,12 @@ parameters:
     name: projectId
     in: query
     description: 'UUID for project'
+    type: string
+    format: uuid
+  layerId:
+    name: layerId
+    in: query
+    description: 'UUID for project layer'
     type: string
     format: uuid
   queryAuthToken:


### PR DESCRIPTION
## Overview

This PR:
- adds projectId and layerId QPs to STAC export list endpoint (support annotate frontend)
- updates STAC export location to use the S3 prefix instead of the absolute location of the `catalog.json` (support annotate frontend)
- updates values for `label:task`, `label:property`, and `label:classes` of the label item

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- `./scripts/load_development_data --download` (this includes the `Florence - AL` project for local testing)
- `./scripts/console`:
   * `api/assembly`
   * `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "AL Project Test 1",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID (will be referred to below as `export ID 1`)
- `POST` below object to `/api/stac`: (this is to test the list endpoint better)
```json
{
	"name": "Test 2",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		},
                 {
			"projectId": "<another project ID>",
			"layerId": "<another project's default layer ID>"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- `GET` to `api/stac?projectId=7e584c31-f5d1-4a02-9428-e83006642375&layerId=1a8c1632-fa91-4a62-b33e-3a87c2ebdf16`. Make sure it lists two records.
- Perform the above `GET` but with different `projectId` and `layerId` combo -- make sure it gives you results as you would expect
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <export ID 1>`
- (if you run into DB connection issue, stop local servers)
- Check on S3 development data bucket -> `stac-exports`, there should be a new folder containing your exported catalog
- Download the label data item, make sure the property fields' values are like below (because these values were not accurate previously):
```json
"properties": {
    ...
    "label:classes": [
      {
        "name": "label",
        "classes": [
          "Passenger Vehicle",
          "Bus",
          "Truck"
        ]
      }
    ],
    "label:task": [
      "detection"
    ],
    "label:property": [
      "label"
    ]
    ...
  }
```
- Look at this export record's `export_location` in DB, it should be an S3 prefix to the export rather than a link to `catalog.json`

Closes #5138 
Closes #5136
