### PR TITLE
Fix permission deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Update annotation projects after upload processing as appropriate [#5324](https://github.com/raster-foundry/raster-foundry/pull/5324), [#5334](https://github.com/raster-foundry/raster-foundry/pull/5334)
-- Added special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327)
+- Added special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327), [#5336](https://github.com/raster-foundry/raster-foundry/pull/5336)
 - Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297), [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
 - Added POST endpoint for annotation projects and their related fields [#5294](https://github.com/raster-foundry/raster-foundry/pull/5294)
 - Added `signed-url` endpoint for uploads to send secure PUTs to s3 [#5290](https://github.com/raster-foundry/raster-foundry/pull/5290)

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -220,7 +220,7 @@ trait AnnotationProjectPermissionRoutes
                .unsafeToFuture
            }
          }) {
-          completeWithOneOrFail {
+          complete {
             AnnotationProjectDao
               .deleteSharedUser(projectId, deleteId)
               .map(c => if (c > 0) 1 else 0)

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -314,7 +314,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -314,7 +314,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",
@@ -344,13 +344,15 @@ object AnnotationProjectDao
       permissionsToKeep = permissions.filter(
         p => p.subjectId.map(id => id != userId).getOrElse(true)
       )
-      permissionsResult <- permissionsToKeep match {
-        case Nil => deletePermissions(projectId) map { _ => permissions }
+      numberDeleted <- permissionsToKeep match {
+        case Nil => deletePermissions(projectId)
         case ps if ps.toSet != permissions.toSet =>
-          replacePermissions(projectId, ps)
+          replacePermissions(projectId, ps) map { _ =>
+            permissions.size - ps.size
+          }
         case _ =>
-          Nil.pure[ConnectionIO]
+          0.pure[ConnectionIO]
       }
-    } yield (permissions.size - permissionsResult.size)
+    } yield numberDeleted
   }
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -341,9 +341,9 @@ object AnnotationProjectDao
   def deleteSharedUser(projectId: UUID, userId: String): ConnectionIO[Int] = {
     for {
       permissions <- getPermissions(projectId)
-      permissionsToKeep = permissions.filter(
-        p => p.subjectId.map(id => id != userId).getOrElse(true)
-      )
+      permissionsToKeep = permissions collect {
+        case p if p.subjectId != Some(userId) => p
+      }
       numberDeleted <- permissionsToKeep match {
         case Nil => deletePermissions(projectId)
         case ps if ps.toSet != permissions.toSet =>


### PR DESCRIPTION
## Overview

This PR fixes bugs where:

- deleting permissions for the only user an annotation project had been shared with went down an exceptional path (from `replacePermissions`'s perspective)
- deleting all of the permissions for a project returned a surprise 404 because of the `completeWithOneOrFail` directive

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Fixes an issue I encountered while testing raster-foundry/annotate#681

## Testing Instructions

- share with exactly one user using the `share` endpoint
- try to delete permissions you added for that user
- it should succeed