### PR TITLE
Upgrade to sbt-gpg and GnuPG 2+

### DIFF
--- a/.bintray/.credentials
+++ b/.bintray/.credentials
@@ -1,4 +1,0 @@
-realm = Bintray API Realm
-host = api.bintray.com
-user =
-password =

--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ metals.sbt
 /.env
 /.envrc
 .env.local
+*.asc
 
 .node_modules
 dist/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node {
 
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\// ) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\//) {
         env.RF_DEPLOYMENT_BRANCH = 'develop'
         env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
 
@@ -48,11 +48,11 @@ node {
                           credentialsId: 'SONATYPE_PASSWORD',
                           variable: 'SONATYPE_PASSWORD'],
                           [$class: 'StringBinding',
-                          credentialsId: 'PGP_HEX_KEY',
-                          variable: 'PGP_HEX_KEY'],
+                          credentialsId: 'GPG_KEY',
+                          variable: 'GPG_KEY'],
                           [$class: 'StringBinding',
-                          credentialsId: 'PGP_PASSPHRASE',
-                          variable: 'PGP_PASSPHRASE']]) {
+                          credentialsId: 'GPG_KEY_ID',
+                          variable: 'GPG_KEY_ID']]) {
           wrap([$class: 'AnsiColorBuildWrapper']) {
             sh './scripts/cipublish'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node {
 
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\//) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\// || env.BRANCH_NAME == 'PR-5423') {
         env.RF_DEPLOYMENT_BRANCH = 'develop'
         env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
 

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -44,21 +44,26 @@ node {
                         credentialsId: 'SONATYPE_PASSWORD',
                         variable: 'SONATYPE_PASSWORD'],
                         [$class: 'StringBinding',
-                        credentialsId: 'PGP_HEX_KEY',
-                        variable: 'PGP_HEX_KEY'],
+                        credentialsId: 'GPG_KEY',
+                        variable: 'GPG_KEY'],
                         [$class: 'StringBinding',
-                        credentialsId: 'PGP_PASSPHRASE',
-                        variable: 'PGP_PASSPHRASE']]) {
+                        credentialsId: 'GPG_KEY_ID',
+                        variable: 'GPG_KEY_ID']]) {
         wrap([$class: 'AnsiColorBuildWrapper']) {
           sh """#!/bin/bash
             docker-compose \
-               -f "docker-compose.test.yml" \
-               run --rm --no-deps \
-               -e SONATYPE_USERNAME="${SONATYPE_USERNAME}" \
-               -e SONATYPE_PASSWORD="${SONATYPE_PASSWORD}" \
-               -e PGP_HEX_KEY="${PGP_HEX_KEY}" \
-               -e PGP_PASSPHRASE="${PGP_PASSPHRASE}" \
-               build "gitSnapshots ;release release-version ${params.RELEASE_TAG} with-defaults"
+                -f "${DIR}/../docker-compose.test.yml" \
+                run --rm --no-deps --entrypoint "bash -c" \
+                -e SONATYPE_USERNAME="${SONATYPE_USERNAME}" \
+                -e SONATYPE_PASSWORD="${SONATYPE_PASSWORD}" \
+                -e GPG_KEY_ID="${GPG_KEY_ID}" \
+                build "
+                    gpg --keyserver keyserver.ubuntu.com \
+                        --recv-keys ${GPG_KEY_ID} &&
+                    echo ${GPG_KEY} | base64 -d >signing_key.asc &&
+                    gpg --import signing_key.asc &&
+                    ./sbt ";sonatypeOpen ${BUILD_NUMBER};publish;sonatypeRelease"
+                "
           """
         }
       }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -146,7 +146,7 @@ lazy val noPublishSettings = Seq(
 lazy val publishSettings = Seq(
   organization := "com.rasterfoundry",
   organizationName := "Raster Foundry",
-  organizationHomepage := Some(new URL("https://rasterfoundry.com/")),
+  organizationHomepage := Some(new URL("https://rasterfoundry.azavea.com/")),
   description := "A platform to find, combine and analyze earth imagery at any scale.",
 ) ++ sonatypeSettings ++ credentialSettings
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -50,7 +50,7 @@ lazy val sharedSettings = Seq(
   version := {
     // TODO: leave an explaination as to why this is here. e.g. Vagrant -> not
     // mounting .git -> separate sbt container for development
-    if(git.gitHeadCommit.value.isEmpty) "dev"
+    if (git.gitHeadCommit.value.isEmpty) "dev"
     else if (git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value)
       git.gitDescribedVersion.value.get + "-SNAPSHOT"
     else

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -48,8 +48,6 @@ lazy val sharedSettings = Seq(
   // only appends the `-SNAPSHOT` suffix if there are uncommitted
   // changes in the workspace.
   version := {
-    // TODO: leave an explaination as to why this is here. e.g. Vagrant -> not
-    // mounting .git -> separate sbt container for development
     if (git.gitHeadCommit.value.isEmpty) "dev"
     else if (git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value)
       git.gitDescribedVersion.value.get + "-SNAPSHOT"

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -1,21 +1,10 @@
 import xerial.sbt.Sonatype._
-import ReleaseTransformations._
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
-
-addCommandAlias(
-  "gitSnapshots",
-  ";set version in ThisBuild := git.gitDescribedVersion.value.get + \"-SNAPSHOT\""
-)
 
 addCommandAlias(
   "fix",
   ";scalafix;scalafmt;scalafmtSbt"
 )
-
-git.gitTagToVersionNumber in ThisBuild := { tag: String =>
-  if (tag matches "[0-9]+\\..*") Some(tag)
-  else None
-}
 
 scalafixDependencies in ThisBuild ++= Seq(
   "com.nequissimus" %% "sort-imports" % "0.3.2",
@@ -55,6 +44,18 @@ scalaVersion in ThisBuild := Version.scala
   * Shared settings across all subprojects
   */
 lazy val sharedSettings = Seq(
+  // We are overriding the default behavior of sbt-git which, by default,
+  // only appends the `-SNAPSHOT` suffix if there are uncommitted
+  // changes in the workspace.
+  version := {
+    // TODO: leave an explaination as to why this is here. e.g. Vagrant -> not
+    // mounting .git -> separate sbt container for development
+    if(git.gitHeadCommit.value.isEmpty) "dev"
+    else if (git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value)
+      git.gitDescribedVersion.value.get + "-SNAPSHOT"
+    else
+      git.gitDescribedVersion.value.get
+  },
   scapegoatVersion in ThisBuild := "1.3.8",
   scalaVersion in ThisBuild := Version.scala,
   unusedCompileDependenciesFilter -= moduleFilter(
@@ -145,13 +146,14 @@ lazy val noPublishSettings = Seq(
 )
 
 lazy val publishSettings = Seq(
-  // Add the default sonatype repository setting
-  publishTo := sonatypePublishTo.value,
-  publishMavenStyle := true,
   organization := "com.rasterfoundry",
   organizationName := "Raster Foundry",
-  organizationHomepage := Some(new URL("https://www.rasterfoundry.com")),
+  organizationHomepage := Some(new URL("https://rasterfoundry.com/")),
   description := "A platform to find, combine and analyze earth imagery at any scale.",
+) ++ sonatypeSettings ++ credentialSettings
+
+lazy val sonatypeSettings = Seq(
+  publishMavenStyle := true,
   sonatypeProfileName := "com.rasterfoundry",
   sonatypeProjectHosting := Some(
     GitHubHosting(
@@ -165,37 +167,28 @@ lazy val publishSettings = Seq(
       id = "azavea",
       name = "Azavea Inc.",
       email = "systems@azavea.com",
-      url = url("https://www.azavea.com")
+      url = url("https://azavea.com/")
     )
   ),
   licenses := Seq(
     "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
   ),
-  pgpPassphrase := Some(
-    System.getenv().getOrDefault("PGP_PASSPHRASE", "").toCharArray
-  ),
-  pgpSecretRing := file("/root/.gnupg/secring.gpg"),
-  usePgpKeyHex(System.getenv().getOrDefault("PGP_HEX_KEY", "0")),
-  releaseProcess := Seq[ReleaseStep](
-    inquireVersions,
-    setReleaseVersion,
-    releaseStepCommand("publishSigned"),
-    releaseStepCommand("sonatypeReleaseAll")
-  )
-) ++ credentialsSettings
+  publishTo := sonatypePublishTo.value
+)
 
-lazy val credentialsSettings = Seq(
-  // http://web.archive.org/web/20170923125655/http://www.cakesolutions.net/teamblogs/publishing-artefacts-to-oss-sonatype-nexus-using-sbt-and-travis-ci
-  credentials ++= (for {
-    username <- Option(System.getenv().get("SONATYPE_USERNAME"))
-    password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
-  } yield
-    Credentials(
-      "Sonatype Nexus Repository Manager",
-      "oss.sonatype.org",
-      username,
-      password
-    )).toSeq
+lazy val credentialSettings = Seq(
+  credentials += Credentials(
+    "GnuPG Key ID",
+    "gpg",
+    System.getenv().get("GPG_KEY_ID"),
+    "ignored"
+  ),
+  credentials += Credentials(
+    "Sonatype Nexus Repository Manager",
+    "oss.sonatype.org",
+    System.getenv().get("SONATYPE_USERNAME"),
+    System.getenv().get("SONATYPE_PASSWORD")
+  )
 )
 
 lazy val root = project

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -1,8 +1,6 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.2")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
-
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 
@@ -15,8 +13,6 @@ addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
-
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.11")
 

--- a/app-backend/version.sbt
+++ b/app-backend/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "dev"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -130,7 +130,6 @@ services:
       - $HOME/.coursier:/root/.coursier
       - $HOME/.sbt:/root/.sbt
       - $HOME/.aws:/root/.aws:ro
-      - $HOME/.gnupg:/root/.gnupg:ro
     working_dir: /opt/raster-foundry/app-backend/
     entrypoint: ./sbt
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -73,7 +73,6 @@ services:
       - ./data/:/opt/data/
       - $HOME/.sbt:/root/.sbt
       - $HOME/.coursier:/root/.coursier
-      - ./.bintray:/root/.bintray
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/api/target/scala-2.12/
@@ -126,7 +125,6 @@ services:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./scratch/:/opt/raster-foundry/scratch/
       - ./.git:/opt/raster-foundry/.git
-      - ./.bintray:/root/.bintray
       - $HOME/.coursier:/root/.coursier
       - $HOME/.sbt:/root/.sbt
       - $HOME/.aws:/root/.aws:ro
@@ -151,7 +149,6 @@ services:
       - ./data/:/opt/data/
       - $HOME/.sbt:/root/.sbt
       - $HOME/.coursier:/root/.coursier
-      - ./.bintray:/root/.bintray
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
       - ./data/:/opt/data/
       - $HOME/.sbt:/root/.sbt
       - $HOME/.coursier:/root/.coursier
-      - ./.bintray:/root/.bintray
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/api/target/scala-2.12/
@@ -184,7 +183,6 @@ services:
       - ./data/:/opt/data/
       - $HOME/.sbt:/root/.sbt
       - $HOME/.coursier:/root/.coursier
-      - ./.bintray:/root/.bintray
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/backsplash-server/target/scala-2.12/
@@ -218,7 +216,6 @@ services:
       - ./data/:/opt/data/
       - $HOME/.sbt:/root/.sbt
       - $HOME/.coursier:/root/.coursier
-      - ./.bintray:/root/.bintray
       - $HOME/.ivy2:/root/.ivy2
       - $HOME/.aws:/root/.aws:ro
     working_dir: /opt/raster-foundry/app-backend/

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -10,7 +10,7 @@ DIR="$(dirname "$0")"
 
 function usage() {
     echo -n \
-"Usage: $(basename "$0")
+        "Usage: $(basename "$0")
 
 Publish container images to Elastic Container Registry (ECR) and
 other artifacts to S3.
@@ -30,8 +30,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         if [[ -n "${AWS_ECR_ENDPOINT}" ]]; then
             echo "Building sbt container for migrations"
             GIT_COMMIT="${GIT_COMMIT}" docker-compose \
-                      -f "${DIR}/../docker-compose.test.yml"\
-                      build app-migrations
+                -f "${DIR}/../docker-compose.test.yml" \
+                build app-migrations
 
             echo "Building JARs (application, backsplash)"
             docker-compose \
@@ -42,13 +42,13 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             echo "Building python lambda functions"
             rm -rf "${DIR}/../app-lambda/opt/"*
             docker-compose -f "${DIR}/../docker-compose.test.yml" \
-                           run --rm --no-deps lambda \
-                           pip install -t opt/ ./
+                run --rm --no-deps lambda \
+                pip install -t opt/ ./
             docker-compose -f "${DIR}/../docker-compose.test.yml" \
-                           run --rm --no-deps lambda \
-                           cp -r "/opt/raster-foundry/app-lambda/rflambda/" "/opt/raster-foundry/app-lambda/opt/"
+                run --rm --no-deps lambda \
+                cp -r "/opt/raster-foundry/app-lambda/rflambda/" "/opt/raster-foundry/app-lambda/opt/"
             pushd "${DIR}/../app-lambda/opt/"
-              zip -9 -r ../package.zip ./*
+            zip -9 -r ../package.zip ./*
             popd
 
             echo "Uploading python Lambda Function"
@@ -57,14 +57,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 "s3://${RF_ARTIFACTS_BUCKET}/lambda-functions/package-${GIT_COMMIT}.zip"
             rm "${DIR}/../app-lambda/package.zip"
 
-	    echo "Generating typescript interface stubs from Scala datamodel"
-	    docker-compose -f docker-compose.test.yml \
-			   run --rm \
-			   panrec
-	    aws s3 cp --recursive \
-		"${DIR}/../stubs/" \
-		"s3://${RF_ARTIFACTS_BUCKET}/ts-stubs/${GIT_COMMIT}/"
-	    rm -r "${DIR}/../stubs"
+            echo "Generating typescript interface stubs from Scala datamodel"
+            docker-compose -f docker-compose.test.yml \
+                run --rm \
+                panrec
+            aws s3 cp --recursive \
+                "${DIR}/../stubs/" \
+                "s3://${RF_ARTIFACTS_BUCKET}/ts-stubs/${GIT_COMMIT}/"
+            rm -r "${DIR}/../stubs"
 
             # Build publishable sbt projects as SNAPSHOT artifacts and
             # publish to Sonatype OSSRH (Snapshot Repository).
@@ -72,38 +72,43 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                 echo "Publishing SNAPSHOT artifacts to Sonatype OSSRH (Snapshot Repository)"
 
                 docker-compose \
-                   -f "${DIR}/../docker-compose.test.yml" \
-                   run --rm --no-deps \
-                   -e SONATYPE_USERNAME="${SONATYPE_USERNAME}" \
-                   -e SONATYPE_PASSWORD="${SONATYPE_PASSWORD}" \
-                   -e PGP_HEX_KEY="${PGP_HEX_KEY}" \
-                   -e PGP_PASSPHRASE="${PGP_PASSPHRASE}" \
-                   build gitSnapshots publishSigned
+                    -f "${DIR}/../docker-compose.test.yml" \
+                    run --rm --no-deps --entrypoint "bash -c" \
+                    -e SONATYPE_USERNAME="${SONATYPE_USERNAME}" \
+                    -e SONATYPE_PASSWORD="${SONATYPE_PASSWORD}" \
+                    -e GPG_KEY_ID="${GPG_KEY_ID}" \
+                    build "
+                        gpg --keyserver keyserver.ubuntu.com \
+                            --recv-keys ${GPG_KEY_ID} &&
+                        echo ${GPG_KEY} | base64 -d >signing_key.asc &&
+                        gpg --import signing_key.asc &&
+                        ./sbt publish
+                    "
             fi
 
             echo "Building container images"
             GIT_COMMIT="${GIT_COMMIT}" docker-compose \
-                      -f "${DIR}/../docker-compose.yml" \
-                      -f "${DIR}/../docker-compose.test.yml"\
-                      build nginx-api api-server nginx-backsplash backsplash
+                -f "${DIR}/../docker-compose.yml" \
+                -f "${DIR}/../docker-compose.test.yml" \
+                build nginx-api api-server nginx-backsplash backsplash
 
             # Evaluate the return value of the get-login subcommand, which
             # is a docker login command with temporarily ECR credentials.
             eval "$(aws ecr get-login --no-include-email)"
 
             docker tag "raster-foundry-nginx-api:${GIT_COMMIT}" \
-                   "${AWS_ECR_ENDPOINT}/raster-foundry-nginx-api:${GIT_COMMIT}"
+                "${AWS_ECR_ENDPOINT}/raster-foundry-nginx-api:${GIT_COMMIT}"
             docker tag "raster-foundry-api-server:${GIT_COMMIT}" \
-                   "${AWS_ECR_ENDPOINT}/raster-foundry-api-server:${GIT_COMMIT}"
+                "${AWS_ECR_ENDPOINT}/raster-foundry-api-server:${GIT_COMMIT}"
             docker tag "raster-foundry-batch:${GIT_COMMIT}" \
-                   "${AWS_ECR_ENDPOINT}/raster-foundry-batch:${GIT_COMMIT}"
+                "${AWS_ECR_ENDPOINT}/raster-foundry-batch:${GIT_COMMIT}"
             docker tag "raster-foundry-app-migrations:${GIT_COMMIT}" \
-                   "${AWS_ECR_ENDPOINT}/raster-foundry-migrations:${GIT_COMMIT}"
+                "${AWS_ECR_ENDPOINT}/raster-foundry-migrations:${GIT_COMMIT}"
 
             docker tag "raster-foundry-nginx-backsplash:${GIT_COMMIT}" \
-                    "${AWS_ECR_ENDPOINT}/raster-foundry-nginx-backsplash:${GIT_COMMIT}"
+                "${AWS_ECR_ENDPOINT}/raster-foundry-nginx-backsplash:${GIT_COMMIT}"
             docker tag "raster-foundry-backsplash:${GIT_COMMIT}" \
-                    "${AWS_ECR_ENDPOINT}/raster-foundry-backsplash:${GIT_COMMIT}"
+                "${AWS_ECR_ENDPOINT}/raster-foundry-backsplash:${GIT_COMMIT}"
 
             docker push "${AWS_ECR_ENDPOINT}/raster-foundry-nginx-api:${GIT_COMMIT}"
 


### PR DESCRIPTION
## Overview

Make the following changes in-order to align the release signing / publishing workflow with that of GeoTrellis [satellite](http://github.com/geotrellis/geotrellis-server) [projects](http://github.com/geotrellis/maml):

- Replace usage of `sbt-release` with direct invocations of `sbt-sonatype` [commands](https://github.com/xerial/sbt-sonatype#commands)
- Replace `gitSnapshots` and `version.sbt` file flow with a `version` variable in `sharedSettings`
- Replace usage of `sbt-pgp` with `sbt-gpg`—use GnuPG within container image so that the builds no longer require state on build executor
- Remove `sbt-bintray` which was blocking the new workflow with `publish`

In addition, the [signing subkey](https://github.com/azavea/operations/blob/master/doc/GPG.md#signing-subkeys) was renewed out-of-band.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

See Jenkins CI build: http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/job/PR-5423/5/display/redirect.

The changes to `Jenkinsfile.central` incorporate the same flow that is used for releases to GeoTrellis projects. @notthatbreezy, can you let me know when the next release of Raster Foundry will be? The path of least resistance (and little consequence) will be to test those changes live.

Resolves #5265 
