### PR TITLE
Add project status filter to annotation project list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Support sample projects for new annotation app users [#5362](https://github.com/raster-foundry/raster-foundry/pull/5362)
+- Add status filter to annotation projects [#5365](https://github.com/raster-foundry/raster-foundry/pull/5365)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -39,6 +39,11 @@ trait QueryParameterDeserializers {
       AnnotationProjectType.fromString(s)
     }
 
+  implicit val deserializerAnnotationProjectStatus
+    : Unmarshaller[String, AnnotationProjectStatus] =
+    Unmarshaller.strict[String, AnnotationProjectStatus] { s =>
+      AnnotationProjectStatus.fromString(s)
+    }
 }
 
 trait QueryParametersCommon extends QueryParameterDeserializers {
@@ -198,12 +203,14 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         )
     ).as(StacExportQueryParameters.apply _)
 
-  def annotationProjectTypeQueryParameters =
+  def annotationProjectFilterQueryParameters =
     parameters(
       (
-        'projectType.as(deserializerAnnotationProjectType).?
+        'projectType.as(deserializerAnnotationProjectType).?,
+        'status.as(deserializerAnnotationProjectStatus).?,
+        'tasksComplete.as[Boolean].?
       )
-    ).as(AnnotationProjectTypeQueryParameters.apply _)
+    ).as(AnnotationProjectFilterQueryParameters.apply _)
 
   def annotationProjectQueryParameters =
     (
@@ -211,6 +218,6 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         searchParams &
         ownershipTypeQueryParameters &
         groupQueryParameters &
-        annotationProjectTypeQueryParameters
+        annotationProjectFilterQueryParameters
     ).as(AnnotationProjectQueryParameters.apply _)
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -19,7 +19,8 @@ final case class AnnotationProject(
     labelersTeamId: Option[UUID],
     validatorsTeamId: Option[UUID],
     projectId: Option[UUID],
-    status: AnnotationProjectStatus
+    status: AnnotationProjectStatus,
+    tasksComplete: Boolean
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -39,7 +40,8 @@ final case class AnnotationProject(
       projectId,
       status,
       tileLayers,
-      labelClassGroups
+      labelClassGroups,
+      tasksComplete
     )
 }
 
@@ -78,7 +80,8 @@ object AnnotationProject {
       projectId: Option[UUID],
       status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
-      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
+      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
+      tasksComplete: Boolean
   ) {
     def toProject: AnnotationProject = AnnotationProject(
       id,
@@ -92,7 +95,8 @@ object AnnotationProject {
       labelersTeamId,
       validatorsTeamId,
       projectId,
-      status
+      status,
+      tasksComplete
     )
 
     def withSummary(
@@ -112,6 +116,7 @@ object AnnotationProject {
         validatorsTeamId,
         projectId,
         status,
+        tasksComplete,
         tileLayers,
         labelClassGroups,
         taskStatusSummary,
@@ -159,6 +164,7 @@ object AnnotationProject {
       validatorsTeamId: Option[UUID],
       projectId: Option[UUID],
       status: AnnotationProjectStatus,
+      tasksComplete: Boolean,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
       taskStatusSummary: Map[TaskStatus, Int],

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -676,17 +676,19 @@ object StacExportQueryParameters {
     deriveDecoder[StacExportQueryParameters]
 }
 
-final case class AnnotationProjectTypeQueryParameters(
-    projectType: Option[AnnotationProjectType] = None
+final case class AnnotationProjectFilterQueryParameters(
+    projectType: Option[AnnotationProjectType] = None,
+    status: Option[AnnotationProjectStatus] = None,
+    tasksComplete: Option[Boolean] = None
 )
 
-object AnnotationProjectTypeQueryParameters {
-  implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectTypeQueryParameters] =
-    deriveEncoder[AnnotationProjectTypeQueryParameters]
-  implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectTypeQueryParameters] =
-    deriveDecoder[AnnotationProjectTypeQueryParameters]
+object AnnotationProjectFilterQueryParameters {
+  implicit def encAnnotationProjectFilterQueryParameters
+    : Encoder[AnnotationProjectFilterQueryParameters] =
+    deriveEncoder[AnnotationProjectFilterQueryParameters]
+  implicit def decAnnotationProjectFilterQueryParameters
+    : Decoder[AnnotationProjectFilterQueryParameters] =
+    deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
 final case class AnnotationProjectQueryParameters(
@@ -695,8 +697,8 @@ final case class AnnotationProjectQueryParameters(
     ownershipTypeParams: OwnershipTypeQueryParameters =
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
-    projectTypeParams: AnnotationProjectTypeQueryParameters =
-      AnnotationProjectTypeQueryParameters()
+    annotationProjectFilterParameters: AnnotationProjectFilterQueryParameters =
+      AnnotationProjectFilterQueryParameters()
 )
 
 object AnnotationProjectQueryParameters {

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -431,8 +431,15 @@ trait Filterables extends RFMeta with LazyLogging {
         Filters.ownerQP(params.ownerParams) ++
           Filters.searchQP(params.searchParams, List("name")) ++
           List(
-            params.projectTypeParams.projectType.map({ projectType =>
-              fr"project_type = $projectType"
+            params.annotationProjectFilterParameters.projectType.map({
+              projectType =>
+                fr"project_type = $projectType"
+            }),
+            params.annotationProjectFilterParameters.status.map({ status =>
+              fr"status = $status"
+            }),
+            params.annotationProjectFilterParameters.tasksComplete.map({ tasksComplete =>
+              fr"tasksComplete = $tasksComplete"
             })
           )
     }


### PR DESCRIPTION
## Overview
See title

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~Swagger specification updated~
- [ ] ~New tables and queries have appropriate indices added~
- [ ] ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [ ] ~Any new SQL strings have tests~
- [ ] ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Start the frontend (annotate)
- load the project list page
- create a new project and don't process it
- copy the request for annotation projects
- stick a "status=WAITING" url param in it and repeat the request
- confirm that it filters correctly

Backend for https://github.com/raster-foundry/annotate/issues/727
