### PR TITLE
Add semantic segmentation project stac exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
-- Support semantic segmentation stac exports [](https://github.com/raster-foundry/raster-foundry/pull/)
+- Support semantic segmentation stac exports [\#5253](https://github.com/raster-foundry/raster-foundry/pull/5253)
 
 ### Changed
 
@@ -18,7 +18,7 @@
 ## [1.33.0](https://github.com/raster-foundry/raster-foundry/compare/1.32.1...1.33.0)
 ### Removed
 - CMR and Shapefile support [\#5247](https://github.com/raster-foundry/raster-foundry/pull/5247)
-- Complex color correction (saturation, per-band clipping, contrast adjustment, etc.) [#5245](https://github.com/raster-foundry/raster-foundry/pull/5245)
+- Complex color correction (saturation, per-band clipping, contrast adjustment, etc.) [\#5245](https://github.com/raster-foundry/raster-foundry/pull/5245)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Support semantic segmentation stac exports [](https://github.com/raster-foundry/raster-foundry/pull/)
 
 ### Changed
 

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -588,7 +588,7 @@ object AnnotationDao extends Dao[Annotation] {
       annotations.machine_generated,
       annotations.confidence,
       annotations.quality,
-      ST_INTERSECTION(annotations.geometry, tasks.geometry) as geometry,
+      ST_INTERSECTION(ST_MAKEVALID(annotations.geometry), tasks.geometry) as geometry,
       annotations.annotation_group,
       annotations.labeled_by,
       annotations.verified_by,

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -564,6 +564,62 @@ object AnnotationDao extends Dao[Annotation] {
       })
   }
 
+  def listSegmentationLayerAnnotationsByTaskStatus(
+      projectId: UUID,
+      layerId: UUID,
+      taskStatuses: List[String]
+  ): ConnectionIO[List[Annotation]] = {
+    val taskStatusF: Fragment =
+      taskStatuses.map(TaskStatus.fromString(_)).toNel match {
+        case Some(taskStatusNel) =>
+          fr"AND" ++ Fragments.in(fr"tasks.status", taskStatusNel)
+        case _ => fr""
+      }
+    (fr"""
+    SELECT
+      annotations.id,
+      annotations.project_id,
+      annotations.created_at,
+      annotations.created_by,
+      annotations.modified_at,
+      annotations.owner,
+      project_labels.name,
+      annotations.description,
+      annotations.machine_generated,
+      annotations.confidence,
+      annotations.quality,
+      ST_INTERSECTION(annotations.geometry, tasks.geometry) as geometry,
+      annotations.annotation_group,
+      annotations.labeled_by,
+      annotations.verified_by,
+      annotations.project_layer_id,
+      annotations.task_id
+    FROM annotations
+    JOIN annotation_groups AS ag
+    ON ag.id = annotations.annotation_group
+      AND ag.project_id = ${projectId}
+      AND ag.project_layer_id = ${layerId}
+      AND ag.name = 'label'
+    JOIN tasks
+    ON tasks.id = annotations.task_id
+       AND tasks.project_id = ${projectId}
+       AND tasks.project_layer_id = ${layerId}
+       AND annotations.project_id = ${projectId}
+       AND annotations.project_layer_id = ${layerId}
+    """ ++ taskStatusF ++ fr"""
+    JOIN (
+      SELECT labels.id, labels.name
+      FROM
+          projects,
+          jsonb_to_recordset((projects.extras->'annotate')::jsonb ->'labels') AS labels(id uuid, name text)
+      WHERE projects.id = ${projectId}
+    ) project_labels
+    ON project_labels.id::uuid = annotations.label::uuid
+     """)
+      .query[Annotation]
+      .to[List]
+  }
+
   def getLayerAnnotationJsonByTaskStatus(
       projectId: UUID,
       layerId: UUID,
@@ -578,6 +634,16 @@ object AnnotationDao extends Dao[Annotation] {
       ).map(annoFC => Some(annoFC.asJson))
     case MLProjectType.ObjectDetection =>
       listDetectionLayerAnnotationsByTaskStatus(
+        projectId,
+        layerId,
+        taskStatuses
+      ).map(annotations => {
+        Some(
+          AnnotationFeatureCollection(annotations.map(_.toGeoJSONFeature)).asJson
+        )
+      })
+    case MLProjectType.SemanticSegmentation =>
+      listSegmentationLayerAnnotationsByTaskStatus(
         projectId,
         layerId,
         taskStatuses

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -399,6 +399,87 @@ class AnnotationDaoSpec
       }
     }
   }
+  test("list segmentation annotations from a layer by task status") {
+    check {
+      forAll {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            (projectAgGroupCreate): (Project.Create, AnnotationGroup.Create),
+            annoAndTaskFeatureCreate: (Task.TaskFeatureCreate,
+                                       List[Annotation.Create]),
+            labelValidateTeamCreate: (Team.Create, Team.Create),
+            labelValidateTeamUgrCreate: (UserGroupRole.Create,
+                                         UserGroupRole.Create)
+        ) =>
+          {
+            val (taskFeatureCreate, annotationsCreate) =
+              annoAndTaskFeatureCreate
+            val (projectCreate, annotationGroupCreate) = projectAgGroupCreate
+            val labelName = "Car"
+            val labelId = UUID.randomUUID()
+            val labelGroupId = UUID.randomUUID()
+            val connIO = for {
+              (dbUser, dbOrg, dbPlatform, dbProject) <- insertUserOrgPlatProject(
+                userCreate,
+                orgCreate,
+                platform,
+                projectCreate
+              )
+              updatedDbProject <- fixupProjectExtrasUpdate(
+                labelValidateTeamCreate,
+                labelValidateTeamUgrCreate,
+                dbOrg,
+                dbUser,
+                dbPlatform,
+                dbProject,
+                Some(List((labelId, labelName, labelGroupId))),
+                Some(Map(labelGroupId -> "Car Group"))
+              )
+              collection <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  features = List(
+                    fixupTaskFeatureCreate(taskFeatureCreate, updatedDbProject)
+                      .withStatus(TaskStatus.Labeled)
+                  )
+                ),
+                dbUser
+              )
+              feature = collection.features.head
+              annotationGroup <- AnnotationGroupDao.createAnnotationGroup(
+                dbProject.id,
+                annotationGroupCreate.copy(name = "label"),
+                dbUser)
+              updatedAnnotationsCreate = annotationsCreate.map(annoCreate => {
+                annoCreate.copy(
+                  label = labelId.toString(),
+                  geometry = Some(feature.geometry),
+                  taskId = Some(feature.id),
+                  annotationGroup = Some(annotationGroup.id)
+                )
+              })
+              insertedAnnotations <- AnnotationDao.insertAnnotations(
+                updatedAnnotationsCreate,
+                dbProject.id,
+                dbUser
+              )
+              listedAnnotations <- AnnotationDao
+                .listSegmentationLayerAnnotationsByTaskStatus(
+                  dbProject.id,
+                  dbProject.defaultLayerId,
+                  List("LABELED")
+                )
+            } yield { (insertedAnnotations, listedAnnotations) }
+
+            val (dbAnnotations, listed) = connIO.transact(xa).unsafeRunSync
+            dbAnnotations.length == listed.length &&
+            listed.map(_.label).toSet == Set(labelName) &&
+            true
+          }
+      }
+    }
+  }
 
   test("list classification annotations from a layer by task status") {
     check {


### PR DESCRIPTION
## Overview
Clip annotations to the task boundaries

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests

### Demo
RF annotations:

![image](https://user-images.githubusercontent.com/4392704/70176224-20450d80-16a6-11ea-8ea3-8ede66ded4ed.png)

Stac export geojson results:
![image](https://user-images.githubusercontent.com/4392704/70176146-f0960580-16a5-11ea-8265-d90772bd2183.png)

### Notes


## Testing Instructions

- build your Api / batch jars
- point your annotate frontend at your local server by changing `.env.local` to look like this:
```
ENABLE_GTM_HISTORY="false"

REACT_APP_AUTH_DOMAIN=raster-foundry-dev.auth0.com
REACT_APP_AUTH_CLIENT_ID=544Cz1V8tqezMCbyN8mNJmlzOpd8H4ex
REACT_APP_AUTH_AUDIENCE=http://localhost:9091/api/
REACT_APP_API_URL=http://localhost:9091/api
REACT_APP_TILE_URL=http://localhost:8081
REACT_APP_LABEL_TEAM_ID=40bdf3a9-7da0-4b4d-9cfa-918430f67357
REACT_APP_VALIDATION_TEAM_ID=e36f5155-cd86-43d1-9942-a8eaeba11ca6
```
Team IDs may differ, check your user teams in RF and create them if you need to.
- start your api, rf frontend, and annotate frontend servers
- Create a segmentation project
- label a few tasks, making sure to have a variety between tasks which are drawn outside the borders and ones which aren't
- create 2 stac exports, one with task statuses that has geojson which should be clipped, and one that should result in empty (eg: validated on an unvalidated project)
- run this command for each stac export you created: ` docker-compose build batch && ./scripts/console batch "java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <export id>"` and verify that it completes successfully
- Download the stac export zips with  `aws s3 --profile raster-foundry cp s3://rasterfoundry-development-data-us-east-1/stac-exports<export-id>/catalog.zip catalog.zip`
- unzip them `unzip catalog.zip` and find the data.json file containing the annotations
- drag + drop the file into geojson.io and verify that shapes are clipped to the task areas.
- You can verify that the empty export contains an empty feature collection by viewing it in a text editor instead of dropping it into geojson.io

Closes https://github.com/raster-foundry/annotate/issues/444
