### PR TITLE
Fix the datasource id for MODIS aqua

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### Fixed
 
+- Made MODIS Aqua datasource id in the frontend a valid UUID [\#5175](https://github.com/raster-foundry/raster-foundry/pull/5175)
+
 ### Security
 
 ## [1.29.1](https://github.com/raster-foundry/raster-foundry/compare/1.29.0...1.29.1)

--- a/app-frontend/src/app/services/scenes/cmrRepository.service.js
+++ b/app-frontend/src/app/services/scenes/cmrRepository.service.js
@@ -14,7 +14,7 @@ export default (app) => {
         initDatasources() {
             this.datasources = [{
                 name: 'MYD09A1: MODIS/Aqua ',
-                uuid: '755735945-9da5-47c3-8ae4-572b5e11205b',
+                uuid: '55735945-9da5-47c3-8ae4-572b5e11205b',
                 id: 'MYD09A1',
                 uploadType: 'MODIS_USGS',
                 fileAdapter(scene) {


### PR DESCRIPTION
## Overview

This PR makes MODIS Aqua UUID a valid UUID and also the ID of the MODIS Aqua datasource in the database.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

:sunglasses:

![upload](https://user-images.githubusercontent.com/5702984/65079930-cc0f7480-d965-11e9-9aeb-0be6721fb02a.gif)

## Testing Instructions

- confirm you can create an upload with the MODIS Aqua datasource from the frontend
- or just watch the gif
- or check that the uuid is a valid uuid in the only change
- your call