### PR TITLE
Add signed zip download link to stac exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Included TaskARN in tile server traces [\#5201](https://github.com/raster-foundry/raster-foundry/pull/5201)
+- Add zipped stac export url to stac objects returned from API [\#5220](https://github.com/raster-foundry/raster-foundry/pull/5220)
 
 ### Changed
 

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -176,6 +176,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       ]
   ): IO[PutObjectResult] = {
     // get root url
+    @SuppressWarnings((Array("TraversableHead")))
     val catalogRootFile = catalog.links.filter(l => l.rel == Self).head.href
 
     val catalogRootPath =

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -7,6 +7,7 @@ import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.S3
+import better.files.{File => ScalaFile}
 
 import geotrellis.server.stac._
 import java.sql.Timestamp
@@ -24,6 +25,34 @@ import com.amazonaws.services.s3.model.{
   PutObjectRequest,
   ObjectMetadata,
   PutObjectResult
+}
+
+case class LayerCollectionAndAssets(
+    layerCollection: StacCollection,
+    sceneCollection: StacCollection,
+    sceneItemList: List[StacItem],
+    labelCollection: StacCollection,
+    labelItem: StacItem,
+    labelData: Option[Json],
+    labelDataLink: String
+)
+
+object LayerCollectionAndAssets {
+  def fromTuples(
+      tuple: (
+          StacCollection, // layer collection
+          (StacCollection, List[StacItem]), // scene collection and scene items
+          (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+      )
+  ) = LayerCollectionAndAssets(
+    tuple._1,
+    tuple._2._1,
+    tuple._2._2,
+    tuple._3._1,
+    tuple._3._2,
+    tuple._3._3._1,
+    tuple._3._3._2
+  )
 }
 
 final case class WriteStacCatalog(exportId: UUID)(
@@ -65,8 +94,121 @@ final case class WriteStacCatalog(exportId: UUID)(
     }
   }
 
+  protected def writeObjectToFileSystem(
+      pathO: Option[String],
+      dataO: Option[Json]
+  ): IO[Option[ScalaFile]] = IO {
+    (pathO, dataO) match {
+      case (Some(path), Some(data)) =>
+        val file = ScalaFile(path)
+        file.createIfNotExists(false, true).append(data.noSpaces)
+        Some(file)
+      case _ =>
+        logger.info("Missing path or data, unable to write file")
+        None
+    }
+  }
+
   protected def getStacSelfLink(stacLinks: List[StacLink]): Option[String] =
     stacLinks.find(_.rel == Self).map(_.href)
+
+  protected def writeCollectionToFileSystem(
+      directory: String,
+      catalogRootPath: String,
+      lca: LayerCollectionAndAssets
+  ): IO[List[ScalaFile]] =
+    for {
+      layerCollectionFile <- {
+        writeObjectToFileSystem(
+          getStacSelfLink(lca.layerCollection.links)
+            .map(sl => sl.replace(catalogRootPath, directory)),
+          Some(lca.layerCollection.asJson)
+        )
+      }
+      sceneCollectionFile <- writeObjectToFileSystem(
+        getStacSelfLink(lca.sceneCollection.links)
+          .map(sl => sl.replace(catalogRootPath, directory)),
+        Some(lca.sceneCollection.asJson)
+      )
+      sceneItemFiles <- lca.sceneItemList.traverse(
+        sceneItem =>
+          writeObjectToFileSystem(
+            getStacSelfLink(sceneItem.links)
+              .map(
+                sl => sl.replace(catalogRootPath, directory)
+              ),
+            Some(sceneItem.asJson)
+        )
+      )
+      labelCollectionFile <- writeObjectToFileSystem(
+        getStacSelfLink(lca.labelCollection.links)
+          .map(sl => sl.replace(catalogRootPath, directory)),
+        Some(lca.labelCollection.asJson)
+      )
+      labelItemsFile <- writeObjectToFileSystem(
+        getStacSelfLink(lca.labelItem.links)
+          .map(sl => sl.replace(catalogRootPath, directory)),
+        Some(lca.labelItem.asJson)
+      )
+      labelDataFile <- writeObjectToFileSystem(
+        Some(lca.labelDataLink)
+          .map(sl => sl.replace(catalogRootPath, directory)),
+        lca.labelData
+      )
+    } yield
+      List(
+        layerCollectionFile,
+        sceneCollectionFile,
+        labelCollectionFile,
+        labelItemsFile,
+        labelDataFile
+      ).flatten ++ sceneItemFiles.flatten
+
+  // Write files locally and zip them up
+  protected def zipAndWriteToS3(
+      catalog: StacCatalog,
+      layerSceneLabelCollectionsItemsAssets: List[
+        (
+            StacCollection, // layer collection
+            (StacCollection, List[StacItem]), // scene collection and scene items
+            (StacCollection, StacItem, (Option[Json], String)) // label collection, label item, label data, and s3 location
+        )
+      ]
+  ): IO[PutObjectResult] = {
+    // get root url
+    val catalogRootFile = catalog.links.filter(l => l.rel == Self).head.href
+
+    val catalogRootPath =
+      catalogRootFile.substring(5, catalogRootFile.lastIndexOf("/"))
+
+    for {
+      tempDirectory <- IO { ScalaFile.newTemporaryDirectory() }
+      // catalog
+      _ <- writeObjectToFileSystem(
+        getStacSelfLink(catalog.links)
+          .map(sl =>
+            sl.replace(s"s3://${catalogRootPath}", tempDirectory.pathAsString)),
+        Some(catalog.asJson)
+      )
+      // layer collections
+      _ <- layerSceneLabelCollectionsItemsAssets.traverse {
+        collectionItemsAndAssets =>
+          writeCollectionToFileSystem(
+            tempDirectory.pathAsString,
+            s"s3://${catalogRootPath}",
+            LayerCollectionAndAssets.fromTuples(collectionItemsAndAssets)
+          )
+      }
+      zipFile <- IO { ScalaFile.newTemporaryFile("catalog", ".zip") }
+      // zip directory to file
+      _ <- IO { tempDirectory.zipTo(destination = zipFile) }
+      _ <- IO { tempDirectory.delete() }
+      s3WriteResult <- IO {
+        s3Client.putObject(catalogRootPath, "catalog.zip", zipFile.toJava)
+      }
+      _ <- IO { zipFile.delete(true) }
+    } yield s3WriteResult
+  }
 
   // Use the SELF type link on each object to upload it to the correct place
   // label items are accopanied by a geojson asset, which should be uploaded relative
@@ -358,7 +500,14 @@ final case class WriteStacCatalog(exportId: UUID)(
       contentAndCatalog <- createCatalogIO
       (contentBundle, catalog, layerSceneLabelCollectionsItemsAssets) = contentAndCatalog
       _ <- IO {
-        logger.info(s"Writing catalog to S3 for record ${exportId}...")
+        logger.info(s"Zipping catalog and writing to s3 for record ${exportId}")
+      }
+      _ <- zipAndWriteToS3(catalog, layerSceneLabelCollectionsItemsAssets)
+      _ <- IO {
+        logger.info(s"Wrote zipped catalog to s3 for record ${exportId}")
+      }
+      _ <- IO {
+        logger.info(s"Writing expanded catalog to S3 for record ${exportId}...")
       }
       _ <- writeToS3(catalog, layerSceneLabelCollectionsItemsAssets)
       _ <- IO { logger.info(s"Wrote catalog to S3 for record ${exportId}...") }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -360,6 +360,7 @@ lazy val batch = project
   .settings(resolvers += Resolver.bintrayRepo("azavea", "geotrellis"))
   .settings({
     libraryDependencies ++= Seq(
+      Dependencies.betterFiles,
       Dependencies.scalatest,
       Dependencies.geotrellisSpark,
       Dependencies.geotrellisS3,

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -25,6 +25,36 @@ object StacExport {
   final case class LayerDefinition(projectId: UUID, layerId: UUID)
 
   @JsonCodec
+  final case class WithSignedDownload(
+      id: UUID,
+      createdAt: Timestamp,
+      createdBy: String,
+      modifiedAt: Timestamp,
+      owner: String,
+      name: String,
+      exportLocation: Option[String],
+      exportStatus: ExportStatus,
+      layerDefinitions: List[StacExport.LayerDefinition],
+      taskStatuses: List[String],
+      downloadUrl: Option[String]
+  )
+
+  def signDownloadUrl(export: StacExport, signedDownload: Option[String]) =
+    WithSignedDownload(
+      export.id,
+      export.createdAt,
+      export.createdBy,
+      export.modifiedAt,
+      export.owner,
+      export.name,
+      export.exportLocation,
+      export.exportStatus,
+      export.layerDefinitions,
+      export.taskStatuses,
+      signedDownload
+    )
+
+  @JsonCodec
   final case class Create(name: String,
                           owner: Option[String],
                           layerDefinitions: List[StacExport.LayerDefinition],

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -8307,10 +8307,10 @@ definitions:
             description: 'STAC export Id'
           exportLocation:
             type: string
-            description: 'The url of the exported STAC catalog'
+            description: 'The s3 url of the exported STAC catalog'
           exportStatus:
             type: string
-            description: 'The url of the exported STAC catalog'
+            description: 'The processing status of STAC catalog'
             enum:
               - 'CREATED'
               - 'EXPORTING'
@@ -8320,6 +8320,9 @@ definitions:
               - 'COMPLETE'
               - 'FAILED'
               - 'ABORTED'
+          downloadUrl:
+            type: string
+            description: 'Signed http download URL for a zip of the stac catalog. Expires in 1 day'
   StacExportPaginated:
     allOf:
       - $ref: '#/definitions/PaginatedResponse'


### PR DESCRIPTION
## Overview
Allow the user to download the entire catalog zipfile in an http link

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
[catalog.zip](https://github.com/raster-foundry/raster-foundry/files/3718225/catalog.zip)

## Testing Instructions

- `batch/assembly`
- Spin up servers and frontend. Grab a token.
- `POST` below object to `/api/stac`:
```json
{
	"name": "florence al test 1",
	"layerDefinitions": [
		{
			"projectId": "7e584c31-f5d1-4a02-9428-e83006642375",
			"layerId": "1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"
		}
	],
	"taskStatuses": ["LABELED", "VALIDATED"]
}
```
- Grab the above export record's ID
- `docker-compose build batch`
- `./scripts/console batch bash`
- `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <stac_export_id>`
- make a GET request to `/api/stac` with your credentials
- Copy the `downloadUrl` field and paste it into your address bar to download.
- verify that the contents of the zipfile are correct.

Closes #5206 
