### PR TITLE
Add routes for listing/deleting users an annotation project is shared with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Update annotation projects after upload processing as appropriate [#5324](https://github.com/raster-foundry/raster-foundry/pull/5324)
-- Added a special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327)
+- Added special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327)
 - Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297), [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
 - Added POST endpoint for annotation projects and their related fields [#5294](https://github.com/raster-foundry/raster-foundry/pull/5294)
 - Added `signed-url` endpoint for uploads to send secure PUTs to s3 [#5290](https://github.com/raster-foundry/raster-foundry/pull/5290)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Update annotation projects after upload processing as appropriate [#5324](https://github.com/raster-foundry/raster-foundry/pull/5324)
-- Added a special share endpoint that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321)
+- Added a special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327)
 - Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297), [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
 - Added POST endpoint for annotation projects and their related fields [#5294](https://github.com/raster-foundry/raster-foundry/pull/5294)
 - Added `signed-url` endpoint for uploads to send secure PUTs to s3 [#5290](https://github.com/raster-foundry/raster-foundry/pull/5290)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -26,6 +26,8 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,post
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,delete
 /api/annotation-projects/{annotationProjectID}/share,annotationProjects:share,post
+/api/annotation-projects/{annotationProjectID}/share,annotationProjects:share,get
+/api/annotation-projects/{annotationProjectID}/share/{userID},annotationProjects:read,delete
 /api/annotation-projects/{annotationProjectID}/tasks/,annotationProjects:readTasks,get
 /api/annotation-projects/{annotationProjectID}/tasks/,annotationProjects:createTasks,post
 /api/annotation-projects/{annotationProjectID}/tasks/,annotationProjects:deleteTasks,delete

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -196,38 +196,38 @@ trait AnnotationProjectPermissionRoutes
         user
       ) {
         (if (user.id == deleteId) {
-          authorizeAuthResultAsync {
+           authorizeAuthResultAsync {
+             AnnotationProjectDao
+               .authorized(
+                 user,
+                 ObjectType.AnnotationProject,
+                 projectId,
+                 ActionType.View
+               )
+               .transact(xa)
+               .unsafeToFuture
+           }
+         } else {
+           authorizeAuthResultAsync {
+             AnnotationProjectDao
+               .authorized(
+                 user,
+                 ObjectType.AnnotationProject,
+                 projectId,
+                 ActionType.Edit
+               )
+               .transact(xa)
+               .unsafeToFuture
+           }
+         }) {
+          completeWithOneOrFail {
             AnnotationProjectDao
-              .authorized(
-                user,
-                ObjectType.AnnotationProject,
-                projectId,
-                ActionType.View
-              )
+              .deleteSharedUser(projectId, deleteId)
+              .map(c => if (c > 0) 1 else 0)
               .transact(xa)
               .unsafeToFuture
-          } 
-        } else {
-          authorizeAuthResultAsync {
-            AnnotationProjectDao
-              .authorized(
-                user,
-                ObjectType.AnnotationProject,
-                projectId,
-                ActionType.Edit
-              )
-              .transact(xa)
-              .unsafeToFuture
-          } 
-        }) {
-            completeWithOneOrFail {
-              AnnotationProjectDao
-                .deleteSharedUser(projectId, deleteId)
-                .map(c => if (c > 0) 1 else 0)
-                .transact(xa)
-                .unsafeToFuture
-            }
           }
+        }
       }
     }
 

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -195,7 +195,7 @@ trait AnnotationProjectPermissionRoutes
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
       ) {
-        if (user.id == deleteId) {
+        (if (user.id == deleteId) {
           authorizeAuthResultAsync {
             AnnotationProjectDao
               .authorized(
@@ -206,15 +206,7 @@ trait AnnotationProjectPermissionRoutes
               )
               .transact(xa)
               .unsafeToFuture
-          } {
-            completeWithOneOrFail {
-              AnnotationProjectDao
-                .deleteSharedUser(projectId, user.id)
-                .map(c => if (c > 0) 1 else 0)
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
+          } 
         } else {
           authorizeAuthResultAsync {
             AnnotationProjectDao
@@ -226,7 +218,8 @@ trait AnnotationProjectPermissionRoutes
               )
               .transact(xa)
               .unsafeToFuture
-          } {
+          } 
+        }) {
             completeWithOneOrFail {
               AnnotationProjectDao
                 .deleteSharedUser(projectId, deleteId)
@@ -235,7 +228,6 @@ trait AnnotationProjectPermissionRoutes
                 .unsafeToFuture
             }
           }
-        }
       }
     }
 

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -52,6 +52,15 @@ trait AnnotationProjectRoutes
             pathEndOrSingleSlash {
               post {
                 shareAnnotationProject(projectId)
+              } ~
+                get {
+                  listAnnotationProjectShares(projectId)
+                }
+            } ~ pathPrefix(Segment) { deleteId =>
+              pathEndOrSingleSlash {
+                delete {
+                  deleteAnnotationProjectShare(projectId, deleteId)
+                }
               }
             }
           } ~

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -248,3 +248,10 @@ object User {
 }
 
 @JsonCodec final case class UserEmail(email: String)
