### PR TITLE
Fix null returned when summing user uploaded bytes if user has no uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Fixed
 - Upload updates now respect all fields [#5330](https://github.com/raster-foundry/raster-foundry/pull/5330)
 - Removed unused route and fixed spelling in Swagger spec [#5273](https://github.com/raster-foundry/raster-foundry/pull/5273)
+- Fix 403 when users with no uploads try to create an upload [#5337](https://github.com/raster-foundry/raster-foundry/pull/5337)
 
 ### Security
 

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -27,7 +27,7 @@ object UploadDao extends Dao[Upload] {
   """ ++ tableF
 
   def getUserBytesUploaded(user: User): ConnectionIO[Long] =
-    fr"SELECT SUM(bytes_uploaded) FROM uploads WHERE owner = ${user.id}"
+    fr"SELECT COALESCE(SUM(bytes_uploaded), 0) FROM uploads WHERE owner = ${user.id}"
       .query[Long]
       .unique
 


### PR DESCRIPTION
## Overview
Fix 403 when testing scope limits for new users

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~Swagger specification updated~
- [ ] ~New tables and queries have appropriate indices added~
- [ ] ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [ ] ~Any new SQL strings have tests~
- [ ] ~Any new endpoints have scope validation and are included in the integration test csv~

### Demo
![image](https://user-images.githubusercontent.com/4392704/75711406-5c334300-5c94-11ea-821f-350c666c384d.png)


## Testing Instructions

- Delete all uploads for your user
- start the annotate frontend, point it at your local server (make sure to set the `REACT_APP_RGB_DATASOURCE` variable to a 3 band datasource
- build your api jar off develop and start the server
- verify that you can't create an upload and get a 403 response
- build your api jar off this branch and restart the server
- verify that you can now create an upload instead of getting a 403

Closes https://github.com/raster-foundry/annotate/issues/673
