### PR TITLE
Fix single band color ramp nodata values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Removed
 
 ### Fixed
+- Remove unnecessary coercion of scenes to a nodata value of 0 in single band mode [\#5173](https://github.com/raster-foundry/raster-foundry/pull/5173)
 
 ### Security
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/color/ColorRampMosaic.scala
@@ -132,8 +132,7 @@ object ColorRampMosaic extends LazyLogging {
           throw new BadAnalysisASTException(message)
       }
 
-    val renderedTile =
-      cmap.render(singleBandTile.interpretAs(IntUserDefinedNoDataCellType(0)))
+    val renderedTile = cmap.render(singleBandTile)
     val r = renderedTile.map(_.red).interpretAs(UByteCellType)
     val g = renderedTile.map(_.green).interpretAs(UByteCellType)
     val b = renderedTile.map(_.blue).interpretAs(UByteCellType)


### PR DESCRIPTION
## Overview
Remove coercion to 0 nodata value

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
Before:
![image](https://user-images.githubusercontent.com/4392704/65069189-29042e00-d958-11e9-8438-e57e27168d98.png)

After
![image](https://user-images.githubusercontent.com/4392704/65068873-8186fb80-d957-11e9-9170-d661edb0c334.png)

### Notes

## Testing Instructions

- Switch a bunch of projects that have a non-zero nodata value for the underlying data to single band mode and verify that they show up correctly.

Closes #5132
Depends on #5169
