### PR TITLE
Hook up async tasks to new AnnotationProject.status field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ metals.sbt
 
 /.env
 /.envrc
+.env.local
 
 .node_modules
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Updated to support STAC exports on annotation projects [#5312](https://github.com/raster-foundry/raster-foundry/pull/5312) [#5323](https://github.com/raster-foundry/raster-foundry/pull/5323)
 - Made permission replacement obey same scope rules [#5343](https://github.com/raster-foundry/raster-foundry/pull/5343)
 - Updated the task grid creation SQL function to clip task cells to project footprint [#5344](https://github.com/raster-foundry/raster-foundry/pull/5344)
+- Change the `ready` boolean field to a `status` enum field for better descriptions of processing failures [#5350](https://github.com/raster-foundry/raster-foundry/pull/5350)
 
 ### Deprecated
 

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -69,7 +69,6 @@ class CreateTaskGrid(
           .update(
             annotationProject.copy(
               aoi = footprint,
-              ready = true,
               taskSizeMeters = Some(taskSizeMeters)
             ),
             annotationProject.id

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -139,6 +139,16 @@ object Generators extends ArbitraryInstances {
     IngestStatus.Failed
   )
 
+  private def annotationProjectStatusGen: Gen[AnnotationProjectStatus] = Gen.oneOf(
+    AnnotationProjectStatus.Waiting,
+    AnnotationProjectStatus.Queued,
+    AnnotationProjectStatus.Processing,
+    AnnotationProjectStatus.Ready,
+    AnnotationProjectStatus.UnknownFailure,
+    AnnotationProjectStatus.TaskGridFailure,
+    AnnotationProjectStatus.ImageIngestionFailure
+  )
+
   private def tileLayerTypeGen: Gen[TileLayerType] = Gen.oneOf(
     TileLayerType.MVT,
     TileLayerType.TMS
@@ -1049,7 +1059,7 @@ object Generators extends ArbitraryInstances {
       Gen.const(None),
       tileLayerCreateGen map { List(_) },
       Gen.listOfN(3, labelClassGroupGen),
-      arbitrary[Boolean]
+      annotationProjectStatusGen
     ).mapN(AnnotationProject.Create.apply _)
 
   private def annotationLabelWithClassesCreateGen

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -19,7 +19,7 @@ final case class AnnotationProject(
     labelersTeamId: Option[UUID],
     validatorsTeamId: Option[UUID],
     projectId: Option[UUID],
-    ready: Boolean
+    status: AnnotationProjectStatus
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -37,7 +37,7 @@ final case class AnnotationProject(
       labelersTeamId,
       validatorsTeamId,
       projectId,
-      ready,
+      status,
       tileLayers,
       labelClassGroups
     )
@@ -57,7 +57,7 @@ object AnnotationProject {
       projectId: Option[UUID],
       tileLayers: List[TileLayer.Create],
       labelClassGroups: List[AnnotationLabelClassGroup.Create],
-      ready: Boolean
+      status: AnnotationProjectStatus
   )
 
   object Create {
@@ -76,7 +76,7 @@ object AnnotationProject {
       labelersTeamId: Option[UUID],
       validatorsTeamId: Option[UUID],
       projectId: Option[UUID],
-      ready: Boolean,
+      status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
   ) {
@@ -92,7 +92,7 @@ object AnnotationProject {
       labelersTeamId,
       validatorsTeamId,
       projectId,
-      ready
+      status
     )
 
     def withSummary(
@@ -111,7 +111,7 @@ object AnnotationProject {
         labelersTeamId,
         validatorsTeamId,
         projectId,
-        ready,
+        status,
         tileLayers,
         labelClassGroups,
         taskStatusSummary,
@@ -158,7 +158,7 @@ object AnnotationProject {
       labelersTeamId: Option[UUID],
       validatorsTeamId: Option[UUID],
       projectId: Option[UUID],
-      ready: Boolean,
+      status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
       taskStatusSummary: Map[TaskStatus, Int],

--- a/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.datamodel
 import cats.implicits._
 import io.circe._
 import io.circe.syntax._
+import scala.util.Try
 
 abstract class AnnotationProjectStatus(val repr: String)
 

--- a/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
@@ -1,0 +1,83 @@
+package com.rasterfoundry.datamodel
+
+import cats.implicits._
+import io.circe._
+import io.circe.syntax._
+
+abstract class AnnotationProjectStatus(val repr: String)
+
+abstract class ProgressStage(val stage: String)
+    extends AnnotationProjectStatus(stage)
+abstract class ErrorStage(val stage: String)
+    extends AnnotationProjectStatus(stage)
+
+object ErrorStage {
+  val fromString = new PartialFunction[String, ErrorStage] {
+    def apply(s: String) = s.toUpperCase match {
+      case "TASK_GRID_FAILURE" => AnnotationProjectStatus.TaskGridFailure
+      case "IMAGE_INGESTION_FAILURE" =>
+        AnnotationProjectStatus.ImageIngestionFailure
+      case "UNKNOWN_FAILURE" => AnnotationProjectStatus.UnknownFailure
+    }
+    def isDefinedAt(s: String): Boolean =
+      Set("TASK_GRID_FAILURE", "IMAGE_INGESTION_FAILURE", "UNKNOWN_FAILURE")
+        .contains(s.toUpperCase)
+  }
+
+}
+
+object ProgressStage {
+  val fromString = new PartialFunction[String, ProgressStage] {
+    def apply(s: String) = s.toUpperCase match {
+      case "WAITING"    => AnnotationProjectStatus.Waiting
+      case "QUEUED"     => AnnotationProjectStatus.Queued
+      case "PROCESSING" => AnnotationProjectStatus.Processing
+      case "READY"      => AnnotationProjectStatus.Ready
+    }
+    def isDefinedAt(s: String): Boolean =
+      Set("WAITING", "QUEUED", "PROCESSING", "READY").contains(s.toUpperCase)
+  }
+}
+
+object AnnotationProjectStatus {
+  case object Waiting extends ProgressStage("WAITING")
+  case object Queued extends ProgressStage("QUEUED")
+  case object Processing extends ProgressStage("PROCESSING")
+  case object Ready extends ProgressStage("READY")
+
+  case object TaskGridFailure extends ErrorStage("TASK_GRID_FAILURE")
+  case object ImageIngestionFailure
+      extends ErrorStage("IMAGE_INGESTION_FAILURE")
+  case object UnknownFailure extends ErrorStage("UNKNOWN_FAILURE")
+
+  implicit val decoderErrorStatus: Decoder[ErrorStage] =
+    Decoder.forProduct1("errorStage")(
+      (stage: String) => ErrorStage.fromString(stage)
+    )
+  implicit val encoderErrorStatus: Encoder[ErrorStage] =
+    Encoder.forProduct1("errorStage")(
+      (stage: ErrorStage) => stage.repr
+    )
+  implicit val decoderProgressStatus: Decoder[ProgressStage] =
+    Decoder.forProduct1("status")(
+      (status: String) => ProgressStage.fromString(status)
+    )
+  implicit val encoderProgressStatus: Encoder[ProgressStage] =
+    Encoder.forProduct1("status")(
+      (status: ProgressStage) => status.repr
+    )
+
+  def fromString: PartialFunction[String, AnnotationProjectStatus] =
+    ErrorStage.fromString.orElse(ProgressStage.fromString)
+
+  implicit def encAnnProjStat: Encoder[AnnotationProjectStatus] =
+    new Encoder[AnnotationProjectStatus] {
+      def apply(thing: AnnotationProjectStatus): Json = thing match {
+        case ps: ProgressStage => Map("status" -> ps.repr).asJson
+        case es: ErrorStage    => Map("errorStage" -> es.repr).asJson
+      }
+    }
+
+  implicit def decAnnProjStat: Decoder[AnnotationProjectStatus] =
+    Decoder[ProgressStage].widen or Decoder[ErrorStage].widen
+}

--- a/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
@@ -59,8 +59,8 @@ object AnnotationProjectStatus {
       (stage: ErrorStage) => stage.repr
     )
   implicit val decoderProgressStatus: Decoder[ProgressStage] =
-    Decoder.forProduct1("status")(
-      (status: String) => ProgressStage.fromString(status)
+    Decoder.decodeString.emapTry(
+      (status: String) => Try { ProgressStage.fromString(status) }
     )
   implicit val encoderProgressStatus: Encoder[ProgressStage] =
     Encoder.forProduct1("status")(

--- a/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProjectStatus.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.datamodel
 import cats.implicits._
 import io.circe._
 import io.circe.syntax._
+
 import scala.util.Try
 
 abstract class AnnotationProjectStatus(val repr: String)

--- a/app-backend/db/src/main/resources/migrations/V36__annotation_project_status.sql
+++ b/app-backend/db/src/main/resources/migrations/V36__annotation_project_status.sql
@@ -1,0 +1,23 @@
+CREATE TYPE public.annotation_project_status AS ENUM (
+    'WAITING',
+    'QUEUED',
+    'PROCESSING',
+    'READY',
+    'UNKNOWN_FAILURE',
+    'TASK_GRID_FAILURE',
+    'IMAGE_INGESTION_FAILURE'
+);
+
+ALTER TABLE public.annotation_projects 
+ADD COLUMN status public.annotation_project_status;
+
+-- set default values and add null constraint
+ALTER TABLE public.annotation_projects ADD CONSTRAINT annotation_project_status_not_null CHECK (status IS NOT NULL) NOT VALID;
+
+UPDATE public.annotation_projects SET status = 'READY' WHERE ready = true;
+UPDATE public.annotation_projects SET status = 'UNKNOWN_FAILURE' WHERE ready = false;
+
+ALTER TABLE public.annotation_projects VALIDATE CONSTRAINT annotation_project_status_not_null;
+
+-- drop old column
+ALTER TABLE annotation_projects DROP COLUMN ready;

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -21,7 +21,7 @@ object AnnotationProjectDao
     SELECT
       id, created_at, owner, name, project_type, task_size_meters,
       task_size_pixels, aoi, labelers_team_id, validators_team_id,
-      project_id, ready
+      project_id, status
     FROM
   """ ++ tableF
 
@@ -129,13 +129,13 @@ object AnnotationProjectDao
   ): ConnectionIO[AnnotationProject.WithRelated] = {
     val projectInsert = (fr"INSERT INTO" ++ tableF ++ fr"""
       (id, created_at, owner, name, project_type, task_size_pixels,
-       aoi, labelers_team_id, validators_team_id, project_id, ready)
+       aoi, labelers_team_id, validators_team_id, project_id, status)
     VALUES
       (uuid_generate_v4(), now(), ${user.id}, ${newAnnotationProject.name},
        ${newAnnotationProject.projectType}, ${newAnnotationProject.taskSizePixels},
        ${newAnnotationProject.aoi}, ${newAnnotationProject.labelersTeamId},
        ${newAnnotationProject.validatorsTeamId},
-       ${newAnnotationProject.projectId}, ${newAnnotationProject.ready})
+       ${newAnnotationProject.projectId}, ${newAnnotationProject.status})
     """).update.withUniqueGeneratedKeys[AnnotationProject](
       "id",
       "created_at",
@@ -148,7 +148,7 @@ object AnnotationProjectDao
       "labelers_team_id",
       "validators_team_id",
       "project_id",
-      "ready"
+      "status"
     )
 
     for {
@@ -230,7 +230,7 @@ object AnnotationProjectDao
       validators_team_id = ${project.validatorsTeamId},
       task_size_meters= ${project.taskSizeMeters},
       aoi = ${project.aoi},
-      ready = ${project.ready}
+      status = ${project.status}
     WHERE
       id = $id
     """).update.run;

--- a/app-backend/db/src/main/scala/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/meta/EnumMeta.scala
@@ -79,6 +79,13 @@ trait EnumMeta {
       _.repr
     )
 
+  implicit val annotationProjectStatusMeta: Meta[AnnotationProjectStatus] =
+    pgEnumString(
+      "annotation_project_status",
+      AnnotationProjectStatus.fromString,
+      _.repr
+    )
+
   implicit val tileLayerTypeMeta: Meta[TileLayerType] =
     pgEnumString(
       "tile_layer_type",

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationProjectDaoSpec.scala
@@ -200,7 +200,7 @@ class AnnotationProjectDaoSpec
           )
 
           assert(
-            afterUpdate.ready == annotationProjectUpdate.ready,
+            afterUpdate.status == annotationProjectUpdate.status,
             "Readiness was updated")
 
           true

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -156,7 +156,7 @@ def process_upload(upload_id):
         )
         if JOB_ATTEMPT >= 3:
             upload.update_upload_status("FAILED")
-            annotationProject.update_status("TASK_GRID_FAILURE")
+            annotationProject.update_status({"errorStage": "TASK_GRID_FAILURE"})
         else:
             upload.update_upload_status("QUEUED")
             if annotationProject is not None:
@@ -167,7 +167,7 @@ def process_upload(upload_id):
             logger.error("Upload for AnnotationProject failed to process: %s", annotationProject.id)
         if JOB_ATTEMPT >= 3:
             upload.update_upload_status("FAILED")
-            annotationProject.update_status("IMAGE_INGESTION_FAILURE")
+            annotationProject.update_status({"errorStage": "IMAGE_INGESTION_FAILURE"})
         else:
             upload.update_upload_status("QUEUED")
             if annotationProject is not None:

--- a/app-tasks/rf/src/rf/models/annotation_project.py
+++ b/app-tasks/rf/src/rf/models/annotation_project.py
@@ -4,19 +4,67 @@ from .base import BaseModel
 class AnnotationProject(BaseModel):
     URL_PATH = "/api/annotation-projects/"
 
-    def __init__(self, id, taskSizePixels):
+    def __init__(
+            self,
+            id,
+            name,
+            projectType,
+            taskSizePixels,
+            status,
+            createdAt=None,
+            createdBy=None,
+            taskSizeMeters=None,
+            aoi=None,
+            labelersTeamId=None,
+            validatorsTeamId=None,
+            projectId=None,
+            ):
         self.id = id
+        self.name = name
+        self.projectType = projectType
         self.taskSizePixels = taskSizePixels
+        self.status = status
+        self.createdAt = createdAt
+        self.createdBy = createdBy
+        self.taskSizeMeters = taskSizeMeters
+        self.aoi = aoi
+        self.labelersTeamId = labelersTeamId
+        self.validatorsTeamId = validatorsTeamId
+        self.projectId = projectId
 
     def to_dict(self):
         return dict(
             id=self.id,
-            taskSizePixels=self.taskSizePixels
+            createdAt=self.createdAt,
+            createdBy=self.createdBy,
+            name=self.name,
+            projectType=self.projectType,
+            taskSizeMeters=self.taskSizeMeters,
+            taskSizePixels=self.taskSizePixels,
+            aoi=self.aoi,
+            labelersTeamId=self.labelersTeamId,
+            validatorsTeamId=self.validatorsTeamId,
+            projectId=self.projectId,
+            status=self.status,
         )
+
+    def update_status(self, status):
+        self.status = status
+        return self.update()
 
     @classmethod
     def from_dict(cls, d):
         return cls(
             d.get("id"),
-            d.get("taskSizePixels")
+            d.get("name"),
+            d.get("projectType"),
+            d.get("taskSizePixels"),
+            d.get("status"),
+            createdAt=d.get("createdAt"),
+            createdBy=d.get("createdBy"),
+            taskSizeMeters=d.get("taskSizeMeters"),
+            aoi=d.get("aoi"),
+            labelersTeamId=d.get("labelersTeamId"),
+            validatorsTeamId=d.get("validatorsTeamId"),
+            projectId=d.get("projectId")
         )


### PR DESCRIPTION
## Overview
Add a more informative status field to annotation projects
Migrate from the ready field to a status field
Set statuses correctly in upload processing

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~Swagger specification updated~
- [x] New tables and queries have appropriate indices added (N/A)
- [ ] ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [ ] ~Any new SQL strings have tests~
- [ ] ~Any new endpoints have scope validation and are included in the integration test csv~

### Demo
Statuses as set by raising exceptions in the appropriate sections of the upload batch process:
![image](https://user-images.githubusercontent.com/4392704/76122414-ff04fd80-5fc3-11ea-808f-ed7a5dbc047f.png)


### Notes
Error handling does not encompass larger scale batch issues (unable to contact API, etc), since we don't have a good way of handling that right now. This should be handled in a later issue

## Testing Instructions
- build your batch jar
- build your batch container
- run migrations
- start the API server, etc.
- start the annotate frontend on the accompanying annotate branch
- create a project with a small upload to make things to quickly
- find the upload id in your database: `select id from uploads where annotation_project_id = '<annotation_project_id>';`
- run the batch command to ingest the upload: `./scripts/console batch 'AWS_BATCH_JOB_ATTEMPT=3 rf process-upload 819c2ce5-e48a-40c3-8a27-f274b1ec4e59'`
- refresh the project list and verify that the status is set to "ready" as expected
- stick a normal exception inside the main `try` catch block, rebuild the batch container, and re-run the batch command. Verify that it sets the status to `IMAGE_INGESTION_FAILURE`
- stick a `TaskGridError` there instead and verify it sets the status to `TASK_GRID_FAILURE`

Closes https://github.com/raster-foundry/annotate/issues/670
