### PR TITLE
Add TracingContext to BacksplashMosaic

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -47,8 +47,7 @@ final case class BacksplashGeotiff(
     singleBandOptions: Option[SingleBandOptions.Params],
     mask: Option[MultiPolygon],
     footprint: MultiPolygon,
-    metadata: SceneMetadataFields,
-    tracingContext: TracingContext[IO]
+    metadata: SceneMetadataFields
 ) extends LazyLogging
     with BacksplashImage[IO] {
 
@@ -167,8 +166,7 @@ case class LandsatHistoricalMultiTiffImage(
     projectId: UUID,
     projectLayerId: UUID,
     mask: Option[MultiPolygon],
-    landsatId: String,
-    tracingContext: TracingContext[IO]
+    landsatId: String
 )(implicit contextShift: ContextShift[IO])
     extends MultiTiffImage[IO, IO.Par] {
   val metadata = SceneMetadataFields()
@@ -206,8 +204,7 @@ case class Sentinel2MultiTiffImage(
     projectId: UUID,
     projectLayerId: UUID,
     mask: Option[MultiPolygon],
-    prefix: String,
-    tracingContext: TracingContext[IO]
+    prefix: String
 )(implicit contextShift: ContextShift[IO])
     extends MultiTiffImage[IO, IO.Par] {
   val metadata = SceneMetadataFields()
@@ -249,8 +246,7 @@ case class Landsat8MultiTiffImage(
     projectId: UUID,
     projectLayerId: UUID,
     mask: Option[MultiPolygon],
-    prefix: String,
-    tracingContext: TracingContext[IO]
+    prefix: String
 )(implicit contextShift: ContextShift[IO])
     extends MultiTiffImage[IO, IO.Par] {
 
@@ -460,7 +456,6 @@ sealed trait BacksplashImage[F[_]] extends LazyLogging {
   val projectLayerId: UUID
   val mask: Option[MultiPolygon]
   val metadata: SceneMetadataFields
-  val tracingContext: TracingContext[F]
 
   val enableGDAL = Config.RasterSource.enableGDAL
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -21,7 +21,7 @@ import ToolStore._
 import ExtentReification._
 import HasRasterExtents._
 import TmsReification._
-import com.colisweb.tracing.{NoOpTracingContext, TracingContext}
+import com.colisweb.tracing.TracingContext
 import com.typesafe.scalalogging.LazyLogging
 import com.rasterfoundry.datamodel.SingleBandOptions
 
@@ -78,8 +78,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
       z: Int,
       baseImage: BacksplashImage[IO],
       config: OverviewConfig,
-      fallbackIms: NEL[BacksplashImage[IO]],
-      tracingContext: TracingContext[IO]): NEL[BacksplashImage[IO]] =
+      fallbackIms: NEL[BacksplashImage[IO]]): NEL[BacksplashImage[IO]] =
     config match {
       case OverviewConfig(Some(overviewLocation), Some(minZoom))
           if z <= minZoom =>
@@ -94,8 +93,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
             baseImage.singleBandOptions,
             baseImage.mask,
             baseImage.footprint,
-            baseImage.metadata,
-            tracingContext
+            baseImage.metadata
           ),
           Nil: _*
         )
@@ -107,15 +105,17 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
       mosaic: NEL[BacksplashImage[IO]],
       z: Int,
       x: Int,
-      y: Int
+      y: Int,
+      tracingContext: TracingContext[IO]
   )(implicit contextShift: ContextShift[IO]): IO[Raster[MultibandTile]] = {
     type MBTTriple = (MultibandTile, SingleBandOptions.Params, Option[Double])
     val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
-    val ioMBTwithSBO: IO[List[MBTTriple]] =
+    val ioMBTwithSBO: IO[List[MBTTriple]] = tracingContext.childSpan(
+      "renderMosaicSingleBand") use { context =>
       mosaic
         .parTraverse((relevant: BacksplashImage[IO]) => {
           logger.debug(s"Band Subset Required: ${relevant.subsetBands}")
-          relevant.read(z, x, y, relevant.tracingContext) map {
+          relevant.read(z, x, y, context) map {
             (_, relevant.singleBandOptions, relevant.metadata.noDataValue)
           }
         })
@@ -123,22 +123,24 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
           nel.collect({
             case (Some(mbtile), Some(sbo), nd) => (mbtile, sbo, nd)
           }))
+    }
     for {
       imagesNel <- ioMBTwithSBO map { _.toNel } flatMap {
         case Some(ims) => IO.pure(ims)
         case None      => IO.raiseError(NoScenesException)
       }
       firstIm = mosaic.head
-      histograms <- {
-        firstIm.singleBandOptions map { _.band } map { bd =>
-          histStore.projectLayerHistogram(firstIm.projectLayerId, List(bd))
-        } getOrElse {
-          IO.raiseError(
-            SingleBandOptionsException(
-              "Must provide band for single band visualization"
+      histograms <- tracingContext.childSpan("renderMosaicSingleBand.histogram") use {
+        _ =>
+          firstIm.singleBandOptions map { _.band } map { bd =>
+            histStore.projectLayerHistogram(firstIm.projectLayerId, List(bd))
+          } getOrElse {
+            IO.raiseError(
+              SingleBandOptionsException(
+                "Must provide band for single band visualization"
+              )
             )
-          )
-        }
+          }
       }
     } yield {
       val combinedHistogram = histograms.reduce(_ merge _)
@@ -182,55 +184,57 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
       mosaic: NEL[BacksplashImage[IO]],
       z: Int,
       x: Int,
-      y: Int
+      y: Int,
+      tracingContext: TracingContext[IO]
   )(implicit contextShift: ContextShift[IO]): IO[Raster[MultibandTile]] = {
     val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
-    val ioMBT = mosaic
-      .parTraverse((relevant: BacksplashImage[IO]) => {
-        val tags = Map("sceneId" -> relevant.imageId.toString,
-                       "projectId" -> relevant.projectId.toString,
-                       "projectLayerId" -> relevant.projectLayerId.toString,
-                       "zoom" -> z.toString)
-        val tracingContext = relevant.tracingContext
+    val ioMBT = tracingContext.childSpan("renderMosaic") use { context =>
+      mosaic
+        .parTraverse((relevant: BacksplashImage[IO]) => {
+          val tags = Map("sceneId" -> relevant.imageId.toString,
+                         "projectId" -> relevant.projectId.toString,
+                         "projectLayerId" -> relevant.projectLayerId.toString,
+                         "zoom" -> z.toString)
 
-        tracingContext.childSpan("renderMosaicMultiband.renderBacksplashImage",
-                                 tags) use {
-          childContext =>
-            for {
-              imFiber <- relevant.read(z, x, y, childContext).start
-              histsFiber <- {
-                childContext.childSpan("renderMosaicMultiband.readHistogram",
-                                       tags) use { _ =>
-                  getHistogramWithCache(relevant)
-                }
-              }.start
-              hists <- histsFiber.join
-              im <- imFiber.join
-              renderedTile <- {
-                childContext.childSpan("renderMosaicMultiband.colorCorrect",
-                                       tags) use {
-                  _ =>
-                    IO.pure {
-                      im map { mbTile =>
-                        val noDataValue = getNoDataValue(mbTile.cellType)
-                        logger.debug(
-                          s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
-                        )
-                        relevant.corrections.colorCorrect(
-                          mbTile,
-                          hists,
-                          relevant.metadata.noDataValue orElse noDataValue orElse Some(
-                            0))
+          context
+            .childSpan("renderMosaicMultiband.renderBacksplashImage", tags) use {
+            childContext =>
+              for {
+                imFiber <- relevant.read(z, x, y, childContext).start
+                histsFiber <- {
+                  childContext.childSpan("renderMosaicMultiband.readHistogram",
+                                         tags) use { _ =>
+                    getHistogramWithCache(relevant, childContext)
+                  }
+                }.start
+                hists <- histsFiber.join
+                im <- imFiber.join
+                renderedTile <- {
+                  childContext.childSpan("renderMosaicMultiband.colorCorrect",
+                                         tags) use {
+                    _ =>
+                      IO.pure {
+                        im map { mbTile =>
+                          val noDataValue = getNoDataValue(mbTile.cellType)
+                          logger.debug(
+                            s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
+                          )
+                          relevant.corrections.colorCorrect(
+                            mbTile,
+                            hists,
+                            relevant.metadata.noDataValue orElse noDataValue orElse Some(
+                              0))
+                        }
                       }
-                    }
+                  }
                 }
+              } yield {
+                renderedTile
               }
-            } yield {
-              renderedTile
-            }
-        }
-      })
-      .map(nel => nel.collect({ case Some(tile) => tile }))
+          }
+        })
+        .map(nel => nel.collect({ case Some(tile) => tile }))
+    }
     mergeTiles(ioMBT).map {
       case Some(t) => Raster(t, extent)
       case _ =>
@@ -248,11 +252,17 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
           val extent =
             BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
           val mosaic = {
-            val mbtIO = self.flatMap { listBsi =>
-              val listIO = listBsi.parTraverse { bsi =>
-                bsi.read(z, x, y, bsi.tracingContext)
-              }
-              listIO.map(_.flatten.reduceOption(_ merge _))
+            val mbtIO = self.flatMap {
+              case (tracingContext, listBsi) =>
+                tracingContext.childSpan("getMergedRawMosaic") use {
+                  childContext =>
+                    val listIO = listBsi.parTraverse { bsi =>
+                      bsi.read(z, x, y, childContext)
+                    }
+                    childContext.childSpan("mergeRawTiles") use { _ =>
+                      listIO.map(_.flatten.reduceOption(_ merge _))
+                    }
+                }
             }
 
             mbtIO.map {
@@ -273,27 +283,31 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
           implicit contextShift: ContextShift[IO]
       ): (Int, Int, Int) => IO[ProjectedRaster[MultibandTile]] =
         (z: Int, x: Int, y: Int) => {
-          val imagesIO: IO[List[BacksplashImage[IO]]] = self
+          val imagesIO: IO[(TracingContext[IO], List[BacksplashImage[IO]])] =
+            self
           (for {
-            imagesNel <- imagesIO map { _.toNel } flatMap {
-              case Some(ims) => IO.pure(ims)
-              case None      => IO.raiseError(NoDataInRegionException)
+            (context, imagesNel) <- imagesIO map {
+              case (tracingContext, images) => (tracingContext, images.toNel)
+            } flatMap {
+              case (tracingContext, Some(ims)) => IO.pure((tracingContext, ims))
+              case (_, None)                   => IO.raiseError(NoDataInRegionException)
             }
             bandCount = imagesNel.head.subsetBands.length
-            overviewConfig <- rendStore.getOverviewConfig(
-              imagesNel.head.projectLayerId,
-              imagesNel.head.tracingContext)
-            mosaic = chooseMosaic(z,
-                                  imagesNel.head,
-                                  overviewConfig,
-                                  imagesNel,
-                                  NoOpTracingContext[IO]())
+            overviewConfig <- context.childSpan("getOverviewConfig") use {
+              childContext =>
+                rendStore.getOverviewConfig(imagesNel.head.projectLayerId,
+                                            childContext)
+            }
+            mosaic = chooseMosaic(z, imagesNel.head, overviewConfig, imagesNel)
             // for single band imagery, after color correction we have RGBA, so
             // the empty tile needs to be four band as well
-            rendered <- if (bandCount == 3) {
-              renderMosaicMultiband(mosaic, z, x, y)
-            } else {
-              renderMosaicSingleBand(mosaic, z, x, y)
+            rendered <- context.childSpan("paintedRender") use {
+              renderContext =>
+                if (bandCount == 3) {
+                  renderMosaicMultiband(mosaic, z, x, y, renderContext)
+                } else {
+                  renderMosaicSingleBand(mosaic, z, x, y, renderContext)
+                }
             }
           } yield {
             ProjectedRaster(rendered, WebMercator)
@@ -320,7 +334,8 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
     * @return
     */
   private def getHistogramWithCache(
-      relevant: BacksplashImage[IO]
+      relevant: BacksplashImage[IO],
+      tracingContext: TracingContext[IO]
   )(implicit @cacheKeyExclude flags: Flags): IO[Array[Histogram[Double]]] =
     memoizeF(None) {
       relevant match {
@@ -330,14 +345,14 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
           histStore.layerHistogram(im.imageId, im.subsetBands)
         case im: Landsat8MultiTiffImage =>
           logger.debug(s"Retrieving histograms for ${im.imageId} from source")
-          im.getHistogram(im.tracingContext)
+          im.getHistogram(tracingContext)
         // Is this hilariously repetitive? Yes! But type erasure :(
         case im: Sentinel2MultiTiffImage =>
           logger.debug(s"Retrieving histograms for ${im.imageId} from source")
-          im.getHistogram(im.tracingContext)
+          im.getHistogram(tracingContext)
         case im: LandsatHistoricalMultiTiffImage =>
           logger.debug(s"Retrieving histograms for ${im.imageId} from source")
-          im.getHistogram(im.tracingContext)
+          im.getHistogram(tracingContext)
       }
     }
 
@@ -361,50 +376,62 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
         (extent: Extent, cs: CellSize) => {
           for {
             bands <- {
-              self.map { bsiList =>
-                bsiList.headOption match {
-                  case Some(image) => image.subsetBands
-                  case _           => throw NoScenesException
-                }
+              self.map {
+                case (_, bsiList) =>
+                  bsiList.headOption match {
+                    case Some(image) => image.subsetBands
+                    case _           => throw NoScenesException
+                  }
               }
             }
             mosaic <- if (bands.length == 3) {
-              val bsm = self.map { bsiList =>
-                {
-                  bsiList parTraverse { relevant =>
-                    for {
-                      imFiber <- relevant
-                        .read(extent, cs, relevant.tracingContext)
-                        .start
-                      histsFiber <- {
-                        histStore.layerHistogram(
-                          relevant.imageId,
-                          relevant.subsetBands
-                        )
-                      }.start
-                      im <- imFiber.join
-                      hists <- histsFiber.join
-                      renderedTile <- relevant.tracingContext.childSpan(
-                        "colorCorrect") use { _ =>
-                        IO.pure {
-                          im map { mbTile =>
-                            logger.debug(
-                              s"N bands in resulting tile: ${mbTile.bands.length}"
-                            )
-                            relevant.corrections.colorCorrect(mbTile,
-                                                              hists,
-                                                              None)
+              val bsm = self.map {
+                case (tracingContext, bsiList) => {
+                  tracingContext.childSpan("paintedMosaicExtentReification") use {
+                    childContext =>
+                      bsiList parTraverse { relevant =>
+                        val tags =
+                          Map("imageId" -> relevant.imageId.toString,
+                              "projectId" -> relevant.projectId.toString)
+                        for {
+                          imFiber <- relevant
+                            .read(extent, cs, childContext)
+                            .start
+                          histsFiber <- childContext.childSpan("layerHistogram",
+                                                               tags) use { _ =>
+                            histStore
+                              .layerHistogram(
+                                relevant.imageId,
+                                relevant.subsetBands
+                              )
+                              .start
+                          }
+                          im <- imFiber.join
+                          hists <- histsFiber.join
+                          renderedTile <- childContext.childSpan("colorCorrect",
+                                                                 tags) use {
+                            _ =>
+                              IO.pure {
+                                im map { mbTile =>
+                                  logger.debug(
+                                    s"N bands in resulting tile: ${mbTile.bands.length}"
+                                  )
+                                  relevant.corrections.colorCorrect(mbTile,
+                                                                    hists,
+                                                                    None)
+                                }
+                              }
+                          }
+                        } yield {
+                          renderedTile match {
+                            case Some(mbTile) =>
+                              Some(
+                                Raster(mbTile.interpretAs(invisiCellType),
+                                       extent))
+                            case _ => None
                           }
                         }
                       }
-                    } yield {
-                      renderedTile match {
-                        case Some(mbTile) =>
-                          Some(
-                            Raster(mbTile.interpretAs(invisiCellType), extent))
-                        case _ => None
-                      }
-                    }
                   }
                 }.map(_.flatten.reduceOption(_ merge _))
                   .map({
@@ -422,21 +449,24 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
               for {
                 histograms <- BacksplashMosaic.getStoreHistogram(self,
                                                                  histStore)
-                imageList <- self
-                corrected <- imageList.traverse { bsi =>
-                  bsi.singleBandOptions match {
-                    case Some(opts) =>
-                      bsi.read(extent, cs, bsi.tracingContext) map {
-                        case Some(mbt) =>
-                          ColorRampMosaic.colorTile(mbt, histograms, opts)
-                        case _ =>
-                          MultibandTile(invisiTile, invisiTile, invisiTile)
-                      }
-                    case _ =>
-                      IO.raiseError(
-                        SingleBandOptionsException(
-                          "Must specify single band options when requesting single band visualization.")
-                      )
+                (tracingContext, imageList) <- self
+                corrected <- tracingContext.childSpan(
+                  "singleBandPaintedExtentReification") use { childContext =>
+                  imageList.traverse { bsi =>
+                    bsi.singleBandOptions match {
+                      case Some(opts) =>
+                        bsi.read(extent, cs, childContext) map {
+                          case Some(mbt) =>
+                            ColorRampMosaic.colorTile(mbt, histograms, opts)
+                          case _ =>
+                            MultibandTile(invisiTile, invisiTile, invisiTile)
+                        }
+                      case _ =>
+                        IO.raiseError(
+                          SingleBandOptionsException(
+                            "Must specify single band options when requesting single band visualization.")
+                        )
+                    }
                   }
                 }
               } yield {
@@ -462,25 +492,36 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
       )(implicit contextShift: ContextShift[IO])
         : (Extent, CellSize) => IO[ProjectedRaster[MultibandTile]] =
         (extent: Extent, cs: CellSize) => {
-          val mosaic = self.map { listBsi =>
-            for {
-              mbts <- listBsi.traverse({ relevant =>
-                relevant.read(extent, cs, relevant.tracingContext)
-              })
-            } yield {
-              val tiles = mbts.collect({ case Some(mbTile) => mbTile })
-              val rasters = tiles.map(Raster(_, extent))
-              rasters.reduceOption(_ merge _) match {
-                case Some(r) => r
-                case _ =>
-                  Raster(
-                    MultibandTile(invisiTile, invisiTile, invisiTile),
-                    extent
-                  )
+          val mosaic = self.map {
+            case (tracingContext, listBsi) =>
+              tracingContext.childSpan("rawMosaicExtentReification") use {
+                childContext =>
+                  for {
+                    mbts <- {
+                      childContext.childSpan("rawMosaicExtentReification.reads") use {
+                        grandContext =>
+                          listBsi.traverse({ relevant =>
+                            relevant.read(extent, cs, grandContext)
+                          })
+                      }
+                    }
+                  } yield {
+                    val tiles = mbts.collect({ case Some(mbTile) => mbTile })
+                    val rasters = tiles.map(Raster(_, extent))
+                    rasters.reduceOption(_ merge _) match {
+                      case Some(r) => r
+                      case _ =>
+                        Raster(
+                          MultibandTile(invisiTile, invisiTile, invisiTile),
+                          extent
+                        )
+                    }
+                  }
               }
-            }
           }
-          mosaic.flatten map { ProjectedRaster(_, WebMercator) }
+          mosaic.flatten map {
+            ProjectedRaster(_, WebMercator)
+          }
         }
     }
 
@@ -493,21 +534,25 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
       def rasterExtents(
           self: BacksplashMosaic
       )(implicit contextShift: ContextShift[IO]): IO[NEL[RasterExtent]] = {
-        val mosaic = self.flatMap { bsiList =>
-          bsiList.traverse({ img =>
-            img.getRasterSource(img.tracingContext) map { rs =>
-              val rasterExtents = rs.resolutions map { res =>
-                ReprojectRasterExtent(RasterExtent(res.extent,
-                                                   res.cellwidth,
-                                                   res.cellheight,
-                                                   res.cols.toInt,
-                                                   res.rows.toInt),
-                                      rs.crs,
-                                      WebMercator)
-              }
-              rasterExtents
+        val mosaic = self.flatMap {
+          case (tracingContext, bsiList) =>
+            tracingContext.childSpan("mosaicRasterExtents") use {
+              childContext =>
+                bsiList.traverse({ img =>
+                  img.getRasterSource(childContext) map { rs =>
+                    val rasterExtents = rs.resolutions map { res =>
+                      ReprojectRasterExtent(RasterExtent(res.extent,
+                                                         res.cellwidth,
+                                                         res.cellheight,
+                                                         res.cols.toInt,
+                                                         res.rows.toInt),
+                                            rs.crs,
+                                            WebMercator)
+                    }
+                    rasterExtents
+                  }
+                })
             }
-          })
         }
         mosaic.map(_.flatten.toNel.getOrElse(
           throw new MetadataException("Cannot get raster extent from mosaic.")))

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -1,13 +1,14 @@
 package com.rasterfoundry
 
 import cats.effect._
+import com.colisweb.tracing.TracingContext
 import io.circe.KeyEncoder
 import org.http4s.Request
 import org.http4s.util.CaseInsensitiveString
 
 package object backsplash {
 
-  type BacksplashMosaic = IO[List[BacksplashImage[IO]]]
+  type BacksplashMosaic = IO[(TracingContext[IO], List[BacksplashImage[IO]])]
 
   implicit val encodeKeyDouble: KeyEncoder[Double] = new KeyEncoder[Double] {
     def apply(key: Double): String = key.toString

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -39,10 +39,11 @@ class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
                                 None,
                                 None,
                                 NoOpTracingContext[IO]())
-            } map { bsiList =>
-              bsiList.map { backsplashImage =>
-                backsplashImage.selectBands(List(bandActual))
-              }
+            } map {
+              case (tracingContext, bsiList) =>
+                (tracingContext, bsiList.map { backsplashImage =>
+                  backsplashImage.selectBands(List(bandActual))
+                })
             }
           Map[String, BacksplashMosaic](
             s"${projId.toString}_${bandActual}" -> mosaic
@@ -58,10 +59,10 @@ class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
             s"${layerId.toString}_${bandActual}" -> (
               layerStore
                 .read(layerId, None, None, None, NoOpTracingContext[IO]()) map {
-                bsiList =>
-                  bsiList map { backsplashIm =>
+                case (tracingContext, bsiList) =>
+                  (tracingContext, bsiList map { backsplashIm =>
                     backsplashIm.selectBands(List(bandActual))
-                  }
+                  })
               }
             )
           )

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/OgcImplicits.scala
@@ -70,12 +70,10 @@ class OgcImplicits[R: RenderableStore](layers: R, xa: Transactor[IO])(
   ): IO[(SimpleSource, List[CRS])] =
     (
       BacksplashMosaic.toRasterSource(
-        layers.read(projectLayer.id, None, None, None, tracingContext),
-        tracingContext
+        layers.read(projectLayer.id, None, None, None, tracingContext)
       ),
       BacksplashMosaic.getRasterSourceOriginalCRS(
-        layers.read(projectLayer.id, None, None, None, tracingContext),
-        tracingContext
+        layers.read(projectLayer.id, None, None, None, tracingContext)
       ),
       getStyles(projectLayer.id)
     ).parMapN(


### PR DESCRIPTION
## Overview

In the first pass of adding tracing to backsplash tracing contexts were added to `BacksplashImage` - in a few cases this wasn't ideal as the nesting for mosaics weren't 100 percent and also we couldn't add tracing to a few areas of the response cycle. This PR removes tracing context from images and adds it to mosaic. Most methods on images already took a tracing context as an argument, the difference now is that we can use child contexts from the mosaic tracing context to better group traces.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
![image](https://user-images.githubusercontent.com/898060/65692167-1a94d100-e040-11e9-880d-7bd10699a3c3.png)

### Notes

Still mostly focused on project layer mosaics since that's where most requests come in.

## Testing Instructions

- Get a JWT token and export it to your environment: `export JWT_TOKEN=<>`
- Assemble backsplash, start it up
- Make a request for a tile that has multiple underlying scenes:
`http :8081/dfc52922-dfc3-4155-9828-d8dfe9fd0f11/16/18192/24312/?token=${JWT_TOKEN}`
- Open up [Jaeger](http://localhost:16686/search) and view the trace to see what it looks like

Closes #5183 
