### PR TITLE
Support campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Added
 
+- Support campaigns [#5397](https://github.com/raster-foundry/raster-foundry/pull/5397)
+
 ### Changed
+
 - Add development support for PostgreSQL 12.x/PostGIS 3.x [#5395](https://github.com/raster-foundry/raster-foundry/pull/5395)
 
 - Changed email invitation copy [#5396](https://github.com/raster-foundry/raster-foundry/pull/5396)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -203,3 +203,14 @@ Path,Domain:Action,Verb
 /api/users/me/roles,users:readSelf,get
 /api/users/search/,users:search,get
 /api/tasks/random,annotationProjects:readTasks,get
+/api/campaigns/,campaigns:read,get
+/api/campaigns/,campaigns:create,post
+/api/campaigns/{campaignId},campaigns:read,get
+/api/campaigns/{campaignId},campaigns:update,put
+/api/campaigns/{campaignId},campaigns:delete,delete
+/api/campaigns/{campaignId}/actions,campaigns:readPermissions,get
+/api/campaigns/{campaignId}/projects,annotationProjects:read,get
+/api/campaigns/{campaignId}/permissions,campaigns:readPermissions,get
+/api/campaigns/{campaignId}/permissions,campaigns:share,put
+/api/campaigns/{campaignId}/permissions,campaigns:share,post
+/api/campaigns/{campaignId}/permissions,campaigns:share,delete

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -128,10 +128,10 @@ trait Router
           } ~
           pathPrefix("tasks") {
             taskRoutes
-          } ~ 
+          } ~
           pathPrefix("campaigns") {
             campaignRoutes
-          } 
+          }
       } ~
       pathPrefix("config") {
         configRoutes

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -1,6 +1,7 @@
 package com.rasterfoundry.api
 
 import com.rasterfoundry.api.annotationProject.AnnotationProjectRoutes
+import com.rasterfoundry.api.campaign.CampaignRoutes
 import com.rasterfoundry.api.config.ConfigRoutes
 import com.rasterfoundry.api.datasource.DatasourceRoutes
 import com.rasterfoundry.api.exports.ExportRoutes
@@ -59,7 +60,8 @@ trait Router
     with PlatformRoutes
     with StacRoutes
     with AnnotationProjectRoutes
-    with TaskRoutes {
+    with TaskRoutes
+    with CampaignRoutes {
 
   val settings = CorsSettings.defaultSettings.copy(
     allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE)
@@ -126,7 +128,10 @@ trait Router
           } ~
           pathPrefix("tasks") {
             taskRoutes
-          }
+          } ~ 
+          pathPrefix("campaigns") {
+            campaignRoutes
+          } 
       } ~
       pathPrefix("config") {
         configRoutes

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -1,0 +1,155 @@
+package com.rasterfoundry.api.campaign
+
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+
+import akka.http.scaladsl.server._
+import cats.effect.IO
+import cats.implicits._
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+
+import java.util.UUID
+
+trait CampaignPermissionRoutes
+    extends CommonHandlers
+    with Directives
+    with Authentication {
+
+  val xa: Transactor[IO]
+
+  def listCampaignPermissions(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.Edit
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        complete {
+          CampaignDao
+            .getPermissions(campaignId)
+            .transact(xa)
+            .unsafeToFuture
+        }
+      }
+    }
+  }
+
+  def replaceCampaignPermissions(campaignId: UUID): Route = authenticate {
+    user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Share, None),
+        user
+      ) {
+        entity(as[List[ObjectAccessControlRule]]) { acrList =>
+          authorizeAsync {
+            (for {
+              auth1 <- CampaignDao.authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
+              auth2 <- acrList traverse { acr =>
+                CampaignDao.isValidPermission(acr, user)
+              }
+            } yield {
+              auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
+                case true =>
+                  CampaignDao.isReplaceWithinScopedLimit(
+                    Domain.Campaigns,
+                    user,
+                    acrList
+                  )
+                case _ => false
+              })
+            }).transact(xa).unsafeToFuture()
+          } {
+            complete {
+              CampaignDao
+                .replacePermissions(campaignId, acrList)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+      }
+  }
+
+  def addCampaignPermission(campaignId: UUID): Route = authenticate { user =>
+    val shareCount =
+      CampaignDao
+        .getShareCount(campaignId, user.id)
+        .transact(xa)
+        .unsafeToFuture
+    authorizeScopeLimit(
+      shareCount,
+      Domain.Campaigns,
+      Action.Share,
+      user
+    ) {
+      entity(as[ObjectAccessControlRule]) { acr =>
+        authorizeAsync {
+          (for {
+            auth1 <- CampaignDao.authorized(
+              user,
+              ObjectType.Campaign,
+              campaignId,
+              ActionType.Edit
+            )
+            auth2 <- CampaignDao.isValidPermission(acr, user)
+          } yield {
+            auth1.toBoolean && auth2
+          }).transact(xa).unsafeToFuture()
+        } {
+          complete {
+            CampaignDao
+              .addPermission(campaignId, acr)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
+  }
+
+  def deleteCampaignPermissions(campaignId: UUID): Route = authenticate {
+    user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Share, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          CampaignDao
+            .authorized(
+              user,
+              ObjectType.Campaign,
+              campaignId,
+              ActionType.Edit
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            CampaignDao
+              .deletePermissions(campaignId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+  }
+
+}

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -1,0 +1,45 @@
+package com.rasterfoundry.api.campaign
+
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+
+import akka.http.scaladsl.server._
+import cats.effect.IO
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+
+import java.util.UUID
+
+trait CampaignProjectRoutes
+    extends CommonHandlers
+    with Directives
+    with Authentication
+    with PaginationDirectives
+    with QueryParametersCommon {
+  val xa: Transactor[IO]
+
+  def listCampaignProjects(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+      user
+    ) {
+      (withPagination & annotationProjectQueryParameters) {
+        (page, annotationProjectQP) =>
+          complete {
+            AnnotationProjectDao
+              .listProjects(
+                page,
+                annotationProjectQP.copy(campaignId = Some(campaignId)),
+                user
+              )
+              .transact(xa)
+              .unsafeToFuture
+          }
+      }
+    }
+  }
+}

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -231,14 +231,14 @@ trait CampaignRoutes
                 .unsafeToFuture
             ) { campaignO =>
               complete {
-                (campaignO map { campaign =>
+                (campaignO traverse { campaign =>
                   campaign.owner == user.id match {
                     case true => List("*").pure[ConnectionIO]
                     case false =>
                       CampaignDao
                         .listUserActions(user, campaignId)
                   }
-                } getOrElse { List[String]().pure[ConnectionIO] })
+                } map { _.getOrElse(List[String]()) })
                   .transact(xa)
                   .unsafeToFuture()
               }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -1,0 +1,250 @@
+package com.rasterfoundry.api.campaign
+
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server._
+import cats.effect.IO
+import cats.implicits._
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie._
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+
+import java.util.UUID
+
+trait CampaignRoutes
+    extends CommonHandlers
+    with Directives
+    with Authentication
+    with PaginationDirectives
+    with QueryParametersCommon
+    with CampaignProjectRoutes
+    with CampaignPermissionRoutes {
+
+  val xa: Transactor[IO]
+
+  val campaignRoutes: Route = {
+    pathEndOrSingleSlash {
+      get {
+        listCampaigns
+      } ~
+        post {
+          createCampaign
+        }
+    } ~
+      pathPrefix(JavaUUID) { campaignId =>
+        pathEndOrSingleSlash {
+          get {
+            getCampaign(campaignId)
+          } ~
+            put {
+              updateCampaign(campaignId)
+            } ~
+            delete {
+              deleteCampaign(campaignId)
+            }
+        } ~
+          pathPrefix("permissions") {
+            pathEndOrSingleSlash {
+              get {
+                listCampaignPermissions(campaignId)
+              } ~
+                put {
+                  replaceCampaignPermissions(campaignId)
+                } ~
+                post {
+                  addCampaignPermission(campaignId)
+                } ~
+                delete {
+                  deleteCampaignPermissions(campaignId)
+                }
+            }
+          } ~
+          pathPrefix("projects") {
+            pathEndOrSingleSlash {
+              get {
+                listCampaignProjects(campaignId)
+              }
+            }
+          } ~ pathPrefix("actions") {
+          pathEndOrSingleSlash {
+            get {
+              listCampaignUserActions(campaignId)
+            }
+          }
+        }
+      }
+  }
+
+  def listCampaigns: Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Read, None),
+      user
+    ) {
+      (withPagination & campaignQueryParameters) { (page, campaignQP) =>
+        complete {
+          CampaignDao
+            .listCampaigns(page, campaignQP, user)
+            .transact(xa)
+            .unsafeToFuture
+        }
+      }
+    }
+  }
+
+  def createCampaign: Route = authenticate { user =>
+    authorizeScopeLimit(
+      CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
+      Domain.Campaigns,
+      Action.Create,
+      user
+    ) {
+      entity(as[Campaign.Create]) { newCampaign =>
+        onSuccess(
+          CampaignDao
+            .insertCampaign(newCampaign, user)
+            .transact(xa)
+            .unsafeToFuture
+        ) { campaign =>
+          complete((StatusCodes.Created, campaign))
+        }
+      }
+    }
+  }
+
+  def getCampaign(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Read, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.View
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        rejectEmptyResponse {
+          complete {
+            CampaignDao
+              .getCampaignById(campaignId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
+  }
+
+  def updateCampaign(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Update, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.Edit
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        entity(as[Campaign]) { updatedCampaign =>
+          onSuccess(
+            CampaignDao
+              .updateCampaign(
+                updatedCampaign,
+                campaignId
+              )
+              .transact(xa)
+              .unsafeToFuture
+          ) {
+            completeSingleOrNotFound
+          }
+        }
+      }
+    }
+  }
+
+  def deleteCampaign(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Delete, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.Delete
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        onSuccess(
+          CampaignDao
+            .deleteCampaign(campaignId, user)
+            .transact(xa)
+            .unsafeToFuture
+        ) {
+          completeSingleOrNotFound
+        }
+      }
+    }
+  }
+
+  def listCampaignUserActions(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.View
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        user.isSuperuser match {
+          case true => complete(List("*"))
+          case false =>
+            onSuccess(
+              CampaignDao
+                .getCampaignById(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            ) { campaignO =>
+              complete {
+                (campaignO map { campaign =>
+                  campaign.owner == user.id match {
+                    case true => List("*").pure[ConnectionIO]
+                    case false =>
+                      CampaignDao
+                        .listUserActions(user, campaignId)
+                  }
+                } getOrElse { List[String]().pure[ConnectionIO] })
+                  .transact(xa)
+                  .unsafeToFuture()
+              }
+            }
+        }
+      }
+    }
+  }
+}

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -214,7 +214,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         groupQueryParameters &
         annotationProjectFilterParameters &
         parameters(
-          'campaignId.as[UUID].?
+          'campaignId.as[UUID].?,
+          'capturedAt.as(deserializerTimestamp).?
         )
     ).as(AnnotationProjectQueryParameters.apply _)
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -212,6 +212,20 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         searchParams &
         ownershipTypeQueryParameters &
         groupQueryParameters &
