### PR TITLE
Make permission replacement obey same scope rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Moved project data for Groundwork from extras jsonb field and a text field to normalized tables [#5286](https://github.com/raster-foundry/raster-foundry/pull/5286)
 - Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)
 - Updated to support STAC exports on annotation projects [#5312](https://github.com/raster-foundry/raster-foundry/pull/5312) [#5323](https://github.com/raster-foundry/raster-foundry/pull/5323)
+- Made permission replacement obey same scope rules [#5343](https://github.com/raster-foundry/raster-foundry/pull/5343)
 
 
 ### Deprecated

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -85,7 +85,15 @@ trait AnnotationProjectPermissionRoutes
               AnnotationProjectDao.isValidPermission(acr, user)
             }
           } yield {
-            auth1.toBoolean && auth2.foldLeft(true)(_ && _)
+            auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
+              case true =>
+                AnnotationProjectDao.isReplaceWithinScopedLimit(
+                  Domain.AnnotationProjects,
+                  user,
+                  acrList
+                )
+              case _ => false
+            })
           }).transact(xa).unsafeToFuture()
         } {
           complete {

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -223,6 +223,14 @@ trait DatasourceRoutes
                 DatasourceDao.isValidPermission(acr, user)
               } map {
                 _.foldLeft(true)(_ && _)
+              } map {
+                case true =>
+                  DatasourceDao.isReplaceWithinScopedLimit(
+                    Domain.Datasources,
+                    user,
+                    acrList
+                  )
+                case _ => false
               }
             ).tupled
               .map({ authTup =>

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -1005,14 +1005,14 @@ trait ProjectRoutes
             } map {
               _.foldLeft(true)(_ && _)
             } map {
-                case true =>
-                  ProjectDao.isReplaceWithinScopedLimit(
-                    Domain.Projects,
-                    user,
-                    acrList
-                  )
-                case _ => false
-              }
+              case true =>
+                ProjectDao.isReplaceWithinScopedLimit(
+                  Domain.Projects,
+                  user,
+                  acrList
+                )
+              case _ => false
+            }
           ).tupled
             .map({ authTup =>
               authTup._1 && authTup._2

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -1004,7 +1004,15 @@ trait ProjectRoutes
               ProjectDao.isValidPermission(acr, user)
             } map {
               _.foldLeft(true)(_ && _)
-            }
+            } map {
+                case true =>
+                  ProjectDao.isReplaceWithinScopedLimit(
+                    Domain.Projects,
+                    user,
+                    acrList
+                  )
+                case _ => false
+              }
           ).tupled
             .map({ authTup =>
               authTup._1 && authTup._2

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -337,6 +337,14 @@ trait SceneRoutes
               SceneDao.isValidPermission(acr, user)
             } map {
               _.foldLeft(true)(_ && _)
+            } map {
+              case true =>
+                SceneDao.isReplaceWithinScopedLimit(
+                  Domain.Scenes,
+                  user,
+                  acrList
+                )
+              case _ => false
             }
           ).tupled
             .map({ authTup =>

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -215,6 +215,14 @@ trait ShapeRoutes
               ShapeDao.isValidPermission(acr, user)
             } map {
               _.foldLeft(true)(_ && _)
+            } map {
+              case true =>
+                ShapeDao.isReplaceWithinScopedLimit(
+                  Domain.Shapes,
+                  user,
+                  acrList
+                )
+              case _ => false
             }
           ).tupled
             .map({ authTup =>

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -87,7 +87,7 @@ trait ToolRunRoutes
             ) {
               complete {
                 val userOQuery
-                    : Option[doobie.ConnectionIO[User]] = tokenO flatMap {
+                  : Option[doobie.ConnectionIO[User]] = tokenO flatMap {
                   token: String =>
                     verifyJWT(token.split(" ").last).toOption
                 } map {
@@ -107,7 +107,7 @@ trait ToolRunRoutes
                           runParams.ownershipTypeParams.ownershipType,
                           runParams.groupQueryParameters.groupType,
                           runParams.groupQueryParameters.groupId
-                        )
+                      )
                     )
                   case _ =>
                     ToolRunDao.listAnalysesWithRelated(

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -87,7 +87,7 @@ trait ToolRunRoutes
             ) {
               complete {
                 val userOQuery
-                  : Option[doobie.ConnectionIO[User]] = tokenO flatMap {
+                    : Option[doobie.ConnectionIO[User]] = tokenO flatMap {
                   token: String =>
                     verifyJWT(token.split(" ").last).toOption
                 } map {
@@ -107,7 +107,7 @@ trait ToolRunRoutes
                           runParams.ownershipTypeParams.ownershipType,
                           runParams.groupQueryParameters.groupType,
                           runParams.groupQueryParameters.groupId
-                      )
+                        )
                     )
                   case _ =>
                     ToolRunDao.listAnalysesWithRelated(
@@ -264,6 +264,14 @@ trait ToolRunRoutes
               ToolRunDao.isValidPermission(acr, user)
             } map {
               _.foldLeft(true)(_ && _)
+            } map {
+              case true =>
+                ToolRunDao.isReplaceWithinScopedLimit(
+                  Domain.Analyses,
+                  user,
+                  acrList
+                )
+              case _ => false
             }
           ).tupled
             .map({ authTup =>

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -241,6 +241,14 @@ trait ToolRoutes
               ToolDao.isValidPermission(acr, user)
             } map {
               _.foldLeft(true)(_ && _)
+            } map {
+              case true =>
+                ToolDao.isReplaceWithinScopedLimit(
+                  Domain.Templates,
+                  user,
+                  acrList
+                )
+              case _ => false
             }
           ).tupled
             .map({ authTup =>

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -238,7 +238,7 @@ trait ObjectPermissions[Model] {
     val inheritedF: Fragment =
       createInheritedF(user, actionType, groupTypeO, groupIdO)
     val acrFilterF
-        : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
+      : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
       .const(s"${tableName}acrs")
 
     ownershipTypeO match {

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -308,7 +308,9 @@ trait ObjectPermissions[Model] {
     ) map { action =>
       (action.limit map { limit =>
         val distinctUsers = acrList.foldLeft(Set.empty[String])({
-          case (accum: Set[String], ObjectAccessControlRule(SubjectType.User, Some(subjId), _)) => accum | Set(subjId)
+          case (accum: Set[String],
+                ObjectAccessControlRule(SubjectType.User, Some(subjId), _)) =>
+            accum | Set(subjId)
           case (accum: Set[String], _) => accum
         })
         distinctUsers.size.toLong <= limit


### PR DESCRIPTION
## Overview

This PR adds a method in `ObjectPermissions` trait to check if the ACR list to be replaced is compliant with the operating user's limit on the scoped actions of a specific domain. It appends such checks on the current endpoints where we perform permission replacement.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Edit your testing user's share action limit on annotation project to 0
- `PUT` to `/api/annotation-projects/<projectId>/permissions` with a positive-length list of `ObjectAccessControlRule`s
- The endpoint should not allow you to replace

Closes https://github.com/raster-foundry/raster-foundry/issues/5307
