### PR TITLE
Fix Minor Scopes Issue and Fix Non Web Mercator Task Grid Generation

### DIFF
--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -147,7 +147,7 @@ Path,Domain:Action,Verb
 /api/scenes/{sceneID}/actions,scenes:readPermissions,get
 /api/scenes/{sceneID}/datasource,datasources:read,get
 /api/scenes/{sceneID}/download,scenes:download,get
-/api/scenes/{sceneID}/sentinel-metadata,scenes:readSentinelMetadata,get
+/api/scenes/{sceneID}/sentinel-metadata/other-random-string,scenes:readSentinelMetadata,get
 /api/scenes/{sceneID}/permissions/,scenes:readPermissions,get
 /api/scenes/{sceneID}/permissions/,scenes:share,put
 /api/scenes/{sceneID}/permissions/,scenes:share,post
@@ -165,8 +165,8 @@ Path,Domain:Action,Verb
 /api/stac/{stacExportID}/,stacExports:read,get
 /api/stac/{stacExportID}/,stacExports:delete,delete
 /api/teams/{teamID},teams:read,get
-/api/thumbnails/sentinel/a-random-sentinel-image,thumbnails:read,get
-/api/thumbnails/{thumbnailID}/,scenes:readThumbnail,get
+/api/thumbnails/sentinel/a-random-sentinel-image/?token={token},scenes:readThumbnail,get
+/api/thumbnails/{thumbnailID}/?token={token},thumbnails:read,get
 /api/tokens/,tokens:read,get
 /api/tokens/{refreshTokenID}/,tokens:delete,delete
 /api/tool-runs/,analyses:read,get

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -147,6 +147,7 @@ Path,Domain:Action,Verb
 /api/scenes/{sceneID}/actions,scenes:readPermissions,get
 /api/scenes/{sceneID}/datasource,datasources:read,get
 /api/scenes/{sceneID}/download,scenes:download,get
+/api/scenes/{sceneID}/sentinel-metadata,scenes:readSentinelMetadata,get
 /api/scenes/{sceneID}/permissions/,scenes:readPermissions,get
 /api/scenes/{sceneID}/permissions/,scenes:share,put
 /api/scenes/{sceneID}/permissions/,scenes:share,post
@@ -164,6 +165,8 @@ Path,Domain:Action,Verb
 /api/stac/{stacExportID}/,stacExports:read,get
 /api/stac/{stacExportID}/,stacExports:delete,delete
 /api/teams/{teamID},teams:read,get
+/api/thumbnails/sentinel/a-random-sentinel-image,thumbnails:read,get
+/api/thumbnails/{thumbnailID}/,scenes:readThumbnail,get
 /api/tokens/,tokens:read,get
 /api/tokens/{refreshTokenID}/,tokens:delete,delete
 /api/tool-runs/,analyses:read,get

--- a/app-backend/api-it/src/test/scala/ScopeSpec.scala
+++ b/app-backend/api-it/src/test/scala/ScopeSpec.scala
@@ -182,7 +182,7 @@ class ScopeSpec extends FunSpec {
     }
     assert(
       resultBody == Right(SimResponse(expectation)),
-      "Authorization expectation failed"
+      s"Authorization expectation failed: received $resultBody, expected $expectation"
     )
   }
 

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -452,10 +452,13 @@ object Scopes {
           Action.Download,
           Action.ReadThumbnail,
           Action.ReadSentinelMetadata
-        ).map(makeScopedAction(Domain.Projects, _)) ++ makeCRUDScopedActions(
+        ).map(makeScopedAction(Domain.Scenes, _)) ++ makeCRUDScopedActions(
           Domain.Scenes
         )
       )
+
+  case object ThumbnailScope
+      extends SimpleScope(Set(ScopedAction(Domain.Thumbnails, Action.Read)))
 
   case object ShapesCRUD
       extends SimpleScope(makeCRUDScopedActions(Domain.Shapes))
