### PR TITLE
Handle more classes of errors in annotation project migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changed
 
+- Improved error handling in Groundwork project migration [#5310](https://github.com/raster-foundry/raster-foundry/pull/5310)
 - Logout can redirect to a custom URL [#5291](https://github.com/raster-foundry/raster-foundry/pull/5291)
 - Moved project data for Groundwork from extras jsonb field and a text field to normalized tables [#5286](https://github.com/raster-foundry/raster-foundry/pull/5286)
 - Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -423,8 +423,8 @@ class ProjectLiberation(tileHost: URI) {
       CreateLabels: FailureStage
     } flatMap { classes =>
       Either.fromOption(
-        classes.intersect(classIds.keys.toList).toList flatMap {
-          key => classIds.get(key)
+        classes.intersect(classIds.keys.toList).toList flatMap { key =>
+          classIds.get(key)
         } toNel,
         CreateLabels: FailureStage
       )

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -178,7 +178,9 @@ class ProjectLiberation(tileHost: URI) {
           .attempt
           .map({ result =>
             result.leftMap({ err =>
-              println(s"Err in annotation project creation for ${project.id} was: $err")
+              println(
+                s"Err in annotation project creation for ${project.id} was: $err"
+              )
               CreateAnnotationProject
             })
           })
@@ -245,8 +247,19 @@ class ProjectLiberation(tileHost: URI) {
           .withGeneratedKeys[UUID]("id")
           .compile
           .to[List]
+          .attempt
+          .map({
+            case Right(ids) => Right(ids)
+            case Left(err) =>
+              println(
+                s"Err in label class group creation was: $err"
+              )
+              Left(CreateLabelClassGroups)
+          })
     } map { opt =>
-      Either.fromOption(opt, CreateLabelClassGroups)
+      opt getOrElse {
+        Either.left[FailureStage, List[UUID]](CreateLabelClassGroups)
+      }
     }
   }
 

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -493,7 +493,10 @@ class ProjectLiberation(tileHost: URI) {
       annotationGroupId: UUID
   ): ConnectionIO[Either[FailureStage, Unit]] = {
     val removeAnnotateKey = fr"""
-        UPDATE projects SET extras = extras - 'annotate' where id = ${project.id}
+        UPDATE projects
+        SET extras = extras - 'annotate',
+            tags = array_remove(tags, 'annotate')
+        WHERE id = ${project.id}
     """
     (AnnotationDao.deleteByProjectLayer(project.id) *>
       AnnotationGroupDao.query.filter(annotationGroupId).delete *>

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -423,7 +423,9 @@ class ProjectLiberation(tileHost: URI) {
       CreateLabels: FailureStage
     } flatMap { classes =>
       Either.fromOption(
-        classes.intersect(classIds.keys.toList).toList.toNel,
+        classes.intersect(classIds.keys.toList).toList flatMap {
+          key => classIds.get(key)
+        } toNel,
         CreateLabels: FailureStage
       )
     }

--- a/app-backend/batch/src/main/scala/projectLiberation/Job.scala
+++ b/app-backend/batch/src/main/scala/projectLiberation/Job.scala
@@ -487,6 +487,7 @@ class ProjectLiberation(tileHost: URI) {
   def liberateProject(
       project: Project
   ): ConnectionIO[Either[(FailureStage, UUID), UUID]] = {
+    println(s"Liberating project: ${project.id}")
     val extras = project.extras getOrElse { ().asJson }
     (for {
       annotationGroupId <- EitherT {

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -30,16 +30,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         ./scripts/bootstrap --env
         ./scripts/bootstrap --sbtopts
 
-#        echo "Building static asset bundle"
-#        docker-compose \
-#            -f "${DIR}/../docker-compose.yml" \
-#            -f "${DIR}/../docker-compose.test.yml" \
-#            run --rm app-frontend install
-#        docker-compose \
-#            -f "${DIR}/../docker-compose.yml" \
-#            -f "${DIR}/../docker-compose.test.yml" \
-#            run --rm app-frontend run build
-#
+        echo "Building static asset bundle"
+        docker-compose \
+            -f "${DIR}/../docker-compose.yml" \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm app-frontend install
+        docker-compose \
+            -f "${DIR}/../docker-compose.yml" \
+            -f "${DIR}/../docker-compose.test.yml" \
+            run --rm app-frontend run build
+
         echo "Building JARs (batch, backsplash-export)"
         docker-compose \
             -f "${DIR}/../docker-compose.test.yml" \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -58,8 +58,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -f "${DIR}/../docker-compose.test.yml" \
                   build batch
 
-#        echo "Running tests"
-#        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
-#        echo "All tests pass!"
+        echo "Running tests"
+        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
+        echo "All tests pass!"
     fi
 fi

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -30,16 +30,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         ./scripts/bootstrap --env
         ./scripts/bootstrap --sbtopts
 
-        echo "Building static asset bundle"
-        docker-compose \
-            -f "${DIR}/../docker-compose.yml" \
-            -f "${DIR}/../docker-compose.test.yml" \
-            run --rm app-frontend install
-        docker-compose \
-            -f "${DIR}/../docker-compose.yml" \
-            -f "${DIR}/../docker-compose.test.yml" \
-            run --rm app-frontend run build
-
+#        echo "Building static asset bundle"
+#        docker-compose \
+#            -f "${DIR}/../docker-compose.yml" \
+#            -f "${DIR}/../docker-compose.test.yml" \
+#            run --rm app-frontend install
+#        docker-compose \
+#            -f "${DIR}/../docker-compose.yml" \
+#            -f "${DIR}/../docker-compose.test.yml" \
+#            run --rm app-frontend run build
+#
         echo "Building JARs (batch, backsplash-export)"
         docker-compose \
             -f "${DIR}/../docker-compose.test.yml" \
@@ -58,8 +58,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   -f "${DIR}/../docker-compose.test.yml" \
                   build batch
 
-        echo "Running tests"
-        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
-        echo "All tests pass!"
+#        echo "Running tests"
+#        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
+#        echo "All tests pass!"
     fi
 fi


### PR DESCRIPTION
## Overview

This PR makes the annotation project migration async job tolerant of more kinds of errors than it was previously.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Any new SQL strings have tests~ nope

### Notes

~Has been run against staging / copy of prod db, mainly needs to be CI'ed after CI gets un-nuked~

## Testing Instructions

- run it against a copy of the prod db and verify that everything that goes wrong is explicable and we have a plan for it

Closes azavea/raster-foundry-platform#952
