### PR TITLE
Move buffering from footprint to tms extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Moved buffering to TMS extents to avoid extreme CPU load resulting from previous buffering strategy [#5375](https://github.com/raster-foundry/raster-foundry/pull/5375)
+
 ### Security
 
 ## [1.38.0](https://github.com/raster-foundry/raster-foundry/compare/1.37.0...1.38.0)

--- a/app-backend/db/src/main/scala/SceneToLayerDao.scala
+++ b/app-backend/db/src/main/scala/SceneToLayerDao.scala
@@ -181,11 +181,12 @@ object SceneToLayerDao extends Dao[SceneToLayer] with LazyLogging {
           results.filter { stl =>
             ((stl.dataFootprint, polygonOption) match {
               case (Some(footprint), Some(polygon)) =>
-                footprint.intersects(
-                  polygon.buffer(
-                    polygon.envelope.width / Config.sceneSearch.bufferPercentage
-                  )
+                val footprintEnvelope = footprint.envelope
+                val footprintEnvelopeBuffered = footprintEnvelope.buffer(
+                  footprintEnvelope.width / Config.sceneSearch.bufferPercentage
                 )
+                val polygonEnvelope = polygon.envelope
+                footprintEnvelopeBuffered.intersects(polygonEnvelope)
               case (None, Some(_)) => false
               case _               => true
             }) &&


### PR DESCRIPTION
## Overview

This PR moves intersection buffering on scenes from the scene footprint (which could be an arbitrarily complex geometry) to the scene footprint extent (which is a rectangle). It makes The Bad Tif :tm: correctly visible through at least zoom 29, which is far more than enough

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Skipping the caching idea, since we dramatically simplified the max complexity of the geometry we're buffering, and this is still supposed just to be a band aid

## Testing Instructions

- watch the gif
- make sure you agree the small code change does what i say it does

Closes #5358 again :disappointed: 
