### PR TITLE
Add routes for MVT layers for tasks and labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- MVT endpoints for annotation project tasks and labels [#5400](https://github.com/raster-foundry/raster-foundry/pull/5400)
 - Support campaigns [#5397](https://github.com/raster-foundry/raster-foundry/pull/5397)
 
 ### Changed

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -1,12 +1,14 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash.error._
+import com.rasterfoundry.database.AnnotationProjectDao
 import com.rasterfoundry.database.{
   ProjectDao,
   ProjectLayerDao,
   SceneDao,
   ToolRunDao
 }
+import com.rasterfoundry.datamodel.AnnotationProject
 import com.rasterfoundry.datamodel.{
   ActionType,
   AuthFailure,
@@ -32,8 +34,6 @@ import scalacache.memoization._
 import scala.concurrent.duration._
 
 import java.util.UUID
-import com.rasterfoundry.datamodel.AnnotationProject
-import com.rasterfoundry.database.AnnotationProjectDao
 
 class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
@@ -119,7 +119,7 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
                 ProjectLayerDao
                   .layerIsInProject(layerID, projectID)
                   .transact(xa)
-            )
+          )
         }
       }
     }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Authorizers.scala
@@ -32,27 +32,53 @@ import scalacache.memoization._
 import scala.concurrent.duration._
 
 import java.util.UUID
+import com.rasterfoundry.datamodel.AnnotationProject
+import com.rasterfoundry.database.AnnotationProjectDao
 
 class Authorizers(xa: Transactor[IO]) extends LazyLogging {
 
   implicit val authCache = Cache.caffeineAuthorizationCache
   implicit val sceneCache = Cache.sceneAuthCache
+  implicit val annotationProjectCache = Cache.annotationProjectAuthCache
   implicit val projectCache = Cache.projectAuthCache
   implicit val toolRunCache = Cache.toolRunAuthCache
   implicit val flags = Cache.authenticationCacheFlags
 
-  private def checkProjectAuthCached(user: User,
-                                     projectId: UUID): IO[AuthResult[Project]] =
+  private def checkAnnotationProjectAuthCached(
+      user: User,
+      annotationProjectId: UUID
+  ): IO[AuthResult[AnnotationProject]] =
+    memoizeF[IO, AuthResult[AnnotationProject]](Some(60 seconds)) {
+      logger.debug(
+        s"Checking Annotation Project Auth User: ${user.id} => Annotation Project: ${annotationProjectId} with DB"
+      )
+      AnnotationProjectDao
+        .authorized(
+          user,
+          ObjectType.AnnotationProject,
+          annotationProjectId,
+          ActionType.View
+        )
+        .transact(xa)
+    }
+
+  private def checkProjectAuthCached(
+      user: User,
+      projectId: UUID
+  ): IO[AuthResult[Project]] =
     memoizeF[IO, AuthResult[Project]](Some(60 seconds)) {
       logger.debug(
-        s"Checking Project Auth User: ${user.id} => Project: ${projectId} with DB")
+        s"Checking Project Auth User: ${user.id} => Project: ${projectId} with DB"
+      )
       ProjectDao
         .authorized(user, ObjectType.Project, projectId, ActionType.View)
         .transact(xa)
     }
 
