### PR TITLE
Use absolute S3 link for label data upload and switch DB log level to debug

### DIFF
--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -249,6 +249,7 @@ class LabelCollectionBuilder[
     // but StacItem from gt-server only accepts `image/cog`
     // or it will throw an exception
     val labelDataRelLink = "./data.geojson"
+    val labelDataS3AbsLink: String = s"${labelItemSelfAbsPath}/data.geojson"
     val labelAsset = Map(
       labelItemId ->
         StacAsset(
@@ -281,7 +282,7 @@ class LabelCollectionBuilder[
         )
         .toStacCollection(),
       labelItem,
-      labelDataRelLink
+      labelDataS3AbsLink
     )
   }
 }

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -48,7 +48,7 @@ object Dao extends LazyLogging {
         .zip(a.map(s => "'" + s + "'"))
         .flatMap({ case (t1, t2) => List(t1, t2) })
         .mkString("")
-      logger.info(s"""Successful Statement Execution:
+      logger.debug(s"""Successful Statement Execution:
         |
         |  ${logString}
         |


### PR DESCRIPTION
## Overview

This PR:
- fixes the upload link of the label data so that it uses absolute S3 link
- switches database log level back from info to debug

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- `api/assembly`
- `batch/assembly`
- spin up servers
- bring up annotate and point it to this branch ([steps](https://github.com/raster-foundry/annotate/wiki/Point-to-Raster-Foundry-local-servers))
- log in annotate as the dev user
- create a chip classification project
- label some tasks
- go to the `Exports` tab and create an export of the labeled tasks
- go to Florence Alabama project and create an export of the validated tasks
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID of the chip classification project>`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac export ID of the Florence Alabama project>`
- after the exports are done: `aws s3 sync <s3 prefix to the export> . --profile raster-foundry`
- make sure both exports have `data.geojson` and view them in a geojson viewer


Closes https://github.com/raster-foundry/raster-foundry/issues/5163
Closes https://github.com/raster-foundry/raster-foundry/issues/5162
