### PR TITLE
Remove gif from new user sharing email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Made email to new users who've been shared with prettier, less Star Wars-y [#5388](https://github.com/raster-foundry/raster-foundry/pull/5388)
+
 ### Security
 
 ## [1.40.0](https://github.com/raster-foundry/raster-foundry/compare/1.39.0...1.40.0)

--- a/app-backend/api/src/main/scala/annotation-project/Notifications.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Notifications.scala
@@ -12,18 +12,65 @@ object Notifications {
   ): (HtmlBody, PlainBody) = {
     val richBody = HtmlBody(s"""
 <html>
-  <p>
-    <img src="https://groundwork.azavea.com/assets/img/GroundworkBranding-ProductOfAzavea.png" width="400"/>
-  </p>
-  <p>
-    ${sharingUserEmail} needs your help! They've invited you to be a collaborator on their project ${annotationProject.name}.
-  </p>
-  <p>
-    <a href="${passwordResetTicket.ticket}">Accept their invitation</a>
-  </p>
-  <p>
-    GroundWork is an image annotation tool designed for working with geospatial data like satellite, drone, and aerial imagery.
-  </p>
+  <head>
+    <style type="text/css">
+      @import url(https://use.typekit.net/yrj5flr.css);.ExternalClass,.ExternalClass div,.ExternalClass font,.ExternalClass p,.ExternalClass span,.ExternalClass td,img{line-height:100%}#outlook a{padding:0}.ExternalClass,.ReadMsgBody{width:100%}a,blockquote,body,li,p,table,td{-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{mso-table-lspace:0;mso-table-rspace:0}img{-ms-interpolation-mode:bicubic;border:0;height:auto;outline:0;text-decoration:none}table{border-collapse:collapse!important}#bodyCell,#bodyTable,body{height:100%!important;margin:0;padding:0;font-family:proxima-nova,sans-serif}#bodyCell{padding:20px}#bodyTable{width:600px}@media only screen and (max-width:480px){#bodyTable,body{width:100%!important}a,blockquote,body,li,p,table,td{-webkit-text-size-adjust:none!important}body{min-width:100%!important}#bodyTable{max-width:600px!important}#signIn{max-width:280px!important}}
+    </style>
+  </head>
+  <body>
+    <center>
+      <table
+        style='width: 600px;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 0;font-family: proxima-nova, sans-serif;border-collapse: collapse !important;height: 100% !important;'
+        align="center"
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        height="100%"
+        width="100%"
+        id="bodyTable"
+      >
+        <tr>
+          <td
+            align="center"
+            valign="top"
+            id="bodyCell"
+            style='-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: proxima-nova, sans-serif;;height: 100% !important;'
+          >
+            <div class="main">
+              <p
+                style="text-align: center;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; margin-bottom: 30px;"
+              >
+                <img
+                  src="https://groundwork.azavea.com/assets/img/groundwork_logo_email_2x.png"
+                  width="200"
+                  alt="GroundWork"
+                  style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;"
+                />
+              </p>
+
+              <h1>Collaboration request</h1>
+
+              <p>
+                <strong>${sharingUserEmail}</strong> needs your help! They've invited you to be a collaborator on their project <strong>${annotationProject.name}</strong>
+              </p>
+
+              <p>
+                <a href="${passwordResetTicket.ticket}">Accept their invitation</a>
+              </p>
+
+              <p>GroundWork is an image annotation tool designed for working with geospatial data like satellite, drone, and aerial imagery.</p>
+
+              <br /><br />
+              <hr style="border: 2px solid #EAEEF3; border-bottom: 0; margin: 20px 0;" />
+              <p style="text-align: center;color: #A9B3BC;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;">
+                If you do not know ${sharingUserEmail}, please ignore this request.
+              </p>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
 </html>
 """)
     val plainBody = PlainBody(s"""

--- a/app-backend/api/src/main/scala/annotation-project/Notifications.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Notifications.scala
@@ -16,9 +16,6 @@ object Notifications {
     <img src="https://groundwork.azavea.com/assets/img/GroundworkBranding-ProductOfAzavea.png" width="400"/>
   </p>
   <p>
-    <img src="https://user-images.githubusercontent.com/12401491/73973100-f00d2b80-48ef-11ea-9e37-06e7a41bafc6.gif" width="400"/>
-  </p>
-  <p>
     ${sharingUserEmail} needs your help! They've invited you to be a collaborator on their project ${annotationProject.name}.
   </p>
   <p>


### PR DESCRIPTION
## Overview

This PR:

- removes the gif from the new user sharing email
- makes the email pretty (thanks @designmatty )

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

~It will accumulate small changes that don't require verification so we don't have to open a bunch of different PRs to get those sorts of changes in.~ there were no more small changes that fit this pattern

## Testing Instructions

- assemble api server
- bring up local rf
- start local annotate pointed to local api server
- share with a user who doesn't exist whose email you can see
- observe how pretty and Obi Wan-less the email is

Closes raster-foundry/annotate#839
