### PR TITLE
Fix file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Unified file extension for label item assets and label item asset links [#5252](https://github.com/raster-foundry/raster-foundry/pull/5252)
+
 ### Security
 
 ## [1.33.0](https://github.com/raster-foundry/raster-foundry/compare/1.32.1...1.33.0)

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -52,7 +52,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       Utils.getLabelCollection(exportDef, catalog, layerCollection)
 
     val annotations = ObjectWithAbsolute(
-      s"$layerCollectionPrefix/${labelCollection.id}/data.json",
+      s"$layerCollectionPrefix/${labelCollection.id}/data.geojson",
       sceneTaskAnnotation.annotations
     )
 


### PR DESCRIPTION
## Overview

This PR makes the extension of label item asset on write the same as [the extension in the asset link](https://github.com/raster-foundry/raster-foundry/blob/85b119663d0a86fbf230dd39ae8294071eb3040c/app-backend/batch/src/main/scala/stacExport/Utils.scala#L157) for the label item. I'm sure you can imagine why that would be important.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Discovered because `pystac` was mad at me about the path. Thanks, pystac!

## Testing Instructions

- make sure they match