### PR TITLE
Upgrade STAC version in export builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Upgraded STAC version in STAC export builder [\#5202](https://github.com/raster-foundry/raster-foundry/pull/5202)
+
 ### Deprecated
 
 ### Removed

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -161,27 +161,32 @@ class SceneCollectionBuilder[
           // ../../../../catalog.json
           val sceneRootPath = s"../${rootPath}"
           val itemLinksAndTitle: (String, String, String) =
-            (s"${sceneAbsPath}/item.json",
-             s"${scene.id}/item.json",
-             s"Scene Item ${scene.id.toString}")
+            (
+              s"${sceneAbsPath}/item.json",
+              s"${scene.id}/item.json",
+              s"Scene Item ${scene.id.toString}"
+            )
           val sceneLinks = List(
             StacLink(
               itemLinksAndTitle._1,
               Self,
               Some(`application/json`),
-              Some(itemLinksAndTitle._3)
+              Some(itemLinksAndTitle._3),
+              List()
             ),
             StacLink(
               "../collection.json",
               Parent,
               Some(`application/json`),
-              Some("Scene Collection")
+              Some("Scene Collection"),
+              List()
             ),
             StacLink(
               sceneRootPath,
               StacRoot,
               Some(`application/json`),
-              Some("Root")
+              Some("Root"),
+              List()
             )
           )
           val sceneProperties = JsonObject.fromMap(
@@ -210,6 +215,8 @@ class SceneCollectionBuilder[
               .withProperties(sceneProperties)
               .withParentPath(absPath, rootPath)
               .withAssets(sceneAsset)
+              .withStacVersion(sceneCollection.stacVersion)
+              .withExtensions(List())
               .build(),
             itemLinksAndTitle
           )
@@ -226,7 +233,8 @@ class SceneCollectionBuilder[
               link._2,
               Item,
               Some(`application/json`),
-              Some(link._2)
+              Some(link._2),
+              List()
             )
           })
         )

--- a/app-backend/batch/src/main/scala/stacExport/StacExtent.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacExtent.scala
@@ -1,17 +1,29 @@
 package com.rasterfoundry.batch.stacExport
 
-import io.circe.Encoder
+import io.circe._
+import io.circe.generic.semiauto._
+import geotrellis.server.stac._
+import geotrellis.server.stac.Implicits._
 
 // Spatial = bbox[lowerleftx, lowerlefty, upperrightx, upperrighty]
 // temportal = ["start date isostring"||null, "end date isostring"||null]
 // https://github.com/radiantearth/stac-spec/blob/dev/collection-spec/collection-spec.md#extent-object
-case class StacExtent(spatial: List[Double], temporal: List[Option[String]])
+case class StacExtent(spatial: SpatialExtent, temporal: TemporalExtent)
+
+case class SpatialExtent(bbox: List[Bbox])
+
+case class TemporalExtent(interval: List[List[Option[String]]])
 
 object StacExtent {
-  implicit val encStacExtent: Encoder[StacExtent] =
-    Encoder.forProduct2("spatial", "temporal")(ext => {
-      val spatial: List[Double] = ext.spatial
-      val temporal: List[String] = ext.temporal.map(_.getOrElse("null"))
-      (spatial, temporal)
-    })
+  implicit val encStacExtent: Encoder[StacExtent] = deriveEncoder[StacExtent]
+}
+
+object SpatialExtent {
+  implicit val encSpatialExtent: Encoder[SpatialExtent] =
+    deriveEncoder[SpatialExtent]
+}
+
+object TemporalExtent {
+  implicit val encTemporalExtent: Encoder[TemporalExtent] =
+    deriveEncoder[TemporalExtent]
 }

