### PR TITLE
Redirect to custom url from buildconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 
+- Logout can redirect to a custom URL [#5291](https://github.com/raster-foundry/raster-foundry/pull/5291)
 - Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)
 
 ### Deprecated

--- a/app-frontend/config/webpack/overrides.js.template
+++ b/app-frontend/config/webpack/overrides.js.template
@@ -67,7 +67,8 @@ module.exports = function (_path) {
                     LOGOURL: JSON.stringify(false),
                     FAVICON_DIR: JSON.stringify('/favicon'),
                     PLATFORM_USERS: PLATFORM_USERS,
-                    EMBED_URI: JSON.stringify('')
+                    EMBED_URI: JSON.stringify(''),
+                    LOGOUT_REDIRECT_URL: JSON.stringify('')
                 },
                 'HELPCONFIG': {
                     HELP_DOCS: JSON.stringify(HELP_DOCS)

--- a/app-frontend/src/app/services/auth/auth.service.js
+++ b/app-frontend/src/app/services/auth/auth.service.js
@@ -402,7 +402,9 @@ export default app => {
             let profileName = (profile, dpr) =>
                 (dpr.name !== profile.email ? dpr.name : null) ||
                 (dpr.nickname !== profile.email ? dpr.nickname : null) ||
-                dpr.given_name || '' + dpr.family_name || '' ||
+                dpr.given_name ||
+                '' + dpr.family_name ||
+                '' ||
                 null;
 
             let p = this.getProfile();
@@ -423,6 +425,8 @@ export default app => {
         }
 
         logout() {
+            let logoutRedirectUrl = BUILDCONFIG.LOGOUT_REDIRECT_URL;
+
             if (typeof heap !== 'undefined' && typeof heap.removeEventProperty === 'function') {
                 heap.removeEventProperty('Logged In');
             }
@@ -434,7 +438,9 @@ export default app => {
             this.rollbarWrapperService.init();
             this.isLoggedIn = false;
             this.intercomService.shutdown();
-            this.$state.go('login');
+            return !!logoutRedirectUrl
+                ? window.location.replace(logoutRedirectUrl)
+                : this.$state.go('login');
         }
 
         clearAuthStorage() {


### PR DESCRIPTION
## Overview

This PR allows redirect to an arbitrary custom url on logout.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

TODO added to azavea/raster-foundry-platform#926 to make sure at deployment time that the redirect is set -- this might get hotfixed though in which case that'll become unnecessary

## Testing Instructions

- copy overrides.js.template to overrides.js
- copy helpDocs.json.template to helpdocs.json
- set LOGOUT_REDIRECT_URL to something other than `''`
- start up frontend and servers
- login
- logout
- you should end up at whatever you set LOGOUT_REDIRECT_URL to

Closes azavea/raster-foundry-platform#934
