### PR TITLE
Add development support for PostgreSQL 12.x/PostGIS 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Add development support for PostgreSQL 12.x/PostGIS 3.x [#5395](https://github.com/raster-foundry/raster-foundry/pull/5395)
 
 ### Deprecated
 

--- a/app-backend/db/Dockerfile.migrations
+++ b/app-backend/db/Dockerfile.migrations
@@ -1,3 +1,3 @@
-FROM boxfuse/flyway:5.2.4
+FROM flyway/flyway:6.0.8
 
 COPY ./src/main/resources/migrations /opt/migrations

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -38,7 +38,7 @@ object Version {
   val dropbox = "3.0.9"
   val elasticacheClient = "1.1.1"
   val ficus = "1.4.0"
-  val flyway = "5.2.4"
+  val flyway = "6.0.8"
   val fs2 = "1.0.5"
   val fs2Cron = "0.1.0"
   val geotrellis = "3.0.0-M3"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   postgres-dev:
-    image: quay.io/azavea/postgis:2.3-postgres9.6-slim
+    image: quay.io/azavea/postgis:3-postgres12.2-slim
     volumes:
       - ./data/:/tmp/data/
     env_file: .env

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   postgres:
-    image: quay.io/azavea/postgis:2.3-postgres9.6-slim
+    image: quay.io/azavea/postgis:3-postgres12.2-slim
     volumes:
       - ./data/:/tmp/data/
     env_file: .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
     entrypoint: ./sbt
 
   app-backend-migrations:
-    image: boxfuse/flyway:5.2.4
+    image: flyway/flyway:6.0.8
     environment:
       - FLYWAY_DRIVER=org.postgresql.Driver
       - FLYWAY_URL=jdbc:postgresql://database.service.rasterfoundry.internal/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "2.3"
 services:
   postgres:
-    image: quay.io/azavea/postgis:2.3-postgres9.6-slim
+    image: quay.io/azavea/postgis:3-postgres12.2-slim
     volumes:
       - ./data/:/tmp/data/
     env_file: .env


### PR DESCRIPTION
## Overview

Bump the container images used to provide a PostGIS enabled PostgreSQL service in development. Ensure that they provide PostgreSQL 12.x and PostGIS 3.x.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] Swagger specification updated~
~- [ ] New tables and queries have appropriate indices added~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
~- [ ] Any new SQL strings have tests~
~- [ ] Any new endpoints have scope validation and are included in the integration test csv~

### Notes

- The changes in this PR depend on the changes in https://github.com/azavea/raster-foundry-deployment/pull/250.
- I updated the version of Flyway because the previous version was emitting a warning regarding lack of PostgreSQL 12 support. I did not update to the most up-to-date version of Flyway (6.4).

## Testing Instructions

- Bring up the local development environment

- Confirm the versions of PostgreSQL and PostGIS

```console
$ ./scripts/psql                                                                      2 ↵
raster-foundry_postgres_1 is up-to-date
psql (12.2 (Debian 12.2-2.pgdg100+1))
Type "help" for help.

rasterfoundry=# select version();
                                                     version
------------------------------------------------------------------------------------------------------------------
 PostgreSQL 12.2 (Debian 12.2-2.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
(1 row)

rasterfoundry=# select postgis_version();
            postgis_version
---------------------------------------
 3.0 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
(1 row)
```

- Load the most recent development database dump; ensure it completes successfully

```console
$ ./scripts/load_development_data
raster-foundry_memcached_1 is up-to-date
raster-foundry_postgres_1 is up-to-date
Creating raster-foundry_api-server-test_1 ... done
Going to remove raster-foundry_api-server-test_1
Removing raster-foundry_api-server-test_1 ... done
Drop rasterfoundry database
Create rasterfoundry database
Restore database from backup
[RF-API] Running migrations with docker-compose
Starting raster-foundry_postgres_1 ... done
Flyway Community Edition 6.0.8 by Redgate
Database: jdbc:postgresql://database.service.rasterfoundry.internal/ (PostgreSQL 12.2)
Successfully validated 50 migrations (execution time 00:00.234s)
Current version of schema "public": 41
Schema "public" is up to date. No migration necessary.
```

- Execute [migrations](https://console.aws.amazon.com/ecs/home?region=us-east-1#/taskDefinitions/StagingAppMigrations/1889/runTask) against the staging database; confirm that the complete successfully in [Papertrail](https://my.papertrailapp.com/groups/4082193/events?q=program%3Astaging%2Fapp-migrations)

Closes https://github.com/azavea/raster-foundry-platform/issues/866
