### PR TITLE
Add task summary field to annotation projects table; Add DB trigger for operations on tasks table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
-- Add task status filter to annotation projects [#5373](https://github.com/raster-foundry/raster-foundry/pull/5373)
+- Add task status filter to annotation projects [#5373](https://github.com/raster-foundry/raster-foundry/pull/5373) [#5379](https://github.com/raster-foundry/raster-foundry/pull/5379)
 
 ### Changed
 

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -19,7 +19,8 @@ final case class AnnotationProject(
     labelersTeamId: Option[UUID],
     validatorsTeamId: Option[UUID],
     projectId: Option[UUID],
-    status: AnnotationProjectStatus
+    status: AnnotationProjectStatus,
+    taskStatusSummary: Map[String, Int]
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -39,7 +40,8 @@ final case class AnnotationProject(
       projectId,
       status,
       tileLayers,
-      labelClassGroups
+      labelClassGroups,
+      taskStatusSummary
     )
 }
 
@@ -78,9 +80,10 @@ object AnnotationProject {
       projectId: Option[UUID],
       status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
-      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
+      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
+      taskStatusSummary: Map[String, Int]
   ) {
-    def toProject: AnnotationProject = AnnotationProject(
+    def toProject = AnnotationProject(
       id,
       createdAt,
       createdBy,
@@ -92,31 +95,30 @@ object AnnotationProject {
       labelersTeamId,
       validatorsTeamId,
       projectId,
-      status
+      status,
+      taskStatusSummary
     )
 
     def withSummary(
-        taskStatusSummary: Map[TaskStatus, Int],
         labelClassSummary: List[AnnotationProject.LabelClassGroupSummary]
-    ): AnnotationProject.WithRelatedAndSummary =
-      AnnotationProject.WithRelatedAndSummary(
-        id,
-        createdAt,
-        createdBy,
-        name,
-        projectType,
-        taskSizeMeters,
-        taskSizePixels,
-        aoi,
-        labelersTeamId,
-        validatorsTeamId,
-        projectId,
-        status,
-        tileLayers,
-        labelClassGroups,
-        taskStatusSummary,
-        labelClassSummary
-      )
+    ) = AnnotationProject.WithRelatedAndLabelClassSummary(
+      id,
+      createdAt,
+      createdBy,
+      name,
+      projectType,
+      taskSizeMeters,
+      taskSizePixels,
+      aoi,
+      labelersTeamId,
+      validatorsTeamId,
+      projectId,
+      status,
+      tileLayers,
+      labelClassGroups,
+      taskStatusSummary,
+      labelClassSummary
+    )
   }
 
   object WithRelated {
@@ -146,7 +148,7 @@ object AnnotationProject {
       deriveEncoder
   }
 
-  final case class WithRelatedAndSummary(
+  final case class WithRelatedAndLabelClassSummary(
       id: UUID,
       createdAt: Instant,
       createdBy: String,
@@ -161,37 +163,13 @@ object AnnotationProject {
       status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
-      taskStatusSummary: Map[TaskStatus, Int],
+      taskStatusSummary: Map[String, Int],
       labelClassSummary: List[LabelClassGroupSummary]
   )
 
-  object WithRelatedAndSummary {
-    implicit val encRelatedAndSummary: Encoder[WithRelatedAndSummary] =
+  object WithRelatedAndLabelClassSummary {
+    implicit val encRelatedAndSummary
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
-  }
-
-  final case class WithTaskStatusSummary(
-      id: UUID,
-      createdAt: Instant,
-      createdBy: String,
-      name: String,
-      projectType: AnnotationProjectType,
-      taskSizeMeters: Option[Double],
-      taskSizePixels: Int,
-      aoi: Option[Projected[Geometry]],
-      labelersTeamId: Option[UUID],
-      validatorsTeamId: Option[UUID],
-      projectId: Option[UUID],
-      status: AnnotationProjectStatus,
-      tileLayers: List[TileLayer],
-      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
-      taskStatusSummary: Map[String, Int]
-  )
-
-  object WithTaskStatusSummary {
-    implicit val encTaskStatusSummary: Encoder[WithTaskStatusSummary] =
-      deriveEncoder
-    implicit val decTaskStatusSummary: Decoder[WithTaskStatusSummary] =
-      deriveDecoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -169,7 +169,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/db/src/main/resources/migrations/V40__Add_task_summary_to_annotation_project.sql
+++ b/app-backend/db/src/main/resources/migrations/V40__Add_task_summary_to_annotation_project.sql
@@ -43,7 +43,6 @@ BEGIN
   SET task_status_summary = task_statuses.summary
   FROM (
     SELECT
-      statuses.annotation_project_id, 
       CREATE_TASK_SUMMARY(
         jsonb_object_agg(
           statuses.status,
@@ -51,14 +50,13 @@ BEGIN
         )
       ) AS summary
     FROM (
-      SELECT status, annotation_project_id, COUNT(id) AS status_count
+      SELECT status, COUNT(id) AS status_count
       FROM public.tasks
       WHERE annotation_project_id = op_project_id
-      GROUP BY status, annotation_project_id
+      GROUP BY status
     ) statuses
-    GROUP BY statuses.annotation_project_id
   ) AS task_statuses
-  WHERE task_statuses.annotation_project_id = annotation_projects.id;
+  WHERE annotation_projects.id = op_project_id;
 
   -- result is ignored since this is an AFTER trigger
   RETURN NULL;

--- a/app-backend/db/src/main/resources/migrations/V40__Add_task_summary_to_annotation_project.sql
+++ b/app-backend/db/src/main/resources/migrations/V40__Add_task_summary_to_annotation_project.sql
@@ -1,0 +1,68 @@
+-- add a jsonb column to annotation_projects table for task status summary
+ALTER TABLE public.annotation_projects 
+ADD COLUMN task_status_summary jsonb DEFAULT '{"UNLABELED": 0, "LABELING_IN_PROGRESS": 0, "LABELED": 0, "VALIDATION_IN_PROGRESS": 0, "VALIDATED": 0 }'::jsonb NOT NULL;
+
+-- populate task_status_summary column for all annotation projects
+UPDATE public.annotation_projects
+SET task_status_summary = statuses.summary
+FROM (
+  SELECT
+    annotation_projects.id as annotation_project_id, 
+    CREATE_TASK_SUMMARY(
+      jsonb_object_agg(
+        statuses.status,
+        statuses.status_count
+      )
+    ) AS summary
+  FROM (
+    SELECT status, annotation_project_id, COUNT(id) AS status_count
+    FROM tasks
+    GROUP BY status, annotation_project_id
+  ) statuses
+  JOIN annotation_projects
+  ON statuses.annotation_project_id = annotation_projects.id
+  GROUP BY annotation_projects.id
+) statuses
+WHERE statuses.annotation_project_id = id;
+
+-- define the trigger function to update task summary for annotation projects
+CREATE OR REPLACE FUNCTION UPDATE_PROJECT_TASK_SUMMARY()
+  RETURNS trigger AS
+$BODY$
+DECLARE
+  project_id uuid;
+BEGIN
+  -- the NEW variable holds row for INSERT/UPDATE operations
+  -- the OLD variable holds row for DELETE operations
+  -- store the annotation project ID
+  IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN
+    project_id := NEW.annotation_project_id;
+  ELSE
+    project_id := OLD.annotation_project_id;
+  END IF;
+  -- update task summary for the stored annotation project
+  UPDATE annotation_projects
+  SET task_status_summary = CREATE_TASK_SUMMARY(jsonb_object_agg(
+    statuses.status,
+    statuses.status_count
+  ))
+  FROM (
+    SELECT status, COUNT(id) AS status_count
+    FROM tasks
+    WHERE annotation_project_id = project_id
+    GROUP BY status
+  ) statuses
+  WHERE annotation_project_id = project_id;
+
+  -- result is ignored since this is an AFTER trigger
+  RETURN NULL;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+-- add a trigger to INSERT OR UPDATE OR DELETE operations on tasks table
+CREATE TRIGGER update_annotation_project_task_summary
+  AFTER INSERT OR UPDATE OR DELETE
+  ON tasks
+  FOR EACH ROW
+  EXECUTE PROCEDURE UPDATE_PROJECT_TASK_SUMMARY();

--- a/app-backend/db/src/main/resources/migrations/V41__Add_gin_index_to_task_summary.sql
+++ b/app-backend/db/src/main/resources/migrations/V41__Add_gin_index_to_task_summary.sql
@@ -1,0 +1,4 @@
+-- add an index on task summary column in case we need sorting
+CREATE INDEX CONCURRENTLY IF NOT EXISTS annotation_projects_task_status_summary 
+ON public.annotation_projects
+USING gin (task_status_summary);

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -383,7 +383,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -189,7 +189,7 @@ object Dao extends LazyLogging {
             (countF ++ Fragments.whereAndOpt(filters: _*))
               .query[Int]
               .unique map { count =>
-              (count, (pageRequest.offset * pageRequest.limit) + 1 < count)
+              (count, (pageRequest.offset + 1) * pageRequest.limit < count)
             }
           }
           case false => {

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -41,7 +41,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-    : Filterable[Any, TimestampQueryParameters] =
+      : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -53,7 +53,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-    : Filterable[Any, ProjectQueryParameters] =
+      : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -82,7 +82,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-    : Filterable[Any, CombinedToolQueryParameters] =
+      : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -95,7 +95,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-    : Filterable[Any, AnnotationQueryParameters] =
+      : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -134,7 +134,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-    : Filterable[Any, CombinedSceneQueryParams] =
+      : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -198,7 +198,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-    : Filterable[Any, ProjectSceneQueryParameters] =
+      : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -213,7 +213,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-    : Filterable[Any, CombinedMapTokenQueryParameters] =
+      : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -221,7 +221,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-    : Filterable[Any, CombinedToolRunQueryParameters] =
+      : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -268,7 +268,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-    : Filterable[Any, DatasourceQueryParameters] =
+      : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -339,7 +339,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-    : Filterable[Any, ThumbnailQueryParameters] =
+      : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -354,7 +354,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-    : Filterable[Any, PlatformQueryParameters] =
+      : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -364,7 +364,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-    : Filterable[Any, OrganizationQueryParameters] =
+      : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -379,14 +379,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-    : Filterable[Organization, SearchQueryParameters] =
+      : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-    : Filterable[User, SearchQueryParameters] =
+      : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -397,7 +397,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-    : Filterable[Any, Projected[MultiPolygon]] =
+      : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -408,7 +408,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-    : Filterable[Any, StacExportQueryParameters] =
+      : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -425,22 +425,22 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationProjectQueryParametersFilter
-    : Filterable[Any, AnnotationProjectQueryParameters] =
+      : Filterable[Any, AnnotationProjectQueryParameters] =
     Filterable[Any, AnnotationProjectQueryParameters] {
       params: AnnotationProjectQueryParameters =>
         val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {
           statusList =>
             val statusFilterF = statusList map { status =>
-              Some(fr"(ts.summary ->> ${status.toString}) > '0'")
+              Some(fr"(task_status_summary ->> ${status.toString}) > '0'")
             }
             Fragment.const("(") ++ Fragments
               .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
         }
-        Filters.ownerQP(params.ownerParams, fr"ap.owner") ++
-          Filters.searchQP(params.searchParams, List("ap.name")) ++
+        Filters.ownerQP(params.ownerParams, fr"owner") ++
+          Filters.searchQP(params.searchParams, List("name")) ++
           List(
             params.projectFilterParams.projectType.map({ projectType =>
-              fr"ap.project_type = $projectType"
+              fr"project_type = $projectType"
             }),
             taskStatusF
           )

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -41,7 +41,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-      : Filterable[Any, TimestampQueryParameters] =
+    : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -53,7 +53,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-      : Filterable[Any, ProjectQueryParameters] =
+    : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -82,7 +82,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-      : Filterable[Any, CombinedToolQueryParameters] =
+    : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -95,7 +95,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-      : Filterable[Any, AnnotationQueryParameters] =
+    : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -134,7 +134,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-      : Filterable[Any, CombinedSceneQueryParams] =
+    : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -198,7 +198,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-      : Filterable[Any, ProjectSceneQueryParameters] =
+    : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -213,7 +213,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-      : Filterable[Any, CombinedMapTokenQueryParameters] =
+    : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -221,7 +221,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-      : Filterable[Any, CombinedToolRunQueryParameters] =
+    : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -268,7 +268,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-      : Filterable[Any, DatasourceQueryParameters] =
+    : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -339,7 +339,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-      : Filterable[Any, ThumbnailQueryParameters] =
+    : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -354,7 +354,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-      : Filterable[Any, PlatformQueryParameters] =
+    : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -364,7 +364,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-      : Filterable[Any, OrganizationQueryParameters] =
+    : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -379,14 +379,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-      : Filterable[Organization, SearchQueryParameters] =
+    : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-      : Filterable[User, SearchQueryParameters] =
+    : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -397,7 +397,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-      : Filterable[Any, Projected[MultiPolygon]] =
+    : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -408,7 +408,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-      : Filterable[Any, StacExportQueryParameters] =
+    : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -425,7 +425,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationProjectQueryParametersFilter
-      : Filterable[Any, AnnotationProjectQueryParameters] =
+    : Filterable[Any, AnnotationProjectQueryParameters] =
     Filterable[Any, AnnotationProjectQueryParameters] {
       params: AnnotationProjectQueryParameters =>
         val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {


### PR DESCRIPTION
## Overview

This PR:
- adds a new field `task_status_summary` to the `annotation_projects` table to store task status distribution for annotation projects
- adds a database trigger on `INSERT`/`UPDATE`/`DELETE` operations on `tasks` table so that `task_status_summary` in `annotation_projects` table is in sync
- adds back the old `authQuery` logic so that the `counts` field should work the same as before
- fixes a bug in the calculation of `hasNext` field in `Dao`

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~ (There is no spec for annotation project set of endpoints)
- [X] New tables and queries have appropriate indices added (a `gin` index is added to `task_status_summary` field, in case we are adding jsonb field sorting)
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (modified existing tests)
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Tests are updated to test the new trigger and new column, so CI should pass
- Run migrations
- `api/assembly` and spin up servers
- If your local DB has and only has these two annotation projects: `Florence - Alabama` and `Sample Project`, then the below steps should pass for you; if your local DB annotation projects are different, run similar tests as below:
     - `GET` to `api/annotation-projects` should list 2 annotation projects
     - `GET` to `api/annotation-projects?taskStatusesInclude=VALIDATED` should list only `Florence - Alabama` project
     - `GET` to `api/annotation-projects?taskStatusesInclude=UNLABELED` should list only `Sample Project` project
     - make sure the `hasNext` field of each of the above return reflect the reality
     - make sure the `count` field of each of the above return reflect the reality
- Choose a task from a project. Check the summary field count of a project by `GET` to `api/annotation-projects/<id>`. Update its status by sending the updated task object to `api/annotation-projects/<id>/tasks/<id>`.  Check the project's status again.
- Perform similar operation as the above, but delete a task this time. Check project task status before and after the deletion.

Closes https://github.com/raster-foundry/raster-foundry/issues/5377
