### PR TITLE
Add signed PUT url endpoint to uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added `signed-url` endpoint for uploads to send secure PUTs to s3 [#5290](https://github.com/raster-foundry/raster-foundry/pull/5290)
 - Added migration for annotate projects and related items [#5284](https://github.com/raster-foundry/raster-foundry/pull/5284)
 - Added scopes to the API, database, and user creation to control access to resources and endpoints [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270), [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275), [#5278](https://github.com/raster-foundry/raster-foundry/pull/5278) [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277)
 - Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -1,19 +1,22 @@
 package com.rasterfoundry.api.uploads
 
-import java.util.UUID
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.api.utils.Config
+import com.rasterfoundry.common.{AWSBatch, S3}
+import com.rasterfoundry.database.UploadDao
+import com.rasterfoundry.database.filter.Filterables._
+import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.headers.HttpChallenge
 import akka.http.scaladsl.server.{AuthenticationFailedRejection, Route}
 import cats.effect.IO
-import com.rasterfoundry.akkautil._
-import com.rasterfoundry.common.AWSBatch
-import com.rasterfoundry.database.UploadDao
-import com.rasterfoundry.database.filter.Filterables._
-import com.rasterfoundry.datamodel._
+import com.amazonaws.HttpMethod
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+
+import java.util.UUID
 
 trait UploadRoutes
     extends Authentication
@@ -21,8 +24,11 @@ trait UploadRoutes
     with PaginationDirectives
     with CommonHandlers
     with UserErrorHandler
-    with AWSBatch {
+    with AWSBatch
+    with Config {
   val xa: Transactor[IO]
+
+  val s3 = S3()
 
   val uploadRoutes: Route = handleExceptions(userExceptionHandler) {
     pathEndOrSingleSlash {
@@ -243,7 +249,12 @@ trait UploadRoutes
           .unsafeToFuture
       } {
         complete {
-          UploadDao.getSignedPutURL(uploadId).transact(xa).unsafeToFuture()
+          val signed = s3.getSignedUrl(
+            dataBucket,
+            s"user-uploads/${user.id}/${uploadId}/${uploadId}.tif",
+            method = HttpMethod.PUT
+          )
+          Upload.PutUrl(s"$signed")
         }
       }
     }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -132,7 +132,7 @@ final case class S3(
       bucket: String,
       key: String,
       duration: Duration = Duration.ofDays(1),
-      method: HttpMethod = HttpMethod.Get
+      method: HttpMethod = HttpMethod.GET
   ): URL = {
     val expiration = LocalDateTime.now + duration
     val generatePresignedUrlRequest =

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -1,10 +1,5 @@
 package com.rasterfoundry.common
 
-import java.io.File
-import java.net._
-import java.time.{Duration, ZoneOffset}
-import java.util.Date
-
 import com.amazonaws.auth.{
   AWSCredentialsProvider,
   DefaultAWSCredentialsProviderChain
@@ -13,13 +8,18 @@ import com.amazonaws.HttpMethod
 import com.amazonaws.regions._
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder, AmazonS3URI}
-import jp.ne.opt.chronoscala.Imports._
 import geotrellis.spark.io.s3.S3InputFormat
+import jp.ne.opt.chronoscala.Imports._
 import org.apache.commons.io.IOUtils
 
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.mutable
+
+import java.io.File
+import java.net._
+import java.time.{Duration, ZoneOffset}
+import java.util.Date
 
 sealed trait S3Region
 final case class S3RegionEnum(s3Region: Regions) extends S3Region
@@ -132,7 +132,7 @@ final case class S3(
       bucket: String,
       key: String,
       duration: Duration = Duration.ofDays(1),
-      method: HttpMethod + HttpMethod.Get
+      method: HttpMethod = HttpMethod.Get
   ): URL = {
     val expiration = LocalDateTime.now + duration
     val generatePresignedUrlRequest =

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -25,10 +25,11 @@ sealed trait S3Region
 final case class S3RegionEnum(s3Region: Regions) extends S3Region
 final case class S3RegionString(s3Region: String) extends S3Region
 
-final case class S3(credentialsProviderChain: AWSCredentialsProvider =
-                      new DefaultAWSCredentialsProviderChain,
-                    region: Option[S3Region] = None)
-    extends Serializable {
+final case class S3(
+    credentialsProviderChain: AWSCredentialsProvider =
+      new DefaultAWSCredentialsProviderChain,
+    region: Option[S3Region] = None
+) extends Serializable {
 
   lazy val client: AmazonS3 = region match {
     case Some(S3RegionEnum(region)) =>
@@ -46,8 +47,10 @@ final case class S3(credentialsProviderChain: AWSCredentialsProvider =
 
   // we want to ignore here, because uri.getHost returns null instead of an Option[String] -- thanks Java
   @SuppressWarnings(Array("NullParameter"))
-  def bucketAndPrefixFromURI(uri: URI,
-                             stripSlash: Boolean = true): (String, String) = {
+  def bucketAndPrefixFromURI(
+      uri: URI,
+      stripSlash: Boolean = true
+  ): (String, String) = {
     val prefix = uri.getPath match {
       case ""                         => ""
       case "/"                        => ""
@@ -72,9 +75,11 @@ final case class S3(credentialsProviderChain: AWSCredentialsProvider =
     client.getObject(s3uri.getBucket, s3uri.getKey)
   }
 
-  def getObject(s3bucket: String,
-                s3prefix: String,
-                requesterPays: Boolean = false): S3Object =
+  def getObject(
+      s3bucket: String,
+      s3prefix: String,
+      requesterPays: Boolean = false
+  ): S3Object =
     client.getObject(new GetObjectRequest(s3bucket, s3prefix, requesterPays))
 
   def listKeys(url: String, ext: String, recursive: Boolean): Array[URI] = {
@@ -83,11 +88,13 @@ final case class S3(credentialsProviderChain: AWSCredentialsProvider =
   }
 
   /** List the keys to files found within a given bucket */
-  def listKeys(s3bucket: String,
-               s3prefix: String,
-               ext: String,
-               recursive: Boolean = false,
-               requesterPays: Boolean = false): Array[URI] = {
+  def listKeys(
+      s3bucket: String,
+      s3prefix: String,
+      ext: String,
+      recursive: Boolean = false,
+      requesterPays: Boolean = false
+  ): Array[URI] = {
     val objectRequest = (new ListObjectsRequest)
       .withBucketName(s3bucket)
       .withPrefix(s3prefix)
@@ -121,21 +128,26 @@ final case class S3(credentialsProviderChain: AWSCredentialsProvider =
     result
   }
 
-  def getSignedUrl(bucket: String,
-                   key: String,
-                   duration: Duration = Duration.ofDays(1)): URL = {
+  def getSignedUrl(
+      bucket: String,
+      key: String,
+      duration: Duration = Duration.ofDays(1),
+      method: HttpMethod + HttpMethod.Get
+  ): URL = {
     val expiration = LocalDateTime.now + duration
     val generatePresignedUrlRequest =
       new GeneratePresignedUrlRequest(bucket, key)
-    generatePresignedUrlRequest.setMethod(HttpMethod.GET)
+    generatePresignedUrlRequest.setMethod(method)
     generatePresignedUrlRequest.setExpiration(
       Date.from(expiration.toInstant(ZoneOffset.UTC))
     )
     client.generatePresignedUrl(generatePresignedUrlRequest)
   }
 
-  def maybeSignUri(uriString: String,
-                   whitelist: List[String] = List()): String = {
+  def maybeSignUri(
+      uriString: String,
+      whitelist: List[String] = List()
+  ): String = {
     val whitelisted =
       whitelist.map(uriString.startsWith(_)).foldLeft(false)(_ || _)
     if (whitelisted) {
@@ -144,9 +156,11 @@ final case class S3(credentialsProviderChain: AWSCredentialsProvider =
     } else uriString
   }
 
-  def getSignedUrls(source: URI,
-                    duration: Duration = Duration.ofDays(1),
-                    stripSlash: Boolean = true): List[URL] = {
+  def getSignedUrls(
+      source: URI,
+      duration: Duration = Duration.ofDays(1),
+      stripSlash: Boolean = true
+  ): List[URL] = {
     @tailrec
     def get(listing: ObjectListing, accumulator: List[URL]): List[URL] = {
       def getObjects: List[URL] =
@@ -248,11 +262,13 @@ final case class S3(credentialsProviderChain: AWSCredentialsProvider =
 
   /** Copy buckets */
   @tailrec
-  def copyListing(bucket: String,
-                  destBucket: String,
-                  sourcePrefix: String,
-                  destPrefix: String,
-                  listing: ObjectListing): Unit = {
+  def copyListing(
+      bucket: String,
+      destBucket: String,
+      sourcePrefix: String,
+      destPrefix: String,
+      listing: ObjectListing
+  ): Unit = {
     listing.getObjectSummaries.asScala.foreach { os =>
       val key = os.getKey
       client.copyObject(

--- a/app-backend/datamodel/src/main/scala/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/Upload.scala
@@ -1,10 +1,10 @@
 package com.rasterfoundry.datamodel
 
-import java.sql.Timestamp
-import java.util.UUID
-
 import io.circe._
 import io.circe.generic.JsonCodec
+
+import java.sql.Timestamp
+import java.util.UUID
 
 @JsonCodec
 final case class Upload(
@@ -107,4 +107,6 @@ object Upload {
       )
     }
   }
+
+  @JsonCodec final case class PutUrl(signedUrl: String)
 }

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -156,6 +156,4 @@ object UploadDao extends Dao[Upload] {
       }
     }
   }
-
-  def getSignedPutURL(id: UUID): ConnectionIO[Upload.PutUrl] = ???
 }

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -110,7 +110,7 @@ object UploadDao extends Dao[Upload] {
      """ ++ Fragments.whereAndOpt(Some(idFilter))).update.run
     (for {
       oldUpload <- oldUploadIO
-      newStatus <- upload.uploadStatus.pure[ConnectionIO]
+      newStatus = upload.uploadStatus
       nAffected <- recordUpdateIO
       userPlatform <- UserDao.unsafeGetUserPlatform(oldUpload.owner)
       owner <- UserDao.unsafeGetUserById(oldUpload.owner)
@@ -156,4 +156,6 @@ object UploadDao extends Dao[Upload] {
       }
     }
   }
+
+  def getSignedPutURL(id: UUID): ConnectionIO[Upload.PutUrl] = ???
 }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -1197,6 +1197,28 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /uploads/{uploadID}/signed-url:
+    x-resource: Uploads
+    get:
+      summary: 'Get a signed URL to upload data to'
+      tags:
+        - Authentication
+        - Imagery
+      parameters:
+        - $ref: '#/parameters/uploadID'
+      responses:
+        200:
+          description: 'A signed URL for HTTP PUT requests'
+          schema:
+            $ref: '#/definitions/UploadSignedUrlResponse'
+        403:
+          description: 'Insufficient permissions for resource or resource does not exist'
+          schema:
+            $ref: '#/definitions/Error'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /scenes/:
     x-resource: Scenes
     get:
@@ -7291,6 +7313,12 @@ definitions:
         $ref: '#/definitions/UploadCredentials'
       bucketPath:
         type: string
+  UploadSignedUrlResponse:
+    type: object
+    properties:
+      signedUrl:
+        type: string
+        format: uri
   SceneParams:
     type: object
     description: 'scene params'


### PR DESCRIPTION
## Overview

This PR adds a `signed-url` route to uploads to request a location on S3 to send PUT http requests to.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated

## Testing Instructions

- assemble api server
- get a bearer token for the dev user and set it to `$RF_TOKEN`
- get a signed url for the upload in the dev database `http :9091/api/uploads/6d7e3416-2975-4281-9929-251ab8d60e60/signed-url Authorization:$RF_TOKEN`
- `cat <some file> | http PUT 'YOUR SIGNED URL'`
- download the file and confirm that it matches what you `PUT`

Closes #5288 
