### PR TITLE
Add special share endpoint for possibly non-existent users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297) [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
+- Added a special share endpoint that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321)
+- Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297), [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
 - Added POST endpoint for annotation projects and their related fields [#5294](https://github.com/raster-foundry/raster-foundry/pull/5294)
 - Added `signed-url` endpoint for uploads to send secure PUTs to s3 [#5290](https://github.com/raster-foundry/raster-foundry/pull/5290)
 - Added migration for annotate projects and related items [#5284](https://github.com/raster-foundry/raster-foundry/pull/5284)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -25,6 +25,7 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,put
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,post
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,delete
+/api/annotation-projects/{annotationProjectID}/share,annotationProjects:share,post
 /api/annotation-projects/{annotationProjectID}/tasks/,annotationProjects:readTasks,get
 /api/annotation-projects/{annotationProjectID}/tasks/,annotationProjects:createTasks,post
 /api/annotation-projects/{annotationProjectID}/tasks/,annotationProjects:deleteTasks,delete

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -206,7 +206,8 @@ trait AnnotationProjectPermissionRoutes
                 case existingUsers =>
                   existingUsers traverse { existingUser =>
                     val acrs = getDefaultShare(existingUser)
-                    Auth0Service.addGroundworkMetadata(existingUser, managementToken) *>
+                    Auth0Service.addGroundworkMetadata(existingUser,
+                                                       managementToken) *>
                       (acrs traverse { acr =>
                         AnnotationProjectDao
                           .addPermission(projectId, acr)

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -203,10 +203,10 @@ trait AnnotationProjectPermissionRoutes
                         .addPermission(projectId, acr)
                     }).transact(xa).unsafeToFuture
                   } yield dbAcrs
-                case us =>
-                  val acrs = getDefaultShare(user)
-                  us traverse { user =>
-                    Auth0Service.addGroundworkMetadata(user, managementToken) *>
+                case existingUsers =>
+                  existingUsers traverse { existingUser =>
+                    val acrs = getDefaultShare(existingUser)
+                    Auth0Service.addGroundworkMetadata(existingUser, managementToken) *>
                       (acrs traverse { acr =>
                         AnnotationProjectDao
                           .addPermission(projectId, acr)

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -183,9 +183,6 @@ trait AnnotationProjectPermissionRoutes
                 .findUsersByEmail(userByEmail.email)
                 .transact(xa)
                 .unsafeToFuture
-              // exist branch:
-              // - share with all users with this email
-              // - update auth0 to make sure those users have annotate access
               permissions <- users match {
                 case Nil =>
                   for {

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -48,13 +48,13 @@ trait AnnotationProjectRoutes
               deleteAnnotationProject(projectId)
             }
         } ~
-        pathPrefix("share") {
-          pathEndOrSingleSlash {
-            post {
-              shareAnnotationProject(projectId)
+          pathPrefix("share") {
+            pathEndOrSingleSlash {
+              post {
+                shareAnnotationProject(projectId)
+              }
             }
-          }
-        } ~
+          } ~
           pathPrefix("permissions") {
             pathEndOrSingleSlash {
               get {

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -48,6 +48,13 @@ trait AnnotationProjectRoutes
               deleteAnnotationProject(projectId)
             }
         } ~
+        pathPrefix("share") {
+          pathEndOrSingleSlash {
+            post {
+              shareAnnotationProject(projectId)
+            }
+          }
+        } ~
           pathPrefix("permissions") {
             pathEndOrSingleSlash {
               get {
@@ -294,5 +301,4 @@ trait AnnotationProjectRoutes
       }
     }
   }
-
 }

--- a/app-backend/api/src/main/scala/token/Token.scala
+++ b/app-backend/api/src/main/scala/token/Token.scala
@@ -34,10 +34,6 @@ object TokenService extends Config with ErrorAccumulatingCirceSupport {
 
   val uri = Uri(s"https://$auth0Domain/api/v2/device-credentials")
 
-  val auth0BearerHeader = List(
-    Authorization(GenericHttpCredentials("Bearer", auth0Bearer))
-  )
-
   val authBearerTokenCache: AsyncLoadingCache[Int, ManagementBearerToken] =
     Scaffeine()
       .expireAfterWrite(1.hour)

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -111,7 +111,7 @@ object Auth0Service extends Config with LazyLogging {
         Unmarshal(entity).to[Auth0User]
       case HttpResponse(StatusCodes.Created, _, entity, _) =>
         Unmarshal(entity).to[Auth0User]
-      case resp @ HttpResponse(StatusCodes.ClientError(400), _, entity, _) =>
+      case HttpResponse(StatusCodes.ClientError(400), _, entity, _) =>
         logger.debug(s"Entity from Auth0 is: $entity")
         throw new IllegalArgumentException(
           "Request must specify a valid field to update"

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -112,8 +112,7 @@ object Auth0Service extends Config with LazyLogging {
       case HttpResponse(StatusCodes.Created, _, entity, _) =>
         Unmarshal(entity).to[Auth0User]
       case resp @ HttpResponse(StatusCodes.ClientError(400), _, entity, _) =>
-        println(s"Entity is: $entity")
-        println(s"Resp is: $resp")
+        logger.debug(s"Entity from Auth0 is: $entity")
         throw new IllegalArgumentException(
           "Request must specify a valid field to update"
         )

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -76,7 +76,7 @@ object UserWithOAuth {
         u.visibility,
         u.dropboxCredential,
         u.planetCredential
-      )
+    )
   )
 }
 @JsonCodec
@@ -111,7 +111,7 @@ object Auth0Service extends Config with LazyLogging {
         Unmarshal(entity).to[Auth0User]
       case HttpResponse(StatusCodes.Created, _, entity, _) =>
         Unmarshal(entity).to[Auth0User]
-      case resp@HttpResponse(StatusCodes.ClientError(400), _, entity, _) =>
+      case resp @ HttpResponse(StatusCodes.ClientError(400), _, entity, _) =>
         println(s"Entity is: $entity")
         println(s"Resp is: $resp")
         throw new IllegalArgumentException(

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -88,15 +88,12 @@ final case class UserWithOAuthUpdate(
     user: User.Create,
     oauth: Auth0UserUpdate
 )
-object Auth0UserService extends Config with LazyLogging {
+object Auth0Service extends Config with LazyLogging {
 
   import com.rasterfoundry.api.AkkaSystem._
 
   val uri = Uri(s"https://$auth0Domain/api/v2/device-credentials")
   val userUri = Uri(s"https://$auth0Domain/api/v2/users")
-  val auth0BearerHeader = List(
-    Authorization(GenericHttpCredentials("Bearer", auth0Bearer))
-  )
 
   val authBearerTokenCache: AsyncLoadingCache[Int, ManagementBearerToken] =
     Scaffeine()
@@ -200,4 +197,7 @@ object Auth0UserService extends Config with LazyLogging {
           throw new Auth0Exception(errCode, error.toString)
       }
   }
+
+  // don't need a read method because patch is idempotent
+  def addGroundworkMetadata(user: User): Future[Unit] = ???
 }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -101,7 +101,7 @@ trait UserRoutes
     authorizeScope(ScopedAction(Domain.Users, Action.UpdateSelf, None), user) {
       entity(as[Auth0UserUpdate]) { userUpdate =>
         complete {
-          Auth0UserService.updateAuth0User(user.id, userUpdate)
+          Auth0Service.updateAuth0User(user.id, userUpdate)
         }
       }
     }

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -246,3 +246,5 @@ object User {
     }
   }
 }
+
+@JsonCodec final case class UserEmail(email: String)

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -265,7 +265,7 @@ object AnnotationProjectDao
                     Some(subjectId),
                     _
                     ) if subjectId != userId =>
-                   Set(subjectId) | accum
+                  Set(subjectId) | accum
                 case _ => accum
               }
             }

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -299,5 +299,7 @@ object UserDao extends Dao[User] with Sanitization {
   }
 
   def findUsersByEmail(email: String): ConnectionIO[List[User]] =
-    query.filter(fr"(email = $email OR personal_info ->> 'email' = $email)").list
+    query
+      .filter(fr"(email = $email OR personal_info ->> 'email' = $email)")
+      .list
 }

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -297,4 +297,7 @@ object UserDao extends Dao[User] with Sanitization {
       _ <- remove(user.cacheKey)(userCache, async[ConnectionIO]).attempt
     } yield query
   }
+
+  def findUsersByEmail(email: String): ConnectionIO[List[User]] =
+    query.filter(fr"(email = $email OR personal_info ->> 'email' = $email)").list
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
     env_file: .env
     expose:
       - "5432"
-    ports:
-      - 5432:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     env_file: .env
     expose:
       - "5432"
+    ports:
+      - 5432:5432
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}"]
       interval: 5s


### PR DESCRIPTION
## Overview

This PR adds a share endpoint to annotation projects that enables sharing with only an email address.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~ nope!
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Notes

We chose explicitly now to worry about user merging -- so if a user who is shared with via email signs in socially... they won't have access to the same stuff. We're opting not to worry about that for now. Automatic merging is an option, but it relies on yet another rule, and rules proliferation is frankly already fairly scary for us. :man_shrugging:  So we're ignoring this problem until it's something that someone asks us to care about.

## Testing Instructions

- assemble API
- get your dev db in order -- `./scripts/load_development_data --download` :tada:
- bring up api, frontend
- get a bearer token for the dev user
- `export JWT_AUTH_TOKEN=<your token, without the Bearer prefix>`
- `echo '{"email": "an email address for a user in the db"} | http --auth-type=jwt :9091/api/annotation-projects/6e35b51e-4d67-4cb0-bf23-ca265ef49b24/share` -- you should see a list of your new permissions for the user you shared with
- `echo '{"email": "an email address for a user not in the db"} | http --auth-type=jwt :9091/api/annotation-projects/6e35b51e-4d67-4cb0-bf23-ca265ef49b24/share` -- you should _also_ see a list of your new permissions for that user, and you should be able to see them in the dev Auth0 tenant new signups, and they should have the app metadata they need, _and_ they should have a `groundworkUser` scope wow much auth

Closes #raster-foundry/annotate#604
