### PR TITLE
Add a continent column to campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Additional statuses for tasks indicating invalid tasks and flagged tasks [#5403](https://github.com/raster-foundry/raster-foundry/pull/5403)
 - MVT endpoints for annotation project tasks and labels [#5400](https://github.com/raster-foundry/raster-foundry/pull/5400)
-- Support campaigns [#5397](https://github.com/raster-foundry/raster-foundry/pull/5397) [#5404](https://github.com/raster-foundry/raster-foundry/pull/5404)
+- Support campaigns [#5397](https://github.com/raster-foundry/raster-foundry/pull/5397) [#5404](https://github.com/raster-foundry/raster-foundry/pull/5404) [#5410](https://github.com/raster-foundry/raster-foundry/pull/5410)
 - Add support for creating users in bulk [#5406](https://github.com/raster-foundry/raster-foundry/pull/5406)
 - Add geometry type and description to Annotation Label Classes [#5408](https://github.com/raster-foundry/raster-foundry/pull/5408)
 - Add image quality to tile layers [#5409](https://github.com/raster-foundry/raster-foundry/pull/5409)

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,9 +34,14 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
+    }
+
+  implicit val deserializerContinent: Unmarshaller[String, Continent] =
+    Unmarshaller.strict[String, Continent] { s =>
+      Continent.fromString(s)
     }
 
 }
@@ -226,7 +231,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         ownershipTypeQueryParameters &
         groupQueryParameters &
         parameters(
-          'campaignType.as(deserializerAnnotationProjectType).?
+          'campaignType.as(deserializerAnnotationProjectType).?,
+          'continent.as(deserializerContinent).?
         )
     ).as(CampaignQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1099,6 +1099,19 @@ object Generators extends ArbitraryInstances {
       Gen.const(Nil)
     ).mapN(AnnotationLabelWithClasses.Create.apply _)
 
+  private def continentOptGen: Gen[Option[Continent]] =
+    Gen.option(
+      Gen.oneOf(
+        Continent.Asia,
+        Continent.Africa,
+        Continent.Antarctica,
+        Continent.Australia,
+        Continent.Europe,
+        Continent.NorthAmerica,
+        Continent.SouthAmerica
+      )
+    )
+
   private def campaignCreateGen: Gen[Campaign.Create] =
     (
       nonEmptyStringGen,
@@ -1108,15 +1121,7 @@ object Generators extends ArbitraryInstances {
       Gen.option(nonEmptyStringGen),
       Gen.option(nonEmptyStringGen),
       Gen.option(uuidGen),
-      Gen.option(Gen.oneOf(
-        Continent.Asia,
-        Continent.Africa,
-        Continent.Antarctica,
-        Continent.Australia,
-        Continent.Europe,
-        Continent.NorthAmerica,
-        Continent.SouthAmerica
-      ))
+      continentOptGen
     ).mapN(Campaign.Create.apply _)
 
   object Implicits {
@@ -1371,6 +1376,10 @@ object Generators extends ArbitraryInstances {
       Arbitrary {
         tileLayerCreateGen
       }
+
+    implicit def arbContinent: Arbitrary[Option[Continent]] = Arbitrary {
+      continentOptGen
+    }
 
     implicit def arbCampaignCreate: Arbitrary[Campaign.Create] =
       Arbitrary {

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1108,6 +1108,15 @@ object Generators extends ArbitraryInstances {
       Gen.option(nonEmptyStringGen),
       Gen.option(nonEmptyStringGen),
       Gen.option(uuidGen),
+      Gen.option(Gen.oneOf(
+        Continent.Asia,
+        Continent.Africa,
+        Continent.Antarctica,
+        Continent.Australia,
+        Continent.Europe,
+        Continent.NorthAmerica,
+        Continent.SouthAmerica
+      ))
     ).mapN(Campaign.Create.apply _)
 
   object Implicits {

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1099,17 +1099,15 @@ object Generators extends ArbitraryInstances {
       Gen.const(Nil)
     ).mapN(AnnotationLabelWithClasses.Create.apply _)
 
-  private def continentOptGen: Gen[Option[Continent]] =
-    Gen.option(
-      Gen.oneOf(
-        Continent.Asia,
-        Continent.Africa,
-        Continent.Antarctica,
-        Continent.Australia,
-        Continent.Europe,
-        Continent.NorthAmerica,
-        Continent.SouthAmerica
-      )
+  private def continentGen: Gen[Continent] =
+    Gen.oneOf(
+      Continent.Asia,
+      Continent.Africa,
+      Continent.Antarctica,
+      Continent.Australia,
+      Continent.Europe,
+      Continent.NorthAmerica,
+      Continent.SouthAmerica
     )
 
   private def campaignCreateGen: Gen[Campaign.Create] =
@@ -1121,7 +1119,7 @@ object Generators extends ArbitraryInstances {
       Gen.option(nonEmptyStringGen),
       Gen.option(nonEmptyStringGen),
       Gen.option(uuidGen),
-      continentOptGen
+      Gen.option(continentGen)
     ).mapN(Campaign.Create.apply _)
 
   object Implicits {
@@ -1377,8 +1375,8 @@ object Generators extends ArbitraryInstances {
         tileLayerCreateGen
       }
 
-    implicit def arbContinent: Arbitrary[Option[Continent]] = Arbitrary {
-      continentOptGen
+    implicit def arbContinent: Arbitrary[Continent] = Arbitrary {
+      continentGen
     }
 
     implicit def arbCampaignCreate: Arbitrary[Campaign.Create] =

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -16,7 +16,8 @@ final case class Campaign(
     videoLink: Option[String] = None,
     partnerName: Option[String] = None,
     partnerLogo: Option[String] = None,
-    parentCampaignId: Option[UUID] = None
+    parentCampaignId: Option[UUID] = None,
+    continent: Option[Continent] = None
 )
 
 object Campaign {
@@ -30,7 +31,8 @@ object Campaign {
       videoLink: Option[String] = None,
       partnerName: Option[String] = None,
       partnerLogo: Option[String] = None,
-      parentCampaignId: Option[UUID] = None
+      parentCampaignId: Option[UUID] = None,
+      continent: Option[Continent] = None
   )
 
   object Create {

--- a/app-backend/datamodel/src/main/scala/Continent.scala
+++ b/app-backend/datamodel/src/main/scala/Continent.scala
@@ -1,0 +1,37 @@
+package com.rasterfoundry.datamodel
+
+import cats.syntax.either._
+import io.circe._
+
+sealed abstract class Continent(val repr: String) {
+  override def toString = repr
+}
+
+object Continent {
+  case object Asia extends Continent("ASIA")
+  case object Africa extends Continent("AFRICA")
+  case object Antarctica extends Continent("ANTARCTICA")
+  case object Australia extends Continent("AUSTRALIA")
+  case object Europe extends Continent("EUROPE")
+  case object NorthAmerica extends Continent("NORTH_AMERICA")
+  case object SouthAmerica extends Continent("SOUTH_AMERICA")
+
+  def fromString(s: String): Continent = s.toUpperCase match {
+    case "ASIA"          => Asia
+    case "AFRICA"        => Africa
+    case "ANTARCTICA"    => Antarctica
+    case "AUSTRALIA"     => Australia
+    case "EUROPE"        => Europe
+    case "NORTH_AMERICA" => NorthAmerica
+    case "SOUTH_AMERICA" => SouthAmerica
+    case _               => throw new Exception(s"Invalid Continent: ${s}")
+  }
+
+  implicit val encContinent: Encoder[Continent] =
+    Encoder.encodeString.contramap[Continent](_.toString)
+
+  implicit val decContinent: Decoder[Continent] =
+    Decoder.decodeString.emap { s =>
+      Either.catchNonFatal(fromString(s)).leftMap(_ => "Continent")
+    }
+}

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -704,10 +704,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -704,10 +704,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 
@@ -717,7 +717,8 @@ final case class CampaignQueryParameters(
     ownershipTypeParams: OwnershipTypeQueryParameters =
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
-    campaignType: Option[AnnotationProjectType] = None
+    campaignType: Option[AnnotationProjectType] = None,
+    continent: Option[Continent] = None
 )
 
 object CampaignQueryParameters {

--- a/app-backend/datamodel/src/main/scala/TileLayerQuality.scala
+++ b/app-backend/datamodel/src/main/scala/TileLayerQuality.scala
@@ -16,6 +16,7 @@ object TileLayerQuality {
     case "GOOD"   => Good
     case "BETTER" => Better
     case "BEST"   => Best
+    case _        => throw new Exception(s"Invalid TileLayerQuality: ${s}")
   }
 
   implicit val encTileLayerQuality: Encoder[TileLayerQuality] =

--- a/app-backend/db/src/main/resources/migrations/V50__add_continent_to_campaigns.sql
+++ b/app-backend/db/src/main/resources/migrations/V50__add_continent_to_campaigns.sql
@@ -10,3 +10,7 @@ CREATE TYPE public.continent AS ENUM (
 
 ALTER TABLE public.campaigns
 ADD COLUMN continent continent;
+
+CREATE INDEX IF NOT EXISTS campaigns_continent_idx
+ON public.campaigns
+USING btree (continent);

--- a/app-backend/db/src/main/resources/migrations/V50__add_continent_to_campaigns.sql
+++ b/app-backend/db/src/main/resources/migrations/V50__add_continent_to_campaigns.sql
@@ -1,0 +1,12 @@
+CREATE TYPE public.continent AS ENUM (
+  'ASIA',
+  'AFRICA',
+  'ANTARCTICA',
+  'AUSTRALIA',
+  'EUROPE',
+  'NORTH_AMERICA',
+  'SOUTH_AMERICA'
+);
+
+ALTER TABLE public.campaigns
+ADD COLUMN continent continent;

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -25,7 +25,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
     "video_link",
     "partner_name",
     "partner_logo",
-    "parent_campaign_id"
+    "parent_campaign_id",
+    "continent"
   )
 
   def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
@@ -92,7 +93,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       (uuid_generate_v4(), now(), ${user.id}, ${campaignCreate.name},
        ${campaignCreate.campaignType}, ${campaignCreate.description},
        ${campaignCreate.videoLink}, ${campaignCreate.partnerName},
-       ${campaignCreate.partnerLogo}, ${campaignCreate.parentCampaignId}
+       ${campaignCreate.partnerLogo}, ${campaignCreate.parentCampaignId},
+       ${campaignCreate.continent}
        )
     """).update.withUniqueGeneratedKeys[Campaign](
       fieldNames: _*
@@ -110,7 +112,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       description = ${campaign.description},
       video_link = ${campaign.videoLink},
       partner_name = ${campaign.partnerName},
-      partner_logo = ${campaign.partnerLogo}
+      partner_logo = ${campaign.partnerLogo},
+      continent = ${campaign.continent}
     WHERE
       id = $id
     """).update.run;
@@ -132,7 +135,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
       fr"""SELECT
              uuid_generate_v4(), now(), ${user.id}, name, campaign_type, description, video_link,
-             partner_name, partner_logo, ${id}""" ++
+             partner_name, partner_logo, ${id}, continent""" ++
       fr"""FROM """ ++ tableF ++ fr"""
            WHERE id = ${id}
         """)

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -468,6 +468,9 @@ trait Filterables extends RFMeta with LazyLogging {
           Filters.searchQP(params.searchParams, List("name")) ++
           List(params.campaignType.map({ campaignType =>
             fr"campaign_type = $campaignType"
+          }),
+          params.continent.map({ continent =>
+            fr"continent = $continent"
           }))
     }
 }

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -468,8 +468,7 @@ trait Filterables extends RFMeta with LazyLogging {
           Filters.searchQP(params.searchParams, List("name")) ++
           List(params.campaignType.map({ campaignType =>
             fr"campaign_type = $campaignType"
-          }),
-          params.continent.map({ continent =>
+          }), params.continent.map({ continent =>
             fr"continent = $continent"
           }))
     }

--- a/app-backend/db/src/main/scala/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/meta/EnumMeta.scala
@@ -106,4 +106,11 @@ trait EnumMeta {
       TileLayerQuality.fromString,
       _.repr
     )
+
+  implicit val continentMeta: Meta[Continent] =
+    pgEnumString(
+      "continent",
+      Continent.fromString,
+      _.repr
+    )
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -258,7 +258,7 @@ class CampaignDaoSpec
             userCreate: User.Create,
             campaignCreates1: List[Campaign.Create],
             campaignCreates2: List[Campaign.Create],
-            continentOpt: Option[Continent]
+            continent: Continent
         ) => {
           val pageSize = 30
           val pageRequest = PageRequest(0, pageSize, Map.empty)
@@ -278,7 +278,7 @@ class CampaignDaoSpec
                 .insertCampaign(
                   toInsert.copy(
                     parentCampaignId = None,
-                    continent = continentOpt
+                    continent = Some(continent)
                   ),
                   user
                 )
@@ -286,7 +286,7 @@ class CampaignDaoSpec
             listed <- CampaignDao
               .listCampaigns(
                 pageRequest,
-                CampaignQueryParameters(continent = continentOpt),
+                CampaignQueryParameters(continent = Some(continent)),
                 user
               )
           } yield (listed, insertedCampaigns2)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -9,7 +9,6 @@ import org.scalacheck.Prop.forAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
-import scala.util.Random
 
 class CampaignDaoSpec
     extends AnyFunSuite
@@ -258,21 +257,11 @@ class CampaignDaoSpec
         (
             userCreate: User.Create,
             campaignCreates1: List[Campaign.Create],
-            campaignCreates2: List[Campaign.Create]
+            campaignCreates2: List[Campaign.Create],
+            continentOpt: Option[Continent]
         ) => {
           val pageSize = 30
           val pageRequest = PageRequest(0, pageSize, Map.empty)
-          val continents = List(
-            Continent.Asia,
-            Continent.Africa,
-            Continent.Antarctica,
-            Continent.Australia,
-            Continent.Europe,
-            Continent.NorthAmerica,
-            Continent.SouthAmerica
-          )
-          val continent = continents((new Random).nextInt(continents.size))
-
           val listIO = for {
             user <- UserDao.create(userCreate)
             _ <- campaignCreates1
@@ -289,7 +278,7 @@ class CampaignDaoSpec
                 .insertCampaign(
                   toInsert.copy(
                     parentCampaignId = None,
-                    continent = Some(continent)
+                    continent = continentOpt
                   ),
                   user
                 )
@@ -297,7 +286,7 @@ class CampaignDaoSpec
             listed <- CampaignDao
               .listCampaigns(
                 pageRequest,
-                CampaignQueryParameters(continent = Some(continent)),
+                CampaignQueryParameters(continent = continentOpt),
                 user
               )
           } yield (listed, insertedCampaigns2)


### PR DESCRIPTION
## Overview

This PR adds a nullable `continent` column to `campaigns` table. A QP is added for this field on the `GET` request to `api/campaigns`. It also updates the data model, dao methods, enum meta, and property tests.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Make sure the new column name and type make sense
- CI should pass

