### PR TITLE
Notify users in intercom when their annotation projects are ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Notify users with Intercom when annotation project processing has completed [#5355](https://github.com/raster-foundry/raster-foundry/pull/5355)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -113,3 +113,8 @@ s3 {
   region = ${?AWS_REGION}
   dataBucket = ${?DATA_BUCKET}
 }
+
+intercom {
+  adminId = ${?INTERCOM_ADMIN_ID}
+  token = ${?INTERCOM_TOKEN}
+}

--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -116,5 +116,9 @@ s3 {
 
 intercom {
   adminId = ${?INTERCOM_ADMIN_ID}
+
   token = ${?INTERCOM_TOKEN}
+
+  rfHost = "https://app.rasterfoundry.com/api"
+  rfHost = ${?RF_HOST}
 }

--- a/app-backend/batch/src/main/scala/Main.scala
+++ b/app-backend/batch/src/main/scala/Main.scala
@@ -3,7 +3,10 @@ package com.rasterfoundry.batch
 import com.rasterfoundry.batch.cogMetadata._
 import com.rasterfoundry.batch.export.{CreateExportDef, UpdateExportStatus}
 import com.rasterfoundry.batch.geojsonImport.ImportGeojsonFiles
-import com.rasterfoundry.batch.groundwork.CreateTaskGrid
+import com.rasterfoundry.batch.groundwork.{
+  CreateTaskGrid,
+  NotifyIntercomProgram
+}
 import com.rasterfoundry.batch.healthcheck.HealthCheck
 import com.rasterfoundry.batch.notification.NotifyIngestStatus
 import com.rasterfoundry.batch.projectLiberation.ProjectLiberation
@@ -22,7 +25,8 @@ object Main {
     UpdateExportStatus.name -> (UpdateExportStatus.main(_)),
     ImportGeojsonFiles.name -> (ImportGeojsonFiles.main(_)),
     ProjectLiberation.name -> (ProjectLiberation.main(_)),
-    CreateTaskGrid.name -> (CreateTaskGrid.main(_))
+    CreateTaskGrid.name -> (CreateTaskGrid.main(_)),
+    NotifyIntercomProgram.name -> (NotifyIntercomProgram.main(_))
   )
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/groundwork/Config.scala
+++ b/app-backend/batch/src/main/scala/groundwork/Config.scala
@@ -1,0 +1,13 @@
+package com.rasterfoundry.batch.groundwork
+
+import com.rasterfoundry.batch.groundwork.types._
+
+import com.typesafe.config.ConfigFactory
+
+object Config {
+
+  val config = ConfigFactory.load()
+  private val intercomConfig = config.getConfig("intercom")
+  val intercomToken = IntercomToken(intercomConfig.getString("token"))
+  val intercomAdminId = UserId(intercomConfig.getString("adminId"))
+}

--- a/app-backend/batch/src/main/scala/groundwork/Config.scala
+++ b/app-backend/batch/src/main/scala/groundwork/Config.scala
@@ -10,4 +10,5 @@ object Config {
   private val intercomConfig = config.getConfig("intercom")
   val intercomToken = IntercomToken(intercomConfig.getString("token"))
   val intercomAdminId = UserId(intercomConfig.getString("adminId"))
+  val apiHost = intercomConfig.getString("rfHost")
 }

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.batch.groundwork
 
-import com.rasterfoundry.batch.groundwork.types._
 import com.rasterfoundry.batch.Job
+import com.rasterfoundry.batch.groundwork.types._
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.{

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -15,6 +15,7 @@ import com.rasterfoundry.datamodel.{Task, TaskStatus}
 import cats.data.OptionT
 import cats.effect.{IO, LiftIO}
 import cats.implicits._
+import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import com.typesafe.scalalogging.LazyLogging
 import doobie.implicits._
 import doobie.{ConnectionIO, Transactor}
@@ -117,13 +118,15 @@ object CreateTaskGrid extends Job {
 
   val name = "create-task-grid"
 
+  implicit val backend = AsyncHttpClientCatsBackend[IO]()
+
   def runJob(args: List[String]): IO[Unit] = args match {
     case annotationProjectId +: taskSizeMeters +: Nil =>
       val xa = RFTransactor.nonHikariTransactor(RFTransactor.TransactorConfig())
       new CreateTaskGrid(
         UUID.fromString(annotationProjectId),
         taskSizeMeters.toDouble,
-        ???,
+        new LiveIntercomNotifier[IO],
         xa
       ).run()
     case _ =>

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -84,7 +84,9 @@ class CreateTaskGrid(
           Config.intercomToken,
           Config.intercomAdminId,
           ExternalId(annotationProject.createdBy),
-          Message("Your project ${annotationProject.name} is ready!")
+          Message(
+            s"Your project ${annotationProject.name} is ready! ${Config.apiHost}/api/annotation-projects/${annotationProject.id}"
+          )
         )
       case None =>
         (for {

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -1,70 +1,8 @@
 package com.rasterfoundry.batch.groundwork
 
-import io.circe.{Decoder, Encoder}
-import io.circe.generic.JsonCodec
-import io.estatico.newtype.macros.newtype
-import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
-
-object types {
-  implicit val jsonConfig: Configuration =
-    Configuration.default.withSnakeCaseMemberNames.copy(transformMemberNames = {
-      case "_type" => "type"
-      case other   => other
-    })
-  @newtype case class ExternalId(underlying: String)
-  object ExternalId {
-    implicit val encExternalId: Encoder[ExternalId] =
-      Encoder.encodeString.contramap(_.underlying)
-    implicit val decExternalId: Decoder[ExternalId] =
-      Decoder.decodeString.map(ExternalId.apply _)
-  }
-
-  @newtype case class Notification(underlying: String)
-  @newtype case class UserId(underlying: String)
-  @newtype case class Message(underlying: String)
-  @newtype case class IntercomToken(underlying: String)
-
-  case class IntercomSearchQuery(externalId: ExternalId)
-  object IntercomSearchQuery {
-    implicit val encIntercomSearchQuery: Encoder[IntercomSearchQuery] =
-      Encoder.forProduct3(
-        "field",
-        "operator",
-        "value"
-      )(query => ("external_id", "=", query.externalId))
-
-    implicit val decIntercomSearchQuery: Decoder[IntercomSearchQuery] =
-      Decoder.forProduct3(
-        "field",
-        "operator",
-        "value"
-      )(
-        (_: String, _: String, email: ExternalId) => IntercomSearchQuery(email)
-      )
-  }
-
-  @JsonCodec case class IntercomUser(id: String)
-  @JsonCodec case class IntercomPost(query: IntercomSearchQuery)
-
-  @ConfiguredJsonCodec case class Pages(
-      _type: String,
-      page: Int,
-      perPage: Int,
-      totalPages: Int
-  )
-
-  @ConfiguredJsonCodec case class IntercomSearchResponse(
-      _type: String,
-      data: List[IntercomUser],
-      totalCount: Int,
-      pages: Pages
-  )
-
-}
+import types._
 
 trait IntercomNotifier[F[_]] {
-  import types._
-
   def notifyUser(
       intercomToken: IntercomToken,
       userId: UserId,
@@ -72,12 +10,11 @@ trait IntercomNotifier[F[_]] {
   ): F[Unit]
   def userByExternalId(
       intercomToken: IntercomToken,
-      email: ExternalId
+      externalId: ExternalId
   ): F[IntercomSearchResponse]
 }
 
 class LiveIntercomNotifier[F[_]] extends IntercomNotifier[F] {
-  import types._
   def notifyUser(
       intercomToken: IntercomToken,
       userId: UserId,
@@ -85,6 +22,6 @@ class LiveIntercomNotifier[F[_]] extends IntercomNotifier[F] {
   ): F[Unit] = ???
   def userByExternalId(
       intercomToken: IntercomToken,
-      email: ExternalId
+      externalId: ExternalId
   ): F[IntercomSearchResponse] = ???
 }

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -65,7 +65,11 @@ object types {
 trait IntercomNotifier[F[_]] {
   import types._
 
-  def notifyUser(userId: UserId, msg: Message): F[Unit]
+  def notifyUser(
+      intercomToken: IntercomToken,
+      userId: UserId,
+      msg: Message
+  ): F[Unit]
   def userByExternalId(
       intercomToken: IntercomToken,
       email: ExternalId
@@ -74,7 +78,11 @@ trait IntercomNotifier[F[_]] {
 
 class LiveIntercomNotifier[F[_]] extends IntercomNotifier[F] {
   import types._
-  def notifyUser(userId: UserId, msg: Message): F[Unit] = ???
+  def notifyUser(
+      intercomToken: IntercomToken,
+      userId: UserId,
+      msg: Message
+  ): F[Unit] = ???
   def userByExternalId(
       intercomToken: IntercomToken,
       email: ExternalId

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -1,10 +1,12 @@
 package com.rasterfoundry.batch.groundwork
 
+import com.rasterfoundry.batch.Job
 import com.rasterfoundry.batch.groundwork.types._
 
-import cats.effect.Sync
+import cats.effect.{IO, Sync}
 import cats.implicits._
 import com.softwaremill.sttp._
+import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import com.softwaremill.sttp.circe._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -52,16 +54,41 @@ class LiveIntercomNotifier[F[_]: Sync](
       msg: Message
   ): F[Unit] = {
     val uri = Uri(java.net.URI.create(s"$sttpApiBase/messages"))
-    val resp = sttp.auth
-      .bearer(intercomToken.underlying)
-      .header("Accept", MediaTypes.Json)
-      .post(uri)
-      .body(MessagePost(adminId, userId, msg))
-      .response(asJson[Json])
-      .send()
+    val resp =
+      Logger[F].debug(s"Notifying $userId") *>
+        sttp.auth
+          .bearer(intercomToken.underlying)
+          .header("Accept", MediaTypes.Json)
+          .post(uri)
+          .body(MessagePost(adminId, userId, msg))
+          .response(asJson[Json])
+          .send()
 
     (resp flatMap { r =>
       responseAsBody[Json](r.body, ().asJson)
     }).void
+  }
+}
+
+object NotifyIntercomProgram extends Job {
+  val name = "notify-intercom"
+
+  implicit val backend = AsyncHttpClientCatsBackend[IO]()
+
+  def runJob(args: List[String]): IO[Unit] = args match {
+    case externalId +: msg +: Nil =>
+      val notifier = new LiveIntercomNotifier[IO]
+      notifier.notifyUser(
+        Config.intercomToken,
+        Config.intercomAdminId,
+        ExternalId(externalId),
+        Message(msg)
+      )
+    case _ =>
+      IO.raiseError(
+        new Exception(
+          s"Arguments should match pattern `USER_ID MESSAGE`. Got $args"
+        )
+      )
   }
 }

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -1,0 +1,83 @@
+package com.rasterfoundry.batch.groundwork
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.JsonCodec
+import io.estatico.newtype.macros.newtype
+import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
+
+object types {
+  implicit val jsonConfig: Configuration =
+    Configuration.default.withSnakeCaseMemberNames.copy(transformMemberNames = {
+      case "_type" => "type"
+      case other   => other
+    })
+  @newtype case class EmailAddress(underlying: String)
+  object EmailAddress {
+    implicit val encEmailAddress: Encoder[EmailAddress] =
+      Encoder.encodeString.contramap(_.underlying)
+    implicit val decEmailAddress: Decoder[EmailAddress] =
+      Decoder.decodeString.map(EmailAddress.apply _)
+  }
+
+  @newtype case class Notification(underlying: String)
+  @newtype case class UserId(underlying: String)
+  @newtype case class Message(underlying: String)
+  @newtype case class IntercomToken(underlying: String)
+
+  case class IntercomSearchQuery(email: EmailAddress)
+  object IntercomSearchQuery {
+    implicit val encIntercomSearchQuery: Encoder[IntercomSearchQuery] =
+      Encoder.forProduct3(
+        "field",
+        "operator",
+        "value"
+      )(query => ("email", "=", query.email))
+
+    implicit val decIntercomSearchQuery: Decoder[IntercomSearchQuery] =
+      Decoder.forProduct3(
+        "field",
+        "operator",
+        "value"
+      )(
+        (_: String, _: String, email: EmailAddress) =>
+          IntercomSearchQuery(email)
+      )
+  }
+
+  @JsonCodec case class IntercomUser(id: String)
+  @JsonCodec case class IntercomPost(query: IntercomSearchQuery)
+
+  @ConfiguredJsonCodec case class Pages(
+      _type: String,
+      page: Int,
+      perPage: Int,
+      totalPages: Int
+  )
+
+  @ConfiguredJsonCodec case class IntercomSearchResponse(
+      _type: String,
+      data: List[IntercomUser],
+      totalCount: Int,
+      pages: Pages
+  )
+
+}
+
+trait IntercomNotifier[F[_]] {
+  import types._
+
+  def notifyUser(userId: UserId, msg: Message): F[Unit]
+  def usersbyEmail(
+      intercomToken: IntercomToken,
+      email: EmailAddress
+  ): F[IntercomSearchResponse]
+}
+
+class LiveIntercomNotifier[F[_]] extends IntercomNotifier[F] {
+  import types._
+  def notifyUser(userId: UserId, msg: Message): F[Unit] = ???
+  def usersbyEmail(
+      intercomToken: IntercomToken,
+      email: EmailAddress
+  ): F[IntercomSearchResponse] = ???
+}

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -11,12 +11,12 @@ object types {
       case "_type" => "type"
       case other   => other
     })
-  @newtype case class EmailAddress(underlying: String)
-  object EmailAddress {
-    implicit val encEmailAddress: Encoder[EmailAddress] =
+  @newtype case class ExternalId(underlying: String)
+  object ExternalId {
+    implicit val encExternalId: Encoder[ExternalId] =
       Encoder.encodeString.contramap(_.underlying)
-    implicit val decEmailAddress: Decoder[EmailAddress] =
-      Decoder.decodeString.map(EmailAddress.apply _)
+    implicit val decExternalId: Decoder[ExternalId] =
+      Decoder.decodeString.map(ExternalId.apply _)
   }
 
   @newtype case class Notification(underlying: String)
@@ -24,14 +24,14 @@ object types {
   @newtype case class Message(underlying: String)
   @newtype case class IntercomToken(underlying: String)
 
-  case class IntercomSearchQuery(email: EmailAddress)
+  case class IntercomSearchQuery(externalId: ExternalId)
   object IntercomSearchQuery {
     implicit val encIntercomSearchQuery: Encoder[IntercomSearchQuery] =
       Encoder.forProduct3(
         "field",
         "operator",
         "value"
-      )(query => ("email", "=", query.email))
+      )(query => ("external_id", "=", query.externalId))
 
     implicit val decIntercomSearchQuery: Decoder[IntercomSearchQuery] =
       Decoder.forProduct3(
@@ -39,8 +39,7 @@ object types {
         "operator",
         "value"
       )(
-        (_: String, _: String, email: EmailAddress) =>
-          IntercomSearchQuery(email)
+        (_: String, _: String, email: ExternalId) => IntercomSearchQuery(email)
       )
   }
 
@@ -67,17 +66,17 @@ trait IntercomNotifier[F[_]] {
   import types._
 
   def notifyUser(userId: UserId, msg: Message): F[Unit]
-  def usersbyEmail(
+  def userByExternalId(
       intercomToken: IntercomToken,
-      email: EmailAddress
+      email: ExternalId
   ): F[IntercomSearchResponse]
 }
 
 class LiveIntercomNotifier[F[_]] extends IntercomNotifier[F] {
   import types._
   def notifyUser(userId: UserId, msg: Message): F[Unit] = ???
-  def usersbyEmail(
+  def userByExternalId(
       intercomToken: IntercomToken,
-      email: EmailAddress
+      email: ExternalId
   ): F[IntercomSearchResponse] = ???
 }

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -51,9 +51,11 @@ class LiveIntercomNotifier[F[_]: Sync](
       userId: ExternalId,
       msg: Message
   ): F[Unit] = {
-    val uri = Uri(java.net.URI.create(s"$sttpApiBase/contacts/search"))
+    println(MessagePost(adminId, userId, msg).asJson.spaces2)
+    val uri = Uri(java.net.URI.create(s"$sttpApiBase/messages"))
     val resp = sttp.auth
       .bearer(intercomToken.underlying)
+      .header("Accept", MediaTypes.Json)
       .post(uri)
       .body(MessagePost(adminId, userId, msg))
       .response(asJson[Json])

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -2,63 +2,65 @@ package com.rasterfoundry.batch.groundwork
 
 import types._
 
-import cats.effect.Async
+import cats.effect.Sync
 import cats.implicits._
 import com.softwaremill.sttp.circe._
 import com.softwaremill.sttp._
+import io.circe.Json
+import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.circe.syntax._
 
 trait IntercomNotifier[F[_]] {
   def notifyUser(
       intercomToken: IntercomToken,
-      userId: UserId,
+      adminId: UserId,
+      userId: ExternalId,
       msg: Message
   ): F[Unit]
-  def userByExternalId(
-      intercomToken: IntercomToken,
-      externalId: ExternalId
-  ): F[IntercomSearchResponse]
 }
 
-class LiveIntercomNotifier[F[_]: Async](
+class LiveIntercomNotifier[F[_]: Sync](
     implicit backend: SttpBackend[F, Nothing]
 ) extends IntercomNotifier[F] {
   val sttpApiBase = "https://api.intercom.io"
 
+  implicit val unsafeLoggerF = Slf4jLogger.getLogger[F]
+
   def responseAsBody[T](
       resp: Either[String, Either[DeserializationError[io.circe.Error], T]],
       fallback: => T
-  ): T =
+  ): F[T] =
     resp match {
       case Left(err) =>
-        fallback
+        Logger[F].error(err) *>
+          Sync[F].delay(fallback)
       case Right(deserialized) =>
         deserialized match {
           case Left(err) =>
-            fallback
+            Logger[F].error(err.error)(err.message) *>
+              Sync[F].delay(fallback)
           case Right(body) =>
-            body
+            Sync[F].delay(body)
         }
     }
 
   def notifyUser(
       intercomToken: IntercomToken,
-      userId: UserId,
+      adminId: UserId,
+      userId: ExternalId,
       msg: Message
-  ): F[Unit] = ???
-
-  def userByExternalId(
-      intercomToken: IntercomToken,
-      externalId: ExternalId
-  ): F[IntercomSearchResponse] = {
+  ): F[Unit] = {
     val uri = Uri(java.net.URI.create(s"$sttpApiBase/contacts/search"))
     val resp = sttp.auth
       .bearer(intercomToken.underlying)
       .post(uri)
-      .body(IntercomPost(IntercomSearchQuery(externalId)))
-      .response(asJson[IntercomSearchResponse])
+      .body(MessagePost(adminId, userId, msg))
+      .response(asJson[Json])
       .send()
-    resp map { r =>
-      responseAsBody(r.body, IntercomSearchResponse.empty)
-    }
+
+    (resp flatMap { r =>
+      responseAsBody[Json](r.body, ().asJson)
+    }).void
   }
 }

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -2,6 +2,11 @@ package com.rasterfoundry.batch.groundwork
 
 import types._
 
+import cats.effect.Async
+import cats.implicits._
+import com.softwaremill.sttp.circe._
+import com.softwaremill.sttp._
+
 trait IntercomNotifier[F[_]] {
   def notifyUser(
       intercomToken: IntercomToken,
@@ -14,14 +19,46 @@ trait IntercomNotifier[F[_]] {
   ): F[IntercomSearchResponse]
 }
 
-class LiveIntercomNotifier[F[_]] extends IntercomNotifier[F] {
+class LiveIntercomNotifier[F[_]: Async](
+    implicit backend: SttpBackend[F, Nothing]
+) extends IntercomNotifier[F] {
+  val sttpApiBase = "https://api.intercom.io"
+
+  def responseAsBody[T](
+      resp: Either[String, Either[DeserializationError[io.circe.Error], T]],
+      fallback: => T
+  ): T =
+    resp match {
+      case Left(err) =>
+        fallback
+      case Right(deserialized) =>
+        deserialized match {
+          case Left(err) =>
+            fallback
+          case Right(body) =>
+            body
+        }
+    }
+
   def notifyUser(
       intercomToken: IntercomToken,
       userId: UserId,
       msg: Message
   ): F[Unit] = ???
+
   def userByExternalId(
       intercomToken: IntercomToken,
       externalId: ExternalId
-  ): F[IntercomSearchResponse] = ???
+  ): F[IntercomSearchResponse] = {
+    val uri = Uri(java.net.URI.create(s"$sttpApiBase/contacts/search"))
+    val resp = sttp.auth
+      .bearer(intercomToken.underlying)
+      .post(uri)
+      .body(IntercomPost(IntercomSearchQuery(externalId)))
+      .response(asJson[IntercomSearchResponse])
+      .send()
+    resp map { r =>
+      responseAsBody(r.body, IntercomSearchResponse.empty)
+    }
+  }
 }

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -51,7 +51,6 @@ class LiveIntercomNotifier[F[_]: Sync](
       userId: ExternalId,
       msg: Message
   ): F[Unit] = {
-    println(MessagePost(adminId, userId, msg).asJson.spaces2)
     val uri = Uri(java.net.URI.create(s"$sttpApiBase/messages"))
     val resp = sttp.auth
       .bearer(intercomToken.underlying)

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -1,14 +1,14 @@
 package com.rasterfoundry.batch.groundwork
 
-import types._
+import com.rasterfoundry.batch.groundwork.types._
 
 import cats.effect.Sync
 import cats.implicits._
-import com.softwaremill.sttp.circe._
 import com.softwaremill.sttp._
-import io.circe.Json
+import com.softwaremill.sttp.circe._
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.circe.Json
 import io.circe.syntax._
 
 trait IntercomNotifier[F[_]] {

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -27,7 +27,7 @@ class LiveIntercomNotifier[F[_]: Sync](
 
   implicit val unsafeLoggerF = Slf4jLogger.getLogger[F]
 
-  def responseAsBody[T](
+  private def responseAsBody[T](
       resp: Either[String, Either[DeserializationError[io.circe.Error], T]],
       fallback: => T
   ): F[T] =

--- a/app-backend/batch/src/main/scala/groundwork/types.scala
+++ b/app-backend/batch/src/main/scala/groundwork/types.scala
@@ -1,0 +1,63 @@
+package com.rasterfoundry.batch.groundwork
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.JsonCodec
+import io.estatico.newtype.macros.newtype
+import io.circe.generic.extras.{Configuration, ConfiguredJsonCodec}
+
+object types {
+  implicit val jsonConfig: Configuration =
+    Configuration.default.withSnakeCaseMemberNames.copy(transformMemberNames = {
+      case "_type" => "type"
+      case other   => other
+    })
+  @newtype case class ExternalId(underlying: String)
+  object ExternalId {
+    implicit val encExternalId: Encoder[ExternalId] =
+      Encoder.encodeString.contramap(_.underlying)
+    implicit val decExternalId: Decoder[ExternalId] =
+      Decoder.decodeString.map(ExternalId.apply _)
+  }
+
+  @newtype case class Notification(underlying: String)
+  @newtype case class UserId(underlying: String)
+  @newtype case class Message(underlying: String)
+  @newtype case class IntercomToken(underlying: String)
+
+  case class IntercomSearchQuery(externalId: ExternalId)
+  object IntercomSearchQuery {
+    implicit val encIntercomSearchQuery: Encoder[IntercomSearchQuery] =
+      Encoder.forProduct3(
+        "field",
+        "operator",
+        "value"
+      )(query => ("external_id", "=", query.externalId))
+
+    implicit val decIntercomSearchQuery: Decoder[IntercomSearchQuery] =
+      Decoder.forProduct3(
+        "field",
+        "operator",
+        "value"
+      )(
+        (_: String, _: String, email: ExternalId) => IntercomSearchQuery(email)
+      )
+  }
+
+  @JsonCodec case class IntercomUser(id: String)
+  @JsonCodec case class IntercomPost(query: IntercomSearchQuery)
+
+  @ConfiguredJsonCodec case class Pages(
+      _type: String,
+      page: Int,
+      perPage: Int,
+      totalPages: Int
+  )
+
+  @ConfiguredJsonCodec case class IntercomSearchResponse(
+      _type: String,
+      data: List[IntercomUser],
+      totalCount: Int,
+      pages: Pages
+  )
+
+}

--- a/app-backend/batch/src/main/scala/groundwork/types.scala
+++ b/app-backend/batch/src/main/scala/groundwork/types.scala
@@ -53,11 +53,26 @@ object types {
       totalPages: Int
   )
 
+  object Pages {
+    def empty: Pages =
+      Pages("pages", 0, 0, 0)
+  }
+
   @ConfiguredJsonCodec case class IntercomSearchResponse(
       _type: String,
       data: List[IntercomUser],
       totalCount: Int,
       pages: Pages
   )
+
+  object IntercomSearchResponse {
+    def empty: IntercomSearchResponse =
+      IntercomSearchResponse(
+        "list",
+        Nil,
+        0,
+        Pages.empty
+      )
+  }
 
 }

--- a/app-backend/batch/src/main/scala/groundwork/types.scala
+++ b/app-backend/batch/src/main/scala/groundwork/types.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.batch.groundwork
 import io.circe.{Decoder, Encoder}
 import io.estatico.newtype.macros.newtype
 
+@SuppressWarnings(Array("AsInstanceOf"))
 object types {
 
   @newtype case class ExternalId(underlying: String)

--- a/app-backend/batch/src/main/scala/groundwork/types.scala
+++ b/app-backend/batch/src/main/scala/groundwork/types.scala
@@ -54,7 +54,7 @@ object types {
           ToObject(messagePost.userId),
           messagePost.msg.underlying,
           "inapp"
-        )
+      )
     )
   }
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -469,6 +469,7 @@ lazy val batch = project
       Dependencies.hadoop,
       Dependencies.hikariCP,
       Dependencies.log4cats,
+      Dependencies.log4catsSlf4j,
       Dependencies.monocleCore,
       Dependencies.newtype,
       Dependencies.refined,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -469,6 +469,7 @@ lazy val batch = project
       Dependencies.hadoop,
       Dependencies.hikariCP,
       Dependencies.monocleCore,
+      Dependencies.newtype,
       Dependencies.refined,
       Dependencies.scaffeine,
       Dependencies.scaffeine,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -480,6 +480,10 @@ lazy val batch = project
       Dependencies.sparkCore,
       Dependencies.spireMath,
       Dependencies.spray,
+      Dependencies.sttpCatsBackend,
+      Dependencies.sttpCore,
+      Dependencies.sttpJson,
+      Dependencies.sttpCirce,
       Dependencies.typesafeConfig
     ) ++ loggingDependencies
   })

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -468,6 +468,7 @@ lazy val batch = project
       Dependencies.guava,
       Dependencies.hadoop,
       Dependencies.hikariCP,
+      Dependencies.log4cats,
       Dependencies.monocleCore,
       Dependencies.newtype,
       Dependencies.refined,

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -206,6 +206,7 @@ object Dependencies {
   val spire = "org.typelevel" %% "spire" % Version.spire
   val spireMath = "org.spire-math" %% "spire" % Version.spireMath
   val spray = "io.spray" %% "spray-json" % Version.spray
+  val sttpCatsBackend = "com.softwaremill.sttp" %% "async-http-client-backend-cats" % Version.sttp
   val sttpCirce = "com.softwaremill.sttp" %% "circe" % Version.sttp
   val sttpCore = "com.softwaremill.sttp" %% "core" % Version.sttp
   val sttpJson = "com.softwaremill.sttp" %% "json-common" % Version.sttp

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -172,7 +172,7 @@ object Dependencies {
   val jaegerCore = "io.jaegertracing" % "jaeger-core" % Version.jaegerCore
   val javaMail = "com.sun.mail" % "javax.mail" % Version.javaMail
   val jsonSmart = "net.minidev" % "json-smart" % Version.jsonSmart
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % Version.log4cats
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j" % Version.log4cats
   val log4jOverslf4j = "org.slf4j" % "slf4j-simple" % Version.slf4j
   val logbackClassic = "ch.qos.logback" % "logback-classic" % Version.logback
   val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % Version.maml

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -52,6 +52,7 @@ object Version {
   val json4s = "3.5.0"
   val jsonSmart = "2.3"
   val jts = "1.16.0"
+  val log4cats = "0.3.0"
   val logback = "1.2.3"
   val maml = "0.4.0"
   val monocle = "1.5.1-cats"
@@ -171,6 +172,7 @@ object Dependencies {
   val jaegerCore = "io.jaegertracing" % "jaeger-core" % Version.jaegerCore
   val javaMail = "com.sun.mail" % "javax.mail" % Version.javaMail
   val jsonSmart = "net.minidev" % "json-smart" % Version.jsonSmart
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % Version.log4cats
   val log4jOverslf4j = "org.slf4j" % "slf4j-simple" % Version.slf4j
   val logbackClassic = "ch.qos.logback" % "logback-classic" % Version.logback
   val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % Version.maml

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -172,7 +172,8 @@ object Dependencies {
   val jaegerCore = "io.jaegertracing" % "jaeger-core" % Version.jaegerCore
   val javaMail = "com.sun.mail" % "javax.mail" % Version.javaMail
   val jsonSmart = "net.minidev" % "json-smart" % Version.jsonSmart
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j" % Version.log4cats
+  val log4cats = "io.chrisdavenport" %% "log4cats-core" % Version.log4cats
+  val log4catsSlf4j = "io.chrisdavenport" %% "log4cats-slf4j" % Version.log4cats
   val log4jOverslf4j = "org.slf4j" % "slf4j-simple" % Version.slf4j
   val logbackClassic = "ch.qos.logback" % "logback-classic" % Version.logback
   val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % Version.maml

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -55,6 +55,7 @@ object Version {
   val logback = "1.2.3"
   val maml = "0.4.0"
   val monocle = "1.5.1-cats"
+  val newtype = "0.4.3"
   val nimbusJose = "0.6.0"
   val nimbusJoseJwt = "4.41.1"
   val openTracing = "0.0.6"
@@ -174,6 +175,7 @@ object Dependencies {
   val logbackClassic = "ch.qos.logback" % "logback-classic" % Version.logback
   val mamlJvm = "com.azavea.geotrellis" %% "maml-jvm" % Version.maml
   val monocleCore = "com.github.julien-truffaut" %% "monocle-core" % Version.monocle
+  val newtype = "io.estatico" %% "newtype" % Version.newtype
   val nimbusJose = "com.guizmaii" %% "scala-nimbus-jose-jwt" % Version.nimbusJose
   val nimbusJoseJwt = "com.nimbusds" % "nimbus-jose-jwt" % Version.nimbusJoseJwt
   val opentracing = "com.colisweb" %% "scala-opentracing" % Version.openTracing

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -161,12 +161,11 @@ def process_upload(upload_id):
                 annotationProject.update_status({"progressStage": "QUEUED"})
         raise
     except:
-        if annotationProject is not None:
+        if JOB_ATTEMPT >= 3 and annotationProject is not None:
             logger.error(
                 "Upload for AnnotationProject failed to process: %s",
                 annotationProject.id,
             )
-        if JOB_ATTEMPT >= 3:
             upload.update_upload_status("FAILED")
             annotationProject.update_status({"errorStage": "IMAGE_INGESTION_FAILURE"})
             notify_intercom(
@@ -177,6 +176,8 @@ def process_upload(upload_id):
                     "groundwork@azavea.com."
                 ).format(annotationProjectName=annotationProject.name),
             )
+        elif JOB_ATTEMPT >= 3:
+            upload.update_upload_status("FAILED")
         else:
             upload.update_upload_status("QUEUED")
             if annotationProject is not None:

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -142,10 +142,6 @@ def process_upload(upload_id):
                 ]
             except Exception as e:
                 raise TaskGridError("Error making task grid: %s", e)
-        if annotationProject is not None:
-            # Don't overwrite fields modified by the task grid creation
-            annotationProject = AnnotationProject.from_id(upload.annotationProjectId)
-            annotationProject.update_status({"progressStage": "READY"})
     except TaskGridError as tge:
         logger.error(
             "Error making task grids annotation project (%s) on upload (%s) for with files %s. %s",

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -11,7 +11,7 @@ from ..uploads.landsat_historical import LandsatHistoricalSceneFactory
 from ..uploads.planet.factories import PlanetSceneFactory
 from ..uploads.modis.factories import MODISSceneFactory
 from ..utils.exception_reporting import wrap_rollbar
-from ..utils.io import get_session
+from ..utils.io import (get_session, notify_intercom)
 
 logger = logging.getLogger(__name__)
 HOST = os.getenv("RF_HOST")
@@ -168,6 +168,10 @@ def process_upload(upload_id):
         if JOB_ATTEMPT >= 3:
             upload.update_upload_status("FAILED")
             annotationProject.update_status({"errorStage": "IMAGE_INGESTION_FAILURE"})
+            notify_intercom(upload.owner,
+                            f"Your project {annotationProject.name} failed to process. If "
+                            "you'd like help troubleshooting, please reach out to us at "
+                            "groundwork@azavea.com.")
         else:
             upload.update_upload_status("QUEUED")
             if annotationProject is not None:

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import shutil
+import subprocess
 import tempfile
 from urllib.parse import urlparse, unquote, quote
 
@@ -123,6 +124,15 @@ def gcs_path_for_landsat_id(landsat_id):
         "L{sensor_id}0{landsat_number}/01/{path}/{row}/{landsat_id}"
     )
     return tmpl.format(**dict(landsat_id=landsat_id, **metadata))
+
+
+def notify_intercom(user_id: str, message: str) -> None:
+    subprocess.check_call(
+        [
+            "java", "-cp", "com.rasterfoundry.batch.Main",
+            "notify-intercom", user_id, message
+        ]
+    )
 
 
 def make_fname_for_band(band, landsat_id):

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -129,7 +129,9 @@ def gcs_path_for_landsat_id(landsat_id):
 def notify_intercom(user_id: str, message: str) -> None:
     subprocess.check_call(
         [
-            "java", "-cp", "com.rasterfoundry.batch.Main",
+            "java", "-cp",
+            "/opt/raster-foundry/jars/batch-assembly.jar",
+            "com.rasterfoundry.batch.Main",
             "notify-intercom", user_id, message
         ]
     )


### PR DESCRIPTION
## Overview

This PR starts the work to notify users in intercom when their projects are ready.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![notification](https://user-images.githubusercontent.com/5702984/76540092-aa440580-644f-11ea-9378-4e14e56de3c1.gif)

### Notes

~It's in Scala because _my god_ that's a complicated datamodel. I'll show a response. It's _huge_. I don't want to remember over time what values are present in this thing in python so instead I'm making the values I'm grabbing from the response json super explicit and we can add more as necessary.~ It turns out that the endpoint we're interacting with is a lot less complicated, but I didn't rewrite it in python after learning that. This is reusable in other batch jobs now, which has value as well. Also, hilariously, there's [no python sdk](https://developers.intercom.com/building-apps/docs/sdks-plugins) anyway.

~This might also move out of `batch` someday if we need it elsewhere but for now I'm thinking it jumps in at the end of the `CreateTaskGrid` job.~

~Still WIP until I make a job that sends notifications that the python code in app-tasks can invoke, but testable at least~

## Testing Instructions

- set up your groundwork to point to local rf (I can send you @Lknechtli's .env.local file that includes commentable regions for every environment if you don't have it)
- grab the new `.env` with `AWS_PROFILE=raster-foundry RF_SETTINGS_BUCKET=<settings bucket> ./scripts/bootstrap --env`
- assemble batch and anything else you haven't assembled recently
- build the batch container
- bring up your api server
- bring up your rf frontend
- log in to rf as the dev user
- log in to Groundwork locally as the dev user
- create a project in Groundwork
- grab the upload id for your new project from `./scripts/psql` -- `select id from uploads order by created_at desc limit 1;`
- process your upload: `./scripts/console batch 'rf process-upload <your upload id>'`
- observe that you got a notification that it's done (ignore the bad url -- configured rf host is odd in development because the container doesn't know how to get to the api under localhost, but it's correct in staging and prod)
- throw an exception into the try block in the python upload processing script -- add a `raise Exception("lol")` [here](https://github.com/raster-foundry/raster-foundry/blob/ab2bf86a8e7644fddbfa319c890513e4360c2aa0/app-tasks/rf/src/rf/commands/process_upload.py#L55)
- rebuild the batch container
- process your upload again but this time saying it's the third try -- `./scripts/console batch 'AWS_BATCH_JOB_ATTEMPT=3  rf process-upload <your upload id>'`
- observe that you get a notification that processing failed

Closes raster-foundry/annotate#640