### PR TITLE
Use fragment combinators for filters in task summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed bug listing task summaries [\#5238](https://github.com/raster-foundry/raster-foundry/pull/5238)
+
 ### Security
 
 ## [1.32.0](https://github.com/raster-foundry/raster-foundry/compare/1.31.0...1.32.0)

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -516,12 +516,11 @@ object TaskDao extends Dao[Task] {
     SELECT
       status,
       ST_Transform(ST_Buffer(ST_Union(ST_Buffer(geometry, 1)), -1), 4326) AS geometry
-    FROM tasks
-    WHERE
-      project_id = ${projectId}
-      AND project_layer_id = ${layerId}
-    """ ++ (taskStatusF(statusO.toList map { _.toString })
-      .getOrElse(Fragment.empty)) ++ fr"GROUP BY status")
+    FROM tasks""" ++ Fragments
+      .whereAndOpt(
+        Some(fr"project_layer_id = ${layerId}"),
+        Some(fr"project_id = ${projectId}"),
+        taskStatusF(statusO.toList map { _.toString })) ++ fr"GROUP BY status")
       .query[UnionedGeomWithStatus]
       .to[List]
       .map(geomWithStatusList => {


### PR DESCRIPTION
## Overview

Fixes a bug where the task summary method on the Dao was generating incorrect SQL

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Re-assemble everything, get a JWT and export it to `JWT_AUTH_TOKEN`, start servers
- Request: `http --auth-type=JWT ":9091/api/projects/7e584c31-f5d1-4a02-9428-e83006642375/layers/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/tasks?format=summary&status=LABELED"`
- See that it works
