### PR TITLE
Add configurable metadata backfill threads

### DIFF
--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -26,7 +26,8 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
   val name = "rastersource-metadata-backfill"
 
   def getScenesToBackfill(
-      implicit xa: Transactor[IO]): IO[List[(UUID, String)]] = {
+      implicit xa: Transactor[IO]
+  ): IO[List[(UUID, String)]] = {
     logger.info("Finding COG scenes without metadata in layer_attributes")
     fr"""select
            id, ingest_location
@@ -44,13 +45,37 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
     }
   }
 
+  def getSceneLocations(ids: List[UUID])(
+      implicit xa: Transactor[IO]
+  ): IO[List[(UUID, String)]] = {
+    logger.info("Finding scenes in arg list")
+
+    ids traverse { id: UUID =>
+      {
+        SceneDao.unsafeGetSceneById(id).transact(xa) map { scene =>
+          scene.ingestLocation match {
+            case Some(ig) => Some((scene.id, ig))
+            case _        => None
+          }
+        }
+      }
+    } map (_.flatten) map { tuples =>
+      {
+        logger.info(s"Found ${tuples.length} scenes to get metadata for")
+        tuples
+      }
+    }
+  }
+
   def getBacksplashInfo(
       id: UUID,
-      path: String): IO[Either[Throwable, BacksplashGeoTiffInfo]] = {
+      path: String
+  ): IO[Either[Throwable, BacksplashGeoTiffInfo]] = {
     IO(BacksplashGeotiffReader.getBacksplashGeotiffInfo(path)).attempt map {
       case l @ Left(_) =>
         logger.error(
-          s"""Scene(id='$id'): Failed to fetch geotiff for path "$path".""")
+          s"""Scene(id='$id'): Failed to fetch geotiff for path "$path"."""
+        )
         l
       case r => r
     }
@@ -58,10 +83,11 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
 
   // presence of the ingest location is guaranteed by the filter in the sql string
   @SuppressWarnings(Array("OptionGet"))
-  def insertRasterSourceMetadata(id: UUID,
-                                 path: String,
-                                 backsplashInfo: BacksplashGeoTiffInfo)(
-      implicit xa: Transactor[IO]): IO[Int] = {
+  def insertRasterSourceMetadata(
+      id: UUID,
+      path: String,
+      backsplashInfo: BacksplashGeoTiffInfo
+  )(implicit xa: Transactor[IO]): IO[Int] = {
     val rasterSourceMetadata = RasterSourceMetadata(
       GDALDataPath(path),
       backsplashInfo.crs,
@@ -79,17 +105,31 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
   }
 
   def insertGeotiffInfo(id: UUID, backsplashInfo: BacksplashGeoTiffInfo)(
-      implicit xa: Transactor[IO]): IO[Int] = {
+      implicit xa: Transactor[IO]
+  ): IO[Int] = {
     logger.info(s"Getting Metadata: ${id}")
     SceneDao.updateSceneGeoTiffInfo(backsplashInfo, id).transact(xa)
   }
 
   def runJob(args: List[String]) = {
-    val threads = args.headOption.map(Integer.parseInt(_)).getOrElse(4)
+    // val threads = args.headOption.map(Integer.parseInt(_)).getOrElse(4)
+    val (threads: Int, ids: List[UUID]) = args match {
+      case Nil => (4, List.empty)
+      case (threads: String) :: ids =>
+        (threads.toInt, ids.map(UUID.fromString(_)))
+    }
 
     RFTransactor.xaResource.use { transactor =>
       implicit val xa = transactor
-      val scenesToUpdate = getScenesToBackfill(xa).unsafeRunSync()
+
+      val idsAndLocations: List[(UUID, String)] = for {
+        idLocationTuples <- ids match {
+          case Nil    => getScenesToBackfill(xa).unsafeRunSync
+          case idsNel => getSceneLocations(idsNel)(xa).unsafeRunSync
+        }
+      } yield idLocationTuples
+
+      // val scenesToUpdate = getScenesToBackfill(xa).unsafeRunSync()
 
       val rasterIO: ContextShift[IO] = IO.contextShift(
         ExecutionContext.fromExecutor(
@@ -97,16 +137,18 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
             threads,
             new ThreadFactoryBuilder().setNameFormat("backfill-%d").build()
           )
-        ))
+        )
+      )
 
       implicit val contextShift: ContextShift[IO] = rasterIO
 
-      val metadataIOs = scenesToUpdate.parTraverse {
+      val metadataIOs = idsAndLocations.parTraverse {
         case (id, uri) =>
           for {
             backsplashInfo <- getBacksplashInfo(id, uri)
             rmdResult <- backsplashInfo.traverse(
-              insertRasterSourceMetadata(id, uri, _))
+              insertRasterSourceMetadata(id, uri, _)
+            )
             geotiffResult <- backsplashInfo.traverse(insertGeotiffInfo(id, _))
           } yield (rmdResult, geotiffResult)
       }
@@ -120,7 +162,8 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
             }
           if (lefts.length > 0) {
             logger.error(
-              s"Failed to insert metadata for ${lefts.length} resources")
+              s"Failed to insert metadata for ${lefts.length} resources"
+            )
           }
           logger.info(s"Inserted metadata for ${rights.length} resources")
         })

--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -85,6 +85,7 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
   }
 
   def runJob(args: List[String]) = {
+    val threads = args.headOption.map(Integer.parseInt(_)).getOrElse(4)
 
     RFTransactor.xaResource.use { transactor =>
       implicit val xa = transactor
@@ -92,7 +93,8 @@ object RasterSourceMetadataBackfill extends Job with RollbarNotifier {
 
       val rasterIO: ContextShift[IO] = IO.contextShift(
         ExecutionContext.fromExecutor(
-          Executors.newCachedThreadPool(
+          Executors.newFixedThreadPool(
+            threads,
             new ThreadFactoryBuilder().setNameFormat("backfill-%d").build()
           )
         ))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
 
   batch:
     image: raster-foundry-batch
+    ports:
+      - "9040:9040"
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-backend/batch/target/scala-2.12/batch-assembly.jar:/opt/raster-foundry/jars/batch-assembly.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
     command: rf
     links:
       - postgres:database.service.rasterfoundry.internal
+      - memcached:memcached.service.rasterfoundry.internal
 
   xray:
     image: amazon/aws-xray-daemon


### PR DESCRIPTION
## Overview
Prevent rastersource metadata backfill from fork-bombing itself

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~~Swagger specification updated~~
- [ ] ~~New tables and queries have appropriate indices added~~
- [ ] ~~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~~
- [ ] ~~Any new SQL strings have tests~~

### Demo
![image](https://user-images.githubusercontent.com/4392704/70658283-ae337200-1c2b-11ea-818f-737c77853841.png)

## Testing Instructions
- install visualvm if you don't have it
- build your batch jar / container
- in psql, run `update scenes set crs = null;` to make it so all ingested scenes get backfilled
- run 
```
./scripts/console batch "java -Dcom.sun.management.jmxremote.rmi.port=9040 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=9040 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.local.only=false -Djava.rmi.server.hostname=localhost -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main rastersource-metadata-backfill 8" 
```
Change the 8 at the end to any number of threads that you want
- open visual vm and connect to `localhost:9040` (file -> add jmx connection)
- verify that there are the specified number of `backfill-{x}` threads
Closes #5251 
