### PR TITLE
Add Collection Links and Fix Histograms in Multi Scene Analyses

### DIFF
--- a/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/LabelCollectionBuilder.scala
@@ -216,6 +216,13 @@ class LabelCollectionBuilder[
         List()
       ),
       StacLink(
+        "../collection.json",
+        Collection,
+        Some(`application/json`),
+        Some("Label Collection"),
+        List()
+      ),
+      StacLink(
         s"../${rootPath}",
         StacRoot,
         Some(`application/json`),

--- a/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
+++ b/app-backend/batch/src/main/scala/stacExport/SceneCollectionBuilder.scala
@@ -196,6 +196,13 @@ class SceneCollectionBuilder[
               List()
             ),
             StacLink(
+              "../collection.json",
+              Collection,
+              Some(`application/json`),
+              Some("Label Collection"),
+              List()
+            ),
+            StacLink(
               sceneRootPath,
               StacRoot,
               Some(`application/json`),

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -410,7 +410,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       new StacCatalogBuilder[
         StacCatalogBuilder.CatalogBuilder.EmptyCatalog
       ]()
-    val stacVersion = "0.8.0-rc1"
+    val stacVersion = "0.8.0"
     val currentPath = s"s3://${dataBucket}/stac-exports"
     val catalogId = contentBundle.export.id.toString
     val catalogParentPath = s"${currentPath}/${catalogId}"

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Version {
   val geotools = "17.1"
   val geotrellisContrib = "3.16.1-M3"
   val geotrellis = "3.0.0-M3"
-  val geotrellisServer = "3.4.0-6-ge843f05-SNAPSHOT"
+  val geotrellisServer = "3.4.0-4-gaac8d7e-SNAPSHOT"
   val hadoop = "2.8.4"
   val http4s = "0.20.11"
   val json4s = "3.5.0"


### PR DESCRIPTION
## Overview

Updates `geotrellis-server` to get multi-scene histogram fix and also adds collection link to exported STAC items.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Swagger specification updated~
~- [ ] New tables and queries have appropriate indices added~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~

### Demo
```
{
  "id": "0b176a97-49eb-44e7-a775-c0405e873c59",
  "stac_version": "0.8.0-rc1",
  "links": [
    {
      "href": "s3://rasterfoundry-development-data-us-east-1/stac-exports/aa9b5613-dc55-4512-87ca-0f4fa2277672/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/2de43c83-ccb9-4279-963b-1290a2014b63/0b176a97-49eb-44e7-a775-c0405e873c59/0b176a97-49eb-44e7-a775-c0405e873c59.json",
      "rel": "self",
      "type": "application/json",
      "title": "Label item 0b176a97-49eb-44e7-a775-c0405e873c59",
      "label:assets": [
        "0b176a97-49eb-44e7-a775-c0405e873c59"
      ]
    },
    {
      "href": "../collection.json",
      "rel": "parent",
      "type": "application/json",
      "title": "Label Collection",
      "label:assets": []
    },
    {
      "href": "../collection.json",
      "rel": "collection",
      "type": "application/json",
      "title": "Label Collection",
      "label:assets": []
    },
    {
      "href": "../../../catalog.json",
      "rel": "root",
      "type": "application/json",
      "title": "Root",
      "label:assets": []
    },
    {
      "href": "../../d43bead8-e3f8-4c51-95d6-e24e750a402b/d43bead8-e3f8-4c51-95d6-e24e750a402b.json",
      "rel": "source",
      "type": "image/vnd.stac.geotiff; cloud-optimized=true",
      "title": "Source image STAC item for the label item",
      "label:assets": []
    }
  ],
  "properties": {
    "label:description": "Labels in layer",
    "label:type": "vector",
    "datetime": "2019-08-07T20:37:10.681Z",
    "label:method": [
      "manual"
    ],
    "label:classes": [
      {
        "name": "label",
        "classes": [
          "Passenger Vehicle",
          "Bus",
          "Truck"
        ]
      }
    ],
    "label:task": [
      "detection"
    ],
    "label:property": [
      "label"
    ]
  },
  "stac_extensions": [
    "label"
  ],
  "type": "Feature",
  "geometry": {
    "type": "Polygon",
    "coordinates": []
  },
  "bbox": [
    -87.75155102590682,
    34.68664518347332,
    -87.43438975193705,
    34.90922697349481
  ],
  "assets": {
    "0b176a97-49eb-44e7-a775-c0405e873c59": {
      "href": "./data.geojson",
      "title": "Label Data Feature Collection",
      "type": "application/geo+json"
    }
  },
  "collection": "2de43c83-ccb9-4279-963b-1290a2014b63"
}
```

### Notes

I _think_ this was all that was to #5232 - just added another relation (duplicate of `parent` really) that specifies the collection. 

## Testing Instructions

Omitted instructions about testing histograms since that was already done

- Rebuild Batch project
- Get auth token and export it to use `http` to create an export:
`echo '{"name":"AL project test","layerDefinitions":[{"projectId":"7e584c31-f5d1-4a02-9428-e83006642375","layerId":"1a8c1632-fa91-4a62-b33e-3a87c2ebdf16"}],"taskStatuses":["LABELED","VALIDATED"]}' | http --auth-type=JWT :9091/api/stac`
- Run an export:
` ./scripts/console batch "java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <export-id-above>"`
- Request export: `http --auth-type=jwt :9091/api/stac/<export-id>`
- Download Zipped URL, inspect an item and see that collection is filled in
- Verify stac version is "0.8.0"
- Verify that the only `self` link is in the root of the catalog

Closes #5232 
Closes #5235 
Closes https://github.com/geotrellis/geotrellis-server/issues/153
Closes #5211