### PR TITLE
Add campaign children count and status flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add support for creating users in bulk [#5406](https://github.com/raster-foundry/raster-foundry/pull/5406)
 - Add geometry type and description to Annotation Label Classes [#5408](https://github.com/raster-foundry/raster-foundry/pull/5408)
 - Add image quality to tile layers [#5409](https://github.com/raster-foundry/raster-foundry/pull/5409)
+- Add campaign children count and status flag [#5412](https://github.com/raster-foundry/raster-foundry/pull/5412)
 - Add campaign clone endpoint, add tags to campaigns table [#5413](https://github.com/raster-foundry/raster-foundry/pull/5413)
 
 ### Changed

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -222,7 +222,7 @@ trait CampaignRoutes
             user,
             ObjectType.Campaign,
             campaignId,
-            ActionType.Edit
+            ActionType.View
           )
           .transact(xa)
           .unsafeToFuture

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -20,7 +20,7 @@ final case class Campaign(
     continent: Option[Continent] = None,
     tags: List[String] = List.empty,
     childrenCount: Int,
-    status: Map[String, Int]
+    projectStatuses: Map[String, Int]
 )
 
 object Campaign {

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -18,7 +18,9 @@ final case class Campaign(
     partnerLogo: Option[String] = None,
     parentCampaignId: Option[UUID] = None,
     continent: Option[Continent] = None,
-    tags: List[String] = List.empty
+    tags: List[String] = List.empty,
+    childrenCount: Int,
+    status: Map[String, Int]
 )
 
 object Campaign {

--- a/app-backend/db/src/main/resources/migrations/V52__add_ready_status_and_children_count_on_campaigns.sql
+++ b/app-backend/db/src/main/resources/migrations/V52__add_ready_status_and_children_count_on_campaigns.sql
@@ -1,0 +1,156 @@
+-- update campaigns table to include children_count and status columns
+ALTER TABLE public.campaigns
+ADD COLUMN children_count INTEGER NOT NULL default 0,
+ADD COLUMN status jsonb NOT NULL default '{"WAITING": 0, "QUEUED": 0, "PROCESSING": 0, "READY": 0, "UNKNOWN_FAILURE": 0, "TASK_GRID_FAILURE": 0, "IMAGE_INGESTION_FAILURE": 0}'::jsonb;
+
+-- add indices
+CREATE INDEX IF NOT EXISTS campaigns_children_count_idx
+ON public.campaigns
+USING btree (children_count);
+CREATE INDEX IF NOT EXISTS campaigns_status_idx
+ON public.campaigns
+USING gin (status);
+
+-- a function to construct status jsonb for campaign
+CREATE OR REPLACE FUNCTION CREATE_CAMPAIGN_STATUS (
+  status jsonb
+)
+RETURNS jsonb AS
+$func$
+DECLARE
+  st text;
+  new_status jsonb := '{}'::jsonb;
+BEGIN
+  FOREACH st IN ARRAY enum_range(NULL::annotation_project_status)::text[] LOOP
+    IF (status->>st) IS NULL THEN
+      new_status := new_status || jsonb_build_object(st, 0);
+    ELSE
+      new_status := new_status || status;
+    END IF;
+  END LOOP;
+  RETURN new_status;
+END;
+$func$
+LANGUAGE 'plpgsql';
+
+-- update children_count column for existing campaigns
+UPDATE public.campaigns
+SET children_count = campaign_children_count.children_count
+FROM (
+  SELECT c1.id, count(c2.id) as children_count
+  FROM public.campaigns c1
+  LEFT JOIN public.campaigns c2
+  ON c1.id = c2.parent_campaign_id
+  group by c1.id
+) campaign_children_count
+WHERE campaign_children_count.id = campaigns.id;
+
+-- update status column for existing campaigns
+UPDATE public.campaigns
+SET status = annotation_project_statuses.project_status
+FROM (
+  SELECT
+  statuses.campaign_id, 
+  CREATE_CAMPAIGN_STATUS(
+    jsonb_object_agg(
+      statuses.status,
+      statuses.status_count
+    )
+  ) AS project_status
+  FROM (
+    SELECT status, campaign_id, COUNT(id) AS status_count
+    FROM public.annotation_projects
+    WHERE campaign_id IS NOT NULL
+    GROUP BY status, campaign_id
+  ) statuses
+  GROUP BY statuses.campaign_id
+) AS annotation_project_statuses
+WHERE annotation_project_statuses.campaign_id = id;
+
+-- define the trigger function to update children_count for campaigns
+CREATE OR REPLACE FUNCTION UPDATE_CAMPAIGN_CHILDREN_COUNT()
+  RETURNS trigger AS
+$BODY$
+DECLARE
+  op_campaign_id uuid;
+  surplus integer;
+BEGIN
+  -- the NEW variable holds row for INSERT/UPDATE operations
+  -- the OLD variable holds row for DELETE operations
+  -- store the parent campaign ID
+  IF TG_OP = 'INSERT' THEN
+    op_campaign_id := NEW.parent_campaign_id;
+    surplus := 1;
+  ELSE
+    op_campaign_id := OLD.parent_campaign_id;
+    surplus := -1;
+  END IF;
+  -- update children_count for the parent campaign
+  IF op_campaign_id IS NOT NULL THEN
+    UPDATE public.campaigns
+    SET children_count = children_count + (surplus)
+    WHERE id = op_campaign_id;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    RETURN NEW;
+  ELSE
+    RETURN OLD;
+  END IF;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+-- define the trigger function to update status for campaigns
+CREATE OR REPLACE FUNCTION UPDATE_CAMPAIGN_STATUS()
+  RETURNS trigger AS
+$BODY$
+DECLARE
+  op_campaign_id uuid;
+BEGIN
+  -- the NEW variable holds row for INSERT/UPDATE operations
+  -- the OLD variable holds row for DELETE operations
+  -- store the campaign ID from the annotation project update
+  IF TG_OP = 'UPDATE' THEN
+    op_campaign_id := NEW.campaign_id;
+  END IF;
+  -- update status for the parent campaign
+  IF op_campaign_id IS NOT NULL THEN
+    UPDATE public.campaigns
+    SET status = annotation_project_statuses.project_status
+    FROM (
+      SELECT
+      CREATE_CAMPAIGN_STATUS(
+        jsonb_object_agg(
+          statuses.status,
+          statuses.status_count
+        )
+      ) AS project_status
+      FROM (
+        SELECT status, COUNT(id) AS status_count
+        FROM public.annotation_projects
+        WHERE campaign_id = op_campaign_id
+        GROUP BY status
+      ) statuses
+    ) AS annotation_project_statuses
+    WHERE id = op_campaign_id;
+  END IF;
+  -- result is ignored since this is an AFTER trigger
+  RETURN NULL;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+-- add a trigger to INSERT OR DELETE operations on campaigns table
+CREATE TRIGGER update_campaign_children_count
+  BEFORE INSERT OR DELETE
+  ON campaigns
+  FOR EACH ROW
+  EXECUTE PROCEDURE UPDATE_CAMPAIGN_CHILDREN_COUNT();
+
+-- add a trigger to UPDATE operation on campaigns table
+CREATE TRIGGER update_campaign_status
+  AFTER UPDATE OF status
+  ON annotation_projects
+  FOR EACH ROW
+  EXECUTE PROCEDURE UPDATE_CAMPAIGN_STATUS();

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -30,7 +30,6 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
     "tags",
     "children_count",
     "status"
-
   )
 
   def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
@@ -95,7 +94,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
     (fr"INSERT INTO" ++ tableF ++ fr"""(
       id, created_at, owner, name, campaign_type, description,
       video_link, partner_name, partner_logo, parent_campaign_id,
-      continent
+      continent, tags
     )""" ++
       fr"""VALUES
       (uuid_generate_v4(), now(), ${user.id}, ${campaignCreate.name},

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -29,7 +29,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
     "continent",
     "tags",
     "children_count",
-    "status"
+    "project_statuses"
   )
 
   def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
@@ -154,7 +154,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
       fr"""SELECT
              uuid_generate_v4(), now(), ${user.id}, name, campaign_type, description, video_link,
-             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, status""" ++
+             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, project_statuses""" ++
       fr"""FROM """ ++ tableF ++ fr"""
            WHERE id = ${id}
         """)

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -27,7 +27,10 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
     "partner_logo",
     "parent_campaign_id",
     "continent",
-    "tags"
+    "tags",
+    "children_count",
+    "status"
+
   )
 
   def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
@@ -89,7 +92,11 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       campaignCreate: Campaign.Create,
       user: User
   ): ConnectionIO[Campaign] =
-    (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+    (fr"INSERT INTO" ++ tableF ++ fr"""(
+      id, created_at, owner, name, campaign_type, description,
+      video_link, partner_name, partner_logo, parent_campaign_id,
+      continent
+    )""" ++
       fr"""VALUES
       (uuid_generate_v4(), now(), ${user.id}, ${campaignCreate.name},
        ${campaignCreate.campaignType}, ${campaignCreate.description},
@@ -148,7 +155,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
       fr"""SELECT
              uuid_generate_v4(), now(), ${user.id}, name, campaign_type, description, video_link,
-             partner_name, partner_logo, ${id}, continent, ${tagCol}""" ++
+             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, status""" ++
       fr"""FROM """ ++ tableF ++ fr"""
            WHERE id = ${id}
         """)

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -115,4 +115,7 @@ trait CirceJsonbMeta {
   implicit val annotationProjectTaskStatusSummaryMeta
     : Meta[Option[Map[String, Int]]] =
     CirceJsonbMeta[Option[Map[String, Int]]]
+
+  implicit val campaignStatusMeta: Meta[Map[String, Int]] =
+    CirceJsonbMeta[Map[String, Int]]
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -255,7 +255,8 @@ class CampaignDaoSpec
 
           assert(
             originalCampaign.childrenCount == userCreates.size,
-            "Original campaign's children count is the same as the number of users to be added")
+            "Original campaign's children count is the same as the number of users to be added"
+          )
 
           userCreates.size match {
             case 0 => true
@@ -347,7 +348,10 @@ class CampaignDaoSpec
             "Copy of the campaign has the parent campaign tags"
           )
           true
-        })}}
+        }
+      )
+    }
+  }
 
   test("list campaigns by continent") {
     check {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -344,8 +344,8 @@ class CampaignDaoSpec
             "Copy of the campaign has the parent campaign id"
           )
           assert(
-            originalCampaign.tags.toSet == copiedCampaign.tags.toSet,
-            "Copy of the campaign has the parent campaign tags"
+            clone.tags.toSet == copiedCampaign.tags.toSet,
+            "Copy of the campaign has the given tags"
           )
           true
         }


