### PR TITLE
Fix decoding mix of canned scopes and actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Removed unused route and fixed spelling in Swagger spec [#5273](https://github.com/raster-foundry/raster-foundry/pull/5273)
+- Fixed a bug in scope decoding that prevented applying simple scopes and canned policies to the same user [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277)
 
 ### Security
 

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -127,12 +127,16 @@ class ScopeSpec
 
   test("decode a mix of simple and complex scopes") {
     val decoded = decode[Scope](""""projects:read;annotateTasks"""").right.get
-    Eq[Scope].eqv(
-      decoded,
-      new ComplexScope(
-        Set(
-          Scopes.AnnotateTasksScope,
-          new SimpleScope(Set(ScopedAction(Domain.Projects, Action.Read, None)))
+    assert(
+      Eq[Scope].eqv(
+        decoded,
+        new ComplexScope(
+          Set(
+            Scopes.AnnotateTasksScope,
+            new SimpleScope(
+              Set(ScopedAction(Domain.Projects, Action.Read, None))
+            )
+          )
         )
       )
     )

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -1,6 +1,8 @@
 package com.rasterfoundry.datamodel
 
+import cats.Eq
 import cats.kernel.laws.discipline.MonoidTests
+import io.circe.parser._
 import io.circe.testing.{ArbitraryInstances, CodecTests}
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.FunSuite
@@ -123,5 +125,17 @@ class ScopeSpec
   checkAll("Scope.MonoidLaws", MonoidTests[Scope].monoid)
   checkAll("Scope.CodecTests", CodecTests[Scope].codec)
 
+  test("decode a mix of simple and complex scopes") {
+    val decoded = decode[Scope](""""projects:read;annotateTasks"""").right.get
+    Eq[Scope].eqv(
+      decoded,
+      new ComplexScope(
+        Set(
+          Scopes.AnnotateTasksScope,
+          new SimpleScope(Set(ScopedAction(Domain.Projects, Action.Read, None)))
+        )
+      )
+    )
+  }
   // TODO test some permissions relationships
 }


### PR DESCRIPTION
## Overview

This PR fixes and tests decoding a mix of canned scopes and actions.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I originally had it set up to try to `decode[Scope]` again if the `ScopedAction` decode failed... but that created a flaky test that sometimes passed and sometimed hit a stack overflow. Oops! Anyway that's fixed now.

## Testing Instructions

- ci is sufficient
