### PR TITLE
Add index to annotations task_id column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 
 - Unified file extension for label item assets and label item asset links [#5252](https://github.com/raster-foundry/raster-foundry/pull/5252)
+- Added index to annotations `task_id` column to make deleting tasks way faster [#5255](https://github.com/raster-foundry/raster-foundry/pull/5255)
 
 ### Security
 

--- a/app-backend/db/src/main/resources/migrations/V19__add_index_to_annotation_task_id.sql
+++ b/app-backend/db/src/main/resources/migrations/V19__add_index_to_annotation_task_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS annotations_tasks_task_id_idx ON annotations  (task_id);


### PR DESCRIPTION
## Overview

This PR adds an index to the `task_id` foreign key on annotations. Without this index, deleting tasks took a really long time. With this index, it's basically instantaneous even for large numbers of tasks.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Currently applied in prod -- you need a lot of annotations to really see the difference so that's the only realistic setting for testing unfortunately

## Testing Instructions

- make sure the migration runs (I also did this)
- extra credit: create an annotation project in production with a smallish grid size
- delete all of its tasks
- it should be really fast

Closes raster-foundry/annotate#313