### PR TITLE
Add annotation label list and delete Dao methods, endpoints, tests; Add annotation project list action endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Added scopes to the API, database, and user creation to control access to resources and endpoints [#5270](https://github.com/raster-foundry/raster-foundry/pull/5270), [#5275](https://github.com/raster-foundry/raster-foundry/pull/5275), [#5278](https://github.com/raster-foundry/raster-foundry/pull/5278) [#5277](https://github.com/raster-foundry/raster-foundry/pull/5277), [#5292](https://github.com/raster-foundry/raster-foundry/pull/5292)
 - Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)
 - Added a migration to add annotation project id to tasks [#5296](https://github.com/raster-foundry/raster-foundry/pull/5296)
-- Added annotation project related data models, `Dao` methods, endpoints, and tests [#5301](https://github.com/raster-foundry/raster-foundry/pull/5301), [#5303](https://github.com/raster-foundry/raster-foundry/pull/5303), [#5308](https://github.com/raster-foundry/raster-foundry/pull/5308)
+- Added annotation project related data models, `Dao` methods, endpoints, and tests [#5301](https://github.com/raster-foundry/raster-foundry/pull/5301), [#5303](https://github.com/raster-foundry/raster-foundry/pull/5303), [#5308](https://github.com/raster-foundry/raster-foundry/pull/5308), [#5318](https://github.com/raster-foundry/raster-foundry/pull/5318)
 
 ### Changed
 

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -36,6 +36,8 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/lock/,annotationProjects:createAnnotation,post
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/lock/,annotationProjects:createAnnotation,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:createAnnotation,post
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:read,get
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:deleteAnnotation,delete
 /api/licenses/,licenses:read,get
 /api/licenses/{licenseID},licenses:read,get
 /api/map-tokens/,mapTokens:read,get

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -403,13 +403,11 @@ trait AnnotationProjectTaskRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          onSuccess(
+          complete {
             AnnotationLabelDao
               .deleteByProjectIdAndTaskId(projectId, task)
               .transact(xa)
               .unsafeToFuture
-          ) {
-            completeSomeOrNotFound
           }
         }
       }

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -326,25 +326,14 @@ trait AnnotationProjectTaskRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          (withPagination) { (page: PageRequest) =>
-            complete {
-              AnnotationLabelDao
-                .listWithClassesByProjectIdAndTaskId(
-                  page,
-                  projectId,
-                  taskId
-                )
-                .transact(xa)
-                .unsafeToFuture
-                .map { p =>
-                  {
-                    fromPaginatedResponseToGeoJson[
-                      AnnotationLabelWithClasses,
-                      AnnotationLabelWithClasses.GeoJSON
-                    ](p)
-                  }
-                }
-            }
+          complete {
+            AnnotationLabelDao
+              .listWithClassesByProjectIdAndTaskId(
+                projectId,
+                taskId
+              )
+              .transact(xa)
+              .unsafeToFuture
           }
         }
       }

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -103,9 +103,15 @@ trait AnnotationProjectRoutes
                 } ~
                   pathPrefix("labels") {
                     pathEndOrSingleSlash {
-                      post {
-                        addTaskLabels(projectId, taskId)
-                      }
+                      get {
+                        listTaskLabels(projectId, taskId)
+                      } ~
+                        post {
+                          addTaskLabels(projectId, taskId)
+                        } ~
+                        delete {
+                          deleteTaskLabels(projectId, taskId)
+                        }
                     }
                   }
               }

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -8,6 +8,7 @@ import com.rasterfoundry.datamodel._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
 import cats.effect.IO
+import cats.implicits._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
@@ -115,7 +116,13 @@ trait AnnotationProjectRoutes
                     }
                   }
               }
+          } ~ pathPrefix("actions") {
+          pathEndOrSingleSlash {
+            get {
+              listUserActions(projectId)
+            }
           }
+        }
       }
   }
 
