### PR TITLE
Generate typescript stubs in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ scratch/
 stats.json
 app-lambda/opt/*
 /app-lambda/package.sh
+
+# Typescript stubs from panrec
+stubs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)
+
 ### Changed
 
 ### Deprecated

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -90,3 +90,17 @@ services:
     volumes:
       - ./:/usr/local/src
     working_dir: /usr/local/src
+
+  panrec:
+    image: jisantuc/panrec:latest
+    volumes:
+      - ./stubs:/opt/data/out
+      - ./app-backend:/opt/data/app-backend
+    entrypoint: "./panrec"
+    command:
+      - "-i"
+      - "scala"
+      - "-o"
+      - "ts-interface"
+      - "/opt/data/app-backend/datamodel/src/main/scala"
+      - "/opt/data/out"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -92,7 +92,7 @@ services:
     working_dir: /usr/local/src
 
   panrec:
-    image: jisantuc/panrec:latest
+    image: jisantuc/panrec:ba13f43
     volumes:
       - ./stubs:/opt/data/out
       - ./app-backend:/opt/data/app-backend

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -60,6 +60,10 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 	    docker-compose -f docker-compose.test.yml \
 			   run --rm \
 			   panrec
+	    aws s3 cp --recursive \
+		"${DIR}/../stubs/" \
+		"s3://${RF_ARTIFACTS_BUCKET}/ts-stubs/${GIT_COMMIT}/"
+	    rm -r "${DIR}/../stubs"
 
             # Build publishable sbt projects as SNAPSHOT artifacts and
             # publish to Sonatype OSSRH (Snapshot Repository).

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -56,6 +56,11 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 "s3://${RF_ARTIFACTS_BUCKET}/lambda-functions/package-${GIT_COMMIT}.zip"
             rm "${DIR}/../app-lambda/package.zip"
 
+	    echo "Generating typescript interface stubs from Scala datamodel"
+	    docker-compose -f docker-compose.test.yml \
+			   run --rm \
+			   panrec
+
             # Build publishable sbt projects as SNAPSHOT artifacts and
             # publish to Sonatype OSSRH (Snapshot Repository).
             if [ "$(whoami)" == "jenkins" ]; then


### PR DESCRIPTION
## Overview

This PR adds a `panrec` step to cipublish to ship typescript interfaces to the artifacts bucket. The test branch `test/js/generate-ts-stubs-in-ci` also includes its changes and tests whether it succeeds.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

[Check it out](https://console.aws.amazon.com/s3/buckets/rasterfoundry-global-artifacts-us-east-1/ts-stubs/?region=us-east-1&tab=overview)

## Testing Instructions

- ci / look at the link