### PR TITLE
Fix STAC exports with no tasks returned from filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Unified file extension for label item assets and label item asset links [#5252](https://github.com/raster-foundry/raster-foundry/pull/5252)
+- Explicitly handled case where aggregation of tasks doesn't return geometry statistics in STAC export [#5256](https://github.com/raster-foundry/raster-foundry/pull/5256)
 
 ### Security
 

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -20,7 +20,7 @@ object TaskDao extends Dao[Task] {
   type MaybeEmptyUnionedGeomExtent =
     Option[Projected[Geometry]] :: Option[Double] :: Option[Double] :: Option[
       Double
-    ] :: Option[Double] :: Option[Double] :: HNil
+    ] :: Option[Double] :: HNil
 
   val tableName = "tasks"
   val joinTableF =

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -431,8 +431,10 @@ class TaskDaoSpec
             projectCreate: Project.Create,
             taskFeatureCreate: Task.TaskFeatureCreate,
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val connIO = for {
@@ -543,8 +545,10 @@ class TaskDaoSpec
             projectCreate: Project.Create,
             taskFeatureCreate: Task.TaskFeatureCreate,
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val connIO = for {
@@ -635,8 +639,10 @@ class TaskDaoSpec
             projectCreate: Project.Create,
             taskFeatureCreate: Task.TaskFeatureCreate,
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val connIO = for {
@@ -729,8 +735,10 @@ class TaskDaoSpec
             projectCreate: Project.Create,
             taskFeatureCreate: Task.TaskFeatureCreate,
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val connIO = for {
@@ -801,7 +809,7 @@ class TaskDaoSpec
             platform: Platform,
             projectCreate: Project.Create,
             taskFeaturesCreateOne: Task.TaskFeatureCollectionCreate,
-            taskFeaturesCreateTwo: Task.TaskFeatureCollectionCreate,
+            taskFeaturesCreateTwo: Task.TaskFeatureCollectionCreate
         ) =>
           {
             val connIO = for {
@@ -812,15 +820,19 @@ class TaskDaoSpec
                 projectCreate
               )
               collectionOne <- TaskDao.insertTasks(
-                fixupTaskFeaturesCollection(taskFeaturesCreateOne,
-                                            dbProject,
-                                            Some(TaskStatus.Labeled)),
+                fixupTaskFeaturesCollection(
+                  taskFeaturesCreateOne,
+                  dbProject,
+                  Some(TaskStatus.Labeled)
+                ),
                 dbUser
               )
               collectionTwo <- TaskDao.insertTasks(
-                fixupTaskFeaturesCollection(taskFeaturesCreateTwo,
-                                            dbProject,
-                                            Some(TaskStatus.Validated)),
+                fixupTaskFeaturesCollection(
+                  taskFeaturesCreateTwo,
+                  dbProject,
+                  Some(TaskStatus.Validated)
+                ),
                 dbUser
               )
               fetched <- TaskDao.listLayerTasksByStatus(
@@ -832,6 +844,38 @@ class TaskDaoSpec
 
             val (colOne, colTwo, listed) = connIO.transact(xa).unsafeRunSync
             colOne.features.length + colTwo.features.length == listed.length
+          }
+      }
+    }
+  }
+
+  test("create a geometric extent even when no tasks returned in query") {
+    check {
+      forAll {
+        (
+            userCreate: User.Create,
+            orgCreate: Organization.Create,
+            platform: Platform,
+            projectCreate: Project.Create
+        ) =>
+          {
+            val connIO = for {
+              (_, _, _, dbProject) <- insertUserOrgPlatProject(
+                userCreate,
+                orgCreate,
+                platform,
+                projectCreate
+              )
+              unionedExtent <- TaskDao.createUnionedGeomExtent(
+                dbProject.id,
+                dbProject.defaultLayerId,
+                Nil
+              )
+            } yield unionedExtent
+
+            val result = connIO.transact(xa).unsafeRunSync
+            result should be(None: Option[UnionedGeomExtent])
+            true
           }
       }
     }


### PR DESCRIPTION
## Overview

This PR makes it so that when we try to create STAC exports for task statuses without labels, we succeed instead of failing with an unrecoverable deserialization error. Also it adds a test to ensure we can't break that particular function in the future.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] ~Any new~ Some old SQL strings have tests

## Notes

Important changes are the [new test](https://github.com/raster-foundry/raster-foundry/pull/5256/files?utf8=%E2%9C%93&diff=split&w=1#diff-a0c18aff8467804d0c25aee7929df7b2R852) and [hlist -> case class conversion](https://github.com/raster-foundry/raster-foundry/pull/5256/files?utf8=%E2%9C%93&diff=split&w=1#diff-1f9a76a8eb4f5dc4dbeb3b5db72aab64R515-R518). Everything else is whitespace.

Because we're doing aggregation, Postgres is perfectly happy to give us a row of `NULL`s back and doesn't think this is inconsistent with the filter we asked for. That leaves us two options:

1. Treat the input query as a subquery and select from within it where geometry is not NULL (since a non-null geometry should guarantee the non-nullness of other columns)
2. Read from the DB as something that I know how to convert to/from the desired type

I opted for 2 over 1 because:

- going with 1 would break the Dao + QueryBuilder pattern (can't pass filters into subqueries)
- going with 1 would in essence do an `Option[_]` conversion in postgres where it's invisible and not typechecked. We're dependent on the relationship between the columns to stay the same and have to express any `NULL` logic on the SQL side forever
- going with 2 lets us use something that doobie is already perfectly happy with (shapeless HLists) and perform an explicit and super readable mapping on the Scala side

## Testing Instructions

- pre-fix: http://jenkins.staging.rasterfoundry.com/blue/organizations/jenkins/Raster%20Foundry%2Fraster-foundry/detail/PR-5256/1/pipeline
- post-fix: http://jenkins.staging.rasterfoundry.com/blue/organizations/jenkins/Raster%20Foundry%2Fraster-foundry/detail/PR-5256/3/pipeline

Closes #5254
