### PR TITLE
Copy sample project when user is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Support sample projects for new annotation app users [#5362](https://github.com/raster-foundry/raster-foundry/pull/5362)
 
 ### Changed
 

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -302,7 +302,7 @@ trait Authentication extends Directives with LazyLogging {
           }
         case _ => Scopes.NoAccess
       }
-    logger.error(s"Setting user scopes: ${userScope}")
+    logger.debug(s"Setting user scopes: ${userScope}")
 
     for {
       platform <- PlatformDao.getPlatformById(platformId)

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -70,6 +70,5 @@ sentinel2 {
 }
 
 groundwork {
-  sampleProject = ""
   sampleProject = ${?GROUNDWORK_SAMPLE_PROJECT}
 }

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -68,3 +68,8 @@ dropbox {
 sentinel2 {
   datasourceId = "4a50cb75-815d-4fe5-8bc1-144729ce5b42"
 }
+
+groundwork {
+  sampleProject = ""
+  sampleProject = ${?GROUNDWORK_SAMPLE_PROJECT}
+}

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -13,6 +13,7 @@ trait Config {
   private val tileServerConfig = config.getConfig("tileServer")
   private val dropboxConfig = config.getConfig("dropbox")
   private val sentinel2Config = config.getConfig("sentinel2")
+  private val groundworkConfig = config.getConfig("groundwork")
 
   val httpHost = httpConfig.getString("interface")
   val httpPort = httpConfig.getInt("port")
@@ -39,4 +40,6 @@ trait Config {
   val scopedUploadRoleArn = s3Config.getString("scopedUploadRoleArn")
 
   val sentinel2DatasourceId = sentinel2Config.getString("datasourceId")
+
+  val groundworkSampleProject = groundworkConfig.getString("sampleProject")
 }

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -25,7 +25,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     "annotation_task_id"
   )
   val selectF: Fragment = fr"SELECT" ++
-    fieldsF ++ fr", classes.class_ids as annotation_label_classes FROM " ++
+    selectFieldsF ++ fr", classes.class_ids as annotation_label_classes FROM " ++
     Fragment.const(tableName) ++
     fr""" JOIN (
       SELECT annotation_label_id, array_agg(annotation_class_id) as class_ids
@@ -41,10 +41,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       user: User
   ): ConnectionIO[List[AnnotationLabelWithClasses]] = {
     val insertAnnotationsFragment: Fragment =
-      fr"INSERT INTO" ++ tableF ++ fr"""(
-      id, created_at, created_by, geometry, annotation_project_id, annotation_task_id
-    ) VALUES
-    """
+      fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr") VALUES"
     val insertClassesFragment: Fragment =
       fr"INSERT INTO" ++ Fragment.const(joinTableName) ++ fr"""(
       annotation_label_id, annotation_class_id

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -434,7 +434,7 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      aProjectCopy <- insertQuery.update
+      annotationProjectCopy <- insertQuery.update
         .withUniqueGeneratedKeys[AnnotationProject](
           fieldNames: _*
         )
@@ -458,20 +458,20 @@ object AnnotationProjectDao
                   )
                 }
               ),
-              aProjectCopy,
+              annotationProjectCopy,
               0
             )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
         projectId,
-        aProjectCopy.id,
+        annotationProjectCopy.id,
         user
       )
       _ <- TileLayerDao.copyTileLayersForProject(
         projectId,
-        aProjectCopy.id
+        annotationProjectCopy.id
       )
