### PR TITLE
Add scopes datamodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Created a composable and flexible datamodel for user scopes [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -265,6 +265,7 @@ lazy val datamodel = project
     libraryDependencies ++= Seq(
       Dependencies.shapeless,
       Dependencies.catsCore,
+      Dependencies.catsLaws,
       Dependencies.monocleCore,
       Dependencies.circeGeneric,
       Dependencies.spray,

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -174,7 +174,7 @@ object ColorCorrect extends LazyLogging {
         // else if stats are available, clip assuming a normal distribution
         // else use the histogram's min/max
         (imin, imax, statsOption) match {
-          case (0, 255, _) => iMaxMin(index) = (0, 255)
+          case (0, 255, _)         => iMaxMin(index) = (0, 255)
           case (_, _, Some(stats)) =>
             // assuming a normal distribution, clips 2nd and 98th percentiles of values
             val newMin = stats.mean + (stats.stddev * -2.05)

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -1,0 +1,73 @@
+package com.rasterfoundry.datamodel
+
+import cats.{Eq, Monoid}
+
+sealed abstract class Scope {
+  val actions: Set[String]
+}
+
+class SimpleScope(val actions: Set[String]) extends Scope
+object SimpleScope {
+  def apply(actions: String*): SimpleScope =
+    new SimpleScope(actions.toSet)
+}
+
+class ComplexScope(scopes: Set[Scope]) extends Scope {
+  val actions = scopes flatMap { _.actions }
+}
+object ComplexScope {
+  def apply(scopes: Scope*): ComplexScope =
+    new ComplexScope(scopes.toSet)
+}
+
+object Scope {
+
+  implicit val eqScope = new Eq[Scope] {
+    def eqv(x: Scope, y: Scope): Boolean =
+      x.actions == y.actions
+  }
+
+  implicit val monoidScope = new Monoid[Scope] {
+    def empty = NoAccess
+    def combine(x: Scope, y: Scope): Scope =
+      ComplexScope(x, y)
+  }
+
+  private def makeCRUDScopes(prefix: String): Set[String] =
+    Set(":read", ":create", ":update", ":delete") map { s =>
+      prefix ++ s
+    }
+
+  // Separate scoped down upload permissions because most users don't need
+  // to be able to edit uploads (since the system user does that in upload
+  // processing)
+  case object Uploader
+      extends SimpleScope(
+        Set("uploads:read", "uploads:create", "uploads:delete")
+      )
+  case object UploadsCRUD
+      extends ComplexScope(Set(Uploader, SimpleScope("uploads:delete")))
+
+  case object ScenesCRUD extends SimpleScope(makeCRUDScopes("scenes"))
+
+  case object ProjectsCRUD extends SimpleScope(makeCRUDScopes("projects"))
+
+  // Not creating a separate permission for getting an export's files, since
+  // I can't currently imagine a case where someone would be allowed to view a
+  // project's exports but not download their files
+  case object ProjectExport
+      extends SimpleScope(Set("projects:listExports", "projects:createExport"))
+
+  case object ProjectsCRUDMultiPlayer
+      extends ComplexScope(
+        Set(ProjectsCRUD, SimpleScope("projects:share"))
+      )
+
+  case object ProjectsFullAccess
+      extends ComplexScope(Set(ProjectsCRUDMultiPlayer, ProjectExport))
+
+  // users with this scope aren't allowed to do anything
+  case object NoAccess extends Scope {
+    val actions = Set.empty
+  }
+}

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -74,6 +74,16 @@ object Action {
   }
 }
 
+/** A ScopedAction is a combination of a domain, an action, and a limit.
+  *
+  * Domains are an enum containing all of the area of the application that can
+  * have permissions attached to them.
+  * Actions are an enum containing all of the things it's possible to do in any
+  * domain.
+  * While making these enums doesn't prevent the creation of bonkers permissions
+  * (e.g. teams:createExport:-4), it at least prevents the creation of permissions
+  * that are one typo away from valid (e.g. projects:createExpert).
+  */
 case class ScopedAction(domain: Domain, action: Action, limit: Option[Long]) {
   def repr: String =
     s"$domain:$action" ++ {

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -46,6 +46,8 @@ object Scopes {
       prefix ++ s
     }
 
+  case object NoAccess extends SimpleScope(Set.empty)
+
   case object Uploader
       extends SimpleScope(
         Set("uploads:read", "uploads:create", "uploads:delete")
@@ -101,8 +103,6 @@ object Scopes {
   case object AnalysesFullAccess
       extends ComplexScope(Set(AnalysesCRUD, AnalysesMultiPlayer))
 
-  case object NoAccess extends SimpleScope(Set.empty)
-
   case object RasterFoundryUser
       extends ComplexScope(
         Set(
@@ -113,7 +113,18 @@ object Scopes {
           ShapesFullAccess,
           TemplatesFullAccess,
           Uploader,
+          // Regular users can view their teams and organizations, but can do nothing
+          // else in that domain
           SimpleScope("teams:read", "organizations:read")
         )
       )
+
+  // TODO
+  case object RasterFoundryTeamAdmin extends ComplexScope(Set.empty)
+
+  // TODO
+  case object RasterFoundryOrganizationAdmin extends ComplexScope(Set.empty)
+
+  // TODO
+  case object RasterFoundryPlatformAdmin extends ComplexScope(Set.empty)
 }

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -1,8 +1,32 @@
 package com.rasterfoundry.datamodel
 
 import cats.{Eq, Monoid}
+import cats.implicits._
+import _root_.io.circe.{Decoder, Encoder, Json}
+import scala.util.{Failure, Success, Try}
 
-case class Action(domain: String, action: String, limit: Option[Long])
+case class Action(domain: String, action: String, limit: Option[Long]) {
+  def repr: String =
+    s"$domain:$action" ++ {
+      limit map { lim =>
+        s":$lim"
+      } getOrElse ""
+    }
+}
+
+object Action {
+  private[datamodel] def fromString(s: String): Try[Action] =
+    s.split(":").toList match {
+      case domain :: action :: Nil =>
+        Success(Action(domain, action, None))
+      case domain :: action :: lim :: Nil =>
+        Success(Action(domain, action, Some(lim.toLong)))
+      case result =>
+        Failure(
+          new Exception(s"Cannot build an action from split string: $result")
+        )
+    }
+}
 
 sealed abstract class Scope {
   val actions: Set[Action]
@@ -12,6 +36,11 @@ sealed class SimpleScope(
     val actions: Set[Action]
 ) extends Scope
 
+object SimpleScope {
+  def unapply(simpleScope: SimpleScope): Option[Set[Action]] =
+    Some(simpleScope.actions)
+}
+
 sealed class ComplexScope(scopes: Set[Scope]) extends Scope {
   val actions = scopes flatMap { _.actions }
 }
@@ -19,9 +48,41 @@ sealed class ComplexScope(scopes: Set[Scope]) extends Scope {
 object ComplexScope {
   private[datamodel] def apply(scopes: Scope*): ComplexScope =
     new ComplexScope(scopes.toSet)
+
+  def unapply(complexScope: ComplexScope): Option[Set[Action]] =
+    Some(complexScope.actions)
 }
 
 object Scope {
+
+  private[datamodel] def fromString(s: String): Try[Scope] = s match {
+    case "uploader"                  => Success(Scopes.Uploader)
+    case "analyses:crud"             => Success(Scopes.AnalysesCRUD)
+    case "analyses:multiplayer"      => Success(Scopes.AnalysesMultiPlayer)
+    case "datasources:crud"          => Success(Scopes.DatasourcesCRUD)
+    case "organizations:userAdmin"   => Success(Scopes.OrganizationsUserAdmin)
+    case "projects:exportFullAccess" => Success(Scopes.ProjectExport)
+    case "projects:fullAccess"       => Success(Scopes.ProjectsFullAccess)
+    case "organizations:admin"       => Success(Scopes.RasterFoundryOrganizationAdmin)
+    case "teams:admin"               => Success(Scopes.RasterFoundryTeamAdmin)
+    case "scenes:crud"               => Success(Scopes.ScenesCRUD)
+    case "scenes:multiplayer"        => Success(Scopes.ScenesMultiPlayer)
+    case "shapes:fullAccess"         => Success(Scopes.ShapesFullAccess)
+    case "teams:edit"                => Success(Scopes.TeamsEdit)
+    case "templates:crud"            => Success(Scopes.TemplatesCRUD)
+    case "templates:multiplayer"     => Success(Scopes.TemplatesMultiPlayer)
+    case "uploads:crud"              => Success(Scopes.UploadsCRUD)
+    case s =>
+      (s.split(";").toList match {
+        case List("") => Success(List.empty)
+        case actions =>
+          actions traverse { scopePart =>
+            Action.fromString(scopePart)
+          }
+      }).map { scopeParts =>
+        new SimpleScope(scopeParts.toSet)
+      }
+  }
 
   implicit val eqScope = new Eq[Scope] {
     def eqv(x: Scope, y: Scope): Boolean =
@@ -34,6 +95,42 @@ object Scope {
       ComplexScope(x, y)
   }
 
+  implicit val encScope: Encoder[Scope] = new Encoder[Scope] {
+    def apply(thing: Scope): Json = thing match {
+      case Scopes.Uploader            => Json.fromString("uploader")
+      case Scopes.AnalysesCRUD        => Json.fromString("analyses:crud")
+      case Scopes.AnalysesMultiPlayer => Json.fromString("analyses:multiplayer")
+      case Scopes.DatasourcesCRUD     => Json.fromString("datasources:crud")
+      case Scopes.OrganizationsUserAdmin =>
+        Json.fromString("organizations:userAdmin")
+      case Scopes.ProjectExport      => Json.fromString("projects:exportFullAccess")
+      case Scopes.ProjectsFullAccess => Json.fromString("projects:fullAccess")
+      case Scopes.RasterFoundryOrganizationAdmin =>
+        Json.fromString("organizations:admin")
+      case Scopes.RasterFoundryTeamAdmin => Json.fromString("teams:admin")
+      case Scopes.ScenesCRUD             => Json.fromString("scenes:crud")
+      case Scopes.ScenesMultiPlayer      => Json.fromString("scenes:multiplayer")
+      case Scopes.ShapesFullAccess       => Json.fromString("shapes:fullAccess")
+      case Scopes.TeamsEdit              => Json.fromString("teams:edit")
+      case Scopes.TemplatesCRUD          => Json.fromString("templates:crud")
+      case Scopes.TemplatesMultiPlayer =>
+        Json.fromString("templates:multiplayer")
+      case Scopes.UploadsCRUD => Json.fromString("uploads:crud")
+      case SimpleScope(actions) =>
+        Json.fromString((actions map { action =>
+          action.repr
+        }).mkString(";"))
+      case ComplexScope(actions) =>
+        Json.fromString((actions map { action =>
+          action.repr
+        }).mkString(";"))
+    }
+  }
+
+  implicit val decScope: Decoder[Scope] = Decoder.decodeString.emapTry {
+    (s: String) =>
+      Scope.fromString(s)
+  }
 }
 
 object Scopes {
@@ -142,8 +239,15 @@ object Scopes {
 
   case object TeamsUserAdmin
       extends SimpleScope(
-        Set("addUser", "removeUser", "promoteUser") map {
+        Set("addUser", "removeUser", "editUserRole") map {
           makeAction("teams", _)
+        }
+      )
+
+  case object OrganizationsUserAdmin
+      extends SimpleScope(
+        Set("addUser", "removeUser", "editUserRole") map {
+          makeAction("organizations", _)
         }
       )
 
@@ -163,19 +267,20 @@ object Scopes {
         )
       )
 
-  // TODO
   case object RasterFoundryOrganizationAdmin
       extends ComplexScope(
         Set(
-          RasterFoundryTeamAdmin
+          RasterFoundryTeamAdmin,
+          OrganizationsUserAdmin,
+          new SimpleScope(Set(makeAction("teams", "create")))
         )
       )
 
-  // TODO
   case object RasterFoundryPlatformAdmin
       extends ComplexScope(
         Set(
-          RasterFoundryOrganizationAdmin
+          RasterFoundryOrganizationAdmin,
+          new SimpleScope(Set(makeAction("organizations", "create")))
         )
       )
 }

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -253,8 +253,8 @@ object Scopes {
           Uploader,
           // Regular users can view their teams and organizations, but can do nothing
           // else in that domain
-          new SimpleScope(Set("team", "organizations") map {
-            makeAction(_, "read")
+          new SimpleScope(Set("teams", "organizations") flatMap { domain =>
+            Set(makeAction(domain, "read"), makeAction(domain, "readUsers"))
           })
         )
       )

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -2,23 +2,20 @@ package com.rasterfoundry.datamodel
 
 import cats.{Eq, Monoid}
 
+case class Action(domain: String, action: String, limit: Option[Long])
+
 sealed abstract class Scope {
-  val actions: Set[String]
+  val actions: Set[Action]
 }
 
-sealed abstract class QuantitativeLimit {
-  val limit: Option[Long]
-}
-
-sealed class SimpleScope(val actions: Set[String]) extends Scope
-object SimpleScope {
-  private[datamodel] def apply(actions: String*): SimpleScope =
-    new SimpleScope(actions.toSet)
-}
+sealed class SimpleScope(
+    val actions: Set[Action]
+) extends Scope
 
 sealed class ComplexScope(scopes: Set[Scope]) extends Scope {
   val actions = scopes flatMap { _.actions }
 }
+
 object ComplexScope {
   private[datamodel] def apply(scopes: Scope*): ComplexScope =
     new ComplexScope(scopes.toSet)
@@ -41,65 +38,87 @@ object Scope {
 
 object Scopes {
 
-  private def makeCRUDScopes(prefix: String): Set[String] =
-    Set(":read", ":create", ":update", ":delete") map { s =>
-      prefix ++ s
+  private def makeCRUDActions(domain: String): Set[Action] =
+    Set("read", "create", "update", "delete") map { s =>
+      makeAction(domain, s)
     }
+
+  private def makeAction(
+      domain: String,
+      action: String,
+      limit: Option[Long] = None
+  ): Action =
+    Action(domain, action, limit)
 
   case object NoAccess extends SimpleScope(Set.empty)
 
   case object Uploader
       extends SimpleScope(
-        Set("uploads:read", "uploads:create", "uploads:delete")
+        Set("read", "create", "delete") map { makeAction("uploads", _) }
       )
 
   case object UploadsCRUD
-      extends ComplexScope(Set(Uploader, SimpleScope("uploads:delete")))
+      extends ComplexScope(
+        Set(
+          Uploader,
+          new SimpleScope(Set(makeAction("uploads", "delete")))
+        )
+      )
 
-  case object ScenesCRUD extends SimpleScope(makeCRUDScopes("scenes"))
+  case object ScenesCRUD extends SimpleScope(makeCRUDActions("scenes"))
 
-  case object ScenesMultiPlayer extends SimpleScope(Set("scenes:share"))
+  case object ScenesMultiPlayer
+      extends SimpleScope(Set(makeAction("scenes", "share")))
 
   case object ScenesFullAccess
       extends ComplexScope(Set(ScenesCRUD, ScenesMultiPlayer))
 
-  case object ProjectsCRUD extends SimpleScope(makeCRUDScopes("projects"))
+  case object ProjectsCRUD extends SimpleScope(makeCRUDActions("projects"))
 
   case object ProjectExport
-      extends SimpleScope(Set("projects:listExports", "projects:createExport"))
+      extends SimpleScope(Set("listExports", "createExport") map {
+        makeAction("projects", _)
+      })
 
   case object ProjectAnnotate
       extends SimpleScope(
         Set(
-          "projects:createAnnotation",
-          "projects:deleteAnnotation",
-          "projects:editAnnotation"
-        )
+          "createAnnotation",
+          "deleteAnnotation",
+          "editAnnotation"
+        ) map {
+          makeAction("projects", _)
+        }
       )
 
-  case object DatasourcesCRUD extends SimpleScope(makeCRUDScopes("datasources"))
+  case object DatasourcesCRUD
+      extends SimpleScope(makeCRUDActions("datasources"))
 
-  case object ProjectsMultiPlayer extends SimpleScope(Set("projects:share"))
+  case object ProjectsMultiPlayer
+      extends SimpleScope(Set(makeAction("projects", "share")))
 
   case object ProjectsFullAccess
       extends ComplexScope(
         Set(ProjectsCRUD, ProjectsMultiPlayer, ProjectExport, ProjectAnnotate)
       )
 
-  case object ShapesCRUD extends SimpleScope(makeCRUDScopes("shapes"))
+  case object ShapesCRUD extends SimpleScope(makeCRUDActions("shapes"))
 
-  case object ShapesMultiPlayer extends SimpleScope(Set("shapes:share"))
+  case object ShapesMultiPlayer
+      extends SimpleScope(Set(makeAction("shapes", "share")))
 
   case object ShapesFullAccess
       extends ComplexScope(Set(ShapesCRUD, ShapesMultiPlayer))
 
-  case object TemplatesCRUD extends SimpleScope(makeCRUDScopes("templates"))
-  case object TemplatesMultiPlayer extends SimpleScope(Set("templates:share"))
+  case object TemplatesCRUD extends SimpleScope(makeCRUDActions("templates"))
+  case object TemplatesMultiPlayer
+      extends SimpleScope(Set(makeAction("templates", "share")))
   case object TemplatesFullAccess
       extends ComplexScope(Set(TemplatesCRUD, TemplatesMultiPlayer))
 
-  case object AnalysesCRUD extends SimpleScope(makeCRUDScopes("analyses"))
-  case object AnalysesMultiPlayer extends SimpleScope(Set("analyses:share"))
+  case object AnalysesCRUD extends SimpleScope(makeCRUDActions("analyses"))
+  case object AnalysesMultiPlayer
+      extends SimpleScope(Set(makeAction("analyses", "share")))
   case object AnalysesFullAccess
       extends ComplexScope(Set(AnalysesCRUD, AnalysesMultiPlayer))
 
@@ -115,16 +134,48 @@ object Scopes {
           Uploader,
           // Regular users can view their teams and organizations, but can do nothing
           // else in that domain
-          SimpleScope("teams:read", "organizations:read")
+          new SimpleScope(Set("team", "organizations") map {
+            makeAction(_, "read")
+          })
+        )
+      )
+
+  case object TeamsUserAdmin
+      extends SimpleScope(
+        Set("addUser", "removeUser", "promoteUser") map {
+          makeAction("teams", _)
+        }
+      )
+
+  case object TeamsEdit
+      extends SimpleScope(
+        Set("edit", "delete") map {
+          makeAction("teams", _)
+        }
+      )
+
+  case object RasterFoundryTeamAdmin
+      extends ComplexScope(
+        Set(
+          RasterFoundryUser,
+          TeamsUserAdmin,
+          TeamsEdit
         )
       )
 
   // TODO
-  case object RasterFoundryTeamAdmin extends ComplexScope(Set.empty)
+  case object RasterFoundryOrganizationAdmin
+      extends ComplexScope(
+        Set(
+          RasterFoundryTeamAdmin
+        )
+      )
 
   // TODO
-  case object RasterFoundryOrganizationAdmin extends ComplexScope(Set.empty)
-
-  // TODO
-  case object RasterFoundryPlatformAdmin extends ComplexScope(Set.empty)
+  case object RasterFoundryPlatformAdmin
+      extends ComplexScope(
+        Set(
+          RasterFoundryOrganizationAdmin
+        )
+      )
 }

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -7,19 +7,53 @@ import io.circe.parser._
 
 import scala.util.{Failure, Success, Try}
 
-sealed abstract class Domain(repr: String) {
+sealed abstract class Domain(repr: String, val validActions: Set[Action]) {
   override def toString: String = repr
 }
 object Domain {
-  case object Uploads extends Domain("uploads")
-  case object Scenes extends Domain("scenes")
-  case object Projects extends Domain("projects")
-  case object Datasources extends Domain("datasources")
-  case object Shapes extends Domain("shapes")
-  case object Templates extends Domain("templates")
-  case object Analyses extends Domain("analyses")
-  case object Teams extends Domain("teams")
-  case object Organizations extends Domain("organizations")
+  val crudActions: Set[Action] =
+    Set(Action.Create, Action.Read, Action.Update, Action.Delete)
+  case object Uploads
+      extends Domain("uploads", crudActions ++ Set(Action.Share))
+  case object Scenes extends Domain("scenes", crudActions ++ Set(Action.Share))
+  case object Projects
+      extends Domain(
+        "projects",
+        crudActions ++ Set(
+          Action.Share,
+          Action.ListExports,
+          Action.CreateExport,
+          Action.CreateAnnotation,
+          Action.DeleteAnnotation,
+          Action.UpdateAnnotation
+        )
+      )
+  case object Datasources extends Domain("datasources", crudActions)
+  case object Shapes extends Domain("shapes", crudActions ++ Set(Action.Share))
+  case object Templates
+      extends Domain("templates", crudActions ++ Set(Action.Share))
+  case object Analyses
+      extends Domain("analyses", crudActions ++ Set(Action.Share))
+  case object Teams
+      extends Domain(
+        "teams",
+        crudActions ++ Set(
+          Action.AddUser,
+          Action.RemoveUser,
+          Action.UpdateUserRole,
+          Action.ReadUsers
+        )
+      )
+  case object Organizations
+      extends Domain(
+        "organizations",
+        crudActions ++ Set(
+          Action.AddUser,
+          Action.RemoveUser,
+          Action.UpdateUserRole,
+          Action.ReadUsers
+        )
+      )
 
   def fromStringTry(s: String): Try[Domain] = s match {
     case "uploads"       => Success(Uploads)
@@ -84,7 +118,7 @@ object Action {
   * (e.g. teams:createExport:-4), it at least prevents the creation of permissions
   * that are one typo away from valid (e.g. projects:createExpert).
   */
-case class ScopedAction(domain: Domain, action: Action, limit: Option[Long]) {
+class ScopedAction(domain: Domain, action: Action, limit: Option[Long]) {
   def repr: String =
     s"$domain:$action" ++ {
       limit map { lim =>
@@ -94,18 +128,29 @@ case class ScopedAction(domain: Domain, action: Action, limit: Option[Long]) {
 }
 
 object ScopedAction {
+  def apply(
+      domain: Domain,
+      action: Action,
+      limit: Option[Long]
+  ): Try[ScopedAction] =
+    if (domain.validActions.contains(action)) {
+      Success(new ScopedAction(domain, action, limit))
+    } else {
+      Failure(new Exception(s"Domain $domain does not support action $action"))
+    }
+
   implicit val decScopedAction: Decoder[ScopedAction] =
     Decoder.decodeString.emapTry { (s: String) =>
       s.split(":").toList match {
         case domain :: action :: Nil =>
-          (Domain.fromStringTry(domain), Action.fromStringTry(action)) mapN {
+          ((Domain.fromStringTry(domain), Action.fromStringTry(action)) mapN {
             case (dom, act) =>
               ScopedAction(dom, act, None)
-          }
+          }).flatten
         case domain :: action :: lim :: Nil =>
-          (Domain.fromStringTry(domain), Action.fromStringTry(action)) mapN {
+          ((Domain.fromStringTry(domain), Action.fromStringTry(action)) mapN {
             case (dom, act) => ScopedAction(dom, act, Some(lim.toLong))
-          }
+          }).flatten
         case result =>
           Failure(
             DecodingFailure(
@@ -249,7 +294,7 @@ object Scopes {
       action: Action,
       limit: Option[Long] = None
   ): ScopedAction =
-    ScopedAction(domain, action, limit)
+    new ScopedAction(domain, action, limit)
 
   case object NoAccess extends SimpleScope(Set.empty)
 
@@ -290,7 +335,7 @@ object Scopes {
         Set(
           Action.CreateAnnotation,
           Action.DeleteAnnotation,
-          Action.UpdateAnnotation,
+          Action.UpdateAnnotation
         ) map {
           makeScopedAction(Domain.Projects, _)
         }
@@ -396,7 +441,8 @@ object Scopes {
         Set(
           RasterFoundryOrganizationAdmin,
           new SimpleScope(
-            Set(makeScopedAction(Domain.Organizations, Action.Create)))
+            Set(makeScopedAction(Domain.Organizations, Action.Create))
+          )
         )
       )
 }

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -230,7 +230,3 @@ object User {
     }
   }
 }
-
-@JsonCodec
-final case class UserWithScopes(user: User,
-                                scopes: Map[ObjectType, List[ActionType]])

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -1,9 +1,9 @@
 package com.rasterfoundry.datamodel
 
-import org.scalatest.FunSuite
-import org.scalacheck.Arbitrary
-import org.typelevel.discipline.scalatest.Discipline
 import cats.kernel.laws.discipline.MonoidTests
+import org.scalacheck.Arbitrary
+import org.scalatest.FunSuite
+import org.typelevel.discipline.scalatest.Discipline
 
 class ScopeSpec extends FunSuite with Discipline {
 
@@ -18,4 +18,7 @@ class ScopeSpec extends FunSuite with Discipline {
   }
 
   checkAll("Scope.MonoidLaws", MonoidTests[Scope].monoid)
+
+  // TODO test ser-de
+  // TODO test some permissions relationships
 }

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -28,10 +28,20 @@ class ScopeSpec
           Domain.Organizations
         )
         action <- Gen.oneOf(
-          "read",
-          "edit",
-          "create",
-          "delete"
+          Action.Read,
+          Action.Create,
+          Action.Delete,
+          Action.Update,
+          Action.Share,
+          Action.ListExports,
+          Action.CreateExport,
+          Action.CreateAnnotation,
+          Action.DeleteAnnotation,
+          Action.UpdateAnnotation,
+          Action.ReadUsers,
+          Action.AddUser,
+          Action.RemoveUser,
+          Action.UpdateUserRole
         )
         limit <- Arbitrary.arbitrary[Option[Long]]
       } yield ScopedAction(domain, action, limit)
@@ -50,7 +60,7 @@ class ScopeSpec
     Scopes.ScenesCRUD,
     Scopes.ScenesMultiPlayer,
     Scopes.ShapesFullAccess,
-    Scopes.TeamsEdit,
+    Scopes.TeamsUpdate,
     Scopes.TemplatesCRUD,
     Scopes.TemplatesMultiPlayer,
     Scopes.UploadsCRUD

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -13,26 +13,29 @@ class ScopeSpec
     with Checkers
     with ArbitraryInstances {
 
-  implicit val arbAction: Arbitrary[Action] = Arbitrary[Action] {
-    for {
-      domain <- Gen.oneOf(
-        "projects",
-        "scenes",
-        "shapes",
-        "templates",
-        "teams",
-        "organizations",
-        "datasources"
-      )
-      action <- Gen.oneOf(
-        "read",
-        "edit",
-        "create",
-        "delete"
-      )
-      limit <- Arbitrary.arbitrary[Option[Long]]
-    } yield Action(domain, action, limit)
-  }
+  implicit val arbScopedAction: Arbitrary[ScopedAction] =
+    Arbitrary[ScopedAction] {
+      for {
+        domain <- Gen.oneOf(
+          Domain.Uploads,
+          Domain.Scenes,
+          Domain.Projects,
+          Domain.Datasources,
+          Domain.Shapes,
+          Domain.Templates,
+          Domain.Analyses,
+          Domain.Teams,
+          Domain.Organizations
+        )
+        action <- Gen.oneOf(
+          "read",
+          "edit",
+          "create",
+          "delete"
+        )
+        limit <- Arbitrary.arbitrary[Option[Long]]
+      } yield ScopedAction(domain, action, limit)
+    }
 
   def cannedPolicyGen: Gen[Scope] = Gen.oneOf(
     Scopes.Uploader,
@@ -60,7 +63,7 @@ class ScopeSpec
   implicit val arbScope: Arbitrary[Scope] = Arbitrary[Scope] {
     for {
       scope <- Gen.oneOf(
-        Arbitrary.arbitrary[Set[Action]] map { new SimpleScope(_) },
+        Arbitrary.arbitrary[Set[ScopedAction]] map { new SimpleScope(_) },
         cannedPolicyGen
       )
     } yield scope

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -1,19 +1,57 @@
 package com.rasterfoundry.datamodel
 
 import cats.kernel.laws.discipline.MonoidTests
-import org.scalacheck.Arbitrary
+import io.circe.testing.{ArbitraryInstances, CodecTests}
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.Discipline
 
-class ScopeSpec extends FunSuite with Discipline {
+class ScopeSpec
+    extends FunSuite
+    with Discipline
+    with Checkers
+    with ArbitraryInstances {
 
   implicit val arbAction: Arbitrary[Action] = Arbitrary[Action] {
     for {
-      domain <- Arbitrary.arbitrary[String]
-      action <- Arbitrary.arbitrary[String]
+      domain <- Gen.oneOf(
+        "projects",
+        "scenes",
+        "shapes",
+        "templates",
+        "teams",
+        "organizations",
+        "datasources"
+      )
+      action <- Gen.oneOf(
+        "read",
+        "edit",
+        "create",
+        "delete"
+      )
       limit <- Arbitrary.arbitrary[Option[Long]]
     } yield Action(domain, action, limit)
   }
+
+  def cannedPolicyGen: Gen[Scope] = Gen.oneOf(
+    Scopes.Uploader,
+    Scopes.AnalysesCRUD,
+    Scopes.AnalysesMultiPlayer,
+    Scopes.DatasourcesCRUD,
+    Scopes.OrganizationsUserAdmin,
+    Scopes.ProjectExport,
+    Scopes.ProjectsFullAccess,
+    Scopes.RasterFoundryOrganizationAdmin,
+    Scopes.RasterFoundryTeamAdmin,
+    Scopes.ScenesCRUD,
+    Scopes.ScenesMultiPlayer,
+    Scopes.ShapesFullAccess,
+    Scopes.TeamsEdit,
+    Scopes.TemplatesCRUD,
+    Scopes.TemplatesMultiPlayer,
+    Scopes.UploadsCRUD
+  )
 
   // Not separating out into a separate object until we have more than
   // one of these. I don't think for the most part we depend on laws holding,
@@ -21,12 +59,15 @@ class ScopeSpec extends FunSuite with Discipline {
   // security
   implicit val arbScope: Arbitrary[Scope] = Arbitrary[Scope] {
     for {
-      actions <- Arbitrary.arbitrary[Set[Action]]
-    } yield new SimpleScope(actions)
+      scope <- Gen.oneOf(
+        Arbitrary.arbitrary[Set[Action]] map { new SimpleScope(_) },
+        cannedPolicyGen
+      )
+    } yield scope
   }
 
   checkAll("Scope.MonoidLaws", MonoidTests[Scope].monoid)
+  checkAll("Scope.CodecTests", CodecTests[Scope].codec)
 
-  // TODO test ser-de
   // TODO test some permissions relationships
 }

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -42,9 +42,11 @@ class ScopeSpec
           Action.AddUser,
           Action.RemoveUser,
           Action.UpdateUserRole
-        )
+        ) suchThat { act =>
+          domain.validActions contains act
+        }
         limit <- Arbitrary.arbitrary[Option[Long]]
-      } yield ScopedAction(domain, action, limit)
+      } yield new ScopedAction(domain, action, limit)
     }
 
   def cannedPolicyGen: Gen[Scope] = Gen.oneOf(

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -1,0 +1,21 @@
+package com.rasterfoundry.datamodel
+
+import org.scalatest.FunSuite
+import org.scalacheck.Arbitrary
+import org.typelevel.discipline.scalatest.Discipline
+import cats.kernel.laws.discipline.MonoidTests
+
+class ScopeSpec extends FunSuite with Discipline {
+
+  // Not separating out into a separate object until we have more than
+  // one of these. I don't think for the most part we depend on laws holding,
+  // but in this case, since it determines user powers, I wanted the extra
+  // security
+  implicit val arbScope: Arbitrary[Scope] = Arbitrary[Scope] {
+    for {
+      actions <- Arbitrary.arbitrary[Set[String]]
+    } yield new SimpleScope(actions)
+  }
+
+  checkAll("Scope.MonoidLaws", MonoidTests[Scope].monoid)
+}

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -42,11 +42,9 @@ class ScopeSpec
           Action.AddUser,
           Action.RemoveUser,
           Action.UpdateUserRole
-        ) suchThat { act =>
-          domain.validActions contains act
-        }
+        )
         limit <- Arbitrary.arbitrary[Option[Long]]
-      } yield new ScopedAction(domain, action, limit)
+      } yield ScopedAction(domain, action, limit)
     }
 
   def cannedPolicyGen: Gen[Scope] = Gen.oneOf(

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -7,13 +7,21 @@ import org.typelevel.discipline.scalatest.Discipline
 
 class ScopeSpec extends FunSuite with Discipline {
 
+  implicit val arbAction: Arbitrary[Action] = Arbitrary[Action] {
+    for {
+      domain <- Arbitrary.arbitrary[String]
+      action <- Arbitrary.arbitrary[String]
+      limit <- Arbitrary.arbitrary[Option[Long]]
+    } yield Action(domain, action, limit)
+  }
+
   // Not separating out into a separate object until we have more than
   // one of these. I don't think for the most part we depend on laws holding,
   // but in this case, since it determines user powers, I wanted the extra
   // security
   implicit val arbScope: Arbitrary[Scope] = Arbitrary[Scope] {
     for {
-      actions <- Arbitrary.arbitrary[Set[String]]
+      actions <- Arbitrary.arbitrary[Set[Action]]
     } yield new SimpleScope(actions)
   }
 

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -81,6 +81,7 @@ object Dependencies {
   val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % Version.caffeine
   val catsCore = "org.typelevel" %% "cats-core" % Version.cats
   val catsEffect = "org.typelevel" %% "cats-effect" % Version.catsEffect
+  val catsLaws = "org.typelevel" %% "cats-laws" % Version.cats % Test
   val catsMeow = "com.olegpy" %% "meow-mtl" % Version.catsMeow
   val catsScalacheck = "io.chrisdavenport" %% "cats-scalacheck" % Version.catsScalacheck % "test"
   val circeCore = "io.circe" %% "circe-core" % Version.circe


### PR DESCRIPTION
## Overview

This PR adds a datamodel for scopes and a bunch of canned policies to make our lives easier.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I left out permissions around project layers on purpose. I also left out permissions for the user endpoints, since all of those endpoints are things that users read about/do to themselves anyway.
I maybe missed more stuff, but I think that it's the case that everything anyone would want to do in the main application is covered here. Regular users explicitly don't have the ability to edit uploads, since that's a system process.

## Testing Instructions

- run tests
- ensure that correct permission relationships are captured by ascending user -> team admin -> organization admin -> platform admin scale

Closes #5259 
