### PR TITLE
Include imagery in STAC exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- STAC exports now include underlying imagery [#5380](https://github.com/raster-foundry/raster-foundry/pull/5380)
+
 ### Deprecated
 
 ### Removed

--- a/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
@@ -22,6 +22,11 @@ import java.nio.charset.Charset
 
 case class ObjectWithAbsolute[A](absolutePath: String, item: A)
 
+case class SceneItemWithAbsolute(
+  item: ObjectWithAbsolute[StacItem],
+  ingestLocation: String
+)
+
 object StacFileIO extends LazyLogging with Config {
 
   protected def s3Client = S3()

--- a/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
@@ -23,8 +23,8 @@ import java.nio.charset.Charset
 case class ObjectWithAbsolute[A](absolutePath: String, item: A)
 
 case class SceneItemWithAbsolute(
-  item: ObjectWithAbsolute[StacItem],
-  ingestLocation: String
+    item: ObjectWithAbsolute[StacItem],
+    ingestLocation: String
 )
 
 object StacFileIO extends LazyLogging with Config {

--- a/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
@@ -17,7 +17,7 @@ import io.circe._
 import io.circe.syntax._
 
 import java.io.{BufferedReader, ByteArrayInputStream, InputStreamReader}
-import java.net.{URI, URLDecoder}
+import java.net.URI
 import java.nio.charset.Charset
 
 case class ObjectWithAbsolute[A](absolutePath: String, item: A)
@@ -71,8 +71,10 @@ object StacFileIO extends LazyLogging with Config {
     val tiffKey =
       (key.split("/").dropRight(1) :+ s"${stacWithAbsolute.item.id}.tiff")
         .mkString("/")
-    val localOutputFile = ScalaFile(s"${tempDir.path}/$tiffKey")
-    val sourceUri = URI.create(URLDecoder.decode(ingestLocation, "utf-8"))
+    val localPath = s"${tempDir.path}/$tiffKey"
+    logger.debug(s"Fetching $ingestLocation to $localPath")
+    val localOutputFile = ScalaFile(localPath)
+    val sourceUri = URI.create(ingestLocation)
     IO { s3Client.getObject(sourceUri) } map { resp =>
       val reader =
         new BufferedReader(new InputStreamReader(resp.getObjectContent()))

--- a/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
@@ -45,6 +45,8 @@ object StacFileIO extends LazyLogging with Config {
     s3Client.putObject(uri.getBucket, uri.getKey, file.toJava)
   }
 
+  def getObject[T](tempDir: ScalaFile, stacWithAbsolute: ObjectWithAbsolute[T], ingestLocation: String): IO[Unit] = ???
+
   def putObjectToS3[A: Encoder](
       stacWithAbsolute: ObjectWithAbsolute[A]): IO[PutObjectResult] = IO {
     val uri = new AmazonS3URI(stacWithAbsolute.absolutePath)

--- a/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/StacFileIO.scala
@@ -12,10 +12,12 @@ import com.amazonaws.services.s3.model.{
   PutObjectResult
 }
 import com.typesafe.scalalogging.LazyLogging
+import geotrellis.server.stac.StacItem
 import io.circe._
 import io.circe.syntax._
 
-import java.io.ByteArrayInputStream
+import java.io.{BufferedReader, ByteArrayInputStream, InputStreamReader}
+import java.net.{URI, URLDecoder}
 import java.nio.charset.Charset
 
 case class ObjectWithAbsolute[A](absolutePath: String, item: A)
@@ -26,7 +28,8 @@ object StacFileIO extends LazyLogging with Config {
 
   def writeObjectToFilesystem[A: Encoder](
       tempDir: ScalaFile,
-      stacWithAbsolute: ObjectWithAbsolute[A]): IO[ScalaFile] = IO {
+      stacWithAbsolute: ObjectWithAbsolute[A]
+  ): IO[ScalaFile] = IO {
     val absolutePathURI = new AmazonS3URI(stacWithAbsolute.absolutePath)
     val key = absolutePathURI.getKey
     val localOutputPath = s"${tempDir.path}/$key"
@@ -45,10 +48,42 @@ object StacFileIO extends LazyLogging with Config {
     s3Client.putObject(uri.getBucket, uri.getKey, file.toJava)
   }
 
-  def getObject[T](tempDir: ScalaFile, stacWithAbsolute: ObjectWithAbsolute[T], ingestLocation: String): IO[Unit] = ???
+  private def writeUntilEmpty(
+      betterFile: ScalaFile,
+      reader: BufferedReader
+  ): Unit = {
+    val lineMaybeNull = reader.readLine()
+    Option(lineMaybeNull) map { line =>
+      betterFile.append(line)
+    } match {
+      case Some(_) => writeUntilEmpty(betterFile, reader)
+      case None    => ()
+    }
+  }
+
+  def getObject(
+      tempDir: ScalaFile,
+      stacWithAbsolute: ObjectWithAbsolute[StacItem],
+      ingestLocation: String
+  ): IO[Unit] = {
+    val absolutePathURI = new AmazonS3URI(stacWithAbsolute.absolutePath)
+    val key = absolutePathURI.getKey
+    val tiffKey =
+      (key.split("/").dropRight(1) :+ s"${stacWithAbsolute.item.id}.tiff")
+        .mkString("/")
+    val localOutputFile = ScalaFile(s"${tempDir.path}/$tiffKey")
+    val sourceUri = URI.create(URLDecoder.decode(ingestLocation, "utf-8"))
+    IO { s3Client.getObject(sourceUri) } map { resp =>
+      val reader =
+        new BufferedReader(new InputStreamReader(resp.getObjectContent()))
+      val created = localOutputFile.createIfNotExists(false, true)
+      writeUntilEmpty(created, reader)
+    }
+  }
 
   def putObjectToS3[A: Encoder](
-      stacWithAbsolute: ObjectWithAbsolute[A]): IO[PutObjectResult] = IO {
+      stacWithAbsolute: ObjectWithAbsolute[A]
+  ): IO[PutObjectResult] = IO {
     val uri = new AmazonS3URI(stacWithAbsolute.absolutePath)
     val key = uri.getKey
     val dataByte = Printer.noSpaces

--- a/app-backend/batch/src/main/scala/stacExport/Utils.scala
+++ b/app-backend/batch/src/main/scala/stacExport/Utils.scala
@@ -237,7 +237,7 @@ object Utils {
       Map(
         scene.id.toString ->
           StacAsset(
-            s"./{scene.id}.tiff",
+            s"./${scene.id}.tiff",
             Some("scene"),
             Some(`image/cog`)
           )

--- a/app-backend/batch/src/main/scala/stacExport/Utils.scala
+++ b/app-backend/batch/src/main/scala/stacExport/Utils.scala
@@ -9,7 +9,7 @@ import geotrellis.vector.reproject.Reproject
 import io.circe._
 import io.circe.syntax._
 
-import java.net.{URI, URLDecoder}
+import java.net.URI
 import java.sql.Timestamp
 import java.util.{Date, UUID}
 
@@ -233,7 +233,7 @@ object Utils {
           .asJson
       )
     )
-    val sceneAssetOption = scene.ingestLocation map { ingestLocation =>
+    val sceneAssetOption = scene.ingestLocation map { _ =>
       Map(
         scene.id.toString ->
           StacAsset(

--- a/app-backend/batch/src/main/scala/stacExport/Utils.scala
+++ b/app-backend/batch/src/main/scala/stacExport/Utils.scala
@@ -237,7 +237,7 @@ object Utils {
       Map(
         scene.id.toString ->
           StacAsset(
-            URLDecoder.decode(ingestLocation, "utf-8"),
+            s"./{scene.id}.tiff",
             Some("scene"),
             Some(`image/cog`)
           )

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -10,7 +10,6 @@ import com.rasterfoundry.datamodel._
 import better.files.{File => ScalaFile}
 import cats.effect.{ContextShift, IO}
 import cats.implicits._
-import com.amazonaws.services.s3.model.PutObjectResult
 import doobie._
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
@@ -32,7 +31,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       tempDir: ScalaFile,
       layerId: UUID,
       sceneTaskAnnotation: ExportData
-  ): IO[(List[PutObjectResult], List[ScalaFile])] = {
+  ): IO[List[ScalaFile]] = {
     logger.info(s"Processing Layer Collection: $layerId")
     val layerCollectionPrefix = s"$exportPath/$layerId"
     val labelRootURI = new URI(layerCollectionPrefix)
@@ -56,7 +55,16 @@ final case class WriteStacCatalog(exportId: UUID)(
     )
 
     val sceneItems = sceneTaskAnnotation.scenes flatMap { scene =>
-      Utils.getSceneItem(catalog, layerCollectionPrefix, sceneCollection, scene)
+      (
+        Utils.getSceneItem(
+          catalog,
+          layerCollectionPrefix,
+          sceneCollection,
+          scene
+        ),
+        scene.ingestLocation
+      ).tupled
+
     }
 
     val absoluteLayerCollection =
@@ -83,7 +91,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       )
 
     val updatedSceneLinks = sceneCollection.links ++ sceneItems.map {
-      itemWithAbsolute =>
+      case (itemWithAbsolute, _) =>
         StacLink(
           s"./${itemWithAbsolute.item.id}.json",
           Item,
@@ -105,7 +113,7 @@ final case class WriteStacCatalog(exportId: UUID)(
         catalog,
         sceneTaskAnnotation,
         labelCollection,
-        sceneItems,
+        sceneItems map { _._1 },
         s"$layerCollectionPrefix/${labelCollection.id}",
         labelRootURI
       )
@@ -123,28 +131,16 @@ final case class WriteStacCatalog(exportId: UUID)(
       labelCollection.copy(links = updatedLabelLinks)
     )
     for {
-      s3LabelCollectionResult <- StacFileIO.putObjectToS3(
-        labelCollectionWithPath
-      )
-      s3SceneItemResults <- sceneItems.parTraverse(
-        item => StacFileIO.putObjectToS3(item)
-      )
-      s3SceneCollectionResults <- StacFileIO.putObjectToS3(
-        sceneCollectionWithPath
-      )
-      s3LabelItemResults <- StacFileIO.putObjectToS3(labelItem)
-      s3LayerCollectionResults <- StacFileIO.putObjectToS3(
-        absoluteLayerCollection
-      )
-      s3AnnotationResults <- StacFileIO.putObjectToS3(annotations)
-
       localLabelCollectionResult <- StacFileIO.writeObjectToFilesystem(
         tempDir,
         labelCollectionWithPath
       )
-      localSceneItemResults <- sceneItems.parTraverse(
-        item => StacFileIO.writeObjectToFilesystem(tempDir, item)
-      )
+      localSceneItemResults <- sceneItems.parTraverse {
+        case (item, ingestLocation) => {
+          StacFileIO.writeObjectToFilesystem(tempDir, item) <*
+            StacFileIO.getObject(tempDir, item, ingestLocation)
+        }
+      }
       localSceneCollectionResults <- StacFileIO.writeObjectToFilesystem(
         tempDir,
         sceneCollectionWithPath
@@ -163,22 +159,13 @@ final case class WriteStacCatalog(exportId: UUID)(
       )
 
     } yield {
-      (
-        List(
-          s3LabelCollectionResult,
-          s3SceneCollectionResults,
-          s3LabelItemResults,
-          s3AnnotationResults,
-          s3LayerCollectionResults
-        ) ++ s3SceneItemResults,
-        List(
-          localLabelCollectionResult,
-          localSceneCollectionResults,
-          localLabelItemResults,
-          localAnnotationResults,
-          localLayerCollectionResults
-        ) ++ localSceneItemResults
-      )
+      List(
+        localLabelCollectionResult,
+        localSceneCollectionResults,
+        localLabelItemResults,
+        localAnnotationResults,
+        localLayerCollectionResults
+      ) ++ localSceneItemResults
     }
   }
 
@@ -232,7 +219,6 @@ final case class WriteStacCatalog(exportId: UUID)(
             )
         }
         for {
-          s3CatalogResults <- StacFileIO.putObjectToS3(catalogWithPath)
           _ <- StacFileIO.writeObjectToFilesystem(tempDir, catalogWithPath)
           layer <- layerIO.toList.sequence
           (s3LayerCollectionResults, _) = layer.unzip

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -63,7 +63,7 @@ final case class WriteStacCatalog(exportId: UUID)(
           scene
         ),
         scene.ingestLocation
-      ).tupled
+      ).mapN(SceneItemWithAbsolute.apply _)
 
     }
 
@@ -91,7 +91,7 @@ final case class WriteStacCatalog(exportId: UUID)(
       )
 
     val updatedSceneLinks = sceneCollection.links ++ sceneItems.map {
-      case (itemWithAbsolute, _) =>
+      case SceneItemWithAbsolute(itemWithAbsolute, _) =>
         StacLink(
           s"./${itemWithAbsolute.item.id}.json",
           Item,
@@ -113,7 +113,7 @@ final case class WriteStacCatalog(exportId: UUID)(
         catalog,
         sceneTaskAnnotation,
         labelCollection,
-        sceneItems map { _._1 },
+        sceneItems map { _.item },
         s"$layerCollectionPrefix/${labelCollection.id}",
         labelRootURI
       )
@@ -136,7 +136,7 @@ final case class WriteStacCatalog(exportId: UUID)(
         labelCollectionWithPath
       )
       localSceneItemResults <- sceneItems.parTraverse {
-        case (item, ingestLocation) => {
+        case SceneItemWithAbsolute(item, ingestLocation) => {
           StacFileIO.writeObjectToFilesystem(tempDir, item) <*
             StacFileIO.getObject(tempDir, item, ingestLocation)
         }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -458,6 +458,7 @@ lazy val batch = project
       Dependencies.fs2,
       Dependencies.fs2,
       Dependencies.geotrellisContribGDAL,
+      Dependencies.geotrellisContribVLM,
       Dependencies.geotrellisProj4,
       Dependencies.geotrellisRaster,
       Dependencies.geotrellisS3,

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -616,7 +616,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
 
   def expireStuckTasks(taskExpiration: FiniteDuration): ConnectionIO[Int] =
     for {
-      _ <- info(s"Expiring stuck tasks")
+      _ <- info("Expiring stuck tasks")
       defaultUser <- UserDao.unsafeGetUserById("default")
       stuckTasks <- query
         .filter(

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -616,7 +616,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
 
   def expireStuckTasks(taskExpiration: FiniteDuration): ConnectionIO[Int] =
     for {
-      _ <- info(s"Expiring stuck tasks: ${Instant.now}")
+      _ <- info(s"Expiring stuck tasks")
       defaultUser <- UserDao.unsafeGetUserById("default")
       stuckTasks <- query
         .filter(


### PR DESCRIPTION
## Overview

This PR fetches and includes imagery in STAC exports adjacent to the scene items it's imagery for.
It also removes a bunch of S3 interaction so we don't end up duplicating everything in the universe anymore, now that there's non-json flying around.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

~wip because no joke I can't figure out how to write a file omg I just want to take bytes from s3 and put them on disk :sob: :sob: :sob:~

## Testing Instructions

- `batch/assembly`
- label your sample project in local Groundwork some
- create an export for it
- grab the most recent id from `stac_exports`
- `./scripts/console batch 'java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <your id>'`
- download the zip file on s3 somewhere, e.g. -- `mkdir catalog && aws --profile raster-foundry s3 cp <export location> catalog/`
- unzip your catalog
- `tree`
- cat the scene item (you'll see it as the item next to `<id>.tiff` and confirm the asset link is to `./<item id>.tiff`
- gdalinfo the tiff

Closes #5298 
