### PR TITLE
Check Band Count During Export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@
 - Added projectId and layerId QPs to STAC export list endpoint [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Added caching for selecting projects, project layers, and users by ID [\#5144](https://github.com/raster-foundry/raster-foundry/pull/5144)
 - Added documentation on choice of tracing libraries [\#5145](https://github.com/raster-foundry/raster-foundry/pull/5145)
+- Added a check for band counts during project exports [\#5154](https://github.com/raster-foundry/raster-foundry/pull/5154)
 
 ### Changed
 
-- Upgrade doobie to 0.7.0 [\#5130](https://github.com/raster-foundry/raster-foundry/pull/5130)
+- Upgraded doobie to 0.7.0 [\#5130](https://github.com/raster-foundry/raster-foundry/pull/5130)
 - Updated STAC export location to use the S3 prefix [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Updated values for label:task, label:property, and label:classes of the STAC label item [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
-- Tune proxy_connect_timeout to make Nginx fail faster [\#5133](https://github.com/raster-foundry/raster-foundry/pull/5133)
+- Tuned proxy_connect_timeout to make Nginx fail faster [\#5133](https://github.com/raster-foundry/raster-foundry/pull/5133)
 
 ### Deprecated
 

--- a/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
+++ b/app-backend/backsplash-export/src/main/scala/com/rasterfoundry/backsplash/TileReification.scala
@@ -77,6 +77,11 @@ object TileReification extends LazyLogging {
                 val rs = RasterSources
                   .getOrUpdate(uri)
                   .reproject(WebMercator, NearestNeighbor)
+                if (bands.length > rs.bandCount) {
+                  val msg =
+                    s"Number of bands requested (${bands.length}) is greater than bands in Raster Source (${rs.bandCount})"
+                  throw new IllegalArgumentException(msg)
+                }
                 logger.debug(s"Raster Source Extent: ${rs.extent}")
                 if (rs.extent.intersects(extent)) {
                   rs.tileToLayout(layoutDefinition, NearestNeighbor)


### PR DESCRIPTION
## Overview

Export definitions that request more bands for export than are available in the source imagery result in an obscure error being thrown during the export process. Ideally, we could prevent this from happening during the export generation process; however, since we can't at the moment this PR adds a check for band count mismatch during export and raises an easier to parse exception.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

```
cbrown@trout:~/projects/raster-foundry$ ./scripts/console batch "java -jar /opt/raster-foundry/jars/backsplash-export-assembly.jar -d file:///opt/data/export-test.json"
[main] INFO  - Beginning tiff export to file:///dev/null.
[main] INFO  - Minimum Tile: 1136, 1519
[main] INFO  - Maximum Tile: 1137, 1519
[main] INFO  - Columns: 2, Rows: 1
[main] INFO  - Retrieved MAML AST at TMS (14, 1136, 1519): RasterVar(identity)
[main] INFO  - Retrieved parameters for TMS (14, 1136, 1519): Map(identity -> List((file:///opt/data/cog-pa_m_4208064_ne_17_1_20150727.tif,List(0, 1, 2, 3, 4),None), (file:///opt/data/cog-pa_m_4208064_nw_17_1_20150727.tif,List(0, 1, 2, 3, 4),None), (file:///opt/data/cog-pa_m_4208064_se_17_1_20150727.tif,List(0, 1, 2, 3),None), (file:///opt/data/cog-pa_m_4208064_sw_17_1_20150727.tif,List(0, 1, 2, 3),None)))
Exception in thread "main" java.lang.IllegalArgumentException: Number of bands requested (5) is greater than bands in Raster Source 4
```
### Notes

I opened https://github.com/raster-foundry/raster-foundry/issues/5153 since ideally this state of the world shouldn't be possible.

## Testing Instructions

- Add the following export definition to the `data/` folder and save it as `export-test.json`:
```json
{"id":"dfea43ba-b396-4086-9fe1-1e659e2f09c0","src":{"zoom":14,"area":{"type":"MultiPolygon","coordinates":[[[[-80.112991,42.09688499999999],[-80.117712,42.05273399999999],[-80.004158,42.05145999999999],[-80.007334,42.09510199999998],[-80.112991,42.09688499999999]]]]},"layers":[["file:///opt/data/cog-pa_m_4208064_ne_17_1_20150727.tif",[0,1,2,3,4],null],["file:///opt/data/cog-pa_m_4208064_nw_17_1_20150727.tif",[0,1,2,3,4],null],["file:///opt/data/cog-pa_m_4208064_se_17_1_20150727.tif",[0,1,2,3],null],["file:///opt/data/cog-pa_m_4208064_sw_17_1_20150727.tif",[0,1,2,3],null]]},"output":{"crs":null,"destination":"file:///dev/null","dropboxCredential":""}}
```
- Assemble the `backsplash-export` jar
- Run the following command: `./scripts/console batch "java -jar /opt/raster-foundry/jars/backsplash-export-assembly.jar -d file:///opt/data/export-test.json"`
- Note the error

Closes https://github.com/azavea/raster-foundry-platform/issues/830
