### PR TITLE
Fix scene item relative links in scene collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Updated STAC export location to use the S3 prefix [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Updated values for label:task, label:property, and label:classes of the STAC label item [\#5140](https://github.com/raster-foundry/raster-foundry/pull/5140)
 - Tuned proxy_connect_timeout to make Nginx fail faster [\#5133](https://github.com/raster-foundry/raster-foundry/pull/5133)
-- Change absolute links in stac export to relative, so they make sense in a local downloaded context [\#5155](https://github.com/raster-foundry/raster-foundry/pull/5155)
+- Change absolute links in stac export to relative, so they make sense in a local downloaded context [\#5155](https://github.com/raster-foundry/raster-foundry/pull/5155), [\#5161](https://github.com/raster-foundry/raster-foundry/pull/5161)
 
 ### Deprecated
 

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -216,9 +216,7 @@ class SceneCollectionBuilder[
         })
 
     val sceneLinks: List[(String, String, String)] =
-      sceneItemsAndLinks
-        .map(_._2)
-        .map(i => (i._1, s"${sceneCollection.id.get}/${i._2}", i._3)) // adjust relative links
+      sceneItemsAndLinks.map(_._2)
 
     (
       sceneCollection

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -29,8 +29,6 @@ final case class WriteStacCatalog(exportId: UUID)(
 
   val name = WriteStacCatalog.name
 
-  def runJob(args: List[String]) = ???
-
   protected def s3Client = S3()
 
   @SuppressWarnings(Array("CatchThrowable"))


### PR DESCRIPTION
## Overview

This PR makes it so that items in scene collections don't have the collection id prepended to their relative paths. It's an attempt to address an error encountered in #5147 (see [comment](https://github.com/raster-foundry/raster-foundry/issues/5147#issuecomment-530311524))

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

will link to logs once I get the test branch up

## Testing Instructions

- from the repo root `mkdir -p data/stac`
- download the STAC export I just created: `aws --profile raster-foundry s3 cp --recursive s3://rasterfoundry-staging-data-us-east-1/stac-exports/a7142852-08bd-47e9-8f6f-74f21b7deceb ./data/stac/`
- fire up a docker container with python (good chance this'll be in your docker cache already) and install `stac_validator`

```bash
$ docker run --rm -it -v (pwd)/data:/opt/data --entrypoint bash python:3.7
$ pip install stac_validator
```

- run `stac_validator` against the catalog, like so:

```bash
$ stac_validator /opt/data/stac/catalog.json --follow --version v0.7.0
{
    "catalogs": {
        "valid": 1,
        "invalid": 0
    },
    "collections": {
        "valid": 3,
        "invalid": 0
    },
    "items": {
        "valid": 2,
        "invalid": 0
    },
    "unknown": 0
}
```
- confirm that you also have only valid results

Closes #5147 