### PR TITLE
Upgrade sbt-assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 
+- Upgraded sbt-assembly to 0.15.0 [#5434](https://github.com/raster-foundry/raster-foundry/pull/5434/files)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Changed
 
-- Upgraded sbt-assembly to 0.15.0 [#5434](https://github.com/raster-foundry/raster-foundry/pull/5434/files)
+- Upgraded sbt-assembly to 0.15.0 and removed superfluous build.sbt files [#5434](https://github.com/raster-foundry/raster-foundry/pull/5434/files)
 
 ### Deprecated
 

--- a/app-backend/api/build.sbt
+++ b/app-backend/api/build.sbt
@@ -1,3 +1,0 @@
-name := "api"
-
-assemblyJarName in assembly := "api-assembly.jar"

--- a/app-backend/batch/build.sbt
+++ b/app-backend/batch/build.sbt
@@ -1,3 +1,0 @@
-name := "batch"
-
-assemblyJarName in assembly := "batch-assembly.jar"

--- a/app-backend/batch/build.sbt
+++ b/app-backend/batch/build.sbt
@@ -1,20 +1,3 @@
 name := "batch"
 
 assemblyJarName in assembly := "batch-assembly.jar"
-
-mainClass in (Compile, assembly) := Some("com.rasterfoundry.batch.Main")
-
-javaOptions += "-Xmx2G"
-
-fork in run := true
-
-test in assembly := {}
-
-assemblyMergeStrategy in assembly := {
-  case "reference.conf"   => MergeStrategy.concat
-  case "application.conf" => MergeStrategy.concat
-  case n if n.endsWith(".SF") || n.endsWith(".RSA") || n.endsWith(".DSA") =>
-    MergeStrategy.discard
-  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
-  case _                      => MergeStrategy.first
-}

--- a/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
+++ b/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
@@ -7,7 +7,7 @@ object HealthCheck extends LazyLogging {
   val name = "healthcheck"
 
   def run(): Unit = {
-    logger.info("Batch containers and he batch jar are friends")
+    logger.info("Batch containers and the batch jar are friends")
   }
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
+++ b/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
@@ -7,9 +7,7 @@ object HealthCheck extends LazyLogging {
   val name = "healthcheck"
 
   def run(): Unit = {
-    val rs = GeoTiffRasterSource("s3://rasterfoundry-development-data-us-east-1/test.tif")
-    rs.tiff
-    logger.info("The batch jar can run and can read tifs")
+    logger.info("Batch containers and he batch jar are friends")
   }
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
+++ b/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
@@ -1,12 +1,15 @@
 package com.rasterfoundry.batch.healthcheck
 
 import com.typesafe.scalalogging.LazyLogging
+import geotrellis.raster.geotiff.GeoTiffRasterSource
 
 object HealthCheck extends LazyLogging {
   val name = "healthcheck"
 
   def run(): Unit = {
-    logger.info("Batch containers and the batch jar are friends")
+    val rs = GeoTiffRasterSource("s3://rasterfoundry-development-data-us-east-1/test.tif")
+    rs.tiff
+    logger.info("The batch jar can run and can read tifs")
   }
 
   def main(args: Array[String]): Unit = {

--- a/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
+++ b/app-backend/batch/src/main/scala/healthcheck/HealthCheck.scala
@@ -1,7 +1,6 @@
 package com.rasterfoundry.batch.healthcheck
 
 import com.typesafe.scalalogging.LazyLogging
-import geotrellis.raster.geotiff.GeoTiffRasterSource
 
 object HealthCheck extends LazyLogging {
   val name = "healthcheck"

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -130,7 +130,8 @@ lazy val sharedSettings = Seq(
     "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full
   ),
   addCompilerPlugin(scalafixSemanticdb), // enable SemanticDB
-  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4")
+  addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.2.4"),
+  test in assembly := {}
 ) ++ publishSettings
 
 lazy val noPublishSettings = Seq(
@@ -216,7 +217,6 @@ lazy val apiSettings = sharedSettings ++ Seq(
   connectInput in run := true,
   cancelable in Global := true,
   resolvers += Resolver.bintrayRepo("azavea", "maven"),
-  test in assembly := {}
 )
 
 lazy val apiDependencies = Seq(
@@ -685,7 +685,6 @@ lazy val backsplashServer =
     })
     .settings(addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.7"))
     .settings(assemblyJarName in assembly := "backsplash-assembly.jar")
-    .settings(test in assembly := {})
 
 /**
   * http4s Utility project

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -272,6 +272,9 @@ lazy val api = project
   .settings({
     libraryDependencies ++= apiDependencies ++ loggingDependencies
   })
+  .settings(
+    assemblyJarName in assembly := "api-assembly.jar"
+  )
 
 lazy val apiIntegrationTest = project
   .in(file("api-it"))
@@ -374,6 +377,7 @@ lazy val datamodel = project
 lazy val db = project
   .in(file("db"))
   .dependsOn(common % "compile->compile;test->test", notification)
+  .settings(name := "database")
   .settings(sharedSettings: _*)
   .settings({
     libraryDependencies ++= Seq(
@@ -423,6 +427,7 @@ lazy val db = project
       Dependencies.typesafeConfig
     ) ++ loggingDependencies
   })
+  .settings(testOptions in Test += Tests.Argument("-oD"))
 
 /**
   * Batch Settings
@@ -504,6 +509,7 @@ lazy val batch = project
         .inAll
     )
   )
+  .settings(assemblyJarName in assembly := "batch-assembly.jar")
 
 /**
   * Akkautil Settings

--- a/app-backend/db/build.sbt
+++ b/app-backend/db/build.sbt
@@ -1,3 +1,0 @@
-name := "database"
-
-testOptions in Test += Tests.Argument("-oD")

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("io.crashbox" % "sbt-gpg" % "0.2.1")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 


### PR DESCRIPTION
## Overview

This PR upgrades sbt assembly. For some reason our assembly merge strategy isn't even being applied, but upgrading sbt changes some order, so it makes the S3RangeReaderProvider visible to the service loader. That's a deeply unsatisfying outcome to this debugging adventure, so I'm opening a second issue to figure out why our merge strategy doesn't seem to be applied at all. It's pretty weird! But this fixes the immediate problem.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possibleion test csv

### Notes

This makes the S3RangeReaderProvider visible to the service loader, but the GDALRasterSourceProvider is still not available. The only place where that might matter is in the raster source metadata backfill batch job, which we don't need to run anymore, so I think that's acceptable. I didn't bother removing that here because I wanted the changes to be as small as possible and for later adventures to consider bigger questions like "is this code actually dead?"

## Testing Instructions

- assemble batch jar
- run a stac export
- it shouldn't explode from not being able to find a range reader that can read from s3

Closes #5429 