### PR TITLE
Enable sorting by childrenCount and capturedAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Enable sorting by `children_count` on `campaigns` table and `captured_at` on `annotation_projects` table [#5416](https://github.com/raster-foundry/raster-foundry/pull/5416)
 
 ### Changed
 

--- a/app-backend/db/src/main/scala/util/Page.scala
+++ b/app-backend/db/src/main/scala/util/Page.scala
@@ -30,6 +30,8 @@ object Page {
       case "id"           => Some("id")
       case "role"         => Some("role")
       case "visibility"   => Some("visibility")
+      case "childrenCount"=> Some("children_count")
+      case "capturedAt"   => Some("captured_at")
       case _              => None
     }
   }

--- a/app-backend/db/src/main/scala/util/Page.scala
+++ b/app-backend/db/src/main/scala/util/Page.scala
@@ -21,18 +21,18 @@ object Page {
       // the COALESCE of these two columns is indexed already
       case "acquisitionDatetime" =>
         Some("COALESCE(acquisition_date, created_at)")
-      case "sunAzimuth"   => Some("sun_azimuth")
-      case "sunElevation" => Some("sun_elevation")
-      case "cloudCover"   => Some("cloud_cover")
-      case "createdAt"    => Some("created_at")
-      case "modifiedAt"   => Some("modified_at")
-      case "title"        => Some("title")
-      case "id"           => Some("id")
-      case "role"         => Some("role")
-      case "visibility"   => Some("visibility")
-      case "childrenCount"=> Some("children_count")
-      case "capturedAt"   => Some("captured_at")
-      case _              => None
+      case "sunAzimuth"    => Some("sun_azimuth")
+      case "sunElevation"  => Some("sun_elevation")
+      case "cloudCover"    => Some("cloud_cover")
+      case "createdAt"     => Some("created_at")
+      case "modifiedAt"    => Some("modified_at")
+      case "title"         => Some("title")
+      case "id"            => Some("id")
+      case "role"          => Some("role")
+      case "visibility"    => Some("visibility")
+      case "childrenCount" => Some("children_count")
+      case "capturedAt"    => Some("captured_at")
+      case _               => None
     }
   }
 


### PR DESCRIPTION
## Overview

This PR makes it so that sorting is enabled for the `children_count` field in `campaigns` table, and    for the `captured_at` field in the `annotation_projects` table.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Make sure you have loaded the development data lately (because there are sample campaign associated with sample project)
- Assemble the api server jar and spin it up
- Log in to frontend as dev user and grab a token
- `docker-compose logs -f --tail 0 postgres`
- Make sure after making the following request, there is a `ORDER BY captured_at ASC` in the SQL log
```bash
curl --location --request GET 'http://localhost:9091/api/campaigns/5c725cdf-e8af-4001-a3c4-98211d02f43e/projects?sort=capturedAt,asc' \
--header 'Authorization: Bearer <your token>'
```
- Make sure after making the following request, there is a `ORDER BY children_count ASC` in the SQL log
```bash
curl --location --request GET 'http://localhost:9091/api/campaigns?sort=childrenCount,asc' \
--header 'Authorization: Bearer <your token>'
```
