### PR TITLE
Implement geojson import batch job

### DIFF
--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -12,6 +12,7 @@ import com.rasterfoundry.batch.aoi.UpdateAOIProject
 import com.rasterfoundry.batch.stacImport.{ReadStacFeature}
 import com.rasterfoundry.batch.stacExport.{WriteStacCatalog}
 import com.rasterfoundry.batch.notification.NotifyIngestStatus
+import com.rasterfoundry.batch.geojsonImport.ImportGeojsonFiles
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
@@ -26,6 +27,7 @@ object Main {
     WriteStacCatalog.name -> (WriteStacCatalog.main(_)),
     UpdateAOIProject.name -> (UpdateAOIProject.main(_)),
     UpdateExportStatus.name -> (UpdateExportStatus.main(_)),
+    ImportGeojsonFiles.name -> (ImportGeojsonFiles.main(_)),
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/geojsonImport/ImportGeojsonFiles.scala
+++ b/app-backend/batch/src/main/scala/geojsonImport/ImportGeojsonFiles.scala
@@ -1,0 +1,162 @@
+package com.rasterfoundry.batch.geojsonImport
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.ExecutionContext
+import com.rasterfoundry.batch.util.conf.Config
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.common.S3
+
+import com.typesafe.scalalogging.LazyLogging
+
+import doobie.ConnectionIO
+import doobie.implicits._
+import cats.implicits._
+import cats.effect._
+
+import scala.util._
+import java.util.UUID
+import java.util.concurrent.Executors
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+
+import java.util.UUID
+import com.rasterfoundry.database.GeojsonUploadDao
+import com.amazonaws.services.s3.AmazonS3URI
+import java.net.URLDecoder
+
+import java.nio.charset.StandardCharsets
+import io.circe.parser.decode
+import com.rasterfoundry.database.UserDao
+import com.rasterfoundry.database.AnnotationDao
+
+object CommandLine {
+  final case class Params(
+      upload: UUID = UUID.randomUUID(),
+      testRun: Boolean = false
+  )
+
+  val parser =
+    new scopt.OptionParser[Params]("raster-foundry-geojson-import") {
+      override def terminate(exitState: Either[String, Unit]): Unit = ()
+
+      head("raster-foundry-geojson-import", "0.1")
+
+      opt[Unit]('t', "test")
+        .action(
+          (_, conf) => conf.copy(testRun = true)
+        )
+        .text("Dry run geojson import to verify created annotations")
+
+      opt[String]('u', "upload")
+        .required()
+        .action(
+          (u, conf) => {
+            conf.copy(upload = UUID.fromString(u))
+          }
+        )
+        .text("GeojsonUpload entry to process")
+    }
+}
+
+object ImportGeojsonFiles extends Config with LazyLogging {
+  val name = "import_geojson_files"
+
+  implicit val contextShift: ContextShift[IO] =
+    IO.contextShift(
+      ExecutionContext.fromExecutor(
+        Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder().setNameFormat("geojson-import-%d").build()
+        )
+      )
+    )
+  implicit val xa = RFTransactor.buildTransactor()
+
+  def processUploadToAnnotations(
+      upload: GeojsonUpload
+  ): List[Annotation.Create] = {
+    val s3Client = S3()
+    // download and parse files
+    upload.files.map { uri =>
+      {
+        logger.info(s"Downloading file: ${uri}")
+        // Only s3 uris are currently supported.
+        // TODO: hmm, this might be a security problem. Anyone can point RF at geojson file that we have
+        // access to, and this will let them view it even if they shouldn't be able to view it.
+        // I think we need a more formal system which requires signed uploads to specific directories, and
+        // reject any s3 urls that aren't in those directories like scene uploads
+        val s3Uri = new AmazonS3URI(URLDecoder.decode(uri, "utf-8"))
+        val s3Object = s3Client.getObject(s3Uri.getBucket, s3Uri.getKey)
+        val geojsonString =
+          new String(S3.getObjectBytes(s3Object), StandardCharsets.UTF_8)
+        logger.info("Annotations downloaded")
+        logger.info("Parsing annotations")
+        val annotations =
+          decode[AnnotationFeatureCollectionCreate](geojsonString) match {
+            case Right(fc) => fc.features.map(_.toAnnotationCreate).toList
+            case Left(e)   => throw e
+          }
+        logger.info("Annotations parsed")
+        annotations
+      }
+    }.flatten
+  }
+
+  def insertAnnotations(
+      annotations: List[Annotation.Create],
+      upload: GeojsonUpload
+  ): ConnectionIO[List[Annotation]] = {
+    // https://makk.es/blog/postgresql-parameter-limitation/
+    // max # of interpolated params in postgres driver = 32,767 (2 byte int)
+    // each annotation = 17 params
+    // 32,767 / 17 = 1927 annotations / batch. Cut that in half to 1000 to be safe.
+    for {
+      user <- UserDao.unsafeGetUserById(upload.createdBy)
+      inserted <- annotations
+        .grouped(1000)
+        .toList
+        .traverse(annotationBatch => {
+          val updatedAnnotationBatch =
+            annotationBatch
+              .map(_.copy(annotationGroup = Some(upload.annotationGroup)))
+          AnnotationDao.insertAnnotations(
+            updatedAnnotationBatch,
+            upload.projectId,
+            user,
+            Some(upload.projectLayerId)
+          )
+        })
+        .map { _.flatten }
+    } yield inserted
+  }
+
+  def main(args: Array[String]): Unit = {
+    val params = CommandLine.parser.parse(args, CommandLine.Params()) match {
+      case Some(params) =>
+        params
+      case None =>
+        logger.info("Invalid params")
+        return
+    }
+    val uploadId = params.upload
+    val uploadO = GeojsonUploadDao
+      .getUploadById(uploadId)
+      .transact(xa)
+      .unsafeRunSync()
+
+    uploadO match {
+      case Some(upload) =>
+        val annotations = processUploadToAnnotations(upload)
+        logger.info(
+          s"Uploading ${annotations.size} annotations to annotation group: ${upload.annotationGroup}"
+        )
+        val inserted =
+          insertAnnotations(annotations, upload).transact(xa).unsafeRunSync()
+        logger.info(s"Annotations uploaded: ${inserted.size}")
+        return
+      case _ =>
+        logger.error(s"Unable to fetch upload with id: ${uploadId}")
+        return
+    }
+  }
+}

