### PR TITLE
Add a query parameter to list tasks union by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added caching for selecting projects, project layers, and users by ID [\#5144](https://github.com/raster-foundry/raster-foundry/pull/5144)
 - Added documentation on choice of tracing libraries [\#5145](https://github.com/raster-foundry/raster-foundry/pull/5145)
 - Added a check for band counts during project exports [\#5154](https://github.com/raster-foundry/raster-foundry/pull/5154)
+- Added a query parameter to list tasks union by status [\#5159](https://github.com/raster-foundry/raster-foundry/pull/5159)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -42,15 +42,24 @@ trait ProjectLayerTaskRoutes
         } {
           (withPagination & taskQueryParameters) { (page, taskParams) =>
             complete {
-              TaskDao
-                .listTasks(
-                  taskParams,
-                  projectId,
-                  layerId,
-                  page
-                )
-                .transact(xa)
-                .unsafeToFuture
+              (
+                taskParams.format match {
+                  case Some(format) if format.toUpperCase == "SUMMARY" =>
+                    TaskDao.listTaskGeomByStatus(
+                      user,
+                      projectId,
+                      layerId
+                    )
+                  case _ =>
+                    TaskDao
+                      .listTasks(
+                        taskParams,
+                        projectId,
+                        layerId,
+                        page
+                      )
+                }
+              ).transact(xa).unsafeToFuture
             }
           }
         }

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -48,7 +48,8 @@ trait ProjectLayerTaskRoutes
                     TaskDao.listTaskGeomByStatus(
                       user,
                       projectId,
-                      layerId
+                      layerId,
+                      taskParams.status
                     )
                   case _ =>
                     TaskDao

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -175,7 +175,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
       'actionStartTime.as(deserializerTimestamp).?,
       'actionEndTime.as(deserializerTimestamp).?,
       'actionMinCount.as[Int].?,
-      'actionMaxCount.as[Int].?
+      'actionMaxCount.as[Int].?,
+      'format.as[String].?
     ).as(TaskQueryParameters.apply _)
 
   def userTaskActivityParameters =

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -659,7 +659,8 @@ final case class TaskQueryParameters(
     actionStartTime: Option[Timestamp] = None,
     actionEndTime: Option[Timestamp] = None,
     actionMinCount: Option[Int] = None,
-    actionMaxCount: Option[Int] = None
+    actionMaxCount: Option[Int] = None,
+    format: Option[String] = None
 ) {
   val bboxPolygon: Option[Seq[Projected[Polygon]]] =
     BboxUtil.toBboxPolygon(bbox)

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -140,7 +140,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-          )
+        )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -157,12 +157,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-        : Decoder[TaskFeatureCollectionCreate] =
+      : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-        : Encoder[TaskFeatureCollectionCreate] =
+      : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -175,10 +175,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-        : Encoder[TaskGridCreateProperties] =
+      : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-        : Decoder[TaskGridCreateProperties] =
+      : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -140,7 +140,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-        )
+          )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -157,12 +157,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-      : Decoder[TaskFeatureCollectionCreate] =
+        : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-      : Encoder[TaskFeatureCollectionCreate] =
+        : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -175,10 +175,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-      : Encoder[TaskGridCreateProperties] =
+        : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-      : Decoder[TaskGridCreateProperties] =
+        : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 
@@ -222,4 +222,10 @@ final case class UnionedGeomExtent(
     yMin: Double,
     xMax: Double,
     yMax: Double
+)
+
+@JsonCodec
+final case class UnionedGeomWithStatus(
+    status: TaskStatus,
+    geometry: Projected[Geometry]
 )

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -305,7 +305,7 @@ object TaskDao extends Dao[Task] {
         NULLIF(users.email, ''),
         NULLIF(users.personal_info->>'email', ''),
         users.id
-      ),
+      ) as name,
       users.profile_image_uri
     FROM user_group_roles AS ugr
     INNER JOIN (

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -298,7 +298,15 @@ object TaskDao extends Dao[Task] {
       params: UserTaskActivityParameters
   ): Fragment =
     fr"""
-    SELECT DISTINCT ugr.user_id, users.name, users.profile_image_uri
+    SELECT DISTINCT
+      ugr.user_id,
+      COALESCE(
+        NULLIF(users.name, ''),
+        NULLIF(users.email, ''),
+        NULLIF(users.personal_info->>'email', ''),
+        users.id
+      ),
+      users.profile_image_uri
     FROM user_group_roles AS ugr
     INNER JOIN (
       SELECT

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3336,6 +3336,7 @@ paths:
         - $ref: '#/parameters/actionEndTime'
         - $ref: '#/parameters/actionMinCount'
         - $ref: '#/parameters/actionMaxCount'
+        - $ref: '#/parameters/format'
       responses:
         200:
           description: 'Paginated geoJSON feature collection containing tasks for this project layer'
@@ -5657,6 +5658,12 @@ parameters:
       Note: CURRENTLY IGNORED.
     in: query
     type: integer
+    required: false
+  format:
+    name: format
+    description: "List tasks union by status if `summary` is specified"
+    in: query
+    type: string
     required: false
   taskId:
     name: taskId

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -5661,7 +5661,7 @@ parameters:
     required: false
   format:
     name: format
-    description: "List tasks union by status if `summary` is specified"
+    description: 'List tasks union by status if `summary` is specified'
     in: query
     type: string
     required: false


### PR DESCRIPTION
## Overview

This PR adds a `format` query parameter to the task list endpoint to list tasks union by status, in order to support speeding up the load of the task map in annotate.

It also adds a user name fallback in the task user summary endpoint so that collaborators table's user names are populated.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- Assemble the api jar
- Spin up frontend and get a token, Florence project's ID and default layer ID
- `GET` to `api/projects/<project ID>/layers/<layer ID>/tasks?format=summary` should return a `FeatureCollection` of all available tasks with geometries unioned by statuses
- `GET` to `api/projects/<project ID>/layers/<layer ID>/tasks?format=summary&status=<a valid task status>` should return a `FeatureCollection` of one unioned task record of that specific status

Closes https://github.com/raster-foundry/annotate/issues/334
Closes https://github.com/raster-foundry/annotate/issues/366