+
+@JsonCodec final case class UserThin(id: String,
+                                     email: String,
+                                     profileImageUri: String)
+object UserThin {
+  def fromUser(user: User) = UserThin(user.id, user.email, user.profileImageUri)
+}

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -333,7 +333,7 @@ object AnnotationProjectDao
         .toNel
       users <- idsNel match {
         case Some(ids) => UserDao.getThinUsersForIds(ids)
-        case _ => List.empty.pure[ConnectionIO]
+        case _         => List.empty.pure[ConnectionIO]
       }
     } yield users
   }

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -304,14 +304,12 @@ object UserDao extends Dao[User] with Sanitization {
       .filter(fr"(email = $email OR personal_info ->> 'email' = $email)")
       .list
 
-  def getThinUsersForIds(ids: List[String]): ConnectionIO[List[UserThin]] =
-    ids.toNel match {
-      case Some(idsNel) =>
-        Nested(
-          query
-            .filter(Fragments.in(fr"id", idsNel))
-            .list
-        ).map(UserThin.fromUser(_)).value
-      case _ => List.empty.pure[ConnectionIO]
-    }
+  def getThinUsersForIds(
+      ids: NonEmptyList[String]
+  ): ConnectionIO[List[UserThin]] =
+    Nested(
+      query
+        .filter(Fragments.in(fr"id", ids))
+        .list
+    ).map(UserThin.fromUser(_)).value
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -443,4 +443,25 @@ class UserDaoSpec
       }
     }
   }
+
+  test("get list of user ids and emails") {
+    check {
+      forAll { (userCreates: NonEmptyList[User.Create]) =>
+        {
+          val listIO = for {
+            _ <- userCreates traverse { userCreate =>
+              UserDao.create(userCreate)
+            }
+            listed <- UserDao.getThinUsersForIds(userCreates.map(_.id).toList)
+          } yield listed
+          val users = listIO.transact(xa).unsafeRunSync
+          assert(
+            users.map(_.id).toSet.equals(userCreates.map(_.id).toList.toSet),
+            "users are listed"
+          )
+          true
+        }
+      }
+    }
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -452,12 +452,12 @@ class UserDaoSpec
             _ <- userCreates traverse { userCreate =>
               UserDao.create(userCreate)
             }
-            listed <- UserDao.getThinUsersForIds(userCreates.map(_.id).toList)
+            listed <- UserDao.getThinUsersForIds(userCreates.map(_.id))
           } yield listed
           val users = listIO.transact(xa).unsafeRunSync
           assert(
-            users.map(_.id).toSet.equals(userCreates.map(_.id).toList.toSet),
-            "users are listed"
+            users.size == userCreates.size,
+            "Same number of users are listed"
           )
           true
         }


### PR DESCRIPTION
## Overview
List endpoint returns a thin user model, containing id, email, and picture

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~Swagger specification updated~
- [ ] ~New tables and queries have appropriate indices added~
- [ ] ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Demo
```
> $ http :9091/api/annotation-projects/3dc49c06-cf04-4ca7-b9c7-c711154b0aee/share --auth-type=jwt
X-Powered-By: Express
connection: close
content-encoding: gzip
content-type: application/json
date: Thu, 27 Feb 2020 16:30:01 GMT
server: nginx
strict-transport-security: max-age=15552000; preload
transfer-encoding: chunked
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block

[
    {
        "email": "rf+public+member@rasterfoundry.com",
        "id": "auth0|5b1edbfaa76b70216925b6a1",
        "profileImageUri": "https://s.gravatar.com/avatar/abb56c6bc743d26ec4e040d86f9d167a?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2Frf.png"
    }
]
```

### Notes
Decided to return the user profile pic anyways, since if they have an email, they can look at gravatar directly anyways so it's not private information

## Testing Instructions

- build API jar
- run server, get an API token
- hit `/api/annotation-projects/{id}/share` with a few email objects: `{email: "email@example.com"}`
- fetch `/api/annotation-projects/{id}/share` and verify that the response makes sense
- hit `/api/annotation-projects/{id}/share/{userId}` with a delete request for the same user twice. Verify that the first time returns a 204, and the second time returns a 404

Closes #5325 
