### PR TITLE
Stretch histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Support semantic segmentation stac exports [\#5253](https://github.com/raster-foundry/raster-foundry/pull/5253)
+- Added default clipping of non-byte rasters to middle 96 percent of values assuming a normal distribution [\#5264](https://github.com/raster-foundry/raster-foundry/pull/5264)
 
 ### Changed
 


### PR DESCRIPTION
## Overview

This PR clips values below the 2nd and above the 98th percentiles in source rasters before normalizing values to 0-255 for RGB visualization. This is done to have better default rendering for imagery that includes very bright areas (clouds, snow) and/or dark areas (water, shadows). The examples in the demo section below show this visualization.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Visualization from this PR:
![image](https://user-images.githubusercontent.com/898060/70834110-7a8d4f00-1dc7-11ea-92bc-4a91cb8d28d4.png)

Visualization from Production:
![image](https://user-images.githubusercontent.com/898060/70834137-92fd6980-1dc7-11ea-8d50-e6608cdfc4dd.png)

Histogram adjustment with QGIS (goal is to be close to this in RF):
![image](https://user-images.githubusercontent.com/898060/70834178-b1fbfb80-1dc7-11ea-9baa-c45cec8e7a95.png)

We're not quite as bright as QGIS - but I think that is _alright_

### Notes

In general I think things look better and the logic added doesn't seem too onerous/clever. Because this is done on a per-scene basis, projects with many scenes from a number of different days will still look a little off. I think some additionally clever merging of histograms for a project and scaling to that _might_ help, but that's not the goal of this PR.

The assumption of a normal distribution of pixel values almost certainly doesn't hold -- it's also why we ignore negative values for clipping because that makes images look worse. If there is a more clever technique I could use here based on the empirical distribution of values I'd be for it, but I couldn't think of a technique and couldn't find one.

## Testing Instructions

- Rebuild servers with this PR (or browse staging) - view some imagery and decide if it makes things worse

Closes #4163 
