### PR TITLE
Add back the update of aoi and taskSizeMeters at the end of creating grids

### DIFF
--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -61,10 +61,17 @@ class CreateTaskGrid(
           .insertTasksByGrid(taskProperties, taskGridFeatureCreate, owner)
       }
       _ <- OptionT.liftF { info("Inserted tasks") }
+      // even though the `aoi` and `taskSizeMeters` are updated when inserting tasks,
+      // the `annotationProject` here does not know that because it happened before
+      // task insert. this is why we update these fields in the following lines
       _ <- OptionT.liftF {
         AnnotationProjectDao
           .update(
-            annotationProject.copy(ready = true),
+            annotationProject.copy(
+              aoi = footprint,
+              ready = true,
+              taskSizeMeters = Some(taskSizeMeters)
+            ),
             annotationProject.id
           )
       }


### PR DESCRIPTION
## Overview

It was done correctly before. I thought I knew everything. But obviously I do not. Adding these lines back with a note to myself so that I won't be tricked by it again.

Also, all annotation projects' associated projects' `tile_visibility` are now `PUBLIC` (with the below code) on staging, so that tiles for the existing annotation projects should show again on GW staging.
```sql
update projects
set tile_visibility = 'PUBLIC'
where id in (select project_id from annotation_projects);
```

Additionally, updating tile visibility is also added as a step in the release issue: https://github.com/azavea/raster-foundry-platform/issues/926

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- 🤠 

Closes https://github.com/raster-foundry/annotate/issues/712
