### PR TITLE
Upgrade `sup` and identify timeouts vs errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 - Added tracing support to tile server [\#5165](https://github.com/raster-foundry/raster-foundry/pull/5165)[\#5171](https://github.com/raster-foundry/raster-foundry/pull/5171)
 
 ### Changed
+
 - Improve histogram generation by using RasterSources [\#5169](https://github.com/raster-foundry/raster-foundry/pull/5169)
+- Adjusted the healthcheck to more easily distinguish between errors and timeouts [\#5179](https://github.com/raster-foundry/raster-foundry/pull/5179)
 
 ### Deprecated
 

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
 
 RUN \
     adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/BacksplashConnectionFactory.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/BacksplashConnectionFactory.scala
@@ -1,10 +1,12 @@
 package com.rasterfoundry.common
 
-import net.spy.memcached.{ClientMode, DefaultConnectionFactory}
+import net.spy.memcached.{ClientMode, DefaultConnectionFactory, FailureMode}
 
 class BacksplashConnectionFactory extends DefaultConnectionFactory() {
   override def getClientMode: ClientMode = Config.memcached.clientMode
 
   override def getOperationTimeout: Long =
     Config.memcached.timeout
+
+  override def getFailureMode: FailureMode = FailureMode.Cancel
 }

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -50,6 +50,7 @@ object RFTransactor {
       hikariConfig.setUsername(user)
       hikariConfig.setPassword(password)
       hikariConfig.setDriverClassName(driver)
+      hikariConfig.setConnectionTimeout(2000)
 
       new HikariDataSource(hikariConfig)
     }

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Version {
   val spark = "2.4.2"
   val spire = "0.16.0"
   val spray = "1.3.4"
-  val sup = "0.2.0"
+  val sup = "0.6.0"
   val openTracing = "0.0.6"
   val jaegerClient = "1.0.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - ./nginx/etc/nginx/conf.d/backsplash.conf:/etc/nginx/conf.d/default.conf
 
   api-server:
+    # If changing container, make sure to update app-backend/api/Dockerfile as well
     image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
     links:
       - postgres:database.service.rasterfoundry.internal
@@ -132,6 +133,7 @@ services:
       - "0.0.0.0:2000"
 
   backsplash:
+    # If changing container, make sure to update app-backend/backsplash-server/Dockerfile as well
     image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
     depends_on:
       postgres:


### PR DESCRIPTION
## Overview

This fixes a problem where the healthcheck failures did not allow for
distinguising between a timeout and an actual error (like not being
able to connect to the database).

There wasn't a _great_ way to propagate the cause of failures to the healthcheck - so now we return a 500 and exception.

In cases where there is a timeout we get a nice error message with the nature of the timeout.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

This is what it looks like when it times out:

```
cbrown@trout:~/projects/raster-foundry-deployment$ time http :8081/healthcheck
HTTP/1.1 503 Service Unavailable
Connection: keep-alive
Content-Length: 36Content-Type: application/json
Date: Wed, 18 Sep 2019 18:29:49 GMTServer: nginx
Strict-Transport-Security: max-age=15552000; preload
X-Content-Type-Options: nosniff

{
    "errors": [
        "cache"
    ],
    "result": "sick"
}


real    0m3.540s
user    0m0.314s
sys     0m0.076s
```

## Testing Instructions

- Rebuild backsplash jar
- Start servers
- ` http :8081/healthcheck` - should succeed
- Stop the database: `docker-compose stop postgres`
- request the healthcheck again, should see error message

Closes #5111 
Closes #5125
