### PR TITLE
Add scene id to scene detail modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 - Added tracing support to tile server [\#5165](https://github.com/raster-foundry/raster-foundry/pull/5165)
+- Expose scene id in the scene detail modal [\#5168](https://github.com/raster-foundry/raster-foundry/pull/5168)
 
 ### Changed
 

--- a/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
+++ b/app-frontend/src/app/components/scenes/sceneDetailModal/sceneDetailModal.html
@@ -31,6 +31,12 @@
         <h5 class="color-dark">Scene properties</h5>
         <dl class="meta-list" ng-if="!$ctrl.editingMetadata && $ctrl.isUploadDone">
           <dt>
+            Scene Id:
+          </dt>
+          <dd>
+            {{$ctrl.scene.id}}
+          </dd>
+          <dt>
             Datasource:
           </dt>
           <dd>


### PR DESCRIPTION
## Overview
Expose scene id in the scene detail modal

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/64880737-e7f1de00-d626-11e9-9104-c91f86434afe.png)


### Notes
Users shouldn't have to open the network tab of their dev tools to find a scene id.

## Testing Instructions

- View a scene detail modal and verify that the id is visible

