### PR TITLE
Don't throw in circejsonbmeta

### DIFF
--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -15,7 +15,7 @@ import scala.reflect.runtime.universe.TypeTag
 
 object CirceJsonbMeta {
   def apply[Type: TypeTag: Encoder: Decoder] = {
-    val get = Get[Json].tmap[Type](_.as[Type].valueOr(throw _))
+    val get = Get[Json].temap[Type](_.as[Type].leftMap(_.message))
     val put = Put[Json].tcontramap[Type](_.asJson)
     new Meta[Type](get, put)
   }


### PR DESCRIPTION
## Overview

This PR makes circejsonbmeta not throw if the json is the wrong type. I don't know what it will do in practice, but that seems good and should let doobie handle what to do with errors instead of just plain exploding.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~

### Notes

upstreamed from work in azavea/franklin#286

## Testing Instructions

- ci