### PR TITLE
Add Datasource + Scene Caching

### DIFF
--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -231,8 +231,11 @@ trait SceneRoutes
         .transact(xa)
         .unsafeToFuture
     } {
-      onSuccess(
-        SceneDao.query.filter(sceneId).delete.transact(xa).unsafeToFuture) {
+      val response = for {
+        result <- SceneDao.query.filter(sceneId).delete.transact(xa)
+        _ <- SceneDao.deleteCache(sceneId).transact(xa)
+      } yield result
+      onSuccess(response.unsafeToFuture) {
         completeSingleOrNotFound
       }
     }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashMosaic.scala
@@ -80,8 +80,10 @@ object BacksplashMosaic extends ToHistogramStoreOps {
         childContext =>
           allImages parTraverse { im =>
             {
-              childContext.childSpan("layerHistogram") use { _ =>
-                histStore.layerHistogram(im.imageId, im.subsetBands)
+              childContext.childSpan("layerHistogram") use { histogramContext =>
+                histStore.layerHistogram(im.imageId,
+                                         im.subsetBands,
+                                         histogramContext)
               }
             }
           }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/HistogramStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/HistogramStore.scala
@@ -3,19 +3,22 @@ package com.rasterfoundry.backsplash
 import cats.effect.IO
 import geotrellis.raster.histogram._
 import simulacrum._
-
 import java.util.UUID
+
+import com.colisweb.tracing.TracingContext
 
 @typeclass trait HistogramStore[A] {
   @op("layerHistogram") def layerHistogram(
       self: A,
       layerId: UUID,
-      subsetBands: List[Int]
+      subsetBands: List[Int],
+      tracingContext: TracingContext[IO]
   ): IO[Array[Histogram[Double]]]
 
   @op("projectLayerHistogram") def projectLayerHistogram(
       self: A,
       projectLayerId: UUID,
-      subsetBands: List[Int]
+      subsetBands: List[Int],
+      tracingContext: TracingContext[IO]
   ): IO[Array[Histogram[Double]]]
 }

--- a/app-backend/datamodel/src/main/scala/Datasource.scala
+++ b/app-backend/datamodel/src/main/scala/Datasource.scala
@@ -53,6 +53,8 @@ object Datasource {
 
   def create = Create.apply _
 
+  def cacheKey(datasourceId: UUID) = s"Datasource:$datasourceId"
+
   @JsonCodec
   final case class Thin(bands: Json, name: String, id: UUID)
 

--- a/app-backend/datamodel/src/main/scala/Scene.scala
+++ b/app-backend/datamodel/src/main/scala/Scene.scala
@@ -158,6 +158,8 @@ final case class Scene(
 
 object Scene {
 
+  def cacheKey(id: UUID) = s"Scene:$id"
+
   /** Case class extracted from a POST request */
   @JsonCodec
   final case class Create(

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -1,6 +1,7 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.common._
+import com.rasterfoundry.database.util.Cache
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.common.color._
 import com.rasterfoundry.datamodel.{Scene, User, _}
@@ -16,6 +17,8 @@ import geotrellis.vector.{Geometry, Polygon, Projected}
 import io.circe.syntax._
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.model.ObjectMetadata
+import scalacache._
+import scalacache.CatsEffect.modes._
 
 import scala.concurrent.duration._
 import java.sql.Timestamp
@@ -31,6 +34,8 @@ object SceneDao
     with ObjectPermissions[Scene]
     with AWSBatch
     with AWSLambda {
+
+  import Cache.SceneCache._
 
   type KickoffIngest = Boolean
 
@@ -48,8 +53,17 @@ object SceneDao
     FROM
   """ ++ tableF
 
-  def getSceneById(id: UUID): ConnectionIO[Option[Scene]] =
-    query.filter(id).selectOption
+  def deleteCache(id: UUID): ConnectionIO[Unit] = {
+    for {
+      _ <- remove(Scene.cacheKey(id))(sceneCache, async[ConnectionIO]).attempt
+    } yield ()
+  }
+
+  def getSceneById(id: UUID): ConnectionIO[Option[Scene]] = {
+    Cache.getOptionCache(Scene.cacheKey(id), Some(30 minutes)) {
+      query.filter(id).selectOption
+    }
+  }
 
   def getSceneById(sceneId: UUID, footprint: Option[Projected[Polygon]])(
       implicit Filter: Filterable[Any, Projected[Geometry]]
@@ -60,8 +74,11 @@ object SceneDao
       } getOrElse { List.empty })): _*
     )).query[Scene].option
 
-  def unsafeGetSceneById(id: UUID): ConnectionIO[Scene] =
-    query.filter(id).select
+  def unsafeGetSceneById(id: UUID): ConnectionIO[Scene] = {
+    cachingF(Scene.cacheKey(id))(Some(30 minutes)) {
+      query.filter(id).select
+    }
+  }
 
   @SuppressWarnings(Array("CollectionIndexOnNonIndexedSeq"))
   def insert(
@@ -198,7 +215,8 @@ object SceneDao
         .whereAndOpt(idFilter))
         .query[(Timestamp, IngestStatus)]
         .unique
-    val updateIO: ConnectionIO[Int] = (sql"""
+    val updateIO: ConnectionIO[Int] = for {
+      result <- (sql"""
     UPDATE scenes
     SET
       modified_at = ${now},
@@ -225,7 +243,9 @@ object SceneDao
       grid_extent = ${scene.metadataFields.gridExtent},
       resolutions = ${scene.metadataFields.resolutions},
       no_data_value = ${scene.metadataFields.noDataValue}
-    """ ++ Fragments.whereAndOpt(idFilter)).update.run
+        """ ++ Fragments.whereAndOpt(idFilter)).update.run
+      _ <- deleteCache(id)
+    } yield result
 
     lastModifiedAndIngestIO flatMap {
       case (ts: Timestamp, prevIngestStatus: IngestStatus) =>

--- a/app-backend/db/src/main/scala/util/Cache.scala
+++ b/app-backend/db/src/main/scala/util/Cache.scala
@@ -71,4 +71,16 @@ object Cache extends LazyLogging {
       MemcachedCache[List[SceneToLayerWithSceneType]](memcachedClient)
     }
   }
+
+  object DatasourceCache {
+    implicit val datasourceCache: Cache[Datasource] = {
+      MemcachedCache[Datasource](memcachedClient)
+    }
+  }
+
+  object SceneCache {
+    implicit val sceneCache: Cache[Scene] = {
+      MemcachedCache[Scene](memcachedClient)
+    }
+  }
 }

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
@@ -37,7 +37,7 @@ object TracedHTTPRoutes {
         "http_method" -> req.method.name,
         "request_url" -> req.uri.path.toString,
         "environment" -> Config.environment
-      ).combine {
+      ) combine {
         req.headers.get(CaseInsensitiveString("X-Amzn-Trace-Id")) match {
           case Some(header) =>
             header.value.split('=').reverse.headOption match {
@@ -45,6 +45,11 @@ object TracedHTTPRoutes {
               case _             => Map.empty[String, String]
             }
           case _ => Map.empty[String, String]
+        }
+      } combine {
+        req.headers.get(CaseInsensitiveString("Referer")) match {
+          case Some(referer) => Map("referer" -> referer.value)
+          case _             => Map.empty[String, String]
         }
       }
 


### PR DESCRIPTION
## Overview

Adds datasource, scene caching for selects by ID. Also adds the referrer to traces as an explicit annotation.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Missing from Cache:
```
13:42:45.689 [FutureNotifyListener] DEBUG com.rasterfoundry.database.util.Cache$ - Cache Miss for Key: Scene:533fdfa0-0f76-49d8-8114-e9326d6c91ad:Datasource
```

Next Request:
```
13:45:24.247 [FutureNotifyListener] DEBUG com.rasterfoundry.database.util.Cache$ - Cache Hit for Key: Scene:533fdfa0-0f76-49d8-8114-e9326d6c91ad:Datasource
```

Referer:
![image](https://user-images.githubusercontent.com/898060/65885030-e125d380-e367-11e9-8138-34b72461abbc.png)

### Notes

This actually became less important after we reduced the number of queries since we are reusing the `AuthObject` results for scenes and not requesting scenes multiple times by ID.

## Testing Instructions

- Re-assemble servers
- Get JWT token and export it in environment: `export JWT_AUTH_TOKEN=<token>`
- Request thumbnail twice - see cache miss the first time:
```
http --auth-type=jwt :8081/scenes/533fdfa0-0f76-49d8-8114-e9326d6c91ad/thumbnail?floor=25&height=128&token=$JWT_AUTH_TOKEN
```

Closes #5123 
Closes #5195 
