### PR TITLE
Make task status reversion dumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Simplified task status reversion logic in automatic task lock expiration [#5389](https://github.com/raster-foundry/raster-foundry/pull/5389)
+
 ### Security
 
 ## [1.41.0](https://github.com/raster-foundry/raster-foundry/compare/1.40.0...1.41.0)


### PR DESCRIPTION
## Overview

This PR makes task status expiration no longer care about the most recent action, and instead just always go down the [chain of being](https://en.wikipedia.org/wiki/Great_chain_of_being), with `Validated` at the top and `Unlabeled` at the bottom.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I'm having trouble thinking of a way to test this behavior in an automated fashion, since our test transactor rolls back and I don't have ideas other than `.transact(xa)` for getting a parallel instance.

## Testing Instructions

- expiration test still passes
- you confirm visually that you can't come up with a way that the resulting function call here can result in cycling task statuses from multiple copies of backsplash doing expiration at the same time

Closes raster-foundry/annotate#851
