### PR TITLE
Downgrade all the jdk containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - Add development support for PostgreSQL 12.x/PostGIS 3.x [#5395](https://github.com/raster-foundry/raster-foundry/pull/5395)
-- Upgraded GeoTrellis and Tyelevel libraries to Cats 2.x releases [#5393](https://github.com/raster-foundry/raster-foundry/pull/5393)
+- Upgraded GeoTrellis and Tyelevel libraries to Cats 2.x releases [#5393](https://github.com/raster-foundry/raster-foundry/pull/5393), [#5401](https://github.com/raster-foundry/raster-foundry/pull/5401)
 - Changed email invitation copy [#5396](https://github.com/raster-foundry/raster-foundry/pull/5396)
 
 ### Deprecated

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
 
 RUN \
     adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf

--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -9,4 +9,4 @@ USER rf
 WORKDIR /var/lib/rf
 
 ENTRYPOINT ["java"]
-CMD ["-jar", "api-assembly.jar"]
+CMD ["-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "api-assembly.jar"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -47,7 +47,7 @@ services:
 
   api-server-test:
     # If changing container, make sure to update app-backend/api/Dockerfile as well
-    image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
+    image: quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
     links:
       - postgres:database.service.rasterfoundry.internal
       - memcached:memcached.service.rasterfoundry.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   api-server:
     # If changing container, make sure to update app-backend/api/Dockerfile as well
-    image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
+    image: quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
     links:
       - postgres:database.service.rasterfoundry.internal
       - memcached:memcached.service.rasterfoundry.internal


### PR DESCRIPTION
## Overview

This PR downgrades all the jdk containers to Java 8. It _should_ fix what happens when posting scenes, like what happened in [this error](https://my.papertrailapp.com/groups/4082193/events?focus=1192887760147595269&q=program%3Astaging%2Fapi-server&selected=1192887760147595269). At least it fixed it in the tile server when we downgraded.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

:crossed_fingers: 

## Testing Instructions

- grep for `jdk11`
- confirm that it's _gone_
