### PR TITLE
Generate tasks after adding scenes to projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Update annotation projects after upload processing as appropriate [#5324](https://github.com/raster-foundry/raster-foundry/pull/5324)
+- Update annotation projects after upload processing as appropriate [#5324](https://github.com/raster-foundry/raster-foundry/pull/5324), [#5334](https://github.com/raster-foundry/raster-foundry/pull/5334)
 - Added a special share endpoint that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321)
 - Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297), [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
 - Added POST endpoint for annotation projects and their related fields [#5294](https://github.com/raster-foundry/raster-foundry/pull/5294)

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -25,9 +25,9 @@ class CreateTaskGrid(
     xa: Transactor[IO]
 ) extends LazyLogging {
 
-  private def debug(s: String): ConnectionIO[Unit] =
+  private def info(s: String): ConnectionIO[Unit] =
     LiftIO[ConnectionIO].liftIO(
-      IO { logger.debug(s) }
+      IO { logger.info(s) }
     )
 
   def run(): IO[Unit] =
@@ -36,7 +36,7 @@ class CreateTaskGrid(
         AnnotationProjectDao.getProjectById(annotationProjectId)
       }
       _ <- OptionT.liftF {
-        debug(s"Got annotation project ${annotationProject.name}")
+        info(s"Got annotation project ${annotationProject.name}")
       }
       owner <- OptionT {
         UserDao.getUserById(annotationProject.createdBy)
@@ -46,7 +46,7 @@ class CreateTaskGrid(
           ProjectDao.getFootprint(projectId)
         }
       } <* OptionT.liftF {
-        debug("Got annotation project footprint")
+        info("Got annotation project footprint")
       }
       taskGridFeatureCreate = Task.TaskGridFeatureCreate(
         Task.TaskGridCreateProperties(Some(taskSizeMeters)),
@@ -60,7 +60,7 @@ class CreateTaskGrid(
         TaskDao
           .insertTasksByGrid(taskProperties, taskGridFeatureCreate, owner)
       }
-      _ <- OptionT.liftF { debug("Inserted tasks") }
+      _ <- OptionT.liftF { info("Inserted tasks") }
       _ <- OptionT.liftF {
         AnnotationProjectDao
           .update(
@@ -72,7 +72,7 @@ class CreateTaskGrid(
             annotationProject.id
           )
       }
-      _ <- OptionT.liftF { debug("Updated annotation project") }
+      _ <- OptionT.liftF { info("Updated annotation project") }
     } yield ()).value.transact(xa).void
 }
 

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -23,4 +23,7 @@ COPY jars/ /opt/raster-foundry/jars/
 
 COPY rf/ /tmp/rf
 COPY completion.bash /tmp/rf/completion.bash
+
 RUN (cat /tmp/rf/completion.bash | tee -a /root/.bashrc && cd /tmp/rf && python3 setup.py install)
+
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.14.3
 boto3==1.7.71
 pytest==2.9.2
 pytest-runner==2.9
-rasterio==1.0a8
+rasterio==1.1.3
 pyproj==1.9.5
 ipython==5.1.0
 pyjwt==1.4.2

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.14.3
 boto3==1.7.71
 pytest==2.9.2
 pytest-runner==2.9
-rasterio==1.1.3
+rasterio==1.0.28
 pyproj==1.9.5
 ipython==5.1.0
 pyjwt==1.4.2

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -125,7 +125,8 @@ def process_upload(upload_id):
         generate_tasks = upload.annotationProjectId is not None and upload.generateTasks
         if generate_tasks:
             [
-                update_annotation_project(upload.annotationProjectId, scene.ingestLocation)
+                update_annotation_project(
+                    upload.annotationProjectId, scene.ingestLocation.replace("%7C", "|"))
                 for scene in created_scenes
             ]
     except:

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -6,6 +6,7 @@ from planet import api
 
 from ..models import Upload
 from ..uploads.geotiff import GeoTiffS3SceneFactory
+from ..uploads.geotiff.io import update_annotation_project
 from ..uploads.landsat_historical import LandsatHistoricalSceneFactory
 from ..uploads.planet.factories import PlanetSceneFactory
 from ..uploads.modis.factories import MODISSceneFactory
@@ -120,6 +121,13 @@ def process_upload(upload_id):
             upload.owner,
             upload.files,
         )
+
+        generate_tasks = upload.annotationProjectId is not None and upload.generateTasks
+        if generate_tasks:
+            [
+                update_annotation_project(upload.annotationProjectId, scene.ingestLocation)
+                for scene in created_scenes
+            ]
     except:
         logger.error(
             "Failed to process upload (%s) for user %s with files %s",

--- a/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/create_bands.py
@@ -46,7 +46,7 @@ def create_geotiff_bands(tif_path):
     bands = []
     with rasterio.open(tif_path) as src:
         for band in src.indexes:
-            colorinterp = src.colorinterp(band)
+            colorinterp = src.colorinterp[band - 1]
             if colorinterp == ColorInterp.undefined:
                 band_data = band_data_lookup["nir"]
             elif colorinterp.name in band_data_lookup:

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -6,7 +6,6 @@ import boto3
 
 from .create_images import create_geotiff_image
 from .create_scenes import create_geotiff_scene
-from .io import update_annotation_project
 from rf.utils import cog
 from rf.utils.io import (
     Visibility,
@@ -44,8 +43,6 @@ class GeoTiffS3SceneFactory(object):
         """
         self._upload = upload
         self.isProjectUpload = upload.projectId is not None
-        self.isAnnotationProjectUpload = upload.annotationProjectId is not None
-        self.generateTasks = self.isAnnotationProjectUpload and upload.generateTasks
         self.files = self._upload.files
         self.owner = upload.owner
         self.visibility = Visibility.PRIVATE
@@ -95,10 +92,6 @@ class GeoTiffS3SceneFactory(object):
                         tmp_fname, unquote(scene.ingestLocation), scene, cog_path
                     )
                 ]
-                if self.generateTasks:
-                    update_annotation_project(
-                        self._upload.annotationProjectId, cog_path
-                    )
 
             scene.thumbnails = []
             scene.images = images


### PR DESCRIPTION
## Overview

This PR makes sure that we don't try to generate tasks for an annotation project until after we've added the scenes to its project. 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo
![image](https://user-images.githubusercontent.com/5702984/75581591-6e607780-5a2f-11ea-841f-997dc2296246.png)

## Testing Instructions

- follow the testing instructions from #5324 
- they should work _the first time_