@@ -240,6 +247,49 @@ trait AnnotationProjectRoutes
             .unsafeToFuture
         ) {
           completeSingleOrNotFound
+        }
+      }
+    }
+  }
+
+  def listUserActions(projectId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        AnnotationProjectDao
+          .authorized(
+            user,
+            ObjectType.AnnotationProject,
+            projectId,
+            ActionType.View
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        user.isSuperuser match {
+          case true => complete(List("*"))
+          case false =>
+            onSuccess(
+              AnnotationProjectDao
+                .getById(projectId)
+                .transact(xa)
+                .unsafeToFuture
+            ) { projectO =>
+              complete {
+                (projectO map { project =>
+                  project.createdBy == user.id match {
+                    case true => List("*").pure[ConnectionIO]
+                    case false =>
+                      AnnotationProjectDao
+                        .listUserActions(user, projectId)
+                  }
+                } getOrElse { List[String]().pure[ConnectionIO] })
+                  .transact(xa)
+                  .unsafeToFuture()
+              }
+            }
         }
       }
     }

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -38,7 +38,8 @@ trait ProjectAnnotationRoutes
             .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
             .transact(xa)
             .unsafeToFuture
-            .map(_.toBoolean)) | projectIsPublic(projectId)) {
+            .map(_.toBoolean)
+        ) | projectIsPublic(projectId)) {
           (withPagination & annotationQueryParams) {
             (page: PageRequest, queryParams: AnnotationQueryParameters) =>
               complete {
@@ -207,13 +208,11 @@ trait ProjectAnnotationRoutes
           .transact(xa)
           .unsafeToFuture
       } {
-        onSuccess(
+        complete {
           AnnotationDao
             .deleteByProjectLayer(projectId)
             .transact(xa)
             .unsafeToFuture
-        ) {
-          completeSomeOrNotFound
         }
       }
     }

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -162,13 +162,11 @@ trait ProjectLayerAnnotationRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          onSuccess(
+          complete {
             AnnotationDao
               .deleteByProjectLayer(projectId, Some(layerId))
               .transact(xa)
               .unsafeToFuture
-          ) {
-            completeSomeOrNotFound
           }
         }
       }

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -122,14 +122,16 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
   }
 
   def listWithClassesByProjectIdAndTaskId(
-      page: PageRequest,
       projectId: UUID,
       taskId: UUID
-  ): ConnectionIO[PaginatedResponse[AnnotationLabelWithClasses]] =
+  ): ConnectionIO[List[AnnotationLabelWithClasses.GeoJSON]] =
     query
       .filter(fr"annotation_project_id=$projectId")
       .filter(fr"annotation_task_id=$taskId")
-      .page(page)
+      .list
+      .map { listed =>
+        listed.map(_.toGeoJSONFeature)
+      }
 
   def deleteByProjectIdAndTaskId(
       projectId: UUID,

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -120,4 +120,23 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
   """)
     fragment.query[AnnotationProject.LabelClassSummary].to[List]
   }
+
+  def listWithClassesByProjectIdAndTaskId(
+      page: PageRequest,
+      projectId: UUID,
+      taskId: UUID
+  ): ConnectionIO[PaginatedResponse[AnnotationLabelWithClasses]] =
+    query
+      .filter(fr"annotation_project_id=$projectId")
+      .filter(fr"annotation_task_id=$taskId")
+      .page(page)
+
+  def deleteByProjectIdAndTaskId(
+      projectId: UUID,
+      taskId: UUID
+  ): ConnectionIO[Int] =
+    (fr"DELETE FROM" ++ tableF ++ Fragments.whereAndOpt(
+      Some(fr"annotation_project_id=$projectId"),
+      Some(fr"annotation_task_id=$taskId")
+    )).update.run
 }


### PR DESCRIPTION
## Overview

This PR:
- [x] adds annotation label list and delete Dao methods, endpoints, tests.
- [x] add `/annotation-projects/:id/actions` endpoint

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Notes

After discussions with @alkamin , the list endpoint for annotations in a task is not paginated in this PR.

## Testing Instructions

- `db/testOnly *AnnotationLabelDaoSpec` should pass
- `GET` to `/api/annotation-projects/<projectId>/tasks/<taskId>/labels` should list labels from this task
- `DELETE` to `/api/annotation-projects/<projectId>/tasks/<taskId>/labels` should remove labels from this task
- Make sure the scopes and acrs are in place. Grab an id of a project that you are an owner of, GET to `/annotation-projects/:id/actions` should be `[*]`
- Change to an account that is a member of a team that has access to this project. Make sure the acrs and scopes are in place. GET to `/annotation-projects/:id/actions` should be `[some actions that this user is allowed to have]`
- Make this account super user. GET to `/annotation-projects/:id/actions` should be `[*]`

Closes #5304 
Closes #5319 
