### PR TITLE
Adjust clipping logic to ignore byte rasters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Changed email invitation copy [#5396](https://github.com/raster-foundry/raster-foundry/pull/5396)
 - Add development support for PostgreSQL 12.x/PostGIS 3.x [#5395](https://github.com/raster-foundry/raster-foundry/pull/5395)
 - Upgraded GeoTrellis and Tyelevel libraries to Cats 2.x releases [#5393](https://github.com/raster-foundry/raster-foundry/pull/5393), [#5401](https://github.com/raster-foundry/raster-foundry/pull/5401), [#5402](https://github.com/raster-foundry/raster-foundry/pull/5402)
+- Relaxed criteria used to determine whether or not to clip and stretch imagery [#5411](https://github.com/raster-foundry/raster-foundry/pull/5411)
 
 ### Deprecated
 

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -183,7 +183,8 @@ object ColorCorrect extends LazyLogging {
               val newMax = stats.mean + (stats.stddev * 2.05)
               // assume non-negative values, otherwise visualization is weird
               // I think this happens because the distribution is non-normal
-              iMaxMin(index) = (if (newMin < 0) 0 else newMin.toInt, newMax.toInt)
+              iMaxMin(index) =
+                (if (newMin < 0) 0 else newMin.toInt, newMax.toInt)
             case (min, max, _) => iMaxMin(index) = (min, max)
           }
         }


### PR DESCRIPTION
## Overview

This relaxes assumptions about if an image needs to be rescaled. Before this commit there needed to be a minimum value of `0` and a maximum value of `255` to _not_ clip and stretch.

Now, if the values of a band are between `0` and `255` the image is not rescaled. This covers cases where there may not be a fully white or black pixel in the image.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Before this fix
![image](https://user-images.githubusercontent.com/898060/82349089-b0161400-99c7-11ea-9890-2b114dbef365.png)

After this fix
![image](https://user-images.githubusercontent.com/898060/82349108-b5735e80-99c7-11ea-8229-8bc77bc71dbb.png)

## Testing Instructions

- On `develop` - upload a byte raster with really white areas and watch the image get blown out
- Re-assemble tile server from this PR's branch and restart service
- See that the image improved

Closes #5357 
