### PR TITLE
use relative links for non-self links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Updated STAC export location to use the S3 prefix [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Updated values for label:task, label:property, and label:classes of the STAC label item [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Tuned proxy_connect_timeout to make Nginx fail faster [\#5133](https://github.com/raster-foundry/raster-foundry/pull/5133)
+- Change absolute links in stac export to relative, so they make sense in a local downloaded context [\#5155](https://github.com/raster-foundry/raster-foundry/pull/5155)
 
 ### Deprecated
 

--- a/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
@@ -178,6 +178,7 @@ class LayerCollectionBuilder[
     // ../../../catalog.json
     val sceneCollectionRootPath = s"../${rootPath}"
     val sceneCollectionAbsLink = s"${sceneCollectionAbsPath}/collection.json"
+    val sceneCollectionRelLink = s"${sceneCollectionId}/collection.json"
     val sceneCollectionOwnLinks = List(
       StacLink(
         sceneCollectionAbsLink,
@@ -192,7 +193,7 @@ class LayerCollectionBuilder[
         Some("Root")
       ),
       StacLink(
-        s"${absPath}/collection.json",
+        "../collection.json",
         Parent,
         Some(`application/json`),
         Some("Layer Collection")
@@ -201,7 +202,7 @@ class LayerCollectionBuilder[
     val (sceneCollection, sceneItems, sceneItemLinks): (
         StacCollection,
         List[StacItem],
-        List[(String, String)]
+        List[(String, String, String)]
     ) = sceneCollectionBuilder
       .withVersion(layerCollection.stacVersion.get)
       .withId(sceneCollectionId)
@@ -224,6 +225,7 @@ class LayerCollectionBuilder[
     // ../../../catalog.json
     val labelCollectionRootPath = s"../${rootPath}"
     val labelCollectionAbsLink = s"${labelCollectionAbsPath}/collection.json"
+    val labelCollectionRelLink = s"${labelCollectionId}/collection.json"
     val labelCollectionOwnLinks = List(
       StacLink(
         labelCollectionAbsLink,
@@ -238,7 +240,7 @@ class LayerCollectionBuilder[
         Some("Root")
       ),
       StacLink(
-        s"${absPath}/collection.json",
+        "../collection.json",
         Parent,
         Some(`application/json`),
         Some("Layer Collection")
@@ -286,20 +288,21 @@ class LayerCollectionBuilder[
         .withParentPath(labelCollectionAbsPath, labelCollectionRootPath)
         .withTasksGeomExtent(tasks, tasksGeomExtent)
         .withItemPropInfo(itemPropsThin.get)
-        .withSceneItemLinks(sceneItemLinks)
+        .withSceneItemLinks(sceneItemLinks.map(i =>
+          (i._1, s"../${i._2}", i._3))) // adjust relative links
         .build()
 
     val updatedLayerCollection: StacCollection = layerCollection
       .copy(
         links = layerCollection.links ++ List(
           StacLink(
-            labelCollectionAbsLink,
+            labelCollectionRelLink,
             Child,
             Some(`application/json`),
             Some("Label Collection")
           ),
           StacLink(
-            sceneCollectionAbsLink,
+            sceneCollectionRelLink,
             Child,
             Some(`application/json`),
             Some("Scene Collection")

--- a/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
@@ -151,7 +151,7 @@ class StacCatalogBuilder[
         val layerOwnLinks = List(
           StacLink(
             // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
-            s"${absPath}/catalog.json",
+            "../catalog.json",
             Parent,
             Some(`application/json`),
             Some(s"Catalog ${stacCatalog.id.get}")
@@ -229,12 +229,12 @@ class StacCatalogBuilder[
         )
       })
 
-    val udpatedStacCatalog = stacCatalog
+    val updatedStacCatalog = stacCatalog
       .copy(
         links = stacCatalog.links ++ layerCollectionList.map {
-          case (_, _, _, layerSelfLink) =>
+          case (layerCollection, _, _, _) =>
             StacLink(
-              layerSelfLink,
+              s"${layerCollection.id}/collection.json",
               Child,
               Some(`application/json`),
               Some("Layer Collection")
@@ -245,6 +245,6 @@ class StacCatalogBuilder[
     val layerInfoList = layerCollectionList.map(layerInfo =>
       (layerInfo._1, layerInfo._2, layerInfo._3))
 
-    (udpatedStacCatalog, layerInfoList)
+    (updatedStacCatalog, layerInfoList)
   }
 }

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -289,9 +289,7 @@ final case class WriteStacCatalog(exportId: UUID)(
     val catalogBuilder =
       new StacCatalogBuilder[StacCatalogBuilder.CatalogBuilder.EmptyCatalog]()
     val stacVersion = "0.7.0"
-    val currentPath =
-      contentBundle.export.exportLocation
-        .getOrElse(s"s3://${dataBucket}/stac-exports")
+    val currentPath = s"s3://${dataBucket}/stac-exports"
     val catalogId = contentBundle.export.id.toString
     val catalogParentPath = s"${currentPath}/${catalogId}"
     val catalogDescription =
@@ -306,7 +304,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       ),
       // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
       StacLink(
-        s"${catalogParentPath}/catalog.json",
+        "catalog.json",
         StacRoot,
         Some(`application/json`),
         Some(s"Catalog ${catalogId}")


### PR DESCRIPTION
## Overview
Convert absolute links to relative links where possible

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
run `aws s3 --profile raster-foundry sync s3://rasterfoundry-development-data-us-east-1/stac-exports/96ef477f-f835-4aa6-826c-b1060fac88fc/ ./stac-exports/` to see exported stac 

## Testing Instructions

- `./scripts/load_development_data --download`
- `./scripts/console`:
   * `api/assembly`
   * `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "Test Stac Export",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID>`
- Check on S3 development data bucket -> `stac-exports`, there should be a new folder containing your exported catalog
- download the export using the `aws s3 sync`
- verify that the only absolute links are self links and assets not stored under the root stac export directory

Closes #5118 
