### PR TITLE
Update type of task status summary in annotation project data model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 - Added a random task endpoint to get a random task meeting some task query parameters in an annotation project satisfying some annotation project query parameters [#5378](https://github.com/raster-foundry/raster-foundry/pull/5378)
-- Add task status filter to annotation projects [#5373](https://github.com/raster-foundry/raster-foundry/pull/5373) [#5379](https://github.com/raster-foundry/raster-foundry/pull/5379)
+- Add task status filter to annotation projects [#5373](https://github.com/raster-foundry/raster-foundry/pull/5373) [#5379](https://github.com/raster-foundry/raster-foundry/pull/5379) [#5382](https://github.com/raster-foundry/raster-foundry/pull/5382)
 
 ### Changed
 

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -169,7 +169,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -20,7 +20,7 @@ final case class AnnotationProject(
     validatorsTeamId: Option[UUID],
     projectId: Option[UUID],
     status: AnnotationProjectStatus,
-    taskStatusSummary: Map[String, Int]
+    taskStatusSummary: Option[Map[String, Int]] = None
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -81,7 +81,7 @@ object AnnotationProject {
       status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
-      taskStatusSummary: Map[String, Int]
+      taskStatusSummary: Option[Map[String, Int]] = None
   ) {
     def toProject = AnnotationProject(
       id,
@@ -163,13 +163,13 @@ object AnnotationProject {
       status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
-      taskStatusSummary: Map[String, Int],
+      taskStatusSummary: Option[Map[String, Int]] = None,
       labelClassSummary: List[LabelClassGroupSummary]
   )
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-      : Encoder[WithRelatedAndLabelClassSummary] =
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -28,7 +28,7 @@ trait CirceJsonbMeta {
       Json.obj(
         ("width", a.width.asJson),
         ("height", a.height.asJson)
-      )
+    )
 
   implicit val cellSizeDecoder: Decoder[CellSize] = (c: HCursor) =>
     for {
@@ -36,7 +36,7 @@ trait CirceJsonbMeta {
       height <- c.downField("height").as[Double]
     } yield {
       new CellSize(width, height)
-    }
+  }
 
   implicit val gridExtentMeta: Meta[GridExtent[Long]] =
     CirceJsonbMeta[GridExtent[Long]]
@@ -109,10 +109,10 @@ trait CirceJsonbMeta {
     CirceJsonbMeta[List[TileLayer]]
 
   implicit val annotationProjectLabelGroupsMeta
-      : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
+    : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
     CirceJsonbMeta[List[AnnotationLabelClassGroup.WithLabelClasses]]
 
   implicit val annotationProjectTaskStatusSummaryMeta
-      : Meta[Option[Map[String, Int]]] =
+    : Meta[Option[Map[String, Int]]] =
     CirceJsonbMeta[Option[Map[String, Int]]]
 }

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -28,7 +28,7 @@ trait CirceJsonbMeta {
       Json.obj(
         ("width", a.width.asJson),
         ("height", a.height.asJson)
-    )
+      )
 
   implicit val cellSizeDecoder: Decoder[CellSize] = (c: HCursor) =>
     for {
@@ -36,7 +36,7 @@ trait CirceJsonbMeta {
       height <- c.downField("height").as[Double]
     } yield {
       new CellSize(width, height)
-  }
+    }
 
   implicit val gridExtentMeta: Meta[GridExtent[Long]] =
     CirceJsonbMeta[GridExtent[Long]]
@@ -109,9 +109,10 @@ trait CirceJsonbMeta {
     CirceJsonbMeta[List[TileLayer]]
 
   implicit val annotationProjectLabelGroupsMeta
-    : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
+      : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
     CirceJsonbMeta[List[AnnotationLabelClassGroup.WithLabelClasses]]
 
-  implicit val annotationProjectTaskStatusSummaryMeta: Meta[Map[String, Int]] =
-    CirceJsonbMeta[Map[String, Int]]
+  implicit val annotationProjectTaskStatusSummaryMeta
+      : Meta[Option[Map[String, Int]]] =
+    CirceJsonbMeta[Option[Map[String, Int]]]
 }


### PR DESCRIPTION
## Overview

This PR updates the type of `taskStatusSummary` field of `AnnotationProject` so that it is of type `Option[Map[String, Int]]` with a default value `None`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~(there is no spec for annotation project related endpoints)
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (existing tests are updated)
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Property tests should pass
- `./scripts/console sbt`
- `batch/assembly`
- `api/assembly`
- `docker-compose build batch`
- `./scripts/server`
- Pull down branch from this GW PR: https://github.com/raster-foundry/annotate/pull/817
- Follow steps in [here](https://github.com/raster-foundry/annotate/wiki/Point-to-Raster-Foundry-local-servers) to point GW frontend to this local RF server
- Open the network tab on GW frontend
- On GW frontend, create a project by uploading an image or connecting to a remote image
- Grab the image upload ID from the network traffic (if not there, find it in DB)
- `./scripts/console batch bash`
- `rf process-upload <Upload ID>`
- Once it is done, look at GW frontend's project list page. The newly created project should be ready with the image you uploaded
- On GW frontend:
     - on project list, make sure the project status filter (under the `view:` dropdown) still works
     - on project list, make sure the project task progress bar works (since it reads from the task summary field)
     - on project detail UI, make sure the "Progress" section displays the progress as well (since it reads from the task summary field)

Closes https://github.com/raster-foundry/raster-foundry/issues/5381
