### PR TITLE
Liberate annotation projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 
+- Moved project data for Groundwork from extras jsonb field and a text field to normalized tables [#5286](https://github.com/raster-foundry/raster-foundry/pull/5286)
 - Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)
 
 ### Deprecated

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -7,6 +7,7 @@ import com.rasterfoundry.batch.stacImport.ReadStacFeature
 import com.rasterfoundry.batch.stacExport.WriteStacCatalog
 import com.rasterfoundry.batch.notification.NotifyIngestStatus
 import com.rasterfoundry.batch.geojsonImport.ImportGeojsonFiles
+import com.rasterfoundry.batch.projectLiberation.ProjectLiberation
 
 object Main {
   val modules = Map[String, Array[String] => Unit](
@@ -19,6 +20,7 @@ object Main {
     WriteStacCatalog.name -> (WriteStacCatalog.main(_)),
     UpdateExportStatus.name -> (UpdateExportStatus.main(_)),
     ImportGeojsonFiles.name -> (ImportGeojsonFiles.main(_)),
+    ProjectLiberation.name -> (ProjectLiberation.main(_))
   )
 
   def main(args: Array[String]): Unit = {
@@ -28,7 +30,8 @@ object Main {
           case Some(main) => main(args.tail)
           case _ =>
             throw new Exception(
-              s"No job ${head} available (all available jobs: ${modules.keys.mkString(", ")})")
+              s"No job ${head} available (all available jobs: ${modules.keys.mkString(", ")})"
+            )
         }
       }
       case _ => throw new Exception(s"No options passed: ${args.toList}")

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -1,0 +1,51 @@
+package com.rasterfoundry.batch.projectLiberation
+
+import com.rasterfoundry.batch.Job
+import com.rasterfoundry.datamodel.Project
+import com.rasterfoundry.database.ProjectDao
+
+import cats.effect.IO
+import doobie.ConnectionIO
+
+import java.util.UUID
+
+object ProjectLiberation extends Job {
+  private def getAnnotationProjects: ConnectionIO[List[Project]] = ???
+
+  // make an annotation project from the existing project
+  private def createAnnotationProject(project: Project): ConnectionIO[UUID] =
+    ???
+
+  // create tiles entries for tms layer
+  private def createProjectTiles(
+      project: Project,
+      annotationProjectId: UUID
+  ): ConnectionIO[Unit] = ???
+
+  // maybe (UUID, name)?
+  private def createLabelClasses(
+      annotationProjectId: UUID
+  ): ConnectionIO[List[(UUID, String)]] = ???
+
+  // create annotation_labels from annotations table
+  private def createLabels(
+      projectId: UUID,
+      annotationProjectId: UUID,
+      classIds: List[(UUID, String)]
+  ): ConnectionIO[Unit] = ???
+
+  // nuke annotate from extras
+  private def nukeStaleData(project: Project): ConnectionIO[Unit] = ???
+
+  // do all the stuff
+  def freeAMind(project: Project): ConnectionIO[Unit] =
+    for {
+      annotationProjectId <- createAnnotationProject(project)
+      _ <- createProjectTiles(project, annotationProjectId)
+      classIds <- createLabelClasses(annotationProjectId)
+      _ <- createLabels(project.id, annotationProjectId, classIds)
+      _ <- nukeStaleData(project)
+    } yield ()
+
+  def runJob(args: List[String]): IO[Unit] = ???
+}

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -200,7 +200,7 @@ class ProjectLiberation(tileHost: URI) {
         }
     } traverse {
       case recordsNel =>
-        (Fragment.const(s"""
+        (Fragment.const("""
             INSERT INTO annotation_label_class_groups (
               id,
               name,
@@ -292,7 +292,7 @@ class ProjectLiberation(tileHost: URI) {
     fragmentsE match {
       case Right(Some(recordsNel)) =>
         (Fragment
-          .const(s"""
+          .const("""
             INSERT INTO annotation_label_classes (
               id,
               name,

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -494,7 +494,6 @@ object ProjectLiberation extends Job {
       val runner = new ProjectLiberation(URI.create(tileHost))
       for {
         projects <- runner.getAnnotationProjects.transact(xa)
-        _ = println(s"Projects: ${projects map { _.id }}")
         results <- projects traverse { project =>
           runner.liberateProject(project).transact(xa)
         }

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -1,51 +1,356 @@
 package com.rasterfoundry.batch.projectLiberation
 
 import com.rasterfoundry.batch.Job
-import com.rasterfoundry.datamodel.Project
+import com.rasterfoundry.datamodel._
 import com.rasterfoundry.database.ProjectDao
+import com.rasterfoundry.database.Implicits._
 
+import cats.data.EitherT
 import cats.effect.IO
-import doobie.ConnectionIO
+import cats.implicits._
+import doobie.{ConnectionIO, Fragment}
+import doobie.implicits._
+import doobie.postgres.implicits._
+import geotrellis.vector.{Geometry, Projected}
+import io.circe.Json
+import io.circe.optics.JsonPath._
+import io.circe.syntax._
+import shapeless._
 
+import scala.util.Try
+import java.net.URI
 import java.util.UUID
 
-object ProjectLiberation extends Job {
-  private def getAnnotationProjects: ConnectionIO[List[Project]] = ???
+sealed abstract class FailureStage extends Throwable
+case object GuessTaskSize extends FailureStage
+case object CreateAnnotationProject extends FailureStage
+case object CreateProjectTiles extends FailureStage
+case object CreateLabelClassGroups extends FailureStage
+case object CreateLabelClasses extends FailureStage
+case object CreateLabels extends FailureStage
+case object NukeStaleData extends FailureStage
+
+sealed abstract class AnnotationProjectType(val repr: String) {
+  override def toString = repr
+}
+case object Detection extends AnnotationProjectType("DETECTION")
+case object Classification extends AnnotationProjectType("CLASSIFICATION")
+case object Segmentation extends AnnotationProjectType("SEGMENTATION")
+
+object AnnotationProjectType {
+  def fromStringO(s: String): Option[AnnotationProjectType] =
+    s.toLowerCase match {
+      case "classification" => Some(Classification)
+      case "detection"      => Some(Detection)
+      case "segmentation"   => Some(Segmentation)
+      case _                => None
+    }
+}
+
+class ProjectLiberation(tileHost: URI) {
+
+  // using only simple types so I don't have to write metas for custom types --
+  // that work can happen when we create Daos / proper datamodels for these things
+  type AnnotationProject =
+    String :: String :: String :: Int :: Option[
+      Projected[Geometry]
+    ] :: Option[UUID] :: Option[UUID] :: Option[UUID] :: HNil
+
+  object AnnotationProject {
+    // need an apply method for mapN in projectToAnnotationProject -- this pattern will
+    // be repeated and is why I'm picking HLists over a big tuple here (type alias + apply for tuple
+    // seemed goofy in a way that this... doesn't. That's pretty subjective and even typing it out
+    // I'm less sure of it that I was 20 seconds ago).
+    // the other benefit is getting to enforce non-optionality in apply where the hlist can still
+    // hold options
+    def apply(
+        createdBy: String,
+        name: String,
+        projectType: AnnotationProjectType,
+        taskSizeMeters: Int,
+        aoi: Projected[Geometry],
+        labelersId: UUID,
+        validatorsId: UUID,
+        projectId: UUID
+    ): AnnotationProject =
+      createdBy :: name :: projectType.repr :: taskSizeMeters :: Option(aoi) :: Option(
+        labelersId
+      ) :: Option(validatorsId) :: Option(projectId) :: HNil
+  }
+
+  def projectToAnnotationProject(
+      project: Project,
+      extras: Json,
+      taskSizeMeters: Int
+  ): Either[FailureStage, AnnotationProject] = {
+    val annotatePartial = root.extras.annotate
+    val projectTypeLens = annotatePartial.projectType.string
+    val labelersLens = annotatePartial.labelers.string
+    val validatorsLens = annotatePartial.validators.string
+    val aoiLens = annotatePartial.aoi.geometry.json
+
+    Either.fromOption(
+      (
+        Option(project.createdBy),
+        Option(project.name),
+        projectTypeLens.getOption(extras) flatMap {
+          AnnotationProjectType.fromStringO _
+        },
+        Option(taskSizeMeters),
+        // this succeeds, even if we have a bad aoi or no aoi,
+        aoiLens
+          .getOption(extras) flatMap { _.as[Projected[Geometry]].toOption } orElse {
+          project.extent
+        },
+        labelersLens.getOption(extras) flatMap { s =>
+          Try { UUID.fromString(s) } toOption
+        },
+        validatorsLens.getOption(extras) flatMap { s =>
+          Try { UUID.fromString(s) } toOption
+        },
+        Option(project.id)
+      ).mapN(
+        AnnotationProject.apply _
+      ),
+      CreateAnnotationProject
+    )
+  }
+
+  private def getAnnotationProjects: ConnectionIO[List[Project]] =
+    ProjectDao.query
+      .filter(
+        Fragment.const("""tags @> '{ "annotate" }'""")
+      )
+      .list
+
+  private def getProjectTaskSizeMeters(
+      project: Project
+  ): ConnectionIO[Either[FailureStage, Int]] = ???
 
   // make an annotation project from the existing project
-  private def createAnnotationProject(project: Project): ConnectionIO[UUID] =
-    ???
+  private def createAnnotationProject(
+      project: Project,
+      extras: Json
+  ): ConnectionIO[Either[FailureStage, UUID]] = {
+    val converted = projectToAnnotationProject(project, extras, ???)
+    converted traverse {
+      case createdBy :: name :: projectType :: taskSizeMeters :: aoi :: labelersId :: validatorsId :: projectId :: HNil =>
+        fr"""
+      insert into annotation_projects (
+        uuid_generate_v4(),
+        now(),
+        ${createdBy},
+        $name,
+        $projectType,
+        $taskSizeMeters,
+        $aoi,
+        $labelersId,
+        $validatorsId,
+        $projectId
+      );
+      """.update.withUniqueGeneratedKeys[UUID]("id")
+    }
+
+  }
 
   // create tiles entries for tms layer
   private def createProjectTiles(
       project: Project,
       annotationProjectId: UUID
-  ): ConnectionIO[Unit] = ???
+  ): ConnectionIO[Either[FailureStage, Unit]] = {
+    // i tried .adaptError(_ => CreateProjectTiles: FailureStage) instead of
+    // the tortured either handling that this wound up with, but adaptError
+    // is invariant in its type parameters
+    fr"""
+      INSERT INTO tiles (
+        uuid_generate_v4(),
+        project.name,
+        s"$tileHost/${project.id}/{z}/{x}/{y}",
+        true,
+        false,
+        'TMS',
+        $annotationProjectId
+      );
+    """.update.run.attempt map { result =>
+      result.bimap(_ => CreateProjectTiles: FailureStage, _ => ())
+    }
+  }
+
+  private def createLabelGroups(
+      extras: Json,
+      annotationProjectId: UUID
+  ): ConnectionIO[Either[FailureStage, List[UUID]]] = {
+    val groupsLens = root.annotate.labelGroups.json
+
+    groupsLens.getOption(extras) flatMap { _.as[Map[UUID, String]].toOption } flatMap {
+      groupsMap =>
+        {
+          val records = groupsMap.zipWithIndex map {
+            case ((groupId, groupName), n) =>
+              Fragment.const(
+                s"($groupId, $groupName, $annotationProjectId, $n)"
+              )
+          }
+          records.toList.toNel
+        }
+    } traverse {
+      case recordsNel =>
+        Fragment.const(s"""
+            INSERT INTO annotation_label_class_groups (
+              id,
+              name,
+              annotation_project_id,
+              idx
+            ) VALUES ${recordsNel.intercalate(fr",")};
+          """).update.withGeneratedKeys[UUID]("id").compile.to[List]
+    }
+  } map { opt =>
+    Either.fromOption(opt, CreateLabelClassGroups)
+  }
+
+  private def getLabelClassInsertFragment(
+      labelClassJson: Json,
+      idx: Int,
+      annotationLabelGroupIds: Set[UUID]
+  ): Either[FailureStage, Fragment] = {
+    // why lenses instead of just decoding to a case class?
+    // I have no idea what the evolution of the extras field looked like.
+    // my assumption is that it changed over time in ways that I won't be able
+    // to figure out from looking at examples, and I don't know what fields are and
+    // aren't necessary. Optics here aren't really different from having a cursor-based
+    // decoder that tolerates missing fields and keeps access / parsing closer to where
+    // I use the data than a case class up top would.
+    val idLens = root.id.string
+    val nameLens = root.name.string
+    val defaultLens = root.default.boolean
+    val labelGroupLens = root.labelGroup.string
+    val determinantLens = root.determinant.boolean
+    val hexCodeLens = root.colorHexCode.string
+
+    (
+      idLens.getOption(labelClassJson),
+      nameLens.getOption(labelClassJson),
+      defaultLens.getOption(labelClassJson) orElse { Some(false) },
+      labelGroupLens.getOption(labelClassJson),
+      determinantLens.getOption(labelClassJson) orElse { Some(false) },
+      hexCodeLens.getOption(labelClassJson)
+    ).mapN {
+      case (
+          idString,
+          name,
+          default,
+          labelGroupIdString,
+          determinant,
+          hexCode
+          ) =>
+        // leftMap necessary because uuid from string can fail,
+        // in which case we get a generic throwable
+        Either
+          .fromTry(
+            Try {
+              val labelGroupId = UUID.fromString(labelGroupIdString)
+              val id = UUID.fromString(idString)
+              if (annotationLabelGroupIds.contains(labelGroupId)) {
+                fr"($id, $name, $labelGroupId, $hexCode, $default, $determinant, $idx)"
+              } else {
+                throw CreateLabelClasses
+              }
+            }
+          )
+          .leftMap { _ =>
+            CreateLabelClasses
+          }
+    } getOrElse { Left(CreateLabelClasses) }
+  }
 
   // maybe (UUID, name)?
   private def createLabelClasses(
-      annotationProjectId: UUID
-  ): ConnectionIO[List[(UUID, String)]] = ???
+      extras: Json,
+      annotationLabelGroupIds: Set[UUID]
+  ): ConnectionIO[Either[FailureStage, List[UUID]]] = {
+    val labelClassesLens = root.annotate.labels.each.json
+    val fragmentsE = labelClassesLens
+      .getAll(extras)
+      .zipWithIndex traverse {
+      case (json, idx) =>
+        getLabelClassInsertFragment(
+          json,
+          idx,
+          annotationLabelGroupIds
+        )
+    } map { _.toNel }
+    fragmentsE match {
+      case Right(Some(recordsNel)) =>
+        Fragment
+          .const(s"""
+            INSERT INTO annotation_label_classes (
+              id,
+              name,
+              annotation_label_group_id,
+              color_hex_code,
+              is_default,
+              is_determinant,
+              idx
+            ) VALUES ${recordsNel.intercalate(fr",")};
+          """)
+          .update
+          .withGeneratedKeys[UUID]("id")
+          .compile
+          .to[List]
+          .attempt
+          .map { result =>
+            result.leftMap { _ =>
+              CreateLabelClasses
+            }
+          }
+      case _ =>
+        // truly astounding sometimes just how little the Scala compiler is able
+        // (or willing) to infer.
+        Either
+          .left[FailureStage, List[UUID]](CreateLabelClasses)
+          .pure[ConnectionIO]
+    }
+
+  }
 
   // create annotation_labels from annotations table
   private def createLabels(
       projectId: UUID,
       annotationProjectId: UUID,
-      classIds: List[(UUID, String)]
-  ): ConnectionIO[Unit] = ???
+      classIds: List[UUID]
+  ): ConnectionIO[Either[FailureStage, Unit]] = ???
 
   // nuke annotate from extras
-  private def nukeStaleData(project: Project): ConnectionIO[Unit] = ???
+  private def nukeStaleData(
+      project: Project
+  ): ConnectionIO[Either[FailureStage, Unit]] = ???
 
   // do all the stuff
-  def freeAMind(project: Project): ConnectionIO[Unit] =
-    for {
-      annotationProjectId <- createAnnotationProject(project)
-      _ <- createProjectTiles(project, annotationProjectId)
-      classIds <- createLabelClasses(annotationProjectId)
-      _ <- createLabels(project.id, annotationProjectId, classIds)
-      _ <- nukeStaleData(project)
-    } yield ()
+  def liberateProject(
+      project: Project
+  ): ConnectionIO[Either[FailureStage, Unit]] = {
+    val extras = project.extras getOrElse { ().asJson }
+    (for {
+      annotationProjectId <- EitherT {
+        createAnnotationProject(project, extras)
+      }
+      _ <- EitherT { createProjectTiles(project, annotationProjectId) }
+      labelGroupIds <- EitherT {
+        createLabelGroups(extras, annotationProjectId)
+      }
+      classIds <- EitherT {
+        createLabelClasses(extras, labelGroupIds.toSet)
+      }
+      _ <- EitherT { createLabels(project.id, annotationProjectId, classIds) }
+      _ <- EitherT { nukeStaleData(project) }
+    } yield ()).value
+  }
+}
+
+object ProjectLiberation extends Job {
+
+  val name: String = "liberate-annotation-projects"
 
   def runJob(args: List[String]): IO[Unit] = ???
+
 }

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -451,7 +451,7 @@ class ProjectLiberation(tileHost: URI) {
 
   def liberateProject(
       project: Project
-  ): ConnectionIO[Either[FailureStage, Unit]] = {
+  ): ConnectionIO[Either[FailureStage, UUID]] = {
     val extras = project.extras getOrElse { ().asJson }
     (for {
       annotationGroupId <- EitherT {
@@ -476,7 +476,7 @@ class ProjectLiberation(tileHost: URI) {
         )
       }
       _ <- EitherT { nukeStaleData(project, annotationGroupId) }
-    } yield ()).value
+    } yield project.id) value
   }
 }
 
@@ -494,7 +494,7 @@ object ProjectLiberation extends Job {
           runner.liberateProject(project).transact(xa)
         }
       } yield {
-        val grouped = results.groupBy(identity).mapValues(_.size)
+        val grouped = results.groupBy(identity)
         println(s"Results: $grouped")
       }
     case _ =>

--- a/app-backend/db/src/main/resources/migrations/V22__make_teams_optional.sql
+++ b/app-backend/db/src/main/resources/migrations/V22__make_teams_optional.sql
@@ -1,0 +1,4 @@
+ALTER TABLE annotation_projects
+  ALTER COLUMN labelers_team_id DROP NOT NULL,
+  ALTER COLUMN validators_team_id DROP NOT NULL,
+  ALTER COLUMN organization_id DROP NOT NULL;

--- a/app-backend/db/src/main/resources/migrations/V22__make_teams_optional.sql
+++ b/app-backend/db/src/main/resources/migrations/V22__make_teams_optional.sql
@@ -1,4 +1,5 @@
 ALTER TABLE annotation_projects
   ALTER COLUMN labelers_team_id DROP NOT NULL,
   ALTER COLUMN validators_team_id DROP NOT NULL,
-  DROP COLUMN organization_id;
+  DROP COLUMN organization_id,
+  ALTER COLUMN task_size_meters DROP NOT NULL;

--- a/app-backend/db/src/main/resources/migrations/V22__make_teams_optional.sql
+++ b/app-backend/db/src/main/resources/migrations/V22__make_teams_optional.sql
@@ -1,4 +1,4 @@
 ALTER TABLE annotation_projects
   ALTER COLUMN labelers_team_id DROP NOT NULL,
   ALTER COLUMN validators_team_id DROP NOT NULL,
-  ALTER COLUMN organization_id DROP NOT NULL;
+  DROP COLUMN organization_id;

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -232,6 +232,10 @@ object Dao extends LazyLogging {
       (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"LIMIT $limit")
         .query[Model]
 
+    /**Provide a stream of responses */
+    def stream: fs2.Stream[ConnectionIO, Model] =
+      listQ.stream
+
     /** Provide a list of responses */
     def list(limit: Int): ConnectionIO[List[Model]] = {
       listQ(limit).to[List]


### PR DESCRIPTION
## Overview

For too long annotation projects have toiled under the heel of a datamodel we built for an entirely different purpose. No longer! Today, annotation projects raise their voices in unison and demand new tables and equal footing with their platform project brethren! etc. It's late and I'm not committed to this joke.

Anyway, this PR adds a batch job that creates annotation projects from existing projects that are marked as annotation projects.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests (these testing instructions -- everything's a private method so no one gets the wrong idea)

### Notes

Why a batch job instead of a migration? Three reasons. Reason 1: I'm going to break staging for annotate to some extent when I move tasks to annotation projects. However, when we _create_ new projects in staging, they'll still become old projects until the switchover is complete in the annotation UI. That means we'll probably have to run the job more than once. Reason 2 is that I looked at rerunnable java migrations and spent 10 minutes trying to get Flyway to know where java migrations were when I wrote them in Scala, and I failed in that 10 minutes, and it didn't seem worth it when I already had another nice rerunnable concept lying around. Reason three is because I was thinking about the sql I'd need to write and started to feel really not pumped about its complexity + the possibility I'd need to do error handling and recovery.

## Testing Instructions

For code review, functions are pretty tightly scoped. For a sense of the overall flow, check out `liberateProject`, which is just a for comprehension that combines other actions. Then you can navigate the flow from there.

For functionality:

- `batch/assembly`, wait until it's done...
- then `./scripts/console batch 'java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main liberate-annotation-projects http://localhost:8081'`
- then for a more reproducible test where I'm not gambling that your database state is compatible with assumptions here (though it's pretty flexible!):
  - `./scripts/load_development_data`
  - `./scripts/psql` -> `update projects set tags = '{ "annotate" }' where id = 'df697018-68ea-4b4e-81b3-50481a4bf15f';`
  - `./scripts/console batch 'java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main liberate-annotation-projects http://localhost:8081'`

Closes #5281 
