### PR TITLE
Optimize long running task queries

### DIFF
--- a/app-backend/db/src/main/resources/migrations/V14__task_actions_time_index.sql
+++ b/app-backend/db/src/main/resources/migrations/V14__task_actions_time_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS task_actions_timestamp_idx ON public.task_actions USING btree (timestamp);


### PR DESCRIPTION
## Overview
* Add index on task actions timestamp
* Don't make a second, unnecessary request for each task in the paged list.
* Only join on task_actions when query params require it

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~


### Notes
This won't completely solve the issue, but I want to see how much it helps things. The long-running query mentioned in the issue was run without action parameters, and that requires a join on a much larger subset of the table which would force it to do a hash join on disk.

## Testing Instructions
- Verify that the migration runs
- Verify that tests complete successfully
- Fetch a task list from `api/projects/{}/layer/{}/tasks` and verify that the request does not do any joints
- Repeat the requests with a param like `actionMinCount=5` (or any other action filter) and verify that it uses the join query as required


Closes #5170 
