### PR TITLE
Refine STAC export builder

### DIFF
--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -60,6 +60,10 @@ case class IncompleteLabelCollection(
     itemPropsThin: StacLabelItemPropertiesThin = StacLabelItemPropertiesThin(),
     sceneItemLinks: List[(String, String, String)] = List()
 ) {
+  // it is ok to use .get in here because stacVersion, id,
+  // description are in the requirement above and only
+  // when they are populated does the compiler agree with
+  // the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def toStacCollection(): StacCollection = {
     val extent: Json = this.extent match {
@@ -164,7 +168,10 @@ class LabelCollectionBuilder[
         sceneItemLinks = labelCollection.sceneItemLinks ++ sceneItemLinks
       )
     )
-
+  // it is ok to use .get in here because paths, tasksGeomExtent,
+  // extent, and id are in the requirement above and only
+  // when they are populated does the compiler agree with
+  // the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def build()(
       implicit ev: CollectionRequirements =:= CompleteCollection

--- a/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LayerCollectionBuilder.scala
@@ -62,6 +62,10 @@ case class IncompleteLayerCollection(
       )
     ] = None
 ) {
+  // it is ok to use .get in here because stacVersion, id,
+  // description are in the requirement above and only
+  // when they are populated does the compiler agree with
+  // the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def toStacCollection(): StacCollection = {
     val extent: Json = this.extent match {
@@ -154,6 +158,9 @@ class LayerCollectionBuilder[
 
   def inspect: IncompleteLayerCollection = layerCollection
 
+  // it is ok to use .get in here because all these fields
+  // are in the requirement above and only when they are
+  // populated does the compiler agree with the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def build()(
       implicit ev: CollectionRequirements =:= CompleteCollection

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -50,6 +50,10 @@ final case class IncompleteSceneCollection(
     rootPath: Option[String] = None,
     sceneList: List[Scene] = List()
 ) {
+  // it is ok to use .get in here because stacVersion, id,
+  // description are in the requirement above and only
+  // when they are populated does the compiler agree with
+  // the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def toStacCollection: StacCollection = {
     val extent: Json = this.extent match {
@@ -130,6 +134,13 @@ class SceneCollectionBuilder[
         .copy(sceneList = sceneCollection.sceneList ++ sceneList)
     )
 
+  // it is ok to use .get in here because paths, id,
+  // are in the requirement above and only when they
+  // are populated does the compiler agree with the
+  // .build() call
+  // for the .get on scene datafootprint and ingest
+  // location, if labels are generated from these
+  // scenes, these fields should have values already
   @SuppressWarnings(Array("OptionGet"))
   def build()(
       implicit ev: CollectionRequirements =:= CompleteCollection

--- a/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacCatalogBuilder.scala
@@ -44,6 +44,10 @@ case class IncompleteStacCatalog(
     links: List[StacLink] = List(),
     contents: Option[ContentBundle] = None
 ) {
+  // it is ok to use .get in here because stacVersion, id,
+  // description are in the requirement above and only when
+  // they are populated does the compiler agree with
+  // the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def toStacCatalog(): StacCatalog = {
     StacCatalog(
@@ -104,6 +108,9 @@ class StacCatalogBuilder[
   ): StacCatalogBuilder[CatalogRequirements with CatalogContents] =
     new StacCatalogBuilder(stacCatalog.copy(contents = Some(contents)))
 
+  // it is ok to use .get in here because parentPath, contents,
+  // id, and stacVersion are in the requirement above and only
+  // when they are populated does the compiler agree with the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def build()(
       implicit ev: CatalogRequirements =:= CompleteCatalog
@@ -183,7 +190,8 @@ class StacCatalogBuilder[
 
           case None =>
             val extent = sceneList
-              .map(_.dataFootprint.get)
+              .map(_.dataFootprint)
+              .flatten
               .map(
                 geom =>
                   Reproject(

--- a/app-backend/batch/src/main/scala/stacExport/StacItemBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacItemBuilder.scala
@@ -43,15 +43,18 @@ case class IncompleteStacItem(
     _type: String = "Feature",
     geometry: Option[Geometry] = None,
     bbox: Option[ItemBbox] = None,
-    links: List[StacLink] = List(), // builders? ids? build function of parent needs to provide. relative links
-    assets: Map[String, StacAsset] = Map(), // relative links to collection, catalog
-    collection: Option[String] = None, // id of collection
+    links: List[StacLink] = List(),
+    assets: Map[String, StacAsset] = Map(),
+    collection: Option[String] = None,
     properties: Option[JsonObject] = None,
     parentPath: Option[String] = None,
     rootPath: Option[String] = None,
     stacVersion: Option[String] = None,
     stacExtensions: List[String] = List()
 ) {
+  // it is ok to use .get in here because these fields are
+  // in the requirement above and only when they are populated
+  // does the compiler agree with the .build() call
   @SuppressWarnings(Array("OptionGet"))
   def toStacItem(): StacItem = {
     val itemBbox = this.bbox.get

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -20,7 +20,11 @@ import io.circe._
 import io.circe.syntax._
 import cats.implicits._
 import cats.effect.IO
-import com.amazonaws.services.s3.model.{PutObjectRequest, ObjectMetadata}
+import com.amazonaws.services.s3.model.{
+  PutObjectRequest,
+  ObjectMetadata,
+  PutObjectResult
+}
 
 final case class WriteStacCatalog(exportId: UUID)(
     implicit val xa: Transactor[IO]
@@ -31,37 +35,35 @@ final case class WriteStacCatalog(exportId: UUID)(
 
   protected def s3Client = S3()
 
-  @SuppressWarnings(Array("CatchThrowable"))
   protected def putObjectToS3(
-      selfLink: String,
-      data: String,
+      selfLinkO: Option[String],
+      dataO: Option[Json],
       contentType: String
-  ) = {
-    val key = selfLink.replace(s"s3://${dataBucket}/", "")
-    val dataByte = data.getBytes(Charset.forName("UTF-8"))
-    val dataStream = new ByteArrayInputStream(dataByte)
-    val dataMd = new ObjectMetadata()
-    dataMd.setContentType(contentType)
-    dataMd.setContentLength(dataByte.length)
-    try {
-      logger.info(s"Writing ${selfLink} to S3...")
-      s3Client.putObject(
-        new PutObjectRequest(dataBucket, key, dataStream, dataMd)
-      )
-      logger.info(s"Successfully wrote ${selfLink} to S3...")
-    } catch {
-      case e: Throwable => {
-        logger.error(
-          s"Failed to upload export ${selfLink} to S3"
+  ): IO[Option[PutObjectResult]] = IO {
+    (selfLinkO, dataO) match {
+      case (Some(selfLink), Some(data)) =>
+        val key = selfLink.replace(s"s3://${dataBucket}/", "")
+        val dataByte = data.noSpaces.getBytes(Charset.forName("UTF-8"))
+        val dataStream = new ByteArrayInputStream(dataByte)
+        val dataMd = new ObjectMetadata()
+        dataMd.setContentType(contentType)
+        dataMd.setContentLength(dataByte.length)
+        Some(
+          s3Client.putObject(
+            new PutObjectRequest(dataBucket, key, dataStream, dataMd)
+          )
         )
-        throw e
-      }
+      case (None, _) =>
+        logger.error("No selflink for label data")
+        None
+      case (_, None) =>
+        logger.error("No label data to upload")
+        None
+      case _ =>
+        logger.error(s"No data and self link to upload")
+        None
     }
   }
-
-  @SuppressWarnings(Array("OptionGet"))
-  protected def unsafeGetStacSelfLink(stacLinks: List[StacLink]): String =
-    getStacSelfLink(stacLinks).get
 
   protected def getStacSelfLink(stacLinks: List[StacLink]): Option[String] =
     stacLinks.find(_.rel == Self).map(_.href)
@@ -78,69 +80,70 @@ final case class WriteStacCatalog(exportId: UUID)(
             (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
         )
       ]
-  ) = {
+  ): IO[List[PutObjectResult]] = {
     // catalog
-    putObjectToS3(
-      unsafeGetStacSelfLink(catalog.links),
-      catalog.asJson.noSpaces,
+    val writeCatalogIO: IO[Option[PutObjectResult]] = putObjectToS3(
+      getStacSelfLink(catalog.links),
+      Some(catalog.asJson),
       "application/json"
     )
 
-    layerSceneLabelCollectionsItemsAssets.foreach {
-      case (
-          layerCollection,
-          (sceneCollection, sceneItemList),
-          (labelCollection, labelItem, (labelData, labelDataLink))
-          ) =>
-        // layer collection
-        putObjectToS3(
-          unsafeGetStacSelfLink(layerCollection.links),
-          layerCollection.asJson.noSpaces,
-          "application/json"
-        )
-        // scene collection
-        putObjectToS3(
-          unsafeGetStacSelfLink(sceneCollection.links),
-          sceneCollection.asJson.noSpaces,
-          "application/json"
-        )
-        // scene items
-        sceneItemList.foreach(
-          sceneItem =>
-            putObjectToS3(
-              unsafeGetStacSelfLink(sceneItem.links),
-              sceneItem.asJson.noSpaces,
-              "application/json"
+    val writeOtherIO: List[IO[Option[PutObjectResult]]] =
+      layerSceneLabelCollectionsItemsAssets.map {
+        case (
+            layerCollection,
+            (sceneCollection, sceneItemList),
+            (labelCollection, labelItem, (labelData, labelDataLink))
+            ) =>
+          // layer collection
+          val writeLayerCollectionIO = putObjectToS3(
+            getStacSelfLink(layerCollection.links),
+            Some(layerCollection.asJson),
+            "application/json"
           )
-        )
-        // label collection
-        putObjectToS3(
-          unsafeGetStacSelfLink(labelCollection.links),
-          labelCollection.asJson.noSpaces,
-          "application/json"
-        )
-        // label item
-        putObjectToS3(
-          unsafeGetStacSelfLink(labelItem.links),
-          labelItem.asJson.noSpaces,
-          "application/json"
-        )
-
-        // label data
-        labelData match {
-          case Some(labels) =>
-            putObjectToS3(
-              labelDataLink,
-              labels.noSpaces,
-              "application/geo+json"
+          // scene collection
+          val writeSceneCollectionIO = putObjectToS3(
+            getStacSelfLink(sceneCollection.links),
+            Some(sceneCollection.asJson),
+            "application/json"
+          )
+          // scene items
+          val writeSceneItemIOs = sceneItemList.map(
+            sceneItem =>
+              putObjectToS3(
+                getStacSelfLink(sceneItem.links),
+                Some(sceneItem.asJson),
+                "application/json"
             )
-          case _ =>
-            logger.warn(
-              s"No label data to be exported for layer ${layerCollection.id}"
-            )
-        }
+          )
+          // label collection
+          val writeLabelCollectionIO = putObjectToS3(
+            getStacSelfLink(labelCollection.links),
+            Some(labelCollection.asJson),
+            "application/json"
+          )
+          // label item
+          val writeLabelItemIO = putObjectToS3(
+            getStacSelfLink(labelItem.links),
+            Some(labelItem.asJson),
+            "application/json"
+          )
+          // label data
+          val writeLabelDataIO = putObjectToS3(
+            Some(labelDataLink),
+            labelData,
+            "application/geo+json"
+          )
+          List(
+            writeLayerCollectionIO,
+            writeSceneCollectionIO,
+            writeLabelCollectionIO,
+            writeLabelItemIO,
+            writeLabelDataIO
+          ) ++ writeSceneItemIOs
+      } flatten
 
-    }
+    (List(writeCatalogIO) ++ writeOtherIO).sequence.map(_.flatten)
   }
 
   protected def sceneTaskAnnotationforLayers(
@@ -219,8 +222,69 @@ final case class WriteStacCatalog(exportId: UUID)(
       )
     }
 
-  @SuppressWarnings(Array("all"))
-  def run(): Unit = {
+  protected def buildCatalog(contentBundle: ContentBundle): (
+      StacCatalog, // catalog
+      List[
+        (
+            StacCollection, // layer collection
+            (StacCollection, List[StacItem]), // scene collection and scene items
+            (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+        )
+      ]
+  ) = {
+    /*
+     Exported Catalog:
+     |-> Layer collection
+     |   |-> Scene Collection
+     |   |   |-> Scene Item
+     |   |   |-> Scene Item
+     |   |   |-> (One or more scene items)
+     |   |-> Label Collection
+     |   |   |-> Label Item (Only one)
+     |   |   |-> Label Data in GeoJSON Feature Collection
+     |-> (One or more Layer Collections)
+     Final structure is going to be on s3
+     */
+    val catalogBuilder =
+      new StacCatalogBuilder[
+        StacCatalogBuilder.CatalogBuilder.EmptyCatalog
+      ]()
+    val stacVersion = "0.8.0-rc1"
+    val currentPath = s"s3://${dataBucket}/stac-exports"
+    val catalogId = contentBundle.export.id.toString
+    val catalogParentPath = s"${currentPath}/${catalogId}"
+    val catalogDescription =
+      s"Exported from Raster Foundry ${(new Timestamp((new Date()).getTime())).toString()}"
+    val catalogOwnLinks = List(
+      StacLink(
+        // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
+        s"${catalogParentPath}/catalog.json",
+        Self,
+        Some(`application/json`),
+        Some(s"Catalog ${catalogId}"),
+        List()
+      ),
+      // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
+      StacLink(
+        "catalog.json",
+        StacRoot,
+        Some(`application/json`),
+        Some(s"Catalog ${catalogId}"),
+        List()
+      )
+    )
+    catalogBuilder
+      .withVersion(stacVersion)
+      .withParentPath(catalogParentPath, true)
+      .withId(contentBundle.export.id.toString)
+      .withTitle(contentBundle.export.name)
+      .withDescription(catalogDescription)
+      .withLinks(catalogOwnLinks)
+      .withContents(contentBundle)
+      .build()
+  }
+
+  def run(): IO[Unit] = {
 
     logger.info(s"Exporting STAC export for record ${exportId}...")
 
@@ -263,98 +327,62 @@ final case class WriteStacCatalog(exportId: UUID)(
     logger.info(
       s"Creating content bundle with layers, scenes, and labels for record ${exportId}..."
     )
-    val (exportDef, layerInfo) = dbIO.transact(xa).unsafeRunSync
-    val contentBundle = ContentBundle(
-      exportDef,
-      layerInfo
-    )
 
-    logger.info(s"Building a catalog for record ${exportId}...")
-    /*
-     Exported Catalog:
-     |-> Layer collection
-     |   |-> Scene Collection
-     |   |   |-> Scene Item
-     |   |   |-> Scene Item
-     |   |   |-> (One or more scene items)
-     |   |-> Label Collection
-     |   |   |-> Label Item (Only one)
-     |   |   |-> Label Data in GeoJSON Feature Collection
-     |-> (One or more Layer Collections)
-
-     Final structure is going to be on s3
-     */
-    val catalogBuilder =
-      new StacCatalogBuilder[StacCatalogBuilder.CatalogBuilder.EmptyCatalog]()
-    val stacVersion = "0.8.0-rc1"
-    val currentPath = s"s3://${dataBucket}/stac-exports"
-    val catalogId = contentBundle.export.id.toString
-    val catalogParentPath = s"${currentPath}/${catalogId}"
-    val catalogDescription =
-      s"Exported from Raster Foundry ${(new Timestamp((new Date()).getTime())).toString()}"
-    val catalogOwnLinks = List(
-      StacLink(
-        // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
-        s"${catalogParentPath}/catalog.json",
-        Self,
-        Some(`application/json`),
-        Some(s"Catalog ${catalogId}"),
-        List()
-      ),
-      // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/catalog.json
-      StacLink(
-        "catalog.json",
-        StacRoot,
-        Some(`application/json`),
-        Some(s"Catalog ${catalogId}"),
-        List()
+    val createCatalogIO: IO[
+      (
+          ContentBundle,
+          StacCatalog,
+          List[
+            (
+                StacCollection, // layer collection
+                (StacCollection, List[StacItem]), // scene collection and scene items
+                (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+            )
+          ]
       )
-    )
-    val (
-      catalog,
-      layerSceneLabelCollectionsItemsAssets
-    ): (
-        StacCatalog, // catalog
-        List[
-          (
-              StacCollection, // layer collection
-              (StacCollection, List[StacItem]), // scene collection and scene items
-              (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
-          )
-        ]
-    ) = catalogBuilder
-      .withVersion(stacVersion)
-      .withParentPath(catalogParentPath, true)
-      .withId(contentBundle.export.id.toString)
-      .withTitle(contentBundle.export.name)
-      .withDescription(catalogDescription)
-      .withLinks(catalogOwnLinks)
-      .withContents(contentBundle)
-      .build()
-    logger.info(s"Built a catalog for record ${exportId}...")
+    ] = dbIO.transact(xa) map {
+      case (exportDef, layerInfo) =>
+        val contentBundle = ContentBundle(
+          exportDef,
+          layerInfo
+        )
+        logger.info(s"Building a catalog for record ${exportId}...")
 
-    logger.info(s"Writing catalog to S3 for record ${exportId}...")
-    writeToS3(catalog, layerSceneLabelCollectionsItemsAssets)
-    logger.info(s"Wrote catalog to S3 for record ${exportId}...")
+        val (catalog, layerSceneLabelCollectionsItemsAssets) =
+          buildCatalog(contentBundle)
+        logger.info(s"Built a catalog for record ${exportId}...")
+        (contentBundle, catalog, layerSceneLabelCollectionsItemsAssets)
+    }
 
-    logger.info(
-      s"Updating export location and status for record ${exportId}..."
-    )
-    val exportUpdateIO = StacExportDao.update(
-      contentBundle.export.copy(
-        exportStatus = ExportStatus.Exported,
-        exportLocation =
-          getStacSelfLink(catalog.links).map(_.replace("/catalog.json", ""))
-      ),
-      contentBundle.export.id
-    )
-
-    val updatedExportRecordCount = exportUpdateIO.transact(xa).unsafeRunSync
-
-    logger
-      .info(
-        s"${updatedExportRecordCount} STAC export record for ${exportId} is updated"
-      )
+    for {
+      contentAndCatalog <- createCatalogIO
+      (contentBundle, catalog, layerSceneLabelCollectionsItemsAssets) = contentAndCatalog
+      _ <- IO {
+        logger.info(s"Writing catalog to S3 for record ${exportId}...")
+      }
+      _ <- writeToS3(catalog, layerSceneLabelCollectionsItemsAssets)
+      _ <- IO { logger.info(s"Wrote catalog to S3 for record ${exportId}...") }
+      _ <- IO {
+        logger.info(
+          s"Updating export location and status for record ${exportId}..."
+        )
+      }
+      exportUpdateCount <- StacExportDao
+        .update(
+          contentBundle.export.copy(
+            exportStatus = ExportStatus.Exported,
+            exportLocation =
+              getStacSelfLink(catalog.links).map(_.replace("/catalog.json", ""))
+          ),
+          contentBundle.export.id
+        )
+        .transact(xa)
+    } yield {
+      logger
+        .info(
+          s"${exportUpdateCount} STAC export record for ${exportId} is updated"
+        )
+    }
   }
 
 }
@@ -369,7 +397,7 @@ object WriteStacCatalog extends Job {
         case List(id: String) => WriteStacCatalog(UUID.fromString(id))
       }
 
-      IO { job.run }
+      job.run
     })
   }
 }


### PR DESCRIPTION
## Overview

This PR:
- [X] makes STAC export builder use `IO` instead of ad hoc `try` / `catch`
- [X] revisits and updates `OptionGet` warning suppressions in STAC export builder and leaves comments on where such usage is actually fine

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Notes

I will change the base of this PR to develop once its base is merged. 

## Testing Instructions

- `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "florence al test 1",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac_export_id>`
- Get this export's S3 prefix from DB
- `aws s3 sync <s3 prefix> . --profile raster-foundry`
- check the downloaded catalog, things should be fine

Closes #5112 
Closes #5143 
