### PR TITLE
Add a migration to add annotation project id to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added migration for annotate projects and related items [#5284](https://github.com/raster-foundry/raster-foundry/pull/5284)
 - Added scopes to the API, database, and user creation to control access to resources and endpoints [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270), [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275), [#5278](https://github.com/raster-foundry/raster-foundry/pull/5278) [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277), [#5292](https://github.com/raster-foundry/raster-foundry/pull/5292)
 - Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)
+- Added a migration to add annotation project id to tasks [#5296](https://github.com/raster-foundry/raster-foundry/pull/5296)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerTaskRoutes.scala
@@ -99,6 +99,9 @@ trait ProjectLayerTaskRoutes
       }
   }
 
+  // TODO: TaskPropertiesCreate's last param needs to be a real annotate project's ID
+  // It is now just a regular project ID
+  // But this function will change after hooking tasks up with annotation projects
   def createLayerTaskGrid(projectId: UUID, layerId: UUID): Route =
     authenticate { user =>
       authorizeScope(
@@ -120,7 +123,8 @@ trait ProjectLayerTaskRoutes
                     Task.TaskPropertiesCreate(
                       projectId,
                       layerId,
-                      TaskStatus.Unlabeled
+                      TaskStatus.Unlabeled,
+                      projectId
                     ),
                     tgf,
                     user

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -951,7 +951,15 @@ object Generators extends ArbitraryInstances {
       projectId <- uuidGen
       projectLayerId <- uuidGen
       status <- taskStatusGen
-    } yield { Task.TaskPropertiesCreate(projectId, projectLayerId, status) }
+      annotationProjectId <- uuidGen
+    } yield {
+      Task.TaskPropertiesCreate(
+        projectId,
+        projectLayerId,
+        status,
+        annotationProjectId
+      )
+    }
 
   private def taskFeatureCreateGen: Gen[Task.TaskFeatureCreate] =
     for {

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -19,7 +19,8 @@ case class Task(
     status: TaskStatus,
     lockedBy: Option[String],
     lockedOn: Option[Instant],
-    geometry: Projected[Geometry]
+    geometry: Projected[Geometry],
+    annotationProjectId: UUID
 ) {
   def toGeoJSONFeature(actions: List[TaskActionStamp]): Task.TaskFeature = {
     Task.TaskFeature(
@@ -41,7 +42,8 @@ case class Task(
       this.status,
       this.lockedBy,
       this.lockedOn,
-      actions
+      actions,
+      this.annotationProjectId
     )
 }
 
@@ -58,13 +60,15 @@ object Task {
       status: TaskStatus,
       lockedBy: Option[String],
       lockedOn: Option[Instant],
-      actions: List[TaskActionStamp]
+      actions: List[TaskActionStamp],
+      annotationProjectId: UUID
   ) {
     def toCreate: TaskPropertiesCreate = {
       TaskPropertiesCreate(
         this.projectId,
         this.projectLayerId,
-        this.status
+        this.status,
+        this.annotationProjectId
       )
     }
   }
@@ -77,7 +81,8 @@ object Task {
   case class TaskPropertiesCreate(
       projectId: UUID,
       projectLayerId: UUID,
-      status: TaskStatus
+      status: TaskStatus,
+      annotationProjectId: UUID
   )
 
   object TaskPropertiesCreate {
@@ -140,7 +145,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-        )
+          )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -157,12 +162,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-      : Decoder[TaskFeatureCollectionCreate] =
+        : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-      : Encoder[TaskFeatureCollectionCreate] =
+        : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -175,10 +180,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-      : Encoder[TaskGridCreateProperties] =
+        : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-      : Decoder[TaskGridCreateProperties] =
+        : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -145,7 +145,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-          )
+        )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -162,12 +162,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-        : Decoder[TaskFeatureCollectionCreate] =
+      : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-        : Encoder[TaskFeatureCollectionCreate] =
+      : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -180,10 +180,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-        : Encoder[TaskGridCreateProperties] =
+      : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-        : Decoder[TaskGridCreateProperties] =
+      : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/db/src/main/resources/migrations/V24__update_task_annotation_project_id.sql
+++ b/app-backend/db/src/main/resources/migrations/V24__update_task_annotation_project_id.sql
@@ -14,3 +14,5 @@ ALTER TABLE public.tasks VALIDATE CONSTRAINT annotation_project_id_not_null;
 ALTER TABLE public.tasks 
 DROP COLUMN project_id,
 DROP COLUMN project_layer_id;
+
+CREATE INDEX CONCURRENTLY annotation_project_id_idx ON tasks(annotation_project_id);

--- a/app-backend/db/src/main/resources/migrations/V24__update_task_annotation_project_id.sql
+++ b/app-backend/db/src/main/resources/migrations/V24__update_task_annotation_project_id.sql
@@ -1,0 +1,16 @@
+ALTER TABLE public.tasks
+ADD COLUMN annotation_project_id uuid references annotation_projects(id);
+
+ALTER TABLE public.tasks
+ADD CONSTRAINT annotation_project_id_not_null CHECK (annotation_project_id IS NOT NULL) NOT VALID;
+
+UPDATE public.tasks AS t
+SET annotation_project_id = ap.id
+FROM annotation_projects AS ap
+WHERE ap.project_id = t.project_id;
+
+ALTER TABLE public.tasks VALIDATE CONSTRAINT annotation_project_id_not_null;
+
+ALTER TABLE public.tasks 
+DROP COLUMN project_id,
+DROP COLUMN project_layer_id;

--- a/app-backend/db/src/main/resources/migrations/V27__update_task_annotation_project_id.sql
+++ b/app-backend/db/src/main/resources/migrations/V27__update_task_annotation_project_id.sql
@@ -14,5 +14,3 @@ ALTER TABLE public.tasks VALIDATE CONSTRAINT annotation_project_id_not_null;
 ALTER TABLE public.tasks 
 DROP COLUMN project_id,
 DROP COLUMN project_layer_id;
-
-CREATE INDEX CONCURRENTLY annotation_project_id_idx ON tasks(annotation_project_id);

--- a/app-backend/db/src/main/resources/migrations/V27__update_task_annotation_project_id.sql
+++ b/app-backend/db/src/main/resources/migrations/V27__update_task_annotation_project_id.sql
@@ -10,7 +10,3 @@ FROM annotation_projects AS ap
 WHERE ap.project_id = t.project_id;
 
 ALTER TABLE public.tasks VALIDATE CONSTRAINT annotation_project_id_not_null;
-
-ALTER TABLE public.tasks 
-DROP COLUMN project_id,
-DROP COLUMN project_layer_id;

--- a/app-backend/db/src/main/resources/migrations/V28__add_index_to_task_annotation_project_id.sql
+++ b/app-backend/db/src/main/resources/migrations/V28__add_index_to_task_annotation_project_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS annotation_project_id_idx ON tasks(annotation_project_id);

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -41,7 +41,8 @@ object TaskDao extends Dao[Task] {
       status,
       locked_by,
       locked_on,
-      geometry
+      geometry,
+      annotation_project_id
     FROM
     """
 
@@ -63,7 +64,8 @@ object TaskDao extends Dao[Task] {
           status,
           locked_by,
           locked_on,
-          geometry
+          geometry,
+          annotation_project_id
      )
      """
 
@@ -72,7 +74,8 @@ object TaskDao extends Dao[Task] {
       project_id = ${update.properties.projectId},
       project_layer_id = ${update.properties.projectLayerId},
       status = ${update.properties.status},
-      geometry = ${update.geometry}
+      geometry = ${update.geometry},
+      annotation_project_id = ${update.properties.annotationProjectId}
     WHERE
       id = $taskId
     """;
@@ -224,7 +227,7 @@ object TaskDao extends Dao[Task] {
     fr"""(
         ${UUID.randomUUID}, ${Instant.now}, ${user.id}, ${Instant.now}, ${user.id},
         ${tfc.properties.projectId}, ${tfc.properties.projectLayerId}, ${tfc.properties.status},
-        null, null, ${tfc.geometry}
+        null, null, ${tfc.geometry}, ${tfc.properties.annotationProjectId}
     )"""
   }
 
@@ -248,7 +251,8 @@ object TaskDao extends Dao[Task] {
           "status",
           "locked_by",
           "locked_on",
-          "geometry"
+          "geometry",
+          "annotation_project_id"
         )
         .compile
         .toList map { (tasks: List[Task]) =>
@@ -290,7 +294,8 @@ object TaskDao extends Dao[Task] {
           ${taskProperties.status},
           null,
           null,
-          cell
+          cell,
+          ${taskProperties.annotationProjectId},
         FROM (
           SELECT (
             ST_Dump(
@@ -567,7 +572,8 @@ object TaskDao extends Dao[Task] {
                 geomWithStatus.status,
                 None,
                 None,
-                List()
+                List(),
+                UUID.randomUUID()
               ),
               geomWithStatus.geometry
             )

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -295,7 +295,7 @@ object TaskDao extends Dao[Task] {
           null,
           null,
           cell,
-          ${taskProperties.annotationProjectId},
+          ${taskProperties.annotationProjectId}
         FROM (
           SELECT (
             ST_Dump(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationDaoSpec.scala
@@ -325,17 +325,29 @@ class AnnotationDaoSpec
             userCreate: User.Create,
             orgCreate: Organization.Create,
             platform: Platform,
-            (projectAgGroupCreate): (Project.Create, AnnotationGroup.Create),
-            annoAndTaskFeatureCreate: (Task.TaskFeatureCreate,
-                                       List[Annotation.Create]),
+            (projectAgGroupCreate): (
+                Project.Create,
+                AnnotationGroup.Create,
+                AnnotationProject.Create
+            ),
+            annoAndTaskFeatureCreate: (
+                Task.TaskFeatureCreate,
+                List[Annotation.Create]
+            ),
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val (taskFeatureCreate, annotationsCreate) =
               annoAndTaskFeatureCreate
-            val (projectCreate, annotationGroupCreate) = projectAgGroupCreate
+            val (
+              projectCreate,
+              annotationGroupCreate,
+              annotationProjectCreate
+            ) = projectAgGroupCreate
             val labelName = "Car"
             val labelId = UUID.randomUUID()
             val labelGroupId = UUID.randomUUID()
@@ -356,11 +368,21 @@ class AnnotationDaoSpec
                 Some(List((labelId, labelName, labelGroupId))),
                 Some(Map(labelGroupId -> "Car Group"))
               )
+              dbAnnotationProj <- AnnotationProjectDao
+                .insertAnnotationProject(
+                  annotationProjectCreate.copy(
+                    projectId = Some(updatedDbProject.id)
+                  ),
+                  dbUser
+                )
               collection <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
-                    fixupTaskFeatureCreate(taskFeatureCreate, updatedDbProject)
-                      .withStatus(TaskStatus.Labeled)
+                    fixupTaskFeatureCreate(
+                      taskFeatureCreate,
+                      updatedDbProject,
+                      dbAnnotationProj
+                    ).withStatus(TaskStatus.Labeled)
                   )
                 ),
                 dbUser
@@ -369,7 +391,8 @@ class AnnotationDaoSpec
               annotationGroup <- AnnotationGroupDao.createAnnotationGroup(
                 dbProject.id,
                 annotationGroupCreate.copy(name = "label"),
-                dbUser)
+                dbUser
+              )
               updatedAnnotationsCreate = annotationsCreate.map(annoCreate => {
                 annoCreate.copy(
                   label = labelId.toString(),
@@ -406,17 +429,29 @@ class AnnotationDaoSpec
             userCreate: User.Create,
             orgCreate: Organization.Create,
             platform: Platform,
-            (projectAgGroupCreate): (Project.Create, AnnotationGroup.Create),
-            annoAndTaskFeatureCreate: (Task.TaskFeatureCreate,
-                                       List[Annotation.Create]),
+            (projectAgGroupCreate): (
+                Project.Create,
+                AnnotationGroup.Create,
+                AnnotationProject.Create
+            ),
+            annoAndTaskFeatureCreate: (
+                Task.TaskFeatureCreate,
+                List[Annotation.Create]
+            ),
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val (taskFeatureCreate, annotationsCreate) =
               annoAndTaskFeatureCreate
-            val (projectCreate, annotationGroupCreate) = projectAgGroupCreate
+            val (
+              projectCreate,
+              annotationGroupCreate,
+              annotationProjectCreate
+            ) = projectAgGroupCreate
             val labelName = "Car"
             val labelId = UUID.randomUUID()
             val labelGroupId = UUID.randomUUID()
@@ -437,11 +472,21 @@ class AnnotationDaoSpec
                 Some(List((labelId, labelName, labelGroupId))),
                 Some(Map(labelGroupId -> "Car Group"))
               )
+              dbAnnotationProj <- AnnotationProjectDao
+                .insertAnnotationProject(
+                  annotationProjectCreate.copy(
+                    projectId = Some(updatedDbProject.id)
+                  ),
+                  dbUser
+                )
               collection <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
-                    fixupTaskFeatureCreate(taskFeatureCreate, updatedDbProject)
-                      .withStatus(TaskStatus.Labeled)
+                    fixupTaskFeatureCreate(
+                      taskFeatureCreate,
+                      updatedDbProject,
+                      dbAnnotationProj
+                    ).withStatus(TaskStatus.Labeled)
                   )
                 ),
                 dbUser
@@ -450,7 +495,8 @@ class AnnotationDaoSpec
               annotationGroup <- AnnotationGroupDao.createAnnotationGroup(
                 dbProject.id,
                 annotationGroupCreate.copy(name = "label"),
-                dbUser)
+                dbUser
+              )
               updatedAnnotationsCreate = annotationsCreate.map(annoCreate => {
                 annoCreate.copy(
                   label = labelId.toString(),
@@ -486,19 +532,29 @@ class AnnotationDaoSpec
       forAll {
         (
             userOrgPlat: (User.Create, Organization.Create, Platform),
-            (projectAgGroupCreate): (Project.Create, AnnotationGroup.Create),
+            (projectAgGroupCreate): (
+                Project.Create,
+                AnnotationGroup.Create,
+                AnnotationProject.Create
+            ),
             annotationCreates: (Annotation.Create, Annotation.Create),
             taskFeatureCreates: (Task.TaskFeatureCreate, Task.TaskFeatureCreate),
             labelValidateTeamCreate: (Team.Create, Team.Create),
-            labelValidateTeamUgrCreate: (UserGroupRole.Create,
-                                         UserGroupRole.Create)
+            labelValidateTeamUgrCreate: (
+                UserGroupRole.Create,
+                UserGroupRole.Create
+            )
         ) =>
           {
             val (userCreate, orgCreate, platform) = userOrgPlat
             val (taskFeatureCreateOne, taskFeatureCreateTwo) =
               taskFeatureCreates
             val (annotationCreateOne, annotationCreateTwo) = annotationCreates
-            val (projectCreate, annotationGroupCreate) = projectAgGroupCreate
+            val (
+              projectCreate,
+              annotationGroupCreate,
+              annotationProjectCreate
+            ) = projectAgGroupCreate
             val labelNameOne = "Finished"
             val labelIdOne = UUID.randomUUID()
             val labelNameTwo = "Partial"
@@ -525,20 +581,31 @@ class AnnotationDaoSpec
                 Some(
                   List(
                     (labelIdOne, labelNameOne, labelGroupIdOne),
-                    (labelIdTwo, labelNameTwo, labelGroupIdTwo),
-                  )),
+                    (labelIdTwo, labelNameTwo, labelGroupIdTwo)
+                  )
+                ),
                 Some(
                   Map(
                     labelGroupIdOne -> labelGroupNameOne,
                     labelGroupIdTwo -> labelGroupNameTwo
-                  ))
+                  )
+                )
               )
+              dbAnnotationProj <- AnnotationProjectDao
+                .insertAnnotationProject(
+                  annotationProjectCreate.copy(
+                    projectId = Some(updatedDbProject.id)
+                  ),
+                  dbUser
+                )
               taskCollectionOne <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
-                    fixupTaskFeatureCreate(taskFeatureCreateOne,
-                                           updatedDbProject)
-                      .withStatus(TaskStatus.Labeled)
+                    fixupTaskFeatureCreate(
+                      taskFeatureCreateOne,
+                      updatedDbProject,
+                      dbAnnotationProj
+                    ).withStatus(TaskStatus.Labeled)
                   )
                 ),
                 dbUser
@@ -546,9 +613,11 @@ class AnnotationDaoSpec
               taskCollectionTwo <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
-                    fixupTaskFeatureCreate(taskFeatureCreateTwo,
-                                           updatedDbProject)
-                      .withStatus(TaskStatus.Validated)
+                    fixupTaskFeatureCreate(
+                      taskFeatureCreateTwo,
+                      updatedDbProject,
+                      dbAnnotationProj
+                    ).withStatus(TaskStatus.Validated)
                   )
                 ),
                 dbUser
@@ -558,7 +627,8 @@ class AnnotationDaoSpec
               annotationGroup <- AnnotationGroupDao.createAnnotationGroup(
                 dbProject.id,
                 annotationGroupCreate.copy(name = "label"),
-                dbUser)
+                dbUser
+              )
               _ <- AnnotationDao.insertAnnotations(
                 List(
                   annotationCreateOne.copy(
@@ -591,12 +661,12 @@ class AnnotationDaoSpec
             listed.`type` == "FeatureCollection" &&
             listed.features.foldLeft(true)((acc, feature) => {
               acc &&
-              feature.properties.asJson.hcursor
-                .get[String](labelGroupNameOne)
-                .toOption == Some(labelNameOne) &&
-              feature.properties.asJson.hcursor
-                .get[String](labelGroupNameTwo)
-                .toOption == Some(labelNameTwo)
+                feature.properties.asJson.hcursor
+                  .get[String](labelGroupNameOne)
+                  .toOption == Some(labelNameOne) &&
+                feature.properties.asJson.hcursor
+                  .get[String](labelGroupNameTwo)
+                  .toOption == Some(labelNameTwo)
             }) &&
             true
           }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -309,32 +309,42 @@ trait PropTestHelpers {
   def fixupTaskFeaturesCollection(
       tfc: Task.TaskFeatureCollectionCreate,
       project: Project,
+      annotationProject: AnnotationProject.WithRelated,
       statusOption: Option[TaskStatus] = None
   ) =
     tfc.copy(
       features =
-        tfc.features map { fixupTaskFeatureCreate(_, project, statusOption) }
+        tfc.features map {
+          fixupTaskFeatureCreate(_, project, annotationProject, statusOption)
+        }
     )
 
   def fixupTaskFeatureCreate(
       tfc: Task.TaskFeatureCreate,
       project: Project,
+      annotationProject: AnnotationProject.WithRelated,
       statusOption: Option[TaskStatus] = None
   ): Task.TaskFeatureCreate =
     tfc.copy(
-      properties =
-        fixupTaskPropertiesCreate(tfc.properties, project, statusOption)
+      properties = fixupTaskPropertiesCreate(
+        tfc.properties,
+        project,
+        annotationProject,
+        statusOption
+      )
     )
 
   def fixupTaskPropertiesCreate(
       tpc: Task.TaskPropertiesCreate,
       project: Project,
+      annotationProject: AnnotationProject.WithRelated,
       statusOption: Option[TaskStatus] = None
   ): Task.TaskPropertiesCreate =
     tpc.copy(
       projectId = project.id,
       projectLayerId = project.defaultLayerId,
-      status = statusOption.getOrElse(tpc.status)
+      status = statusOption.getOrElse(tpc.status),
+      annotationProjectId = annotationProject.id
     )
 
   def fixupProjectExtrasUpdate(
@@ -420,7 +430,8 @@ trait PropTestHelpers {
           true,
           None,
           labelGroups
-        ))
+        )
+      )
     case _ =>
       val defaultLabelId = UUID.randomUUID()
       val defaultLayerGroupId = UUID.randomUUID()
@@ -442,7 +453,8 @@ trait PropTestHelpers {
           true,
           None,
           Map(defaultLayerGroupId -> "Test Group")
-        ))
+        )
+      )
   }
 
   def fixupStacExportCreate(


### PR DESCRIPTION
## Overview

This PR adds a migration to add a `annotation_project_id` field to `tasks` table and populates this field with `id`s of `annotation_projects` project. 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~

### Demo

```
$ ./scripts/migrate migrate
[RF-API] Running migrations with docker-compose
Starting raster-foundry_postgres_1 ... done
Flyway Community Edition 5.2.4 by Boxfuse
Database: jdbc:postgresql://database.service.rasterfoundry.internal/ (PostgreSQL 9.6)
Successfully validated 33 migrations (execution time 00:00.450s)
Current version of schema "public": 23
Migrating schema "public" to version 24 - update task annotation project id
Successfully applied 1 migration to schema "public" (execution time 00:00.193s)
```

## Testing Instructions

- Follow steps here: https://github.com/raster-foundry/raster-foundry/pull/5286 if there is no annotation project in your DB
- `./scripts/migrate migrate`
- make sure it works and make sure it adds a new `annotation_project_id` column to `tasks` column with right constraints and has values populated

Closes https://github.com/raster-foundry/raster-foundry/issues/5289
