### PR TITLE
Get a task for any project, subject to constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Added a random task endpoint to get a random task meeting some task query parameters in an annotation project satisfying some annotation project query parameters [#5378](https://github.com/raster-foundry/raster-foundry/pull/5378)
 - Add task status filter to annotation projects [#5373](https://github.com/raster-foundry/raster-foundry/pull/5373) [#5379](https://github.com/raster-foundry/raster-foundry/pull/5379)
 
 ### Changed

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -202,3 +202,4 @@ Path,Domain:Action,Verb
 /api/users/me/limits,users:readSelf,get
 /api/users/me/roles,users:readSelf,get
 /api/users/search/,users:search,get
+/api/tasks/random,annotationProjects:readTasks,get

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -14,6 +14,7 @@ import com.rasterfoundry.api.project.ProjectRoutes
 import com.rasterfoundry.api.scene.SceneRoutes
 import com.rasterfoundry.api.shape.ShapeRoutes
 import com.rasterfoundry.api.stac.StacRoutes
+import com.rasterfoundry.api.tasks.TaskRoutes
 import com.rasterfoundry.api.team.TeamRoutes
 import com.rasterfoundry.api.thumbnail.ThumbnailRoutes
 import com.rasterfoundry.api.token.TokenRoutes
@@ -57,7 +58,8 @@ trait Router
     with TeamRoutes
     with PlatformRoutes
     with StacRoutes
-    with AnnotationProjectRoutes {
+    with AnnotationProjectRoutes
+    with TaskRoutes {
 
   val settings = CorsSettings.defaultSettings.copy(
     allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE)
@@ -121,6 +123,9 @@ trait Router
           } ~
           pathPrefix("annotation-projects") {
             annotationProjectRoutes
+          } ~
+          pathPrefix("tasks") {
+            taskRoutes
           }
       } ~
       pathPrefix("config") {

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -83,7 +83,7 @@ trait AnnotationProjectRoutes
           pathPrefix("tasks") {
             pathEndOrSingleSlash {
               get {
-                listTasks(projectId)
+                listAnnotationProjectTasks(projectId)
               } ~ post {
                 createTasks(projectId)
               } ~ delete {

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -1,0 +1,70 @@
+package com.rasterfoundry.api.tasks
+
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server._
+import cats.implicits._
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie.implicits._
+
+import scala.util.{Failure, Success}
+
+import java.util.UUID
+
+trait TaskRoutes
+    extends Authentication
+    with CommonHandlers
+    with PaginationDirectives
+    with QueryParametersCommon
+    with UserErrorHandler {
+
+  val taskRoutes = handleExceptions(userExceptionHandler) {
+    pathPrefix("random") {
+      pathEndOrSingleSlash {
+        get { listTasks }
+      }
+    }
+  }
+
+  def listTasks: Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+      user
+    ) {
+      (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
+        'annotationProjectId.as[UUID].?
+      )) { (page, annotationProjectParams, taskParams, annotationProjectId) =>
+        onComplete {
+          (for {
+            annotationProjects <- AnnotationProjectDao
+              .authQuery(user, ObjectType.AnnotationProject, None, None, None)
+              .filter(annotationProjectParams)
+              .filter(annotationProjectId)
+              .list(page.limit) map { projects =>
+              projects map { _.id }
+            }
+            taskO <- annotationProjects.toNel traverse { projectIds =>
+              TaskDao
+                .randomTask(taskParams, projectIds)
+            }
+          } yield {
+            taskO.flatten
+          }).transact(xa).unsafeToFuture
+        } {
+          case Success(Some(task)) =>
+            complete { task }
+          case Success(None) =>
+            complete { HttpResponse(StatusCodes.OK) }
+          case Failure(e) =>
+            logger.error(e.getMessage)
+            complete { HttpResponse(StatusCodes.BadRequest) }
+        }
+      }
+    }
+  }
+}

--- a/app-backend/datamodel/src/main/scala/PaginatedGeoJsonResponse.scala
+++ b/app-backend/datamodel/src/main/scala/PaginatedGeoJsonResponse.scala
@@ -37,6 +37,18 @@ object GeoJsonCodec {
       _type: String = "FeatureCollection"
   )
 
+  object PaginatedGeoJsonResponse {
+    def empty[T](pageSize: Int): PaginatedGeoJsonResponse[T] =
+      PaginatedGeoJsonResponse(
+        0,
+        false,
+        false,
+        0,
+        pageSize,
+        Nil
+      )
+  }
+
   def fromSeqToFeatureCollection[T1 <: GeoJSONSerializable[T2],
                                  T2 <: GeoJSONFeature](
       features: Iterable[T1]

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -174,13 +174,8 @@ object AnnotationProjectDao
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
-  def annotationProjectByIdQuery(id: UUID): Query0[AnnotationProject] = {
-    (selectF ++ Fragments.whereAndOpt(Some(fr"id = ${id}")))
-      .query[AnnotationProject]
-  }
-
   def getById(id: UUID): ConnectionIO[Option[AnnotationProject]] =
-    annotationProjectByIdQuery(id).option
+    query.filter(id).selectOption
 
   def unsafeGetById(id: UUID): ConnectionIO[AnnotationProject] =
     annotationProjectByIdQuery(id).unique
@@ -383,7 +378,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",
@@ -431,7 +426,7 @@ object AnnotationProjectDao
   ): ConnectionIO[AnnotationProject] = {
     val insertQuery = (fr"""
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
-      fr"""SELECT 
+      fr"""SELECT
              uuid_generate_v4(), now(), ${user.id}, name, project_type, task_size_meters, task_size_pixels,
              aoi, labelers_team_id, validators_team_id, project_id, status, task_status_summary
            FROM """ ++ tableF ++ fr"""

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -378,7 +378,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -178,7 +178,7 @@ object AnnotationProjectDao
     query.filter(id).selectOption
 
   def unsafeGetById(id: UUID): ConnectionIO[AnnotationProject] =
-    annotationProjectByIdQuery(id).unique
+    query.filter(id).select
 
   def getWithRelatedById(
       id: UUID

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -30,6 +30,11 @@ trait Filterables extends RFMeta with LazyLogging {
       List(f1)
     }
 
+  implicit val idFilter: Filterable[Any, UUID] =
+    Filterable[Any, UUID] { id: UUID =>
+      List(Some(fr"id = $id"))
+    }
+
   implicit val userQueryParamsFilter: Filterable[Any, UserQueryParameters] =
     Filterable[Any, UserQueryParameters] { userParams: UserQueryParameters =>
       Filters.userQP(userParams)
@@ -431,16 +436,17 @@ trait Filterables extends RFMeta with LazyLogging {
         val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {
           statusList =>
             val statusFilterF = statusList map { status =>
-              Some(fr"(task_status_summary ->> ${status.toString}) > '0'")
+              Some(fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'")
             }
             Fragment.const("(") ++ Fragments
               .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
         }
-        Filters.ownerQP(params.ownerParams, fr"owner") ++
-          Filters.searchQP(params.searchParams, List("name")) ++
+        Filters.ownerQP(params.ownerParams, fr"annotation_projects.owner") ++
+          Filters.searchQP(params.searchParams,
+                           List("annotation_projects.name")) ++
           List(
             params.projectFilterParams.projectType.map({ projectType =>
-              fr"project_type = $projectType"
+              fr"annotation_projects.project_type = $projectType"
             }),
             taskStatusF
           )

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -436,7 +436,8 @@ trait Filterables extends RFMeta with LazyLogging {
         val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {
           statusList =>
             val statusFilterF = statusList map { status =>
-              Some(fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'")
+              Some(
+                fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'")
             }
             Fragment.const("(") ++ Fragments
               .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")


### PR DESCRIPTION
## Overview

This PR adds an endpoint to grab a list of tasks in projects, subject to task query params and annotation project query params. ~Currently it compiles, is untested, and the behavior might be wrong, _a triple threat_.~

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Notes

I also had to make some pretty huge (in surface area) changes to the `AnnotationProjectDao`, since there was inconsistent handling of the table name alias. In some cases, we referred to the table as `ap.`, and in others we didn't. In particular, the `Filterable` instance for its query parameters used `ap.`, which made the `tableName` value worthless. Now, everything uses `annotation_projects.` instead, since `Dao` constructs column names as `tableName.fieldName`. This would be scary, but tests pass, so we know all the methods work.

Pagination is applied to the annotation project query. This makes the resulting task not truly random -- it's random within the first twenty projects matching the annotation project query parameters. I think that will be enough, and it will prevent a potentially huge sql query from ever being constructed. However, if we actually want to search over all of the projects matching the query parameters, that's fine, it's simple to remove.

This will have a few conflicts once #5379 is merged, but they'll be smaller I think if I wait than the other way around

## Testing Instructions

- ci
- assemble api server
- bring up frontend, servers, and get a bearer token
- `export JWT_AUTH_TOKEN=<your token without the Bearer prefix>`
- `http --auth-type=jwt :9091/api/tasks/random` a few times -- you should get different tasks back
- pick an annotation project that has some tasks, then: `http --auth-type=jwt :9091/api/tasks/random annotationProjectId==<your project id>` -- you should get different tasks back, but they should all be in that project
- pick a labeling status that has a few tasks, then: `http --auth-type=jwt :9091/api/tasks/random status==<your status>` a few times -- you should get different tasks back, but they should all have that status
- pick a project type that has a project with tasks, then: `http --auth-type=jwt :9091/api/tasks/random projectType==<your project type>` a few times -- you should get different tasks back, and all of their projects should have the project type you specified
- combine the last two steps -- filter by both project type _and_ task status. it should behave as expected

Closes #5376