-  private def checkSceneAuthCached(user: User,
-                                   sceneId: UUID): IO[AuthResult[Scene]] =
+  private def checkSceneAuthCached(
+      user: User,
+      sceneId: UUID
+  ): IO[AuthResult[Scene]] =
     memoizeF[IO, AuthResult[Scene]](Some(60 seconds)) {
       logger.debug(
         s"Checking Scene Auth User: ${user.id} => Scene: ${sceneId} with DB"
@@ -62,11 +88,14 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
         .transact(xa)
     }
 
-  private def checkToolRunAuth(user: User,
-                               toolRunId: UUID): IO[AuthResult[ToolRun]] =
+  private def checkToolRunAuth(
+      user: User,
+      toolRunId: UUID
+  ): IO[AuthResult[ToolRun]] =
     memoizeF[IO, AuthResult[ToolRun]](Some(10 seconds)) {
       logger.debug(
-        s"Checking Tool Run Auth User: ${user.id} => Project: ${toolRunId} with DB")
+        s"Checking Tool Run Auth User: ${user.id} => Project: ${toolRunId} with DB"
+      )
       ToolRunDao
         .authorized(user, ObjectType.Analysis, toolRunId, ActionType.View)
         .transact(xa)
@@ -75,38 +104,50 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
   private def checkProjectLayerCached(
       projectID: UUID,
       layerID: UUID,
-      tracingContext: TracingContext[IO]): IO[Boolean] = {
+      tracingContext: TracingContext[IO]
+  ): IO[Boolean] = {
     val tags =
       Map("projectId" -> projectID.toString, "layerID" -> layerID.toString)
     tracingContext.span("checkProjectLayerCached", tags) use { childContext =>
       {
         memoizeF[IO, Boolean](Some(10 seconds)) {
           logger.debug(
-            s"Checking whether layer ${layerID} is in project ${projectID}")
-          childContext.span("layerIsInProject", tags) use (_ =>
-            ProjectLayerDao.layerIsInProject(layerID, projectID).transact(xa))
+            s"Checking whether layer ${layerID} is in project ${projectID}"
+          )
+          childContext.span("layerIsInProject", tags) use (
+              _ =>
+                ProjectLayerDao
+                  .layerIsInProject(layerID, projectID)
+                  .transact(xa)
+            )
         }
       }
     }
   }
 
-  private def checkProjectAnalysisCached(projectId: UUID,
-                                         analysisId: UUID): IO[Boolean] =
+  private def checkProjectAnalysisCached(
+      projectId: UUID,
+      analysisId: UUID
+  ): IO[Boolean] =
     memoizeF[IO, Boolean](Some(10 seconds)) {
       logger.debug(
-        s"Checking whether analysis $analysisId references project $projectId")
+        s"Checking whether analysis $analysisId references project $projectId"
+      )
       ToolRunDao.analysisReferencesProject(analysisId, projectId).transact(xa)
     }
 
-  def authObject[T](f: (User, UUID) => IO[AuthResult[T]],
-                    user: User,
-                    objectId: UUID): IO[T] =
+  def authObject[T](
+      f: (User, UUID) => IO[AuthResult[T]],
+      user: User,
+      objectId: UUID
+  ): IO[T] =
     f(user, objectId) flatMap {
       case AuthFailure() =>
         IO.raiseError[T](
           NotAuthorizedException(
             s"User ${user.id} is not authorized to view $objectId"
-          ))
+          )
+        )
       case AuthSuccess(v) => IO.pure { v }
     }
 
@@ -116,38 +157,61 @@ class Authorizers(xa: Transactor[IO]) extends LazyLogging {
   def authProject(user: User, projectId: UUID): IO[Project] =
     authObject(checkProjectAuthCached, user, projectId)
 
-  def authProject(user: User,
-                  projectId: UUID,
-                  tracingContext: TracingContext[IO]): IO[Project] =
+  def authProject(
+      user: User,
+      projectId: UUID,
+      tracingContext: TracingContext[IO]
+  ): IO[Project] =
     tracingContext.span(
       "authProject",
-      Map("user" -> user.id, "projectId" -> projectId.toString)) use { _ =>
+      Map("user" -> user.id, "projectId" -> projectId.toString)
+    ) use { _ =>
       authObject(checkProjectAuthCached, user, projectId)
+    }
+
+  def authAnnotationProject(
+      user: User,
+      annotationProjectId: UUID,
+      tracingContext: TracingContext[IO]
+  ): IO[AnnotationProject] =
+    tracingContext.span(
+      "authAnnotationProject",
+      Map(
+        "user" -> user.id,
+        "annotationProjectId" -> annotationProjectId.toString
+      )
+    ) use { _ =>
+      authObject(checkAnnotationProjectAuthCached, user, annotationProjectId)
     }
 
   def authScene(user: User, sceneId: UUID): IO[Scene] =
     authObject(checkSceneAuthCached, user, sceneId)
 
-  def authProjectLayer(projectID: UUID,
-                       layerID: UUID,
-                       tracingContext: TracingContext[IO] =
-                         NoOpTracingContext[IO]("no-op-read")): IO[Unit] = {
+  def authProjectLayer(
+      projectID: UUID,
+      layerID: UUID,
+      tracingContext: TracingContext[IO] = NoOpTracingContext[IO]("no-op-read")
+  ): IO[Unit] = {
     checkProjectLayerCached(projectID, layerID, tracingContext) flatMap {
       case false =>
         IO.raiseError(
           NotAuthorizedException(
             s"Layer ${layerID} is not in project ${projectID}"
-          ))
+          )
+        )
       case _ => IO.pure { () }
     }
   }
 
