### PR TITLE
Add migration for annotation projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added migration for annotate projects and related items [#5284](https://github.com/raster-foundry/raster-foundry/pull/5284)
 - Added scopes to the API, database, and user creation to control access to resources and endpoints [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270), [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275), [#5278](https://github.com/raster-foundry/raster-foundry/pull/5278) [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277)
 - Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)
 

--- a/app-backend/db/src/main/resources/migrations/V21__groundwork_projects.sql
+++ b/app-backend/db/src/main/resources/migrations/V21__groundwork_projects.sql
@@ -1,0 +1,71 @@
+CREATE TYPE public.annotation_project_type AS ENUM (
+    'DETECTION',
+    'CLASSIFICATION',
+    'SEGMENTATION'
+);
+
+CREATE TYPE public.tile_layer_type AS ENUM (
+    'TMS',
+    'MVT'
+);
+
+CREATE TABLE public.annotation_projects (
+    id uuid primary key,
+    created_at timestamp without time zone NOT NULL,
+    created_by character varying(255) NOT NULL references users(id),
+    name text NOT NULL,
+    project_type public.annotation_project_type NOT NULL,
+    task_size_meters integer NOT NULL,
+    aoi public.geometry(Geometry,3857),
+    organization_id uuid NOT NULL references organizations(id),
+    labelers_team_id uuid NOT NULL references teams(id),
+    validators_team_id uuid NOT NULL references teams(id),
+    project_id uuid references projects(id)
+);
+
+CREATE TABLE public.tiles(
+  id uuid primary key,
+  name text NOT NULL,
+  url text NOT NULL,
+  is_default boolean NOT NULL default false,
+  is_overlay boolean NOT NULL default false,
+  layer_type tile_layer_type NOT NULL default 'TMS',
+  annotation_project_id uuid NOT NULL references annotation_projects(id)
+);
+
+CREATE TABLE public.annotation_label_class_groups (
+    id uuid primary key,
+    name text NOT NULL,
+    annotation_project_id uuid NOT NULL references annotation_projects(id),
+    idx int default 0 NOT NULL
+);
+
+CREATE TABLE public.annotation_label_classes (
+    id uuid primary key,
+    name text NOT NULL,
+    annotation_label_group_id uuid NOT NULL references annotation_label_class_groups(id),
+    color_hex_code text NOT NULL,
+    is_default boolean default false,
+    is_determinant boolean default false,
+    idx int NOT NULL default 0
+);
+
+CREATE TABLE public.annotation_labels (
+    id uuid primary key,
+    created_at timestamp without time zone NOT NULL,
+    created_by character varying(255) NOT NULL references users(id),
+    annotation_project_id uuid NOT NULL references annotation_projects(id),
+    annotation_task_id uuid NOT NULL references tasks(id),
+    geometry public.geometry(Geometry,3857)
+);
+
+CREATE INDEX annotation_labels_annotation_project_id_idx
+  ON annotation_labels (annotation_project_id);
+
+CREATE TABLE annotation_labels_annotation_label_classes (
+  annotation_label_id uuid NOT NULL references annotation_labels(id),
+  annotation_class_id uuid NOT NULL references annotation_label_classes(id)
+);
+
+CREATE INDEX annotation_labels_annotation_label_classes_label_id_idx
+  ON annotation_labels_annotation_label_classes (annotation_label_id);


### PR DESCRIPTION
## Overview

This PR adds a migration for the liberation of Groundwork projects from the Raster Foundry projects domain.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] New tables and queries have appropriate indices added
- Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- ~Any new SQL strings have tests~ many new SQL strings, but not time to test them yet since they're... run by sql

### Notes

I believe that I've added sufficient indices for fast project deletion to still work. i can't add the foreign key to annotation projects to `tasks` yet (unless we're planning to make a new tasks table?) without making it nullable, so I think that should happen as part of #5281.

I had to change the name of the `order` field because `order` is a reserved word.

## Testing Instructions

- run the migration

Closes #5280 
