### PR TITLE
Include http4sUtil in aggregate so it gets sent to sonatype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed serialization of scenes to layer cache to binary [\#5218](https://github.com/raster-foundry/raster-foundry/pull/5218)
 - Upgraded STAC version in STAC export builder [\#5202](https://github.com/raster-foundry/raster-foundry/pull/5202)
 - Upgrade http4s to 0.20.11 [\#5213](https://github.com/raster-foundry/raster-foundry/)
+- Started publishing `http4s-util` artifact [\#5224](https://github.com/raster-foundry/raster-foundry/pull/5224)
 
 ### Deprecated
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -533,6 +533,7 @@ lazy val http4sUtil = Project("http4s-util", file("http4s-util"))
       Dependencies.awsXrayRecorder,
       Dependencies.awsXraySdk,
       Dependencies.doobieCore,
+      Dependencies.jaegerClient,
       Dependencies.opentracing,
       Dependencies.nimbusJose,
       Dependencies.scalacacheCore,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -533,7 +533,6 @@ lazy val http4sUtil = Project("http4s-util", file("http4s-util"))
       Dependencies.awsXrayRecorder,
       Dependencies.awsXraySdk,
       Dependencies.doobieCore,
-      Dependencies.jaegerClient,
       Dependencies.opentracing,
       Dependencies.nimbusJose,
       Dependencies.scalacacheCore,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -184,6 +184,7 @@ lazy val root = project
     db,
     common,
     datamodel,
+    http4sUtil,
     batch,
     backsplashCore,
     backsplashServer,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -528,7 +528,7 @@ lazy val backsplashServer =
 lazy val http4sUtil = Project("http4s-util", file("http4s-util"))
   .dependsOn(db)
   .settings(sharedSettings: _*)
-  .settings(noPublishSettings)
+  .settings(publishSettings)
   .settings({
     libraryDependencies ++= Seq(
       Dependencies.awsXrayRecorder,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -53,8 +53,11 @@ lazy val sharedSettings = Seq(
   ),
   unusedCompileDependenciesFilter -= moduleFilter(
     "org.apache.spark",
-    "spark-core",
-    "io.jaegertracing"
+    "spark-core"
+  ),
+  unusedCompileDependenciesFilter -= moduleFilter(
+    "io.jaegertracing",
+    "jaeger-client"
   ),
   // Try to keep logging sane and make sure to use slf4j + logback
   excludeDependencies ++= Seq(

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -53,7 +53,8 @@ lazy val sharedSettings = Seq(
   ),
   unusedCompileDependenciesFilter -= moduleFilter(
     "org.apache.spark",
-    "spark-core"
+    "spark-core",
+    "io.jaegertracing"
   ),
   // Try to keep logging sane and make sure to use slf4j + logback
   excludeDependencies ++= Seq(

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
@@ -56,7 +56,7 @@ object TracedHTTPRoutes {
       val operationName = "http4s-request"
       val tags = Map(
         "http_method" -> req.method.name,
-        "request_url" -> req.uri.path.toString,
+        "request_url" -> req.uri.path,
         "environment" -> Config.environment
       ) combine {
         req.headers.get(CaseInsensitiveString("X-Amzn-Trace-Id")) match {
@@ -99,7 +99,7 @@ object TracedHTTPRoutes {
             val request =
               XrayRequest(
                 req.method.name,
-                req.uri.path.toString,
+                req.uri.path,
                 req.headers
                   .get(CaseInsensitiveString("User-Agent"))
                   .map(_.toString),

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
-addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.9")
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.11")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.1")
 


### PR DESCRIPTION
## Overview

This PR makes sure that `http4sUtil` also gets published. Oops.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- ci