### PR TITLE
Remove API spec publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Removed
 
+- Remove API spec publishing [\#5174](https://github.com/raster-foundry/raster-foundry/pull/5174)
+
 ### Fixed
 
 ### Security

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ node {
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
     if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\// ) {
-        env.RF_DOCS_BUCKET = 'rasterfoundry-staging-docs-site-us-east-1'
         env.RF_DEPLOYMENT_BRANCH = 'develop'
         env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
 

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -19,7 +19,6 @@ node {
       name: 'RELEASE_TAG', 
       regex: /^\d+\.\d+\.\d+$/],
       string(defaultValue: 'rasterfoundry-production-config-us-east-1', description: 'Location of Terraform state & vars files.', name: 'RF_SETTINGS_BUCKET', trim: false),
-      string(defaultValue: 'rasterfoundry-production-docs-site-us-east-1', description: 'Location of API documentation & specs.', name: 'RF_DOCS_BUCKET', trim: false),
       string(defaultValue: 'Production', description: 'Environment name, used to target Batch Compute Environments.', name: 'RF_DEPLOYMENT_ENVIRONMENT', trim: false),
       string(defaultValue: 'master', description: 'Branch of azavea/raster-foundry-deployment used for deployment.', name: 'RF_DEPLOYMENT_BRANCH', trim: false)
     ])
@@ -58,13 +57,6 @@ node {
           }
         }
       }
-    }
-
-    stage('publish-specs') {
-      sh """#!/bin/bash
-        aws s3 sync docs/swagger/ s3://${params.RF_DOCS_BUCKET}/spec/${params.RELEASE_TAG}/
-        aws s3 sync docs/swagger/ s3://${params.RF_DOCS_BUCKET}/spec/
-      """
     }
 
     stage('infra') {

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -61,16 +61,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 "${DIR}/../app-backend/lambda-overviews/target/scala-2.12/lambda-overviews-assembly.jar" \
                 "s3://${RF_ARTIFACTS_BUCKET}/lambda-functions/lambda-overviews-${GIT_COMMIT}.jar"
 
-            echo "Uploading API specs"
-            # At the most recent version prefixed
-            aws s3 sync \
-                "${DIR}/../docs/swagger/" \
-                "s3://${RF_DOCS_BUCKET}/spec/$(git describe --abbrev=0 --tags)/"
-            # At the root
-            aws s3 sync \
-                "${DIR}/../docs/swagger/" \
-                "s3://${RF_DOCS_BUCKET}/spec/"
-
             # Build publishable sbt projects as SNAPSHOT artifacts and
             # publish to Sonatype OSSRH (Snapshot Repository).
             if [ "$(whoami)" == "jenkins" ]; then


### PR DESCRIPTION
## Overview

This PR removes all remnants of API spec publishing to S3.

Connects https://github.com/azavea/raster-foundry-platform/issues/814

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

## Testing Instructions

See this Slack conversation where it was determined we are no longer relying on spec.rasterfoundry.com: https://azavea.slack.com/archives/C089LBS6S/p1568744948022300