-    } yield aProjectCopy
+    } yield annotationProjectCopy
   }
 }

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -28,8 +28,10 @@ abstract class Dao[Model: Read: Write] extends Filterables {
   val fieldNames: List[String] = List()
 
   /** Helper to use in selectF and avoid writing out */
-  def fieldsF =
+  def selectFieldsF =
     Fragment.const(fieldNames.map(f => tableName ++ "." ++ f).mkString(", "))
+  def insertFieldsF =
+    Fragment.const(fieldNames.mkString(", "))
 
   /** The fragment which holds the associated table's name */
   def tableF = Fragment.const(tableName)

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -17,6 +17,19 @@ import java.util.UUID
 
 object TaskDao extends Dao[Task] {
 
+  override val fieldNames = List(
+    "id",
+    "created_at",
+    "created_by",
+    "modified_at",
+    "owner",
+    "status",
+    "locked_by",
+    "locked_on",
+    "geometry",
+    "annotation_project_id"
+  )
+
   type MaybeEmptyUnionedGeomExtent =
     Option[Projected[Geometry]] :: Option[Double] :: Option[Double] :: Option[
       Double
@@ -51,19 +64,7 @@ object TaskDao extends Dao[Task] {
     cols ++ joinTableF
 
   val insertF: Fragment =
-    fr"INSERT INTO " ++ tableF ++ fr"""(
-          id,
-          created_at,
-          created_by,
-          modified_at,
-          owner,
-          status,
-          locked_by,
-          locked_on,
-          geometry,
-          annotation_project_id
-     )
-     """
+    fr"INSERT INTO " ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")"
 
   def updateF(taskId: UUID, update: Task.TaskFeatureCreate): Fragment =
     fr"UPDATE " ++ tableF ++ fr"""SET
@@ -229,16 +230,7 @@ object TaskDao extends Dao[Task] {
     featureInserts.toNel map { inserts =>
       (insertF ++ fr"VALUES " ++ inserts.intercalate(fr",")).update
         .withGeneratedKeys[Task](
-          "id",
-          "created_at",
-          "created_by",
-          "modified_at",
-          "owner",
-          "status",
-          "locked_by",
-          "locked_on",
-          "geometry",
-          "annotation_project_id"
+          fieldNames: _*
         )
         .compile
         .toList map { (tasks: List[Task]) =>
@@ -399,7 +391,7 @@ object TaskDao extends Dao[Task] {
       action: String,
       params: UserTaskActivityParameters
   ): Fragment = {
-    val selectF = fr"""
+    val joinSelectF = fr"""
       SELECT
         to_in_progress.user_id,
         COUNT(DISTINCT to_in_progress.task_id) AS task_count,
@@ -448,7 +440,7 @@ object TaskDao extends Dao[Task] {
         )
     }
 
-    selectF ++ inProgressTaskActionTimeF ++ innerJoinF ++ completeTaskActionTimeF ++ joinTargetF
+    joinSelectF ++ inProgressTaskActionTimeF ++ innerJoinF ++ completeTaskActionTimeF ++ joinTargetF
   }
 
   def getTaskUserSummary(
@@ -583,5 +575,20 @@ object TaskDao extends Dao[Task] {
       .filter(fr"annotation_project_id = $annotationProjectId")
       .filter(taskStatusF(taskStatuses))
       .list
+  }
+
+  def copyAnnotationProjectTasks(
+      fromProject: UUID,
+      toProject: UUID,
+      user: User
+  ): ConnectionIO[Int] = {
+    (fr"""
+           INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+      fr"""SELECT
+           uuid_generate_v4(), now(), ${user.id}, now(), ${user.id},
+           status, locked_by, locked_on, geometry, ${toProject}
+           FROM """ ++ tableF ++ fr"""
+           WHERE annotation_project_id = ${fromProject}
+      """).update.run
   }
 }

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -23,7 +23,8 @@ and overwrites the existing dump.
 function create_database_backup() {
     if [ -f data/database.pgdump ]; then
         echo "Renaming old database dump"
-        mv data/database.pgdump data/database.pgdump.$(date +'%N')
+        HASH=$(date + '%N')
+        mv "data/database.pgdump" "data/database.pgdump.${HASH}"
     fi
     echo "Creating new dev database dump"
     docker-compose exec -T postgres pg_dump -U rasterfoundry -Fc -f /tmp/data/database.pgdump

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -20,6 +20,27 @@ and overwrites the existing dump.
 "
 }
 
+function create_database_backup() {
+    if [ -f data/database.pgdump ]; then
+        echo "Renaming old database dump"
+        mv data/database.pgdump data/database.pgdump.$(date +'%N')
+    fi
+    echo "Creating new dev database dump"
+    docker-compose exec -T postgres pg_dump -U rasterfoundry -Fc -f /tmp/data/database.pgdump
+}
+
+function upload_database_backup() {
+    if [ ! -f data/database.pgdump ]; then
+        logInfo "No databaes dump found"
+    else
+        # create backup of old dump
+        HASH=$(date +'%N')
+        aws s3 mv --sse AES256 "s3://${RF_SETTINGS_BUCKET}/database.pgdump" "s3://${RF_SETTINGS_BUCKET}/databaseArchives/database.pgdump.${HASH}"
+        # upload new dump
+        aws s3 cp --sse AES256 "data/database.pgdump" "s3://${RF_SETTINGS_BUCKET}/database.pgdump"
+    fi
+}
+
 function download_database_backup() {
 
     pushd "${DIR}/.."
@@ -59,23 +80,29 @@ then
     then
         usage
     else
-        if [ "${1:-}" = "--download" ] || [ ! -f data/database.pgdump ]; then
-            download_database_backup
-            download_development_images
+        if [ "${1:-}" = "--create" ]; then
+            create_database_backup
+        elif [ "${1:-}" = "--upload" ]; then
+            upload_database_backup
+        else
+            if [ "${1:-}" = "--download" ] || [ ! -f data/database.pgdump ]; then
+                download_database_backup
+                download_development_images
+            fi
+
+            # API server won't start until Postgres is passing Health Checks
+            docker-compose \
+                -f "${DIR}/../docker-compose.yml" \
+                -f "${DIR}/../docker-compose.test.yml" \
+                up -d api-server-test
+
+            docker-compose \
+                -f "${DIR}/../docker-compose.yml" \
+                -f "${DIR}/../docker-compose.test.yml" \
+                rm -sf api-server-test
+
+            load_database_backup
         fi
-
-        # API server won't start until Postgres is passing Health Checks
-        docker-compose \
-            -f "${DIR}/../docker-compose.yml" \
-            -f "${DIR}/../docker-compose.test.yml" \
-            up -d api-server-test
-
-        docker-compose \
-            -f "${DIR}/../docker-compose.yml" \
-            -f "${DIR}/../docker-compose.test.yml" \
-            rm -sf api-server-test
-
-        load_database_backup
     fi
     exit
 fi


### PR DESCRIPTION
## Overview
* Add env variables for setting sample project
* Make Annotation project deletion only delete user owned resources
* Mess around with some dao stuff
* add options for creating / uploading db dumps to the `load_development_data` script

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~Swagger specification updated~
- [ ] ~New tables and queries have appropriate indices added~
- [ ] ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [ ] ~Any new SQL strings have tests~
- [ ] ~Any new endpoints have scope validation and are included in the integration test csv~

### TODO
- [x] Update the dev database with a sample project
- [x] Update the dev .env file with a sample project id
- [x] Fix any broken tests?

### Demo
![image](https://user-images.githubusercontent.com/4392704/76904782-03100580-6877-11ea-85c1-d41b54654735.png)

### Notes
When creating a project to use as a sample project, you'll need to set `visibility="PUBLIC"` on the associated RF project. This RF project is not replicated across users, and any changes to it will affect the sample project on every user.
Labels are not copied right now, but tasks, label classes, label class groups, annotation project are.

## Testing Instructions
- in your RF repo, run `./scripts/bootstrap --env` to fetch the latest `.env` file from s3
- in your annotate repo, use the following `env.local` values: (Yes, they changed)
```
REACT_APP_AUTH_DOMAIN=raster-foundry-dev.auth0.com
REACT_APP_AUTH_CLIENT_ID=BNAJrZc2hSG7m60DdBSwhghM9BvReT4u
REACT_APP_AUTH_AUDIENCE=http://localhost:9091/api/
REACT_APP_API_URL=http://localhost:9100/api
REACT_APP_TILE_URL=http://localhost:8081
REACT_APP_LABEL_TEAM_ID=40bdf3a9-7da0-4b4d-9cfa-918430f67357
REACT_APP_VALIDATION_TEAM_ID=e36f5155-cd86-43d1-9942-a8eaeba11ca6
REACT_APP_RGB_DATASOURCE="c14c8e97-ba85-4677-ac9c-069cfef1f0b1"
ENABLE_GTM_HISTORY="false"
```
- fetch the latest dev database with `./scripts/load_development_data --download`
- rebuild your api jar and start your server
- start the annotate frontend `npm run start`
- from the annotate frontend, create a new user using a non-social login
  The first login may have some errors due to multiple simultaneos requests trying to create a user at the same time, see https://github.com/raster-foundry/annotate/issues/766
- reload the page. verify that there's a sample project
- label some stuff
- delete the project, verify that creating a new user with a sample project still works and no underlying data was deleted on the original projects

Closes https://github.com/raster-foundry/annotate/issues/750
Closes https://github.com/raster-foundry/raster-foundry/pull/5362