### PR DESCRIPTION
## Overview

This PR:
- adds `children_count` field to campaigns and adds a DB trigger on `campaigns` table, so that each time an `INSERT` or a `DELETE` is performed on the table, it updates the `children_count` field of the corresponding campaign
- adds `is_ready` field to campaigns and adds a DB trigger on `annotation_projects` table, so that each time an `UPDATE` is performed and if the `campaign_id` field is not empty, plus there is a `status` change, it updates the aggregated status on the `campaigns` table of the corresponding campaign

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [x] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should pass since DB triggers are tested there

Below should already be covered by the CI, but to check it in actions:
- pull down the new `.env` file from development data config bucket, a new auth0 db connection is in there
- `./scripts/load_development_data --download` to get the sample campaign, which has a sample project connected to it. (Feel free to skip it, but remember to: run migrations, create a campaign, and connect some annotation projects to the campaign)
- assemble api server jar
- grab a token from frontend, make sure the account you use is admin of the `Public` organization
- give your dev account "users:bulkCreate" scope in addition to the existing scopes/policies
- run the following to create 5 user: note that the IDs shouldn't need changes if dev DB is updated with the new pgdump; `peudoUserNameType` can be other values too like `GAME_OF_THRONES`, `HARRY_POTTER`, `HOBBIT`, `LORD_OF_THE_RINGS`, `POKEMON`, `RICK_AND_MORTY`, `SUPER_HERO`, `STAR_TREK`
```bash
curl --location --request POST 'http://localhost:9091/api/users/bulk-create' \
--header 'Authorization: Bearer <your token goes here>' \
--header 'Content-Type: application/json' \
--data-raw '{
	"count": 5,
	"peudoUserNameType": "STAR_TREK",
	"platformId": "31277626-968b-4e40-840b-559d9c67863c",
	"organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
	"campaignId": "5c725cdf-e8af-4001-a3c4-98211d02f43e"
}'
```
- Check in the DB that campaign `5c725cdf-e8af-4001-a3c4-98211d02f43e` now has 5 children, which means that the trigger works
- Update `status` of an annotation project, which is connected with a campaign. Check that the campaign's `is_ready` field is changed after updating your project status
