### PR TITLE
STAC bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Stopped serializing null label extension fields on STAC label items [\#5227](https://github.com/raster-foundry/raster-foundry/pull/5227)
 - Changed serialization of scenes to layer cache to binary [\#5218](https://github.com/raster-foundry/raster-foundry/pull/5218)
 - Upgraded STAC version in STAC export builder [\#5202](https://github.com/raster-foundry/raster-foundry/pull/5202)
 - Upgrade http4s to 0.20.11 [\#5213](https://github.com/raster-foundry/raster-foundry/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 ### Changed
 
-- Stopped serializing null label extension fields on STAC label items [\#5227](https://github.com/raster-foundry/raster-foundry/pull/5227)
 - Changed serialization of scenes to layer cache to binary [\#5218](https://github.com/raster-foundry/raster-foundry/pull/5218)
 - Upgraded STAC version in STAC export builder [\#5202](https://github.com/raster-foundry/raster-foundry/pull/5202)
 - Upgrade http4s to 0.20.11 [\#5213](https://github.com/raster-foundry/raster-foundry/)
@@ -24,6 +23,7 @@
 
 ### Fixed
 
+- STAC bug fixes: Stopped serializing null label extension fields on STAC label items, stopped URL encoding absolute links, fixed failure of STAC export if no task statuses selected [\#5227](https://github.com/raster-foundry/raster-foundry/pull/5227)
 - Fixed a routing bug that prevented viewing tiles under the `/scenes/` routes [\#5213](https://github.com/raster-foundry/raster-foundry/)
 
 ### Security

--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -256,7 +256,10 @@ class LabelCollectionBuilder[
         "label:method" -> labelItemProperties.method.asJson,
         "label:overview" -> labelItemProperties.overview.asJson,
         "datetime" -> labelItemProperties.datetime.asJson
-      )
+      ).filter({
+        case (k, v) =>
+          !v.isNull
+      })
     )
     val labelDataRelLink = "./data.geojson"
     val labelDataS3AbsLink: String = s"${labelItemSelfAbsPath}/data.geojson"

--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -256,10 +256,7 @@ class LabelCollectionBuilder[
         "label:method" -> labelItemProperties.method.asJson,
         "label:overview" -> labelItemProperties.overview.asJson,
         "datetime" -> labelItemProperties.datetime.asJson
-      ).filter({
-        case (k, v) =>
-          !v.isNull
-      })
+      )
     )
     val labelDataRelLink = "./data.geojson"
     val labelDataS3AbsLink: String = s"${labelItemSelfAbsPath}/data.geojson"

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -1,13 +1,16 @@
 package com.rasterfoundry.batch.stacExport
 
+import com.rasterfoundry.batch.stacExport.{StacExtent => BatchStacExtent}
+import com.rasterfoundry.datamodel._
+
 import geotrellis.vector.reproject.Reproject
 import geotrellis.proj4.CRS
-import com.rasterfoundry.datamodel._
-import io.circe._
-import io.circe.syntax._
 import geotrellis.server.stac._
 import geotrellis.server.stac.{StacExtent => _}
-import com.rasterfoundry.batch.stacExport.{StacExtent => BatchStacExtent}
+import io.circe._
+import io.circe.syntax._
+
+import java.net.URLDecoder
 
 object SceneCollectionBuilder {
   sealed trait CollectionRequirements
@@ -212,7 +215,7 @@ class SceneCollectionBuilder[
           val sceneAsset = Map(
             scene.id.toString ->
               StacAsset(
-                scene.ingestLocation.get,
+                URLDecoder.decode(scene.ingestLocation.get, "utf-8"),
                 Some("scene"),
                 Some(`image/cog`)
               )


### PR DESCRIPTION
## Overview

This PR makes it so that we don't print `null` for `label:overview` or other properties on label items, so we don't URL encode scene ingest locations, and so we can run STAC exports without specifying task statuses.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Nevermind all this -- just not printing any `null`s is fine

~This wound up being messier than we expected. It's not obvious to me that we want _never_ to print `null` anywhere, but we also only invoke the printer once, at the end of the universe: https://github.com/raster-foundry/raster-foundry/blob/develop/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala#L75. This means it's difficult to use a custom `Printer` for just this one case: https://github.com/circe/circe/blob/master/modules/core/shared/src/main/scala/io/circe/Printer.scala#L32. Separately, [as of the circe 0.12 series](https://github.com/circe/circe/commit/f106a9ba108042238a7ad291c7606faf6d8bdb00), it's possible to call `dropNullValues` on `Json` directly (which would let us handle this in the `Encoder`), but we can't upgrade until we get to GeoTrellis 3.0.0 (typelevel reasons), and we aren't even using the `Encoder` -- https://github.com/raster-foundry/raster-foundry/blob/develop/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala#L249-L260. I assumed there was a reason for this so didn't change it.~

~I wound up applying the same filter from what `dropNullValues` looks like~

Notes on #5215 -- the only URIs that should be url encoded are ingest locations for scenes. The self links for other items are all along the STAC path, which doesn't have any url encoding. The root URI also doesn't have any url encoding, since it's just off of `stac-exports/` (instead of including user ids).

## Testing Instructions

- Create a new STAC export of a local project with an uploaded scene and run it following instructions in #5202 -- use project id d8ad6591-b587-4237-b3f9-5b800fe87f1c and project layer id 196f1c36-ca36-44a6-9322-447f8c89d3f4 (if you don't have them, reload development data with `--download`)
- sync it to local
- grep / rg / ag for `label:overview` -- you should get no results
- bolder -- grep / rg / ag for "null" -- you should also get no results
- ensure that asset links in the scene collection aren't url encoded -- you can check because it should say `auth0|` instead of `auth0%7C`
- create a new stac export without any task statuses
- run it
- it shouldn't fail

Closes geotrellis/geotrellis-server#156

Closes #5215

Closes #5160 