### PR TITLE
Use ids for item URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixed
 
+- Used item IDs instead of `"item.json"` for STAC item names [\#5226](https://github.com/raster-foundry/raster-foundry/pull/5226)
 - Fixed a routing bug that prevented viewing tiles under the `/scenes/` routes [\#5213](https://github.com/raster-foundry/raster-foundry/)
 
 ### Security

--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -198,8 +198,8 @@ class LabelCollectionBuilder[
     // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>
     val labelItemSelfAbsPath = s"${absPath}/${labelItemId}"
     // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>/item.json
-    val labelItemSelfAbsLink = s"${labelItemSelfAbsPath}/item.json"
-    val labelItemSelfRelLink = s"${labelItemId}/item.json"
+    val labelItemSelfAbsLink = s"${labelItemSelfAbsPath}/${labelItemId}.json"
+    val labelItemSelfRelLink = s"${labelItemId}/${labelItemId}.json"
     val labelItemLinks = List(
       StacLink(
         labelItemSelfAbsLink,

--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -197,7 +197,7 @@ class LabelCollectionBuilder[
 
     // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>
     val labelItemSelfAbsPath = s"${absPath}/${labelItemId}"
-    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>/item.json
+    // s3://rasterfoundry-production-data-us-east-1/stac-exports/<catalogId>/<layerCollectionId>/<labelCollectionId>/<labelItemId>/<labelItemid>.json
     val labelItemSelfAbsLink = s"${labelItemSelfAbsPath}/${labelItemId}.json"
     val labelItemSelfRelLink = s"${labelItemId}/${labelItemId}.json"
     val labelItemLinks = List(

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -173,8 +173,8 @@ class SceneCollectionBuilder[
           val sceneRootPath = s"../${rootPath}"
           val itemLinksAndTitle: (String, String, String) =
             (
-              s"${sceneAbsPath}/item.json",
-              s"${scene.id}/item.json",
+              s"${sceneAbsPath}/${scene.id}.json",
+              s"${scene.id}/${scene.id}.json",
               s"Scene Item ${scene.id.toString}"
             )
           val sceneLinks = List(


### PR DESCRIPTION
## Overview

This PR uses ids for STAC item file names instead of `item.json`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- assemble batch jar
- Create and run a STAC export following instructions in #5202 (or rerun an existing STAC export)
- sync its file location
- confirm that nothing is called `item.json` anymore: `find -name item.json` should return nothing from where you synced the export locally
- confirm that nothing links to `item.json` anymore `rg item.json` should return nothing from where you synced the export locally (if you don't have `rg` / ripgrep, use `ag` or whatever other searcher you use) 

Closes #5214 
