### PR TITLE
Clip task cell to project footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Clear Python Lambda function pip cache [#5274](https://github.com/raster-foundry/raster-foundry/pull/5274)
 - Updated to support STAC exports on annotation projects [#5312](https://github.com/raster-foundry/raster-foundry/pull/5312) [#5323](https://github.com/raster-foundry/raster-foundry/pull/5323)
 - Made permission replacement obey same scope rules [#5343](https://github.com/raster-foundry/raster-foundry/pull/5343)
-
+- Updated the task grid creation SQL function to clip task cells to project footprint [#5344](https://github.com/raster-foundry/raster-foundry/pull/5344)
 
 ### Deprecated
 

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -64,11 +64,7 @@ class CreateTaskGrid(
       _ <- OptionT.liftF {
         AnnotationProjectDao
           .update(
-            annotationProject.copy(
-              aoi = footprint,
-              ready = true,
-              taskSizeMeters = Some(taskSizeMeters)
-            ),
+            annotationProject.copy(ready = true),
             annotationProject.id
           )
       }

--- a/app-backend/db/src/main/resources/migrations/V35__update_make_grid_to_clip_cell_to_project_bound.sql
+++ b/app-backend/db/src/main/resources/migrations/V35__update_make_grid_to_clip_cell_to_project_bound.sql
@@ -1,0 +1,60 @@
+CREATE OR REPLACE FUNCTION public.ST_MakeGrid (
+  bound_polygon public.geometry,
+  width_step double precision,
+  height_step double precision
+)
+RETURNS public.geometry AS
+$body$
+DECLARE
+  Xmin DOUBLE PRECISION;
+  Xmax DOUBLE PRECISION;
+  Ymax DOUBLE PRECISION;
+  X DOUBLE PRECISION;
+  Y DOUBLE PRECISION;
+  NextX DOUBLE PRECISION;
+  NextY DOUBLE PRECISION;
+  CPoint public.geometry;
+  sectors public.geometry[];
+  newSector public.geometry;
+  i INTEGER;
+  SRID INTEGER;
+  source_srid INTEGER;
+BEGIN
+  source_srid := ST_SRID(bound_polygon);
+  bound_polygon := ST_Transform(bound_polygon, 4326);
+  Xmin := ST_XMin(bound_polygon);
+  Xmax := ST_XMax(bound_polygon);
+  Ymax := ST_YMax(bound_polygon);
+  SRID := 4326;
+  Y := ST_YMin(bound_polygon); --current sector's corner coordinate
+  i := -1;
+  <<yloop>>
+  LOOP
+    IF (Y > Ymax) THEN
+        EXIT;
+    END IF;
+    X := Xmin;
+    <<xloop>>
+    LOOP
+      IF (X > Xmax) THEN
+          EXIT;
+      END IF;
+      CPoint := ST_SetSRID(ST_MakePoint(X, Y), SRID);
+      NextX := ST_X(ST_Project(CPoint, $2, radians(90))::geometry);
+      NextY := ST_Y(ST_Project(CPoint, $3, radians(0))::geometry);
+      i := i + 1;
+      newSector := ST_MakeEnvelope(X, Y, NextX, NextY, SRID);
+      IF (ST_Intersects(newSector, bound_polygon)) THEN
+        sectors[i] := ST_Transform(ST_Intersection(newSector, bound_polygon), source_srid);
+      END IF;
+      X := NextX;
+    END LOOP xloop;
+    CPoint := ST_SetSRID(ST_MakePoint(X, Y), SRID);
+    NextY := ST_Y(ST_Project(CPoint, $3, radians(0))::geometry);
+    Y := NextY;
+  END LOOP yloop;
+
+  RETURN ST_Collect(sectors);
+END;
+$body$
+LANGUAGE 'plpgsql';

--- a/scripts/server
+++ b/scripts/server
@@ -17,7 +17,7 @@ then
     else
         TILE_SERVER_LOCATION="http://localhost:8081" \
                             docker-compose \
-                            up nginx-backsplash backsplash api-server nginx-api
+                            up nginx-backsplash backsplash api-server nginx-api memcached
     fi
     exit
 fi


### PR DESCRIPTION
## Overview

This PR updates the `ST_MakeGrid` function so that each cell for the task grid is a result of applying  `ST_Intersection` on the calculated `newSector` and the passed in geometry `bound_polygon`  (which, for task grid creation, is the project footprint under the hood).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

### Demo

<img width="1738" alt="Screen Shot 2020-03-04 at 11 50 37 AM" src="https://user-images.githubusercontent.com/16109558/75902910-c7a12000-5e0e-11ea-8bc3-9508ef65846b.png">

## Testing Instructions

- run migrations
- Make your testing user's scope `"groundworkUser;platforms:admin;"`
- Grab the id of project `Local File Single Scene`
- `POST` to `api/annotation-projects` with the following:
```json
{
    "name": "GW|Local File Single Scene",
    "projectType": "CLASSIFICATION",
    "tileLayers": [],
    "labelClassGroups": [
	{
	    "name": "green things",
	    "classes": [
		{
		    "name": "so green",
		    "colorHexCode": "#00ff00",
		    "index": 0
		},
		{
		    "name": "pretty green",
		    "colorHexCode": "#00dd00",
		    "index": 0
		}
	    ]
	}
    ],
    "projectId": "<YOUR PROJECT ID>",
    "taskSizePixels": 200,
    "ready": false
}
```
- Grab the annotation project ID from the above request's response
- The dao method being called under the hood of this following request is the same as the one when running the task grid creation batch job. So, `POST` to `api/annotation-projects/<annotation project ID>/tasks/grid` with the following:
```json
{
  "geometry": {
    "type": "Polygon",
    "coordinates": [
      [
        [
          -100.81800544812673,
          41.12110187268947
        ],
        [
          -100.81800544812673,
          41.191357235936
        ],
        [
          -100.7445369637344,
          41.191357235936
        ],
        [
          -100.7445369637344,
          41.12110187268947
        ],
        [
          -100.81800544812673,
          41.12110187268947
        ]
      ]
    ]
  },
  "properties": {
    "sizeMeters": 200
  },
  "type": "Feature"
}
```
the `geometry` above is the same as the project's footprint(`extent` field) to mock the actual use case when creating grid for an annotation project
* `GET` to `api/annotation-projects/<annotation project ID>/tasks?pageSize=9999` to get a `FeatureCollection` of all tasks from this annotation project and save it as `tasks.geojson`
* Open `tasks.geojson` in QGIS and zoom in to the edge of the entire grid, there should be some tiny tasks as a result of clipping

Closes https://github.com/raster-foundry/raster-foundry/issues/5300
