### PR TITLE
Expire stale locks on labeled and validated tasks as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- `LABELED` and `VALIDATED` task locks also automatically expire [#5390](https://github.com/raster-foundry/raster-foundry/pull/5390)
+
 ### Security
 
 ## [1.40.2](https://github.com/raster-foundry/raster-foundry/compare/1.40.1...1.40.2)

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -606,6 +606,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
     taskStatus match {
       case TaskStatus.LabelingInProgress   => Some(TaskStatus.Unlabeled)
       case TaskStatus.ValidationInProgress => Some(TaskStatus.Labeled)
+      case TaskStatus.Labeled              => Some(TaskStatus.Labeled)
+      case TaskStatus.Validated            => Some(TaskStatus.Validated)
       case _                               => None
     }
 
@@ -618,7 +620,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           taskStatusF(
             List(
               TaskStatus.ValidationInProgress.repr,
-              TaskStatus.LabelingInProgress.repr
+              TaskStatus.LabelingInProgress.repr,
+              TaskStatus.Labeled.repr,
+              TaskStatus.Validated.repr
             )
           )
         )


### PR DESCRIPTION
## Overview

This PR includes `LABELED` and `VALIDATED` tasks in the scope of what locks get automatically expired.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

We didn't previously know this was a possible place they could get stuck :thinking: 

## Testing Instructions

- CI
- inspect status regression logic
