### PR TITLE
Include metadataFields in python scenes model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Repaired python scene codec for API interaction in scene ingests [\#5148](https://github.com/raster-foundry/raster-foundry/pull/5148)
 - Eliminated superfluous scene queries in thumbnail rendering [\#5139](https://github.com/raster-foundry/raster-foundry/pull/5139)
 
 ### Security

--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -22,7 +22,7 @@ class Scene(BaseModel):
                  cloudCover=None, acquisitionDate=None, id=None, thumbnails=None,
                  tileFootprint=None, dataFootprint=None, images=None, createdAt=None,
                  modifiedAt=None, createdBy=None, ingestLocation=None,
-                 owner=None, sceneType="AVRO"):
+                 owner=None, sceneType="AVRO", metadataFields=None):
         """Create a new Scene
 
         Args:
@@ -72,6 +72,7 @@ class Scene(BaseModel):
         self.images = images
         self.createdAt = createdAt
         self.modifiedAt = modifiedAt
+        self.metadataFields = metadataFields
 
     def __repr__(self):
         return '<Scene: {}>'.format(self.name)
@@ -102,7 +103,8 @@ class Scene(BaseModel):
             filter_fields.get('sunAzimuth'), filter_fields.get('sunElevation'), filter_fields.get('cloudCover'),
             filter_fields.get('acquisitionDate'), d.get('id'), thumbnails, tile_footprint, data_footprint,
             images, d.get('createdAt'), d.get('modifiedAt'), d.get('createdBy'),
-            d.get('ingestLocation', ''), owner=d.get('owner'), sceneType=d.get('sceneType')
+            d.get('ingestLocation', ''), owner=d.get('owner'), sceneType=d.get('sceneType'),
+            metadataFields=d.get('metadataFields')
         )
 
     def to_dict(self):
@@ -114,7 +116,8 @@ class Scene(BaseModel):
             visibility=self.visibility,
             tags=self.tags, datasource=self.datasource, sceneMetadata=self.sceneMetadata, filterFields=filterFields,
             name=self.name, statusFields=statusFields, metadataFiles=self.metadataFiles,
-            ingestLocation=self.ingestLocation, owner=self.owner, sceneType=self.sceneType)
+            ingestLocation=self.ingestLocation, owner=self.owner, sceneType=self.sceneType,
+            metadataFields=self.metadataFields)
 
         if self.sunAzimuth:
             filterFields['sunAzimuth'] = self.sunAzimuth


### PR DESCRIPTION
## Overview

This PR fixes the python codecs for scenes. They were missing `metadataFields`.
 
### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- bring up your servers
- choose an uningested Sentinel-2 scene from your database. I chose `fe40bad5-d5dd-4720-a014-2fa7c35161d9`
- `./scripts/console batch 'rf ingest-scene fe40bad5-d5dd-4720-a014-2fa7c35161d9'`
- it should fail with the error that Rollbar reported (view logs from the links in Rollbar)
- `docker-compose build batch`
- `./scripts/console batch 'rf ingest-scene fe40bad5-d5dd-4720-a014-2fa7c35161d9'`
- it should complete successfully
