### PR TITLE
Include note when reverting to flagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+
 - Enable sorting by `children_count` on `campaigns` table and `captured_at` on `annotation_projects` table [#5416](https://github.com/raster-foundry/raster-foundry/pull/5416)
 
 ### Changed
 
-- Task lock expiration now consults previous status, unlocks tasks in any status [#5414](https://github.com/raster-foundry/raster-foundry/pull/5414)
+- Task lock expiration now consults previous status, unlocks tasks in any status, and preserves notes [#5414](https://github.com/raster-foundry/raster-foundry/pull/5414), [#5419](https://github.com/raster-foundry/raster-foundry/pull/5419)
 
 ### Deprecated
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -156,7 +156,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
     statusReapingConfig.taskStatusExpirationSeconds.seconds
   private val everyMinute = Cron.unsafeParse("0 * * ? * *")
   val scheduled
-    : fs2.Stream[IO, Int] = awakeEveryCron[IO](everyMinute) *> (fs2.Stream
+      : fs2.Stream[IO, Int] = awakeEveryCron[IO](everyMinute) *> (fs2.Stream
     .eval {
       TaskDao.expireStuckTasks(statusExpirationDuration).transact(xa)
     })
@@ -191,7 +191,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
       .bindHttp(8080, "0.0.0.0")
       .withHttpApp(router.orNotFound)
       .serve
-      .concurrently(scheduled)
+      .concurrently(scheduled.attempt)
 
   val canSelect = sql"SELECT 1".query[Int].unique.transact(xa).unsafeRunSync
   logger.info(s"Server Started (${canSelect})")

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -83,14 +83,14 @@ object Generators extends ArbitraryInstances {
     Gen.oneOf(Visibility.Public, Visibility.Organization, Visibility.Private)
 
   private def taskStatusGen: Gen[TaskStatus] =
-    Gen.oneOf(
-      TaskStatus.Unlabeled,
-      TaskStatus.LabelingInProgress,
-      TaskStatus.Labeled,
-      TaskStatus.ValidationInProgress,
-      TaskStatus.Validated,
-      TaskStatus.Flagged,
-      TaskStatus.Invalid
+    Gen.frequency(
+      (1, TaskStatus.Unlabeled),
+      (1, TaskStatus.LabelingInProgress),
+      (1, TaskStatus.Labeled),
+      (1, TaskStatus.ValidationInProgress),
+      (1, TaskStatus.Validated),
+      (6, TaskStatus.Flagged),
+      (1, TaskStatus.Invalid)
     )
 
   private def userVisibilityGen: Gen[UserVisibility] =


### PR DESCRIPTION
## Overview

This PR makes it so that the task unlocker includes the previous note when a task is reverted to `FLAGGED`. It also makes it so the tile server doesn't fall down if the scheduled task fails. What an oversight! 😞 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

It's not clear to me why the test was passing before. There should have been a `FLAGGED` reversion in those tests somewhere... which should have failed. I'm a little bit confused.

## Testing Instructions

- look at the changes and think about them, since I'm not sure how to make the failure exist in a test

Closes #5418 
