### PR TITLE
Update campaign clone endpoint; update user bulk create endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Task lock expiration now consults previous status, unlocks tasks in any status, and preserves notes [#5414](https://github.com/raster-foundry/raster-foundry/pull/5414), [#5419](https://github.com/raster-foundry/raster-foundry/pull/5419)
+- Update campaign clone endpoint and user bulk create endpoint [#5425](https://github.com/raster-foundry/raster-foundry/pull/5425)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -260,7 +260,7 @@ trait CampaignRoutes
                     Some(campaignClone.tags)
                   )
                   copiedProjects <- AnnotationProjectDao.listByCampaign(
-                    campaignId
+                    copiedCampaign.id
                   )
                   originalCampaignO <- CampaignDao.getCampaignById(campaignId)
                   originalCampaignOwnerO = originalCampaignO map { _.owner }

--- a/app-backend/api/src/main/scala/user/PseudoUsernameService.scala
+++ b/app-backend/api/src/main/scala/user/PseudoUsernameService.scala
@@ -35,7 +35,7 @@ object PseudoUsernameService {
         s"${faker.superhero().prefix()} ${faker
           .superhero()
           .descriptor()} ${uuidSegOne} ${uuidSegTwo}"
-    }).replaceAll("\\s", "-")
+    }).replaceAll("\\s", "-").toLowerCase().capitalize
   }
 
   def createPseudoNames(

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1125,7 +1125,10 @@ object Generators extends ArbitraryInstances {
     ).mapN(Campaign.Create.apply _)
 
   private def campaignCloneGen: Gen[Campaign.Clone] =
-    stringListGen.map(Campaign.Clone.apply _)
+    (
+      stringListGen,
+      arbitrary[Boolean]
+    ).mapN(Campaign.Clone.apply _)
 
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] = Arbitrary {

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -45,7 +45,8 @@ object Campaign {
   }
 
   final case class Clone(
-      tags: List[String] = List.empty
+      tags: List[String] = List.empty,
+      grantAccessToParentCampaignOwner: Boolean = false
   )
 
   object Clone {

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -264,7 +264,9 @@ case class UserBulkCreate(
     peudoUserNameType: PseudoUsernameType,
     organizationId: UUID,
     platformId: UUID,
-    campaignId: Option[UUID] = None
+    campaignId: Option[UUID] = None,
+    grantAccessToParentCampaignOwner: Boolean = false,
+    grantAccessToChildrenCampaignOwner: Boolean = false
 )
 
 object UserBulkCreate {
@@ -276,3 +278,5 @@ case class UserInfo(
     email: String,
     name: String
 )
+
+case class UserWithCampaign(user: User, campaignO: Option[Campaign])

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",
@@ -468,4 +468,38 @@ object AnnotationProjectDao
 
   def listByCampaign(campaignId: UUID): ConnectionIO[List[AnnotationProject]] =
     query.filter(fr"campaign_id = $campaignId").list
+
+  def assignUsersToProjectsByCampaign(
+      campaignId: UUID,
+      usersO: Option[List[User]]
+  ): ConnectionIO[List[AnnotationProject]] =
+    for {
+      projects <- AnnotationProjectDao.listByCampaign(
+        campaignId
+      )
+      _ <- projects traverse { project =>
+        usersO traverse { users =>
+          val rules =
+            users.foldLeft(List[ObjectAccessControlRule]())(
+              (acc, user) =>
+                acc ++ List(
+                  ObjectAccessControlRule(
+                    SubjectType.User,
+                    Some(user.id),
+                    ActionType.View
+                  ),
+                  ObjectAccessControlRule(
+                    SubjectType.User,
+                    Some(user.id),
+                    ActionType.Annotate
+                  )
+                )
+            )
+          AnnotationProjectDao.addPermissionsMany(
+            project.id,
+            rules
+          )
+        }
+      }
+    } yield projects
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",
@@ -493,7 +493,7 @@ object AnnotationProjectDao
                     Some(user.id),
                     ActionType.Annotate
                   )
-                )
+              )
             )
           AnnotationProjectDao.addPermissionsMany(
             project.id,


### PR DESCRIPTION
## Overview

This PR updates the campaign clone endpoint and user bulk create endpoint so that:
- when a user `A` clones a campaign from one of the existing campaigns owned by `B`, the existing campaign owner `B` will have:
     - `VIEW` access to the cloned campaign
     - `VIEW` and `ANNOTATE` accesses to the cloned campaign projects
- when a user `A` creates more users (`BCD...`) in bulk that are owners of the cloned campaigns:
     - user `A` will have:
              - `VIEW` access to the cloned campaigns
              - `VIEW` and `ANNOTATE` accesses to all the cloned campaign projects
     - the users `BCD...` will have:
              - `VIEW` and `ANNOTATE` accesses to all the cloned campaign projects

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~


## Testing Instructions

- Make sure you have loaded the most recent dev db dump. Run migrations if you have not done it in a while. 
- Make sure the dev user has the following scopes in DB in addition to its existing scopes: `users:bulkCreate;campaigns:clone;`
- Log in with the dev user from frontend, grab a `token`
- Test the campaign clone endpoint:
```
curl --location --request POST 'http://localhost:9091/api/campaigns/5c725cdf-e8af-4001-a3c4-98211d02f43e/clone' \
--header 'Authorization: Bearer <token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "tags": ["CompSci"],
    "grantAccessToParentCampaignOwner": true
}'
```
- Grab the `id` from the response of the above request, I will name it as `campaignId` from here on
- In DB, test the following and make sure it shows something similar as the example:
```bash
rasterfoundry=# select acrs from campaigns where id = '<campaignId>';
                    acrs                    
--------------------------------------------
 {USER;auth0|59318a9d2fbbca3e16bcfc92;VIEW}
(1 row)

rasterfoundry=# select acrs from annotation_projects where campaign_id = '<campaignId>';
                                          acrs                                           
-----------------------------------------------------------------------------------------
 {USER;auth0|59318a9d2fbbca3e16bcfc92;VIEW,USER;auth0|59318a9d2fbbca3e16bcfc92;ANNOTATE}
(1 row)
```
- Test the user bulk create endpoint:
```bash
curl --location --request POST 'http://localhost:9091/api/users/bulk-create' \
--header 'Authorization: Bearer <token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "count": 2,
    "peudoUserNameType": "POKEMON",
    "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
    "platformId": "31277626-968b-4e40-840b-559d9c67863c",
    "campaignId": "<campaignId>",
    "grantAccessToParentCampaignOwner": true,
    "grantAccessToChildrenCampaignOwner": true
}'
```
- In DB, test the following and make sure it shows something similar as the example:
```bash
rasterfoundry=# select acrs from campaigns where parent_campaign_id = '<campaignId>';
                    acrs                    
--------------------------------------------
 {USER;auth0|59318a9d2fbbca3e16bcfc92;VIEW}
 {USER;auth0|59318a9d2fbbca3e16bcfc92;VIEW}
(2 rows)

rasterfoundry=# select acrs from annotation_projects where campaign_id in ( select id  from campaigns where parent_campaign_id = '<campaignId>');
                                                                                                                                acrs                                                                                
                                                 
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------
 {USER;auth0|59318a9d2fbbca3e16bcfc92;VIEW,USER;auth0|59318a9d2fbbca3e16bcfc92;ANNOTATE,USER;auth0|5ef279a72da9bb00136e66cc;VIEW,USER;auth0|5ef279a72da9bb00136e66cc;ANNOTATE,USER;auth0|5ef279a76769d8001322eb72;VI
EW,USER;auth0|5ef279a76769d8001322eb72;ANNOTATE}
 {USER;auth0|59318a9d2fbbca3e16bcfc92;VIEW,USER;auth0|59318a9d2fbbca3e16bcfc92;ANNOTATE,USER;auth0|5ef279a72da9bb00136e66cc;VIEW,USER;auth0|5ef279a72da9bb00136e66cc;ANNOTATE,USER;auth0|5ef279a76769d8001322eb72;VI
EW,USER;auth0|5ef279a76769d8001322eb72;ANNOTATE}
(2 rows)
```

Closes https://github.com/azavea/earthrise/issues/52
