### PR TITLE
Link to somewhere in Groundwork, not to RF API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Notify users with Intercom when annotation project processing has completed [#5355](https://github.com/raster-foundry/raster-foundry/pull/5355)
+- Notify users with Intercom when annotation project processing has completed [#5355](https://github.com/raster-foundry/raster-foundry/pull/5355), [#5361](https://github.com/raster-foundry/raster-foundry/pull/5361)
 
 ### Changed
 

--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -119,6 +119,5 @@ intercom {
 
   token = ${?INTERCOM_TOKEN}
 
-  groundworkUrlBase = "https://develop--raster-foundry-annotate.netlify.com/app"
   groundworkUrlBase = ${?GROUNDWORK_URL_BASE}
 }

--- a/app-backend/batch/src/main/resources/application.conf
+++ b/app-backend/batch/src/main/resources/application.conf
@@ -119,6 +119,6 @@ intercom {
 
   token = ${?INTERCOM_TOKEN}
 
-  rfHost = "https://app.rasterfoundry.com/api"
-  rfHost = ${?RF_HOST}
+  groundworkUrlBase = "https://develop--raster-foundry-annotate.netlify.com/app"
+  groundworkUrlBase = ${?GROUNDWORK_URL_BASE}
 }

--- a/app-backend/batch/src/main/scala/groundwork/Config.scala
+++ b/app-backend/batch/src/main/scala/groundwork/Config.scala
@@ -10,5 +10,5 @@ object Config {
   private val intercomConfig = config.getConfig("intercom")
   val intercomToken = IntercomToken(intercomConfig.getString("token"))
   val intercomAdminId = UserId(intercomConfig.getString("adminId"))
-  val apiHost = intercomConfig.getString("rfHost")
+  val groundworkUrlBase = intercomConfig.getString("groundworkUrlBase")
 }

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -87,7 +87,7 @@ class CreateTaskGrid(
           Config.intercomAdminId,
           ExternalId(annotationProject.createdBy),
           Message(
-            s"""Your project "${annotationProject.name}" is ready! ${Config.apiHost}/api/annotation-projects/${annotationProject.id}"""
+            s"""Your project "${annotationProject.name}" is ready! ${Config.groundworkUrlBase}/app/projects/${annotationProject.id}/overview"""
           )
         )
       case None =>
@@ -114,7 +114,7 @@ class CreateTaskGrid(
                   Message(
                     s"""
                   | Your project "${projectName}" failed to process. If you'd like help
-                  | troubleshooting, please reach out to us at
+                  | troubleshooting, please reach out to us here or at
                   | groundwork@azavea.com."
                   """.trim.stripMargin
                   )

--- a/app-tasks/rf/src/rf/commands/process_upload.py
+++ b/app-tasks/rf/src/rf/commands/process_upload.py
@@ -172,7 +172,7 @@ def process_upload(upload_id):
                 upload.owner,
                 (
                     "Your project \"{annotationProjectName}\" failed to process. If "
-                    "you'd like help troubleshooting, please reach out to us at "
+                    "you'd like help troubleshooting, please reach out to us here or at "
                     "groundwork@azavea.com."
                 ).format(annotationProjectName=annotationProject.name),
             )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
     env_file: .env
     environment:
       - RF_HOST=http://rasterfoundry.com:9000
+      - GROUNDWORK_URL_BASE=http://localhost:3000/app
       - POSTGRES_DB_POOL_SIZE=2
       - LOCAL_INGEST_CORES=2
       - LOCAL_INGEST_MEM_GB=4


### PR DESCRIPTION
## Overview

This PR updates the `CreateTaskGrid` job and `process_upload.py` to:

- use a link to somewhere that exists in the Groundwork application instead of to the Raster Foundry API
- ask users to reach out in Intercom first, _or_ by email, since we clearly have in app chat capabilities

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- lazy version: look at the link, look at the way it's being templated, think for a minute about whether that's a more useful link than a link to somewhere in the RF API (the notification machinery has already been tested and you can visually confirm these are all just string changes)
- non-lazy version:
  - bring up local annotate pointing to local rf
  - assemble batch jar
  - build the batch container
  - bring up your rf servers / frontend
  - create a project in local annotate
  - process the upload
  - you should get a notification in the annotate app when it's done, and the link should be _not useless_
