### PR TITLE
Buffer TMS grid polygon by 5% to find scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 
+- TMS polygons are buffered when querying for scenes to put a band aid on errors in footprint calculation in upload processing [#5374](https://github.com/raster-foundry/raster-foundry/pull/5374)
+
 ### Deprecated
 
 ### Removed

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -102,3 +102,8 @@ publicData {
   enableMultiTiff = false
   enableMultiTiff = ${?BACKSPLASH_ENABLE_MULTITIFF}
 }
+
+sceneSearch {
+  bufferPercentage = 0.1
+  bufferPercentage = ${?DB_SCENE_SEARCH_BUFFER_PERCENTAGE}
+}

--- a/app-backend/db/src/main/scala/Config.scala
+++ b/app-backend/db/src/main/scala/Config.scala
@@ -18,4 +18,9 @@ object Config {
     val enableMultiTiff =
       publicDataConfig.getBoolean("enableMultiTiff")
   }
+
+  object sceneSearch {
+    private val tmsConfig = config.getConfig("sceneSearch")
+    val bufferPercentage = tmsConfig.getDouble("bufferPercentage")
+  }
 }

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -40,12 +40,12 @@ object SceneToLayerDao extends Dao[SceneToLayer] with LazyLogging {
       g: Projected[Geometry]
   ): Projected[Geometry] = {
     val newGeom = g.as[Polygon] map { g =>
-      g.buffer(g.envelope.width / 20d): Geometry
+      g.buffer(g.envelope.width * Config.sceneSearch.bufferPercentage): Geometry
     } orElse {
       g.as[MultiPolygon] map { g =>
         val polys = g.polygons
         MultiPolygon(polys map { poly =>
-          poly.buffer(poly.envelope.width / 20d)
+          poly.buffer(poly.envelope.width * Config.sceneSearch.bufferPercentage)
         }): Geometry
       }
     } getOrElse { g.geom }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,6 +173,7 @@ services:
       - BACKSPLASH_SERVER_REQUEST_LIMIT=0
       - BACKSPLASH_ENABLE_MULTITIFF=false
       - AWS_REQUEST_PAYER=requester
+      - DB_SCENE_SEARCH_BUFFER_PERCENTAGE=0.1
     ports:
       - "8080:8080"
       - "9030:9030"


### PR DESCRIPTION
## Overview

This PR buffers scene data footprints by 5% when deciding whether they intersect with the search polygon. The reason for this is that the footprint calculation in upload processing is not great it turns out and ends up skewed pretty frequently, and this is a quicker fix than figuring out how/why it's skewed.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

The strategy proposed in the issue wasn't actually possible, since we don't have the raster source information until after we determine the intersecting scenes.

Data loss for The Bad Tif :tm: still occurs at zoom 22:

![loss-at-22](https://user-images.githubusercontent.com/5702984/77352019-882e6b00-6d0c-11ea-92f3-9997a6b00af2.gif)

We can do a larger buffer (10%?) to push that down further, but with the band-aid in place it might be more worthwhile to figure out what's going on in footprint calculation.

## Testing Instructions

- assemble api, backsplash-server
- bring up server
- process The Bad Tif :tm: if you don't have it in a project
- look at its footprint over the visualization of it -- it should still look bad
- zoom in outside the edge of its footprint but where there's definitely data -- you should lose data as you zoom in (within reason)

Closes #5358 
