### PR TITLE
Fix overview size calculation math for new GT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Changed
 
 - Add development support for PostgreSQL 12.x/PostGIS 3.x [#5395](https://github.com/raster-foundry/raster-foundry/pull/5395)
-- Upgraded GeoTrellis and Tyelevel libraries to Cats 2.x releases [#5393](https://github.com/raster-foundry/raster-foundry/pull/5393), [#5401](https://github.com/raster-foundry/raster-foundry/pull/5401)
+- Upgraded GeoTrellis and Tyelevel libraries to Cats 2.x releases [#5393](https://github.com/raster-foundry/raster-foundry/pull/5393), [#5401](https://github.com/raster-foundry/raster-foundry/pull/5401), [#5402](https://github.com/raster-foundry/raster-foundry/pull/5402)
 - Changed email invitation copy [#5396](https://github.com/raster-foundry/raster-foundry/pull/5396)
 
 ### Deprecated

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -65,7 +65,7 @@ object CogUtils extends LazyLogging {
                   r =>
                     scala.math.abs(
                       100000 - (rasterSource.rows / r.height) * (rasterSource.cols / r.width)
-                    )
+                  )
                 )
               )
             )


### PR DESCRIPTION
## Overview

This PR updates the overview selection math to respect the new value returned by `RasterSource.resolutions`. The previous type had a height and width, as does `CellSize`, but the implications of doing height and width math with `GridExtent`s are very different from doing height and width math with `CellSize`s. This is a change that we requested but I forgot to track it down when doing the gt upgrade. It also adds some more debug logging that will help us in case this fails in the future. It shouldn't for anything that has overviews, since 256x256 << 400000 and that's where gdal by default stops adding overviews to things, but at least it'll be a little bit easier to tell what happened if it does.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- download the tif from the linked issue (see `Closes:`)
- bring up Groundwork pointed to local RF
- assemble api server and batch if you haven't in a while
- bring up your api server
- upload the tif from the issue while watching the network
- get your upload id from the response to POST uploads
- finish creating the groundwork project
- `./scripts/console batch 'rf process-upload <upload id>'`
- your processing should fail in the notification step since the dev user is all messed up in one of Intercom or Auth0 apparently, but not in creating the scene

Closes azavea/raster-foundry-platform#1031