### PR TITLE
Add a migration to attach user scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Created a composable and flexible datamodel for user scopes [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270)
+- Added a migration to attach user scopes to users [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275)
 
 ### Changed
 

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -183,7 +183,7 @@ object Scope {
       case Scopes.RasterFoundryOrganizationAdmin =>
         Json.fromString("organizations:admin")
       case Scopes.RasterFoundryUser =>
-        Json.fromString("users:member")
+        Json.fromString("platformUser")
       case Scopes.RasterFoundryPlatformAdmin => Json.fromString("platforms:admin")
       case Scopes.RasterFoundryTeamAdmin => Json.fromString("teams:admin")
       case Scopes.ScenesCRUD             => Json.fromString("scenes:crud")
@@ -217,7 +217,7 @@ object Scope {
       case Some("projects:fullAccess")       => Right(Scopes.ProjectsFullAccess)
       case Some("organizations:admin") =>
         Right(Scopes.RasterFoundryOrganizationAdmin)
-      case Some("users:member") => Right(Scopes.RasterFoundryUser)
+      case Some("platformUser") => Right(Scopes.RasterFoundryUser)
       case Some("platforms:admin") => Right (Scopes.RasterFoundryPlatformAdmin)
       case Some("teams:admin")           => Right(Scopes.RasterFoundryTeamAdmin)
       case Some("scenes:crud")           => Right(Scopes.ScenesCRUD)

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -182,6 +182,8 @@ object Scope {
       case Scopes.ProjectsFullAccess => Json.fromString("projects:fullAccess")
       case Scopes.RasterFoundryOrganizationAdmin =>
         Json.fromString("organizations:admin")
+      case Scopes.RasterFoundryUser =>
+        Json.fromString("users:member")
       case Scopes.RasterFoundryPlatformAdmin => Json.fromString("platforms:admin")
       case Scopes.RasterFoundryTeamAdmin => Json.fromString("teams:admin")
       case Scopes.ScenesCRUD             => Json.fromString("scenes:crud")
@@ -215,6 +217,7 @@ object Scope {
       case Some("projects:fullAccess")       => Right(Scopes.ProjectsFullAccess)
       case Some("organizations:admin") =>
         Right(Scopes.RasterFoundryOrganizationAdmin)
+      case Some("users:member") => Right(Scopes.RasterFoundryUser)
       case Some("platforms:admin") => Right (Scopes.RasterFoundryPlatformAdmin)
       case Some("teams:admin")           => Right(Scopes.RasterFoundryTeamAdmin)
       case Some("scenes:crud")           => Right(Scopes.ScenesCRUD)

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -182,6 +182,7 @@ object Scope {
       case Scopes.ProjectsFullAccess => Json.fromString("projects:fullAccess")
       case Scopes.RasterFoundryOrganizationAdmin =>
         Json.fromString("organizations:admin")
+      case Scopes.RasterFoundryPlatformAdmin => Json.fromString("platforms:admin")
       case Scopes.RasterFoundryTeamAdmin => Json.fromString("teams:admin")
       case Scopes.ScenesCRUD             => Json.fromString("scenes:crud")
       case Scopes.ScenesMultiPlayer      => Json.fromString("scenes:multiplayer")
@@ -214,6 +215,7 @@ object Scope {
       case Some("projects:fullAccess")       => Right(Scopes.ProjectsFullAccess)
       case Some("organizations:admin") =>
         Right(Scopes.RasterFoundryOrganizationAdmin)
+      case Some("platforms:admin") => Right (Scopes.RasterFoundryPlatformAdmin)
       case Some("teams:admin")           => Right(Scopes.RasterFoundryTeamAdmin)
       case Some("scenes:crud")           => Right(Scopes.ScenesCRUD)
       case Some("scenes:multiplayer")    => Right(Scopes.ScenesMultiPlayer)

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -63,7 +63,9 @@ class ScopeSpec
     Scopes.TeamsUpdate,
     Scopes.TemplatesCRUD,
     Scopes.TemplatesMultiPlayer,
-    Scopes.UploadsCRUD
+    Scopes.UploadsCRUD,
+    Scopes.RasterFoundryPlatformAdmin,
+    Scopes.RasterFoundryUser
   )
 
   // Not separating out into a separate object until we have more than

--- a/app-backend/db/src/main/resources/migrations/V20__update_user_scopes.sql
+++ b/app-backend/db/src/main/resources/migrations/V20__update_user_scopes.sql
@@ -1,0 +1,85 @@
+-- updated user scopes in the users table with new JSONB strings
+
+ALTER TABLE public.users ALTER COLUMN scopes SET DEFAULT '""'::jsonb;
+
+
+UPDATE public.users SET scopes = '""'::jsonb;
+
+
+UPDATE
+   public.users 
+SET
+   scopes = 'platforms:admin'::jsonb 
+WHERE
+   id in 
+   (
+      SELECT
+         DISTINCT user_id 
+      FROM
+         user_group_roles 
+      WHERE
+         group_type = 'PLATFORM' 
+         AND group_role = 'ADMIN' 
+         AND is_active = true 
+         AND membership_status = 'APPROVED'
+   )
+   AND scopes = '""'::jsonb;
+
+
+UPDATE
+   public.users 
+SET
+   scopes = 'organizations:admin'::jsonb 
+WHERE
+   id in 
+   (
+      SELECT
+         DISTINCT user_id 
+      FROM
+         user_group_roles 
+      WHERE
+         group_type = 'ORGANIZATION' 
+         AND group_role = 'ADMIN' 
+         AND is_active = true 
+         AND membership_status = 'APPROVED'
+   )
+   AND scopes = '""'::jsonb;
+
+
+UPDATE
+   public.users 
+SET
+   scopes = 'teams:admin'::jsonb 
+WHERE
+   id in 
+   (
+      SELECT
+         DISTINCT user_id 
+      FROM
+         user_group_roles 
+      WHERE
+         group_type = 'TEAM' 
+         AND group_role = 'ADMIN' 
+         AND is_active = true 
+         AND membership_status = 'APPROVED'
+   )
+   AND scopes = '""'::jsonb;
+
+
+UPDATE
+   public.users 
+SET
+   scopes = 'users:member'::jsonb 
+WHERE
+   id in 
+   (
+      SELECT
+         DISTINCT user_id 
+      FROM
+         user_group_roles 
+      WHERE
+         group_role = 'MEMBER' 
+         AND is_active = true 
+         AND membership_status = 'APPROVED'
+   )
+   AND scopes = '""'::jsonb;

--- a/app-backend/db/src/main/resources/migrations/V20__update_user_scopes.sql
+++ b/app-backend/db/src/main/resources/migrations/V20__update_user_scopes.sql
@@ -9,7 +9,7 @@ UPDATE public.users SET scopes = '""'::jsonb;
 UPDATE
    public.users 
 SET
-   scopes = 'platforms:admin'::jsonb 
+   scopes = '"platforms:admin"'::jsonb 
 WHERE
    id in 
    (
@@ -29,7 +29,7 @@ WHERE
 UPDATE
    public.users 
 SET
-   scopes = 'organizations:admin'::jsonb 
+   scopes = '"organizations:admin"'::jsonb 
 WHERE
    id in 
    (
@@ -49,7 +49,7 @@ WHERE
 UPDATE
    public.users 
 SET
-   scopes = 'teams:admin'::jsonb 
+   scopes = '"teams:admin"'::jsonb 
 WHERE
    id in 
    (
@@ -69,7 +69,7 @@ WHERE
 UPDATE
    public.users 
 SET
-   scopes = 'users:member'::jsonb 
+   scopes = '"users:member"'::jsonb 
 WHERE
    id in 
    (

--- a/app-backend/db/src/main/resources/migrations/V20__update_user_scopes.sql
+++ b/app-backend/db/src/main/resources/migrations/V20__update_user_scopes.sql
@@ -69,7 +69,7 @@ WHERE
 UPDATE
    public.users 
 SET
-   scopes = '"users:member"'::jsonb 
+   scopes = '"platformUser"'::jsonb 
 WHERE
    id in 
    (


### PR DESCRIPTION
## Overview

This PR does the following:
- adds encoders and decoders for `RasterFoundryPlatformAdmin` and `RasterFoundryUser`
- adds a migration that attaches appropriate user scopes to `scopes` field in the `users` table based on `user_group_roles`:
    * it first changes the `scopes` column default to an empty `jsonb` string
    * it then updates all values in this `scopes` column to empty `jsonb` string
    * based on `user_group_roles`: platform admin, organization admin, team admin, member (no matter what group type), it populates the field according to active (`is_active=true`) and approved (`membership_status='APPROVED'`) user group role in this listed order. Upon each update of a record, it only updates the field when the `scopes` field is empty, so that lower role does not overwrite higher role.


### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (`Scope` monoid laws and codec are tested)


## Testing Instructions

- `./scripts/console sbt`
- `datamodel/test` should pass
- Not very sure tbh, but one could apply the migration and check if the specified scope of a user matches the role/group type in `user_group_roles`

Closes #5260 
