### PR TITLE
Improve footprint and task grid calculations

### DIFF
--- a/app-backend/batch/src/main/scala/stacExport/DatabaseIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/DatabaseIO.scala
@@ -41,7 +41,7 @@ object DatabaseIO {
   ): ConnectionIO[Option[ExportData]] = {
     for {
       scenes <- ProjectLayerScenesDao.listLayerScenesRaw(layerId)
-      scenesGeomExtentOption <- ProjectLayerScenesDao.createUnionedGeomExtent(
+      scenesGeomExtentOption <- ProjectLayerScenesDao.getUnionedGeomExtent(
         layerId)
       tasks <- TaskDao.listLayerTasksByStatus(projectId, layerId, taskStatuses)
       tasksGeomExtentOption <- TaskDao.createUnionedGeomExtent(

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -946,7 +946,7 @@ object Generators extends ArbitraryInstances {
   private def taskFeatureCreateGen: Gen[Task.TaskFeatureCreate] =
     for {
       properties <- taskPropertiesCreateGen
-      geometry <- projectedMultiPolygonGen3857
+      geometry <- Gen.option(projectedMultiPolygonGen3857)
     } yield { Task.TaskFeatureCreate(properties, geometry) }
 
   private def taskFeatureCollectionCreateGen

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -946,7 +946,7 @@ object Generators extends ArbitraryInstances {
   private def taskFeatureCreateGen: Gen[Task.TaskFeatureCreate] =
     for {
       properties <- taskPropertiesCreateGen
-      geometry <- Gen.option(projectedMultiPolygonGen3857)
+      geometry <- projectedMultiPolygonGen3857
     } yield { Task.TaskFeatureCreate(properties, geometry) }
 
   private def taskFeatureCollectionCreateGen
@@ -968,7 +968,7 @@ object Generators extends ArbitraryInstances {
   private def taskGridFeatureCreateGen: Gen[Task.TaskGridFeatureCreate] =
     for {
       properties <- taskGridCreatePropertiesGen
-      geometry <- projectedMultiPolygonGen3857
+      geometry <- Gen.option(projectedMultiPolygonGen3857)
     } yield {
       Task.TaskGridFeatureCreate(properties, geometry)
     }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -184,7 +184,7 @@ object Task {
 
   case class TaskGridFeatureCreate(
       properties: TaskGridCreateProperties,
-      geometry: Projected[Geometry],
+      geometry: Option[Projected[Geometry]],
       _type: String = "Feature"
   )
 

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -162,7 +162,7 @@ object ProjectLayerScenesDao extends Dao[Scene] {
   ): ConnectionIO[Option[Projected[Geometry]]] =
     (fr"""
     SELECT
-      ST_Transform(ST_Union(s.data_footprint), 4326) AS geometry,
+      ST_Transform(ST_Union(s.data_footprint), 4326) AS geometry
     FROM scenes s
     JOIN scenes_to_layers stl
     ON s.id = stl.scene_id

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -167,5 +167,5 @@ object ProjectLayerScenesDao extends Dao[Scene] {
     JOIN scenes_to_layers stl
     ON s.id = stl.scene_id
     WHERE stl.project_layer_id = ${layerId}
-  """).query[Projected[Geometry]].option
+  """).query[Option[Projected[Geometry]]].unique
 }

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -1,17 +1,16 @@
 package com.rasterfoundry.database
 
+import com.rasterfoundry.common.SceneToLayer
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
+import cats.implicits._
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import doobie.postgres.circe.jsonb.implicits._
-import cats._
-import cats.implicits._
-import com.rasterfoundry.datamodel.{Order, PageRequest}
-import java.util.UUID
+import geotrellis.vector.{Geometry, Projected}
 
-import com.rasterfoundry.common.SceneToLayer
+import java.util.UUID
 
 object ProjectLayerScenesDao extends Dao[Scene] {
   val tableName =
@@ -45,7 +44,8 @@ object ProjectLayerScenesDao extends Dao[Scene] {
 
   def listLayerScenesRaw(
       layerId: UUID,
-      splitOptionsO: Option[SplitOptions] = None): ConnectionIO[List[Scene]] = {
+      splitOptionsO: Option[SplitOptions] = None
+  ): ConnectionIO[List[Scene]] = {
     val sceneParams = splitOptionsO match {
       case Some(splitOptions: SplitOptions) =>
         CombinedSceneQueryParams(
@@ -141,7 +141,7 @@ object ProjectLayerScenesDao extends Dao[Scene] {
     }
   }
 
-  def createUnionedGeomExtent(
+  def getUnionedGeomExtent(
       layerId: UUID
   ): ConnectionIO[Option[UnionedGeomExtent]] =
     (fr"""
@@ -156,4 +156,16 @@ object ProjectLayerScenesDao extends Dao[Scene] {
     ON s.id = stl.scene_id
     WHERE stl.project_layer_id = ${layerId}
   """).query[UnionedGeomExtent].option
+
+  def getUnionedGeomFootprint(
+      layerId: UUID
+  ): ConnectionIO[Option[Projected[Geometry]]] =
+    (fr"""
+    SELECT
+      ST_Transform(ST_Union(s.data_footprint), 4326) AS geometry,
+    FROM scenes s
+    JOIN scenes_to_layers stl
+    ON s.id = stl.scene_id
+    WHERE stl.project_layer_id = ${layerId}
+  """).query[Projected[Geometry]].option
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -548,7 +548,7 @@ class ProjectDaoSpec
                 fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
               acrs <- ProjectDao.addPermissionsMany(projectInsert1.id,
                                                     acrListToInsert)
-              _ = logger.info(s"ACRS Added: $acrs")
+              _ = logger.debug(s"ACRS Added: $acrs")
               action = Random.shuffle(acrListToInsert.map(_.actionType)).head
               isPermitted1 <- ProjectDao.authorized(dbGrantedUser,
                                                     ObjectType.Project,

--- a/app-tasks/rf/src/rf/cli.py
+++ b/app-tasks/rf/src/rf/cli.py
@@ -6,22 +6,18 @@ import logging
 
 import click
 
-from .commands import (
-    export,
-    ingest_scene,
-    process_upload,
-)
+from .commands import export, ingest_scene, process_upload
 
-logger = logging.getLogger('rf')
+logger = logging.getLogger("rf")
 
 
 @click.group()
-@click.option('--verbose/--quiet')
+@click.option("--verbose/--quiet")
 def run(verbose):
     """Console script for raster_foundry_batch_tasks."""
     if verbose:
         logger.setLevel(logging.DEBUG)
-        logger.debug('VERBOSE logging enabled')
+        logger.debug("VERBOSE logging enabled")
     else:
         logger.setLevel(logging.INFO)
 

--- a/app-tasks/rf/src/rf/commands/export.py
+++ b/app-tasks/rf/src/rf/commands/export.py
@@ -10,15 +10,16 @@ import click
 
 from ..utils.exception_reporting import wrap_rollbar
 from ..utils.io import s3_upload_export, dropbox_upload_export, get_tempdir
+
 logger = logging.getLogger(__name__)
 
-HOST = os.getenv('RF_HOST')
-API_PATH = '/api/exports/'
-RETRY = os.getenv('AWS_BATCH_JOB_ATTEMPT', '-1')
+HOST = os.getenv("RF_HOST")
+API_PATH = "/api/exports/"
+RETRY = os.getenv("AWS_BATCH_JOB_ATTEMPT", "-1")
 
 
-@click.command(name='export')
-@click.argument('export_id')
+@click.command(name="export")
+@click.argument("export_id")
 @wrap_rollbar
 def export(export_id):
     """Perform export configured by user
@@ -26,45 +27,46 @@ def export(export_id):
     Args:
         export_id (str): ID of export job to process
     """
-    logger.info('Creating Export Definition')
-    final_status = 'EXPORTED'
+    logger.info("Creating Export Definition")
+    final_status = "EXPORTED"
     try:
         export_uri = create_export_definition(export_id)
-        logger.info('Retrieving Export Definition %s', export_uri)
+        logger.info("Retrieving Export Definition %s", export_uri)
         export_definition = get_export_definition(export_uri)
         with get_tempdir(True) as local_dir:
-            logger.info('Created Working Directory %s', local_dir)
-            logger.info('Rewriting Export Definition')
+            logger.info("Created Working Directory %s", local_dir)
+            logger.info("Rewriting Export Definition")
             local_path = write_export_definition(export_definition, local_dir)
-            logger.info('Rewrote export definition to %s', local_path)
-            logger.info('Preparing to Run Export')
-            run_export('file://' + local_path, export_id)
+            logger.info("Rewrote export definition to %s", local_path)
+            logger.info("Preparing to Run Export")
+            run_export("file://" + local_path, export_id)
             out_path = local_tif_path_from_export_definition(
                 export_definition, local_dir
-            ).replace('file://', '')
+            ).replace("file://", "")
             upload_processed_tif(out_path, export_definition)
     except subprocess.CalledProcessError as e:
-        logger.error('Output from failed command: %s', e.output)
-        final_status = 'FAILED'
+        logger.error("Output from failed command: %s", e.output)
+        final_status = "FAILED"
         raise e
     except Exception as e:
-        logger.error('Wrapper error: %s', e)
-        final_status = 'FAILED'
+        logger.error("Wrapper error: %s", e)
+        final_status = "FAILED"
         raise e
     finally:
         # The max number of retries is currently hardcoded in batch.tf
         # in the deployment repo. Please make sure that both areas are updated if
         # this needs to be changed to a configurable variable
-        if final_status == 'EXPORTED' or int(RETRY) >= 3:
-            logger.info('Sending email notifications for export %s on try: %s',
-                        export_id, RETRY)
+        if final_status == "EXPORTED" or int(RETRY) >= 3:
+            logger.info(
+                "Sending email notifications for export %s on try: %s", export_id, RETRY
+            )
             update_export_status(export_id, final_status)
         else:
-            logger.info('Export failed, on try %s/3', RETRY)
+            logger.info("Export failed, on try %s/3", RETRY)
 
 
 def local_tif_path_from_export_definition(export_definition, local_dir):
-    return 'file://{}/{}.tif'.format(local_dir, export_definition['id'])
+    return "file://{}/{}.tif".format(local_dir, export_definition["id"])
 
 
 def create_export_definition(export_id):
@@ -73,54 +75,66 @@ def create_export_definition(export_id):
     Args:
         export_id (str): ID of export job to process
     """
-    bucket = os.getenv('DATA_BUCKET')
-    key = 'export-definitions/{}'.format(export_id)
-    logger.info('Creating export definition for %s', export_id)
+    bucket = os.getenv("DATA_BUCKET")
+    key = "export-definitions/{}".format(export_id)
+    logger.info("Creating export definition for %s", export_id)
     command = [
-        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
-        'com.rasterfoundry.batch.Main', 'create_export_def', export_id, bucket,
-        key
+        "java",
+        "-cp",
+        "/opt/raster-foundry/jars/batch-assembly.jar",
+        "com.rasterfoundry.batch.Main",
+        "create_export_def",
+        export_id,
+        bucket,
+        key,
     ]
-    logger.info('Running Command %s', ' '.join(command))
+    logger.info("Running Command %s", " ".join(command))
     subprocess.check_call(command)
 
-    logger.info('Created export definition for %s', export_id)
-    return 's3://{}/{}'.format(bucket, key)
+    logger.info("Created export definition for %s", export_id)
+    return "s3://{}/{}".format(bucket, key)
 
 
 def get_export_definition(export_uri):
     """Reads export definition from S3, returns dict"""
-    s3 = boto3.resource('s3')
+    s3 = boto3.resource("s3")
 
     parsed_uri = urlparse(export_uri)
-    logger.info('Downloading export defintion %s', export_uri)
-    data = s3.Object(parsed_uri.netloc, parsed_uri.path[1:]).get()['Body'].read().decode('utf-8')
+    logger.info("Downloading export defintion %s", export_uri)
+    data = (
+        s3.Object(parsed_uri.netloc, parsed_uri.path[1:])
+        .get()["Body"]
+        .read()
+        .decode("utf-8")
+    )
     return json.loads(data)
 
 
 def write_export_definition(export_definition, local_dir):
     """Returns local path where tiffs will be exported"""
-    local_ed_path = os.path.join(local_dir, 'export_definition.json')
+    local_ed_path = os.path.join(local_dir, "export_definition.json")
     copied = deepcopy(export_definition)
     # Only two slashes in file:// because local_dir is an absolute unix path
-    copied['output']['destination'] = local_tif_path_from_export_definition(
-        export_definition, local_dir)
-    with open(local_ed_path, 'w') as outf:
+    copied["output"]["destination"] = local_tif_path_from_export_definition(
+        export_definition, local_dir
+    )
+    with open(local_ed_path, "w") as outf:
         outf.write(json.dumps(copied))
     return local_ed_path
 
 
 def upload_processed_tif(merged_tiff_path, export_definition):
     """Uses original export definition location to upload to s3 or dropbox"""
-    dest = os.path.join(export_definition['output']['destination'], 'export.tif')
-    logger.info('Preparing to upload processed export to: %s', dest)
-    export_type = 's3' if dest.startswith('s3') else 'dropbox'
-    dropbox_access_token = export_definition['output'].get('dropboxCredential')
-    if export_type == 's3':
+    dest = os.path.join(export_definition["output"]["destination"], "export.tif")
+    logger.info("Preparing to upload processed export to: %s", dest)
+    export_type = "s3" if dest.startswith("s3") else "dropbox"
+    dropbox_access_token = export_definition["output"].get("dropboxCredential")
+    if export_type == "s3":
         s3_upload_export(merged_tiff_path, dest)
     else:
-        dropbox_upload_export(dropbox_access_token, merged_tiff_path,
-                              dest.replace('dropbox:///', '/'))
+        dropbox_upload_export(
+            dropbox_access_token, merged_tiff_path, dest.replace("dropbox:///", "/")
+        )
 
 
 def run_export(export_s3_uri, export_id):
@@ -131,16 +145,19 @@ def run_export(export_s3_uri, export_id):
         export_id (str): ID of export job to process
 
     """
-    status_uri = 's3://{}/export-statuses/{}'.format(
-        os.getenv('DATA_BUCKET'), export_id)
+    status_uri = "s3://{}/export-statuses/{}".format(
+        os.getenv("DATA_BUCKET"), export_id
+    )
 
     command = [
-        'java', '-jar',
-        '/opt/raster-foundry/jars/backsplash-export-assembly.jar', '-d',
-        export_s3_uri
+        "java",
+        "-jar",
+        "/opt/raster-foundry/jars/backsplash-export-assembly.jar",
+        "-d",
+        export_s3_uri,
     ]
     subprocess.check_call(command)
-    logger.info('Finished exporting %s', export_s3_uri)
+    logger.info("Finished exporting %s", export_s3_uri)
     return status_uri
 
 
@@ -153,10 +170,14 @@ def update_export_status(export_id, export_status):
     """
 
     command = [
-        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
-        'com.rasterfoundry.batch.Main', 'update_export_status', export_id,
-        export_status
+        "java",
+        "-cp",
+        "/opt/raster-foundry/jars/batch-assembly.jar",
+        "com.rasterfoundry.batch.Main",
+        "update_export_status",
+        export_id,
+        export_status,
     ]
-    logger.info('Preparing to update export status with command: %s', command)
+    logger.info("Preparing to update export status with command: %s", command)
     output = subprocess.check_output(command)
-    logger.info('Output from update command was: %s', output)
+    logger.info("Output from update command was: %s", output)

--- a/app-tasks/rf/src/rf/commands/ingest_scene.py
+++ b/app-tasks/rf/src/rf/commands/ingest_scene.py
@@ -22,8 +22,8 @@ def execute(cmd):
         raise subprocess.CalledProcessError(return_code, cmd)
 
 
-@click.command(name='ingest-scene')
-@click.argument('scene_id')
+@click.command(name="ingest-scene")
+@click.argument("scene_id")
 @wrap_rollbar
 def ingest_scene(scene_id):
     """Ingest a scene into Raster Foundry
@@ -43,56 +43,66 @@ def ingest(scene_id):
             scene = Scene.from_id(scene_id)
             originalScene = copy.deepcopy(scene)
             # updates status
-            if scene.ingestStatus != 'INGESTED':
-                scene.ingestStatus = 'INGESTING'
+            if scene.ingestStatus != "INGESTED":
+                scene.ingestStatus = "INGESTING"
                 scene.update()
         except Exception:
-            logger.error('Error while setting scene up for ingestion')
+            logger.error("Error while setting scene up for ingestion")
             raise
         else:
-            logger.info('Fetched and set ingest status on scene to INGESTING')
+            logger.info("Fetched and set ingest status on scene to INGESTING")
 
-        image_locations = [(x.sourceUri, x.filename) for x in sorted(
-            scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0]))]
+        image_locations = [
+            (x.sourceUri, x.filename)
+            for x in sorted(
+                scene.images, key=lambda x: io.sort_key(scene.datasource, x.bands[0])
+            )
+        ]
 
         try:
             io.create_cog(image_locations, scene).update()
         except Exception:
-            logger.error('There as an error converting the scene to a COG')
+            logger.error("There as an error converting the scene to a COG")
             raise
 
-        logger.info('Cog created, writing histogram to attribute store')
+        logger.info("Cog created, writing histogram to attribute store")
         try:
             metadata_to_postgres(scene.id)
         except Exception:
-            logger.error('error while writing metadata to postgres')
+            logger.error("error while writing metadata to postgres")
             raise
 
-        logger.info('Histogram added to attribute store, updating scene ingest status')
+        logger.info("Histogram added to attribute store, updating scene ingest status")
         try:
-            scene.ingestStatus = 'INGESTED'
+            scene.ingestStatus = "INGESTED"
             scene.update()
         except Exception as e:
-            logger.error('Error updating scene status after ingestion:\n%s', e)
+            logger.error("Error updating scene status after ingestion:\n%s", e)
             raise
 
-        logger.info('Scene finished ingesting. Notifying interested parties')
+        logger.info("Scene finished ingesting. Notifying interested parties")
         try:
             notify_for_scene_ingest_status(scene.id)
         except subprocess.CalledProcessError as e:
-            logger.error('There was error while notifying users of ingest status, but the ingest succeeded:\n%s', e)
+            logger.error(
+                "There was error while notifying users of ingest status, but the ingest succeeded:\n%s",
+                e,
+            )
 
     except Exception as e:
-        logger.error('There was an unrecoverable error during the ingest:\n%s', e)
+        logger.error("There was an unrecoverable error during the ingest:\n%s", e)
         if originalScene is not None:
             try:
-                logger.info('Reverting scene and setting status to failed.')
-                originalScene.ingestStatus = 'FAILED'
+                logger.info("Reverting scene and setting status to failed.")
+                originalScene.ingestStatus = "FAILED"
                 originalScene.update()
-                logger.info('Scene status set to failed.')
+                logger.info("Scene status set to failed.")
             except Exception as e:
-                logger.error('Unable to revert scene to original state with failed status:\n%s', e)
-        sys.exit('There was an unrecoverable error during scene ingestion: %s' % e)
+                logger.error(
+                    "Unable to revert scene to original state with failed status:\n%s",
+                    e,
+                )
+        sys.exit("There was an unrecoverable error during scene ingestion: %s" % e)
 
 
 def metadata_to_postgres(scene_id):
@@ -103,17 +113,19 @@ def metadata_to_postgres(scene_id):
     """
 
     bash_cmd = [
-        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
-        'com.rasterfoundry.batch.Main', 'cog-histogram-backfill',
-        scene_id
+        "java",
+        "-cp",
+        "/opt/raster-foundry/jars/batch-assembly.jar",
+        "com.rasterfoundry.batch.Main",
+        "cog-histogram-backfill",
+        scene_id,
     ]
 
-    logger.debug('Bash command to store histogram: %s', ' '.join(bash_cmd))
+    logger.debug("Bash command to store histogram: %s", " ".join(bash_cmd))
     for output in execute(bash_cmd):
         logger.info(output)
 
-    logger.info('Successfully completed metadata postgres write for scene %s',
-                scene_id)
+    logger.info("Successfully completed metadata postgres write for scene %s", scene_id)
     return True
 
 
@@ -126,8 +138,12 @@ def notify_for_scene_ingest_status(scene_id):
     """
 
     bash_cmd = [
-        'java', '-cp', '/opt/raster-foundry/jars/batch-assembly.jar',
-        'com.rasterfoundry.batch.Main', 'notify_ingest_status', scene_id
+        "java",
+        "-cp",
+        "/opt/raster-foundry/jars/batch-assembly.jar",
+        "com.rasterfoundry.batch.Main",
+        "notify_ingest_status",
+        scene_id,
     ]
 
     for output in execute(bash_cmd):

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -13,11 +13,12 @@ from ..utils.exception_reporting import wrap_rollbar
 from ..utils.io import get_session
 
 logger = logging.getLogger(__name__)
-HOST = os.getenv('RF_HOST')
-JOB_ATTEMPT = int(os.getenv('AWS_BATCH_JOB_ATTEMPT', -1))
+HOST = os.getenv("RF_HOST")
+JOB_ATTEMPT = int(os.getenv("AWS_BATCH_JOB_ATTEMPT", -1))
 
-@click.command(name='process-upload')
-@click.argument('upload_id')
+
+@click.command(name="process-upload")
+@click.argument("upload_id")
 @wrap_rollbar
 def process_upload(upload_id):
     """Create Raster Foundry scenes and attach to relevant projects
@@ -27,22 +28,26 @@ def process_upload(upload_id):
     """
     click.echo("Processing upload")
 
-    logger.info('Getting upload')
+    logger.info("Getting upload")
     upload = Upload.from_id(upload_id)
-    logger.info('Updating upload status')
-    upload.update_upload_status('Processing')
+    logger.info("Updating upload status")
+    upload.update_upload_status("Processing")
 
-    logger.info('Processing upload (%s) for user %s with files %s',
-                upload.id, upload.owner, upload.files)
+    logger.info(
+        "Processing upload (%s) for user %s with files %s",
+        upload.id,
+        upload.owner,
+        upload.files,
+    )
 
     try:
-        if upload.uploadType.lower() in ['local', 's3']:
-            logger.info('Processing a geotiff upload')
+        if upload.uploadType.lower() in ["local", "s3"]:
+            logger.info("Processing a geotiff upload")
             factory = GeoTiffS3SceneFactory(upload)
-        elif upload.uploadType.lower() == 'planet':
-            logger.info('Processing a planet upload. This might take a while...')
-            logger.info('Retrieving Planet API Client')
-            client = api.ClientV1(upload.metadata.get('planetKey'))
+        elif upload.uploadType.lower() == "planet":
+            logger.info("Processing a planet upload. This might take a while...")
+            logger.info("Retrieving Planet API Client")
+            client = api.ClientV1(upload.metadata.get("planetKey"))
             factory = PlanetSceneFactory(
                 upload.files,
                 upload.datasource,
@@ -52,10 +57,10 @@ def process_upload(upload_id):
                 upload.layerId,
                 upload.visibility,
                 [],
-                upload.owner
+                upload.owner,
             )
-        elif upload.uploadType.lower() == 'modis_usgs':
-            logger.info('Processing MODIS upload from USGS')
+        elif upload.uploadType.lower() == "modis_usgs":
+            logger.info("Processing MODIS upload from USGS")
             factory = MODISSceneFactory(
                 upload.files,
                 upload.datasource,
@@ -63,42 +68,67 @@ def process_upload(upload_id):
                 upload.projectId,
                 upload.layerId,
                 upload.visibility,
-                upload.owner
+                upload.owner,
             )
-        elif upload.uploadType.lower() in ['landsat_historical']:
-            logger.info('Processing historical Landsat data from USGS and GCS')
+        elif upload.uploadType.lower() in ["landsat_historical"]:
+            logger.info("Processing historical Landsat data from USGS and GCS")
             factory = LandsatHistoricalSceneFactory(upload)
         else:
-            raise Exception('upload type ({}) didn\'t make any sense'.format(upload.uploadType))
+            raise Exception(
+                "upload type ({}) didn't make any sense".format(upload.uploadType)
+            )
         scenes = factory.generate_scenes()
-        logger.info('Creating scene objects for upload %s, preparing to POST to API', upload.id)
+        logger.info(
+            "Creating scene objects for upload %s, preparing to POST to API", upload.id
+        )
 
         created_scenes = [scene.create() for scene in scenes]
-        logger.info('Successfully created %s scenes (%s)', len(created_scenes), [s.id for s in created_scenes])
+        logger.info(
+            "Successfully created %s scenes (%s)",
+            len(created_scenes),
+            [s.id for s in created_scenes],
+        )
 
         if upload.layerId and upload.projectId:
-            logger.info('Upload specified to a project layer. Linking scenes to layer %s', upload.layerId)
+            logger.info(
+                "Upload specified to a project layer. Linking scenes to layer %s",
+                upload.layerId,
+            )
             scene_ids = [scene.id for scene in created_scenes]
-            batch_scene_to_layer_url = '{HOST}/api/projects/{PROJECT}/layers/{LAYER}/scenes'.format(
-                HOST=HOST, PROJECT=upload.projectId, LAYER=upload.layerId)
+            batch_scene_to_layer_url = "{HOST}/api/projects/{PROJECT}/layers/{LAYER}/scenes".format(
+                HOST=HOST, PROJECT=upload.projectId, LAYER=upload.layerId
+            )
             session = get_session()
             response = session.post(batch_scene_to_layer_url, json=scene_ids)
             response.raise_for_status()
         elif upload.projectId:
-            logger.info('Upload specified a project. Linking scenes to project %s', upload.projectId)
+            logger.info(
+                "Upload specified a project. Linking scenes to project %s",
+                upload.projectId,
+            )
             scene_ids = [scene.id for scene in created_scenes]
-            batch_scene_to_project_url = '{HOST}/api/projects/{PROJECT}/scenes'.format(HOST=HOST, PROJECT=upload.projectId)
+            batch_scene_to_project_url = "{HOST}/api/projects/{PROJECT}/scenes".format(
+                HOST=HOST, PROJECT=upload.projectId
+            )
             session = get_session()
             response = session.post(batch_scene_to_project_url, json=scene_ids)
             response.raise_for_status()
-        upload.update_upload_status('Complete')
-        logger.info('Finished importing scenes for upload (%s) for user %s with files %s',
-                    upload.id, upload.owner, upload.files)
+        upload.update_upload_status("Complete")
+        logger.info(
+            "Finished importing scenes for upload (%s) for user %s with files %s",
+            upload.id,
+            upload.owner,
+            upload.files,
+        )
     except:
-        logger.error('Failed to process upload (%s) for user %s with files %s',
-                     upload.id, upload.owner, upload.files)
+        logger.error(
+            "Failed to process upload (%s) for user %s with files %s",
+            upload.id,
+            upload.owner,
+            upload.files,
+        )
         if JOB_ATTEMPT >= 3:
-            upload.update_upload_status('FAILED')
+            upload.update_upload_status("FAILED")
         else:
-            upload.update_upload_status('QUEUED')
+            upload.update_upload_status("QUEUED")
         raise

--- a/app-tasks/rf/src/rf/ingest/io.py
+++ b/app-tasks/rf/src/rf/ingest/io.py
@@ -1,8 +1,11 @@
 """Utilities for transforming public scenes into COGs"""
 
-from rf.ingest.settings import (landsat8_band_order, sentinel2_band_order,
-                                landsat8_datasource_id,
-                                sentinel2_datasource_id)
+from rf.ingest.settings import (
+    landsat8_band_order,
+    sentinel2_band_order,
+    landsat8_datasource_id,
+    sentinel2_datasource_id,
+)
 from rf.utils import cog
 from rf.utils.io import get_tempdir
 
@@ -12,9 +15,9 @@ import logging
 import os
 from urllib.parse import quote_plus
 
-DATA_BUCKET = os.getenv('DATA_BUCKET')
+DATA_BUCKET = os.getenv("DATA_BUCKET")
 
-s3client = boto3.client('s3')
+s3client = boto3.client("s3")
 logger = logging.getLogger(__name__)
 
 
@@ -39,9 +42,16 @@ def create_cog(image_locations, scene, same_path=False):
         cog_path = cog.convert_to_cog(merged_tif, local_dir)
         if same_path:
             updated_scene = upload_tif(
-                cog_path, scene,
-                os.path.join('user-uploads', scene.owner, '{}_COG.tif'.format(scene.id)),
-                os.path.join('user-uploads', quote_plus(scene.owner), '{}_COG.tif'.format(scene.id))
+                cog_path,
+                scene,
+                os.path.join(
+                    "user-uploads", scene.owner, "{}_COG.tif".format(scene.id)
+                ),
+                os.path.join(
+                    "user-uploads",
+                    quote_plus(scene.owner),
+                    "{}_COG.tif".format(scene.id),
+                ),
             )
         else:
             updated_scene = upload_tif(cog_path, scene)
@@ -49,18 +59,18 @@ def create_cog(image_locations, scene, same_path=False):
         return updated_scene
 
 
-def upload_tif(tif_path, scene, key='', ingest_location=''):
+def upload_tif(tif_path, scene, key="", ingest_location=""):
     if len(key) == 0:
-        key = os.path.join('public-cogs', '{}_COG.tif'.format(scene.id))
+        key = os.path.join("public-cogs", "{}_COG.tif".format(scene.id))
 
-    s3uri = 's3://{}/{}'.format(DATA_BUCKET, key)
-    ingestUri = 's3://{}/{}'.format(DATA_BUCKET, ingest_location)
-    logger.info('Uploading tif to S3 at %s', s3uri)
-    with open(tif_path, 'rb') as inf:
+    s3uri = "s3://{}/{}".format(DATA_BUCKET, key)
+    ingestUri = "s3://{}/{}".format(DATA_BUCKET, ingest_location)
+    logger.info("Uploading tif to S3 at %s", s3uri)
+    with open(tif_path, "rb") as inf:
         s3client.put_object(Bucket=DATA_BUCKET, Key=key, Body=inf)
-    logger.info('Tif uploaded successfully')
+    logger.info("Tif uploaded successfully")
     scene.ingestLocation = s3uri if len(ingest_location) == 0 else ingestUri
-    scene.sceneType = 'COG'
+    scene.sceneType = "COG"
     return scene
 
 
@@ -71,5 +81,6 @@ def sort_key(datasource_id, band):
         return landsat8_band_order[band.name]
     else:
         raise ValueError(
-            'Trying to run public COG ingest for scene with mysterious datasource',
-            datasource_id)
+            "Trying to run public COG ingest for scene with mysterious datasource",
+            datasource_id,
+        )

--- a/app-tasks/rf/src/rf/ingest/settings.py
+++ b/app-tasks/rf/src/rf/ingest/settings.py
@@ -1,32 +1,32 @@
-landsat8_datasource_id = '697a0b91-b7a8-446e-842c-97cda155554d'
-sentinel2_datasource_id = '4a50cb75-815d-4fe5-8bc1-144729ce5b42'
+landsat8_datasource_id = "697a0b91-b7a8-446e-842c-97cda155554d"
+sentinel2_datasource_id = "4a50cb75-815d-4fe5-8bc1-144729ce5b42"
 
 landsat8_band_order = {
-    'blue - 2': 2,
-    'cirrus - 9': 9,
-    'coastal aerosol - 1': 1,
-    'green - 3': 3,
-    'near infrared - 5': 5,
-    'panchromatic - 8': 8,
-    'red - 4': 4,
-    'swir - 6': 6,
-    'swir - 7': 7,
-    'thermal infrared - 10': 10,
-    'thermal infrared - 11': 11
+    "blue - 2": 2,
+    "cirrus - 9": 9,
+    "coastal aerosol - 1": 1,
+    "green - 3": 3,
+    "near infrared - 5": 5,
+    "panchromatic - 8": 8,
+    "red - 4": 4,
+    "swir - 6": 6,
+    "swir - 7": 7,
+    "thermal infrared - 10": 10,
+    "thermal infrared - 11": 11,
 }
 
 sentinel2_band_order = {
-    'cirrus - 10': 11,
-    'water vapor - 9': 10,
-    'coastal aerosol - 1': 1,
-    'short-wave infrared - 12': 13,
-    'short-wave infrared - 11': 12,
-    'near infrared - 8a': 9,
-    'near infrared - 7': 7,
-    'near infrared - 6': 6,
-    'near infrared - 5': 5,
-    'near infrared - 8': 8,
-    'red - 4': 4,
-    'green - 3': 3,
-    'blue - 2': 2
+    "cirrus - 10": 11,
+    "water vapor - 9": 10,
+    "coastal aerosol - 1": 1,
+    "short-wave infrared - 12": 13,
+    "short-wave infrared - 11": 12,
+    "near infrared - 8a": 9,
+    "near infrared - 7": 7,
+    "near infrared - 6": 6,
+    "near infrared - 5": 5,
+    "near infrared - 8": 8,
+    "red - 4": 4,
+    "green - 3": 3,
+    "blue - 2": 2,
 }

--- a/app-tasks/rf/src/rf/models/band.py
+++ b/app-tasks/rf/src/rf/models/band.py
@@ -4,7 +4,6 @@ from .base import BaseModel
 
 
 class Band(BaseModel):
-
     def __init__(self, name, number, wavelength):
         """Create a new Band. Created band is a python representation of the Band.Create
         case class in the scala datamodel
@@ -20,13 +19,11 @@ class Band(BaseModel):
         self.wavelength = wavelength
 
     def __repr__(self):
-        return '<Band: {name}-{number}>'.format(name=self.name, number=self.number)
+        return "<Band: {name}-{number}>".format(name=self.name, number=self.number)
 
     @classmethod
     def from_dict(cls, d):
-        return cls(
-            d.get('name'), d.get('number'), d.get('wavelength')
-        )
+        return cls(d.get("name"), d.get("number"), d.get("wavelength"))
 
     def to_dict(self):
-        return {'name': self.name, 'number': self.number, 'wavelength': self.wavelength}
+        return {"name": self.name, "number": self.number, "wavelength": self.wavelength}

--- a/app-tasks/rf/src/rf/models/base.py
+++ b/app-tasks/rf/src/rf/models/base.py
@@ -16,7 +16,8 @@ class BaseModel(object):
      - creating a new object via the API
      - loading objects from JSON
     """
-    HOST = os.getenv('RF_HOST')
+
+    HOST = os.getenv("RF_HOST")
     URL_PATH = None
 
     @classmethod
@@ -26,7 +27,7 @@ class BaseModel(object):
         Raises:
             requests.exceptions.HTTPError
         """
-        url = '{HOST}{URL_PATH}{id}'.format(HOST=cls.HOST, URL_PATH=cls.URL_PATH, id=id)
+        url = "{HOST}{URL_PATH}{id}".format(HOST=cls.HOST, URL_PATH=cls.URL_PATH, id=id)
         session = get_session()
         response = session.get(url)
         response.raise_for_status()
@@ -35,10 +36,10 @@ class BaseModel(object):
 
     @classmethod
     def from_dict(cls, d):
-        raise NotImplementedError('from_dict is not implemented for this derived class')
+        raise NotImplementedError("from_dict is not implemented for this derived class")
 
     def to_dict(self):
-        raise NotImplementedError('to_dict is not implemented for this derived class')
+        raise NotImplementedError("to_dict is not implemented for this derived class")
 
     def to_json(self):
         return json.dumps(self.to_dict())
@@ -48,25 +49,29 @@ class BaseModel(object):
         return cls.from_dict(json_string)
 
     def create(self):
-        url = '{HOST}{URL_PATH}'.format(HOST=self.HOST, URL_PATH=self.URL_PATH)
+        url = "{HOST}{URL_PATH}".format(HOST=self.HOST, URL_PATH=self.URL_PATH)
         session = get_session()
         response = session.post(url, json=self.to_dict())
         try:
             response.raise_for_status()
         except:
-            logger.exception('Unable to create object via API: %s', response.text)
-            logger.exception('Attempted to POST: \n%s\n', self.to_json())
-            logger.exception('Response was: %s', response.content)
+            logger.exception("Unable to create object via API: %s", response.text)
+            logger.exception("Attempted to POST: \n%s\n", self.to_json())
+            logger.exception("Response was: %s", response.content)
             raise
         return self.from_dict(response.json())
 
     def update(self):
-        url = '{HOST}{URL_PATH}{id}/'.format(HOST=self.HOST, URL_PATH=self.URL_PATH, id=self.id)
+        url = "{HOST}{URL_PATH}{id}/".format(
+            HOST=self.HOST, URL_PATH=self.URL_PATH, id=self.id
+        )
         session = get_session()
         response = session.put(url, json=self.to_dict())
         try:
             response.raise_for_status()
         except:
-            logger.exception('Unable to update: %s with %s', response.text, self.to_dict())
+            logger.exception(
+                "Unable to update: %s with %s", response.text, self.to_dict()
+            )
             raise
         return response

--- a/app-tasks/rf/src/rf/models/footprint.py
+++ b/app-tasks/rf/src/rf/models/footprint.py
@@ -5,9 +5,11 @@ from .base import BaseModel
 
 class Footprint(BaseModel):
 
-    URL_PATH = '/api/footprints/'
+    URL_PATH = "/api/footprints/"
 
-    def __init__(self, multipolygon, id=None, sceneId=None, createdAt=None, modifiedAt=None):
+    def __init__(
+        self, multipolygon, id=None, sceneId=None, createdAt=None, modifiedAt=None
+    ):
         """Create a new Footprint
 
         Args:
@@ -25,18 +27,21 @@ class Footprint(BaseModel):
         self.modifiedAt = modifiedAt
 
     def __repr__(self):
-        return '<Footprint: {}>'.format(self.id)
+        return "<Footprint: {}>".format(self.id)
 
     @classmethod
     def from_dict(cls, d):
         return cls(
-            d.get('coordinates'), d.get('id'), d.get('sceneId'),
-            d.get('createdAt'), d.get('modifiedAt')
+            d.get("coordinates"),
+            d.get("id"),
+            d.get("sceneId"),
+            d.get("createdAt"),
+            d.get("modifiedAt"),
         )
 
     def to_dict(self):
-        return {'type': 'MultiPolygon', 'coordinates': self.multipolygon}
+        return {"type": "MultiPolygon", "coordinates": self.multipolygon}
 
     def create(self):
-        assert self.sceneId, 'Scene ID is required to create a Footprint'
+        assert self.sceneId, "Scene ID is required to create a Footprint"
         return super(Footprint, self).create()

--- a/app-tasks/rf/src/rf/models/image.py
+++ b/app-tasks/rf/src/rf/models/image.py
@@ -3,13 +3,24 @@
 from .base import BaseModel
 from .band import Band
 
+
 class Image(BaseModel):
 
-    URL_PATH = '/api/images/'
+    URL_PATH = "/api/images/"
 
-    def __init__(self, rawDataBytes, visibility, filename,
-                 sourceuri, bands, imageMetadata, resolutionMeters, metadataFiles,
-                 scene=None, owner=None):
+    def __init__(
+        self,
+        rawDataBytes,
+        visibility,
+        filename,
+        sourceuri,
+        bands,
+        imageMetadata,
+        resolutionMeters,
+        metadataFiles,
+        scene=None,
+        owner=None,
+    ):
         """Create a new Image
 
         Args:
@@ -34,15 +45,22 @@ class Image(BaseModel):
         self.owner = owner
 
     def __repr__(self):
-        return '<Image: {}>'.format(self.filename)
+        return "<Image: {}>".format(self.filename)
 
     @classmethod
     def from_dict(cls, d):
-        bands = [Band.from_dict(band) for band in d.get('bands')]
+        bands = [Band.from_dict(band) for band in d.get("bands")]
         return cls(
-            d.get('rawDataBytes'), d.get('visibility'), d.get('filename'),
-            d.get('sourceUri'), bands, d.get('imageMetadata'), d.get('resolutionMeters'),
-            d.get('metadataFiles'), d.get('scene'), d.get('owner')
+            d.get("rawDataBytes"),
+            d.get("visibility"),
+            d.get("filename"),
+            d.get("sourceUri"),
+            bands,
+            d.get("imageMetadata"),
+            d.get("resolutionMeters"),
+            d.get("metadataFiles"),
+            d.get("scene"),
+            d.get("owner"),
         )
 
     def to_dict(self):
@@ -55,13 +73,13 @@ class Image(BaseModel):
             imageMetadata=self.imageMetadata,
             metadataFiles=self.metadataFiles,
             resolutionMeters=self.resolutionMeters,
-            owner=self.owner
+            owner=self.owner,
         )
 
         if self.scene:
-            image_dict['scene'] = self.scene
+            image_dict["scene"] = self.scene
         return image_dict
 
     def create(self):
-        assert self.scene, 'Scene is required to create an Image'
+        assert self.scene, "Scene is required to create an Image"
         return super(Image, self).create()

--- a/app-tasks/rf/src/rf/models/scene.py
+++ b/app-tasks/rf/src/rf/models/scene.py
@@ -14,15 +14,36 @@ logger = logging.getLogger(__name__)
 
 class Scene(BaseModel):
 
-    URL_PATH = '/api/scenes/'
+    URL_PATH = "/api/scenes/"
 
-    def __init__(self, visibility, tags,
-                 datasource, sceneMetadata, name, thumbnailStatus, boundaryStatus,
-                 ingestStatus, metadataFiles, sunAzimuth=None, sunElevation=None,
-                 cloudCover=None, acquisitionDate=None, id=None, thumbnails=None,
-                 tileFootprint=None, dataFootprint=None, images=None, createdAt=None,
-                 modifiedAt=None, createdBy=None, ingestLocation=None,
-                 owner=None, sceneType="AVRO", metadataFields=None):
+    def __init__(
+        self,
+        visibility,
+        tags,
+        datasource,
+        sceneMetadata,
+        name,
+        thumbnailStatus,
+        boundaryStatus,
+        ingestStatus,
+        metadataFiles,
+        sunAzimuth=None,
+        sunElevation=None,
+        cloudCover=None,
+        acquisitionDate=None,
+        id=None,
+        thumbnails=None,
+        tileFootprint=None,
+        dataFootprint=None,
+        images=None,
+        createdAt=None,
+        modifiedAt=None,
+        createdBy=None,
+        ingestLocation=None,
+        owner=None,
+        sceneType="AVRO",
+        metadataFields=None,
+    ):
         """Create a new Scene
 
         Args:
@@ -75,17 +96,19 @@ class Scene(BaseModel):
         self.metadataFields = metadataFields
 
     def __repr__(self):
-        return '<Scene: {}>'.format(self.name)
+        return "<Scene: {}>".format(self.name)
 
     @classmethod
     def from_dict(cls, d):
-        statuses = d.get('statusFields')
-        filter_fields = d.get('filterFields')
-        images = [Image.from_dict(image) for image in d.get('images')]
-        thumbnails = [Thumbnail.from_dict(thumbnail) for thumbnail in d.get('thumbnails')]
+        statuses = d.get("statusFields")
+        filter_fields = d.get("filterFields")
+        images = [Image.from_dict(image) for image in d.get("images")]
+        thumbnails = [
+            Thumbnail.from_dict(thumbnail) for thumbnail in d.get("thumbnails")
+        ]
 
-        tile_footprint_dict = d.get('tileFootprint')
-        data_footprint_dict = d.get('dataFootprint')
+        tile_footprint_dict = d.get("tileFootprint")
+        data_footprint_dict = d.get("dataFootprint")
 
         if tile_footprint_dict:
             tile_footprint = Footprint.from_dict(tile_footprint_dict)
@@ -97,62 +120,91 @@ class Scene(BaseModel):
             data_footprint = None
 
         return cls(
-            d.get('visibility'),
-            d.get('tags'), d.get('datasource')['id'], d.get('sceneMetadata'), d.get('name'), statuses.get('thumbnailStatus'),
-            statuses.get('boundaryStatus'), statuses.get('ingestStatus'), d.get('metadataFiles'),
-            filter_fields.get('sunAzimuth'), filter_fields.get('sunElevation'), filter_fields.get('cloudCover'),
-            filter_fields.get('acquisitionDate'), d.get('id'), thumbnails, tile_footprint, data_footprint,
-            images, d.get('createdAt'), d.get('modifiedAt'), d.get('createdBy'),
-            d.get('ingestLocation', ''), owner=d.get('owner'), sceneType=d.get('sceneType'),
-            metadataFields=d.get('metadataFields')
+            d.get("visibility"),
+            d.get("tags"),
+            d.get("datasource")["id"],
+            d.get("sceneMetadata"),
+            d.get("name"),
+            statuses.get("thumbnailStatus"),
+            statuses.get("boundaryStatus"),
+            statuses.get("ingestStatus"),
+            d.get("metadataFiles"),
+            filter_fields.get("sunAzimuth"),
+            filter_fields.get("sunElevation"),
+            filter_fields.get("cloudCover"),
+            filter_fields.get("acquisitionDate"),
+            d.get("id"),
+            thumbnails,
+            tile_footprint,
+            data_footprint,
+            images,
+            d.get("createdAt"),
+            d.get("modifiedAt"),
+            d.get("createdBy"),
+            d.get("ingestLocation", ""),
+            owner=d.get("owner"),
+            sceneType=d.get("sceneType"),
+            metadataFields=d.get("metadataFields"),
         )
 
     def to_dict(self):
         filterFields = {}
-        statusFields = dict(thumbnailStatus=self.thumbnailStatus,
-                            boundaryStatus=self.boundaryStatus,
-                            ingestStatus=self.ingestStatus)
+        statusFields = dict(
+            thumbnailStatus=self.thumbnailStatus,
+            boundaryStatus=self.boundaryStatus,
+            ingestStatus=self.ingestStatus,
+        )
         scene_dict = dict(
             visibility=self.visibility,
-            tags=self.tags, datasource=self.datasource, sceneMetadata=self.sceneMetadata, filterFields=filterFields,
-            name=self.name, statusFields=statusFields, metadataFiles=self.metadataFiles,
-            ingestLocation=self.ingestLocation, owner=self.owner, sceneType=self.sceneType,
-            metadataFields=self.metadataFields)
+            tags=self.tags,
+            datasource=self.datasource,
+            sceneMetadata=self.sceneMetadata,
+            filterFields=filterFields,
+            name=self.name,
+            statusFields=statusFields,
+            metadataFiles=self.metadataFiles,
+            ingestLocation=self.ingestLocation,
+            owner=self.owner,
+            sceneType=self.sceneType,
+            metadataFields=self.metadataFields,
+        )
 
         if self.sunAzimuth:
-            filterFields['sunAzimuth'] = self.sunAzimuth
+            filterFields["sunAzimuth"] = self.sunAzimuth
         if self.sunElevation:
-            filterFields['sunElevation'] = self.sunElevation
+            filterFields["sunElevation"] = self.sunElevation
         if self.cloudCover is not None:
-            filterFields['cloudCover'] = self.cloudCover
+            filterFields["cloudCover"] = self.cloudCover
         if self.acquisitionDate:
-            filterFields['acquisitionDate'] = self.acquisitionDate
+            filterFields["acquisitionDate"] = self.acquisitionDate
         if self.id:
-            scene_dict['id'] = self.id
+            scene_dict["id"] = self.id
 
         if self.thumbnails:
-            scene_dict['thumbnails'] = [thumbnail.to_dict() for thumbnail in self.thumbnails]
+            scene_dict["thumbnails"] = [
+                thumbnail.to_dict() for thumbnail in self.thumbnails
+            ]
         else:
-            scene_dict['thumbnails'] = []
+            scene_dict["thumbnails"] = []
 
         if self.images:
-            scene_dict['images'] = [image.to_dict() for image in self.images]
+            scene_dict["images"] = [image.to_dict() for image in self.images]
         else:
-            scene_dict['images'] = []
+            scene_dict["images"] = []
 
         if self.tileFootprint:
-            scene_dict['tileFootprint'] = self.tileFootprint.to_dict()
+            scene_dict["tileFootprint"] = self.tileFootprint.to_dict()
         if self.dataFootprint:
-            scene_dict['dataFootprint'] = self.dataFootprint.to_dict()
+            scene_dict["dataFootprint"] = self.dataFootprint.to_dict()
 
         if self.createdAt:
-            scene_dict['createdAt'] = self.createdAt
+            scene_dict["createdAt"] = self.createdAt
 
         if self.modifiedAt:
-            scene_dict['modifiedAt'] = self.modifiedAt
+            scene_dict["modifiedAt"] = self.modifiedAt
 
         if self.createdBy:
-            scene_dict['createdBy'] = self.createdBy
+            scene_dict["createdBy"] = self.createdBy
 
         return scene_dict
 
@@ -163,19 +215,14 @@ class Scene(BaseModel):
             if exc.response.status_code != 409:
                 raise
             else:
-                logger.info('Tried to create duplicate object: %s', self)
+                logger.info("Tried to create duplicate object: %s", self)
                 return None
 
     def get_extent(self):
         """Helper method to return extent of scene"""
 
-        assert self.tileFootprint, 'Must have tile footprint to extract extent'
+        assert self.tileFootprint, "Must have tile footprint to extract extent"
         coords = self.tileFootprint.multipolygon[0][0]
         longitudes = [coord[0] for coord in coords]
         latitudes = [coord[1] for coord in coords]
-        return [
-            min(longitudes),
-            min(latitudes),
-            max(longitudes),
-            max(latitudes)
-        ]
+        return [min(longitudes), min(latitudes), max(longitudes), max(latitudes)]

--- a/app-tasks/rf/src/rf/models/thumbnail.py
+++ b/app-tasks/rf/src/rf/models/thumbnail.py
@@ -5,7 +5,7 @@ from .base import BaseModel
 
 class Thumbnail(BaseModel):
 
-    URL_PATH = '/api/thumbnails/'
+    URL_PATH = "/api/thumbnails/"
 
     def __init__(self, widthPx, heightPx, thumbnailSize, url, id=None, sceneId=None):
         """Creates a new Thumbnail
@@ -27,13 +27,17 @@ class Thumbnail(BaseModel):
         self.sceneId = sceneId
 
     def __repr__(self):
-        return '<Thumbnail: size-{} loc-{}>'.format(self.thumbnailSize, self.url)
+        return "<Thumbnail: size-{} loc-{}>".format(self.thumbnailSize, self.url)
 
     @classmethod
     def from_dict(cls, d):
         return cls(
-            d.get('widthPx'), d.get('heightPx'), d.get('thumbnailSize'), d.get('url'),
-            d.get('id'), d.get('sceneId')
+            d.get("widthPx"),
+            d.get("heightPx"),
+            d.get("thumbnailSize"),
+            d.get("url"),
+            d.get("id"),
+            d.get("sceneId"),
         )
 
     def to_dict(self):
@@ -41,15 +45,15 @@ class Thumbnail(BaseModel):
             widthPx=self.widthPx,
             heightPx=self.heightPx,
             thumbnailSize=self.thumbnailSize,
-            url=self.url
+            url=self.url,
         )
 
         if self.id:
-            thumbnail_dict['id'] = self.id
+            thumbnail_dict["id"] = self.id
         if self.sceneId:
-            thumbnail_dict['sceneId'] = self.sceneId
+            thumbnail_dict["sceneId"] = self.sceneId
         return thumbnail_dict
 
     def create(self):
-        assert self.sceneId, 'Scene ID is required to create a Thumbnail'
+        assert self.sceneId, "Scene ID is required to create a Thumbnail"
         return super(Thumbnail, self).create()

--- a/app-tasks/rf/src/rf/models/upload.py
+++ b/app-tasks/rf/src/rf/models/upload.py
@@ -1,13 +1,28 @@
 from .base import BaseModel
 from rf.utils.io import get_session
 
-class Upload(BaseModel):
-    URL_PATH = '/api/uploads/'
 
-    def __init__(self, uploadStatus, fileType, uploadType, files,
-                 datasource, metadata, visibility, id=None, createdAt=None,
-                 createdBy=None, modifiedAt=None, owner=None,
-                 projectId=None, layerId=None, keepInSourceBucket=None):
+class Upload(BaseModel):
+    URL_PATH = "/api/uploads/"
+
+    def __init__(
+        self,
+        uploadStatus,
+        fileType,
+        uploadType,
+        files,
+        datasource,
+        metadata,
+        visibility,
+        id=None,
+        createdAt=None,
+        createdBy=None,
+        modifiedAt=None,
+        owner=None,
+        projectId=None,
+        layerId=None,
+        keepInSourceBucket=None,
+    ):
         self.id = id
         self.createdAt = createdAt
         self.createdBy = createdBy
@@ -40,7 +55,7 @@ class Upload(BaseModel):
             owner=self.owner,
             projectId=self.projectId,
             layerId=self.layerId,
-            keepInSourceBucket=self.keepInSourceBucket
+            keepInSourceBucket=self.keepInSourceBucket,
         )
 
     def update_upload_status(self, status):
@@ -50,35 +65,37 @@ class Upload(BaseModel):
     @classmethod
     def from_dict(cls, d):
         return cls(
-            d.get('uploadStatus'),
-            d.get('fileType'),
-            d.get('uploadType'),
-            d.get('files'),
-            d.get('datasource'),
-            d.get('metadata'),
-            d.get('visibility'),
-            id=d.get('id'),
-            createdAt=d.get('createdAt'),
-            createdBy=d.get('createdBy'),
-            modifiedAt=d.get('modifiedAt'),
-            owner=d.get('owner'),
-            projectId=d.get('projectId'),
-            layerId=d.get('layerId'),
-            keepInSourceBucket=d.get('keepInSourceBucket')
+            d.get("uploadStatus"),
+            d.get("fileType"),
+            d.get("uploadType"),
+            d.get("files"),
+            d.get("datasource"),
+            d.get("metadata"),
+            d.get("visibility"),
+            id=d.get("id"),
+            createdAt=d.get("createdAt"),
+            createdBy=d.get("createdBy"),
+            modifiedAt=d.get("modifiedAt"),
+            owner=d.get("owner"),
+            projectId=d.get("projectId"),
+            layerId=d.get("layerId"),
+            keepInSourceBucket=d.get("keepInSourceBucket"),
         )
 
     @classmethod
     def get_importable_uploads(cls):
-        url = '{HOST}{URL_PATH}'.format(HOST=cls.HOST, URL_PATH=cls.URL_PATH)
+        url = "{HOST}{URL_PATH}".format(HOST=cls.HOST, URL_PATH=cls.URL_PATH)
         session = get_session()
-        response = session.get(url, params={'uploadStatus': 'uploaded'})
+        response = session.get(url, params={"uploadStatus": "uploaded"})
         response.raise_for_status()
 
         parsed = response.json()
-        ids = [rec['id'] for rec in parsed['results']]
+        ids = [rec["id"] for rec in parsed["results"]]
         page = 0
-        while parsed['hasNext']:
+        while parsed["hasNext"]:
             page += 1
-            parsed = session.get(url, params={'uploadStatus': 'uploaded', 'page': page}).json()
-            ids += [rec['id'] for rec in parsed['results']]
+            parsed = session.get(
+                url, params={"uploadStatus": "uploaded", "page": page}
+            ).json()
+            ids += [rec["id"] for rec in parsed["results"]]
         return ids

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
@@ -24,13 +24,13 @@ logger = logging.getLogger(__name__)
 # RGB bands. I'm assuming than the panchromatic band has a width equal to the
 # sum of the other four bands (RGB + NIR).
 band_data_lookup = {
-    'nir': ('Near Infrared', [670, 760]),
-    'red': ('Red', [590, 670]),
-    'green': ('Green', [490, 590]),
-    'blue': ('Blue', [400, 490]),
-    'pan': ('Panchromatic', [400, 760]),
-    'gray': ('Gray', [0, 0]),
-    'alpha': ('Alpha', [0, 0])
+    "nir": ("Near Infrared", [670, 760]),
+    "red": ("Red", [590, 670]),
+    "green": ("Green", [490, 590]),
+    "blue": ("Blue", [400, 490]),
+    "pan": ("Panchromatic", [400, 760]),
+    "gray": ("Gray", [0, 0]),
+    "alpha": ("Alpha", [0, 0]),
 }
 
 
@@ -48,13 +48,13 @@ def create_geotiff_bands(tif_path):
         for band in src.indexes:
             colorinterp = src.colorinterp(band)
             if colorinterp == ColorInterp.undefined:
-                band_data = band_data_lookup['nir']
+                band_data = band_data_lookup["nir"]
             elif colorinterp.name in band_data_lookup:
                 band_data = band_data_lookup[colorinterp.name]
             else:
                 # If we get a name for a layer that we can't map to anything, log
                 # and ignore it.
-                logger.warning('Could not map layer with name %s', colorinterp.name)
+                logger.warning("Could not map layer with name %s", colorinterp.name)
                 continue
             bands.append(Band(band_data[0], band, band_data[1]))
     return bands

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_images.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_images.py
@@ -7,9 +7,16 @@ from .io import get_geotiff_size_bytes, get_geotiff_resolution
 from .create_bands import create_geotiff_bands
 
 
-def create_geotiff_image(tif_path, sourceuri, filename=None,
-                         visibility=Visibility.PRIVATE, imageMetadata={}, scene=None,
-                         owner=None, band_create_function=create_geotiff_bands):
+def create_geotiff_image(
+    tif_path,
+    sourceuri,
+    filename=None,
+    visibility=Visibility.PRIVATE,
+    imageMetadata={},
+    scene=None,
+    owner=None,
+    band_create_function=create_geotiff_bands,
+):
     """Create an Image object from a GeoTIFF.
 
     Args:
@@ -35,5 +42,5 @@ def create_geotiff_image(tif_path, sourceuri, filename=None,
         get_geotiff_resolution(tif_path)[0],
         [],
         scene=scene,
-        owner=owner
+        owner=owner,
     )

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
@@ -1,19 +1,33 @@
 import logging
 import uuid
 
-from rf.models import Scene
+from rf.models import Footprint, Scene
 from rf.utils.io import IngestStatus, JobStatus, Visibility
+from rf.utils.footprint import complex_footprint
+from shapely.geometry import mapping, MultiPolygon, Polygon
 
 from .io import get_geotiff_metadata, get_geotiff_name
 
 logger = logging.getLogger(__name__)
 
 
-def create_geotiff_scene(tif_path, datasource, acquisitionDate=None, cloudCover=0,
-                         visibility=Visibility.PRIVATE, tags=[],
-                         sceneMetadata=None, name=None, thumbnailStatus=JobStatus.QUEUED,
-                         boundaryStatus=JobStatus.QUEUED, ingestStatus=IngestStatus.TOBEINGESTED,
-                         metadataFiles=[], owner=None, sceneType="COG", **kwargs):
+def create_geotiff_scene(
+    tif_path,
+    datasource,
+    acquisitionDate=None,
+    cloudCover=0,
+    visibility=Visibility.PRIVATE,
+    tags=[],
+    sceneMetadata=None,
+    name=None,
+    thumbnailStatus=JobStatus.QUEUED,
+    boundaryStatus=JobStatus.QUEUED,
+    ingestStatus=IngestStatus.TOBEINGESTED,
+    metadataFiles=[],
+    owner=None,
+    sceneType="COG",
+    **kwargs
+):
     """Returns scenes that can be created via API given a local path to a geotiff.
 
     Does not create Images because those require a Source URI, which this doesn't know about. Use
@@ -35,22 +49,24 @@ def create_geotiff_scene(tif_path, datasource, acquisitionDate=None, cloudCover=
     Returns:
         List[Scene]
     """
-    logger.info('Generating Scene from %s', tif_path)
+    logger.info("Generating Scene from %s", tif_path)
 
     # Start with default values
     sceneMetadata = sceneMetadata if sceneMetadata else get_geotiff_metadata(tif_path)
     name = name if name else get_geotiff_name(tif_path)
 
     sceneKwargs = {
-        'sunAzimuth': None,  # TODO: Calculate from acquisitionDate and tif center.
-        'sunElevation': None,  # TODO: Same
-        'cloudCover': cloudCover,
-        'acquisitionDate': acquisitionDate,
-        'id': str(uuid.uuid4()),
-        'thumbnails': None
+        "sunAzimuth": None,  # TODO: Calculate from acquisitionDate and tif center.
+        "sunElevation": None,  # TODO: Same
+        "cloudCover": cloudCover,
+        "acquisitionDate": acquisitionDate,
+        "id": str(uuid.uuid4()),
+        "thumbnails": None,
     }
     # Override defaults with kwargs
     sceneKwargs.update(kwargs)
+    data_footprint = complex_footprint(tif_path)
+    tile_footprint = MultiPolygon([Polygon.from_bounds(*data_footprint.bounds)])
 
     # Construct Scene
     scene = Scene(
@@ -65,6 +81,8 @@ def create_geotiff_scene(tif_path, datasource, acquisitionDate=None, cloudCover=
         metadataFiles,
         owner=owner,
         sceneType=sceneType,
+        dataFootprint=Footprint(mapping(data_footprint)['coordinates']),
+        tileFootprint=Footprint(mapping(tile_footprint)['coordinates']),
         **sceneKwargs
     )
 

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_scenes.py
@@ -81,8 +81,8 @@ def create_geotiff_scene(
         metadataFiles,
         owner=owner,
         sceneType=sceneType,
-        dataFootprint=Footprint(mapping(data_footprint)['coordinates']),
-        tileFootprint=Footprint(mapping(tile_footprint)['coordinates']),
+        dataFootprint=Footprint(mapping(data_footprint)["coordinates"]),
+        tileFootprint=Footprint(mapping(tile_footprint)["coordinates"]),
         **sceneKwargs
     )
 

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_thumbnails.py
@@ -28,12 +28,10 @@ def create_thumbnails(tif_path, scene_id):
     """
 
     r_tif_path = os.path.join(
-        os.path.dirname(tif_path),
-        'resampled_{}'.format(os.path.basename(tif_path))
+        os.path.dirname(tif_path), "resampled_{}".format(os.path.basename(tif_path))
     )
     rp_tif_path = os.path.join(
-        os.path.dirname(tif_path),
-        'reprojected_{}'.format(os.path.basename(tif_path))
+        os.path.dirname(tif_path), "reprojected_{}".format(os.path.basename(tif_path))
     )
 
     dim = get_geotiff_dimensions(tif_path)
@@ -51,62 +49,76 @@ def create_thumbnails(tif_path, scene_id):
     tempdir = os.path.dirname(tif_path)
 
     # Create paths for each size thumb
-    path_large = os.path.join(tempdir, '{}-LARGE.png'.format(scene_id))
-    path_small = os.path.join(tempdir, '{}-SMALL.png'.format(scene_id))
+    path_large = os.path.join(tempdir, "{}-LARGE.png".format(scene_id))
+    path_small = os.path.join(tempdir, "{}-SMALL.png".format(scene_id))
 
     # Color Corrected
-    path_cc_large = os.path.join(tempdir, '{}-CC-LARGE.png'.format(scene_id))
-    path_cc_small = os.path.join(tempdir, '{}-CC-SMALL.png'.format(scene_id))
+    path_cc_large = os.path.join(tempdir, "{}-CC-LARGE.png".format(scene_id))
+    path_cc_small = os.path.join(tempdir, "{}-CC-SMALL.png".format(scene_id))
 
     # Create urls for each size Thumbnail
-    url_large = '/thumbnails/{}'.format(os.path.basename(path_cc_large))
-    url_small = '/thumbnails/{}'.format(os.path.basename(path_cc_small))
+    url_large = "/thumbnails/{}".format(os.path.basename(path_cc_large))
+    url_small = "/thumbnails/{}".format(os.path.basename(path_cc_small))
 
-    try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small, path_cc_large, path_cc_small])
+    try_to_remove_files(
+        [r_tif_path, rp_tif_path, path_large, path_small, path_cc_large, path_cc_small]
+    )
 
     if os.path.isfile(tif_path):
         try:
 
-            logger.info('Performing thumbnail resampling')
-            subprocess.check_call([
-                'gdal_translate', tif_path, r_tif_path,
-                '-outsize', str(dim_large[0]), str(dim_large[1]),
-            ])
+            logger.info("Performing thumbnail resampling")
+            subprocess.check_call(
+                [
+                    "gdal_translate",
+                    tif_path,
+                    r_tif_path,
+                    "-outsize",
+                    str(dim_large[0]),
+                    str(dim_large[1]),
+                ]
+            )
 
-            logger.info('Performing thumbnail warping')
-            subprocess.check_call([
-                'gdalwarp', r_tif_path, rp_tif_path,
-                '-t_srs', 'EPSG:3857',
-                '-q'
-            ])
+            logger.info("Performing thumbnail warping")
+            subprocess.check_call(
+                ["gdalwarp", r_tif_path, rp_tif_path, "-t_srs", "EPSG:3857", "-q"]
+            )
 
             # Create a temporary env object
             mod_env = os.environ.copy()
             # Add variable to avoid sidecar files
-            mod_env['GDAL_PAM_ENABLED'] = 'NO'
+            mod_env["GDAL_PAM_ENABLED"] = "NO"
 
             with rasterio.open(rp_tif_path) as src:
                 num_bands = src.count
                 if num_bands >= 3:
-                    bands = ['-b', '1',
-                             '-b', '2',
-                             '-b', '3']
+                    bands = ["-b", "1", "-b", "2", "-b", "3"]
                 else:
-                    bands = ['-b', '1']
+                    bands = ["-b", "1"]
 
-            logger.info('Creating thumbnail files')
+            logger.info("Creating thumbnail files")
             large_thumbnail_gdal_command = [
-                'gdal_translate', rp_tif_path, path_large,
-                '-outsize', str(dim_large[0]), str(dim_large[1]),
-                '-of', 'PNG',
-                '-q'
+                "gdal_translate",
+                rp_tif_path,
+                path_large,
+                "-outsize",
+                str(dim_large[0]),
+                str(dim_large[1]),
+                "-of",
+                "PNG",
+                "-q",
             ] + bands
 
             small_thumbnail_gdal_command = [
-                'gdal_translate', rp_tif_path, path_small,
-                '-outsize', str(dim_small[0]), str(dim_small[1]),
-                '-of', 'PNG',
-                '-q'
+                "gdal_translate",
+                rp_tif_path,
+                path_small,
+                "-outsize",
+                str(dim_small[0]),
+                str(dim_small[1]),
+                "-of",
+                "PNG",
+                "-q",
             ] + bands
 
             # Convert tif to pngs (large)
@@ -116,56 +128,44 @@ def create_thumbnails(tif_path, scene_id):
             subprocess.check_call(small_thumbnail_gdal_command, env=mod_env)
 
             # Do basic histogram normalization to improve thumbnails
-            subprocess.check_call([
-                'convert',
-                path_small,
-                '-normalize',
-                path_cc_small
-            ])
+            subprocess.check_call(["convert", path_small, "-normalize", path_cc_small])
 
             # Do basic histogram normalization to improve thumbnails
-            subprocess.check_call([
-                'convert',
-                path_large,
-                '-normalize',
-                path_cc_large
-            ])
+            subprocess.check_call(["convert", path_large, "-normalize", path_cc_large])
 
         except:
             # If any subprocess calls fail, we need to clean up before exiting
             try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
             raise
         if os.path.isfile(path_large) and os.path.isfile(path_small):
-            logger.info('Uploading thumbnails to S3')
-            s3_bucket_name = os.getenv('THUMBNAIL_BUCKET')
-            s3_bucket = boto3.resource('s3').Bucket(s3_bucket_name)
-            s3_bucket.upload_file(path_cc_large, os.path.basename(path_cc_large), {'ContentType': 'image/png'})
-            s3_bucket.upload_file(path_cc_small, os.path.basename(path_cc_small), {'ContentType': 'image/png'})
+            logger.info("Uploading thumbnails to S3")
+            s3_bucket_name = os.getenv("THUMBNAIL_BUCKET")
+            s3_bucket = boto3.resource("s3").Bucket(s3_bucket_name)
+            s3_bucket.upload_file(
+                path_cc_large,
+                os.path.basename(path_cc_large),
+                {"ContentType": "image/png"},
+            )
+            s3_bucket.upload_file(
+                path_cc_small,
+                os.path.basename(path_cc_small),
+                {"ContentType": "image/png"},
+            )
         try_to_remove_files([r_tif_path, rp_tif_path, path_large, path_small])
     else:
         return
 
     # Return List[Thumbnail]
     return [
-        Thumbnail(
-            dim_small[0],
-            dim_small[1],
-            'SMALL',
-            url_small,
-            sceneId=scene_id
-        ),
-        Thumbnail(
-            dim_large[0],
-            dim_large[1],
-            'LARGE',
-            url_large,
-            sceneId=scene_id
-        )
+        Thumbnail(dim_small[0], dim_small[1], "SMALL", url_small, sceneId=scene_id),
+        Thumbnail(dim_large[0], dim_large[1], "LARGE", url_large, sceneId=scene_id),
     ]
+
 
 def try_to_remove_files(files):
     for f in files:
         try_to_remove(f)
+
 
 def try_to_remove(path):
     try:

--- a/app-tasks/rf/src/rf/uploads/geotiff/io.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/io.py
@@ -54,7 +54,7 @@ def get_geotiff_size_bytes(tif_path):
 
 
 def s3_url(bucket, key):
-    return 's3://{bucket}/{key}'.format(bucket=bucket, key=key)
+    return "s3://{bucket}/{key}".format(bucket=bucket, key=key)
 
 
 def get_geotiff_dimensions(tif_path):

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/factories.py
@@ -15,46 +15,48 @@ from .parse_mtl import extract_metadata
 
 logger = logging.getLogger(__name__)
 
-data_bucket = os.getenv('DATA_BUCKET',
-                        'rasterfoundry-development-data-us-east-1')
+data_bucket = os.getenv("DATA_BUCKET", "rasterfoundry-development-data-us-east-1")
 
 
 class MultiSpectralScannerConfig(object):
-    bands = OrderedDict([('1', Band('Green', 1,
-                                    [500, 600])), ('2',
-                                                   Band('Red', 2, [600, 700])),
-                         ('3', Band('NIR - 1', 3, [700, 800])),
-                         ('4', Band('NIR - 2', 4, [800, 1100]))])
+    bands = OrderedDict(
+        [
+            ("1", Band("Green", 1, [500, 600])),
+            ("2", Band("Red", 2, [600, 700])),
+            ("3", Band("NIR - 1", 3, [700, 800])),
+            ("4", Band("NIR - 2", 4, [800, 1100])),
+        ]
+    )
 
 
 class ThematicMapperConfig(object):
     bands = OrderedDict(
-        [('1', Band('Blue', 1, [450, 520])), ('2', Band(
-            'Green', 2, [520, 600])), ('3', Band('Red', 3, [630, 690])),
-         ('4', Band('NIR', 4, [760, 900])), ('5',
-                                             Band('SWIR - 1', 5,
-                                                  [1550, 1750])),
-         ('6', Band('Thermal', 6, [10400, 12500])), ('7',
-                                                     Band(
-                                                         'SWIR - 2', 7,
-                                                         [2080, 2350]))])
+        [
+            ("1", Band("Blue", 1, [450, 520])),
+            ("2", Band("Green", 2, [520, 600])),
+            ("3", Band("Red", 3, [630, 690])),
+            ("4", Band("NIR", 4, [760, 900])),
+            ("5", Band("SWIR - 1", 5, [1550, 1750])),
+            ("6", Band("Thermal", 6, [10400, 12500])),
+            ("7", Band("SWIR - 2", 7, [2080, 2350])),
+        ]
+    )
 
 
 class EnhancedThematicMapperConfig(object):
     bands = OrderedDict(
-        [('1', Band('Blue', 1, [450, 520])), ('2', Band(
-            'Green', 2, [520, 600])), ('3', Band('Red', 3, [630, 690])),
-         ('4', Band('NIR', 4, [760, 900])), ('5',
-                                             Band('SWIR - 1', 5,
-                                                  [1550, 1750])),
-         ('6_VCID_1', Band('Thermal', 6,
-                           [10400, 12500])), ('6_VCID_2',
-                                              Band('Thermal', 7,
-                                                   [10400, 12500])),
-         ('7', Band('SWIR - 2', 8, [2080, 2350])), ('8',
-                                                    Band(
-                                                        'Panchromatic', 9,
-                                                        [520, 900]))])
+        [
+            ("1", Band("Blue", 1, [450, 520])),
+            ("2", Band("Green", 2, [520, 600])),
+            ("3", Band("Red", 3, [630, 690])),
+            ("4", Band("NIR", 4, [760, 900])),
+            ("5", Band("SWIR - 1", 5, [1550, 1750])),
+            ("6_VCID_1", Band("Thermal", 6, [10400, 12500])),
+            ("6_VCID_2", Band("Thermal", 7, [10400, 12500])),
+            ("7", Band("SWIR - 2", 8, [2080, 2350])),
+            ("8", Band("Panchromatic", 9, [520, 900])),
+        ]
+    )
 
 
 class LandsatHistoricalSceneFactory(object):
@@ -66,88 +68,97 @@ class LandsatHistoricalSceneFactory(object):
         scenes = []
         for landsat_id in self.upload.files:
             path_meta = io.base_metadata_for_landsat_id(landsat_id)
-            sensor = path_meta['sensor_id']
+            sensor = path_meta["sensor_id"]
             config = {
-                'M': MultiSpectralScannerConfig,
-                'T': ThematicMapperConfig,
-                'E': EnhancedThematicMapperConfig
+                "M": MultiSpectralScannerConfig,
+                "T": ThematicMapperConfig,
+                "E": EnhancedThematicMapperConfig,
             }[sensor]
             with io.get_tempdir() as temp_dir:
-                scene = create_scene(self.upload.owner, temp_dir, landsat_id,
-                                     config, self.upload.datasource)
+                scene = create_scene(
+                    self.upload.owner,
+                    temp_dir,
+                    landsat_id,
+                    config,
+                    self.upload.datasource,
+                )
                 scenes.append(scene)
         return scenes
 
 
 def create_scene(owner, prefix, landsat_id, config, datasource):
-    logger.info('Creating scene for landsat id {}'.format(landsat_id))
+    logger.info("Creating scene for landsat id {}".format(landsat_id))
     gcs_prefix = io.gcs_path_for_landsat_id(landsat_id)
     metadata_resp = requests.get(io.make_path_for_mtl(gcs_prefix, landsat_id))
     if metadata_resp.status_code == 404:
-        logger.error('Landsat scene %s is not available yet in GCS',
-                     landsat_id)
-        raise Exception('Could not find landsat scene %s', landsat_id)
+        logger.error("Landsat scene %s is not available yet in GCS", landsat_id)
+        raise Exception("Could not find landsat scene %s", landsat_id)
     filter_metadata = extract_metadata(metadata_resp.content)
     (filename, cog_fname) = process_to_cog(prefix, gcs_prefix, landsat_id, config)
     s3_location = upload_file(owner, filename, cog_fname)
-    logger.info('Creating image')
-    ingest_location = 's3://{}/{}'.format(data_bucket, quote(s3_location))
+    logger.info("Creating image")
+    ingest_location = "s3://{}/{}".format(data_bucket, quote(s3_location))
     scene = Scene(
-        'PRIVATE', [],
-        datasource, {},
+        "PRIVATE",
+        [],
+        datasource,
+        {},
         landsat_id,
-        'SUCCESS',
-        'SUCCESS',
-        'INGESTED', [io.make_path_for_mtl(gcs_prefix, landsat_id)],
+        "SUCCESS",
+        "SUCCESS",
+        "INGESTED",
+        [io.make_path_for_mtl(gcs_prefix, landsat_id)],
         ingestLocation=ingest_location,
-        cloudCover=filter_metadata['cloud_cover'],
-        acquisitionDate=filter_metadata['acquisition_date'],
-        sceneType='COG',
-        owner=owner)
+        cloudCover=filter_metadata["cloud_cover"],
+        acquisitionDate=filter_metadata["acquisition_date"],
+        sceneType="COG",
+        owner=owner,
+    )
     image = create_geotiff_image(
         filename,
         ingest_location,
         filename=cog_fname,
         owner=owner,
         scene=scene.id,
-        band_create_function=lambda x: list(config.bands.values()))
+        band_create_function=lambda x: list(config.bands.values()),
+    )
     scene.images = [image]
     return scene
 
 
 def process_to_cog(prefix, gcs_prefix, landsat_id, config):
-    logger.info('Fetching all bands')
+    logger.info("Fetching all bands")
     for band in list(config.bands.keys()):
         fetch_band(prefix, gcs_prefix, band, landsat_id)
-    cog_fname = '{}_COG.tif'.format(landsat_id)
-    stacked_fname = '{}_STACKED.tif'.format(landsat_id)
+    cog_fname = "{}_COG.tif".format(landsat_id)
+    stacked_fname = "{}_STACKED.tif".format(landsat_id)
     filenames = {
-        'COG': os.path.join(prefix, cog_fname),
-        'STACKED': os.path.join(prefix, stacked_fname)
+        "COG": os.path.join(prefix, cog_fname),
+        "STACKED": os.path.join(prefix, stacked_fname),
     }
-    local_paths = sorted(glob.glob('{}/{}*.TIF'.format(prefix, landsat_id)))
+    local_paths = sorted(glob.glob("{}/{}*.TIF".format(prefix, landsat_id)))
     warped_paths = cog.warp_tifs(local_paths, prefix)
     merged = cog.merge_tifs(warped_paths, prefix)
     cog.add_overviews(merged)
     cog_path = cog.convert_to_cog(merged, prefix)
-    shutil.move(cog_path, filenames['COG'])
-    return (filenames['COG'], cog_fname)
+    shutil.move(cog_path, filenames["COG"])
+    return (filenames["COG"], cog_fname)
 
 
 def upload_file(owner, local_path, remote_fname):
-    s3_client = boto3.client('s3')
-    key = 'user-uploads/{}/{}'.format(owner, remote_fname)
-    s3_client.put_object(
-        Bucket=data_bucket, Key=key, Body=open(local_path, 'r'))
-    logger.info("Uploading COG: %s => (Bucket: %s, Key: %s)", local_path,
-                data_bucket, key)
+    s3_client = boto3.client("s3")
+    key = "user-uploads/{}/{}".format(owner, remote_fname)
+    s3_client.put_object(Bucket=data_bucket, Key=key, Body=open(local_path, "r"))
+    logger.info(
+        "Uploading COG: %s => (Bucket: %s, Key: %s)", local_path, data_bucket, key
+    )
     return key
 
 
 def fetch_band(local_prefix, gcs_prefix, band, landsat_id):
     with open(
-            os.path.join(local_prefix, io.make_fname_for_band(
-                band, landsat_id)), 'wb') as outf:
+        os.path.join(local_prefix, io.make_fname_for_band(band, landsat_id)), "wb"
+    ) as outf:
         outf.write(
-            requests.get(io.make_path_for_band(gcs_prefix, band,
-                                               landsat_id)).content)
+            requests.get(io.make_path_for_band(gcs_prefix, band, landsat_id)).content
+        )

