### PR TITLE
Use RasterSource to generate better histograms for cogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added tracing support to tile server [\#5165](https://github.com/raster-foundry/raster-foundry/pull/5165)[\#5171](https://github.com/raster-foundry/raster-foundry/pull/5171)
 
 ### Changed
+- Improve histogram generation by using RasterSources [\#5169](https://github.com/raster-foundry/raster-foundry/pull/5169)
 
 ### Deprecated
 

--- a/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.batch.Job
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.utils.CogUtils
 import com.rasterfoundry.common.LayerAttribute
-import com.rasterfoundry.datamodel.TiffWithMetadata
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.{LayerAttributeDao, SceneDao}
 
@@ -19,7 +18,6 @@ import io.circe.parser._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-import scala.concurrent.ExecutionContext
 import java.util.UUID
 
 object HistogramBackfill
@@ -55,94 +53,81 @@ object HistogramBackfill
   @SuppressWarnings(Array("OptionGet"))
   def insertHistogramLayerAttribute(cogTuple: CogTuple)(
       implicit xa: Transactor[IO],
-      ec: ExecutionContext): IO[Option[LayerAttribute]] = (
-    for {
-      histogram <- getSceneHistogram(cogTuple._2.get)
-      inserted <- parse(histogram.toJson.toString).toOption match {
-        case Some(x) if x.toString == "null" =>
-          None.pure[IO]
-        case None =>
-          None.pure[IO]
-        case Some(parsed) =>
-          LayerAttributeDao
-            .insertLayerAttribute(
-              LayerAttribute(
-                cogTuple._1.toString,
-                0,
-                "histogram",
-                parsed
-              )
+  ): IO[Option[LayerAttribute]] = {
+    val histogram = getSceneHistogram(cogTuple._2.get)
+    parse(histogram.toJson.toString).toOption match {
+      case Some(x) if x.toString == "null" =>
+        None.pure[IO]
+      case None =>
+        None.pure[IO]
+      case Some(parsed) =>
+        LayerAttributeDao
+          .insertLayerAttribute(
+            LayerAttribute(
+              cogTuple._1.toString,
+              0,
+              "histogram",
+              parsed
             )
-            .map({ layerAttribute: LayerAttribute =>
-              Some(layerAttribute)
-            })
-            .transact(xa)
-      }
-    } yield inserted
-  )
-
-  def getSceneHistogram(ingestLocation: String)(
-      implicit ec: ExecutionContext): IO[Option[List[Histogram[Double]]]] = {
-    logger.info(s"Fetching histogram for scene at $ingestLocation")
-    IO.fromFuture {
-      IO(
-        (CogUtils.fromUri(ingestLocation) map {
-          case TiffWithMetadata(tiff, _) =>
-            CogUtils.geoTiffDoubleHistogram(tiff).toList
-        }).value
-      )
-    } recoverWith ({
-      case t: Throwable =>
-        sendError(t)
-        logger.info(s"Fetching histogram for scene at $ingestLocation failed")
-        logger.error(t.getMessage, t)
-        Option.empty[List[Histogram[Double]]].pure[IO]
-    })
+          )
+          .map({ layerAttribute: LayerAttribute =>
+            Some(layerAttribute)
+          })
+          .transact(xa)
+    }
   }
 
-  def runJob(args: List[String]): IO[Unit] =
-    threadPoolResource.use { pool =>
-      implicit val xa =
-        RFTransactor.nonHikariTransactor(RFTransactor.TransactorConfig())
-      implicit val ec = ExecutionContext.fromExecutor(pool)
-      for {
-        sceneTupleChunks <- args map { UUID.fromString(_) } match {
-          // If we don't have any ids, just get all the COG scenes without histograms
-          case Nil => getScenesToBackfill
-          // If we do have some ids, go get those scenes. Assume the user has picked scenes correctly
-          case ids =>
-            ids traverse { id =>
-              {
-                SceneDao.unsafeGetSceneById(id).transact(xa) map { scene =>
-                  (scene.id, scene.ingestLocation)
-                }
+  def getSceneHistogram(
+      ingestLocation: String): Option[Array[Histogram[Double]]] = {
+    logger.info(s"Fetching histogram for scene at $ingestLocation")
+    val histO = CogUtils.histogramFromUri(ingestLocation)
+    if (histO.isEmpty) {
+      logger.info(s"Fetching histogram for scene at $ingestLocation failed")
+    }
+    histO
+  }
+
+  def runJob(args: List[String]): IO[Unit] = {
+    implicit val xa =
+      RFTransactor.nonHikariTransactor(RFTransactor.TransactorConfig())
+    for {
+      sceneTupleChunks <- args map { UUID.fromString(_) } match {
+        // If we don't have any ids, just get all the COG scenes without histograms
+        case Nil => getScenesToBackfill
+        // If we do have some ids, go get those scenes. Assume the user has picked scenes correctly
+        case ids =>
+          ids traverse { id =>
+            {
+              SceneDao.unsafeGetSceneById(id).transact(xa) map { scene =>
+                (scene.id, scene.ingestLocation)
               }
-            } map { List(_) }
-        }
-        ios <- IO {
-          sceneTupleChunks map { chunk =>
-            chunk traverse { idWithIngestLoc =>
-              insertHistogramLayerAttribute(idWithIngestLoc)
             }
+          } map { List(_) }
+      }
+      ios <- IO {
+        sceneTupleChunks map { chunk =>
+          chunk traverse { idWithIngestLoc =>
+            insertHistogramLayerAttribute(idWithIngestLoc)
           }
         }
-        allResults = ios flatMap {
-          _.recoverWith({
-            case t: Throwable =>
-              sendError(t)
-              logger.error(t.getMessage, t)
-              IO(List.empty[Option[LayerAttribute]])
-          }).unsafeRunSync
-        }
-        errors = allResults filter { _.isEmpty }
-        successes = allResults filter { !_.isEmpty }
-      } yield {
-        logger.info(
-          s"""
+      }
+      allResults = ios flatMap {
+        _.recoverWith({
+          case t: Throwable =>
+            sendError(t)
+            logger.error(t.getMessage, t)
+            IO(List.empty[Option[LayerAttribute]])
+        }).unsafeRunSync
+      }
+      errors = allResults filter { _.isEmpty }
+      successes = allResults filter { !_.isEmpty }
+    } yield {
+      logger.info(
+        s"""
               | Created histograms for ${successes.length} scenes.
               | Failed to create histograms for ${errors.length} scenes.
               """.trim.stripMargin
-        )
-      }
+      )
     }
+  }
 }

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -3,107 +3,49 @@ package com.rasterfoundry.common.utils
 import com.rasterfoundry.common.cache._
 import com.rasterfoundry.common.cache.kryo._
 import com.rasterfoundry.common.{Config => CommonConfig}
-import com.rasterfoundry.datamodel.TiffWithMetadata
 
 import geotrellis.vector._
 import geotrellis.raster._
 import geotrellis.raster.histogram._
-import geotrellis.raster.io.geotiff._
-import geotrellis.raster.io.geotiff.reader.{GeoTiffReader, TiffTagsReader}
+import geotrellis.contrib.vlm.gdal.GDALRasterSource
 import geotrellis.proj4._
 import geotrellis.vector.Projected
 
-import cats.data._
 import cats.implicits._
 
-import scala.concurrent._
+import com.typesafe.scalalogging.LazyLogging
 
-object CogUtils {
+object CogUtils extends LazyLogging {
   lazy val cacheConfig = CommonConfig.memcached
   lazy val memcachedClient = KryoMemcachedClient.default
   lazy val rfCache = new CacheClient(memcachedClient)
 
-  /** Read GeoTiff from URI while caching the header bytes in memcache */
-  def fromUri(uri: String)(
-      implicit ec: ExecutionContext): OptionT[Future, TiffWithMetadata] = {
-    val cacheKey = s"cog-header-${URIUtils.withNoParams(uri)}"
-    val cacheSize = 1 << 18
-
-    rfCache
-      .cachingOptionT(cacheKey, doCache = cacheConfig.tool.enabled) {
-        OptionT {
-          Future {
-            RangeReaderUtils.fromUri(uri).map(_.readRange(0, cacheSize))
-          }
-        }
-      }
-      .mapFilter { headerBytes =>
-        RangeReaderUtils.fromUri(uri).map { rr =>
-          val crr = CacheRangeReader(rr, headerBytes)
-          TiffWithMetadata(GeoTiffReader.readMultiband(crr, streaming = true),
-                           TiffTagsReader.read(crr))
-        }
-      }
+  def getTiffExtent(uri: String): Projected[MultiPolygon] = {
+    val rasterSource = GDALRasterSource(uri)
+    val crs = rasterSource.crs
+    Projected(
+      MultiPolygon(rasterSource.extent.reproject(crs, WebMercator).toPolygon()),
+      3857)
   }
 
-  def getTiffExtent(uri: String): Option[Projected[MultiPolygon]] = {
-    for {
-      rr <- RangeReaderUtils.fromUri(uri)
-      tiff = GeoTiffReader.readMultiband(rr, streaming = true)
-    } yield {
-      val crs = tiff.crs
-      Projected(
-        MultiPolygon(tiff.extent.reproject(crs, WebMercator).toPolygon()),
-        3857)
-    }
-  }
-
-  def geoTiffDoubleHistogram(tiff: GeoTiff[MultibandTile],
-                             buckets: Int = 80,
-                             size: Int = 128): Array[Histogram[Double]] = {
-
-    def diagonal(tiff: GeoTiff[MultibandTile]): Int =
-      math.sqrt(tiff.cols * tiff.cols + tiff.rows * tiff.rows).toInt
-
-    val goldyLocksOverviews = tiff.overviews.filter { tiff =>
-      val d = diagonal(tiff)
-      (d >= size && d <= size * 4)
-    }
-
-    if (goldyLocksOverviews.nonEmpty) {
-      // case: overview that is close enough to the size, not more than 4x larger
-      // -- read the overview and get histogram
-      val theOne = goldyLocksOverviews.minBy(diagonal)
-      val hists = Array.fill(tiff.bandCount)(DoubleHistogram(buckets))
-      theOne.tile.foreachDouble { (band, v) =>
-        if (!v.isNaN) {
-          hists(band).countItem(v, 1)
-        }
-      }
-      hists.toArray
-    } else {
-      // case: such oveview can't be found
-      // -- take min overview and sample window from center
-      val theOne = tiff.overviews.minBy(diagonal)
-      val sampleBounds = {
-        val side = math.sqrt(size * size / 2)
-        val centerCol = theOne.cols / 2
-        val centerRow = theOne.rows / 2
-        GridBounds(
-          colMin = math.max(0, centerCol - (side / 2)).toInt,
-          rowMin = math.max(0, centerRow - (side / 2)).toInt,
-          colMax = math.min(theOne.cols - 1, centerCol + (side / 2)).toInt,
-          rowMax = math.min(theOne.rows - 1, centerRow + (side / 2)).toInt
-        )
-      }
-      val sample = theOne.crop(List(sampleBounds)).next._2
-      val hists = Array.fill(tiff.bandCount)(DoubleHistogram(buckets))
-      sample.foreachDouble { (band, v) =>
-        if (!v.isNaN) {
-          hists(band).countItem(v, 1)
-        }
-      }
-      hists.toArray
-    }
+  def histogramFromUri(uri: String,
+                       buckets: Int = 80): Option[Array[Histogram[Double]]] = {
+    // use the resolution that's closest to 100,000 pixels and not greater than 400,000 pixels
+    // this must fit in a request/response cycle. A 500x500 overview is reasonable, and that adds
+    // up to 250,000 pixels
+    // We may need to adjust this number depending on how fast our API is able to process it, these
+    // numbers are based off local testing
+    val rasterSource = GDALRasterSource(uri)
+    rasterSource.resolutions
+      .filter(r => r.rows * r.cols < 400000)
+      .toNel
+      .flatMap(
+        resNel =>
+          rasterSource
+            .resampleToGrid(
+              resNel.toList.minBy(r => scala.math.abs(100000 - r.rows * r.cols))
+            )
+            .read()
+            .map(_.tile.histogramDouble(buckets)))
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - ./nginx/etc/nginx/conf.d/backsplash.conf:/etc/nginx/conf.d/default.conf
 
   api-server:
-    image: openjdk:11-slim
+    image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
     links:
       - postgres:database.service.rasterfoundry.internal
       - memcached:tile-cache.service.rasterfoundry.internal
@@ -64,6 +64,7 @@ services:
       - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
       - BACKSPLASH_ENABLE_MULTITIFF=true
+      - AWS_DEFAULT_PROFILE=raster-foundry
     ports:
       - "9000:9000"
       - "9010:9010"


### PR DESCRIPTION
## Overview
CogUtils histogram generation is old and flawed, replace it with RasterSource histograms

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions
- Create a new scene with the `PSScene4Band-20180205_171853_103d-analytic_sr.tif` image in your `data` folder. Verify that the scene renders
- Use scenes from https://app.staging.rasterfoundry.com/projects/edit/4a298fe2-ac20-4377-90eb-fc6a7e3a9584/scenes?page=1 and verify that they are now colored correctly (use the staging systems user to get the urls, these are client scenes)
- Use a couple other cogs that have acted up in the past and verify that they generate histograms correctly

Closes #5166