### PR TITLE
Various Changes Related to Troubleshooting

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -113,7 +113,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
     val ioMBTwithSBO: IO[List[MBTTriple]] = tracingContext.childSpan(
       "renderMosaicSingleBand") use { context =>
       mosaic
-        .parTraverse((relevant: BacksplashImage[IO]) => {
+        .traverse((relevant: BacksplashImage[IO]) => {
           logger.debug(s"Band Subset Required: ${relevant.subsetBands}")
           relevant.read(z, x, y, context) map {
             (_, relevant.singleBandOptions, relevant.metadata.noDataValue)
@@ -192,7 +192,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
     val extent = BacksplashImage.tmsLevels(z).mapTransform.keyToExtent(x, y)
     val ioMBT = tracingContext.childSpan("renderMosaic") use { context =>
       mosaic
-        .parTraverse((relevant: BacksplashImage[IO]) => {
+        .traverse((relevant: BacksplashImage[IO]) => {
           val tags = Map("sceneId" -> relevant.imageId.toString,
                          "projectId" -> relevant.projectId.toString,
                          "projectLayerId" -> relevant.projectLayerId.toString,
@@ -258,7 +258,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
               case (tracingContext, listBsi) =>
                 tracingContext.childSpan("getMergedRawMosaic") use {
                   childContext =>
-                    val listIO = listBsi.parTraverse { bsi =>
+                    val listIO = listBsi.traverse { bsi =>
                       bsi.read(z, x, y, childContext)
                     }
                     childContext.childSpan("mergeRawTiles") use { _ =>
@@ -391,7 +391,7 @@ class MosaicImplicits[HistStore: HistogramStore, RendStore: RenderableStore](
                 case (tracingContext, bsiList) => {
                   tracingContext.childSpan("paintedMosaicExtentReification") use {
                     childContext =>
-                      bsiList parTraverse { relevant =>
+                      bsiList traverse { relevant =>
                         val tags =
                           Map("imageId" -> relevant.imageId.toString,
                               "projectId" -> relevant.projectId.toString)

--- a/app-backend/backsplash-server/src/main/resources/logback.xml
+++ b/app-backend/backsplash-server/src/main/resources/logback.xml
@@ -9,7 +9,7 @@
   <logger name="org.http4s.blaze.channel.nio1" level="WARN"/>
   <logger name="geotrellis.server" level="WARN"/>
   <logger name="com.colisweb.tracing" level="${TRACING_LOG_LEVEL:-WARN}"/>
-  <logger name="com.zaxxer.hikari" level="${HIKARI_LOG_LEVEL:-DEBUG}"/>
+  <logger name="com.zaxxer.hikari" level="${HIKARI_LOG_LEVEL:-INFO}"/>
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />

--- a/app-backend/backsplash-server/src/main/resources/logback.xml
+++ b/app-backend/backsplash-server/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
   <logger name="org.http4s.blaze.channel.nio1" level="WARN"/>
   <logger name="geotrellis.server" level="WARN"/>
   <logger name="com.colisweb.tracing" level="${TRACING_LOG_LEVEL:-WARN}"/>
+  <logger name="com.zaxxer.hikari" level="${HIKARI_LOG_LEVEL:-DEBUG}"/>
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -22,22 +22,16 @@ object RFTransactor {
       user: String = Properties.envOrElse("POSTGRES_USER", "rasterfoundry"),
       password: String =
         Properties.envOrElse("POSTGRES_PASSWORD", "rasterfoundry"),
-      statementTimeout: String =
-        Properties.envOrElse("POSTGRES_STATEMENT_TIMEOUT", "30000"),
       maximumPoolSize: Int =
         Properties.envOrElse("POSTGRES_DB_POOL_SIZE", "32").toInt,
-      poolName: String = "Raster-Foundry-Hikari-Pool",
-      maybeInitSql: Option[String] = None
+      poolName: String = "Raster-Foundry-Hikari-Pool"
   ) {
     val url = postgresUrl ++ dbName
-    val initSql =
-      maybeInitSql.getOrElse(s"SET statement_timeout = ${statementTimeout};")
 
     lazy val hikariDataSource = {
       val hikariConfig = new HikariConfig()
       hikariConfig.setPoolName(poolName)
       hikariConfig.setMaximumPoolSize(maximumPoolSize)
-      hikariConfig.setConnectionInitSql(initSql)
       hikariConfig.setJdbcUrl(url)
       hikariConfig.setUsername(user)
       hikariConfig.setPassword(password)

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -44,6 +44,7 @@ object RFTransactor {
       hikariConfig.setDriverClassName(driver)
       hikariConfig.setConnectionTimeout(2000)
       hikariConfig.setLeakDetectionThreshold(30 * 1000)
+      hikariConfig.setAutoCommit(false)
       new HikariDataSource(hikariConfig)
     }
 

--- a/app-backend/db/src/main/scala/util/database.scala
+++ b/app-backend/db/src/main/scala/util/database.scala
@@ -43,7 +43,7 @@ object RFTransactor {
       hikariConfig.setPassword(password)
       hikariConfig.setDriverClassName(driver)
       hikariConfig.setConnectionTimeout(2000)
-
+      hikariConfig.setLeakDetectionThreshold(30 * 1000)
       new HikariDataSource(hikariConfig)
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
         condition: service_healthy
     env_file: .env
     environment:
+      - HIKARI_LOG_LEVEL=DEBUG
       - RF_LOG_LEVEL=DEBUG
       - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
@@ -146,6 +147,7 @@ services:
     env_file: .env
     environment:
       - RF_LOG_LEVEL=DEBUG
+      - HIKARI_LOG_LEVEL=DEBUG
       - TRACING_LOG_LEVEL=TRACE
       - COURSIER_CACHE=/root/.coursier
       - DB_THREADPOOL_THREADS=16


### PR DESCRIPTION
## Overview

A few things happening here:
 - setting `autocommit` to false in `hikari` aligns that setting with `doobie`
 - adds leak detection to `hikari` for 30 seconds
 - enables debug logging for hikari
 - changes `parTraverse`'s to `traverse` since that was a little heavy

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Assemble and browse the application