### PR TITLE
Update user bulk create endpoint for ACRs

### DIFF
--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -340,7 +340,7 @@ trait UserRoutes
                               Some(user.id),
                               ActionType.View
                             )
-                          }
+                        }
                       )
                       (
                         campaingRulesO match {

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -334,16 +334,13 @@ trait UserRoutes
                     campaigns traverse { campaign =>
                       val campaingRulesO = usersO.map(
                         users =>
-                          users.foldLeft(List[ObjectAccessControlRule]())(
-                            (acc, user) =>
-                              acc ++ List(
-                                ObjectAccessControlRule(
-                                  SubjectType.User,
-                                  Some(user.id),
-                                  ActionType.View
-                                )
+                          users map { user =>
+                            ObjectAccessControlRule(
+                              SubjectType.User,
+                              Some(user.id),
+                              ActionType.View
                             )
-                        )
+                          }
                       )
                       (
                         campaingRulesO match {

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -18,6 +18,7 @@ import cats.implicits._
 import com.dropbox.core.{DbxAppInfo, DbxRequestConfig, DbxWebAuth}
 import com.typesafe.scalalogging.LazyLogging
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 
@@ -331,8 +332,33 @@ trait UserRoutes
                   }
                   _ <- campaignsO traverse { campaigns =>
                     campaigns traverse { campaign =>
-                      AnnotationProjectDao
-                        .assignUsersToProjectsByCampaign(campaign.id, usersO)
+                      val campaingRulesO = usersO.map(
+                        users =>
+                          users.foldLeft(List[ObjectAccessControlRule]())(
+                            (acc, user) =>
+                              acc ++ List(
+                                ObjectAccessControlRule(
+                                  SubjectType.User,
+                                  Some(user.id),
+                                  ActionType.View
+                                )
+                              )
+                          )
+                      )
+                      (
+                        campaingRulesO match {
+                          case Some(rules) =>
+                            CampaignDao.addPermissionsMany(
+                              campaign.id,
+                              rules
+                            )
+                          case _ =>
+                            List[ObjectAccessControlRule]().pure[ConnectionIO]
+
+                        },
+                        AnnotationProjectDao
+                          .assignUsersToProjectsByCampaign(campaign.id, usersO)
+                      ).tupled
                         .transact(xa)
                         .unsafeToFuture()
                     }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -342,8 +342,8 @@ trait UserRoutes
                                   Some(user.id),
                                   ActionType.View
                                 )
-                              )
-                          )
+                            )
+                        )
                       )
                       (
                         campaingRulesO match {


### PR DESCRIPTION
## Overview

This PR updates the user bulk create endpoint, so that the cloned campaigns are shared to the created users with `VIEW` action, when `grantAccessToChildrenCampaignOwner` is set to `true` in the request body.

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Make sure you have loaded the most recent dev db dump. Run migrations if you have not done it in a while. 
- Make sure the dev user has the following scopes in DB in addition to its existing scopes: `users:bulkCreate;`
- Log in with the dev user from frontend, grab a `token`
- Grab a `campaignId`  from the DB
- Test the user bulk create endpoint:
```bash
curl --location --request POST 'http://localhost:9091/api/users/bulk-create' \
--header 'Authorization: Bearer <token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "count": 2,
    "peudoUserNameType": "POKEMON",
    "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
    "platformId": "31277626-968b-4e40-840b-559d9c67863c",
    "campaignId": "<campaignId>",
    "grantAccessToParentCampaignOwner": true,
    "grantAccessToChildrenCampaignOwner": true
}'
```
- In DB, test the following:
```bash
select acrs from campaigns where parent_campaign_id = '<campaignId>';
```
- Make sure that you see the user IDs of the two newly created users, and that they are given `VIEW` access
