### PR TITLE
Delete locks in task expiration function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Set `lockedBy` and `lockedOn` to null when expiring tasks [#5385](https://github.com/raster-foundry/raster-foundry/pull/5385)
+
 ### Security
 
 ## [1.39.0](https://github.com/raster-foundry/raster-foundry/compare/1.38.1...1.39.0)

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -641,7 +641,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
               ),
               task.geometry
             )
-          updateTask(task.id, update, defaultUser)
+          updateTask(task.id, update, defaultUser) <* deleteLock(task.id)
         }
       }
     } yield stuckTasks.length

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -641,7 +641,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
               ),
               task.geometry
             )
-          updateTask(task.id, update, defaultUser) <* deleteLock(task.id)
+          updateTask(task.id, update, defaultUser) <* unlockTask(task.id)
         }
       }
     } yield stuckTasks.length

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -1187,6 +1187,17 @@ class TaskDaoSpec
               (listed map { _.status } toSet) == Set(TaskStatus.Unlabeled),
               "All tasks reverted to unlabeled"
             )
+
+            assert(
+              listed flatMap { _.lockedBy } == Nil,
+              "All tasks reverted to not being locked by anyone"
+            )
+
+            assert(
+              listed flatMap { _.lockedOn } == Nil,
+              "All tasks reverted to not being locked at any time"
+            )
+
             true
           }
       }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -1189,12 +1189,12 @@ class TaskDaoSpec
             )
 
             assert(
-              listed flatMap { _.lockedBy } == Nil,
+              (listed flatMap { _.lockedBy }) == Nil,
               "All tasks reverted to not being locked by anyone"
             )
 
             assert(
-              listed flatMap { _.lockedOn } == Nil,
+              (listed flatMap { _.lockedOn }) == Nil,
               "All tasks reverted to not being locked at any time"
             )
 


### PR DESCRIPTION
## Overview

This PR calls `deleteLock` in the task status expiration function so that it actually does the thing that we care most about :man_facepalming: 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

Testing with `testOnly db/TaskDaoSpec -- -z "expire"`

Without the change:

```
Message: List("2080bf31-2f0d-4ca0-9a39-8da95d0aaa2e") did not equal List() All tasks reverted to not being locked by anyone
...
*** 1 TEST FAILED ***
```

With the change:

```
[info] All tests passed.
```

## Testing Instructions

- tests

Closes raster-foundry/annotate#848