--- a/app-backend/batch/src/main/scala/stacExport/StacItemBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacItemBuilder.scala
@@ -22,6 +22,8 @@ object StacItemBuilder {
     trait ItemProperties extends ItemRequirements
     trait ItemParentPath extends ItemRequirements
     trait ItemAssets extends ItemRequirements
+    trait ItemVersion extends ItemRequirements
+    trait ItemExtensions extends ItemRequirements
     type CompleteItem =
       EmptyItem
         with ItemId
@@ -31,12 +33,14 @@ object StacItemBuilder {
         with ItemProperties
         with ItemParentPath
         with ItemAssets
+        with ItemVersion
+        with ItemExtensions
   }
 }
 
 case class IncompleteStacItem(
     id: Option[String] = None,
-    _type: String = "feature",
+    _type: String = "Feature",
     geometry: Option[Geometry] = None,
     bbox: Option[ItemBbox] = None,
     links: List[StacLink] = List(), // builders? ids? build function of parent needs to provide. relative links
@@ -45,12 +49,17 @@ case class IncompleteStacItem(
     properties: Option[JsonObject] = None,
     parentPath: Option[String] = None,
     rootPath: Option[String] = None,
+    stacVersion: Option[String] = None,
+    stacExtensions: List[String] = List()
 ) {
   @SuppressWarnings(Array("OptionGet"))
   def toStacItem(): StacItem = {
     val itemBbox = this.bbox.get
     StacItem(
       id = this.id.get,
+      stacVersion = this.stacVersion.get,
+      stacExtensions = this.stacExtensions,
+      _type = this._type,
       geometry = this.geometry.get,
       bbox = TwoDimBbox(
         itemBbox.lowerLeftLng,
@@ -67,7 +76,8 @@ case class IncompleteStacItem(
 }
 
 class StacItemBuilder[ItemRequirements <: StacItemBuilder.ItemRequirements](
-    stacItem: IncompleteStacItem = IncompleteStacItem()) {
+    stacItem: IncompleteStacItem = IncompleteStacItem()
+) {
   import StacItemBuilder.ItemBuilder._
 
   def withId(id: String): StacItemBuilder[ItemRequirements with ItemId] =
@@ -75,33 +85,50 @@ class StacItemBuilder[ItemRequirements <: StacItemBuilder.ItemRequirements](
 
   def withGeometries(
       geometry: Geometry,
-      bbox: ItemBbox): StacItemBuilder[ItemRequirements with ItemGeometries] =
+      bbox: ItemBbox
+  ): StacItemBuilder[ItemRequirements with ItemGeometries] =
     new StacItemBuilder(
-      stacItem.copy(geometry = Some(geometry), bbox = Some(bbox)))
+      stacItem.copy(geometry = Some(geometry), bbox = Some(bbox))
+    )
 
   def withLinks(
-      links: List[StacLink]): StacItemBuilder[ItemRequirements with ItemLinks] =
+      links: List[StacLink]
+  ): StacItemBuilder[ItemRequirements with ItemLinks] =
     new StacItemBuilder(stacItem.copy(links = stacItem.links ++ links))
 
-  def withCollection(collectionId: String)
-    : StacItemBuilder[ItemRequirements with ItemCollection] =
+  def withCollection(
+      collectionId: String
+  ): StacItemBuilder[ItemRequirements with ItemCollection] =
     new StacItemBuilder(stacItem.copy(collection = Some(collectionId)))
 
-  def withProperties(properties: JsonObject)
-    : StacItemBuilder[ItemRequirements with ItemProperties] =
+  def withProperties(
+      properties: JsonObject
+  ): StacItemBuilder[ItemRequirements with ItemProperties] =
     new StacItemBuilder(stacItem.copy(properties = Some(properties)))
 
   def withParentPath(
       path: String,
-      rootPath: String): StacItemBuilder[ItemRequirements with ItemParentPath] =
+      rootPath: String
+  ): StacItemBuilder[ItemRequirements with ItemParentPath] =
     new StacItemBuilder(
-      stacItem.copy(parentPath = Some(path), rootPath = Some(rootPath)))
+      stacItem.copy(parentPath = Some(path), rootPath = Some(rootPath))
+    )
 
-  def withAssets(assets: Map[String, StacAsset])
-    : StacItemBuilder[ItemRequirements with ItemAssets] =
+  def withAssets(
+      assets: Map[String, StacAsset]
+  ): StacItemBuilder[ItemRequirements with ItemAssets] =
     new StacItemBuilder(stacItem.copy(assets = stacItem.assets ++ assets))
 
-  @SuppressWarnings(Array("OptionGet"))
+  def withStacVersion(
+      stacVersion: Option[String]
+  ): StacItemBuilder[ItemRequirements with ItemVersion] =
+    new StacItemBuilder(stacItem.copy(stacVersion = stacVersion))
+
+  def withExtensions(
+      stacExtensions: List[String]
+  ): StacItemBuilder[ItemRequirements with ItemExtensions] =
+    new StacItemBuilder(stacItem.copy(stacExtensions = stacExtensions))
+
   def build()(implicit ev: ItemRequirements =:= CompleteItem): StacItem = {
     ev.unused // Silence unused warning because scalac warns about phantom types
     stacItem.toStacItem

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -286,7 +286,7 @@ final case class WriteStacCatalog(exportId: UUID)(
      */
     val catalogBuilder =
       new StacCatalogBuilder[StacCatalogBuilder.CatalogBuilder.EmptyCatalog]()
-    val stacVersion = "0.7.0"
+    val stacVersion = "0.8.0-rc1"
     val currentPath = s"s3://${dataBucket}/stac-exports"
     val catalogId = contentBundle.export.id.toString
     val catalogParentPath = s"${currentPath}/${catalogId}"
@@ -298,14 +298,16 @@ final case class WriteStacCatalog(exportId: UUID)(
         s"${catalogParentPath}/catalog.json",
         Self,
         Some(`application/json`),
-        Some(s"Catalog ${catalogId}")
+        Some(s"Catalog ${catalogId}"),
+        List()
       ),
       // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
       StacLink(
         "catalog.json",
         StacRoot,
         Some(`application/json`),
-        Some(s"Catalog ${catalogId}")
+        Some(s"Catalog ${catalogId}"),
+        List()
       )
     )
     val (

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -64,8 +64,8 @@ lazy val sharedSettings = Seq(
   scalacOptions := scalaOptions,
   // https://github.com/sbt/sbt/issues/3570
   scalacOptions in (Compile, console) ~= (_.filterNot(
-    _ == "-Ywarn-unused-import")
-    .filterNot(_ == "-Xfatal-warnings")
+    _ == "-Ywarn-unused-import"
+  ).filterNot(_ == "-Xfatal-warnings")
     .filterNot(_ == "-Ywarn-unused")
     .filterNot(_ == "-Ywarn-unused-import")),
   updateOptions := updateOptions.value.withGigahorse(false),
@@ -153,7 +153,6 @@ lazy val publishSettings = Seq(
   pgpSecretRing := file("/root/.gnupg/secring.gpg"),
   usePgpKeyHex(System.getenv().getOrDefault("PGP_HEX_KEY", "0")),
   releaseProcess := Seq[ReleaseStep](
-    checkSnapshotDependencies,
     inquireVersions,
     setReleaseVersion,
     releaseStepCommand("publishSigned"),
@@ -179,16 +178,18 @@ lazy val root = project
   .in(file("."))
   .settings(sharedSettings: _*)
   .settings(noPublishSettings)
-  .aggregate(api,
-             akkautil,
-             db,
-             common,
-             datamodel,
-             batch,
-             backsplashCore,
-             backsplashServer,
-             backsplashExport,
-             lambdaOverviews)
+  .aggregate(
+    api,
+    akkautil,
+    db,
+    common,
+    datamodel,
+    batch,
+    backsplashCore,
+    backsplashServer,
+    backsplashExport,
+    lambdaOverviews
+  )
 
 lazy val loggingDependencies = Seq(
   Dependencies.scalaLogging % Runtime,
@@ -240,8 +241,8 @@ lazy val lambdaOverviews = project
     mainClass in assembly := Some("com.rasterfoundry.lambda.overviews.Main"),
     addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
     addCompilerPlugin(scalafixSemanticdb),
-    assemblyOption in assembly := (assemblyOption in assembly).value.copy(
-      includeScala = false),
+    assemblyOption in assembly := (assemblyOption in assembly).value
+      .copy(includeScala = false),
     assemblyJarName in assembly := "lambda-overviews-assembly.jar"
   )
   .settings({
@@ -292,7 +293,7 @@ lazy val common = project
       Dependencies.apacheCommonsEmail,
       Dependencies.scalaCheck,
       Dependencies.catsScalacheck,
-      Dependencies.awsLambdaSdk,
+      Dependencies.awsLambdaSdk
     ) ++ loggingDependencies
   })
 

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Version {
   val geotools = "17.1"
   val geotrellisContrib = "3.16.1-M3"
   val geotrellis = "3.0.0-M3"
-  val geotrellisServer = "3.4.0"
+  val geotrellisServer = "3.4.0-6-ge843f05-SNAPSHOT"
   val hadoop = "2.8.4"
   val http4s = "0.20.0"
   val json4s = "3.5.0"
@@ -109,10 +109,10 @@ object Dependencies {
   val geotrellisGeotools = "org.locationtech.geotrellis" %% "geotrellis-geotools" % Version.geotrellis
   val geotrellisRaster = "org.locationtech.geotrellis" %% "geotrellis-raster" % Version.geotrellis
   val geotrellisS3 = "org.locationtech.geotrellis" %% "geotrellis-s3" % Version.geotrellis
-  val geotrellisServer = "com.azavea" %% "geotrellis-server-core" % Version.geotrellisServer
+  val geotrellisServer = "com.azavea.geotrellis" %% "geotrellis-server-core" % Version.geotrellisServer
   val geotrellisProj4 = "org.locationtech.geotrellis" %% "geotrellis-proj4" % Version.geotrellis
-  val geotrellisServerOgc = "com.azavea" %% "geotrellis-server-ogc" % Version.geotrellisServer
-  val geotrellisServerStac = "com.azavea" %% "geotrellis-server-stac" % Version.geotrellisServer
+  val geotrellisServerOgc = "com.azavea.geotrellis" %% "geotrellis-server-ogc" % Version.geotrellisServer
+  val geotrellisServerStac = "com.azavea.geotrellis" %% "geotrellis-server-stac" % Version.geotrellisServer
   val geotrellisShapefile = "org.locationtech.geotrellis" %% "geotrellis-shapefile" % Version.geotrellis
   val geotrellisSpark = "org.locationtech.geotrellis" %% "geotrellis-spark" % Version.geotrellis
   val geotrellisUtil = "org.locationtech.geotrellis" %% "geotrellis-util" % Version.geotrellis


### PR DESCRIPTION
## Overview

This PR:
- updates gt-server version
- updates the shape of the field `extent` in STAC Collections to match [the spec](https://github.com/radiantearth/stac-spec/blob/v0.8.0-rc1/collection-spec/collection-spec.md#extent-object)
- adds `stac_version` field for STAC items
- adds `stac_extensions` for the label items in the export
- adds `label:asset` field for `StacLink`, and populates this field with keys in the map of assets in label items.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

## Testing Instructions

- `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "florence al test 1",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac_export_id>`
- Get this export's S3 prefix from DB
- `aws s3 sync <s3 prefix> . --profile raster-foundry`
- check the downloaded catalog and check off the below list:
    * [x] updated the shape of the field `extent` in STAC Collections to match [the spec](https://github.com/radiantearth/stac-spec/blob/v0.8.0-rc1/collection-spec/collection-spec.md#extent-object)
    * [x] updated `stac_version` value for catalog, collections, items
    * [x] added `stac_version` field for STAC items
    * [x] added `stac_extensions` for the label items in the export
    * [x] added a `label:asset` field for `StacLink`, and populated this field with keys in the map of assets in label items.

Closes https://github.com/raster-foundry/raster-foundry/issues/5137
