### PR TITLE
Add task metadata to tracing tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Included TaskARN in tile server traces [\#5201](https://github.com/raster-foundry/raster-foundry/pull/5201)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
@@ -7,9 +7,13 @@ import com.colisweb.tracing._
 import com.colisweb.tracing.TracingContext.TracingContextBuilder
 import com.rasterfoundry.datamodel.User
 import com.rasterfoundry.http4s.xray.{XrayHttp, XrayRequest}
+import io.circe.parser._
 import io.opentracing._
 import org.http4s._
 import org.http4s.util.CaseInsensitiveString
+
+import scala.io.Source
+import scala.util.Properties
 
 object TracedHTTPRoutes {
 
@@ -25,6 +29,19 @@ object TracedHTTPRoutes {
       }
     wrapHttpRoutes(tracedRoutes, builder)
   }
+
+  val metadataLocation = Properties.envOrNone("ECS_CONTAINER_METADATA_FILE")
+  val instanceMetadataTags: Map[String, String] = (for {
+    inf <- metadataLocation
+    unparsed = Source.fromFile(inf).mkString
+    rawJson <- parse(unparsed).toOption
+    obj <- rawJson.asObject
+  } yield {
+    val tags = obj.toList filter { _._2.isString } map {
+      case (k, v) => (k, v.toString.replace("\"", ""))
+    }
+    Map(tags: _*)
+  }) getOrElse Map.empty
 
   def wrapHttpRoutes[F[_]: Sync](
       routes: Kleisli[OptionT[F, ?], AuthedTraceRequest[F], Response[F]],
@@ -51,15 +68,16 @@ object TracedHTTPRoutes {
           case Some(referer) => Map("referer" -> referer.value)
           case _             => Map.empty[String, String]
         }
-      }
+      } combine { instanceMetadataTags }
 
       def transformResponse(
-          context: TracingContext[F]): F[Option[Response[F]]] = {
+          context: TracingContext[F]
+      ): F[Option[Response[F]]] = {
         val tracedRequest = AuthedTraceRequest[F](authedReq, context)
         val responseOptionWithTags = routes.run(tracedRequest) semiflatMap {
           response =>
             val traceTags = Map(
-              "http_status" -> response.status.code.toString,
+              "http_status" -> response.status.code.toString
             ) ++ tags ++
               response.headers.toList
                 .map(h => (s"response_header_${h.name}" -> h.value))
@@ -75,19 +93,23 @@ object TracedHTTPRoutes {
         builder match {
           case b: XRayTracer.XRayTracingContextBuilder[F] => {
             val request =
-              XrayRequest(req.method.name,
-                          req.uri.path.toString,
-                          req.headers
-                            .get(CaseInsensitiveString("User-Agent"))
-                            .map(_.toString),
-                          req.from.map(_.toString))
+              XrayRequest(
+                req.method.name,
+                req.uri.path.toString,
+                req.headers
+                  .get(CaseInsensitiveString("User-Agent"))
+                  .map(_.toString),
+                req.from.map(_.toString)
+              )
             val http = XrayHttp(Some(request), None)
-            b(operationName, tags, Some(http)) use (context =>
-              transformResponse(context))
+            b(operationName, tags, Some(http)) use (
+                context => transformResponse(context)
+            )
           }
           case _ => {
-            builder(operationName, tags) use (context =>
-              transformResponse(context))
+            builder(operationName, tags) use (
+                context => transformResponse(context)
+            )
           }
         }
       }
@@ -96,8 +118,9 @@ object TracedHTTPRoutes {
 
   object using {
 
-    def unapply[F[_], T <: Tracer, S <: Span](tr: AuthedTraceRequest[F])
-      : Option[(AuthedRequest[F, User], TracingContext[F])] =
+    def unapply[F[_], T <: Tracer, S <: Span](
+        tr: AuthedTraceRequest[F]
+    ): Option[(AuthedRequest[F, User], TracingContext[F])] =
       Some(tr.authedRequest -> tr.tracingContext)
   }
 }


### PR DESCRIPTION
## Overview

This PR includes instance metadata in traces from backsplash.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Check out this [trace](https://console.aws.amazon.com/xray/home?region=us-east-1#/traces/1-5d93c1db-1f69c9fa25c206c809ac9361)

## Testing Instructions

- while `test/js/include-instance-metadata-in-traces` is in staging, make some requests
- check out the annotations for your requests and make sure they include a TaskARN

Closes #5176 
