### PR TITLE
Explicitly set width of imagery in email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Notify Groundwork users when annotation projects are shared with them [#5383](https://github.com/raster-foundry/raster-foundry/pull/5383), [#5386](https://github.com/raster-foundry/raster-foundry/pull/5386)
+
 ### Changed
 
 ### Deprecated
@@ -22,7 +24,6 @@
 
 - Added a random task endpoint to get a random task meeting some task query parameters in an annotation project satisfying some annotation project query parameters [#5378](https://github.com/raster-foundry/raster-foundry/pull/5378)
 - Add task status filter to annotation projects [#5373](https://github.com/raster-foundry/raster-foundry/pull/5373) [#5379](https://github.com/raster-foundry/raster-foundry/pull/5379) [#5382](https://github.com/raster-foundry/raster-foundry/pull/5382)
-- Notify Groundwork users when annotation projects are shared with them [#5383](https://github.com/raster-foundry/raster-foundry/pull/5383)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/annotation-project/Notifications.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Notifications.scala
@@ -13,7 +13,7 @@ object Notifications {
     val richBody = HtmlBody(s"""
 <html>
   <p>
-    <img src="https://groundwork.azavea.com/assets/img/GroundworkBranding-ProductOfAzavea.svg" width="400"/>
+    <img src="https://groundwork.azavea.com/assets/img/GroundworkBranding-ProductOfAzavea.png" width="400"/>
   </p>
   <p>
     <img src="https://user-images.githubusercontent.com/12401491/73973100-f00d2b80-48ef-11ea-9e37-06e7a41bafc6.gif" width="400"/>

--- a/app-backend/api/src/main/scala/annotation-project/Notifications.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Notifications.scala
@@ -13,10 +13,10 @@ object Notifications {
     val richBody = HtmlBody(s"""
 <html>
   <p>
-    <img src="https://groundwork.azavea.com/assets/img/GroundworkBranding-ProductOfAzavea.svg"/>
+    <img src="https://groundwork.azavea.com/assets/img/GroundworkBranding-ProductOfAzavea.svg" width="400"/>
   </p>
   <p>
-    <img src="https://user-images.githubusercontent.com/12401491/73973100-f00d2b80-48ef-11ea-9e37-06e7a41bafc6.gif" />
+    <img src="https://user-images.githubusercontent.com/12401491/73973100-f00d2b80-48ef-11ea-9e37-06e7a41bafc6.gif" width="400"/>
   </p>
   <p>
     ${sharingUserEmail} needs your help! They've invited you to be a collaborator on their project ${annotationProject.name}.


### PR DESCRIPTION
## Overview

This PR sets the width of the gif and banner image explicitly so that the SVG doesn't end up hilariously huge.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I can't see the svg in my email at all so I don't know what's wrong there. However, @aaronxsu could see the svg in his email, and when I copy the notification out to an html file everything cooperates, so maybe it's fine.

## Testing Instructions

- see email instructions for #5383 for longer form instructions
- invite a user who doesn't exist for an email address you control
- look at the email
- the Groundwork logo should be a reasonable size
