### PR TITLE
Add MultiTiff image rendering for more datasources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Added
 
-- Added support for visualizing Landsat 8 scenes directly from AWS without ingest [\#5167](https://github.com/raster-foundry/raster-foundry/pull/5167)
+- Added (feature flagged) support for visualizing Landsat 8 scenes directly from AWS without ingest [\#5167](https://github.com/raster-foundry/raster-foundry/pull/5167), currently ineffective support for multitiff imagery for Landsats 4 / 5 / 7 and Sentinel-2 [\#5178](https://github.com/raster-foundry/raster-foundry/pull/5178)
 - Expose scene id in the scene detail modal [\#5168](https://github.com/raster-foundry/raster-foundry/pull/5168)
 - Added tracing support to tile server [\#5165](https://github.com/raster-foundry/raster-foundry/pull/5165)[\#5171](https://github.com/raster-foundry/raster-foundry/pull/5171)
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -198,7 +198,7 @@ case class Sentinel2MultiTiffImage(
     "imageId" -> s"$imageId",
     "subsetBands" -> subsetBands.mkString(","),
     "prefix" -> prefix,
-    "readType" -> "LandsatMultitiff"
+    "readType" -> "Sentinel2Multitiff"
   )
 
   def makeBandName(bandNum: Int): String = bandNum match {

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -196,7 +196,7 @@ case class LandsatHistoricalMultiTiffImage(
     *
     * Landsat IDs look like LT05_L1TP_046029_20090302_20160905_01_T1
     */
-  val pattern = """L([\d]).(\d)_.{4}_(\d{3})(\d{3}).*""".r
+  val pattern = """L(.).(\d)_.{4}_(\d{3})(\d{3}).*""".r
   val pattern(sensor, landsatNum, path, row) = landsatId
 
   val prefix =

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -24,6 +24,7 @@ import TmsReification._
 import com.colisweb.tracing.{NoOpTracingContext, TracingContext}
 import com.typesafe.scalalogging.LazyLogging
 import com.rasterfoundry.datamodel.SingleBandOptions
+import com.rasterfoundry.datamodel.UploadType.LandsatHistorical
 
 class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
     histStore: HistStore,
@@ -333,6 +334,9 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
           im.getHistogram(im.tracingContext)
         // Is this hilariously repetitive? Yes! But type erasure :(
         case im: Sentinel2MultiTiffImage =>
+          logger.debug(s"Retrieving histograms for ${im.imageId} from source")
+          im.getHistogram(im.tracingContext)
+        case im: LandsatHistoricalMultiTiffImage =>
           logger.debug(s"Retrieving histograms for ${im.imageId} from source")
           im.getHistogram(im.tracingContext)
       }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -24,7 +24,6 @@ import TmsReification._
 import com.colisweb.tracing.{NoOpTracingContext, TracingContext}
 import com.typesafe.scalalogging.LazyLogging
 import com.rasterfoundry.datamodel.SingleBandOptions
-import com.rasterfoundry.datamodel.UploadType.LandsatHistorical
 
 class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
     histStore: HistStore,

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -331,6 +331,10 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
         case im: Landsat8MultiTiffImage =>
           logger.debug(s"Retrieving histograms for ${im.imageId} from source")
           im.getHistogram(im.tracingContext)
+        // Is this hilariously repetitive? Yes! But type erasure :(
+        case im: Sentinel2MultiTiffImage =>
+          logger.debug(s"Retrieving histograms for ${im.imageId} from source")
+          im.getHistogram(im.tracingContext)
       }
     }
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -13,6 +13,10 @@ object Config {
       UUID.fromString(publicDataConfig.getString("landsat8DatasourceId"))
     val sentinel2DatasourceId =
       UUID.fromString(publicDataConfig.getString("sentinel2DatasourceId"))
+    val landsat45ThematicMapperDatasourceId =
+      UUID.fromString(publicDataConfig.getString("landsat45TMDatasourceId"))
+    val landsat7ETMDatasourceId =
+      UUID.fromString(publicDataConfig.getString("landsat7ETMDatasourceId"))
     val enableMultiTiff =
       publicDataConfig.getBoolean("enableMultiTiff")
   }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
@@ -101,6 +101,22 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
           } getOrElse { "" },
           tracingContext
         )
+      case Config.publicData.sentinel2DatasourceId
+          if Config.publicData.enableMultiTiff =>
+        Sentinel2MultiTiffImage(
+          sceneId,
+          footprint,
+          subsetBands,
+          colorCorrectParameters,
+          singleBandOptions,
+          mosaicDefinition.projectId,
+          projId,
+          mosaicDefinition.mask,
+          mosaicDefinition.metadataFiles.headOption map { uri =>
+            s"s3://sentinel-s2-l1c/${prefixFromHttpsS3Path(uri)}"
+          } getOrElse { "" },
+          tracingContext
+        )
       case _ =>
         val ingestLocation = mosaicDefinition.ingestLocation getOrElse {
           throw UningestedScenesException(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
@@ -117,6 +117,21 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
           } getOrElse { "" },
           tracingContext
         )
+      case Config.publicData.landsat45ThematicMapperDatasourceId |
+          Config.publicData.landsat7ETMDatasourceId
+          if Config.publicData.enableMultiTiff =>
+        LandsatHistoricalMultiTiffImage(
+          sceneId,
+          footprint,
+          subsetBands,
+          colorCorrectParameters,
+          singleBandOptions,
+          mosaicDefinition.projectId,
+          projId,
+          mosaicDefinition.mask,
+          mosaicDefinition.sceneName,
+          tracingContext
+        )
       case _ =>
         val ingestLocation = mosaicDefinition.ingestLocation getOrElse {
           throw UningestedScenesException(

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -100,6 +100,8 @@ geotrellis {
 publicData {
   landsat8DatasourceId = "697a0b91-b7a8-446e-842c-97cda155554d"
   sentinel2DatasourceId = "4a50cb75-815d-4fe5-8bc1-144729ce5b42"
+  landsat45TMDatasourceId = "e8c4d923-5a73-430d-8fe4-53bd6a12ce6a"
+  landsat7ETMDatasourceId = "5a462d31-5744-4ab9-9e80-5dbcb118f72f"
 
   enableMultiTiff = false
   enableMultiTiff = ${?BACKSPLASH_ENABLE_MULTITIFF}

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/MosaicDefinition.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/MosaicDefinition.scala
@@ -13,6 +13,7 @@ final case class MosaicDefinition(
     sceneId: UUID,
     projectId: UUID,
     datasource: UUID,
+    sceneName: String,
     colorCorrections: ColorCorrect.Params,
     sceneType: Option[SceneType] = None,
     ingestLocation: Option[String],

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/SceneToLayer.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/SceneToLayer.scala
@@ -26,6 +26,7 @@ final case class SceneToLayerWithSceneType(
     sceneId: UUID,
     projectId: UUID,
     datasource: UUID,
+    sceneName: String,
     projectLayerId: UUID,
     accepted: Boolean,
     sceneOrder: Option[Int] = None,

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -15,13 +15,15 @@ import cats.implicits._
 
 import com.typesafe.scalalogging.LazyLogging
 
+import java.net.URLDecoder
+
 object CogUtils extends LazyLogging {
   lazy val cacheConfig = CommonConfig.memcached
   lazy val memcachedClient = KryoMemcachedClient.default
   lazy val rfCache = new CacheClient(memcachedClient)
 
   def getTiffExtent(uri: String): Projected[MultiPolygon] = {
-    val rasterSource = GDALRasterSource(uri)
+    val rasterSource = GDALRasterSource(URLDecoder.decode(uri, "UTF-8"))
     val crs = rasterSource.crs
     Projected(
       MultiPolygon(rasterSource.extent.reproject(crs, WebMercator).toPolygon()),
@@ -35,7 +37,7 @@ object CogUtils extends LazyLogging {
     // up to 250,000 pixels
     // We may need to adjust this number depending on how fast our API is able to process it, these
     // numbers are based off local testing
-    val rasterSource = GDALRasterSource(uri)
+    val rasterSource = GDALRasterSource(URLDecoder.decode(uri, "UTF-8"))
     rasterSource.resolutions
       .filter(r => r.rows * r.cols < 400000)
       .toNel

--- a/app-backend/db/src/main/scala/Config.scala
+++ b/app-backend/db/src/main/scala/Config.scala
@@ -11,6 +11,10 @@ object Config {
       publicDataConfig.getString("landsat8DatasourceId")
     val sentinel2DatasourceId =
       publicDataConfig.getString("sentinel2DatasourceId")
+    val landsat45ThematicMapperDatasourceId =
+      publicDataConfig.getString("landsat45TMDatasourceId")
+    val landsat7ETMDatasourceId =
+      publicDataConfig.getString("landsat7ETMDatasourceId")
     val enableMultiTiff =
       publicDataConfig.getBoolean("enableMultiTiff")
   }

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -310,6 +310,7 @@ object SceneDao
             scene.id,
             UUID.randomUUID, // we don't have a project id here, so fake it
             scene.datasource,
+            scene.name,
             ColorCorrect.Params(
               redBand,
               greenBand,

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -130,7 +130,9 @@ object SceneToLayerDao
           Fragment.const(s"""
           | (ingest_status = 'INGESTED' OR datasource IN
           | ('${Config.publicData.landsat8DatasourceId}' :: uuid,
-          |  '${Config.publicData.sentinel2DatasourceId}' :: uuid))
+          |  '${Config.publicData.sentinel2DatasourceId}' :: uuid,
+          |  '${Config.publicData.landsat45ThematicMapperDatasourceId} :: uuid,
+          |  '${Config.publicData.landsat7ETMDatasourceId}))
           | """.trim.stripMargin)
         )
       } else {
@@ -154,7 +156,8 @@ object SceneToLayerDao
     val select =
       fr"""
     SELECT
-      scene_id, project_id, datasource, project_layer_id, accepted, scene_order, mosaic_definition,
+      scene_id, project_id, datasource, name, project_layer_id, accepted, scene_order,
+      mosaic_definition,
       scene_type, ingest_location, data_footprint, is_single_band, single_band_options,
       geometry, data_path, crs, band_count, cell_type, grid_extent, resolutions, no_data_value, metadata_files
     FROM (
@@ -181,6 +184,7 @@ object SceneToLayerDao
                 stp.sceneId,
                 stp.projectId,
                 stp.datasource,
+                stp.sceneName,
                 stp.colorCorrectParams.copy(
                   redBand = r,
                   greenBand = g,
@@ -204,6 +208,7 @@ object SceneToLayerDao
               stp.sceneId,
               stp.projectId,
               stp.datasource,
+              stp.sceneName,
               stp.colorCorrectParams,
               stp.sceneType,
               stp.ingestLocation,

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -131,8 +131,8 @@ object SceneToLayerDao
           | (ingest_status = 'INGESTED' OR datasource IN
           | ('${Config.publicData.landsat8DatasourceId}' :: uuid,
           |  '${Config.publicData.sentinel2DatasourceId}' :: uuid,
-          |  '${Config.publicData.landsat45ThematicMapperDatasourceId} :: uuid,
-          |  '${Config.publicData.landsat7ETMDatasourceId}))
+          |  '${Config.publicData.landsat45ThematicMapperDatasourceId}' :: uuid,
+          |  '${Config.publicData.landsat7ETMDatasourceId}' :: uuid))
           | """.trim.stripMargin)
         )
       } else {
@@ -156,7 +156,7 @@ object SceneToLayerDao
     val select =
       fr"""
     SELECT
-      scene_id, project_id, datasource, name, project_layer_id, accepted, scene_order,
+      scene_id, project_id, datasource, scenes_stl.name, project_layer_id, accepted, scene_order,
       mosaic_definition,
       scene_type, ingest_location, data_footprint, is_single_band, single_band_options,
       geometry, data_path, crs, band_count, cell_type, grid_extent, resolutions, no_data_value, metadata_files

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -48,16 +48,20 @@ object SceneToLayerDao
     """.update.run
   }
 
-  def acceptScenes(projectLayerId: UUID,
-                   sceneIds: List[UUID]): ConnectionIO[Int] = {
+  def acceptScenes(
+      projectLayerId: UUID,
+      sceneIds: List[UUID]
+  ): ConnectionIO[Int] = {
     sceneIds.toNel match {
       case Some(ids) => acceptScenes(projectLayerId, ids)
       case _         => 0.pure[ConnectionIO]
     }
   }
 
-  def acceptScenes(projectLayerId: UUID,
-                   sceneIds: NEL[UUID]): ConnectionIO[Int] = {
+  def acceptScenes(
+      projectLayerId: UUID,
+      sceneIds: NEL[UUID]
+  ): ConnectionIO[Int] = {
     (
       fr"""
         UPDATE scenes_to_layers
@@ -85,9 +89,11 @@ object SceneToLayerDao
     """).update.run
   }
 
-  def setManualOrder(projectId: UUID,
-                     projectLayerId: UUID,
-                     sceneIds: Seq[UUID]): ConnectionIO[Seq[UUID]] = {
+  def setManualOrder(
+      projectId: UUID,
+      projectLayerId: UUID,
+      sceneIds: Seq[UUID]
+  ): ConnectionIO[Seq[UUID]] = {
     val updates = for {
       i <- sceneIds.indices
     } yield {
@@ -103,30 +109,37 @@ object SceneToLayerDao
     } yield {
       logger
         .info(
-          s"Kicking off layer overview creation for project-$projectId-layer-$projectLayerId")
+          s"Kicking off layer overview creation for project-$projectId-layer-$projectLayerId"
+        )
       kickoffLayerOverviewCreate(projectId, projectLayerId)
       sceneIds
     }
   }
 
-  def getMosaicDefinition(projectLayerId: UUID,
-                          polygonOption: Option[Projected[Polygon]],
-                          redBand: Option[Int] = None,
-                          greenBand: Option[Int] = None,
-                          blueBand: Option[Int] = None,
-                          sceneIdSubset: List[UUID] = List.empty)
-    : ConnectionIO[List[MosaicDefinition]] = {
+  def getMosaicDefinition(
+      projectLayerId: UUID,
+      polygonOption: Option[Projected[Polygon]],
+      redBand: Option[Int] = None,
+      greenBand: Option[Int] = None,
+      blueBand: Option[Int] = None,
+      sceneIdSubset: List[UUID] = List.empty
+  ): ConnectionIO[List[MosaicDefinition]] = {
     val ingestFilter: Option[Fragment] =
       if (Config.publicData.enableMultiTiff) {
         Some(
-          fr"(ingest_status = 'INGESTED' OR datasource = ${Config.publicData.landsat8DatasourceId} :: uuid)"
+          Fragment.const(s"""
+          | (ingest_status = 'INGESTED' OR datasource IN
+          | ('${Config.publicData.landsat8DatasourceId}' :: uuid,
+          |  '${Config.publicData.sentinel2DatasourceId}' :: uuid))
+          | """.trim.stripMargin)
         )
       } else {
         Some(fr"ingest_status = 'INGESTED'")
       }
     val filters = List(
-      polygonOption.map(polygon =>
-        fr"ST_Intersects(tile_footprint, ${polygon})"),
+      polygonOption.map(
+        polygon => fr"ST_Intersects(tile_footprint, ${polygon})"
+      ),
       Some(fr"project_layer_id = ${projectLayerId}"),
       Some(fr"accepted = true"),
       ingestFilter,
@@ -212,16 +225,19 @@ object SceneToLayerDao
   }
 
   def getMosaicDefinition(
-      projectLayerId: UUID): ConnectionIO[List[MosaicDefinition]] = {
+      projectLayerId: UUID
+  ): ConnectionIO[List[MosaicDefinition]] = {
     getMosaicDefinition(projectLayerId, None)
   }
 
   def getColorCorrectParams(
       projectLayerId: UUID,
-      sceneId: UUID): ConnectionIO[ColorCorrect.Params] = {
+      sceneId: UUID
+  ): ConnectionIO[ColorCorrect.Params] = {
     query
       .filter(
-        fr"project_layer_id = ${projectLayerId} AND scene_id = ${sceneId}")
+        fr"project_layer_id = ${projectLayerId} AND scene_id = ${sceneId}"
+      )
       .select
       .map { stl: SceneToLayer =>
         stl.colorCorrectParams
@@ -231,30 +247,37 @@ object SceneToLayerDao
   def setColorCorrectParams(
       projectLayerId: UUID,
       sceneId: UUID,
-      colorCorrectParams: ColorCorrect.Params): ConnectionIO[SceneToLayer] = {
+      colorCorrectParams: ColorCorrect.Params
+  ): ConnectionIO[SceneToLayer] = {
     fr"""
       UPDATE scenes_to_layers
       SET mosaic_definition = ${colorCorrectParams}
       WHERE project_layer_id = ${projectLayerId} AND scene_id = ${sceneId}
-    """.update.withUniqueGeneratedKeys("scene_id",
-                                       "project_layer_id",
-                                       "accepted",
-                                       "scene_order",
-                                       "mosaic_definition")
+    """.update.withUniqueGeneratedKeys(
+      "scene_id",
+      "project_layer_id",
+      "accepted",
+      "scene_order",
+      "mosaic_definition"
+    )
   }
 
   def setColorCorrectParamsBatch(
       projectLayerId: UUID,
-      batchParams: BatchParams): ConnectionIO[List[SceneToLayer]] = {
+      batchParams: BatchParams
+  ): ConnectionIO[List[SceneToLayer]] = {
     batchParams.items
-      .map(params =>
-        setColorCorrectParams(projectLayerId, params.sceneId, params.params))
+      .map(
+        params =>
+          setColorCorrectParams(projectLayerId, params.sceneId, params.params)
+      )
       .sequence
   }
 
   def setProjectLayerColorBands(
       projectLayerId: UUID,
-      colorBands: ProjectColorModeParams): ConnectionIO[Int] = {
+      colorBands: ProjectColorModeParams
+  ): ConnectionIO[Int] = {
     // TODO support setting color band by datasource instead of project wide
     // if there is not a mosaic definition at this point, then the scene_to_project row was not created correctly
     (fr"""
@@ -272,7 +295,8 @@ object SceneToLayerDao
   }
 
   def getProjectsAndLayersBySceneId(
-      sceneId: UUID): ConnectionIO[List[SceneWithProjectIdLayerId]] = {
+      sceneId: UUID
+  ): ConnectionIO[List[SceneWithProjectIdLayerId]] = {
     (fr"""
       SELECT scene_id, project_id, project_layer_id
       FROM (

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -88,11 +88,11 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
                      landsat_id)
         raise Exception('Could not find landsat scene %s', landsat_id)
     filter_metadata = extract_metadata(metadata_resp.content)
-    (filename, cog_fname) = process_to_cog(prefix, gcs_prefix, landsat_id, config)
-    s3_location = upload_file(owner, filename, cog_fname)
-    logger.info('Creating image')
-    ingest_location = 's3://{}/{}'.format(data_bucket,
-                                          urllib.quote(s3_location))
+    # (filename, cog_fname) = process_to_cog(prefix, gcs_prefix, landsat_id, config)
+    # s3_location = upload_file(owner, filename, cog_fname)
+    # logger.info('Creating image')
+    # ingest_location = 's3://{}/{}'.format(data_bucket,
+    #                                       urllib.quote(s3_location))
     scene = Scene(
         'PRIVATE', [],
         datasource, {},
@@ -100,19 +100,19 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
         'SUCCESS',
         'SUCCESS',
         'INGESTED', [io.make_path_for_mtl(gcs_prefix, landsat_id)],
-        ingestLocation=ingest_location,
+        ingestLocation=io.make_path_for_band(gcs_prefix, landsat_id, 1), # ingest_location,
         cloudCover=filter_metadata['cloud_cover'],
         acquisitionDate=filter_metadata['acquisition_date'],
         sceneType='COG',
         owner=owner)
-    image = create_geotiff_image(
-        filename,
-        ingest_location,
-        filename=cog_fname,
-        owner=owner,
-        scene=scene.id,
-        band_create_function=lambda x: config.bands.values())
-    scene.images = [image]
+#    image = create_geotiff_image(
+#        filename,
+#        ingest_location,
+#        filename=cog_fname,
+#        owner=owner,
+#        scene=scene.id,
+#        band_create_function=lambda x: config.bands.values())
+    scene.images = []
     return scene
 
 

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -88,11 +88,6 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
                      landsat_id)
         raise Exception('Could not find landsat scene %s', landsat_id)
     filter_metadata = extract_metadata(metadata_resp.content)
-    # (filename, cog_fname) = process_to_cog(prefix, gcs_prefix, landsat_id, config)
-    # s3_location = upload_file(owner, filename, cog_fname)
-    # logger.info('Creating image')
-    # ingest_location = 's3://{}/{}'.format(data_bucket,
-    #                                       urllib.quote(s3_location))
     scene = Scene(
         'PRIVATE', [],
         datasource, {},
@@ -105,13 +100,6 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
         acquisitionDate=filter_metadata['acquisition_date'],
         sceneType='COG',
         owner=owner)
-#    image = create_geotiff_image(
-#        filename,
-#        ingest_location,
-#        filename=cog_fname,
-#        owner=owner,
-#        scene=scene.id,
-#        band_create_function=lambda x: config.bands.values())
     scene.images = []
     return scene
 

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -88,6 +88,10 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
                      landsat_id)
         raise Exception('Could not find landsat scene %s', landsat_id)
     filter_metadata = extract_metadata(metadata_resp.content)
+    (filename, cog_fname) = process_to_cog(prefix, gcs_prefix, landsat_id, config)
+    s3_location = upload_file(owner, filename, cog_fname)
+    logger.info('Creating image')
+    ingest_location = 's3://{}/{}'.format(data_bucket, urllib.quote(s3_location))
     scene = Scene(
         'PRIVATE', [],
         datasource, {},
@@ -95,12 +99,19 @@ def create_scene(owner, prefix, landsat_id, config, datasource):
         'SUCCESS',
         'SUCCESS',
         'INGESTED', [io.make_path_for_mtl(gcs_prefix, landsat_id)],
-        ingestLocation=io.make_path_for_band(gcs_prefix, landsat_id, 1), # ingest_location,
+        ingestLocation=ingest_location,
         cloudCover=filter_metadata['cloud_cover'],
         acquisitionDate=filter_metadata['acquisition_date'],
         sceneType='COG',
         owner=owner)
-    scene.images = []
+    image = create_geotiff_image(
+        filename,
+        ingest_location,
+        filename=cog_fname,
+        owner=owner,
+        scene=scene.id,
+        band_create_function=lambda x: config.bands.values())
+    scene.images = [image]
     return scene
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - RF_LOG_LEVEL=DEBUG
       - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
-      - BACKSPLASH_ENABLE_MULTITIFF=true
+      - BACKSPLASH_ENABLE_MULTITIFF=false
       - AWS_DEFAULT_PROFILE=raster-foundry
     ports:
       - "9000:9000"
@@ -164,7 +164,7 @@ services:
       - BACKSPLASH_CORE_STREAM_CONCURRENCY=16
       - BACKSPLASH_ENABLE_REQUEST_METRICS=false
       - BACKSPLASH_SERVER_REQUEST_LIMIT=0
-      - BACKSPLASH_ENABLE_MULTITIFF=true
+      - BACKSPLASH_ENABLE_MULTITIFF=false
       - AWS_REQUEST_PAYER=requester
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,6 +165,7 @@ services:
       - BACKSPLASH_ENABLE_REQUEST_METRICS=false
       - BACKSPLASH_SERVER_REQUEST_LIMIT=0
       - BACKSPLASH_ENABLE_MULTITIFF=true
+      - AWS_REQUEST_PAYER=requester
     ports:
       - "8080:8080"
       - "9030:9030"


### PR DESCRIPTION
## Overview

This PR enables multitiff imagery rendering for more datasources.

- [x] Sentinel-2
- [x] Landsat 4 / 5
- [x] Landsat 7
- [ ] MODIS

It however doesn't work1 Landsat 4/5/7 it turns out aren't stored as COGs, so they'll always require some processing. MODIS also isn't stored as a COG.

However! This doesn't need to be catastrophic. We can change what upload processing / ingest means for Sentinel-2 / the other datasources so that we don't have to do quite as much work and we'll still get better import performance.

For Sentinel-2 this means gdal_translate to make the internal tiling scheme have smaller tiles. For the others, this means adding overviews at all. They already have internal tiling, but that's not enough --

```bash
$ gdalinfo /vsicurl/https://storage.googleapis.com/gcp-public-data-landsat/LT05/01/004/027/LT05_L1TP_004027_19850918_20170218_01_T1/LT05_L1TP_0040
27_19850918_20170218_01_T1_B1.TIF
Driver: GTiff/GeoTIFF
Files: /vsicurl/https://storage.googleapis.com/gcp-public-data-landsat/LT05/01/004/027/LT05_L1TP_004027_19850918_20170218_01_T1/LT05_L1TP_004027_19850918_20170218_01_T1_B1.TIF
       /vsicurl/https://storage.googleapis.com/gcp-public-data-landsat/LT05/01/004/027/LT05_L1TP_004027_19850918_20170218_01_T1/LT05_L1TP_004027_19850918_20170218_01_T1_MTL.txt
Size is 7961, 7261
Coordinate System is:
PROJCS["WGS 84 / UTM zone 21N",
    GEOGCS["WGS 84",
        DATUM["WGS_1984",
            SPHEROID["WGS 84",6378137,298.257223563,
                AUTHORITY["EPSG","7030"]],
            AUTHORITY["EPSG","6326"]],
        PRIMEM["Greenwich",0,
            AUTHORITY["EPSG","8901"]],
        UNIT["degree",0.0174532925199433,
            AUTHORITY["EPSG","9122"]],
        AUTHORITY["EPSG","4326"]],
    PROJECTION["Transverse_Mercator"],
    PARAMETER["latitude_of_origin",0],
    PARAMETER["central_meridian",-57],
    PARAMETER["scale_factor",0.9996],
    PARAMETER["false_easting",500000],
    PARAMETER["false_northing",0],
    UNIT["metre",1,
        AUTHORITY["EPSG","9001"]],
    AXIS["Easting",EAST],
    AXIS["Northing",NORTH],
    AUTHORITY["EPSG","32621"]]
Origin = (383085.000000000000000,5364015.000000000000000)
Pixel Size = (30.000000000000000,-30.000000000000000)
Metadata:
  AREA_OR_POINT=Point
  METADATATYPE=ODL
Image Structure Metadata:
  COMPRESSION=LZW
  INTERLEAVE=BAND
Corner Coordinates:
Upper Left  (  383085.000, 5364015.000) ( 58d34'48.59"W, 48d25' 6.36"N)
Lower Left  (  383085.000, 5146185.000) ( 58d31'21.18"W, 46d27'32.76"N)
Upper Right (  621915.000, 5364015.000) ( 55d21' 8.24"W, 48d25' 2.94"N)
Lower Right (  621915.000, 5146185.000) ( 55d24'44.50"W, 46d27'29.58"N)
Center      (  502500.000, 5255100.000) ( 56d58' 0.61"W, 47d26'57.62"N)
Band 1 Block=256x256 Type=Byte, ColorInterp=Gray
```

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Sentinel-2 imagery only works if it's one of the small slivers. I suspect this is due to a combination of the data being in eu-central-1 (so far away) and having a large internal tiling system (1024x1024) for some bands, which makes reading data more expensive. I don't know how to confirm this exactly though. It's possible it would be fine if we pushed histogram calculation down to gdal (see #5172) but we don't know that that's the case.

Acknowledging that it's broken in certain ways, I think it's still fine, since it's effectively feature flagged :man_shrugging:, and it's still good I think to test known ways that it's broken and get the feature flagged thing out

## Testing Instructions

- add a Landsat 4 /5 and a Landsat 7 image to a project from the CMR
- ~try to process it -- you should get an error from the API about missing overviews~ <-- that was true before I realized that I'd break upload processing everywhere. Instead, _it should be fine_, to prove that in reverting those changes I didn't break anything
- turn BACKSPLASH_ENABLE_MULTITIFF on in docker-compose for the api-server and backsplash
- start servers + frontend
- head to the stock sentinel project (http://localhost:9091/projects/edit/df697018-68ea-4b4e-81b3-50481a4bf15f/scenes?page=1) and zoom in on it so you can see that visualizing it works
- add a Landsat 8 unprocessed image to a project to confirm I didn't break that

Closes #4879

Closes #5181
