### PR TITLE
Make STAC export query param consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - Logout can redirect to a custom URL [#5291](https://github.com/raster-foundry/raster-foundry/pull/5291)
 - Moved project data for Groundwork from extras jsonb field and a text field to normalized tables [#5286](https://github.com/raster-foundry/raster-foundry/pull/5286)
 - Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)
+- Updated to support STAC exports on annotation projects [#5312](https://github.com/raster-foundry/raster-foundry/pull/5312) [#5323](https://github.com/raster-foundry/raster-foundry/pull/5323)
+
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -194,7 +194,7 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         searchParams &
         parameters(
           'exportStatus.as[String].?,
-          'projectId.as[UUID].?
+          'annotationProjectId.as[UUID].?
         )
     ).as(StacExportQueryParameters.apply _)
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }


### PR DESCRIPTION
## Overview

Putting this one up just for consistency.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- assemble jars and spin up servers
- create a stac export with the below:
```json
{
	"name": "test",
	"owner": null,
	"license": {
		"license": "proprietary",
		"url": ""
	},
	"taskStatuses": [],
	"annotationProjectId": "<your annotation project ID>"
}
```
- get `/stac?annotationProjectId=<your annotation project ID>` should give you the export you created for this annotation project
