### PR TITLE
Make scope resolution smarter about limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Changed
 
+- Altered permission resolution to prefer scoped actions with higher limits [#5316](https://github.com/raster-foundry/raster-foundry/pull/5316/files)
 - Improved error handling in Groundwork project migration [#5310](https://github.com/raster-foundry/raster-foundry/pull/5310)
 - Logout can redirect to a custom URL [#5291](https://github.com/raster-foundry/raster-foundry/pull/5291)
 - Moved project data for Groundwork from extras jsonb field and a text field to normalized tables [#5286](https://github.com/raster-foundry/raster-foundry/pull/5286)

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -18,6 +18,7 @@ import scala.util.{Failure, Success, Try}
 sealed abstract class Domain(repr: String) {
   override def toString: String = repr
 }
+
 object Domain {
   case object Analyses extends Domain("analyses")
   case object AnnotationGroups extends Domain("annotationGroups")
@@ -219,7 +220,7 @@ object SimpleScope {
   }
 }
 
-sealed class ComplexScope(scopes: Set[Scope]) extends Scope {
+sealed class ComplexScope(val scopes: Set[Scope]) extends Scope {
   val actions: Set[ScopedAction] = scopes flatMap { _.actions }
 }
 
@@ -290,6 +291,28 @@ object Scope {
 }
 
 object Scopes {
+
+  def resolveFor(
+      domain: Domain,
+      action: Action,
+      actions: Set[ScopedAction]
+  ): Option[ScopedAction] =
+    actions.foldLeft(Option.empty[ScopedAction])(
+      (resolved: Option[ScopedAction], candidate: ScopedAction) => {
+        if (candidate.domain != domain || candidate.action != action) {
+          resolved
+        } else {
+          resolved map { resolvedAction =>
+            (resolvedAction.limit, candidate.limit) match {
+              case (Some(lim1), Some(lim2)) =>
+                if (lim1 > lim2) resolvedAction else candidate
+              case (Some(_), None) => candidate
+              case (None, _)       => resolvedAction
+            }
+          } orElse { Some(candidate) }
+        }
+      }
+    )
 
   def cannedPolicyFromString(s: String): Either[Error, Scope] = s match {
     case "organizations:admin" =>

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -220,7 +220,7 @@ object SimpleScope {
   }
 }
 
-sealed class ComplexScope(val scopes: Set[Scope]) extends Scope {
+sealed class ComplexScope(scopes: Set[Scope]) extends Scope {
   val actions: Set[ScopedAction] = scopes flatMap { _.actions }
 }
 

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -141,5 +141,31 @@ class ScopeSpec
       )
     )
   }
-  // TODO test some permissions relationships
+
+  test("action resolution prefers ScopedActions without limits") {
+    val action1 = ScopedAction(Domain.Projects, Action.Create, None)
+    val action2 = ScopedAction(Domain.Projects, Action.Create, Some(10L))
+    assert(
+      Scopes
+        .resolveFor(Domain.Projects, Action.Create, Set(action1, action2)) == Some(
+        action1
+      )
+    )
+  }
+
+  test("action resolution prefers higher limits to lower limits") {
+    val action1 = ScopedAction(Domain.Projects, Action.Create, Some(5L))
+    val action2 = ScopedAction(Domain.Projects, Action.Create, Some(10L))
+    assert(
+      Scopes
+        .resolveFor(Domain.Projects, Action.Create, Set(action1, action2)) == Some(
+        action2
+      )
+    )
+  }
+
+  test("action resolution should not resolve missing actions") {
+    val action = ScopedAction(Domain.Projects, Action.Create, Some(5L))
+    assert(Scopes.resolveFor(Domain.Scenes, Action.Create, Set(action)).isEmpty)
+  }
 }


### PR DESCRIPTION
## Overview

This PR makes scope resolution follow rules for resolving scoped actions for a given domain and action. If two scoped actions have the same domain and action, the following rules are applied:

- if one has a limit and the other doesn't, prefer the one without a limit
- if both have limits, prefer the higher limit

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Optional. Screenshots, `curl` examples, etc.

## Testing Instructions

- confirm changes make sense
- I wanted local testing instructions but annotate pointing to local rf seems kind of broken right now, so :man_shrugging:
- we could push this to a test branch to prove things, but I think the changes are small enough and easy enough to reason about that I don't think that's necessary

Closes #5315 