-  def authProjectAnalysis(user: User,
-                          projectId: UUID,
-                          analysisId: UUID): IO[Unit] = {
+  def authProjectAnalysis(
+      user: User,
+      projectId: UUID,
+      analysisId: UUID
+  ): IO[Unit] = {
     Applicative[IO].map2(
       checkProjectAuthCached(user, projectId),
-      checkProjectAnalysisCached(projectId, analysisId))(_.toBoolean && _) map {
+      checkProjectAnalysisCached(projectId, analysisId)
+    )(_.toBoolean && _) map {
       case false =>
         throw NotAuthorizedException(
           s"Analysis $analysisId does not reference project $projectId"

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -1,5 +1,6 @@
 package com.rasterfoundry.backsplash.server
 
+import com.rasterfoundry.datamodel.AnnotationProject
 import com.rasterfoundry.datamodel.{
   AuthResult,
   Project,
@@ -13,7 +14,6 @@ import com.rasterfoundry.http4s.{Cache => Http4sUtilCache}
 import com.typesafe.scalalogging.LazyLogging
 import scalacache._
 import scalacache.caffeine._
-import com.rasterfoundry.datamodel.AnnotationProject
 
 object Cache extends LazyLogging {
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Cache.scala
@@ -13,17 +13,21 @@ import com.rasterfoundry.http4s.{Cache => Http4sUtilCache}
 import com.typesafe.scalalogging.LazyLogging
 import scalacache._
 import scalacache.caffeine._
+import com.rasterfoundry.datamodel.AnnotationProject
 
 object Cache extends LazyLogging {
 
   val requestCounter = CaffeineCache[Int]
 
-  val authorizationCacheFlags = Flags(Config.cache.authorizationCacheEnable,
-                                      Config.cache.authorizationCacheEnable)
+  val authorizationCacheFlags = Flags(
+    Config.cache.authorizationCacheEnable,
+    Config.cache.authorizationCacheEnable
+  )
   val caffeineAuthorizationCache: Cache[Boolean] =
     CaffeineCache[Boolean]
   logger.info(
-    s"Authorization Cache Status (read/write) ${authorizationCacheFlags}")
+    s"Authorization Cache Status (read/write) ${authorizationCacheFlags}"
+  )
 
   val caffeineSceneCache: Cache[Scene] =
     CaffeineCache[Scene]
@@ -35,13 +39,17 @@ object Cache extends LazyLogging {
   val caffeineAuthenticationCache: Cache[Option[User]] =
     CaffeineCache[Option[User]]
   logger.info(
-    s"Authentication Cache Status, backsplash: ${authenticationCacheFlags}")
+    s"Authentication Cache Status, backsplash: ${authenticationCacheFlags}"
+  )
 
   val sceneAuthCache: Cache[AuthResult[Scene]] =
     CaffeineCache[AuthResult[Scene]]
 
   val projectAuthCache: Cache[AuthResult[Project]] =
     CaffeineCache[AuthResult[Project]]
+
+  val annotationProjectAuthCache: Cache[AuthResult[AnnotationProject]] =
+    CaffeineCache[AuthResult[AnnotationProject]]
 
   val toolRunAuthCache: Cache[AuthResult[ToolRun]] =
     CaffeineCache[AuthResult[ToolRun]]

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -156,7 +156,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
     statusReapingConfig.taskStatusExpirationSeconds.seconds
   private val everyMinute = Cron.unsafeParse("0 * * ? * *")
   val scheduled
-      : fs2.Stream[IO, Int] = awakeEveryCron[IO](everyMinute) *> (fs2.Stream
+    : fs2.Stream[IO, Int] = awakeEveryCron[IO](everyMinute) *> (fs2.Stream
     .eval {
       TaskDao.expireStuckTasks(statusExpirationDuration).transact(xa)
     })

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -144,11 +144,19 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
       new SceneService(sceneMosaicImplicits, xa).routes
     )
 
+  val annotationProjectMVTService = authenticators.tokensAuthMiddleware(
+    new AnnotationProjectMVTService(xa).routes
+  )
+
+  val healthcheckService: HttpRoutes[IO] = new HealthcheckService(
+    xa
+  ).routes
+
   private val statusExpirationDuration =
     statusReapingConfig.taskStatusExpirationSeconds.seconds
   private val everyMinute = Cron.unsafeParse("0 * * ? * *")
   val scheduled
-    : fs2.Stream[IO, Int] = awakeEveryCron[IO](everyMinute) *> (fs2.Stream
+      : fs2.Stream[IO, Int] = awakeEveryCron[IO](everyMinute) *> (fs2.Stream
     .eval {
       TaskDao.expireStuckTasks(statusExpirationDuration).transact(xa)
     })
@@ -158,11 +166,10 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
       baseMiddleware {
         Router(
           "/" -> mosaicService,
+          "/mvt" -> annotationProjectMVTService,
           "/scenes" -> sceneMosaicService,
           "/tools" -> analysisService,
-          "/healthcheck" -> new HealthcheckService(
-            xa
-          ).routes
+          "/healthcheck" -> healthcheckService
         )
       }
     }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/AnnotationProjectMVTService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/AnnotationProjectMVTService.scala
@@ -1,0 +1,106 @@
+package com.rasterfoundry.backsplash.server
+
+import com.rasterfoundry.database.MVTLayerDao
+
+import cats.data.OptionT
+import cats.effect._
+import cats.implicits._
+import com.colisweb.tracing.core.TracingContextBuilder
+import doobie.ConnectionIO
+import doobie.implicits._
+import doobie.util.transactor.Transactor
+
+import java.util.UUID
+import com.rasterfoundry.http4s.TracedHTTPRoutes
+import com.rasterfoundry.http4s.TracedHTTPRoutes._
+import org.http4s.dsl.Http4sDsl
+import com.typesafe.scalalogging.LazyLogging
+import org.http4s.Response
+import com.colisweb.tracing.core.TracingContext
+import com.rasterfoundry.datamodel.User
+import org.http4s.Header
+
+class AnnotationProjectMVTService(xa: Transactor[IO])(
+    implicit contextShift: ContextShift[IO],
+    builder: TracingContextBuilder[IO]
+) extends Http4sDsl[IO]
+    with LazyLogging {
+
+  val authorizers = new Authorizers(xa)
+
+  private def getTags(
+      annotationProjectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int
+  ): Map[String, String] =
+    Map(
+      "annotationProjectId" -> annotationProjectId.toString,
+      "zxy" -> s"$z/$x/$y"
+    )
+
+  private def getTile(
+      f: (UUID, Int, Int, Int) => ConnectionIO[Option[Array[Byte]]],
+      operationLabel: String,
+      user: User,
+      annotationProjectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int,
+      tracingContext: TracingContext[IO]
+  ): IO[Response[IO]] =
+    for {
+      _ <- authorizers.authAnnotationProject(
+        user,
+        annotationProjectId,
+        tracingContext
+      )
+      respO <- tracingContext.span(
+        operationLabel,
+        getTags(annotationProjectId, z, x, y)
+      ) use { _ =>
+        f(annotationProjectId, z, x, y)
+          .transact(xa)
+      }
+      resp <- OptionT {
+        respO traverse { byteArray =>
+          Ok(
+            byteArray,
+            Header("content-type", "application/vnd.mapbox-vector-tile")
+          )
+        }
+      } getOrElseF NotFound()
+    } yield resp
+
+  val routes =
+    TracedHTTPRoutes[IO] {
+      case GET -> Root / UUIDVar(annotationProjectId) / "labels" / IntVar(z) / IntVar(
+            x
+          ) / IntVar(y) as user using context =>
+        getTile(
+          MVTLayerDao.getAnnotationProjectLabels,
+          "get-mvt-labels-byte-array",
+          user,
+          annotationProjectId,
+          z,
+          x,
+          y,
+          context
+        )
+
+      case GET -> Root / UUIDVar(annotationProjectId) / "labels" / IntVar(z) / IntVar(
+            x
+          ) / IntVar(y) as user using context =>
+        getTile(
+          MVTLayerDao.getAnnotationProjectTasks,
+          "get-mvt-tasks-byte-array",
+          user,
+          annotationProjectId,
+          z,
+          x,
+          y,
+          context
+        )
+    }
+
+}

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/AnnotationProjectMVTService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/AnnotationProjectMVTService.scala
@@ -88,7 +88,7 @@ class AnnotationProjectMVTService(xa: Transactor[IO])(
           context
         )
 
-      case GET -> Root / UUIDVar(annotationProjectId) / "labels" / IntVar(z) / IntVar(
+      case GET -> Root / UUIDVar(annotationProjectId) / "tasks" / IntVar(z) / IntVar(
             x
           ) / IntVar(y) as user using context =>
         getTile(

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/AnnotationProjectMVTService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/AnnotationProjectMVTService.scala
@@ -1,24 +1,24 @@
 package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.database.MVTLayerDao
+import com.rasterfoundry.datamodel.User
+import com.rasterfoundry.http4s.TracedHTTPRoutes
+import com.rasterfoundry.http4s.TracedHTTPRoutes._
 
 import cats.data.OptionT
 import cats.effect._
 import cats.implicits._
+import com.colisweb.tracing.core.TracingContext
 import com.colisweb.tracing.core.TracingContextBuilder
+import com.typesafe.scalalogging.LazyLogging
 import doobie.ConnectionIO
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import org.http4s.Header
+import org.http4s.Response
+import org.http4s.dsl.Http4sDsl
 
 import java.util.UUID
-import com.rasterfoundry.http4s.TracedHTTPRoutes
-import com.rasterfoundry.http4s.TracedHTTPRoutes._
-import org.http4s.dsl.Http4sDsl
-import com.typesafe.scalalogging.LazyLogging
-import org.http4s.Response
-import com.colisweb.tracing.core.TracingContext
-import com.rasterfoundry.datamodel.User
-import org.http4s.Header
 
 class AnnotationProjectMVTService(xa: Transactor[IO])(
     implicit contextShift: ContextShift[IO],

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -401,6 +401,7 @@ lazy val db = project
       Dependencies.doobieHikari,
       Dependencies.doobiePostgres,
       Dependencies.doobiePostgresCirce,
+      Dependencies.doobieScalatest,
       Dependencies.elasticacheClient,
       Dependencies.flyway % Test,
       Dependencies.fs2,

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.database
 
 import doobie._
-import doobie.postgres.implicits._
 
 import java.util.UUID
 

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -1,6 +1,8 @@
 package com.rasterfoundry.database
 
 import doobie._
+import doobie.implicits._
+import doobie.postgres.implicits._
 
 import java.util.UUID
 
@@ -11,17 +13,83 @@ import java.util.UUID
   * Or fieldnames? Or table name?
   */
 object MVTLayerDao {
+  private[database] def getAnnotationProjectTasksQ(
+      annotationProjectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int
+  ): Query0[Array[Byte]] =
+    fr"""WITH mvtgeom AS
+      (
+        SELECT
+          ST_AsMVTGeom(
+            geometry,
+            ST_TileEnvelope(${z},${x},${y})
+          ) AS geom,
+          *
+        FROM tasks
+        WHERE
+          ST_Intersects(
+            geometry,
+            ST_TileEnvelope(${z},${x},${y})
+          ) AND
+          annotation_project_id = ${annotationProjectId}
+      )
+    SELECT ST_AsMVT(mvtgeom.*) FROM mvtgeom;""".query[Array[Byte]]
+
   def getAnnotationProjectTasks(
       annotationProjectId: UUID,
       z: Int,
       x: Int,
       y: Int
-  ): ConnectionIO[Option[Array[Byte]]] = ???
+  ): ConnectionIO[Option[Array[Byte]]] =
+    getAnnotationProjectTasksQ(annotationProjectId, z, x, y).option
+
+  private[database] def getAnnotationProjectLabelsQ(
+      annotationProjectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int
+  ): Query0[Array[Byte]] =
+    fr"""WITH mvtgeom AS
+      (
+        SELECT
+          ST_AsMVTGeom(
+            annotations.geometry,
+            ST_TileEnvelope(${z},${x},${y})
+          ) AS geom,
+          annotations.id,
+          annotations.project_id,
+          annotations.created_at,
+          annotations.created_by,
+          annotations.modified_at,
+          annotations.owner,
+          annotations.label,
+          annotations.description,
+          annotations.machine_generated,
+          annotations.confidence,
+          annotations.quality,
+          annotations.annotation_group,
+          annotations.labeled_by,
+          annotations.verified_by,
+          annotations.project_layer_id,
+          annotations.task_id
+        FROM annotations JOIN tasks on annotations.task_id = tasks.id
+        WHERE
+          ST_Intersects(
+            annotations.geometry,
+            ST_TileEnvelope(${z},${x},${y})
+          ) AND
+          tasks.annotation_project_id = ${annotationProjectId}
+      )
+    SELECT ST_AsMVT(mvtgeom.*) FROM mvtgeom;""".query[Array[Byte]]
 
   def getAnnotationProjectLabels(
       annotationProjectId: UUID,
       z: Int,
       x: Int,
       y: Int
-  ): ConnectionIO[Option[Array[Byte]]] = ???
+  ): ConnectionIO[Option[Array[Byte]]] =
+    getAnnotationProjectLabelsQ(annotationProjectId, z, x, y).option
+
 }

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -1,0 +1,28 @@
+package com.rasterfoundry.database
+
+import doobie._
+import doobie.postgres.implicits._
+
+import java.util.UUID
+
+/** Container for methods required to get byte arrays of MVT layers from the db
+  *
+  * Claims to be a Dao, but doesn't extend Dao[Option[Array[Byte]]] because we can't provide
+  * sensible values for some of the required Dao fields, e.g., what should the `selectF` be?
+  * Or fieldnames? Or table name?
+  */
+object MVTLayerDao {
+  def getAnnotationProjectTasks(
+      annotationProjectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int
+  ): ConnectionIO[Option[Array[Byte]]] = ???
+
+  def getAnnotationProjectLabels(
+      annotationProjectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int
+  ): ConnectionIO[Option[Array[Byte]]] = ???
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/MVTLayerDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/MVTLayerDaoSpec.scala
@@ -1,0 +1,28 @@
+package com.rasterfoundry.database
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.UUID
+
+class MVTLayerDaoSpec
+    extends AnyFunSuite
+    with doobie.scalatest.IOChecker
+    with DBTestConfig {
+
+  val transactor = xa
+
+  val mockAnnotationProjectId = UUID.randomUUID
+
+  test("labels mvt query is valid") {
+    check(
+      MVTLayerDao.getAnnotationProjectLabelsQ(mockAnnotationProjectId, 0, 0, 0)
+    )
+  }
+
+  test("tasks mvt query is valid") {
+    check(
+      MVTLayerDao.getAnnotationProjectTasksQ(mockAnnotationProjectId, 0, 0, 0)
+    )
+  }
+
+}

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -140,7 +140,7 @@ object Dependencies {
   val doobieHikari = "org.tpolecat" %% "doobie-hikari" % Version.doobie
   val doobiePostgres = "org.tpolecat" %% "doobie-postgres" % Version.doobie
   val doobiePostgresCirce = "org.tpolecat" %% "doobie-postgres-circe" % Version.doobie
-  val doobieScalatest = "org.tpolecat" %% "doobie-scalatest" % Version.doobie
+  val doobieScalatest = "org.tpolecat" %% "doobie-scalatest" % Version.doobie % "test"
   val doobieSpecs = "org.tpolecat" %% "doobie-specs2" % Version.doobie
   val dropbox = "com.dropbox.core" % "dropbox-core-sdk" % Version.dropbox
   val elasticacheClient = "com.amazonaws" % "elasticache-java-cluster-client" % Version.elasticacheClient

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -141,7 +141,6 @@ object Dependencies {
   val doobiePostgres = "org.tpolecat" %% "doobie-postgres" % Version.doobie
   val doobiePostgresCirce = "org.tpolecat" %% "doobie-postgres-circe" % Version.doobie
   val doobieScalatest = "org.tpolecat" %% "doobie-scalatest" % Version.doobie % "test"
-  val doobieSpecs = "org.tpolecat" %% "doobie-specs2" % Version.doobie
   val dropbox = "com.dropbox.core" % "dropbox-core-sdk" % Version.dropbox
   val elasticacheClient = "com.amazonaws" % "elasticache-java-cluster-client" % Version.elasticacheClient
   val ficus = "com.iheart" %% "ficus" % Version.ficus


### PR DESCRIPTION
## Overview

This PR adds a service to serve vector tiles for labels and tasks in annotation projects. It doesn't actually fetch the vector tiles from the db yet though but I want coffee before I write anything else and that's a good time for Jenkins to hang out and do stuff.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~ no scope checking in tile server

### Notes

The tasks mvts are returning all of their data. The label mvts are just returning geometry + class name + color hex code, since I'm going through a join and don't know what related info to fetch. If we need more stuff, it's not that hard to get it.

The tests don't have any expectations about results because I don't know what kind of expectations we can create about byte arrays. Maybe that something should be a `Some`? It doesn't seem very  helpful.

These endpoints will basically double the tile requests that hit the server when we load project dashboards. However, that should probably be ok, because they're _very fast_, at least in early results -- without auth cached and I think with having to acquire a database connection after startup, total request time was 300ms, and most requests are like 20ms

![image](https://user-images.githubusercontent.com/5702984/80761820-e7984b80-8b00-11ea-9dfc-659bfb86704d.png)


## Testing Instructions

- assemble backsplash
- bring up servers
- bring up groundwork pointed to local rf
- start labeling in the sample project -- label a bunch of tasks by randomly paint bucket filling them with one of the classes
- once you've done like 15 or 20 of those, go back to the project dashboard and look at the pattern you've created
- get a JWT
- `export token=<your JWT>`
- install [`mvtview`](https://github.com/mapbox/mvtview)
- sign up for mapbox if you don't already have an account and grab your default public token from [your account page](https://account.mapbox.com/)
- `export MapboxAccessToken=<your token>`
- get an MVT from backsplash for the labels you made: `http :8081/mvt/13dd152a-db3a-45f7-ba6b-c7274e679351/labels/10/206/401 token==$token > mvt-labels`
- `mvtview mvt-labels` -- the pattern should look like the pattern of labels you wound up with
- `ctrl+c` your `mvtview` process
- get an MVT from backsplash for the tasks for that annotation project: `http :8081/mvt/13dd152a-db3a-45f7-ba6b-c7274e679351/tasks/10/206/401 token==$token > mvt-tasks`
- `mvtview mvt-tasks` -- the pattern should look like a task grid

Closes raster-foundry/annotate#866
