### PR TITLE
Don't copy a couple fields on sample project tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
-- Support sample projects for new annotation app users [#5362](https://github.com/raster-foundry/raster-foundry/pull/5362)
+- Support sample projects for new annotation app users [#5362](https://github.com/raster-foundry/raster-foundry/pull/5362), [#5368](https://github.com/raster-foundry/raster-foundry/pull/5368)
 
 ### Changed
 

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -586,7 +586,7 @@ object TaskDao extends Dao[Task] {
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
       fr"""SELECT
            uuid_generate_v4(), now(), ${user.id}, now(), ${user.id},
-           status, locked_by, locked_on, geometry, ${toProject}
+           'UNLABELED', null, null, geometry, ${toProject}
            FROM """ ++ tableF ++ fr"""
            WHERE annotation_project_id = ${fromProject}
       """).update.run


### PR DESCRIPTION
## Overview
It's really easy to accidentally change a task status on a sample project. This ignores them.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] ~Swagger specification updated~
- [ ] ~New tables and queries have appropriate indices added~
- [ ] ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [ ] ~Any new SQL strings have tests~
- [ ] ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- reset your dev database and make sure you have the latest version
- on `dev@rasterfoundry.com`, edit the sample project by labeling a few tasks
- create a new account, and verify that the sample project doesn't have any labeled tasks

