### PR TITLE
Make upload PUT update all fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 ### Removed
 
 ### Fixed
-
+- Upload updates now respect all fields [#5330](https://github.com/raster-foundry/raster-foundry/pull/5330)
 - Removed unused route and fixed spelling in Swagger spec [#5273](https://github.com/raster-foundry/raster-foundry/pull/5273)
 
 ### Security

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -123,7 +123,9 @@ object UploadDao extends Dao[Upload] {
           layer_id = ${upload.layerId},
           source = ${upload.source},
           keep_in_source_bucket = ${upload.keepInSourceBucket},
-          bytes_uploaded = ${upload.bytesUploaded}
+          bytes_uploaded = ${upload.bytesUploaded},
+          annotation_project_id = ${upload.annotationProjectId},
+          generate_tasks = ${upload.generateTasks}
      """ ++ Fragments.whereAndOpt(Some(idFilter))).update.run
     (for {
       oldUpload <- oldUploadIO

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
@@ -51,7 +51,8 @@ class UploadDaoSpec
             dbUpload.files == upload.files &&
             dbUpload.metadata == upload.metadata &&
             dbUpload.visibility == upload.visibility &&
-            dbUpload.source == upload.source
+            dbUpload.source == upload.source &&
+            dbUpload.generateTasks === upload.generateTasks
           }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UploadDaoSpec.scala
@@ -223,7 +223,10 @@ class UploadDaoSpec
             updatedUpload.metadata == updateUpload.metadata &&
             updatedUpload.visibility == updateUpload.visibility &&
             updatedUpload.projectId == updateUpload.projectId &&
-            updatedUpload.source == updateUpload.source
+            updatedUpload.source == updateUpload.source &&
+            updatedUpload.annotationProjectId ==
+            updateUpload.annotationProjectId &&
+            updatedUpload.generateTasks == updateUpload.generateTasks
           }
       }
     }


### PR DESCRIPTION
## Overview

This PR updates UploadDao and the UploadDaoSpec so that the update method updates the values of `generateTasks` and `annotationProjectId` along with all the other fields.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

- Create an upload
- Update the upload with a different value for `generateTasks` and `annotationProjectId` and see that they are reflected in the DB

Closes #5329
