### PR TITLE
Add endpoint to list owners of clones of campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add endpoint for listing users who own a clone of a specified campaign [#5424](https://github.com/raster-foundry/raster-foundry/pull/5424)
 - Enable sorting by `children_count` on `campaigns` table and `captured_at` on `annotation_projects` table [#5416](https://github.com/raster-foundry/raster-foundry/pull/5416)
 - Add description field to annotation label [#5420](https://github.com/raster-foundry/raster-foundry/pull/5420)
 

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -216,3 +216,4 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/permissions,campaigns:share,post
 /api/campaigns/{campaignId}/permissions,campaigns:share,delete
 /api/campaigns/{campaignId}/clone,campaigns:clone,post
+/api/campaigns/{campaignId}/clone-owners,campaigns:clone,get

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -303,4 +303,30 @@ trait CampaignRoutes
       }
     }
   }
+
+  def listCampaignCloneOwners(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Clone, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.Edit
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        complete {
+          CampaignDao
+            .getCloneOwners(campaignId)
+            .transact(xa)
+            .unsafeToFuture
+        }
+      }
+    }
+  }
 }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -54,22 +54,30 @@ trait CampaignRoutes
                 cloneCampaign(campaignId)
               }
             }
-          } ~ pathPrefix("permissions") {
-          pathEndOrSingleSlash {
-            get {
-              listCampaignPermissions(campaignId)
-            } ~
-              put {
-                replaceCampaignPermissions(campaignId)
-              } ~
-              post {
-                addCampaignPermission(campaignId)
-              } ~
-              delete {
-                deleteCampaignPermissions(campaignId)
+          } ~
+          pathPrefix("clone-owners") {
+            pathEndOrSingleSlash {
+              get {
+                listCampaignCloneOwners(campaignId)
               }
-          }
-        } ~
+            }
+          } ~
+          pathPrefix("permissions") {
+            pathEndOrSingleSlash {
+              get {
+                listCampaignPermissions(campaignId)
+              } ~
+                put {
+                  replaceCampaignPermissions(campaignId)
+                } ~
+                post {
+                  addCampaignPermission(campaignId)
+                } ~
+                delete {
+                  deleteCampaignPermissions(campaignId)
+                }
+            }
+          } ~
           pathPrefix("projects") {
             pathEndOrSingleSlash {
               get {

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -178,4 +178,12 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
 
   def isActiveCampaign(id: UUID): ConnectionIO[Boolean] =
     query.filter(id).filter(fr"is_active = ${true}").exists
+
+  def getCloneOwners(id: UUID): ConnectionIO[List[UserThin]] =
+    for {
+      campaigns <- query.filter(fr"parent_campaign_id = ${id}").list
+      userIds = campaigns.map(_.owner)
+      users <- UserDao.getUsersByIds(userIds)
+      userThins = users.map(u => UserThin.fromUser(u))
+    } yield userThins
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -181,7 +181,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
 
   def getCloneOwners(id: UUID): ConnectionIO[List[UserThin]] =
     for {
-      campaigns <- query.filter(fr"parent_campaign_id = ${id}").list
+      campaigns <- query.filter(fr"parent_campaign_id = $id").list
       userIds = campaigns.map(_.owner)
       users <- UserDao.getUsersByIds(userIds)
       userThins = users.map(u => UserThin.fromUser(u))

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -507,7 +507,7 @@ class CampaignDaoSpec
             insertedCampaignAfterCopy <- CampaignDao.unsafeGetCampaignById(
               insertedCampaign.id
             )
-          } yield insertedCampaignAfterCopy
+          } yield insertedCampaign
 
           val originalCampaign = copyIO.transact(xa).unsafeRunSync
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -504,20 +504,13 @@ class CampaignDaoSpec
             _ <- children traverse { child =>
               CampaignDao.copyCampaign(insertedCampaign.id, child)
             }
-            insertedCampaignAfterCopy <- CampaignDao.unsafeGetCampaignById(
-              insertedCampaign.id
-            )
-          } yield insertedCampaign
+            cloneOwners <- CampaignDao.getCloneOwners(insertedCampaign.id)
+          } yield cloneOwners
 
-          val originalCampaign = copyIO.transact(xa).unsafeRunSync
-
-          val cloneOwners = CampaignDao
-            .getCloneOwners(originalCampaign.id)
-            .transact(xa)
-            .unsafeRunSync
+          val cloneOwners = copyIO.transact(xa).unsafeRunSync
 
           assert(
-            cloneOwners.length == userCreates.size,
+            cloneOwners.length == userCreates.length,
             "Returned number of clone owners matches the number of users created"
           )
           true


### PR DESCRIPTION
## Overview

This PR adds an endpoint  `/campaigns/{id}/clone-owners` that returns a list of users who own clones for a given campaign.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Notes
The endpoint is a little dumb and does not de-duplicate

## Testing Instructions

- Verify that CI passes and that the tests are sufficient and sensible
- If you want, create a campaign and hit the endpoint, verify you an empty list back. Add some clones and verify that the endpoint returns the owners of those clones
