### PR TITLE
Make task unlocker even smarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Task lock expiration now consults previous status, unlocks tasks in any status [#5414](https://github.com/raster-foundry/raster-foundry/pull/5414)
+
 ### Deprecated
 
 ### Removed

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -420,6 +420,7 @@ lazy val db = project
       Dependencies.hikariCP,
       Dependencies.jts,
       Dependencies.mamlJvm,
+      Dependencies.monocleCore,
       Dependencies.postgis,
       Dependencies.postgres,
       Dependencies.refined,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -420,7 +420,7 @@ lazy val db = project
       Dependencies.hikariCP,
       Dependencies.jts,
       Dependencies.mamlJvm,
-      Dependencies.monocleCore,
+      Dependencies.monocleCore % "test",
       Dependencies.postgis,
       Dependencies.postgres,
       Dependencies.refined,

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1329,6 +1329,10 @@ object Generators extends ArbitraryInstances {
       } yield { NEL(h, t) }
     }
 
+    implicit def arbTaskStatus: Arbitrary[TaskStatus] = Arbitrary {
+      taskStatusGen
+    }
+
     implicit def arbTaskFeatureCreate: Arbitrary[Task.TaskFeatureCreate] =
       Arbitrary {
         taskFeatureCreateGen


### PR DESCRIPTION
## Overview

Y'all know what's next right

![](https://media.giphy.com/media/2xBz3g8UXVjUY/giphy.gif)

Anyway, this PR adjusts the task unlocking logic to accomplish three things:

- tasks get automatically unlocked regardless of what their current status is
- if tasks aren't in progress (labeling or validation), then we don't alter their status when we unlock them
- if tasks _are_ in progress, we get their most recent task action stamp and use its `fromStatus`. if there's no action, we revert to unlabeled (how it got into a locked state in progress with no task actions is an exercise for future us if it happens :crossed_fingers: )

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

### Notes

The bulk of the changes are in the test to make sure that we respect the previous status unless we don't need to https://github.com/raster-foundry/raster-foundry/pull/5414/files#diff-a0c18aff8467804d0c25aee7929df7b2R1240

I used optics there to [decrease some copy-pasta](https://github.com/raster-foundry/raster-foundry/pull/5414/commits/5aeb170fc6c5a4681c425e52a2c39f6f1b95d412). I think it's a lot clearer. However, if you, future reader, disagree, I'm not going to die on this hill, since tests especially need to be readable to several people. :man_shrugging:

## Testing Instructions

- verify tests confirm the behavior i described in the overview

Closes raster-foundry/annotate#898
