### PR TITLE
Use Default Execution Contexts, Adjust Doobie Execution Contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 ### Added
 
 ### Changed
+
 - Optimize long-running task query [\#5187](https://github.com/raster-foundry/raster-foundry/pull/5187)
+- Use default execution contexts for http4s and blaze and switch to using an unbounded pool for doobie transactions [\#5188](https://github.com/raster-foundry/raster-foundry/pull/5188)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -1,12 +1,15 @@
 package com.rasterfoundry.api
 
+import java.util.concurrent.Executors
+
 import akka.actor.{ActorSystem, Terminated}
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
+import cats.effect.{ContextShift, IO}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.rasterfoundry.akkautil.RFRejectionHandler._
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.database.util.RFTransactor
-
 import doobie.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -20,6 +23,15 @@ object Main extends App with Config with Router {
 
   implicit val system = AkkaSystem.system
   implicit val materializer = AkkaSystem.materializer
+
+  implicit val contextShift: ContextShift[IO] =
+    IO.contextShift(
+      ExecutionContext.fromExecutor(
+        Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setNameFormat("db-transactor-%d").build()
+        )
+      )
+    )
 
   val xa = RFTransactor.buildTransactor()
   implicit val ec = ExecutionContext.Implicits.global

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -251,7 +251,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
             val mbtIO = self.flatMap { listBsi =>
               val listIO = listBsi.map { bsi =>
                 bsi.read(z, x, y, bsi.tracingContext)
-              }.sequence
+              }.parSequence
               listIO.map(_.flatten.reduceOption(_ merge _))
             }
 
@@ -406,7 +406,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
                       }
                     }
                   }
-                }.sequence
+                }.parSequence
                   .map(_.flatten.reduceOption(_ merge _))
                   .map({
                     case Some(r) => r

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -249,9 +249,9 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
             BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
           val mosaic = {
             val mbtIO = self.flatMap { listBsi =>
-              val listIO = listBsi.map { bsi =>
+              val listIO = listBsi.parTraverse { bsi =>
                 bsi.read(z, x, y, bsi.tracingContext)
-              }.parSequence
+              }
               listIO.map(_.flatten.reduceOption(_ merge _))
             }
 
@@ -371,7 +371,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
             mosaic <- if (bands.length == 3) {
               val bsm = self.map { bsiList =>
                 {
-                  bsiList map { relevant =>
+                  bsiList parTraverse { relevant =>
                     for {
                       imFiber <- relevant
                         .read(extent, cs, relevant.tracingContext)
@@ -406,8 +406,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
                       }
                     }
                   }
-                }.parSequence
-                  .map(_.flatten.reduceOption(_ merge _))
+                }.map(_.flatten.reduceOption(_ merge _))
                   .map({
                     case Some(r) => r
                     case _ =>

--- a/app-backend/backsplash-server/src/main/resources/application.conf
+++ b/app-backend/backsplash-server/src/main/resources/application.conf
@@ -1,14 +1,4 @@
 parallelism {
-
-  dbThreadPoolSize = 20
-  dbThreadPoolSize = ${?DB_THREADPOOL_THREADS}
-
-  http4sThreadPoolSize = 20
-  http4sThreadPoolSize = ${?HTTP4S_THREADPOOL_THREADS}
-
-  blazeThreadPoolSize = 20
-  blazeThreadPoolSize = ${?BLAZE_THREADPOOL_THREADS}
-
   blazeConnectorPoolSize = 20
   blazeConnectorPoolSize = ${?BLAZE_CONNECTOR_POOL_SIZE}
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -23,9 +23,6 @@ object Config {
 
   object parallelism {
     private val parallelismConfig = config.getConfig("parallelism")
-    val dbThreadPoolSize = parallelismConfig.getInt("dbThreadPoolSize")
-    val http4sThreadPoolSize = parallelismConfig.getInt("http4sThreadPoolSize")
-    val blazeThreadPoolSize = parallelismConfig.getInt("blazeThreadPoolSize")
     val blazeConnectorPoolSize =
       parallelismConfig.getInt("blazeConnectorPoolSize")
   }

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/xray/UdpClient.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/xray/UdpClient.scala
@@ -6,7 +6,7 @@ import cats.effect.Sync
 import io.circe.syntax._
 import io.circe.Printer
 
-class UdpClient[F[_]: Sync] {
+object UdpClient {
 
   val printer = Printer(
     preserveOrder = true,
@@ -17,12 +17,13 @@ class UdpClient[F[_]: Sync] {
   val address = new InetSocketAddress("xray.service.internal", 2000)
   val socket = new DatagramSocket()
 
-  def write(segment: Segment[F]): F[Unit] = Sync[F].delay {
-    val segmentJson = printer.pretty(segment.asJson)
-    val versionString = """{"format": "json", "version": 1}"""
-    val payload = s"$versionString\n$segmentJson".getBytes
-    val packet = new DatagramPacket(payload, payload.length, address)
-    socket.send(packet)
-  }
+  def write[F[_]](segment: Segment[F])(implicit sf: Sync[F]): F[Unit] =
+    Sync[F].delay {
+      val segmentJson = printer.pretty(segment.asJson)
+      val versionString = """{"format": "json", "version": 1}"""
+      val payload = s"$versionString\n$segmentJson".getBytes
+      val packet = new DatagramPacket(payload, payload.length, address)
+      socket.send(packet)
+    }
 
 }

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/xray/XRayTracingContext.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/xray/XRayTracingContext.scala
@@ -54,8 +54,6 @@ object XRayTracingContext {
       tags: Map[String, String],
       http: Option[XrayHttp]): TracingContextResource[F] = {
 
-    val xrayClient = new UdpClient[F]()
-
     val acquire: F[(Segment[F], Ref[F, Map[String, String]])] = {
       val spanId = f"${Random.nextLong()}%016x"
       for {
@@ -91,8 +89,7 @@ object XRayTracingContext {
                 http)
           }
         }
-        _ <- xrayClient.write(segment)
-
+        _ <- UdpClient.write(segment).attempt
       } yield (segment, tagsRef)
     }
 
@@ -107,7 +104,7 @@ object XRayTracingContext {
                      in_progress = None,
                      annotations = tags)
         }
-        _ <- xrayClient.write(updatedSegment)
+        _ <- UdpClient.write(updatedSegment).attempt
       } yield ()
     }
     Resource


### PR DESCRIPTION
## Overview

In debugging some issues with a hanging application under load and doing additional load tests I adjusted some of execution contexts/context shifts in the application. Mostly with an aim to do the following:

 - Use defaults where possible since it's unclear if our changes were having a net-positive effect
 - Fix up any errors being seen during the load tests -- mostly this happened around doobie transactions and the UdpClient failing to initialize under load
 - Follow guidelines and best practices around execution contexts for Doobie execution contexts

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Additional notes in https://github.com/azavea/raster-foundry-platform/issues/849 provide some context

## Testing Instructions

I don't have a good sense for what testing here should involve, so exercising the servers I think seems appropriate.

- Reassemble Servers
- Test that tile serving and the API works

Closes https://github.com/azavea/raster-foundry-platform/issues/849
