### PR TITLE
Fix chip classification STAC data export and scene item datetime field for both project types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 - Repaired python scene codec for API interaction in scene ingests [\#5148](https://github.com/raster-foundry/raster-foundry/pull/5148)
 - Eliminated superfluous scene queries in thumbnail rendering [\#5139](https://github.com/raster-foundry/raster-foundry/pull/5139)
+- Fixed chip classification STAC data export and scene item `datetime` field for both project types [\#5158](https://github.com/raster-foundry/raster-foundry/pull/5158)
 
 ### Security
 

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -5,7 +5,6 @@ import geotrellis.proj4.CRS
 import com.rasterfoundry.datamodel._
 import io.circe._
 import io.circe.syntax._
-import io.circe.parser._
 import geotrellis.server.stac._
 import geotrellis.server.stac.{StacExtent => _}
 import com.rasterfoundry.batch.stacExport.{StacExtent => BatchStacExtent}
@@ -82,7 +81,8 @@ class SceneCollectionBuilder[
       version: String
   ): SceneCollectionBuilder[CollectionRequirements with CollectionStacVersion] =
     new SceneCollectionBuilder(
-      sceneCollection.copy(stacVersion = Some(version)))
+      sceneCollection.copy(stacVersion = Some(version))
+    )
 
   def withId(
       id: String
@@ -182,12 +182,13 @@ class SceneCollectionBuilder[
               Some("Root")
             )
           )
-          val sceneProperties = JsonObject(
-            (
-              "datetime",
-              parse(
-                scene.filterFields.acquisitionDate.get.toLocalDateTime.toString
-              ).getOrElse(Json.Null)
+          val sceneProperties = JsonObject.fromMap(
+            Map(
+              "datetime" -> scene.filterFields.acquisitionDate
+                .getOrElse(scene.createdAt)
+                .toLocalDateTime
+                .toString
+                .asJson
             )
           )
           val sceneAsset = Map(

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -113,7 +113,7 @@ final case class WriteStacCatalog(exportId: UUID)(
               unsafeGetStacSelfLink(sceneItem.links),
               sceneItem.asJson.noSpaces,
               "application/json"
-          )
+            )
         )
         // label collection
         putObjectToS3(
@@ -181,7 +181,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       projectId: UUID,
       layerId: UUID,
       taskStatuses: List[String],
-      projectType: String
+      projectType: MLProjectType
   ): ConnectionIO[Option[
     (
         List[Scene],

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -113,7 +113,7 @@ final case class WriteStacCatalog(exportId: UUID)(
               unsafeGetStacSelfLink(sceneItem.links),
               sceneItem.asJson.noSpaces,
               "application/json"
-            )
+          )
         )
         // label collection
         putObjectToS3(

--- a/app-backend/datamodel/src/main/scala/MLProjectType.scala
+++ b/app-backend/datamodel/src/main/scala/MLProjectType.scala
@@ -1,0 +1,30 @@
+package com.rasterfoundry.datamodel
+
+import io.circe._
+import cats.syntax.either._
+
+sealed abstract class MLProjectType(val repr: String) {
+  override def toString = repr
+}
+
+object MLProjectType {
+  case object ObjectDetection extends MLProjectType("DETECTION")
+  case object ChipClassification extends MLProjectType("CLASSIFICATION")
+  case object SemanticSegmentation extends MLProjectType("SEGMENTATION")
+
+  def fromString(s: String): MLProjectType = s.toUpperCase match {
+    case "DETECTION"      => ObjectDetection
+    case "CLASSIFICATION" => ChipClassification
+    case "SEGMENTATION"   => SemanticSegmentation
+    case _ =>
+      throw new Exception(s"Unsupported Machine Learning Project Type: ${s}")
+  }
+
+  implicit val MLProjectTypeEncoder: Encoder[MLProjectType] =
+    Encoder.encodeString.contramap[MLProjectType](_.toString)
+
+  implicit val MLProjectTypeDecoder: Decoder[MLProjectType] =
+    Decoder.decodeString.emap { s =>
+      Either.catchNonFatal(fromString(s)).leftMap(_ => "MLProjectType")
+    }
+}

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -568,15 +568,15 @@ object AnnotationDao extends Dao[Annotation] {
       projectId: UUID,
       layerId: UUID,
       taskStatuses: List[String],
-      projectType: String
+      projectType: MLProjectType
   ): ConnectionIO[Option[Json]] = projectType match {
-    case "classfication" =>
+    case MLProjectType.ChipClassification =>
       listClassificationLayerAnnotationsByTaskStatus(
         projectId,
         layerId,
         taskStatuses
       ).map(annoFC => Some(annoFC.asJson))
-    case "detection" =>
+    case MLProjectType.ObjectDetection =>
       listDetectionLayerAnnotationsByTaskStatus(
         projectId,
         layerId,

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -607,7 +607,9 @@ object ProjectDao
     }
   }
 
-  def getAnnotationProjectType(projectId: UUID): ConnectionIO[Option[String]] =
+  def getAnnotationProjectType(
+      projectId: UUID
+  ): ConnectionIO[Option[MLProjectType]] =
     for {
       projectO <- getProjectById(projectId)
       projectType = projectO match {
@@ -626,7 +628,7 @@ object ProjectDao
           }
         case _ => None
       }
-    } yield { projectType }
+    } yield { projectType.map(MLProjectType.fromString(_)) }
 
   def getAnnotationProjectStacInfo(
       projectId: UUID
@@ -661,7 +663,7 @@ object ProjectDao
           case 0 => None
           case _ =>
             val stacClasses
-              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
                 case Some(groupName) if groupName.nonEmpty => groupName
                 case _                                     => "label"

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -663,7 +663,7 @@ object ProjectDao
           case 0 => None
           case _ =>
             val stacClasses
-                : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
+              : List[StacLabelItemProperties.StacLabelItemClasses] = (infoList
               .groupBy(_.labelGroupName match {
                 case Some(groupName) if groupName.nonEmpty => groupName
                 case _                                     => "label"


### PR DESCRIPTION
## Overview

This PR fixes:
- chip classification project label data export
- scene item `datetime` field value for both project types

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- `api/assembly`
- `batch/assembly`
- spin up servers
- bring up annotate and point it to this branch
- log in annotate as the dev user
- create a chip classification project
- label some tasks
- go to the `Exports` tab and create an export of the labeled tasks
- go to Florence Alabama project and create an export of the validated tasks
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID of the chip classification project>`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID of the Florence Alabama project>`
- after the exports are done: `aws s3 sync <s3 prefix to the export> . --profile raster-foundry`
- make sure both exports have `data.geojson` and view them in a geojson viewer
- make sure all scene items have `datetime` property populated correctly

Closes #5156 
Closes #5157 