-        annotationProjectFilterParameters
+        annotationProjectFilterParameters &
+        parameters(
+          'campaignId.as[UUID].?
+        )
     ).as(AnnotationProjectQueryParameters.apply _)
+
+  def campaignQueryParameters =
+    (
+      ownerQueryParameters &
+        searchParams &
+        ownershipTypeQueryParameters &
+        groupQueryParameters &
+        parameters(
+          'campaignType.as(deserializerAnnotationProjectType).?
+        )
+    ).as(CampaignQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -139,15 +139,16 @@ object Generators extends ArbitraryInstances {
     IngestStatus.Failed
   )
 
-  private def annotationProjectStatusGen: Gen[AnnotationProjectStatus] = Gen.oneOf(
-    AnnotationProjectStatus.Waiting,
-    AnnotationProjectStatus.Queued,
-    AnnotationProjectStatus.Processing,
-    AnnotationProjectStatus.Ready,
-    AnnotationProjectStatus.UnknownFailure,
-    AnnotationProjectStatus.TaskGridFailure,
-    AnnotationProjectStatus.ImageIngestionFailure
-  )
+  private def annotationProjectStatusGen: Gen[AnnotationProjectStatus] =
+    Gen.oneOf(
+      AnnotationProjectStatus.Waiting,
+      AnnotationProjectStatus.Queued,
+      AnnotationProjectStatus.Processing,
+      AnnotationProjectStatus.Ready,
+      AnnotationProjectStatus.UnknownFailure,
+      AnnotationProjectStatus.TaskGridFailure,
+      AnnotationProjectStatus.ImageIngestionFailure
+    )
 
   private def tileLayerTypeGen: Gen[TileLayerType] = Gen.oneOf(
     TileLayerType.MVT,
@@ -726,7 +727,7 @@ object Generators extends ArbitraryInstances {
     }
 
   private def userOrgPlatformGen
-    : Gen[(User.Create, Organization.Create, Platform)] =
+      : Gen[(User.Create, Organization.Create, Platform)] =
     for {
       platform <- platformGen
       orgCreate <- organizationCreateGen map {
@@ -978,7 +979,7 @@ object Generators extends ArbitraryInstances {
     } yield { Task.TaskFeatureCreate(properties, geometry) }
 
   private def taskFeatureCollectionCreateGen
-    : Gen[Task.TaskFeatureCollectionCreate] =
+      : Gen[Task.TaskFeatureCollectionCreate] =
     for {
       features <- Gen.nonEmptyListOf(taskFeatureCreateGen)
     } yield {
@@ -1003,12 +1004,11 @@ object Generators extends ArbitraryInstances {
   private def taskStatusListGen: Gen[List[TaskStatus]] =
     Gen.oneOf(0, 5) flatMap { Gen.listOfN(_, taskStatusGen) }
 
-
   private def stacExportCreateGen: Gen[StacExport.Create] =
     for {
       name <- nonEmptyStringGen
       owner <- Gen.const(None)
-      annotationProjectId <-  uuidGen
+      annotationProjectId <- uuidGen
       taskStatuses <- taskStatusListGen
     } yield {
       StacExport.Create(
@@ -1059,17 +1059,26 @@ object Generators extends ArbitraryInstances {
       Gen.const(None),
       tileLayerCreateGen map { List(_) },
       Gen.listOfN(3, labelClassGroupGen),
-      annotationProjectStatusGen
+      annotationProjectStatusGen,
+      Gen.const(None),
+      Gen.const(None)
     ).mapN(AnnotationProject.Create.apply _)
 
   private def annotationLabelWithClassesCreateGen
-    : Gen[AnnotationLabelWithClasses.Create] =
+      : Gen[AnnotationLabelWithClasses.Create] =
     (
       projectedMultiPolygonGen3857 map { (geom: Projected[MultiPolygon]) =>
         Option(geom)
       },
       Gen.const(Nil)
     ).mapN(AnnotationLabelWithClasses.Create.apply _)
+  
+  private def campaignCreateGen
+      : Gen[Campaign.Create] =
+    (
+      nonEmptyStringGen,
+      annotationProjectTypeGen,
+    ).mapN(Campaign.Create.apply _)
 
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
@@ -1081,12 +1090,12 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbCombinedSceneQueryParams
-      : Arbitrary[CombinedSceneQueryParams] = Arbitrary {
+        : Arbitrary[CombinedSceneQueryParams] = Arbitrary {
       combinedSceneQueryParamsGen
     }
 
     implicit def arbProjectsceneQueryParameters
-      : Arbitrary[ProjectSceneQueryParameters] =
+        : Arbitrary[ProjectSceneQueryParameters] =
       Arbitrary { projectSceneQueryParametersGen }
 
     implicit def arbAnnotationCreate: Arbitrary[Annotation.Create] = Arbitrary {
@@ -1198,7 +1207,7 @@ object Generators extends ArbitraryInstances {
     implicit def arbPlatform: Arbitrary[Platform] = Arbitrary { platformGen }
 
     implicit def arbUserOrgPlatform
-      : Arbitrary[(User.Create, Organization.Create, Platform)] = Arbitrary {
+        : Arbitrary[(User.Create, Organization.Create, Platform)] = Arbitrary {
       userOrgPlatformGen
     }
 
@@ -1214,11 +1223,11 @@ object Generators extends ArbitraryInstances {
       Arbitrary { searchQueryParametersGen }
 
     implicit def arbObjectAccessControlRule
-      : Arbitrary[ObjectAccessControlRule] =
+        : Arbitrary[ObjectAccessControlRule] =
       Arbitrary { objectAccessControlRuleGen }
 
     implicit def arbListObjectAccessControlRule
-      : Arbitrary[List[ObjectAccessControlRule]] =
+        : Arbitrary[List[ObjectAccessControlRule]] =
       Arbitrary {
         Gen.nonEmptyListOf[ObjectAccessControlRule](
           arbitrary[ObjectAccessControlRule]
@@ -1246,7 +1255,7 @@ object Generators extends ArbitraryInstances {
       Arbitrary { projectLayerCreateGen }
 
     implicit def arbProjectLayerCreateWithScenes
-      : Arbitrary[List[(ProjectLayer.Create, List[Scene.Create])]] = {
+        : Arbitrary[List[(ProjectLayer.Create, List[Scene.Create])]] = {
       val tupGen = for {
         projectLayerCreate <- arbitrary[ProjectLayer.Create]
         sceneCreates <- arbitrary[List[Scene.Create]]
@@ -1255,7 +1264,7 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbAnnotationQueryParameters
-      : Arbitrary[AnnotationQueryParameters] = Arbitrary {
+        : Arbitrary[AnnotationQueryParameters] = Arbitrary {
       annotationQueryParametersGen
     }
 
@@ -1280,13 +1289,13 @@ object Generators extends ArbitraryInstances {
       }
 
     implicit def arbTaskFeatureCollectionCreate
-      : Arbitrary[Task.TaskFeatureCollectionCreate] =
+        : Arbitrary[Task.TaskFeatureCollectionCreate] =
       Arbitrary {
         taskFeatureCollectionCreateGen
       }
 
     implicit def arbTaskGridFeatureCreate
-      : Arbitrary[Task.TaskGridFeatureCreate] =
+        : Arbitrary[Task.TaskGridFeatureCreate] =
       Arbitrary {
         taskGridFeatureCreateGen
       }
@@ -1302,19 +1311,19 @@ object Generators extends ArbitraryInstances {
       }
 
     implicit def arbStacExportQueryParameters
-      : Arbitrary[StacExportQueryParameters] =
+        : Arbitrary[StacExportQueryParameters] =
       Arbitrary {
         stacExportQueryParametersGen
       }
 
     implicit def arbAnnotationProjectCreate
-      : Arbitrary[AnnotationProject.Create] =
+        : Arbitrary[AnnotationProject.Create] =
       Arbitrary {
         annotationProjectCreateGen
       }
 
     implicit def arbAnnotationLabelWithClassesCreate
-      : Arbitrary[AnnotationLabelWithClasses.Create] =
+        : Arbitrary[AnnotationLabelWithClasses.Create] =
       Arbitrary {
         annotationLabelWithClassesCreateGen
       }
@@ -1322,6 +1331,11 @@ object Generators extends ArbitraryInstances {
     implicit def arbTileLayerCreate: Arbitrary[TileLayer.Create] =
       Arbitrary {
         tileLayerCreateGen
+      }
+    
+    implicit def arbCampaignCreate: Arbitrary[Campaign.Create] =
+      Arbitrary {
+        campaignCreateGen
       }
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -4,8 +4,8 @@ import geotrellis.vector.{Geometry, Projected}
 import io.circe._
 import io.circe.generic.semiauto._
 
-import java.time.Instant
 import java.sql.Timestamp
+import java.time.Instant
 import java.util.UUID
 
 final case class AnnotationProject(
@@ -184,7 +184,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -183,7 +183,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -5,6 +5,7 @@ import io.circe._
 import io.circe.generic.semiauto._
 
 import java.time.Instant
+import java.sql.Timestamp
 import java.util.UUID
 
 final case class AnnotationProject(
@@ -22,7 +23,7 @@ final case class AnnotationProject(
     status: AnnotationProjectStatus,
     taskStatusSummary: Option[Map[String, Int]] = None,
     campaignId: Option[UUID] = None,
-    capturedAt: Option[Instant] = None
+    capturedAt: Option[Timestamp] = None
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -65,7 +66,7 @@ object AnnotationProject {
       labelClassGroups: List[AnnotationLabelClassGroup.Create],
       status: AnnotationProjectStatus,
       campaignId: Option[UUID] = None,
-      capturedAt: Option[Instant] = None
+      capturedAt: Option[Timestamp] = None
   )
 
   object Create {
@@ -89,7 +90,7 @@ object AnnotationProject {
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
       taskStatusSummary: Option[Map[String, Int]] = None,
       campaignId: Option[UUID] = None,
-      capturedAt: Option[Instant] = None
+      capturedAt: Option[Timestamp] = None
   ) {
     def toProject = AnnotationProject(
       id,
@@ -178,12 +179,12 @@ object AnnotationProject {
       taskStatusSummary: Option[Map[String, Int]] = None,
       labelClassSummary: List[LabelClassGroupSummary],
       campaignId: Option[UUID] = None,
-      capturedAt: Option[Instant] = None
+      capturedAt: Option[Timestamp] = None
   )
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-      : Encoder[WithRelatedAndLabelClassSummary] =
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -20,7 +20,9 @@ final case class AnnotationProject(
     validatorsTeamId: Option[UUID],
     projectId: Option[UUID],
     status: AnnotationProjectStatus,
-    taskStatusSummary: Option[Map[String, Int]] = None
+    taskStatusSummary: Option[Map[String, Int]] = None,
+    campaignId: Option[UUID] = None,
+    capturedAt: Option[Instant] = None
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -41,7 +43,9 @@ final case class AnnotationProject(
       status,
       tileLayers,
       labelClassGroups,
-      taskStatusSummary
+      taskStatusSummary,
+      campaignId,
+      capturedAt
     )
 }
 
@@ -59,7 +63,9 @@ object AnnotationProject {
       projectId: Option[UUID],
       tileLayers: List[TileLayer.Create],
       labelClassGroups: List[AnnotationLabelClassGroup.Create],
-      status: AnnotationProjectStatus
+      status: AnnotationProjectStatus,
+      campaignId: Option[UUID] = None,
+      capturedAt: Option[Instant] = None
   )
 
   object Create {
@@ -81,7 +87,9 @@ object AnnotationProject {
       status: AnnotationProjectStatus,
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
-      taskStatusSummary: Option[Map[String, Int]] = None
+      taskStatusSummary: Option[Map[String, Int]] = None,
+      campaignId: Option[UUID] = None,
+      capturedAt: Option[Instant] = None
   ) {
     def toProject = AnnotationProject(
       id,
@@ -96,7 +104,9 @@ object AnnotationProject {
       validatorsTeamId,
       projectId,
       status,
-      taskStatusSummary
+      taskStatusSummary,
+      campaignId,
+      capturedAt
     )
 
     def withSummary(
@@ -117,7 +127,9 @@ object AnnotationProject {
       tileLayers,
       labelClassGroups,
       taskStatusSummary,
-      labelClassSummary
+      labelClassSummary,
+      campaignId,
+      capturedAt
     )
   }
 
@@ -164,12 +176,14 @@ object AnnotationProject {
       tileLayers: List[TileLayer],
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
       taskStatusSummary: Option[Map[String, Int]] = None,
-      labelClassSummary: List[LabelClassGroupSummary]
+      labelClassSummary: List[LabelClassGroupSummary],
+      campaignId: Option[UUID] = None,
+      capturedAt: Option[Instant] = None
   )
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-      : Encoder[WithRelatedAndLabelClassSummary] =
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -3,12 +3,12 @@ package com.rasterfoundry.datamodel
 import io.circe._
 import io.circe.generic.semiauto._
 
-import java.time.Instant
+import java.sql.Timestamp
 import java.util.UUID
 
 final case class Campaign(
     id: UUID,
-    createdAt: Instant,
+    createdAt: Timestamp,
     owner: String,
     name: String,
     campaignType: AnnotationProjectType

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -1,0 +1,29 @@
+package com.rasterfoundry.datamodel
+
+import io.circe._
+import io.circe.generic.semiauto._
+
+import java.time.Instant
+import java.util.UUID
+
+final case class Campaign(
+    id: UUID,
+    createdAt: Instant,
+    owner: String,
+    name: String,
+    campaignType: AnnotationProjectType
+)
+
+object Campaign {
+  implicit val encCampaign: Encoder[Campaign] = deriveEncoder
+  implicit val decCampaignt: Decoder[Campaign] = deriveDecoder
+
+  final case class Create(
+      name: String,
+      campaignType: AnnotationProjectType
+  )
+
+  object Create {
+    implicit val decCreate: Decoder[Create] = deriveDecoder
+  }
+}

--- a/app-backend/datamodel/src/main/scala/ObjectType.scala
+++ b/app-backend/datamodel/src/main/scala/ObjectType.scala
@@ -27,6 +27,7 @@ object ObjectType {
   case object ToolTag extends ObjectType("TOOLTAG")
   case object ToolCategory extends ObjectType("TOOLCATEGORY")
   case object AnnotationProject extends ObjectType("ANNOTATIONPROJECT")
+  case object Campaign extends ObjectType("CAMPAIGN")
 
   def fromString(s: String): ObjectType = s.toUpperCase match {
     case "PROJECT"           => Project
@@ -48,6 +49,7 @@ object ObjectType {
     case "TOOLTAG"           => ToolTag
     case "TOOLCATEGORY"      => ToolCategory
     case "ANNOTATIONPROJECT" => AnnotationProject
+    case "CAMPAIGN"          => Campaign
     case _                   => throw new Exception(s"Invalid ObjectType: ${s}")
   }
 

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -697,14 +697,33 @@ final case class AnnotationProjectQueryParameters(
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
     projectFilterParams: AnnotationProjectFilterQueryParameters =
-      AnnotationProjectFilterQueryParameters()
+      AnnotationProjectFilterQueryParameters(),
+    campaignId: Option[UUID] = None
 )
 
 object AnnotationProjectQueryParameters {
-  implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+  implicit def encAnnotationProjectQueryParameters
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
-  implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+  implicit def decAnnotationProjectQueryParameters
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
+}
+
+final case class CampaignQueryParameters(
+    ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
+    searchParams: SearchQueryParameters = SearchQueryParameters(),
+    ownershipTypeParams: OwnershipTypeQueryParameters =
+      OwnershipTypeQueryParameters(),
+    groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
+    campaignType: Option[AnnotationProjectType] = None
+)
+
+object CampaignQueryParameters {
+  implicit def encCampaignQueryParameters
+      : Encoder[CampaignQueryParameters] =
+    deriveEncoder[CampaignQueryParameters]
+  implicit def decCampaignQueryParameters
+      : Decoder[CampaignQueryParameters] =
+    deriveDecoder[CampaignQueryParameters]
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -703,10 +703,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 
@@ -720,10 +720,8 @@ final case class CampaignQueryParameters(
 )
 
 object CampaignQueryParameters {
-  implicit def encCampaignQueryParameters
-      : Encoder[CampaignQueryParameters] =
+  implicit def encCampaignQueryParameters: Encoder[CampaignQueryParameters] =
     deriveEncoder[CampaignQueryParameters]
-  implicit def decCampaignQueryParameters
-      : Decoder[CampaignQueryParameters] =
+  implicit def decCampaignQueryParameters: Decoder[CampaignQueryParameters] =
     deriveDecoder[CampaignQueryParameters]
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -704,10 +704,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -698,15 +698,16 @@ final case class AnnotationProjectQueryParameters(
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
     projectFilterParams: AnnotationProjectFilterQueryParameters =
       AnnotationProjectFilterQueryParameters(),
-    campaignId: Option[UUID] = None
+    campaignId: Option[UUID] = None,
+    capturedAt: Option[Timestamp] = None
 )
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -47,6 +47,7 @@ object Domain {
   case object Uploads extends Domain("uploads")
   case object Users extends Domain("users")
   case object AnnotationProjects extends Domain("annotationProjects")
+  case object Campaigns extends Domain("campaigns")
 
   def fromStringTry(s: String): Try[Domain] = s match {
     case "analyses"           => Success(Analyses)
@@ -70,6 +71,7 @@ object Domain {
     case "uploads"            => Success(Uploads)
     case "users"              => Success(Users)
     case "annotationProjects" => Success(AnnotationProjects)
+    case "campaigns"          => Success(Campaigns)
     case _                    => Failure(new Exception(s"Cannot parse Domain from string $s"))
   }
 }
@@ -576,7 +578,13 @@ object Scopes {
             Some(10.toLong)
           ),
           ScopedAction(Domain.AnnotationProjects, Action.Share, Some(5.toLong)),
-          ScopedAction(Domain.Projects, Action.Create, None)
+          ScopedAction(Domain.Projects, Action.Create, None),
+          ScopedAction(
+            Domain.Campaigns,
+            Action.Create,
+            Some(10.toLong)
+          ),
+          ScopedAction(Domain.Campaigns, Action.Share, Some(5.toLong))
         ) ++ Set(
           Action.Read,
           Action.Update,
@@ -592,6 +600,21 @@ object Scopes {
           Action.AddScenes,
           Action.ReadPermissions
         ).map(makeScopedAction(Domain.AnnotationProjects, _, None)) ++
+          Set(
+            Action.Read,
+            Action.Update,
+            Action.Delete,
+            Action.CreateAnnotation,
+            Action.DeleteAnnotation,
+            Action.UpdateAnnotation,
+            Action.CreateTaskGrid,
+            Action.CreateTasks,
+            Action.DeleteTasks,
+            Action.UpdateTasks,
+            Action.ReadTasks,
+            Action.AddScenes,
+            Action.ReadPermissions
+          ).map(makeScopedAction(Domain.Campaigns, _, None)) ++
           StacExportsCRUD.actions ++
           UserSelfScope.actions ++
           FeatureFlagsScope.actions

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -604,15 +604,6 @@ object Scopes {
             Action.Read,
             Action.Update,
             Action.Delete,
-            Action.CreateAnnotation,
-            Action.DeleteAnnotation,
-            Action.UpdateAnnotation,
-            Action.CreateTaskGrid,
-            Action.CreateTasks,
-            Action.DeleteTasks,
-            Action.UpdateTasks,
-            Action.ReadTasks,
-            Action.AddScenes,
             Action.ReadPermissions
           ).map(makeScopedAction(Domain.Campaigns, _, None)) ++
           StacExportsCRUD.actions ++

--- a/app-backend/db/src/main/resources/migrations/V42__Add_campaigns.sql
+++ b/app-backend/db/src/main/resources/migrations/V42__Add_campaigns.sql
@@ -1,0 +1,19 @@
+CREATE TABLE public.campaigns (
+    id uuid primary key,
+    created_at timestamp without time zone NOT NULL,
+    owner character varying(255) NOT NULL references users(id) ON DELETE CASCADE,
+    name text NOT NULL,
+    campaign_type public.annotation_project_type NOT NULL,
+    acrs text[] NOT NULL DEFAULT '{}' :: text[]
+);
+
+ALTER TABLE public.annotation_projects
+ADD COLUMN campaign_id uuid REFERENCES campaigns(id) ON DELETE CASCADE,
+ADD COLUMN captured_at timestamp without time zone;
+
+CREATE INDEX IF NOT EXISTS annotation_project_campaign_idx ON public.annotation_projects USING btree (campaign_id);
+CREATE INDEX IF NOT EXISTS annotation_project_captured_at_idx ON public.annotation_projects USING btree (captured_at);
+CREATE INDEX IF NOT EXISTS campaigns_name_idx ON public.campaigns USING btree (name);
+CREATE INDEX IF NOT EXISTS campaigns_owner_idx ON public.campaigns USING btree (owner);
+CREATE INDEX IF NOT EXISTS campaigns_acrs_idx ON public.campaigns USING gin (acrs);
+CREATE INDEX IF NOT EXISTS campaigns_type_idx ON public.campaigns USING btree (campaign_type);

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -324,27 +324,6 @@ object AnnotationProjectDao
   def countUserProjects(user: User): ConnectionIO[Long] =
     query.filter(user).count
 
-  def getShareCount(id: UUID, userId: String): ConnectionIO[Long] =
-    getPermissions(id)
-      .map { acrList =>
-        acrList
-          .foldLeft(Set.empty[String])(
-            (accum: Set[String], acr: ObjectAccessControlRule) => {
-              acr match {
-                case ObjectAccessControlRule(
-                    SubjectType.User,
-                    Some(subjectId),
-                    _
-                    ) if subjectId != userId =>
-                  Set(subjectId) | accum
-                case _ => accum
-              }
-            }
-          )
-          .size
-          .toLong
-      }
-
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
       projectIds <- (fr"select id from " ++ Fragment.const(tableName) ++ fr" where owner = $userId")
@@ -381,7 +360,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -381,7 +381,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -360,7 +360,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -1,0 +1,114 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.datamodel._
+
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
+
+import java.util.UUID
+
+object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
+
+  val tableName = "campaigns"
+
+  override val fieldNames = List(
+    "id",
+    "created_at",
+    "owner",
+    "name",
+    "campaign_type"
+  )
+
+  def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
+
+  def authQuery(
+      user: User,
+      objectType: ObjectType,
+      ownershipTypeO: Option[String],
+      groupTypeO: Option[GroupType],
+      groupIdO: Option[UUID]
+  ): Dao.QueryBuilder[Campaign] =
+    user.isSuperuser match {
+      case true =>
+        Dao.QueryBuilder[Campaign](selectF, tableF, List.empty)
+      case false =>
+        Dao.QueryBuilder[Campaign](
+          selectF,
+          tableF,
+          List(
+            queryObjectsF(
+              user,
+              objectType,
+              ActionType.View,
+              ownershipTypeO,
+              groupTypeO,
+              groupIdO
+            )
+          )
+        )
+    }
+
+  def authorized(
+      user: User,
+      objectType: ObjectType,
+      objectId: UUID,
+      actionType: ActionType
+  ): ConnectionIO[AuthResult[Campaign]] =
+    this.query
+      .filter(authorizedF(user, objectType, actionType))
+      .filter(objectId)
+      .selectOption
+      .map(AuthResult.fromOption _)
+
+  def listCampaigns(
+      page: PageRequest,
+      params: CampaignQueryParameters,
+      user: User
+  ): ConnectionIO[PaginatedResponse[Campaign]] =
+    authQuery(
+      user,
+      ObjectType.Campaign,
+      params.ownershipTypeParams.ownershipType,
+      params.groupQueryParameters.groupType,
+      params.groupQueryParameters.groupId
+    ).filter(params)
+      .page(page)
+
+  def insertCampaign(
+      campaignCreate: Campaign.Create,
+      user: User
+  ): ConnectionIO[Campaign] =
+    (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+      fr"""VALUES
+      (uuid_generate_v4(), now(), ${user.id}, ${campaignCreate.name},
+       ${campaignCreate.campaignType}
+       )
+    """).update.withUniqueGeneratedKeys[Campaign](
+      fieldNames: _*
+    )
+
+  def getCampaignById(id: UUID): ConnectionIO[Option[Campaign]] =
+    query.filter(id).selectOption
+
+  def unsafeGetCampaignById(id: UUID): ConnectionIO[Campaign] =
+    query.filter(id).select
+
+  def updateCampaign(campaign: Campaign, id: UUID): ConnectionIO[Int] =
+    (fr"UPDATE " ++ tableF ++ fr"""SET
+      name = ${campaign.name}
+    WHERE
+      id = $id
+    """).update.run;
+
+  def deleteCampaign(id: UUID, user: User): ConnectionIO[Int] =
+    for {
+      projects <- AnnotationProjectDao.listByCampaign(id)
+      _ <- projects traverse { p =>
+        AnnotationProjectDao.deleteById(p.id, user)
+      }
+      n <- query.filter(fr"id = ${id}").delete
+    } yield n
+}

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -111,4 +111,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       }
       n <- query.filter(fr"id = ${id}").delete
     } yield n
+
+  def countUserCampaigns(user: User): ConnectionIO[Long] =
+    query.filter(user).count
+
 }

--- a/app-backend/db/src/main/scala/ObjectPermissions.scala
+++ b/app-backend/db/src/main/scala/ObjectPermissions.scala
@@ -248,7 +248,7 @@ trait ObjectPermissions[Model] {
     val inheritedF: Fragment =
       createInheritedF(user, actionType, groupTypeO, groupIdO)
     val acrFilterF
-        : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
+      : Fragment = fr"array_cat(" ++ sharedF ++ fr"," ++ inheritedF ++ fr") &&" ++ Fragment
       .const(s"${tableName}acrs")
 
     ownershipTypeO match {

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -246,18 +246,6 @@ object ProjectDao
     }
   }
 
-  def getShareCount(projectId: UUID, userId: String): ConnectionIO[Long] =
-    ProjectDao
-      .getPermissions(projectId)
-      .map { acrList =>
-        acrList.collect {
-          case ObjectAccessControlRule(subjType, Some(subjectId), _)
-              if subjType == SubjectType.User && subjectId != userId =>
-            subjectId
-        }
-      }
-      .map(_.distinct.length.toLong)
-
   def updateSceneIngestStatus(projectLayerId: UUID): ConnectionIO[Int] = {
     val updateStatusQuery =
       sql"""

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -449,6 +449,9 @@ trait Filterables extends RFMeta with LazyLogging {
             params.projectFilterParams.projectType.map({ projectType =>
               fr"annotation_projects.project_type = $projectType"
             }),
+            params.capturedAt.map({ capturedAt =>
+              fr"annotation_projects.captured_at = $capturedAt"
+            }),
             params.campaignId.map({ campaignId =>
               fr"annotation_projects.campaign_id = $campaignId"
             }),

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -443,14 +443,27 @@ trait Filterables extends RFMeta with LazyLogging {
               .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
         }
         Filters.ownerQP(params.ownerParams, fr"annotation_projects.owner") ++
-          Filters.searchQP(params.searchParams,
-                           List("annotation_projects.name")) ++
+          Filters.searchQP(params.searchParams, List("annotation_projects.name")) ++
           List(
             params.projectFilterParams.projectType.map({ projectType =>
               fr"annotation_projects.project_type = $projectType"
             }),
+            params.campaignId.map({ campaignId =>
+              fr"annotation_projects.campaign_id = $campaignId"
+            }),
             taskStatusF
           )
+    }
+
+    implicit val campaignQueryParametersFilter
+    : Filterable[Any, CampaignQueryParameters] =
+    Filterable[Any, CampaignQueryParameters] {
+      params: CampaignQueryParameters =>
+        Filters.ownerQP(params.ownerParams, fr"owner") ++
+          Filters.searchQP(params.searchParams, List("name")) ++
+          List(params.campaignType.map({ campaignType =>
+              fr"campaign_type = $campaignType"
+            }))
     }
 }
 

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -443,7 +443,8 @@ trait Filterables extends RFMeta with LazyLogging {
               .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
         }
         Filters.ownerQP(params.ownerParams, fr"annotation_projects.owner") ++
-          Filters.searchQP(params.searchParams, List("annotation_projects.name")) ++
+          Filters.searchQP(params.searchParams,
+                           List("annotation_projects.name")) ++
           List(
             params.projectFilterParams.projectType.map({ projectType =>
               fr"annotation_projects.project_type = $projectType"
@@ -455,15 +456,15 @@ trait Filterables extends RFMeta with LazyLogging {
           )
     }
 
-    implicit val campaignQueryParametersFilter
+  implicit val campaignQueryParametersFilter
     : Filterable[Any, CampaignQueryParameters] =
     Filterable[Any, CampaignQueryParameters] {
       params: CampaignQueryParameters =>
         Filters.ownerQP(params.ownerParams, fr"owner") ++
           Filters.searchQP(params.searchParams, List("name")) ++
           List(params.campaignType.map({ campaignType =>
-              fr"campaign_type = $campaignType"
-            }))
+            fr"campaign_type = $campaignType"
+          }))
     }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.database
 import com.rasterfoundry.common.Generators.Implicits._
 import com.rasterfoundry.datamodel._
 
+import cats.implicits._
 import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest._
@@ -47,4 +48,132 @@ class CampaignDaoSpec
       )
     }
   }
+
+  test("list campaigns") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            campaignCreates: List[Campaign.Create]
+        ) => {
+          val pageSize = 30
+          val pageRequest = PageRequest(0, pageSize, Map.empty)
+
+          val listIO = for {
+            user <- UserDao.create(userCreate)
+            insertedCampaigns <- campaignCreates
+              .take(pageSize) traverse { toInsert =>
+              CampaignDao.insertCampaign(toInsert, user)
+            }
+            listed <- CampaignDao
+              .listCampaigns(
+                pageRequest,
+                CampaignQueryParameters(),
+                user
+              )
+          } yield (listed, insertedCampaigns)
+
+          val (listedCampaigns, dbCampaigns) = listIO.transact(xa).unsafeRunSync
+
+          val expectedIds = (dbCampaigns.take(pageSize) map { _.id }).toSet
+
+          assert(
+            expectedIds == (listedCampaigns.results map { _.id }).toSet,
+            "Listed campaigns are those expected from campaign insertion"
+          )
+
+          true
+        }
+      )
+    }
+  }
+
+  test("get a campaign by id") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            campaignCreate: Campaign.Create
+        ) => {
+          val getIO = for {
+            user <- UserDao.create(userCreate)
+            inserted <- CampaignDao
+              .insertCampaign(campaignCreate, user)
+            fetched <- CampaignDao
+              .getCampaignById(inserted.id)
+          } yield (inserted, fetched)
+
+          val (dbCampaign, Some(fetchedCampaign)) =
+            getIO.transact(xa).unsafeRunSync
+
+          assert(
+            dbCampaign == fetchedCampaign,
+            "Inserted campaign matched the fetched campaign"
+          )
+
+          true
+        }
+      )
+    }
+  }
+
+  test("update a campaign") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            campaignCreate: Campaign.Create,
+            campaignCreateUpdate: Campaign.Create
+        ) => {
+          val updateIO = for {
+            user <- UserDao.create(userCreate)
+            inserted1 <- CampaignDao
+              .insertCampaign(campaignCreate, user)
+            inserted2 <- CampaignDao
+              .insertCampaign(campaignCreateUpdate, user)
+            _ <- CampaignDao.updateCampaign(inserted2, inserted1.id)
+            fetched <- CampaignDao.getCampaignById(inserted1.id)
+          } yield fetched
+
+          val Some(afterUpdate) = updateIO.transact(xa).unsafeRunSync
+
+          assert(
+            afterUpdate.name == campaignCreateUpdate.name,
+            "Name was updated"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("delete a campaign") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            campaignCreate: Campaign.Create
+        ) => {
+          val deleteIO = for {
+            user <- UserDao.create(userCreate)
+            inserted <- CampaignDao
+              .insertCampaign(campaignCreate, user)
+            deleted <- CampaignDao.deleteCampaign(inserted.id, user)
+            fetched <- CampaignDao.getCampaignById(inserted.id)
+          } yield { (deleted, fetched) }
+
+          val (count, result) = deleteIO.transact(xa).unsafeRunSync
+
+          assert(count == 1, "A campaign was removed")
+          assert(
+            result == Option.empty[Campaign],
+            "The inserted campaign was gone after deletion"
+          )
+
+          true
+        }
+      )
+    }
+  }
+
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -1,0 +1,50 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.common.Generators.Implicits._
+import com.rasterfoundry.datamodel._
+
+import doobie.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest._
+import org.scalatestplus.scalacheck.Checkers
+
+class CampaignDaoSpec
+    extends FunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+  test("insert a campaign") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            campaignCreate: Campaign.Create
+        ) => {
+          val insertIO = for {
+            user <- UserDao.create(userCreate)
+            inserted <- CampaignDao
+              .insertCampaign(campaignCreate, user)
+          } yield (inserted, user)
+
+          val (insertedCampaign, insertedUser) =
+            insertIO.transact(xa).unsafeRunSync
+
+          assert(
+            insertedCampaign.name == campaignCreate.name,
+            "Inserted campaign name is correct"
+          )
+          assert(
+            insertedCampaign.campaignType == campaignCreate.campaignType,
+            "Inserted campaign type is correct"
+          )
+          assert(
+            insertedCampaign.owner == insertedUser.id,
+            "Inserted campaign owner is correct"
+          )
+          true
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR:
- [X] a migration to support campaigns
- [X] campaign data model
- [X] campaign dao
- [x] campaign dao spec
- [x] campaign api
- [X] campaign query params
- [X] update annotation projects related data model, dao methods, tests, and query params

Done in this issue but not in code of this PR:
- [X] include an example campaign in DB

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [X] New tables and queries have appropriate indices added
-~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- `./scripts/load_development_data --download`
- Assemble api server. Spin up servers and frontend. Log in as the dev user and grab a token
- `export TOKEN=<your bearer token>`
- List campaigns. It should include 1 campaign, since an example campaign is included in the updated pgdump
```bash
curl --location --request GET 'http://localhost:9091/api/campaigns' \
--header "Authorization: Bearer ${TOKEN}" 
```
- Create a campaign:
```bash
curl --location --request POST 'http://localhost:9091/api/campaigns' \
--header "Authorization: Bearer ${TOKEN}" \
--header 'Content-Type: application/json' \
--data-raw '{
	"name": "New Campaign",
	"campaignType": "SEGMENTATION"
}'
```
- Get the details of the sample campaign
```bash
curl --location --request GET 'http://localhost:9091/api/campaigns/5c725cdf-e8af-4001-a3c4-98211d02f43e' \
--header "Authorization: Bearer ${TOKEN}" 
```
- Update sample campaign name:
```bash
curl --location --request PUT 'http://localhost:9091/api/campaigns/5c725cdf-e8af-4001-a3c4-98211d02f43e' \
--header "Authorization: Bearer ${TOKEN}"  \
--header 'Content-Type: application/json' \
--data-raw '{
    "id": "5c725cdf-e8af-4001-a3c4-98211d02f43e",
    "createdAt": "2020-04-27T22:03:08.056212Z",
    "owner": "auth0|59318a9d2fbbca3e16bcfc92",
    "name": "Sample Campaign Renamed",
    "campaignType": "SEGMENTATION"
}'
```
- List campaign projects
```bash
curl --location --request GET 'http://localhost:9091/api/campaigns/5c725cdf-e8af-4001-a3c4-98211d02f43e/projects' \
--header "Authorization: Bearer ${TOKEN}" 
```
- Delete the campaign you created in step 5
```bash
export id=<id of a campaign you created>
curl --location --request DELETE "http://localhost:9091/api/campaigns/${id}" \
--header "Authorization: Bearer ${TOKEN}" 
```
- Filter annotation projects by `captured_at` field:
```bash
curl --location --request GET 'http://localhost:9091/api/annotation-projects?capturedAt=2020-03-18T20:02:15.643Z' \
--header "Authorization: Bearer ${TOKEN}" 
```
- Also test the GET `/api/campaigns/<id>/actions` and GET, POST, PUT, DELETE`/api/campaigns/<id>/permissions` endpoints -- they are not included in the scope of the issue, but they sort of come for free since the `CampaignDao` extends `ObjectPermissions` trait.

Closes https://github.com/azavea/earthrise/issues/7
