### PR TITLE
Enable archiving campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add image quality to tile layers [#5409](https://github.com/raster-foundry/raster-foundry/pull/5409)
 - Add campaign children count and status flag [#5412](https://github.com/raster-foundry/raster-foundry/pull/5412)
 - Add campaign clone endpoint, add tags to campaigns table [#5413](https://github.com/raster-foundry/raster-foundry/pull/5413)
+- Enable archiving campaigns [#5415](https://github.com/raster-foundry/raster-foundry/pull/5415)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -27,19 +27,27 @@ trait CampaignProjectRoutes
       ScopedAction(Domain.AnnotationProjects, Action.Read, None),
       user
     ) {
-      (withPagination & annotationProjectQueryParameters) {
-        (page, annotationProjectQP) =>
-          complete {
-            AnnotationProjectDao
-              .listProjects(
-                page,
-                annotationProjectQP.copy(campaignId = Some(campaignId)),
-                user
-              )
-              .transact(xa)
-              .unsafeToFuture
-          }
+      authorizeAsync {
+        CampaignDao
+          .isActiveCampaign(campaignId)
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        (withPagination & annotationProjectQueryParameters) {
+          (page, annotationProjectQP) =>
+            complete {
+              AnnotationProjectDao
+                .listProjects(
+                  page,
+                  annotationProjectQP.copy(campaignId = Some(campaignId)),
+                  user
+                )
+                .transact(xa)
+                .unsafeToFuture
+            }
+        }
       }
+
     }
   }
 }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -217,6 +217,23 @@ trait CampaignRoutes
       user
     ) {
       authorizeAsync {
+        (
+          CampaignDao
+            .authorized(
+              user,
+              ObjectType.Campaign,
+              campaignId,
+              ActionType.View
+            ) map {
+            _.toBoolean
+          },
+          CampaignDao.isActiveCampaign(campaignId)
+        ).tupled
+          .map({ authTup =>
+            authTup._1 && authTup._2
+          })
+          .transact(xa)
+          .unsafeToFuture
         (for {
           auth1 <- CampaignDao
             .authorized(

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -232,7 +232,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         groupQueryParameters &
         parameters(
           'campaignType.as(deserializerAnnotationProjectType).?,
-          'continent.as(deserializerContinent).?
+          'continent.as(deserializerContinent).?,
+          'isActive.as[Boolean].?
         )
     ).as(CampaignQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -20,7 +20,8 @@ final case class Campaign(
     continent: Option[Continent] = None,
     tags: List[String] = List.empty,
     childrenCount: Int,
-    projectStatuses: Map[String, Int]
+    projectStatuses: Map[String, Int],
+    isActive: Boolean
 )
 
 object Campaign {

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -718,7 +718,8 @@ final case class CampaignQueryParameters(
       OwnershipTypeQueryParameters(),
     groupQueryParameters: GroupQueryParameters = GroupQueryParameters(),
     campaignType: Option[AnnotationProjectType] = None,
-    continent: Option[Continent] = None
+    continent: Option[Continent] = None,
+    isActive: Option[Boolean] = None
 )
 
 object CampaignQueryParameters {

--- a/app-backend/db/src/main/resources/migrations/V53__add_is_active_to_campaigns.sql
+++ b/app-backend/db/src/main/resources/migrations/V53__add_is_active_to_campaigns.sql
@@ -1,0 +1,7 @@
+-- update campaigns table to include is_active column
+ALTER TABLE public.campaigns
+ADD COLUMN is_active boolean NOT NULL default true;
+
+CREATE INDEX IF NOT EXISTS campaigns_is_active_idx
+ON public.campaigns
+USING btree (is_active);

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -156,7 +156,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
       fr"""SELECT
              uuid_generate_v4(), now(), ${user.id}, name, campaign_type, description, video_link,
-             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, project_statuses, ${true}""" ++
+             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, project_statuses, true""" ++
       fr"""FROM """ ++ tableF ++ fr"""
            WHERE id = ${id}
         """)

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -29,7 +29,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
     "continent",
     "tags",
     "children_count",
-    "project_statuses"
+    "project_statuses",
+    "is_active"
   )
 
   def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
@@ -121,7 +122,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       partner_name = ${campaign.partnerName},
       partner_logo = ${campaign.partnerLogo},
       continent = ${campaign.continent},
-      tags = ${campaign.tags}
+      tags = ${campaign.tags},
+      is_active = ${campaign.isActive}
     WHERE
       id = $id
     """).update.run;
@@ -154,7 +156,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            INSERT INTO""" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
       fr"""SELECT
              uuid_generate_v4(), now(), ${user.id}, name, campaign_type, description, video_link,
-             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, project_statuses""" ++
+             partner_name, partner_logo, ${id}, continent, ${tagCol}, ${0}, project_statuses, ${true}""" ++
       fr"""FROM """ ++ tableF ++ fr"""
            WHERE id = ${id}
         """)
@@ -173,4 +175,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       }
     } yield campaignCopy
   }
+
+  def isActiveCampaign(id: UUID): ConnectionIO[Boolean] =
+    query.filter(id).filter(fr"is_active = ${true}").exists
 }

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -47,7 +47,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-      : Filterable[Any, TimestampQueryParameters] =
+    : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -59,7 +59,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-      : Filterable[Any, ProjectQueryParameters] =
+    : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -88,7 +88,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-      : Filterable[Any, CombinedToolQueryParameters] =
+    : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -101,7 +101,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-      : Filterable[Any, AnnotationQueryParameters] =
+    : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -140,7 +140,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-      : Filterable[Any, CombinedSceneQueryParams] =
+    : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -204,7 +204,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-      : Filterable[Any, ProjectSceneQueryParameters] =
+    : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -219,7 +219,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-      : Filterable[Any, CombinedMapTokenQueryParameters] =
+    : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -227,7 +227,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-      : Filterable[Any, CombinedToolRunQueryParameters] =
+    : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -274,7 +274,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-      : Filterable[Any, DatasourceQueryParameters] =
+    : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -345,7 +345,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-      : Filterable[Any, ThumbnailQueryParameters] =
+    : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -360,7 +360,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-      : Filterable[Any, PlatformQueryParameters] =
+    : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -370,7 +370,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-      : Filterable[Any, OrganizationQueryParameters] =
+    : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -385,14 +385,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-      : Filterable[Organization, SearchQueryParameters] =
+    : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-      : Filterable[User, SearchQueryParameters] =
+    : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -403,7 +403,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-      : Filterable[Any, Projected[MultiPolygon]] =
+    : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -414,7 +414,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-      : Filterable[Any, StacExportQueryParameters] =
+    : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -431,7 +431,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationProjectQueryParametersFilter
-      : Filterable[Any, AnnotationProjectQueryParameters] =
+    : Filterable[Any, AnnotationProjectQueryParameters] =
     Filterable[Any, AnnotationProjectQueryParameters] {
       params: AnnotationProjectQueryParameters =>
         val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {
@@ -464,7 +464,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val campaignQueryParametersFilter
-      : Filterable[Any, CampaignQueryParameters] =
+    : Filterable[Any, CampaignQueryParameters] =
     Filterable[Any, CampaignQueryParameters] {
       params: CampaignQueryParameters =>
         Filters.ownerQP(params.ownerParams, fr"owner") ++

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -47,7 +47,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-    : Filterable[Any, TimestampQueryParameters] =
+      : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -59,7 +59,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-    : Filterable[Any, ProjectQueryParameters] =
+      : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -88,7 +88,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-    : Filterable[Any, CombinedToolQueryParameters] =
+      : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -101,7 +101,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-    : Filterable[Any, AnnotationQueryParameters] =
+      : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -140,7 +140,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-    : Filterable[Any, CombinedSceneQueryParams] =
+      : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -204,7 +204,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-    : Filterable[Any, ProjectSceneQueryParameters] =
+      : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -219,7 +219,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-    : Filterable[Any, CombinedMapTokenQueryParameters] =
+      : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -227,7 +227,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-    : Filterable[Any, CombinedToolRunQueryParameters] =
+      : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -274,7 +274,7 @@ trait Filterables extends RFMeta with LazyLogging {
   }
 
   implicit val datasourceQueryparamsFilter
-    : Filterable[Any, DatasourceQueryParameters] =
+      : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -345,7 +345,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-    : Filterable[Any, ThumbnailQueryParameters] =
+      : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -360,7 +360,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-    : Filterable[Any, PlatformQueryParameters] =
+      : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -370,7 +370,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-    : Filterable[Any, OrganizationQueryParameters] =
+      : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -385,14 +385,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-    : Filterable[Organization, SearchQueryParameters] =
+      : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-    : Filterable[User, SearchQueryParameters] =
+      : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -403,7 +403,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-    : Filterable[Any, Projected[MultiPolygon]] =
+      : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -414,7 +414,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-    : Filterable[Any, StacExportQueryParameters] =
+      : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -431,21 +431,24 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationProjectQueryParametersFilter
-    : Filterable[Any, AnnotationProjectQueryParameters] =
+      : Filterable[Any, AnnotationProjectQueryParameters] =
     Filterable[Any, AnnotationProjectQueryParameters] {
       params: AnnotationProjectQueryParameters =>
         val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {
           statusList =>
             val statusFilterF = statusList map { status =>
               Some(
-                fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'")
+                fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'"
+              )
             }
             Fragment.const("(") ++ Fragments
               .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
         }
         Filters.ownerQP(params.ownerParams, fr"annotation_projects.owner") ++
-          Filters.searchQP(params.searchParams,
-                           List("annotation_projects.name")) ++
+          Filters.searchQP(
+            params.searchParams,
+            List("annotation_projects.name")
+          ) ++
           List(
             params.projectFilterParams.projectType.map({ projectType =>
               fr"annotation_projects.project_type = $projectType"
@@ -461,16 +464,22 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val campaignQueryParametersFilter
-    : Filterable[Any, CampaignQueryParameters] =
+      : Filterable[Any, CampaignQueryParameters] =
     Filterable[Any, CampaignQueryParameters] {
       params: CampaignQueryParameters =>
         Filters.ownerQP(params.ownerParams, fr"owner") ++
           Filters.searchQP(params.searchParams, List("name")) ++
-          List(params.campaignType.map({ campaignType =>
-            fr"campaign_type = $campaignType"
-          }), params.continent.map({ continent =>
-            fr"continent = $continent"
-          }))
+          List(
+            params.campaignType.map({ campaignType =>
+              fr"campaign_type = $campaignType"
+            }),
+            params.continent.map({ continent =>
+              fr"continent = $continent"
+            }),
+            params.isActive.map({ isActive =>
+              fr"is_active = $isActive"
+            })
+          )
     }
 }
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -448,7 +448,7 @@ class CampaignDaoSpec
             }
             listed <- CampaignDao
               .listCampaigns(
-                pageRequest,
+                pageRequest.copy(limit = pageSize * 2),
                 CampaignQueryParameters(isActive = Some(true)),
                 user
               )


### PR DESCRIPTION
## Overview

This PR adds an `is_active` field in the `campaigns` table to support archiving and unarchiving.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Run migration
- Assemble the api jar, spin up servers
- Log in with the dev account and grab a token
- Test the following request, adjust the `isActive` QP to either `true` or `false`, and make sure it works:
```bash
curl --location --request GET 'http://localhost:9091/api/campaigns?isActive=true' \
--header 'Authorization: Bearer <your token>' \
--header 'Content-Type: application/json' \
```
- Make sure that property tests cover the related dao method in the above request, plus, dao methods for updating this `is_active` field.
