### PR TITLE
Add scopes from JWT for new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 
 ### Added
 
-- Created a composable and flexible datamodel for user scopes [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270)
+- Added scopes to the API, database, and user creation to control access to resources and endpoints [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270), [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275), [#5278](https://github.com/raster-foundry/raster-foundry/pull/5278) [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277)
 - Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)
-- Added a migration to attach user scopes to users [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275)
 
 ### Changed
 
@@ -19,7 +18,6 @@
 ### Fixed
 
 - Removed unused route and fixed spelling in Swagger spec [#5273](https://github.com/raster-foundry/raster-foundry/pull/5273)
-- Fixed a bug in scope decoding that prevented applying simple scopes and canned policies to the same user [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277)
 
 ### Security
 

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -84,13 +84,13 @@ trait Authentication extends Directives with LazyLogging {
       (Option(claims.getStringClaim(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-    }
+      }
 
     val compareDelegatedToEmail = (field: String) =>
       (delegatedProfile.map(_.getAsString(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-    }
+      }
 
     compareToEmail("name")
       .orElse(compareToEmail("nickname"))
@@ -122,7 +122,7 @@ trait Authentication extends Directives with LazyLogging {
       str match {
         case s if !s.trim.isEmpty => Some(s)
         case _                    => None
-    }
+      }
 
     val defaultFromClaims = (field: String, str: String) =>
       optionEmpty(field)
@@ -158,7 +158,6 @@ trait Authentication extends Directives with LazyLogging {
             case UserOptionAndRoles(Some(user), roles) =>
               (user, roles).pure[ConnectionIO]
             case UserOptionAndRoles(None, _) => {
-              println(s"CREATING USER: $userId")
               createUserWithRoles(userId, email, name, picture, jwtClaims)
             }
 

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -84,13 +84,13 @@ trait Authentication extends Directives with LazyLogging {
       (Option(claims.getStringClaim(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-      }
+    }
 
     val compareDelegatedToEmail = (field: String) =>
       (delegatedProfile.map(_.getAsString(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-      }
+    }
 
     compareToEmail("name")
       .orElse(compareToEmail("nickname"))
@@ -122,7 +122,7 @@ trait Authentication extends Directives with LazyLogging {
       str match {
         case s if !s.trim.isEmpty => Some(s)
         case _                    => None
-      }
+    }
 
     val defaultFromClaims = (field: String, str: String) =>
       optionEmpty(field)

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -266,13 +266,6 @@ object Scope {
 
   implicit val decScope: Decoder[Scope] = new Decoder[Scope] {
     def apply(c: HCursor): Decoder.Result[Scope] = c.value.asString match {
-      case Some("organizations:admin") =>
-        Right(Scopes.OrganizationAdmin)
-      case Some("platformUser") => Right(Scopes.RasterFoundryUser)
-      case Some("groundworkUser") =>
-        Right(Scopes.GroundworkUser)
-      case Some("platforms:admin") => Right(Scopes.RasterFoundryPlatformAdmin)
-      case Some("teams:admin")     => Right(Scopes.RasterFoundryTeamsAdmin)
       case Some(s) =>
         Scopes.cannedPolicyFromString(s).orElse {
           s.split(";").toList match {

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -244,7 +244,7 @@ object Scope {
 
   implicit val encScope: Encoder[Scope] = new Encoder[Scope] {
     def apply(thing: Scope): Json = thing match {
-      case Scopes.OrganizationAdmin =>
+      case Scopes.RasterFoundryOrganizationAdmin =>
         Json.fromString("organizations:admin")
       case Scopes.RasterFoundryUser =>
         Json.fromString("platformUser")
@@ -291,7 +291,7 @@ object Scopes {
 
   def cannedPolicyFromString(s: String): Either[Error, Scope] = s match {
     case "organizations:admin" =>
-      Right(Scopes.OrganizationAdmin)
+      Right(Scopes.RasterFoundryOrganizationAdmin)
     case "platformUser"    => Right(Scopes.RasterFoundryUser)
     case "groundworkUser"  => Right(Scopes.GroundworkUser)
     case "platforms:admin" => Right(Scopes.RasterFoundryPlatformAdmin)

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -86,7 +86,8 @@ object UserDao extends Dao[User] with Sanitization {
   def createUserWithJWT(
       creatingUser: User,
       jwtUser: User.JwtFields,
-      userRole: GroupRole
+      userRole: GroupRole,
+      scope: Scope
   ): ConnectionIO[(User, List[UserGroupRole])] = {
     for {
       organization <- OrganizationDao.query
@@ -100,7 +101,8 @@ object UserDao extends Dao[User] with Sanitization {
               Viewer,
               jwtUser.email,
               jwtUser.name,
-              jwtUser.picture
+              jwtUser.picture,
+              scope
             )
             create(newUser)
           case None =>

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -60,7 +60,8 @@ class UserDaoSpec
               UserDao.createUserWithJWT(
                 creatingUser,
                 newUserFields,
-                GroupRole.Member
+                GroupRole.Member,
+                Scopes.RasterFoundryUser
               )
             }
             userRoles <- UserGroupRoleDao.listByUser(newUser)


### PR DESCRIPTION
## Overview

This adds support for attaching scopes to users when they're created from a JWT. If for some reason the JWT does not include a scope we give them `NoAccess` and assume that something broke in the creation of the JWT.

The rule added to Auth0 :sweat: is the following:

```javascript
function (user, context, callback) {

  var path = 'https://app.rasterfoundry.com;scopes';
  if (context.clientId === configuration.annotateApplicationID) {
    context.idToken[path] = 'groundworkUser';
  } else {
    context.idToken[path] = 'platformUser';
  }

  callback(null, user, context);
}
```

This has a setting (in Auth0) that checks if the connection is coming from the annotation application, if it is, then it attaches a canned policy of `groundworkUser` else assumes the user is a regular platform user. So everyone should at least get that.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

- This is most brittle on the Auth0 side IMO - but that should be all configured, reviewing that PR should include reviewing the Auth0 rules, but those changes aren't encoded anywhere here
- I updated a few other things along the way based on things I noticed in staging when testing
- The acceptance criteria in the related issue includes:
> on a fresh dev db, when you use SSO for the first time from local annotate, your new user gets an appropriate scope
However, this is not possible in development because the development version of annotate does not use a separate application in Auth0 for authentication so there isn't a separate ID to use there

## Testing Instructions

- Compile everything, etc.; start servers and frontend
- Make sure you don't have a social login user in your dev setup, if you do then delete that user
- Create an account via social login for your development environment login
- Start a db shell and run the following:
`select email, scopes from users where email = {login-you-used-in-previous-step}`
- Verify scope is `platformUser`
- Grab a JWT from an API request - also verify that the JWT fields include one for scopes

Closes #5262
