### PR TITLE
Add /user/me/limits endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Generate typescript interfaces in CI [#5271](https://github.com/raster-foundry/raster-foundry/pull/5271)
 - Added a migration to add annotation project id to tasks [#5296](https://github.com/raster-foundry/raster-foundry/pull/5296)
 - Added annotation project related data models, `Dao` methods, endpoints, and tests [#5301](https://github.com/raster-foundry/raster-foundry/pull/5301), [#5303](https://github.com/raster-foundry/raster-foundry/pull/5303), [#5308](https://github.com/raster-foundry/raster-foundry/pull/5308), [#5318](https://github.com/raster-foundry/raster-foundry/pull/5318)
+- Add /user/me/limits endpoint for listing how many projects, shared, and how much upload space a user is using  [#5320](https://github.com/raster-foundry/raster-foundry/pull/5320)
 
 ### Changed
 

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -193,5 +193,6 @@ Path,Domain:Action,Verb
 /api/users/me/,users:readSelf,get
 /api/users/me/,users:updateSelf,patch
 /api/users/me/,users:updateSelf,put
+/api/users/me/limits,users:readSelf,get
 /api/users/me/roles,users:readSelf,get
 /api/users/search/,users:search,get

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -206,9 +206,7 @@ trait UserRoutes
     }
   }
 
-  /*
-  Hard coded limits
-   */
+  // Hard coded limits
   def getUserLimits: Route = authenticate { user =>
     authorizeScope(ScopedAction(Domain.Users, Action.ReadSelf, None), user) {
       val io = for {
@@ -234,14 +232,14 @@ trait UserRoutes
           .flatMap(_.limit.map(_.toFloat))
       } yield
         List(
-          ScopeLimit(
+          ScopeUsage(
             Domain.AnnotationProjects,
             Action.Create,
             None,
             projectCount,
             projectLimit
           ),
-          ScopeLimit(
+          ScopeUsage(
             Domain.Uploads,
             Action.Create,
             None,
@@ -250,7 +248,7 @@ trait UserRoutes
           )
         ) ++ projectShares.toList.map {
           case (id, count) =>
-            ScopeLimit(
+            ScopeUsage(
               Domain.AnnotationProjects,
               Action.Share,
               Some(id.toString),

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -11,7 +11,7 @@ import io.circe.{
   Error,
   HCursor,
   Json,
-  ParsingFailure,
+  ParsingFailure
 }
 
 import scala.util.{Failure, Success, Try}

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.datamodel
 
 import cats.implicits._
 import cats.{Eq, Monoid}
+import io.circe.generic.semiauto._
 import io.circe.parser._
 import io.circe.{
   Decoder,
@@ -10,7 +11,7 @@ import io.circe.{
   Error,
   HCursor,
   Json,
-  ParsingFailure
+  ParsingFailure,
 }
 
 import scala.util.{Failure, Success, Try}
@@ -20,6 +21,11 @@ sealed abstract class Domain(repr: String) {
 }
 
 object Domain {
+  implicit val domainEncoder: Encoder[Domain] =
+    Encoder.encodeString.contramap[Domain] { domain =>
+      domain.toString
+    }
+
   case object Analyses extends Domain("analyses")
   case object AnnotationGroups extends Domain("annotationGroups")
   case object AnnotationUploads extends Domain("annotationUploads")
@@ -73,6 +79,10 @@ sealed abstract class Action(repr: String) {
 }
 
 object Action {
+  implicit val actionEncoder: Encoder[Action] =
+    Encoder.encodeString.contramap[Action] { action =>
+      action.toString
+    }
   case object AddScenes extends Action("addScenes")
   case object AddUser extends Action("addUser")
   case object ColorCorrect extends Action("colorCorrect")
@@ -574,4 +584,15 @@ object Scopes {
           UserSelfScope.actions ++
           FeatureFlagsScope.actions
       )
+}
+
+case class ScopeLimit(domain: Domain,
+                      action: Action,
+                      objectId: Option[String],
+                      used: Float,
+                      limit: Option[Float])
+
+object ScopeLimit {
+  implicit val scopeLimitEncoder: Encoder[ScopeLimit] =
+    deriveEncoder[ScopeLimit]
 }

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -586,13 +586,13 @@ object Scopes {
       )
 }
 
-case class ScopeLimit(domain: Domain,
+case class ScopeUsage(domain: Domain,
                       action: Action,
                       objectId: Option[String],
                       used: Float,
                       limit: Option[Float])
 
-object ScopeLimit {
-  implicit val scopeLimitEncoder: Encoder[ScopeLimit] =
-    deriveEncoder[ScopeLimit]
+object ScopeUsage {
+  implicit val scopeUsageEncoder: Encoder[ScopeUsage] =
+    deriveEncoder[ScopeUsage]
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -264,6 +264,16 @@ object AnnotationProjectDao
       }
       .map(_.distinct.length.toLong)
 
+  def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
+    for {
+      projectIds <- (fr"select id from " ++ Fragment.const(tableName) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
+      projectShareCounts <- projectIds traverse { id =>
+        getShareCount(id, userId).map((id -> _))
+      }
+    } yield projectShareCounts.toMap
+
   def getAnnotationProjectStacInfo(
       annotationProjectId: UUID
   ): ConnectionIO[Option[StacLabelItemPropertiesThin]] =

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -200,7 +200,7 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/UserScopeLimit'
+              $ref: '#/definitions/UserScopeUsage'
         default:
           description: 'Unexpected error'
           schema:
@@ -6126,7 +6126,7 @@ definitions:
       token_type:
         type: string
         description: 'Type of token returned by using the refresh token'
-  UserScopeLimit:
+  UserScopeUsage:
     type: object
     properties:
       domain:

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -190,6 +190,21 @@ paths:
           description: 'Unexpected error'
           schema:
             $ref: '#/definitions/Error'
+  /users/me/limits:
+    x-resource: Users
+    get:
+      summary: "Get a logged in user's account limits"
+      responses:
+        200:
+          description: 'Limits fetched'
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/UserScopeLimit'
+        default:
+          description: 'Unexpected error'
+          schema:
+            $ref: '#/definitions/Error'
   /users/me/roles:
     x-resource: Users
     get:
@@ -6111,7 +6126,24 @@ definitions:
       token_type:
         type: string
         description: 'Type of token returned by using the refresh token'
-
+  UserScopeLimit:
+    type: object
+    properties:
+      domain:
+        type: string
+        description: 'Domain that the limit applies to'
+      action:
+        type: string
+        description: 'Action that the limit applies to'
+      objectId:
+        type: string
+        description: 'Object Id that that limit applies to'
+      used:
+        type: number
+        description: 'Used portion of limit'
+      limit:
+        type: number
+        description: 'Maximum of limit'
   UserRole:
     type: object
     properties:


### PR DESCRIPTION
## Overview
Add endpoint for fetching user account limitations and usage

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated
- [ ] ~~New tables and queries have appropriate indices added~~
- [ ] ~~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~~
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Demo
```
> $ http --auth-type=jwt :9091/api/users/me/limits                                                                                                                                                         
HTTP/1.1 200 OK
X-Powered-By: Express
connection: close
content-encoding: gzip
content-type: application/json
date: Mon, 24 Feb 2020 22:15:23 GMT
server: nginx
strict-transport-security: max-age=15552000; preload
transfer-encoding: chunked
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block

[
    {
        "action": "create",
        "domain": "annotationProjects",
        "limit": 10.0,
        "objectId": null,
        "used": 1.0
    },
    {
        "action": "create",
        "domain": "uploads",
        "limit": null,
        "objectId": null,
        "used": 0.0
    },
    {
        "action": "share",
        "domain": "annotationProjects",
        "limit": 5.0,
        "objectId": "84db6e9f-a7d4-4f06-90c0-184e35965f72",
        "used": 0.0
    }
]
```

### Notes
Scopes which are included are hard-coded.
Only new limit code is for fetching the share count of all users projects, didn't examine how accurate upload / project limits are since those functions are used on the actual endpoints to determine limitations.

## Testing Instructions

- Build your API jar
- start the API server and frontend
- Use a token and request `/api/users/me/limits` to receive a list of user limits
- change your user scopes, restart memcached, and hit the endpoint again. verify that the numbers are accurate.
-verify that the new test makes sense

Closes https://github.com/azavea/raster-foundry-platform/issues/917
