### PR TITLE
Update planet dependency to avoid syntax bug on import

### DIFF
--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -8,7 +8,7 @@ ipython==5.1.0
 pyjwt==1.4.2
 rollbar==0.14.6
 dnspython==1.15.0
-planet==1.0
+planet==1.4.5
 retrying==1.3.3
 click==6.7
 dropbox==9.0.0


### PR DESCRIPTION
## Overview

When we upgraded `pyproj` something incompatible was introduced that caused an exception to be thrown when the planet library was imported

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

CI

Closes #5353 
