### PR TITLE
Fix scene metadata backfills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixed
 
 - Fixed usage of license types for STAC exports [\#5240](https://github.com/raster-foundry/raster-foundry/pull/5240)
+- Fix metadata backfill batch job [\#5249](https://github.com/raster-foundry/raster-foundry/pull/5249)
 
 ### Security
 

--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -112,7 +112,10 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
       metadataIOs
         .map(metadataInserts => {
           val (lefts, rights) =
-            metadataInserts.partition(t => t._1.isLeft || t._2.isLeft)
+            metadataInserts partition {
+              case (Right(_), Right(_)) => false
+              case _                    => true
+            }
           if (lefts.length > 0) {
             logger.error(
               s"Failed to insert metadata for ${lefts.length} resources")

--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -44,8 +44,16 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
     }
   }
 
-  def getBacksplashInfo(path: String): IO[BacksplashGeoTiffInfo] = {
-    IO(BacksplashGeotiffReader.getBacksplashGeotiffInfo(path))
+  def getBacksplashInfo(
+      id: UUID,
+      path: String): IO[Either[Throwable, BacksplashGeoTiffInfo]] = {
+    IO(BacksplashGeotiffReader.getBacksplashGeotiffInfo(path)).attempt map {
+      case l @ Left(_) =>
+        logger.error(
+          s"""Scene(id='$id'): Failed to fetch geotiff for path "$path".""")
+        l
+      case r => r
+    }
   }
 
   // presence of the ingest location is guaranteed by the filter in the sql string
@@ -91,17 +99,26 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
 
       implicit val contextShift: ContextShift[IO] = rasterIO
 
-      val response = scenesToUpdate.parTraverse {
+      val metadataIOs = scenesToUpdate.parTraverse {
         case (id, uri) =>
           for {
-            backsplashInfo <- getBacksplashInfo(uri)
-            rmdResult <- insertRasterSourceMetadata(id, uri, backsplashInfo)
-            geotiffResult <- insertGeotiffInfo(id, backsplashInfo)
+            backsplashInfo <- getBacksplashInfo(id, uri)
+            rmdResult <- backsplashInfo.traverse(
+              insertRasterSourceMetadata(id, uri, _))
+            geotiffResult <- backsplashInfo.traverse(insertGeotiffInfo(id, _))
           } yield (rmdResult, geotiffResult)
       }
 
-      response
-        .map(rsm => println(s"Inserted metadata for ${rsm.length} resources"))
+      metadataIOs
+        .map(metadataInserts => {
+          val (lefts, rights) =
+            metadataInserts.partition(t => t._1.isLeft || t._2.isLeft)
+          if (lefts.length > 0) {
+            logger.error(
+              s"Failed to insert metadata for ${lefts.length} resources")
+          }
+          logger.info(s"Inserted metadata for ${rights.length} resources")
+        })
     }
   }
 }

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -87,8 +87,8 @@ object ColorCorrect extends LazyLogging {
       specificBand.fold(allBands)(Some(_)).fold(Some(tileDefault))(x => Some(x))
 
   def normalize(rgbTile: MultibandTile,
-                          layerNormalizeArgs: Map[String, ClipBounds],
-                          noDataValue: Option[Double]): MultibandTile = {
+                layerNormalizeArgs: Map[String, ClipBounds],
+                noDataValue: Option[Double]): MultibandTile = {
     val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
     val tileCellType = UByteConstantNoDataCellType
     val (dstRed, dstGreen, dstBlue) = (


### PR DESCRIPTION
## Overview
Log counts for failing / successful metadata back-fills instead of failing

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo
![image](https://user-images.githubusercontent.com/4392704/69445577-9a79a780-0d20-11ea-9bd1-996be2462645.png)


### Notes

## Testing Instructions
- build your batch jar `./sbt batch/assembly`
- build your batch container `docker-compose build batch`
- in psql, change a few scene ingest locations to invalid locations:
```
update scenes set ingest_location = 's3:///rasterfoundry-production-data-us-east-1/invalid_upload_location.tif' where id in (select id from scenes where scene_type = 'COG' and ingest_location is not null and crs is null limit 10);
```
- run the rastersource-metadata-backfill job in your batch container: `./scripts/console batch "java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main rastersource-metadata-backfill"`
- Verify that it completes successfully and logs the failing scenes with final counts instead of failing the job entirely

Closes https://github.com/raster-foundry/raster-foundry/issues/5244
