### PR TITLE
Fix upload processing for simple footprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Unified file extension for label item assets and label item asset links [#5252](https://github.com/raster-foundry/raster-foundry/pull/5252)
 - Added index to annotations `task_id` column to make deleting tasks way faster [#5255](https://github.com/raster-foundry/raster-foundry/pull/5255)
 - Explicitly handled case where aggregation of tasks doesn't return geometry statistics in STAC export [#5256](https://github.com/raster-foundry/raster-foundry/pull/5256)
+- Fixed upload processing bug that caused all scenes with simple footprints to fail upload processing [#5268](https://github.com/raster-foundry/raster-foundry/pull/5268)
 
 ### Security
 

--- a/app-tasks/rf/src/rf/utils/footprint.py
+++ b/app-tasks/rf/src/rf/utils/footprint.py
@@ -51,10 +51,14 @@ def complex_footprint(tif_path: str) -> MultiPolygon:
             ),
             resampling=Resampling.bilinear,
         )
+    nodata = ds.nodata
     downsampled_transform = ds.transform * ds.transform.scale(DOWNSAMPLE_FACTOR)
     src_proj = Proj(ds.crs)
     dst_proj = Proj({"init": "EPSG:4326"})
-    data_mask = (band > 0).astype(np.uint8)
+    if nodata is not None:
+        data_mask = (band != nodata).astype(np.uint8)
+    else:
+        data_mask = (band > 0).astype(np.uint8)
     polys = shapes(data_mask, transform=downsampled_transform)
     footprint = cascaded_union([shape(x[0]) for x in polys if x[1] == 1]).simplify(0.05)
     # if it has an __iter__ attribute, it's probably a multipolygon, so reproject all


### PR DESCRIPTION
## Overview

This PR fixes two things:

- when a scene has a simple footprint, it doesn't try to iterate over the polygon, which python/shapely reasonably say isn't iterable
- when an upload to be processed has a nodata value in its dataset metadata, uses that value to figure out the nodata mask instead of deciding everything is 0. I don't know how many more times I'm going to learn that lesson.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- if you haven't done so in a while, assemble api, backsplash-server
- bring up servers + frontend
- create an upload for a scene that doesn't have a crazy footprint with many little data islands and holes
- `docker-compose build batch`
- process it -- `./scripts/console batch 'rf process-upload UPLOAD-ID`
- it should succeed
- create an upload for a scene that _does_ have a crazy footprint with many little data islands and holes
- process it
- it should also succeed and the footprint should look appropriately crazy

Closes #5267 
