### PR TITLE
Improve error-handling with sharing by email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Update annotation projects after upload processing as appropriate [#5324](https://github.com/raster-foundry/raster-foundry/pull/5324), [#5334](https://github.com/raster-foundry/raster-foundry/pull/5334)
-- Added special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327), [#5336](https://github.com/raster-foundry/raster-foundry/pull/5336)
+- Added special share endpoints that can be used with just an email for annotation projects [#5321](https://github.com/raster-foundry/raster-foundry/pull/5321), [#5327](https://github.com/raster-foundry/raster-foundry/pull/5327), [#5336](https://github.com/raster-foundry/raster-foundry/pull/5336), [#5338](https://github.com/raster-foundry/raster-foundry/pull/5338)
 - Added a CSV-configurable scope checking integration test [#5297](https://github.com/raster-foundry/raster-foundry/pull/5297), [#5306](https://github.com/raster-foundry/raster-foundry/pull/5306)
 - Added POST endpoint for annotation projects and their related fields [#5294](https://github.com/raster-foundry/raster-foundry/pull/5294)
 - Added `signed-url` endpoint for uploads to send secure PUTs to s3 [#5290](https://github.com/raster-foundry/raster-foundry/pull/5290)

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -37,7 +37,7 @@ final case class Auth0User(
     created_at: Option[String],
     updated_at: Option[String],
     identities: Option[Json],
-    app_metadata: Option[Json],
+    // app_metadata: Option[Json],
     user_metadata: Option[Json],
     picture: Option[String],
     name: Option[String],

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -78,7 +78,7 @@ object UserWithOAuth {
         u.visibility,
         u.dropboxCredential,
         u.planetCredential
-      )
+    )
   )
 }
 @JsonCodec

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -24,6 +24,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
 
+import java.net.URLEncoder
+
 @JsonCodec
 final case class Auth0User(
     email: Option[String],
@@ -35,7 +37,7 @@ final case class Auth0User(
     created_at: Option[String],
     updated_at: Option[String],
     identities: Option[Json],
-    // app_metadata: Option[Json],
+    app_metadata: Option[Json],
     user_metadata: Option[Json],
     picture: Option[String],
     name: Option[String],
@@ -76,7 +78,7 @@ object UserWithOAuth {
         u.visibility,
         u.dropboxCredential,
         u.planetCredential
-    )
+      )
   )
 }
 @JsonCodec
@@ -105,7 +107,13 @@ object Auth0Service extends Config with LazyLogging {
       .maximumSize(1)
       .buildAsyncFuture((_: Int) => getManagementBearerToken())
 
-  private def responseAsAuth0User(response: HttpResponse): Future[Auth0User] =
+  private def getBearerHeaders(bearerToken: ManagementBearerToken) = List(
+    Authorization(
+      GenericHttpCredentials(bearerToken.token_type, bearerToken.access_token)
+    )
+  )
+
+  private def responseAsAuth0User(response: HttpResponse): Future[Auth0User] = {
     response match {
       case HttpResponse(StatusCodes.OK, _, entity, _) =>
         Unmarshal(entity).to[Auth0User]
@@ -126,6 +134,7 @@ object Auth0Service extends Config with LazyLogging {
         logger.info(s"error $error")
         throw new Auth0Exception(errCode, error.toString)
     }
+  }
 
   def getManagementBearerToken(): Future[ManagementBearerToken] = {
     val bearerTokenUri = Uri(s"https://$auth0Domain/oauth/token")
@@ -157,9 +166,8 @@ object Auth0Service extends Config with LazyLogging {
       userId: String,
       bearerToken: ManagementBearerToken
   ): Future[Auth0User] = {
-    val auth0UserBearerHeader = List(
-      Authorization(GenericHttpCredentials("Bearer", bearerToken.access_token))
-    )
+    val auth0UserBearerHeader = getBearerHeaders(bearerToken)
+
     Http()
       .singleRequest(
         HttpRequest(
@@ -198,9 +206,7 @@ object Auth0Service extends Config with LazyLogging {
       auth0UserUpdate: Auth0UserUpdate,
       bearerToken: ManagementBearerToken
   ): Future[Auth0User] = {
-    val auth0UserBearerHeader = List(
-      Authorization(GenericHttpCredentials("Bearer", bearerToken.access_token))
-    )
+    val auth0UserBearerHeader = getBearerHeaders(bearerToken)
     Http()
       .singleRequest(
         HttpRequest(
@@ -222,11 +228,7 @@ object Auth0Service extends Config with LazyLogging {
       bearerToken: ManagementBearerToken
   ): Future[Unit] = {
     val patch = Map("app_metadata" -> Map("annotateApp" -> true)).asJson
-    val managementBearerHeaders = List(
-      Authorization(
-        GenericHttpCredentials(bearerToken.token_type, bearerToken.access_token)
-      )
-    )
+    val managementBearerHeaders = getBearerHeaders(bearerToken)
 
     Http()
       .singleRequest(
@@ -243,7 +245,8 @@ object Auth0Service extends Config with LazyLogging {
       .flatMap {
         case HttpResponse(StatusCodes.OK, _, _, _) =>
           Future.successful(())
-        case HttpResponse(StatusCodes.ClientError(400), _, _, _) =>
+        case HttpResponse(StatusCodes.ClientError(400), _, entity, _) =>
+          logger.debug(s"Entity from Auth0 is: $entity")
           throw new IllegalArgumentException(
             "Request must specify a valid field to update"
           )
@@ -259,6 +262,39 @@ object Auth0Service extends Config with LazyLogging {
       }
   }
 
+  def findGroundworkUser(
+      email: String,
+      bearerToken: ManagementBearerToken
+  ): Future[Option[Auth0User]] = {
+    val managementBearerHeaders = getBearerHeaders(bearerToken)
+
+    val queryString =
+      URLEncoder.encode(s"name:$email* OR email:$email*", "utf-8")
+    val fields =
+      URLEncoder.encode(
+        "user_id,name,email,phone_number,identities,picture,lastLogin,loginsCount,user_metadata,app_metadata,blocked,email_verified",
+        "utf-8"
+      )
+
+    Http()
+      .singleRequest(
+        HttpRequest(
+          method = GET,
+          uri = s"$userUri?q=$queryString&fields=$fields",
+          headers = managementBearerHeaders
+        )
+      ) flatMap {
+      case HttpResponse(StatusCodes.OK, _, entity, _) =>
+        Unmarshal(entity).to[List[Auth0User]] map { users =>
+          logger.debug(s"Returned users: $users")
+          users.headOption
+        }
+      case HttpResponse(_, _, error, _) =>
+        logger.debug(s"There was an error: $error")
+        Future.successful(None)
+    }
+  }
+
   def createGroundworkUser(
       email: String,
       bearerToken: ManagementBearerToken
@@ -271,11 +307,8 @@ object Auth0Service extends Config with LazyLogging {
       "app_metadata" -> Map("annotateApp" -> true).asJson
     ).asJson
 
-    val managementBearerHeaders = List(
-      Authorization(
-        GenericHttpCredentials(bearerToken.token_type, bearerToken.access_token)
-      )
-    )
+    val managementBearerHeaders = getBearerHeaders(bearerToken)
+
     Http()
       .singleRequest(
         HttpRequest(

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -37,16 +37,10 @@ final case class Auth0User(
     created_at: Option[String],
     updated_at: Option[String],
     identities: Option[Json],
-    // app_metadata: Option[Json],
     user_metadata: Option[Json],
     picture: Option[String],
     name: Option[String],
     nickname: Option[String],
-    // multifactor: Option[Seq[String]],
-    // last_ip: Option[String],
-    // last_login: Option[String],
-    // logins_count: Option[Int],
-    // blocked: Option[Boolean],
     given_name: Option[String],
     family_name: Option[String]
 )

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -147,7 +147,8 @@ trait ObjectPermissions[Model] {
           )
         case Nil if replace =>
           ApplicativeError[ConnectionIO, Throwable].raiseError(
-            new Exception("Cannot replace permissions with empty permission list")
+            new Exception(
+              "Cannot replace permissions with empty permission list")
           )
         case _ =>
           updatePermissionsF(id, acrList, replace).update
@@ -244,7 +245,7 @@ trait ObjectPermissions[Model] {
     val inheritedF: Fragment =
       createInheritedF(user, actionType, groupTypeO, groupIdO)
     val acrFilterF
-        : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
+      : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
       .const(s"${tableName}acrs")
 
     ownershipTypeO match {

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.database
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
 
+import cats.ApplicativeError
 import cats.implicits._
 import doobie._
 import doobie.implicits._
@@ -122,9 +123,10 @@ trait ObjectPermissions[Model] {
       permExists = permissions.contains(acr)
       addPermission <- permExists match {
         case true =>
-          throw new Exception(
-            s"${acr.toObjAcrString} exists for ${tableName} ${id}"
-          )
+          // if the permission already exists, return the list of permissions.
+          // a client's expressed intent -- perm a should be included for this object --
+          // is satisfied, so don't make them care about prior states of the world
+          permissions.pure[ConnectionIO]
         case false =>
           appendPermissionF(id, acr).update
             .withUniqueGeneratedKeys[List[String]]("acrs")
@@ -140,9 +142,13 @@ trait ObjectPermissions[Model] {
     for {
       addPermissionsMany <- acrList match {
         case Nil if !replace =>
-          throw new Exception(s"All permissions exist for ${tableName} ${id}")
+          ApplicativeError[ConnectionIO, Throwable].raiseError(
+            new Exception(s"All permissions exist for ${tableName} ${id}")
+          )
         case Nil if replace =>
-          throw new Exception("List of permissions do not have valid subjects")
+          ApplicativeError[ConnectionIO, Throwable].raiseError(
+            new Exception("Cannot replace permissions with empty permission list")
+          )
         case _ =>
           updatePermissionsF(id, acrList, replace).update
             .withUniqueGeneratedKeys[List[String]]("acrs")
@@ -154,8 +160,8 @@ trait ObjectPermissions[Model] {
   def replacePermissions(
       id: UUID,
       acrList: List[ObjectAccessControlRule]
-  ): ConnectionIO[List[ObjectAccessControlRule]] =
-    addPermissionsMany(id, acrList, true)
+  ): ConnectionIO[Either[Throwable, List[ObjectAccessControlRule]]] =
+    addPermissionsMany(id, acrList, true).attempt
 
   def deletePermissions(id: UUID): ConnectionIO[Int] =
     updatePermissionsF(id, List[ObjectAccessControlRule]()).update.run
@@ -238,7 +244,7 @@ trait ObjectPermissions[Model] {
     val inheritedF: Fragment =
       createInheritedF(user, actionType, groupTypeO, groupIdO)
     val acrFilterF
-      : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
+        : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
       .const(s"${tableName}acrs")
 
     ownershipTypeO match {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -25,16 +25,20 @@ class ProjectDaoSpec
   test("insert a project") {
     check {
       forAll {
-        (user: User.Create,
-         org: Organization.Create,
-         project: Project.Create,
-         platform: Platform) =>
+        (
+            user: User.Create,
+            org: Organization.Create,
+            project: Project.Create,
+            platform: Platform
+        ) =>
           {
             val projInsertIO = for {
-              (_, _, _, dbProject) <- insertUserOrgPlatProject(user,
-                                                               org,
-                                                               platform,
-                                                               project)
+              (_, _, _, dbProject) <- insertUserOrgPlatProject(
+                user,
+                org,
+                platform,
+                project
+              )
             } yield dbProject
             val insertedProject =
               projInsertIO.transact(xa).unsafeRunSync
@@ -55,22 +59,27 @@ class ProjectDaoSpec
   test("update a project") {
     check {
       forAll {
-        (user: User.Create,
-         org: Organization.Create,
-         insertProject: Project.Create,
-         updateProject: Project.Create,
-         platform: Platform) =>
+        (
+            user: User.Create,
+            org: Organization.Create,
+            insertProject: Project.Create,
+            updateProject: Project.Create,
+            platform: Platform
+        ) =>
           {
             val rowsAndUpdateIO = for {
               (dbUser, _, _, dbProject) <- insertUserOrgPlatProject(
                 user,
                 org,
                 platform,
-                insertProject)
+                insertProject
+              )
               fixedUpUpdateProject = fixupProjectCreate(dbUser, updateProject)
                 .toProject(dbUser, dbProject.defaultLayerId)
-              affectedRows <- ProjectDao.updateProject(fixedUpUpdateProject,
-                                                       dbProject.id)
+              affectedRows <- ProjectDao.updateProject(
+                fixedUpUpdateProject,
+                dbProject.id
+              )
               fetched <- ProjectDao.unsafeGetProjectById(dbProject.id)
             } yield { (affectedRows, fetched) }
 
@@ -96,16 +105,20 @@ class ProjectDaoSpec
   test("delete a project") {
     check {
       forAll {
-        (user: User.Create,
-         org: Organization.Create,
-         project: Project.Create,
-         platform: Platform) =>
+        (
+            user: User.Create,
+            org: Organization.Create,
+            project: Project.Create,
+            platform: Platform
+        ) =>
           {
             val deleteIO = for {
-              (_, _, _, dbProject) <- insertUserOrgPlatProject(user,
-                                                               org,
-                                                               platform,
-                                                               project)
+              (_, _, _, dbProject) <- insertUserOrgPlatProject(
+                user,
+                org,
+                platform,
+                project
+              )
               fetched <- ProjectDao.getProjectById(dbProject.id)
               _ <- ProjectDao.deleteProject(dbProject.id)
               fetched2 <- ProjectDao.getProjectById(dbProject.id)
@@ -122,17 +135,21 @@ class ProjectDaoSpec
   test("list projects") {
     check {
       forAll {
-        (user: User.Create,
-         org: Organization.Create,
-         project: Project.Create,
-         platform: Platform,
-         pageRequest: PageRequest) =>
+        (
+            user: User.Create,
+            org: Organization.Create,
+            project: Project.Create,
+            platform: Platform,
+            pageRequest: PageRequest
+        ) =>
           {
             val projectsListIO = for {
-              (dbUser, _, _, _) <- insertUserOrgPlatProject(user,
-                                                            org,
-                                                            platform,
-                                                            project)
+              (dbUser, _, _, _) <- insertUserOrgPlatProject(
+                user,
+                org,
+                platform,
+                project
+              )
               listedProjects <- {
                 ProjectDao
                   .authQuery(dbUser, ObjectType.Project)
@@ -146,7 +163,8 @@ class ProjectDaoSpec
               projectsListIO.transact(xa).unsafeRunSync.results.head.owner
             assert(
               projectsWithRelatedPage.id == user.id,
-              "Listed project's owner should be the same as the creating user")
+              "Listed project's owner should be the same as the creating user"
+            )
             true
           }
       }
@@ -157,20 +175,25 @@ class ProjectDaoSpec
   test("add a permission to a project and get it back") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acr: ObjectAccessControlRule,
-         project: Project.Create,
-         grantedUser: User.Create) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acr: ObjectAccessControlRule,
+            project: Project.Create,
+            grantedUser: User.Create
+        ) =>
           {
             val projectPermissionIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
               (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
               dbGrantedUser <- UserDao.create(grantedUser)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               acrInsert = fixUpObjectAcr(acr, dbUserGrantedTeamOrgPlat)
               _ <- ProjectDao.addPermission(projectInsert.id, acrInsert)
               permissions <- ProjectDao.getPermissions(projectInsert.id)
@@ -181,7 +204,8 @@ class ProjectDaoSpec
 
             assert(
               permissions.headOption == Some(acrInsert),
-              "Inserting a permission to a project and get it back should return the same granted permission.")
+              "Inserting a permission to a project and get it back should return the same granted permission."
+            )
             true
           }
       }
@@ -192,25 +216,32 @@ class ProjectDaoSpec
   test("add multiple permissions to a project and get them back") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acrList: List[ObjectAccessControlRule],
-         project: Project.Create,
-         grantedUser: User.Create) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acrList: List[ObjectAccessControlRule],
+            project: Project.Create,
+            grantedUser: User.Create
+        ) =>
           {
             val projectPermissionsIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
               (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
               dbGrantedUser <- UserDao.create(grantedUser)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               acrListToInsert = acrList.map(
-                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
+                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat)
+              )
               permissionsInsert <- ProjectDao.addPermissionsMany(
                 projectInsert.id,
-                acrListToInsert)
+                acrListToInsert
+              )
               permissionsBack <- ProjectDao.getPermissions(projectInsert.id)
             } yield { (permissionsInsert, permissionsBack) }
 
@@ -219,7 +250,8 @@ class ProjectDaoSpec
 
             assert(
               permissionsInsert.diff(permissionsBack).length == 0,
-              "Inserting a list of permissions and getting them back should be the same list of permissions.")
+              "Inserting a list of permissions and getting them back should be the same list of permissions."
+            )
             true
           }
       }
@@ -230,29 +262,42 @@ class ProjectDaoSpec
   test("add a permission to a project and replace it with many others") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acr1: ObjectAccessControlRule,
-         acrList: List[ObjectAccessControlRule],
-         project: Project.Create,
-         grantedUser: User.Create) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acr1: ObjectAccessControlRule,
+            acrList: List[ObjectAccessControlRule],
+            project: Project.Create,
+            grantedUser: User.Create
+        ) =>
           {
             val projectReplacePermissionsIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
               (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
               dbGrantedUser <- UserDao.create(grantedUser)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               acrInsert1 = fixUpObjectAcr(acr1, dbUserGrantedTeamOrgPlat)
-              permissions <- ProjectDao.addPermission(projectInsert.id,
-                                                      acrInsert1)
+              permissions <- ProjectDao.addPermission(
+                projectInsert.id,
+                acrInsert1
+              )
               _ = logger.trace(s"Access Control Rules Available: $permissions")
               acrListToInsert = acrList.map(
-                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
-              permReplaced <- ProjectDao.replacePermissions(projectInsert.id,
-                                                            acrListToInsert)
+                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat)
+              )
+              // Right(permReplaced) is a warning, but `map { _.right.get }` is _fine_
+              // and scapegoat doesn't care about our testing code -- if that changes
+              // we'll need to suppress a warning here
+              permReplaced <- ProjectDao.replacePermissions(
+                projectInsert.id,
+                acrListToInsert
+              ) map { _.right.get }
               permissionsBack <- ProjectDao.getPermissions(projectInsert.id)
             } yield { (permReplaced, permissionsBack) }
 
@@ -261,7 +306,8 @@ class ProjectDaoSpec
 
             assert(
               permReplaced.diff(permissionsBack).length == 0,
-              "Replacing project permissions and get them back should return same permissions.")
+              "Replacing project permissions and get them back should return same permissions."
+            )
             true
           }
       }
@@ -272,24 +318,32 @@ class ProjectDaoSpec
   test("add permissions to a project and delete them") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acrList: List[ObjectAccessControlRule],
-         project: Project.Create,
-         grantedUser: User.Create) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acrList: List[ObjectAccessControlRule],
+            project: Project.Create,
+            grantedUser: User.Create
+        ) =>
           {
             val projectDeletePermissionsIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
               (projectInsert, dbUserTeamOrgPlat) = projMiscInsert
               dbGrantedUser <- UserDao.create(grantedUser)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               acrListToInsert = acrList.map(
-                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
-              _ <- ProjectDao.addPermissionsMany(projectInsert.id,
-                                                 acrListToInsert)
+                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat)
+              )
+              _ <- ProjectDao.addPermissionsMany(
+                projectInsert.id,
+                acrListToInsert
+              )
               permsDeleted <- ProjectDao.deletePermissions(projectInsert.id)
               permissionsBack <- ProjectDao.getPermissions(projectInsert.id)
             } yield { (permsDeleted, permissionsBack) }
@@ -299,10 +353,12 @@ class ProjectDaoSpec
 
             assert(
               permsDeleted == 1,
-              "Deleting project permissions should give number of rows updated.")
+              "Deleting project permissions should give number of rows updated."
+            )
             assert(
               permissionsBack.length == 0,
-              "Getting back permissions after deletion should return an empty list.")
+              "Getting back permissions after deletion should return an empty list."
+            )
             true
           }
       }
@@ -313,13 +369,17 @@ class ProjectDaoSpec
   test("add permissions to a project and list user actions") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acrList: List[ObjectAccessControlRule],
-         project: Project.Create,
-         grantedUser: User.Create) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acrList: List[ObjectAccessControlRule],
+            project: Project.Create,
+            grantedUser: User.Create
+        ) =>
           {
             val userActionsIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project)
@@ -327,37 +387,52 @@ class ProjectDaoSpec
               (dbUser, dbTeam, dbOrg, dbPlatform) = dbUserTeamOrgPlat
               dbGrantedUser <- UserDao.create(grantedUser)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               ugr <- {
                 UserGroupRoleDao.create(
                   UserGroupRole
-                    .Create(dbGrantedUser.id,
-                            GroupType.Platform,
-                            dbPlatform.id,
-                            GroupRole.Member)
-                    .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+                    .Create(
+                      dbGrantedUser.id,
+                      GroupType.Platform,
+                      dbPlatform.id,
+                      GroupRole.Member
+                    )
+                    .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                ) >>
                   UserGroupRoleDao.create(
                     UserGroupRole
-                      .Create(dbGrantedUser.id,
-                              GroupType.Organization,
-                              dbOrg.id,
-                              GroupRole.Member)
-                      .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+                      .Create(
+                        dbGrantedUser.id,
+                        GroupType.Organization,
+                        dbOrg.id,
+                        GroupRole.Member
+                      )
+                      .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                  ) >>
                   UserGroupRoleDao.create(
                     UserGroupRole
-                      .Create(dbGrantedUser.id,
-                              GroupType.Team,
-                              dbTeam.id,
-                              GroupRole.Member)
-                      .toUserGroupRole(dbUser, MembershipStatus.Approved))
+                      .Create(
+                        dbGrantedUser.id,
+                        GroupType.Team,
+                        dbTeam.id,
+                        GroupRole.Member
+                      )
+                      .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                  )
               }
               _ = logger.trace(s"Created UGR: $ugr")
               acrListToInsert = acrList.map(
-                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
-              _ <- ProjectDao.addPermissionsMany(projectInsert.id,
-                                                 acrListToInsert)
-              actions <- ProjectDao.listUserActions(dbGrantedUser,
-                                                    projectInsert.id)
+                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat)
+              )
+              _ <- ProjectDao.addPermissionsMany(
+                projectInsert.id,
+                acrListToInsert
+              )
+              actions <- ProjectDao.listUserActions(
+                dbGrantedUser,
+                projectInsert.id
+              )
               permissionsBack <- ProjectDao.getPermissions(projectInsert.id)
             } yield { (actions, permissionsBack) }
 
@@ -369,7 +444,8 @@ class ProjectDaoSpec
 
             assert(
               acrActionsDistinct.diff(userActions).length == 0,
-              "Listing actions granted to a user on a project should return all action string")
+              "Listing actions granted to a user on a project should return all action string"
+            )
             true
           }
       }
@@ -379,15 +455,19 @@ class ProjectDaoSpec
   test("list projects a user can view") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acrList: List[ObjectAccessControlRule],
-         project1: Project.Create,
-         project2: Project.Create,
-         grantedUser: User.Create,
-         page: PageRequest) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acrList: List[ObjectAccessControlRule],
+            project1: Project.Create,
+            project2: Project.Create,
+            grantedUser: User.Create,
+            page: PageRequest
+        ) =>
           {
             val listProjectsIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project1)
@@ -395,63 +475,83 @@ class ProjectDaoSpec
               (dbUser, dbTeam, dbOrg, dbPlatform) = dbUserTeamOrgPlat
               projectInsert2 <- ProjectDao.insertProject(
                 fixupProjectCreate(dbUser, project2),
-                dbUser)
+                dbUser
+              )
               dbGrantedUserInsert <- UserDao.create(grantedUser)
               dbGrantedUser = dbGrantedUserInsert.copy(isSuperuser = false)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               ugr <- {
                 UserGroupRoleDao.create(
                   UserGroupRole
-                    .Create(dbGrantedUser.id,
-                            GroupType.Platform,
-                            dbPlatform.id,
-                            GroupRole.Member)
-                    .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+                    .Create(
+                      dbGrantedUser.id,
+                      GroupType.Platform,
+                      dbPlatform.id,
+                      GroupRole.Member
+                    )
+                    .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                ) >>
                   UserGroupRoleDao.create(
                     UserGroupRole
-                      .Create(dbGrantedUser.id,
-                              GroupType.Organization,
-                              dbOrg.id,
-                              GroupRole.Member)
-                      .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+                      .Create(
+                        dbGrantedUser.id,
+                        GroupType.Organization,
+                        dbOrg.id,
+                        GroupRole.Member
+                      )
+                      .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                  ) >>
                   UserGroupRoleDao.create(
                     UserGroupRole
-                      .Create(dbGrantedUser.id,
-                              GroupType.Team,
-                              dbTeam.id,
-                              GroupRole.Member)
-                      .toUserGroupRole(dbUser, MembershipStatus.Approved))
+                      .Create(
+                        dbGrantedUser.id,
+                        GroupType.Team,
+                        dbTeam.id,
+                        GroupRole.Member
+                      )
+                      .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                  )
               }
               _ = logger.trace(s"Created UGR: $ugr")
               acrListToInsert = acrList.map(
-                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
-              _ <- ProjectDao.addPermissionsMany(projectInsert1.id,
-                                                 acrListToInsert)
+                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat)
+              )
+              _ <- ProjectDao.addPermissionsMany(
+                projectInsert1.id,
+                acrListToInsert
+              )
               permissionsBack <- ProjectDao.getPermissions(projectInsert1.id)
               paginatedProjects <- ProjectDao
                 .authQuery(dbGrantedUser, ObjectType.Project)
                 .filter(fr"owner=${dbUser.id}")
                 .page(page)
             } yield {
-              (projectInsert1,
-               projectInsert2,
-               permissionsBack,
-               paginatedProjects)
+              (
+                projectInsert1,
+                projectInsert2,
+                permissionsBack,
+                paginatedProjects
+              )
             }
 
-            val (projectInsert1,
-                 projectInsert2,
-                 permissionsBack,
-                 paginatedProjects) =
+            val (
+              projectInsert1,
+              projectInsert2,
+              permissionsBack,
+              paginatedProjects
+            ) =
               listProjectsIO.transact(xa).unsafeRunSync
 
             val hasViewPermission =
               permissionsBack.exists(_.actionType == ActionType.View)
 
-            (hasViewPermission,
-             projectInsert1.visibility,
-             projectInsert2.visibility) match {
+            (
+              hasViewPermission,
+              projectInsert1.visibility,
+              projectInsert2.visibility
+            ) match {
               case (true, _, Visibility.Public) =>
                 paginatedProjects.results
                   .map(_.id)
@@ -489,14 +589,18 @@ class ProjectDaoSpec
   test("check if a user can have a certain action on a project") {
     check {
       forAll {
-        (userTeamOrgPlat: (User.Create,
-                           Team.Create,
-                           Organization.Create,
-                           Platform),
-         acrList: List[ObjectAccessControlRule],
-         project1: Project.Create,
-         project2: Project.Create,
-         grantedUser: User.Create) =>
+        (
+            userTeamOrgPlat: (
+                User.Create,
+                Team.Create,
+                Organization.Create,
+                Platform
+            ),
+            acrList: List[ObjectAccessControlRule],
+            project1: Project.Create,
+            project2: Project.Create,
+            grantedUser: User.Create
+        ) =>
           {
             val projectCreateIO = for {
               projMiscInsert <- fixUpProjMiscInsert(userTeamOrgPlat, project1)
@@ -504,66 +608,90 @@ class ProjectDaoSpec
               (dbUser, dbTeam, dbOrg, dbPlatform) = dbUserTeamOrgPlat
               projectInsert2 <- ProjectDao.insertProject(
                 fixupProjectCreate(dbUser, project2),
-                dbUser)
+                dbUser
+              )
               dbGrantedUserInsert <- UserDao.create(grantedUser)
               dbGrantedUser = dbGrantedUserInsert.copy(isSuperuser = false)
               dbUserGrantedTeamOrgPlat = dbUserTeamOrgPlat.copy(
-                _1 = dbGrantedUser)
+                _1 = dbGrantedUser
+              )
               _ <- {
                 UserGroupRoleDao.create(
                   UserGroupRole
-                    .Create(dbGrantedUser.id,
-                            GroupType.Platform,
-                            dbPlatform.id,
-                            GroupRole.Member)
-                    .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+                    .Create(
+                      dbGrantedUser.id,
+                      GroupType.Platform,
+                      dbPlatform.id,
+                      GroupRole.Member
+                    )
+                    .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                ) >>
                   UserGroupRoleDao.create(
                     UserGroupRole
-                      .Create(dbGrantedUser.id,
-                              GroupType.Organization,
-                              dbOrg.id,
-                              GroupRole.Member)
-                      .toUserGroupRole(dbUser, MembershipStatus.Approved)) >>
+                      .Create(
+                        dbGrantedUser.id,
+                        GroupType.Organization,
+                        dbOrg.id,
+                        GroupRole.Member
+                      )
+                      .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                  ) >>
                   UserGroupRoleDao.create(
                     UserGroupRole
-                      .Create(dbGrantedUser.id,
-                              GroupType.Team,
-                              dbTeam.id,
-                              GroupRole.Member)
-                      .toUserGroupRole(dbUser, MembershipStatus.Approved))
+                      .Create(
+                        dbGrantedUser.id,
+                        GroupType.Team,
+                        dbTeam.id,
+                        GroupRole.Member
+                      )
+                      .toUserGroupRole(dbUser, MembershipStatus.Approved)
+                  )
               }
             } yield {
-              (projectInsert1,
-               projectInsert2,
-               dbUserGrantedTeamOrgPlat,
-               dbGrantedUser)
+              (
+                projectInsert1,
+                projectInsert2,
+                dbUserGrantedTeamOrgPlat,
+                dbGrantedUser
+              )
             }
 
             val isUserPermittedIO = for {
               projectCreate <- projectCreateIO
-              (projectInsert1,
-               projectInsert2,
-               dbUserGrantedTeamOrgPlat,
-               dbGrantedUser) = projectCreate
+              (
+                projectInsert1,
+                projectInsert2,
+                dbUserGrantedTeamOrgPlat,
+                dbGrantedUser
+              ) = projectCreate
               acrListToInsert = acrList.map(
-                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat))
-              acrs <- ProjectDao.addPermissionsMany(projectInsert1.id,
-                                                    acrListToInsert)
+                fixUpObjectAcr(_, dbUserGrantedTeamOrgPlat)
+              )
+              acrs <- ProjectDao.addPermissionsMany(
+                projectInsert1.id,
+                acrListToInsert
+              )
               _ = logger.debug(s"ACRS Added: $acrs")
               action = Random.shuffle(acrListToInsert.map(_.actionType)).head
-              isPermitted1 <- ProjectDao.authorized(dbGrantedUser,
-                                                    ObjectType.Project,
-                                                    projectInsert1.id,
-                                                    action)
-              isPermitted2 <- ProjectDao.authorized(dbGrantedUser,
-                                                    ObjectType.Project,
-                                                    projectInsert2.id,
-                                                    action)
+              isPermitted1 <- ProjectDao.authorized(
+                dbGrantedUser,
+                ObjectType.Project,
+                projectInsert1.id,
+                action
+              )
+              isPermitted2 <- ProjectDao.authorized(
+                dbGrantedUser,
+                ObjectType.Project,
+                projectInsert2.id,
+                action
+              )
             } yield {
-              (action,
-               projectInsert2,
-               isPermitted1.toBoolean,
-               isPermitted2.toBoolean)
+              (
+                action,
+                projectInsert2,
+                isPermitted1.toBoolean,
+                isPermitted2.toBoolean
+              )
             }
 
             val (action, projectInsert2, isPermitted1, isPermitted2) =


### PR DESCRIPTION
## Overview

This PR makes a few changes to how exceptional cases are handled when sharing annotation projects with users by email:

- It checks for a user's prior existence in Auth0 by email before trying to create a user with that email address. If a user exists, it proceeds with that `Auth0User`.
- it stops error-ing when trying to add a permission to a list of ACRs that is already present. Instead, it returns the existing list, since the db already reflects the state indicated by the user's request
- it makes potential errors in `replacePermissions` explicit in the type so that it'll at least be obvious where errors are coming from if we run into more exceptional cases in the future

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

This doesn't really change what happens in error cases -- but it does fix what occurs in several previous unexpected errors

## Testing Instructions

- assemble api server
- `docker-compose up nginx-api api-server memcached` (doing this explicitly so that `ctrl+c` will also kill memcached -- it saves a step later)
- get a dev user JWT and `export JWT_AUTH_TOKEN=<your token>`
- `echo '{"email": "bogususer@bogus.com"}' | http --auth-type=jwt :9000/api/annotation-projects/6e35b51e-4d67-4cb0-bf23-ca265ef49b24/share` -- this user already exists in Auth0 but will not exist in your local db. This should succeed.
- delete the created user in your db -- you can find them by email. Note that this will not delete the ACRs, since the ACRs column doesn't have any way to keep track of changes in the users table
- repeat the request above -- it should succeed again

Closes #5333 