--- a/app-tasks/rf/src/rf/uploads/landsat_historical/parse_mtl.py
+++ b/app-tasks/rf/src/rf/uploads/landsat_historical/parse_mtl.py
@@ -6,16 +6,18 @@ from datetime import datetime
 import re
 
 
-cloud_cover_re = re.compile(r'CLOUD_COVER = (?P<cloud_cover>\d{1,2}(\.\d+)?)')
-acquisition_date_re = re.compile(r'DATE_ACQUIRED = (?P<acquisition_date>\d{4}-\d{2}-\d{2})')
+cloud_cover_re = re.compile(r"CLOUD_COVER = (?P<cloud_cover>\d{1,2}(\.\d+)?)")
+acquisition_date_re = re.compile(
+    r"DATE_ACQUIRED = (?P<acquisition_date>\d{4}-\d{2}-\d{2})"
+)
 
 
 def extract_metadata(inf_string):
-    cloud_cover = cloud_cover_re.search(inf_string).group('cloud_cover')
-    acquisition_date = acquisition_date_re.search(inf_string).group('acquisition_date')
-    acquisition_date_dt = datetime.strptime(acquisition_date, '%Y-%m-%d')
+    cloud_cover = cloud_cover_re.search(inf_string).group("cloud_cover")
+    acquisition_date = acquisition_date_re.search(inf_string).group("acquisition_date")
+    acquisition_date_dt = datetime.strptime(acquisition_date, "%Y-%m-%d")
     return {
-        'cloud_cover': cloud_cover,
-        'acquisition_date': acquisition_date_dt.isoformat() + 'Z',
-        'raw': inf_string
+        "cloud_cover": cloud_cover,
+        "acquisition_date": acquisition_date_dt.isoformat() + "Z",
+        "raw": inf_string,
     }

