### PR TITLE
Make app-tasks python3.7 compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Removed
 
 ### Fixed
+- Upgrade pyproj to make app-tasks python3.7 compatible [#5352](https://github.com/raster-foundry/raster-foundry/pull/5352)
 - Upload updates now respect all fields [#5330](https://github.com/raster-foundry/raster-foundry/pull/5330)
 - Removed unused route and fixed spelling in Swagger spec [#5273](https://github.com/raster-foundry/raster-foundry/pull/5273)
 - Fix 403 when users with no uploads try to create an upload [#5337](https://github.com/raster-foundry/raster-foundry/pull/5337)

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -3,7 +3,7 @@ boto3==1.7.71
 pytest==2.9.2
 pytest-runner==2.9
 rasterio==1.0.28
-pyproj==1.9.5
+pyproj==2.4.2
 ipython==5.1.0
 pyjwt==1.4.2
 rollbar==0.14.6


### PR DESCRIPTION
## Overview

Because that's what Jenkins wants all of a sudden?

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Somehow, running the exact same step from `cibuild` to build the batch container locally... doesn't reproduce the issue, even with `--no-cache`. I'm baffled and sitting here with :crossed_fingers: .

## Testing Instructions

- ci

Closes azavea/raster-foundry-platform#984
