### PR TITLE
Clear Python Lambda function pip cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)
+
 ### Deprecated
 
 ### Removed

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -40,6 +40,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 build "; api/assembly; backsplash-server/assembly"
 
             echo "Building python lambda functions"
+            rm -rf "${DIR}/../app-lambda/opt/"*
             docker-compose -f "${DIR}/../docker-compose.test.yml" \
                            run --rm --no-deps lambda \
                            pip install -t opt/ ./


### PR DESCRIPTION
## Overview

Since dependencies are not pinned in `app-lambda/requirements.txt`, new versions of dependencies would accumulate under `/opt` while the old versions were not cleared out.

This PR cleans the `/opt` folder before installing dependencies.

I don't think the lack of a cache will increase build times, since, even if they already exist, it appears that pip tries to download dependencies each time.

Resolves https://github.com/azavea/raster-foundry-platform/issues/878

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests

## Testing Instructions

I had performed a directory listing of `/var/lib/jenkins/workspace/r_Foundry_raster-foundry_develop/app-lambda/opt` to demonstrate that 10+ versions of various dependencies, like `boto3`, had accumulated. Unfortunately, I cleared the folder out and lost my console session so I can't demonstrate what it was like before.

This Jenkins build shows that this change does not break anything in the CI pipeline: http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/test%252Fjrb%252Fclear-lambda-pip-cache/2/consoleFull