--- a/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
+++ b/app-tasks/rf/src/rf/uploads/modis/create_geotiff.py
@@ -11,25 +11,26 @@ from rasterio.warp import calculate_default_transform, reproject, Resampling
 logger = logging.getLogger(__name__)
 
 
-def warp_tif(combined_tif_path, warped_tif_path, dst_crs={
-        'init': 'EPSG:3857'
-}):
-    logger.info('Warping tif to web mercator: %s', combined_tif_path)
+def warp_tif(combined_tif_path, warped_tif_path, dst_crs={"init": "EPSG:3857"}):
+    logger.info("Warping tif to web mercator: %s", combined_tif_path)
     with rasterio.open(combined_tif_path) as src:
         meta = src.meta
         new_meta = meta.copy()
         transform, width, height = calculate_default_transform(
-            src.crs, dst_crs, src.width, src.height, *src.bounds)
-        new_meta.update({
-            'crs': dst_crs,
-            'transform': transform,
-            'width': width,
-            'height': height,
-            'nodata': -28762
-        })
+            src.crs, dst_crs, src.width, src.height, *src.bounds
+        )
+        new_meta.update(
+            {
+                "crs": dst_crs,
+                "transform": transform,
+                "width": width,
+                "height": height,
+                "nodata": -28762,
+            }
+        )
         with rasterio.open(
-                warped_tif_path, 'w', compress='DEFLATE', tiled=True,
-                **new_meta) as dst:
+            warped_tif_path, "w", compress="DEFLATE", tiled=True, **new_meta
+        ) as dst:
             for i in range(1, src.count):
                 reproject(
                     source=rasterio.band(src, i),
@@ -39,19 +40,17 @@ def warp_tif(combined_tif_path, warped_tif_path, dst_crs={
                     dst_transform=transform,
                     dst_crs=dst_crs,
                     resampling=Resampling.nearest,
-                    src_nodata=-28762
+                    src_nodata=-28762,
                 )
 
 
 def hdf_to_geotiffs(modis_path, local_dir):
     # Separate out into tifs for each band
-    logger.info('Splitting MODIS bands from SDS %s', modis_path)
-    split_base_path = os.path.join(local_dir, 'split.tif')
-    translate_command = [
-        'gdal_translate', '-sds', modis_path, split_base_path
-    ]
+    logger.info("Splitting MODIS bands from SDS %s", modis_path)
+    split_base_path = os.path.join(local_dir, "split.tif")
+    translate_command = ["gdal_translate", "-sds", modis_path, split_base_path]
     subprocess.check_call(translate_command)
-    return glob.glob('{}/split*'.format(local_dir))
+    return glob.glob("{}/split*".format(local_dir))
 
 
 def create_geotiffs(modis_path, local_dir):
@@ -66,12 +65,12 @@ def create_geotiffs(modis_path, local_dir):
         modis_path (str): path to modis HDF file
         local_dir (str): directory to output tiffs to
     """
-    logger.info('Preparing to create geotiffs')
+    logger.info("Preparing to create geotiffs")
 
-    post_web_mercator_path = os.path.join(local_dir, 'warp2.tif')
+    post_web_mercator_path = os.path.join(local_dir, "warp2.tif")
 
     tifs = sorted(hdf_to_geotiffs(modis_path, local_dir))
-    logger.info('Tifs: %s', '\n'.join(tifs))
+    logger.info("Tifs: %s", "\n".join(tifs))
     warped_paths = cog.warp_tifs(tifs, local_dir)
     merged_tif = cog.merge_tifs(warped_paths, local_dir)
     warp_tif(merged_tif, post_web_mercator_path)

--- a/app-tasks/rf/src/rf/uploads/modis/download_modis.py
+++ b/app-tasks/rf/src/rf/uploads/modis/download_modis.py
@@ -6,8 +6,8 @@ from html.parser import HTMLParser
 
 logger = logging.getLogger(__name__)
 
-EARTHDATA_USER = os.getenv('RF_EARTHDATA_USER')
-EARTHDATA_PASS = os.getenv('RF_EARTHDATA_PASS')
+EARTHDATA_USER = os.getenv("RF_EARTHDATA_USER")
+EARTHDATA_PASS = os.getenv("RF_EARTHDATA_PASS")
 
 
 def get_stream(session, url, auth, previous_tries):
@@ -34,12 +34,13 @@ def get_stream(session, url, auth, previous_tries):
 
 class LinkFinder(HTMLParser):
     """Simple parser to find download link for MODIS data"""
+
     def __init__(self):
         self.reset()
         self.download_link = None
 
     def handle_starttag(self, tag, attrs):
-        if attrs and attrs[0][0] == 'href':
+        if attrs and attrs[0][0] == "href":
             self.download_link = attrs[0][1]
 
 
@@ -56,8 +57,8 @@ def download_hdf(url, outdir):
     stream = get_stream(session, url, auth, [])
     chunk_size = 1024
     try:
-        with open(download_path, 'wb') as f:
-            logger.info('Saving %s' % download_path)
+        with open(download_path, "wb") as f:
+            logger.info("Saving %s" % download_path)
             for chunk in stream.iter_content(chunk_size):
                 f.write(chunk)
     except:

--- a/app-tasks/rf/src/rf/uploads/modis/factories.py
+++ b/app-tasks/rf/src/rf/uploads/modis/factories.py
@@ -10,58 +10,61 @@ from rf.models import Scene
 from rf.uploads.geotiff import create_geotiff_image
 from rf.uploads.modis.create_geotiff import create_geotiffs
 from rf.uploads.modis.download_modis import download_hdf
-from rf.utils.io import (
-    get_tempdir,
-    upload_tifs,
-    IngestStatus,
-    JobStatus,
-    Visibility
-)
+from rf.utils.io import get_tempdir, upload_tifs, IngestStatus, JobStatus, Visibility
 
 logger = logging.getLogger(__name__)
 
 modis_configs = {
-    'a11b768b-d869-476e-a1ed-0ac3205ed761': {
-        'thumbnail_bands': [1, 4, 3],
-        'bands': {
-            'B01.tif': Band('Red', 0, [620, 670]),
-            'B02.tif': Band('NIR', 0, [841, 876]),
-            'B03.tif': Band('Blue', 0, [459, 479]),
-            'B04.tif': Band('Green', 0, [545, 565]),
-            'B05.tif': Band('SWIR - 1', 0, [1230, 1250]),
-            'B06.tif': Band('SWIR - 2', 0, [1628, 1652]),
-            'B07.tif': Band('SWIR - 3', 0, [2105, 2155]),
-            'B08.tif': Band('Reflectance Band Quality', 0, [0, 0]),
-            'B09.tif': Band('Solar Zenith Angle', 0, [0, 0]),
-            'B10.tif': Band('View Zenith Angle', 0, [0, 0]),
-            'B11.tif': Band('Relative Azimuth Angle', 0, [0, 0]),
-            'B12.tif': Band('State Flags', 0, [0, 0]),
-            'B13.tif': Band('Day of Year', 0, [0, 0])
-        }
+    "a11b768b-d869-476e-a1ed-0ac3205ed761": {
+        "thumbnail_bands": [1, 4, 3],
+        "bands": {
+            "B01.tif": Band("Red", 0, [620, 670]),
+            "B02.tif": Band("NIR", 0, [841, 876]),
+            "B03.tif": Band("Blue", 0, [459, 479]),
+            "B04.tif": Band("Green", 0, [545, 565]),
+            "B05.tif": Band("SWIR - 1", 0, [1230, 1250]),
+            "B06.tif": Band("SWIR - 2", 0, [1628, 1652]),
+            "B07.tif": Band("SWIR - 3", 0, [2105, 2155]),
+            "B08.tif": Band("Reflectance Band Quality", 0, [0, 0]),
+            "B09.tif": Band("Solar Zenith Angle", 0, [0, 0]),
+            "B10.tif": Band("View Zenith Angle", 0, [0, 0]),
+            "B11.tif": Band("Relative Azimuth Angle", 0, [0, 0]),
+            "B12.tif": Band("State Flags", 0, [0, 0]),
+            "B13.tif": Band("Day of Year", 0, [0, 0]),
+        },
     },
-    '55735945-9da5-47c3-8ae4-572b5e11205b': {
-        'thumbnail_bands': [1, 4, 3],
-        'bands': {
-            'B01.tif': Band('Red', 0, [620, 670]),
-            'B02.tif': Band('NIR', 0, [841, 876]),
-            'B03.tif': Band('Blue', 0, [459, 479]),
-            'B04.tif': Band('Green', 0, [545, 565]),
-            'B05.tif': Band('SWIR - 1', 0, [1230, 1250]),
-            'B06.tif': Band('SWIR - 2', 0, [1628, 1652]),
-            'B07.tif': Band('SWIR - 3', 0, [2105, 2155]),
-            'B08.tif': Band('Reflectance Band Quality', 0, [0, 0]),
-            'B09.tif': Band('Solar Zenith Angle', 0, [0, 0]),
-            'B10.tif': Band('View Zenith Angle', 0, [0, 0]),
-            'B11.tif': Band('Relative Azimuth Angle', 0, [0, 0]),
-            'B12.tif': Band('State Flags', 0, [0, 0]),
-            'B13.tif': Band('Day of Year', 0, [0, 0])
-        }
-    }
+    "55735945-9da5-47c3-8ae4-572b5e11205b": {
+        "thumbnail_bands": [1, 4, 3],
+        "bands": {
+            "B01.tif": Band("Red", 0, [620, 670]),
+            "B02.tif": Band("NIR", 0, [841, 876]),
+            "B03.tif": Band("Blue", 0, [459, 479]),
+            "B04.tif": Band("Green", 0, [545, 565]),
+            "B05.tif": Band("SWIR - 1", 0, [1230, 1250]),
+            "B06.tif": Band("SWIR - 2", 0, [1628, 1652]),
+            "B07.tif": Band("SWIR - 3", 0, [2105, 2155]),
+            "B08.tif": Band("Reflectance Band Quality", 0, [0, 0]),
+            "B09.tif": Band("Solar Zenith Angle", 0, [0, 0]),
+            "B10.tif": Band("View Zenith Angle", 0, [0, 0]),
+            "B11.tif": Band("Relative Azimuth Angle", 0, [0, 0]),
+            "B12.tif": Band("State Flags", 0, [0, 0]),
+            "B13.tif": Band("Day of Year", 0, [0, 0]),
+        },
+    },
 }
 
 
 class MODISSceneFactory(object):
-    def __init__(self, hdf_urls, datasource, upload, project_id=None, layer_id=None, visibility=Visibility.PRIVATE, owner=None):
+    def __init__(
+        self,
+        hdf_urls,
+        datasource,
+        upload,
+        project_id=None,
+        layer_id=None,
+        visibility=Visibility.PRIVATE,
+        owner=None,
+    ):
         """Create factory for generating MODIS scenes
 
         Args:
@@ -100,15 +103,27 @@ def create_scene(hdf_url, temp_directory, user_id, datasource):
         datasource (str): ID of datasource for new MODIS scene
     """
     config = modis_configs[datasource]
-    granule_parts = os.path.basename(hdf_url).split('.')
+    granule_parts = os.path.basename(hdf_url).split(".")
 
-    acquisition_datetime = datetime.strptime(granule_parts[1][1:], '%Y%j')
-    name = '.'.join(granule_parts[:-1])
+    acquisition_datetime = datetime.strptime(granule_parts[1][1:], "%Y%j")
+    name = ".".join(granule_parts[:-1])
     id = str(uuid.uuid4())
 
-    scene = Scene(Visibility.PRIVATE, [], datasource, {}, name,
-                  JobStatus.SUCCESS, JobStatus.SUCCESS, IngestStatus.INGESTED, [], owner=user_id, id=id,
-                  acquisitionDate=acquisition_datetime.isoformat() + 'Z', cloudCover=0)
+    scene = Scene(
+        Visibility.PRIVATE,
+        [],
+        datasource,
+        {},
+        name,
+        JobStatus.SUCCESS,
+        JobStatus.SUCCESS,
+        IngestStatus.INGESTED,
+        [],
+        owner=user_id,
+        id=id,
+        acquisitionDate=acquisition_datetime.isoformat() + "Z",
+        cloudCover=0,
+    )
 
     hdf_filepath = download_hdf(hdf_url, temp_directory)
 
@@ -120,12 +135,17 @@ def create_scene(hdf_url, temp_directory, user_id, datasource):
     get_band_func = partial(get_image_band, modis_config=config)
     for local_path, remote_path in zip(tifs, s3_uris):
 
-        image = create_geotiff_image(local_path, unquote(s3_uris[0]),
-                                     scene=scene.id, owner=user_id, band_create_function=get_band_func)
+        image = create_geotiff_image(
+            local_path,
+            unquote(s3_uris[0]),
+            scene=scene.id,
+            owner=user_id,
+            band_create_function=get_band_func,
+        )
         images.append(image)
     scene.images = images
     scene.ingestLocation = s3_uris[0]
-    scene.sceneType = 'COG'
+    scene.sceneType = "COG"
 
     return scene
 
@@ -137,7 +157,7 @@ def get_image_band(filepath, modis_config=None):
         modis_config (dict): dictionary of configuration for a particular MODIS datasource
         filepath (str): path to file to get image band for
     """
-    bands = list(modis_config['bands'].values())
+    bands = list(modis_config["bands"].values())
     if not bands:
-        logger.warn('Could not find bands for file: %s', filepath)
+        logger.warn("Could not find bands for file: %s", filepath)
     return bands

--- a/app-tasks/rf/src/rf/uploads/planet/create_footprints.py
+++ b/app-tasks/rf/src/rf/uploads/planet/create_footprints.py
@@ -9,7 +9,7 @@ def bbox_from_planet_feature(planet_feature):
     """
 
     # it's a geojson polygon, so drill in
-    coords = planet_feature['geometry']['coordinates'][0]
+    coords = planet_feature["geometry"]["coordinates"][0]
     xs = [p[0] for p in coords]
     ys = [p[1] for p in coords]
     min_x = min(xs)
@@ -17,8 +17,14 @@ def bbox_from_planet_feature(planet_feature):
     min_y = min(ys)
     max_y = max(ys)
 
-    return [[[[min_x, min_y],
-              [max_x, min_y],
-              [max_x, max_y],
-              [min_x, max_y],
-              [min_x, min_y]]]]
+    return [
+        [
+            [
+                [min_x, min_y],
+                [max_x, min_y],
+                [max_x, max_y],
+                [min_x, max_y],
+                [min_x, min_y],
+            ]
+        ]
+    ]

--- a/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
+++ b/app-tasks/rf/src/rf/uploads/planet/create_scenes.py
@@ -6,11 +6,18 @@ from rf.utils.io import Visibility, JobStatus
 from ..geotiff.create_images import create_geotiff_image
 
 import logging
+
 logger = logging.getLogger(__name__)
 
 
-def create_planet_scene(planet_feature, datasource, planet_key,
-                        visibility=Visibility.PRIVATE, tags=[], owner=None):
+def create_planet_scene(
+    planet_feature,
+    datasource,
+    planet_key,
+    visibility=Visibility.PRIVATE,
+    tags=[],
+    owner=None,
+):
     """Create a Raster Foundry scene from Planet scenes
 
     Args:
@@ -25,33 +32,35 @@ def create_planet_scene(planet_feature, datasource, planet_key,
         Scene
     """
 
-    props = planet_feature['properties']
+    props = planet_feature["properties"]
     datasource = datasource
-    name = planet_feature['id']
-    acquisitionDate = props['acquired']
-    cloudCover = props['cloud_cover']
+    name = planet_feature["id"]
+    acquisitionDate = props["acquired"]
+    cloudCover = props["cloud_cover"]
     visibility = visibility
     tags = tags
 
     scene_kwargs = {
-        'sunAzimuth': props['sun_azimuth'],
-        'sunElevation': props['sun_elevation'],
-        'cloudCover': cloudCover,
-        'acquisitionDate': acquisitionDate,
-        'id': str(uuid.uuid4()),
-        'thumbnails': None,
-        'ingestLocation': planet_feature['added_props']['s3Location'].replace(
-            '|', '%7C'
-        )
+        "sunAzimuth": props["sun_azimuth"],
+        "sunElevation": props["sun_elevation"],
+        "cloudCover": cloudCover,
+        "acquisitionDate": acquisitionDate,
+        "id": str(uuid.uuid4()),
+        "thumbnails": None,
+        "ingestLocation": planet_feature["added_props"]["s3Location"].replace(
+            "|", "%7C"
+        ),
     }
 
-    images = [create_geotiff_image(
-        planet_feature['added_props']['localPath'],
-        planet_feature['added_props']['s3Location'],
-        scene=scene_kwargs['id'],
-        visibility=visibility,
-        owner=owner
-    )]
+    images = [
+        create_geotiff_image(
+            planet_feature["added_props"]["localPath"],
+            planet_feature["added_props"]["s3Location"],
+            scene=scene_kwargs["id"],
+            visibility=visibility,
+            owner=owner,
+        )
+    ]
 
     scene = Scene(
         visibility,
@@ -61,11 +70,11 @@ def create_planet_scene(planet_feature, datasource, planet_key,
         name,
         JobStatus.QUEUED,
         JobStatus.QUEUED,
-        'INGESTED',
+        "INGESTED",
         [],
         owner=owner,
         images=images,
-        sceneType='COG',
+        sceneType="COG",
         **scene_kwargs
     )
 

--- a/app-tasks/rf/src/rf/utils/exception_reporting.py
+++ b/app-tasks/rf/src/rf/utils/exception_reporting.py
@@ -5,11 +5,11 @@ import rollbar
 
 logger = logging.getLogger(__name__)
 
-environment = os.getenv('ENVIRONMENT')
-rollbar_token = os.getenv('ROLLBAR_SERVER_TOKEN')
+environment = os.getenv("ENVIRONMENT")
+rollbar_token = os.getenv("ROLLBAR_SERVER_TOKEN")
 
 # Avoid use of threads by default in case the worker exits before sending message
-rollbar.init(rollbar_token, environment, handler='blocking')
+rollbar.init(rollbar_token, environment, handler="blocking")
 
 
 def wrap_rollbar(func):
@@ -26,7 +26,9 @@ def wrap_rollbar(func):
             if all([environment, rollbar_token]):
                 rollbar.report_exc_info()
             else:
-                logger.warning('Both ENVIRONMENT and ROLLBAR_SERVER_TOKEN must be set to log exceptions to rollbar')
+                logger.warning(
+                    "Both ENVIRONMENT and ROLLBAR_SERVER_TOKEN must be set to log exceptions to rollbar"
+                )
             raise
 
     return func_wrapper

--- a/app-tasks/rf/src/rf/utils/footprint.py
+++ b/app-tasks/rf/src/rf/utils/footprint.py
@@ -1,0 +1,58 @@
+from multiprocessing import Pool
+from typing import List, Tuple
+
+import numpy as np
+from pyproj import Proj, transform
+import rasterio
+from rasterio.enums import Resampling
+from rasterio.features import shapes
+from shapely.geometry import shape, MultiPolygon, Polygon
+from shapely.ops import cascaded_union
+
+Point = Tuple[float, float]
+
+
+def transform_point_curried(tup: (Proj, Proj, Point)) -> Point:
+    (src_proj, dst_proj, (x, y)) = tup
+    return transform(src_proj, dst_proj, x, y)
+
+
+def transform_point_seq(
+    src_proj: Proj, dst_proj: Proj, points: List[Point]
+) -> (float, float):
+    with Pool() as pool:
+        return pool.map(
+            transform_point_curried, [(src_proj, dst_proj, p) for p in points]
+        )
+
+
+def transform_poly(src_proj: Proj, dst_proj: Proj, poly: Polygon) -> Polygon:
+    ext_coords = poly.exterior.coords
+    int_coords = [x.coords for x in poly.interiors]
+    return Polygon(
+        transform_point_seq(src_proj, dst_proj, ext_coords),
+        [transform_point_seq(src_proj, dst_proj, interior) for interior in int_coords],
+    )
+
+
+def complex_footprint(tif_path: str) -> MultiPolygon:
+    with rasterio.open(tif_path, "r") as ds:
+        band = ds.read(
+            1,
+            out_shape=(int(ds.height / 8.0), int(ds.width / 8.0)),
+            resampling=Resampling.bilinear,
+        )
+    print("band is read")
+    src_proj = Proj(ds.crs["init"])
+    dst_proj = Proj("EPSG:4326")
+    print("calculating shapes")
+    data_mask = (band > 0).astype(np.uint8)
+    polys = shapes(data_mask, transform=ds.transform)
+    print("shapes calculated, doing big ol' union")
+    multipoly = cascaded_union([shape(x[0]) for x in polys if x[1] == 1])
+    print("transforming polygons")
+    transformed = [
+        transform_poly(src_proj, dst_proj, p) for p in multipoly.simplify(0.05)
+    ]
+    print("transform complete, constructing multipoly")
+    return MultiPolygon(transformed)

--- a/app-tasks/rf/src/rf/utils/footprint.py
+++ b/app-tasks/rf/src/rf/utils/footprint.py
@@ -14,7 +14,8 @@ Point = Tuple[float, float]
 
 def transform_point_curried(tup: (Proj, Proj, Point)) -> Point:
     (src_proj, dst_proj, (x, y)) = tup
-    return transform(src_proj, dst_proj, x, y)
+    (y, x) = transform(src_proj, dst_proj, x, y)
+    return (x, y)
 
 
 def transform_point_seq(

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -4,7 +4,7 @@ import os
 import re
 import shutil
 import tempfile
-from urllib.parse import (urlparse, unquote, quote)
+from urllib.parse import urlparse, unquote, quote
 
 import boto3
 from dropbox.dropbox import Dropbox
@@ -14,7 +14,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-s3 = boto3.resource('s3', region_name='eu-central-1')
+s3 = boto3.resource("s3", region_name="eu-central-1")
 
 
 @contextmanager
@@ -59,14 +59,14 @@ def create_s3_obj(url):
     Args:
         url (str): either an s3 or https URL for an object stored in S3
     """
-    s3 = boto3.resource('s3')
+    s3 = boto3.resource("s3")
     parsed_url = urlparse(url)
-    if parsed_url.scheme == 's3':
+    if parsed_url.scheme == "s3":
         return s3.Object(parsed_url.netloc, parsed_url.path)
-    elif parsed_url.scheme == 'https' and parsed_url.netloc == 's3.amazonaws.com':
-        parts = parsed_url.path[1:].split('/')
+    elif parsed_url.scheme == "https" and parsed_url.netloc == "s3.amazonaws.com":
+        parts = parsed_url.path[1:].split("/")
         bucket = parts[0]
-        key = '/'.join(parts[1:])
+        key = "/".join(parts[1:])
         return s3.Object(bucket, key)
 
 
@@ -81,11 +81,11 @@ def download_s3_obj_by_key(bucket, key):
         str: the name of the tempfile holding the s3 object
     """
 
-    client = boto3.client('s3')
+    client = boto3.client("s3")
     obj = client.get_object(Bucket=bucket, Key=key)
     tf = tempfile.mktemp()
-    with open(tf, 'wb') as outf:
-        outf.write(obj['Body'].read())
+    with open(tf, "wb") as outf:
+        outf.write(obj["Body"].read())
     return tf
 
 
@@ -101,11 +101,13 @@ def s3_obj_exists(url):
 
 def base_metadata_for_landsat_id(landsat_id):
     pattern = re.compile(
-        r'L(?P<sensor_id>.).(?P<landsat_number>\d)_.{4}_(?P<path>\d{3})(?P<row>\d{3}).*'
+        r"L(?P<sensor_id>.).(?P<landsat_number>\d)_.{4}_(?P<path>\d{3})(?P<row>\d{3}).*"
     )
     match = pattern.match(landsat_id)
     if not match:
-        raise Exception('Could not parse Landsat ID. Make sure you entered it correctly.')
+        raise Exception(
+            "Could not parse Landsat ID. Make sure you entered it correctly."
+        )
     return match.groupdict()
 
 
@@ -117,43 +119,41 @@ def gcs_path_for_landsat_id(landsat_id):
     """
     metadata = base_metadata_for_landsat_id(landsat_id)
     tmpl = (
-        'https://storage.googleapis.com/gcp-public-data-landsat/'
-        'L{sensor_id}0{landsat_number}/01/{path}/{row}/{landsat_id}'
+        "https://storage.googleapis.com/gcp-public-data-landsat/"
+        "L{sensor_id}0{landsat_number}/01/{path}/{row}/{landsat_id}"
     )
     return tmpl.format(**dict(landsat_id=landsat_id, **metadata))
 
 
 def make_fname_for_band(band, landsat_id):
-    return '{}_B{}.TIF'.format(landsat_id, band)
+    return "{}_B{}.TIF".format(landsat_id, band)
 
 
 def make_fname_for_mtl(landsat_id):
-    return '{}_MTL.txt'.format(landsat_id)
+    return "{}_MTL.txt".format(landsat_id)
 
 
 def make_path_for_band(prefix, band, landsat_id):
-    return '/'.join([prefix, make_fname_for_band(band, landsat_id)])
+    return "/".join([prefix, make_fname_for_band(band, landsat_id)])
 
 
 def make_path_for_mtl(prefix, landsat_id):
-    return '/'.join([prefix, make_fname_for_mtl(landsat_id)])
+    return "/".join([prefix, make_fname_for_mtl(landsat_id)])
 
 
 def get_jwt():
     """Fetch an access token from the Auth0 API"""
     r = requests.post(
-        'https://{}/oauth/token'.format(
-            os.getenv('AUTH0_DOMAIN')
-        ),
+        "https://{}/oauth/token".format(os.getenv("AUTH0_DOMAIN")),
         data={
-            'grant_type': 'refresh_token',
-            'client_id': os.getenv('AUTH0_CLIENT_ID'),
-            'refresh_token': os.getenv('AUTH0_SYSTEM_REFRESH_TOKEN')
-        }
+            "grant_type": "refresh_token",
+            "client_id": os.getenv("AUTH0_CLIENT_ID"),
+            "refresh_token": os.getenv("AUTH0_SYSTEM_REFRESH_TOKEN"),
+        },
     )
     r.raise_for_status()
     json = r.json()
-    return json['id_token']
+    return json["id_token"]
 
 
 def get_session():
@@ -162,8 +162,8 @@ def get_session():
     encoded_jwt = get_jwt()
     session = requests.Session()
 
-    session.headers.update({'Authorization': 'Bearer {}'.format(encoded_jwt)})
-    session.headers.update({'User-Agent': 'RF/App-Tasks Client'})
+    session.headers.update({"Authorization": "Bearer {}".format(encoded_jwt)})
+    session.headers.update({"User-Agent": "RF/App-Tasks Client"})
     return session
 
 
@@ -178,31 +178,29 @@ def upload_tifs(tifs, user_id, scene_id, bucket_name=None):
     Returns:
         list[str]: list of s3 URIs for tiffs
     """
-    bucket = bucket_name or os.getenv('DATA_BUCKET')
-    s3_directory = os.path.join('user-uploads', user_id, scene_id)
-    s3_client = boto3.client('s3')
+    bucket = bucket_name or os.getenv("DATA_BUCKET")
+    s3_directory = os.path.join("user-uploads", user_id, scene_id)
+    s3_client = boto3.client("s3")
     s3_uris = []
     for tif in tifs:
         filename = os.path.basename(tif)
         key = os.path.join(s3_directory, filename)
-        logger.info('Uploading %s => bucket: %s, key: %s', tif, bucket, key)
+        logger.info("Uploading %s => bucket: %s, key: %s", tif, bucket, key)
 
-        s3_uris.append('s3://{}/{}'.format(bucket, quote(key)))
-        with open(tif, 'rb') as inf:
-            s3_client.put_object(
-                Bucket=bucket,
-                Body=inf,
-                Key=key
-            )
+        s3_uris.append("s3://{}/{}".format(bucket, quote(key)))
+        with open(tif, "rb") as inf:
+            s3_client.put_object(Bucket=bucket, Body=inf, Key=key)
     return s3_uris
 
 
 def s3_upload_export(local_path, source):
-    object_acl = None if os.getenv('DATA_BUCKET') in source else 'bucket-owner-full-control'
-    s3_client = boto3.client('s3')
+    object_acl = (
+        None if os.getenv("DATA_BUCKET") in source else "bucket-owner-full-control"
+    )
+    s3_client = boto3.client("s3")
     (bucket, key) = s3_bucket_and_key_from_url(unquote(source))
-    logger.info('Uploading %s => bucket: %s, key: %s', local_path, bucket, key)
-    with open(local_path, 'rb') as inf:
+    logger.info("Uploading %s => bucket: %s, key: %s", local_path, bucket, key)
+    with open(local_path, "rb") as inf:
         if object_acl:
             s3_client.put_object(Bucket=bucket, Body=inf, Key=key, ACL=object_acl)
         else:
@@ -212,7 +210,7 @@ def s3_upload_export(local_path, source):
 
 def dropbox_upload_export(access_token, local_path, remote_fname):
     client = Dropbox(access_token)
-    with open(local_path, 'rb') as inf:
+    with open(local_path, "rb") as inf:
         chunk_size = int(1.5e8 - 1)
         next_bytes = inf.read(chunk_size)
         upload_session_result = client.files_upload_session_start(next_bytes)
@@ -223,28 +221,30 @@ def dropbox_upload_export(access_token, local_path, remote_fname):
             client.files_upload_session_append_v2(next_bytes, cursor)
             next_bytes = inf.read(chunk_size)
             uploaded_so_far += chunk_size
-            cursor = UploadSessionCursor(upload_session_result.session_id, uploaded_so_far)
-        client.files_upload_session_finish('', cursor, CommitInfo(remote_fname))
+            cursor = UploadSessionCursor(
+                upload_session_result.session_id, uploaded_so_far
+            )
+        client.files_upload_session_finish("", cursor, CommitInfo(remote_fname))
 
 
 class JobStatus(object):
-    QUEUED = 'QUEUED'
-    PROCESSING = 'PROCESSING'
-    FAILURE = 'FAILURE'
-    SUCCESS = 'SUCCESS'
-    UPLOADING = 'UPLOADING'
-    PARTIALFAILURE = 'PARTIALFAILURE'
+    QUEUED = "QUEUED"
+    PROCESSING = "PROCESSING"
+    FAILURE = "FAILURE"
+    SUCCESS = "SUCCESS"
+    UPLOADING = "UPLOADING"
+    PARTIALFAILURE = "PARTIALFAILURE"
 
 
 class IngestStatus(object):
-    NOTINGESTED = 'NOTINGESTED'
-    TOBEINGESTED = 'TOBEINGESTED'
-    INGESTING = 'INGESTING'
-    INGESTED = 'INGESTED'
-    FAILED = 'FAILED'
+    NOTINGESTED = "NOTINGESTED"
+    TOBEINGESTED = "TOBEINGESTED"
+    INGESTING = "INGESTING"
+    INGESTED = "INGESTED"
+    FAILED = "FAILED"
 
 
 class Visibility(object):
-    PUBLIC = 'PUBLIC'
-    ORGANIZATION = 'ORGANIZATION'
-    PRIVATE = 'PRIVATE'
+    PUBLIC = "PUBLIC"
+    ORGANIZATION = "ORGANIZATION"
+    PRIVATE = "PRIVATE"


### PR DESCRIPTION
## Overview

This PR:

- calculates a more complex footprint for scenes that go through geotiff processing
- calculates a more complex task grid if the user doesn't post a geometry to the grid endpoint

## Notes

~I didn't do the annotate testing because my local annotate hits the login loop on both chrome and firefox right now~  :sob:don't need annotate for testing it turns out :sunglasses: 

EASIER CODE REVIEW:

https://github.com/raster-foundry/raster-foundry/pull/5266/files/b8209f4e6c89e923855b5639ab38522c75063a55

I noticed some inconsistency with whether I'd remembered to format after saving in my changes, so I `black`'ed everything, but that makes the code changes impossible to read.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests (exercised by existing grid test + generator update -- expecting them to fail)

## Testing Instructions

- assemble api
- bring up your server + frontend
- get The Bad Tif :tm: (I'll send it to you via s3)
- upload it into a project
- process that upload
- mouse over the scene in the project scenes list to observe your super cool footprint with holes and weird edges
- get a token from the frontend and export is as `RF_TOKEN`
- send a task grid request for your project with a nulled out geometry, like this:
  - put this json in `post.json`
```json
{
  "type": "Feature",
  "properties": {
    "xSizeMeters": "25",
    "ySizeMeters": "25"
  },
  "geometry": null,
  "projectId": "YOUR-PROJECT-ID",
  "layerId": "YOUR-PROJECT'S-DEFAULT-LAYER-ID"
}
```
  - `cat post.json | http :9091/api/projects/YOUR-PROJECT-ID/layers/YOUR-PROJECT'S-DEFAULT-LAYER-ID/tasks/grid Authorization:$RF_TOKEN`
- get a feature collection of your task with: `http :9091/api/projects/YOUR-PROJECT-ID/layers/YOUR-PROJECT'S-DEFAULT-LAYER-ID/tasks Authorization:$RF_TOKEN> features.json`
- copy `features.json` into `geojson.io` and see that the task grid follows the weird footprint

- it should succeed
- request the task grid 

Closes raster-foundry/annotate#461
