### PR TITLE
Don't write self link to catalog root in stac export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Fixed
 
+- Don't write `self` links to STAC roots [#5405](https://github.com/raster-foundry/raster-foundry/pull/5405)
+
 ### Security
 
 ## [1.40.3](https://github.com/raster-foundry/raster-foundry/compare/1.40.2...1.40.3)

--- a/app-backend/batch/src/main/scala/stacExport/Utils.scala
+++ b/app-backend/batch/src/main/scala/stacExport/Utils.scala
@@ -36,24 +36,14 @@ object Utils {
   )
 
   def getStacCatalog(
-      currentPath: String,
       export: StacExport,
       stacVersion: String,
       layerIds: List[UUID]
   ): StacCatalog = {
     val catalogId = export.id.toString
-    val catalogParentPath = s"$currentPath/$catalogId"
     val catalogDescription =
       s"Exported from Raster Foundry ${new Timestamp(new Date().getTime).toString}"
     val catalogOwnLinks = List(
-      StacLink(
-        // s3://<prefix>/<catalogId>/catalog.json
-        s"$catalogParentPath/catalog.json",
-        Self,
-        Some(`application/json`),
-        Some(s"Catalog $catalogId"),
-        List()
-      ),
       // s3://<prefix>/<catalogId>/catalog.json
       StacLink(
         "./catalog.json",

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -200,7 +200,7 @@ final case class WriteStacCatalog(exportId: UUID)(
         logger.info(s"Writing export under prefix: $exportPath")
         val layerIds = layerInfoMap.keys.toList
         val catalog: StacCatalog =
-          Utils.getStacCatalog(currentPath, exportDef, "0.8.0", layerIds)
+          Utils.getStacCatalog(exportDef, "0.8.0", layerIds)
         val catalogWithPath =
           ObjectWithAbsolute(s"$exportPath/catalog.json", catalog)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,6 @@ services:
     image: raster-foundry-batch
     ports:
       - "9040:9040"
-      - "9020:9020"
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-backend/batch/target/scala-2.12/batch-assembly.jar:/opt/raster-foundry/jars/batch-assembly.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
     image: raster-foundry-batch
     ports:
       - "9040:9040"
+      - "9020:9020"
     volumes:
       - ./app-tasks/rf/:/opt/raster-foundry/app-tasks/rf/
       - ./app-backend/batch/target/scala-2.12/batch-assembly.jar:/opt/raster-foundry/jars/batch-assembly.jar


### PR DESCRIPTION
## Overview

This PR removes the only self link that I found from the `WriteStacCatalog` batch job.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

download this: `s3://rasterfoundry-development-data-us-east-1/stac-exports/1dd96375-2d13-4ec7-94b7-3310dc8efa50/catalog.zip` and grep for `self` / `Self` ( I don't know whehter it would have been capitalized but they're both gone)

## Testing Instructions

- assemble batch / api (api only if you haven't recently -- there's nothing new there)
- bring up memcached + postgres
- bring up local annotate pointed to local rf
- while watching your network tab, create an export in annotate and grab its id from the response
- `./scripts/console batch bash`
- run this command:

```bash
java \
  -Dcom.sun.management.jmxremote.rmi.port=9040 \
  -Dcom.sun.management.jmxremote=true \
  -Dcom.sun.management.jmxremote.port=9040 \
  -Dcom.sun.management.jmxremote.ssl=false \
  -Dcom.sun.management.jmxremote.authenticate=false \
  -Dcom.sun.management.jmxremote.local.only=false \
  -Djava.rmi.server.hostname=localhost \
  -cp /opt/raster-foundry/jars/batch-assembly.jar \
  com.rasterfoundry.batch.Main \
  write_stac_catalog \
  1dd96375-2d13-4ec7-94b7-3310dc8efa50 # replace with your export id
```

- while it's running fire up visualvm, click the `+jmx` icon, and add localhost:9040

![image](https://user-images.githubusercontent.com/5702984/81323646-4f97e600-905b-11ea-8408-07dbd379eab3.png)

- double click the connection you just added, then watch "threads" to keep track of what's going on:

![image](https://user-images.githubusercontent.com/5702984/81323713-663e3d00-905b-11ea-983d-cfd15616e00c.png)

- you should eventually end up with a single thread in `ioapp-compute` that's hanging out green. it might seem like nothing's happening, but something is, i promise
- when it's done, download the catalog you created (it'll be in logs following `DEBUG - Writing to`)
- unzip it and grep for `self` / `Self`


Closes #5392 
