### PR TITLE
Add AnnotationLabel model and dao

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ api-server/.ensime_cache/*
 metals.lock.db
 .metals/
 .bloop/
+metals.sbt
 
 /.env
 /.envrc

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -34,9 +34,12 @@ val scalaOptions = Seq(
   "-Ywarn-unused-import",
   "-Ypartial-unification",
   "-Ybackend-parallelism",
-  "4",
-  "-Ypatmat-exhaust-depth",
-  "100"
+  "4"
+  // This options appears to be broken. bloop appends some params after it, and
+  // the compiler treats them as additional parameters to this argument, despite
+  // it being a single param argument
+  // "-Ypatmat-exhaust-depth",
+  // "100"
 )
 
 /**

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -11,7 +11,6 @@ import io.circe._
 import io.circe.syntax._
 import io.circe.generic.semiauto._
 
-
 final case class AnnotationLabel(
     id: UUID,
     createdAt: Timestamp,
@@ -70,10 +69,10 @@ object AnnotationLabelWithClasses {
   def tupled = (AnnotationLabel.apply _).tupled
 
   final case class Create(
-    geometry: Option[Projected[Geometry]],
-    annotationProjectId: UUID,
-    annotationTaskId: UUID,
-    annotationLabelClasses: List[UUID]
+      geometry: Option[Projected[Geometry]],
+      annotationProjectId: UUID,
+      annotationTaskId: UUID,
+      annotationLabelClasses: List[UUID]
   ) {
     def toAnnotationLabelWithClasses(user: User): AnnotationLabelWithClasses = {
       val now = new Timestamp(new java.util.Date().getTime)
@@ -96,13 +95,14 @@ object AnnotationLabelWithClasses {
       properties: AnnotationLabelWithClassesProperties,
       _type: String = "Feature"
   ) extends GeoJSONFeature
-  
+
   @JsonCodec
   final case class GeoJSONFeatureCreate(
-    geometry: Option[Projected[Geometry]],
-    properties: AnnotationLabelWithClassesPropertiesCreate
+      geometry: Option[Projected[Geometry]],
+      properties: AnnotationLabelWithClassesPropertiesCreate
   ) {
-    def toAnnotationLabelWithClassesCreate: AnnotationLabelWithClasses.Create = {
+    def toAnnotationLabelWithClassesCreate
+      : AnnotationLabelWithClasses.Create = {
       AnnotationLabelWithClasses.Create(
         geometry,
         properties.annotationProjectId,
@@ -111,7 +111,6 @@ object AnnotationLabelWithClasses {
       )
     }
   }
-  
 
   object GeoJSON {
     implicit val annoLabelWithClassesGeojonEncoder: Encoder[GeoJSON] =
@@ -124,9 +123,9 @@ object AnnotationLabelWithClasses {
 
 @JsonCodec
 final case class AnnotationLabelWithClassesPropertiesCreate(
-  annotationProjectId: UUID,
-  annotationTaskId: UUID,
-  annotationLabelClasses: List[UUID]
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+    annotationLabelClasses: List[UUID]
 )
 
 @JsonCodec
@@ -142,7 +141,8 @@ object AnnotationLabelWithClassesProperties {
   implicit val annotationLabelWithClassesPropertiesEncoder
     : Encoder[AnnotationLabelWithClassesProperties] =
     new Encoder[AnnotationLabelWithClassesProperties] {
-      final def apply(properties: AnnotationLabelWithClassesProperties): Json = {
+      final def apply(
+          properties: AnnotationLabelWithClassesProperties): Json = {
         (
           Map(
             "createdAt" -> properties.createdAt.asJson,

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -1,0 +1,168 @@
+package com.rasterfoundry.datamodel
+
+import java.sql.Timestamp
+import java.util.UUID
+
+import geotrellis.vector.{Geometry, Projected, io => _}
+import io.circe.generic.JsonCodec
+import io.circe.generic.extras._
+import io.circe.Encoder
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+
+
+final case class AnnotationLabel(
+    id: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    geometry: Option[Projected[Geometry]],
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+)
+
+final case class AnnotationLabelProperties(
+    createdAt: Timestamp,
+    createdBy: String,
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+)
+
+final case class AnnotationLabelPropertiesCreate(
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+)
+
+@JsonCodec
+final case class AnnotationLabelWithClassesFeatureCollectionCreate(
+    features: Seq[AnnotationLabelWithClasses.GeoJSONFeatureCreate]
+)
+
+@JsonCodec
+final case class AnnotationLabelWithClasses(
+    id: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    geometry: Option[Projected[Geometry]],
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+    annotationLabelClasses: List[UUID]
+) extends GeoJSONSerializable[AnnotationLabelWithClasses.GeoJSON] {
+  def toGeoJSONFeature = AnnotationLabelWithClasses.GeoJSON(
+    this.id,
+    this.geometry,
+    AnnotationLabelWithClassesProperties(
+      this.createdAt,
+      this.createdBy,
+      this.annotationProjectId,
+      this.annotationTaskId,
+      this.annotationLabelClasses
+    )
+  )
+}
+
+object AnnotationLabelWithClasses {
+  implicit val config: Configuration =
+    Configuration.default.copy(transformMemberNames = {
+      case "_type" => "type"
+      case other   => other
+    })
+  def tupled = (AnnotationLabel.apply _).tupled
+
+  final case class Create(
+    geometry: Option[Projected[Geometry]],
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+    annotationLabelClasses: List[UUID]
+  ) {
+    def toAnnotationLabelWithClasses(user: User): AnnotationLabelWithClasses = {
+      val now = new Timestamp(new java.util.Date().getTime)
+      AnnotationLabelWithClasses(
+        UUID.randomUUID,
+        now,
+        user.id,
+        geometry,
+        annotationProjectId,
+        annotationTaskId,
+        annotationLabelClasses
+      )
+    }
+  }
+
+  @ConfiguredJsonCodec
+  final case class GeoJSON(
+      id: UUID,
+      geometry: Option[Projected[Geometry]],
+      properties: AnnotationLabelWithClassesProperties,
+      _type: String = "Feature"
+  ) extends GeoJSONFeature
+  
+  @JsonCodec
+  final case class GeoJSONFeatureCreate(
+    geometry: Option[Projected[Geometry]],
+    properties: AnnotationLabelWithClassesPropertiesCreate
+  ) {
+    def toAnnotationLabelWithClassesCreate: AnnotationLabelWithClasses.Create = {
+      AnnotationLabelWithClasses.Create(
+        geometry,
+        properties.annotationProjectId,
+        properties.annotationTaskId,
+        properties.annotationLabelClasses
+      )
+    }
+  }
+  
+
+  object GeoJSON {
+    implicit val annoLabelWithClassesGeojonEncoder: Encoder[GeoJSON] =
+      Encoder.forProduct4("id", "geometry", "properties", "type")(
+        geojson =>
+          (geojson.id, geojson.geometry, geojson.properties, geojson._type)
+      )
+  }
+}
+
+@JsonCodec
+final case class AnnotationLabelWithClassesPropertiesCreate(
+  annotationProjectId: UUID,
+  annotationTaskId: UUID,
+  annotationLabelClasses: List[UUID]
+)
+
+@JsonCodec
+final case class AnnotationLabelWithClassesProperties(
+    createdAt: Timestamp,
+    createdBy: String,
+    annotationProjectId: UUID,
+    annotationTaskId: UUID,
+    annotationLabelClasses: List[UUID]
+)
+
+object AnnotationLabelWithClassesProperties {
+  implicit val annotationLabelWithClassesPropertiesEncoder
+    : Encoder[AnnotationLabelWithClassesProperties] =
+    new Encoder[AnnotationLabelWithClassesProperties] {
+      final def apply(properties: AnnotationLabelWithClassesProperties): Json = {
+        (
+          Map(
+            "createdAt" -> properties.createdAt.asJson,
+            "createdBy" -> properties.createdBy.asJson,
+            "annotationProjectId" -> properties.annotationProjectId.asJson,
+            "annotationTaskId" -> properties.annotationTaskId.asJson,
+            "annotationLabelClasses" -> properties.annotationLabelClasses.asJson
+          )
+        ).asJson
+      }
+    }
+}
+
+final case class AnnotationLabelWithClassesFeatureCollection(
+    features: List[AnnotationLabelWithClasses.GeoJSON],
+    `type`: String = "FeatureCollection"
+)
+
+object AnnotationLabelWithClassesFeatureCollection {
+  implicit val annoLabelWithClassesFCEncoder
+    : Encoder[AnnotationLabelWithClassesFeatureCollection] =
+    deriveEncoder[AnnotationLabelWithClassesFeatureCollection]
+}

--- a/app-backend/db/src/main/scala/util/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/util/AnnotationLabelDao.scala
@@ -1,0 +1,99 @@
+package com.rasterfoundry.database
+
+import java.util.UUID
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.database.Implicits._
+
+object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
+  val tableName = "annotation_labels"
+  val joinTableName = "annotation_labels_annotation_label_classes"
+  val selectF: Fragment = fr"""
+  SELECT
+    id, created_at, created_by, annotation_project_id, annotation_task_id,
+    classes.class_ids as annotation_label_classes, geometry
+  FROM ${tableName} JOIN (
+    SELECT annotation_label_id, array_agg(annotation_class_id) as class_ids
+    FROM ${joinTableName}
+    GROUP BY annotation_label_id
+  ) as classes
+  """
+  def insertAnnotations(
+      annotations: List[AnnotationLabelWithClasses.Create],
+      user: User
+  ): ConnectionIO[List[AnnotationLabelWithClasses]] = {
+    val insertAnnotationsFragment: Fragment = fr"""
+    INSERT INTO ${tableName} (
+      id, created_at, created_by, annotation_project_id, annotation_task_id, geometry
+    ) VALUES
+    """
+    val insertClassesFragment: Fragment = fr"""
+    INSERT INTO ${joinTableName} (
+      annotation_label_id, annotation_label_class_id
+    ) VALUES
+    """
+    val annotationLabelsWithClasses =
+      annotations.map(_.toAnnotationLabelWithClasses(user))
+    val annotationFragments: List[Fragment] = annotationLabelsWithClasses.map(
+      (annotationLabel: AnnotationLabelWithClasses) => fr"""(
+         ${annotationLabel.id}, ${annotationLabel.createdAt},
+        ${annotationLabel.createdBy}, ${annotationLabel.annotationProjectId},
+        ${annotationLabel.annotationTaskId}, ${annotationLabel.geometry}
+       )"""
+    )
+    val labelClassFragments: List[Fragment] = annotationLabelsWithClasses.flatMap(
+      (annotationLabel: AnnotationLabelWithClasses) =>
+        annotationLabel.annotationLabelClasses
+          .map(
+            labelClassId => fr"${annotationLabel.id}, ${labelClassId}"
+          )
+          .toList
+    )
+    for {
+      insertedAnnotations <- annotationFragments.toNel.map(
+        fragments =>
+          (insertAnnotationsFragment ++ fragments.intercalate(fr",")).update
+            .withGeneratedKeys[AnnotationLabel](
+              "id",
+              "created_at",
+              "created_by",
+              "annotation_project_id",
+              "annotation_task_id"
+            )
+            .compile
+            .toList
+      ).getOrElse(List[AnnotationLabel]().pure[ConnectionIO])
+      insertedAnnotationClasses <- labelClassFragments.toNel.map(
+        fragments =>
+          (insertClassesFragment ++ fragments.intercalate(fr",")).update
+            .withGeneratedKeys[(UUID, UUID)](
+              "annotation_label_id",
+              "annotation_label_class_id"
+            ).compile.toList
+      ).getOrElse(List[(UUID,UUID)]().pure[ConnectionIO])
+      labelsToClasses = insertedAnnotationClasses.groupBy(_._1)
+      insertedAnnotationsWithClasses = insertedAnnotations.map(
+        anno =>
+          AnnotationLabelWithClasses(
+            anno.id,
+            anno.createdAt,
+            anno.createdBy,
+            anno.geometry,
+            anno.annotationProjectId,
+            anno.annotationTaskId,
+            labelsToClasses.getOrElse(anno.id, Seq[(UUID,UUID)]()).map(_._2).toList
+          )
+      )
+    } yield insertedAnnotationsWithClasses
+  }
+
+  def listProjectLabels(
+      projectId: UUID
+  ): ConnectionIO[List[AnnotationLabelWithClasses]] = {
+    query.filter(fr"annotation_project_id = ${projectId}").list
+  }
+}


### PR DESCRIPTION
## Overview
* Add model for AnnotationLabel. AnnotationLabelWithClasses is what we want to be sending to/from the API, AnnotationLabel is used internally for deserializing stuff from the database.
* Implemented the insert and list dao functions.
* Disable compiler option that seems to be breaking metals/bloop
### Checklist

- [ ] ~~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~~
- [ ] ~~Swagger specification updated~~
- [ ] ~~New tables and queries have appropriate indices added~~
- [ ] ~~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~~
- [ ] ~~Any new SQL strings have tests~~ See https://github.com/raster-foundry/raster-foundry/issues/5302

## Testing Instructions

- Verify that it compiles and the queries make sense