@@ -523,6 +526,7 @@ object Scopes {
           StacExportsCRUD,
           TeamsCRUD,
           TemplatesCRUD,
+          ThumbnailScope,
           TokensCRUD,
           UploadsCRUD,
           UserSelfScope,

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -458,7 +458,8 @@ object Scopes {
       )
 
   case object ThumbnailScope
-      extends SimpleScope(Set(ScopedAction(Domain.Thumbnails, Action.Read, None)))
+      extends SimpleScope(
+        Set(ScopedAction(Domain.Thumbnails, Action.Read, None)))
 
   case object ShapesCRUD
       extends SimpleScope(makeCRUDScopedActions(Domain.Shapes))

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -458,7 +458,7 @@ object Scopes {
       )
 
   case object ThumbnailScope
-      extends SimpleScope(Set(ScopedAction(Domain.Thumbnails, Action.Read)))
+      extends SimpleScope(Set(ScopedAction(Domain.Thumbnails, Action.Read, None)))
 
   case object ShapesCRUD
       extends SimpleScope(makeCRUDScopedActions(Domain.Shapes))

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -72,12 +72,15 @@ class GeoTiffS3SceneFactory(object):
                 bucket.download_file(key, tmp_fname)
 
                 if self.fileType == "NON_SPATIAL":
-                    tmp_fname = cog.georeference_file(tmp_fname)
+                    warped_fname = cog.georeference_file(tmp_fname)
+                else:
+                    warped_fname = cog.reproject_to_webmercator(tmp_fname)
 
-                cog.add_overviews(tmp_fname)
-                cog_path = cog.convert_to_cog(tmp_fname, tempdir)
+                cog.add_overviews(warped_fname)
+
+                cog_path = cog.convert_to_cog(warped_fname, tempdir)
                 scene = self.create_geotiff_scene(
-                    tmp_fname, os.path.splitext(filename)[0]
+                    warped_fname, os.path.splitext(filename)[0]
                 )
                 if self.keep_in_source_bucket:
                     scene.ingestLocation = upload_tifs(
@@ -89,7 +92,7 @@ class GeoTiffS3SceneFactory(object):
                     )[0]
                 images = [
                     self.create_geotiff_image(
-                        tmp_fname, unquote(scene.ingestLocation), scene, cog_path
+                        warped_fname, unquote(scene.ingestLocation), scene, cog_path
                     )
                 ]
 

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -21,6 +21,22 @@ DATA_BUCKET = os.getenv("DATA_BUCKET")
 s3client = boto3.client("s3")
 logger = logging.getLogger(__name__)
 
+def reproject_to_webmercator(file_path):
+    logger.info("Reprojecting %s", file_path)
+    output_dir, source_filename = os.path.split(file_path)
+    warped_tiff = os.path.join(
+        output_dir, "{}-warped.tif".format(source_filename.split(".")[0])
+    )
+    warped_command = [
+        "gdalwarp",
+        "-t_srs",
+        "epsg:3857",
+        file_path,
+        warped_tiff,
+    ]
+    logger.debug("Running warp command: %s", warped_command)
+    subprocess.check_call(warped_command)
+    return warped_tiff
 
 def georeference_file(file_path):
     logger.info("Georeferencing %s", file_path)


### PR DESCRIPTION
## Overview

This PR fixes two issues that came up in user testing:
 1. Users were unable to download scenes from the UI because scopes were incorrectly added for projects when it should have been scenes
 2. Task grid generation failed because the grid being generated did not make any sense for the CRS of the generated COG. The conversion of the task size pixels to task size meters assumed the tiff was in a projection whose unit was meters. This lead to task size grids being generated that were _way_ too small that would cause the database to crash.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any ~new~ old endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- Rebuild batch container and make sure your API server is up-to-date
- Create a project, copy its ID:
```
export JWT_AUTH_TOKEN=<JWT TOKEN FROM UI>
echo '{"name":"new-project-4326","description":"a new project","visibility":"PRIVATE","tileVisibility":"PUBLIC","owner":null,"isAOIProject":false,"aoiCadenceMillis":0,"tags":[],"isSingleBand":false,"singleBandOptions":null,"extras":{}}' | http :9091/api/projects --auth-type=jwt
```
- Create an annotation project, inserting the project id from the previous step. Save the annotation project ID.
```
echo '{"name":"new-project-4326","projectType":"CLASSIFICATION","tileLayers":[],"labelClassGroups":[{"name":"green things","classes":[{"name":"so green","colorHexCode":"#00ff00","index":0},{"name":"pretty green","colorHexCode":"#00dd00","index":0}]}],"projectId":"<PROJECT ID>","taskSizePixels":512,"ready":false}' | http :9091/api/annotation-projects --auth-type=jwt
```
- Create an upload, insert the project ID and the annotation project ID. Copy the upload ID.
```
echo '{"uploadStatus":"UPLOADED","fileType":"geotiff","uploadType":"S3","files":["s3://rasterfoundry-development-data-us-east-1/6987cb68-b63c-4f41-8faf-c2543c7e4f82.tif"],"datasource":"c14c8e97-ba85-4677-ac9c-069cfef1f0b1","metadata":{},"visibility":"PRIVATE","projectId":"<PROJECT ID>","annotationProjectId":"<ANNOTATION PROJECT ID>","generateTasks":true}' | http :9091/api/uploads/ --auth-type=jwt
```
- Run upload processing:
```
./scripts/console batch 'rf process-upload <UPLOAD ID>'
```
- Go to [this](http://localhost:9091/projects/edit/df697018-68ea-4b4e-81b3-50481a4bf15f/scenes?page=1) project and try to download the scene

Closes #5339 
