### PR TITLE
Handle simultaneous user creation that throws errors

### DIFF
--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -189,7 +189,7 @@ trait Authentication extends Directives with LazyLogging {
                   .attempt flatMap {
                   case Right(s) => IO.pure(s)
                   case Left(e: PSQLException) if e.getSQLState == "23505" => {
-                    logger.debug(s"Handling Duplicate User: $e")
+                    logger.debug("Handling Duplicate User")
                     UserDao.getUserAndActiveRolesById(userId).transact(xa) map {
                       case UserOptionAndRoles(Some(user), roles) =>
                         Some((user, roles))


### PR DESCRIPTION
## Overview

This PR fixes an error that happens when simultaneous requests come from a new user. Before this commit an error would be thrown because the same user would try to be created multiple times and this would violate uniqueness constraints.

After this PR the various stages of checking for an existing user and creating a new one are separated out into their own transactions. This allows us to catch when a uniqueness constraint has been violated and re-request the user given an ID from the database.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated

### Notes

I _wanted_ to use `exceptSqlState` from `doobie`, but I couldn't because a lot of logic was in a _single_ transaction. After an error in a transaction, postgres ignores subsequent SQL statements. I tried relaxing the commits within a transaction, but this lead to different race conditions since sometimes on the re-request from the DB the user was created, but metadata hadn't been filled in (like platform). Instead, I had to split the transactions out logically using `.transact`. This wasn't too bad.

## Testing Instructions

- Assemble and start API server
- Start GroundWork locally
- Go through signup workflow and create a new user with a non-Azavea domain address with your network tab open
- There shouldn't be any errors on project loading, there should be a log message in your API server logs for `Handling Duplicate User`

Closes https://github.com/raster-foundry/annotate/issues/766
