### PR TITLE
Add description field to annotation label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+
 - Enable sorting by `children_count` on `campaigns` table and `captured_at` on `annotation_projects` table [#5416](https://github.com/raster-foundry/raster-foundry/pull/5416)
+- Add description field to annotation label [#5420](https://github.com/raster-foundry/raster-foundry/pull/5420)
 
 ### Changed
 

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1096,7 +1096,8 @@ object Generators extends ArbitraryInstances {
       projectedMultiPolygonGen3857 map { (geom: Projected[MultiPolygon]) =>
         Option(geom)
       },
-      Gen.const(Nil)
+      Gen.const(Nil),
+      Gen.option(nonEmptyStringGen)
     ).mapN(AnnotationLabelWithClasses.Create.apply _)
 
   private def continentGen: Gen[Continent] =

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -137,7 +137,7 @@ object AnnotationLabelWithClasses {
       properties: AnnotationLabelWithClassesPropertiesCreate
   ) {
     def toAnnotationLabelWithClassesCreate
-        : AnnotationLabelWithClasses.Create = {
+      : AnnotationLabelWithClasses.Create = {
       AnnotationLabelWithClasses.Create(
         geometry,
         properties.annotationLabelClasses,
@@ -204,7 +204,7 @@ object AnnotationLabelWithClasses {
                 "annotationTaskId" -> geojson.properties.annotationTaskId.asJson
               ) ++ geojson.classMap.map(e => (e._1 -> e._2.asJson))
             )
-          )
+        )
       )
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -49,8 +49,8 @@ final case class AnnotationLabelWithClasses(
     geometry: Option[Projected[Geometry]],
     annotationProjectId: UUID,
     annotationTaskId: UUID,
-    annotationLabelClasses: List[UUID],
-    description: Option[String] = None
+    description: Option[String] = None,
+    annotationLabelClasses: List[UUID]
 ) extends GeoJSONSerializable[AnnotationLabelWithClasses.GeoJSON] {
   def toGeoJSONFeature = AnnotationLabelWithClasses.GeoJSON(
     this.id,
@@ -118,8 +118,8 @@ object AnnotationLabelWithClasses {
         geometry,
         annotationProjectId,
         annotationTaskId,
-        annotationLabelClasses,
-        description
+        description,
+        annotationLabelClasses
       )
     }
   }

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -17,7 +17,8 @@ final case class AnnotationLabel(
     createdBy: String,
     geometry: Option[Projected[Geometry]],
     annotationProjectId: UUID,
-    annotationTaskId: UUID
+    annotationTaskId: UUID,
+    description: Option[String] = None
 )
 
 @JsonCodec
@@ -25,12 +26,14 @@ final case class AnnotationLabelProperties(
     createdAt: Timestamp,
     createdBy: String,
     annotationProjectId: UUID,
-    annotationTaskId: UUID
+    annotationTaskId: UUID,
+    description: Option[String] = None
 )
 
 final case class AnnotationLabelPropertiesCreate(
     annotationProjectId: UUID,
-    annotationTaskId: UUID
+    annotationTaskId: UUID,
+    description: Option[String] = None
 )
 
 @JsonCodec
@@ -46,7 +49,8 @@ final case class AnnotationLabelWithClasses(
     geometry: Option[Projected[Geometry]],
     annotationProjectId: UUID,
     annotationTaskId: UUID,
-    annotationLabelClasses: List[UUID]
+    annotationLabelClasses: List[UUID],
+    description: Option[String] = None
 ) extends GeoJSONSerializable[AnnotationLabelWithClasses.GeoJSON] {
   def toGeoJSONFeature = AnnotationLabelWithClasses.GeoJSON(
     this.id,
@@ -56,7 +60,8 @@ final case class AnnotationLabelWithClasses(
       this.createdBy,
       this.annotationProjectId,
       this.annotationTaskId,
-      this.annotationLabelClasses
+      this.annotationLabelClasses,
+      this.description
     )
   )
 
@@ -97,7 +102,8 @@ object AnnotationLabelWithClasses {
 
   final case class Create(
       geometry: Option[Projected[Geometry]],
-      annotationLabelClasses: List[UUID]
+      annotationLabelClasses: List[UUID],
+      description: Option[String] = None
   ) {
     def toAnnotationLabelWithClasses(
         annotationProjectId: UUID,
@@ -112,7 +118,8 @@ object AnnotationLabelWithClasses {
         geometry,
         annotationProjectId,
         annotationTaskId,
-        annotationLabelClasses
+        annotationLabelClasses,
+        description
       )
     }
   }
@@ -130,10 +137,11 @@ object AnnotationLabelWithClasses {
       properties: AnnotationLabelWithClassesPropertiesCreate
   ) {
     def toAnnotationLabelWithClassesCreate
-      : AnnotationLabelWithClasses.Create = {
+        : AnnotationLabelWithClasses.Create = {
       AnnotationLabelWithClasses.Create(
         geometry,
-        properties.annotationLabelClasses
+        properties.annotationLabelClasses,
+        properties.description
       )
     }
   }
@@ -196,14 +204,15 @@ object AnnotationLabelWithClasses {
                 "annotationTaskId" -> geojson.properties.annotationTaskId.asJson
               ) ++ geojson.classMap.map(e => (e._1 -> e._2.asJson))
             )
-        )
+          )
       )
   }
 }
 
 @JsonCodec
 final case class AnnotationLabelWithClassesPropertiesCreate(
-    annotationLabelClasses: List[UUID]
+    annotationLabelClasses: List[UUID],
+    description: Option[String] = None
 )
 
 @JsonCodec
@@ -212,7 +221,8 @@ final case class AnnotationLabelWithClassesProperties(
     createdBy: String,
     annotationProjectId: UUID,
     annotationTaskId: UUID,
-    annotationLabelClasses: List[UUID]
+    annotationLabelClasses: List[UUID],
+    description: Option[String] = None
 )
 
 final case class StacGeoJSONFeatureCollection(

--- a/app-backend/db/src/main/resources/migrations/V54__add_description_to_labels.sql
+++ b/app-backend/db/src/main/resources/migrations/V54__add_description_to_labels.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.annotation_labels
+ADD COLUMN description text;

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -23,7 +23,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     "created_by",
     "geometry",
     "annotation_project_id",
-    "annotation_task_id"
+    "annotation_task_id",
+    "description"
   )
   val selectF: Fragment = fr"SELECT" ++
     selectFieldsF ++ fr", classes.class_ids as annotation_label_classes FROM " ++
@@ -60,7 +61,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       (annotationLabel: AnnotationLabelWithClasses) => fr"""(
         ${annotationLabel.id}, ${annotationLabel.createdAt},
         ${annotationLabel.createdBy}, ${annotationLabel.geometry},
-        ${annotationLabel.annotationProjectId}, ${annotationLabel.annotationTaskId}
+        ${annotationLabel.annotationProjectId}, ${annotationLabel.annotationTaskId},
+        ${annotationLabel.description}
        )"""
     )
     val labelClassFragments: List[Fragment] =


### PR DESCRIPTION
## Overview

This PR adds a `description` field to `annotation_labels` table and updates it related data models, dao methods, and generators for property tests. This is to support adding label level descriptions by users.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Make sure the new field makes sense
- CI should pass