--- a/app-backend/batch/src/main/scala/geojsonImport/ImportGeojsonFiles.scala
+++ b/app-backend/batch/src/main/scala/geojsonImport/ImportGeojsonFiles.scala
@@ -46,7 +46,7 @@ object CommandLine {
         .action(
           (_, conf) => conf.copy(testRun = true)
         )
-        .text("Dry run geojson import to verify created annotations")
+        .text("Dry run geojson import to verify geojson file parses correctly to annotations")
 
       opt[String]('u', "upload")
         .required()

--- a/app-backend/batch/src/main/scala/geojsonImport/ImportGeojsonFiles.scala
+++ b/app-backend/batch/src/main/scala/geojsonImport/ImportGeojsonFiles.scala
@@ -150,9 +150,17 @@ object ImportGeojsonFiles extends Config with LazyLogging {
         logger.info(
           s"Uploading ${annotations.size} annotations to annotation group: ${upload.annotationGroup}"
         )
-        val inserted =
-          insertAnnotations(annotations, upload).transact(xa).unsafeRunSync()
-        logger.info(s"Annotations uploaded: ${inserted.size}")
+        params.testRun match {
+          case true =>
+            logger.info(
+              s"Test run: Not inserting ${annotations.size} annotations")
+          case _ =>
+            val inserted =
+              insertAnnotations(annotations, upload)
+                .transact(xa)
+                .unsafeRunSync()
+            logger.info(s"Annotations uploaded: ${inserted.size}")
+        }
         return
       case _ =>
         logger.error(s"Unable to fetch upload with id: ${uploadId}")


### PR DESCRIPTION
## Overview
Implement geojson import batch job

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

### Demo
```
rasterfoundry=# select count(*) from annotations where annotation_group = '6d448c26-e2b9-47e9-938b-c5125b663cc5';
 count 
-------
 80376
(1 row)
```

### Notes
There is no security on the s3 urls. We need to implement something similar to what we have on scene imports with signed uploads to specific s3 locations, and disallow users trom accessing anything outside of their personal s3 prefixes. See https://github.com/raster-foundry/raster-foundry/issues/5229

## Testing Instructions
- Follow the instructions in https://github.com/raster-foundry/raster-foundry/pull/5223 to create a geojson upload task
  Use `["s3://rasterfoundry-development-data-us-east-1/batch-geojson-test.geojson"]` as the file url. It's 80k training annotations modified to have label = classId
- rebuild your batch jar if you haven't done so on this branch
- rebuild the batch container `docker-compose build batch`
- start the batch container shell with `./scripts/console batch bash`
- start the geojson import 
` java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main import_geojson_files -u <geojson upload id>`
- wait about 8 minutes for it to parse the file, and 2 seconds for it to write it to the database
- Verify that the annotations are in the database and make sense

Closes #5209 