### PR TITLE
Implement endpoint for campaign random review task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Campaigns can provide a random reviewable task for users to review [#5435](https://github.com/raster-foundry/raster-foundry/pull/5435)
 - Campaigns can copy labels back from their children's annotation projects [#5436](https://github.com/raster-foundry/raster-foundry/pull/5436)
 
 ### Changed

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -218,3 +218,4 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/permissions,campaigns:share,delete
 /api/campaigns/{campaignId}/clone,campaigns:clone,post
 /api/campaigns/{campaignId}/clone-owners,campaigns:clone,get
+/api/campaigns/{campaignId}/random-review-task,campaigns:read,get

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -405,32 +405,32 @@ trait CampaignRoutes
       }
 
     }
+  }
 
-    def retrieveChildCampaignLabels(campaignId: UUID): Route = authenticate {
-      user =>
-        authorizeScope(
-          ScopedAction(Domain.Campaigns, Action.Clone, None),
-          user
-        ) {
-          authorizeAuthResultAsync {
+  def retrieveChildCampaignLabels(campaignId: UUID): Route = authenticate {
+    user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Clone, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          CampaignDao
+            .authorized(
+              user,
+              ObjectType.Campaign,
+              campaignId,
+              ActionType.Edit
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess {
             CampaignDao
-              .authorized(
-                user,
-                ObjectType.Campaign,
-                campaignId,
-                ActionType.Edit
-              )
+              .retrieveChildCampaignAnnotations(campaignId)
               .transact(xa)
               .unsafeToFuture
-          } {
-            onSuccess {
-              CampaignDao
-                .retrieveChildCampaignAnnotations(campaignId)
-                .transact(xa)
-                .unsafeToFuture
-            } { complete(StatusCodes.NoContent) }
-          }
+          } { complete(StatusCodes.NoContent) }
         }
-    }
+      }
   }
 }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -62,6 +62,13 @@ trait CampaignRoutes
               }
             }
           } ~
+          pathPrefix("random-review-task") {
+            pathEndOrSingleSlash {
+              get {
+                getReviewTask(campaignId)
+              }
+            }
+          } ~
           pathPrefix("permissions") {
             pathEndOrSingleSlash {
               get {
@@ -365,6 +372,31 @@ trait CampaignRoutes
             .unsafeToFuture
         }
       }
+    }
+  }
+
+  def getReviewTask(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Read, None),
+      user
+    ) {
+      authorizeAsync {
+        CampaignDao
+          .isActiveCampaign(campaignId)
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        complete {
+          CampaignDao
+            .randomReviewTask(
+              campaignId,
+              user
+            )
+            .transact(xa)
+            .unsafeToFuture
+        }
+      }
+
     }
   }
 }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -405,26 +405,32 @@ trait CampaignRoutes
       }
 
     }
-    
-  def retrieveChildCampaignLabels(campaignId: UUID): Route = authenticate {
-    user =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Clone, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(user, ObjectType.Campaign, campaignId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess {
+
+    def retrieveChildCampaignLabels(campaignId: UUID): Route = authenticate {
+      user =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Clone, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             CampaignDao
-              .retrieveChildCampaignAnnotations(campaignId)
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
               .transact(xa)
               .unsafeToFuture
-          } { complete(StatusCodes.NoContent) }
+          } {
+            onSuccess {
+              CampaignDao
+                .retrieveChildCampaignAnnotations(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            } { complete(StatusCodes.NoContent) }
+          }
         }
-      }
+    }
   }
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.database
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
 
+import cats.data.OptionT
 import cats.implicits._
 import doobie._
 import doobie.implicits._
@@ -186,4 +187,79 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       users <- UserDao.getUsersByIds(userIds)
       userThins = users.map(u => UserThin.fromUser(u))
     } yield userThins
+
+  def randomReviewTask(
+      campaignId: UUID,
+      user: User
+  ): ConnectionIO[Option[Task.TaskFeatureWithCampaign]] = {
+    fr"""
+      WITH parent_tasks (id) AS (
+        SELECT t1.id
+        FROM tasks t1
+        WHERE t1.annotation_project_id IN (
+          SELECT id
+          FROM annotation_projects
+          WHERE campaign_id IN (
+            SELECT id
+            FROM campaigns c
+            WHERE c.parent_campaign_id = ${campaignId}
+          )
+        )
+        AND t1.task_type = ${TaskType.Label.toString}::task_type
+        AND t1.parent_task_id IS NULL
+      ),
+      -- ids of tasks that have at least 3 validated sub-tasks
+      validated_ids (id) AS (
+        SELECT t1.id
+        FROM parent_tasks t1
+        JOIN tasks t2
+          ON t2.parent_task_id = t1.id
+        WHERE t2.task_type = ${TaskType.Review.toString}::task_type
+          AND t2.status <> ${TaskStatus.Labeled.toString}::task_status
+        GROUP BY t1.id
+        HAVING COUNT(t2.id) >= 3
+      ),
+      reviewed_by_user_counts (id, id2, reviewed) AS (
+        SELECT t1.id, t2.id, COUNT(ta.*)
+        FROM parent_tasks t1
+        JOIN tasks t2
+          ON t2.parent_task_id = t1.id
+        JOIN task_actions ta
+          ON ta.task_id = t2.id
+          AND ta.user_id = ${user.id}
+          AND ta.to_status = ${TaskStatus.Validated.toString}::task_status
+        WHERE t2.task_type = ${TaskType.Review.toString}::task_type
+        GROUP BY t1.id, t2.id
+      ),
+      reviewed_ids (id) AS (
+        SELECT parent_tasks.id
+        FROM parent_tasks
+        JOIN reviewed_by_user_counts r
+          ON r.id = parent_tasks.id
+        GROUP BY parent_tasks.id
+        HAVING SUM(r.reviewed) >= 1
+      )
+      SELECT *, annotation_projects.campaign_id
+      FROM tasks
+      JOIN annotation_projects
+        ON tasks.annotation_project_id = annotation_projects.id
+      WHERE
+        parent_task_id NOT IN (SELECT id FROM validated_ids)
+        AND parent_task_id NOT IN (SELECT id FROM reviewed_ids)
+        AND parent_task_id IS NOT NULL
+        AND task_type = ${TaskType.Review.toString}::task_type
+      ORDER BY RANDOM() LIMIT 1;
+    """
+      .query[Task.TaskWithCampaign]
+      .to[List] flatMap { tasks =>
+      tasks.toNel traverse { tasks =>
+        (for {
+          task <- OptionT(TaskDao.getTaskById(tasks.head.id))
+          actions <- OptionT.liftF(TaskDao.getTaskActions(task.id))
+        } yield {
+          tasks.head.toGeoJSONFeature(actions)
+        }).value
+      }
+    } map { _.flatten }
+  }
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -193,7 +193,6 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       userThins = users.map(u => UserThin.fromUser(u))
     } yield userThins
 
-  <<<<<<< HEAD
   def randomReviewTask(
       campaignId: UUID,
       user: User
@@ -268,7 +267,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       }
     } map { _.flatten }
   }
-  =======
+
   def getProjectMapping(
       childCampaignId: UUID,
       parentDateMap: Map[Timestamp, UUID]
@@ -312,5 +311,4 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
           AnnotationLabelDao.copyProjectAnnotations(childId, parentId)
       }
     } yield ()
-  >>>>>>> develop
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -193,7 +193,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       userThins = users.map(u => UserThin.fromUser(u))
     } yield userThins
 
-<<<<<<< HEAD
+  <<<<<<< HEAD
   def randomReviewTask(
       campaignId: UUID,
       user: User
@@ -268,7 +268,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       }
     } map { _.flatten }
   }
-=======
+  =======
   def getProjectMapping(
       childCampaignId: UUID,
       parentDateMap: Map[Timestamp, UUID]
@@ -312,5 +312,5 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
           AnnotationLabelDao.copyProjectAnnotations(childId, parentId)
       }
     } yield ()
->>>>>>> develop
+  >>>>>>> develop
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassDaoSpec.scala
@@ -68,7 +68,7 @@ class AnnotationLabelClassDaoSpec
                   alc.index,
                   alc.geometryType,
                   alc.description
-                )
+              )
             )
             .toSet
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -417,7 +417,12 @@ class AnnotationLabelDaoSpec
                 group.classes
                   .map(_.name)
                   .toSet
-                  .contains(labelProperties.toMap.get(groupName).map(_.asString).flatten.get),
+                  .contains(
+                    labelProperties.toMap
+                      .get(groupName)
+                      .map(_.asString)
+                      .flatten
+                      .get),
                 "stac label value for group name exists"
               )
             })

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -511,4 +511,321 @@ class CampaignDaoSpec
       )
     }
   }
+
+  test("no tasks are returned when all have been validated") {
+    check {
+      forAll(
+        (
+            userCreateBase: User.Create,
+            userCreates: List[User.Create],
+            userCreate: User.Create,
+            campaignCreate: Campaign.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate
+        ) => {
+          val copyIO = for {
+            parent <- UserDao.create(userCreate)
+            children <- userCreateBase :: userCreates traverse { u =>
+              UserDao.create(u)
+            }
+            insertedCampaign <- CampaignDao
+              .insertCampaign(
+                campaignCreate.copy(parentCampaignId = None),
+                parent
+              )
+            insertedProject <- AnnotationProjectDao
+              .insert(
+                annotationProjectCreate.copy(
+                  campaignId = Some(insertedCampaign.id),
+                  status = AnnotationProjectStatus.Waiting
+                ),
+                parent
+              )
+            _ <- AnnotationProjectDao.update(
+              insertedProject.toProject
+                .copy(status = AnnotationProjectStatus.Ready),
+              insertedProject.id
+            )
+            campaignCopies <- children traverse { child =>
+              CampaignDao.copyCampaign(insertedCampaign.id, child)
+            }
+            projectCopies <- (campaignCopies traverse { c =>
+              AnnotationProjectDao.listByCampaign(c.id)
+            }) map (_.flatten)
+            projectCopiesWithRelated <- projectCopies traverse { pc =>
+              AnnotationProjectDao.getWithRelatedById(pc.id)
+            } map (_.flatten)
+            tasks <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                taskFeaturesCreate,
+                projectCopiesWithRelated.head
+              ),
+              parent
+            )
+            _ <- TaskDao.updateTask(
+              tasks.features.head.id,
+              Task.TaskFeatureCreate(
+                tasks.features.head.properties.toCreate
+                  .copy(
+                    status = TaskStatus.Labeled,
+                    parentTaskId = None,
+                    taskType = Some(TaskType.Label)
+                  ),
+                tasks.features.head.geometry,
+                "Feature"
+              ),
+              parent
+            )
+            _ <- tasks.features.tail traverse { f =>
+              TaskDao.updateTask(
+                f.id,
+                Task.TaskFeatureCreate(
+                  f.properties.toCreate
+                    .copy(
+                      status = TaskStatus.Validated,
+                      parentTaskId = Some(tasks.features.head.id),
+                      taskType = Some(TaskType.Review)
+                    ),
+                  f.geometry,
+                  "Feature"
+                ),
+                parent
+              )
+            }
+            randomTask <- CampaignDao
+              .randomReviewTask(insertedCampaign.id, parent)
+          } yield randomTask
+
+          val randomTask = copyIO.transact(xa).unsafeRunSync
+
+          assert(
+            randomTask.isEmpty,
+            "When all tasks are validated no tasks should be returned"
+          )
+
+          true
+        }
+      )
+    }
+  }
+
+  test("a task is returned when none have been validated") {
+    check {
+      forAll(
+        (
+            userCreate1: User.Create,
+            userCreate2: User.Create,
+            userCreates: List[User.Create],
+            userCreate: User.Create,
+            campaignCreate: Campaign.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate
+        ) => {
+          val copyIO = for {
+            parent <- UserDao.create(userCreate)
+            children <- userCreate1 :: userCreate2 :: userCreates traverse {
+              u =>
+                UserDao.create(u)
+            }
+            insertedCampaign <- CampaignDao
+              .insertCampaign(
+                campaignCreate.copy(parentCampaignId = None),
+                parent
+              )
+            insertedProject <- AnnotationProjectDao
+              .insert(
+                annotationProjectCreate.copy(
+                  campaignId = Some(insertedCampaign.id),
+                  status = AnnotationProjectStatus.Waiting
+                ),
+                parent
+              )
+            _ <- AnnotationProjectDao.update(
+              insertedProject.toProject
+                .copy(status = AnnotationProjectStatus.Ready),
+              insertedProject.id
+            )
+            campaignCopies <- children traverse { child =>
+              CampaignDao.copyCampaign(insertedCampaign.id, child)
+            }
+            projectCopies <- (campaignCopies traverse { c =>
+              AnnotationProjectDao.listByCampaign(c.id)
+            }) map (_.flatten)
+            projectCopiesWithRelated <- projectCopies traverse { pc =>
+              AnnotationProjectDao.getWithRelatedById(pc.id)
+            } map (_.flatten)
+            tasks <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                taskFeaturesCreate,
+                projectCopiesWithRelated.head
+              ),
+              parent
+            )
+            _ <- TaskDao.updateTask(
+              tasks.features.head.id,
+              Task.TaskFeatureCreate(
+                tasks.features.head.properties.toCreate
+                  .copy(
+                    status = TaskStatus.Labeled,
+                    taskType = Some(TaskType.Label)
+                  ),
+                tasks.features.head.geometry,
+                "Feature"
+              ),
+              parent
+            )
+            _ <- tasks.features.tail traverse { f =>
+              TaskDao.updateTask(
+                f.id,
+                Task.TaskFeatureCreate(
+                  f.properties.toCreate
+                    .copy(
+                      status = TaskStatus.Labeled,
+                      parentTaskId = Some(tasks.features.head.id),
+                      taskType = Some(TaskType.Review)
+                    ),
+                  f.geometry,
+                  "Feature"
+                ),
+                parent
+              )
+            }
+            randomTask <- CampaignDao
+              .randomReviewTask(insertedCampaign.id, parent)
+          } yield (tasks, randomTask)
+          val (tasks, randomTask) = copyIO.transact(xa).unsafeRunSync
+
+          assert(
+            tasks.features.length > 1 == randomTask.isDefined,
+            "When no tasks are validated one task should be returned"
+          )
+
+          true
+        }
+      )
+    }
+  }
+
+  test("a task is not returned when parent has been validated by user") {
+    check {
+      forAll {
+        (
+            userCreates: List[User.Create],
+            userCreates1: (User.Create, User.Create, User.Create),
+            campaignCreate: Campaign.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeatureCreates: (Task.TaskFeatureCreate, Task.TaskFeatureCreate),
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+        ) =>
+          {
+            val (userCreate1, userCreate2, userCreate3) = userCreates1
+            val (taskFeatureCreate1, taskFeatureCreate2) = taskFeatureCreates
+            val copyIO = for {
+              parent <- UserDao.create(userCreate1)
+              children <- userCreate2 :: userCreate3 :: userCreates traverse {
+                u =>
+                  UserDao.create(u)
+              }
+              insertedCampaign <- CampaignDao
+                .insertCampaign(
+                  campaignCreate.copy(parentCampaignId = None),
+                  parent
+                )
+              insertedProject <- AnnotationProjectDao
+                .insert(
+                  annotationProjectCreate.copy(
+                    campaignId = Some(insertedCampaign.id),
+                    status = AnnotationProjectStatus.Waiting
+                  ),
+                  parent
+                )
+              _ <- AnnotationProjectDao.update(
+                insertedProject.toProject
+                  .copy(status = AnnotationProjectStatus.Ready),
+                insertedProject.id
+              )
+              campaignCopies <- children traverse { child =>
+                CampaignDao.copyCampaign(insertedCampaign.id, child)
+              }
+              projectCopies <- (campaignCopies traverse { c =>
+                AnnotationProjectDao.listByCampaign(c.id)
+              }) map (_.flatten)
+              projectCopiesWithRelated <- projectCopies traverse { pc =>
+                AnnotationProjectDao.getWithRelatedById(pc.id)
+              } map (_.flatten)
+              tasks <- TaskDao.insertTasks(
+                fixupTaskFeaturesCollection(
+                  Task.TaskFeatureCollectionCreate(
+                    features = taskFeatureCreate1 :: taskFeatureCreate2.copy(
+                      properties = taskFeatureCreate2.properties.copy(
+                        status = TaskStatus.Labeled
+                      )
+                    ) :: taskFeatureCollectionCreate.features
+                  ),
+                  projectCopiesWithRelated.head
+                ),
+                parent
+              )
+              _ <- TaskDao.updateTask(
+                tasks.features.head.id,
+                Task.TaskFeatureCreate(
+                  tasks.features.head.properties.toCreate
+                    .copy(
+                      status = TaskStatus.Labeled,
+                      taskType = Some(TaskType.Label)
+                    ),
+                  tasks.features.head.geometry,
+                  "Feature"
+                ),
+                parent
+              )
+              _ <- TaskDao.updateTask(
+                tasks.features(1).id,
+                Task.TaskFeatureCreate(
+                  tasks
+                    .features(1)
+                    .properties
+                    .toCreate
+                    .copy(
+                      status = TaskStatus.Validated,
+                      parentTaskId = Some(tasks.features.head.id),
+                      taskType = Some(TaskType.Review)
+                    ),
+                  tasks.features(1).geometry,
+                  "Feature"
+                ),
+                parent
+              )
+              _ <- tasks.features.drop(2) traverse { f =>
+                TaskDao.updateTask(
+                  f.id,
+                  Task.TaskFeatureCreate(
+                    f.properties.toCreate
+                      .copy(
+                        status = TaskStatus.Labeled,
+                        parentTaskId = Some(tasks.features.head.id),
+                        taskType = Some(TaskType.Review)
+                      ),
+                    f.geometry,
+                    "Feature"
+                  ),
+                  parent
+                )
+              }
+              randomTask <- CampaignDao
+                .randomReviewTask(insertedCampaign.id, parent)
+            } yield randomTask
+
+            val randomTask = copyIO.transact(xa).unsafeRunSync
+
+            assert(
+              randomTask.isEmpty,
+              "When a user has already validated a task, no tasks are returned"
+            )
+
+            true
+          }
+      }
+    }
+  }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -827,6 +827,7 @@ class CampaignDaoSpec
               randomTask.isEmpty,
               "When a user has already validated a task, no tasks are returned"
             )
+            true
           }
       }
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -827,6 +827,10 @@ class CampaignDaoSpec
               randomTask.isEmpty,
               "When a user has already validated a task, no tasks are returned"
             )
+          }
+      }
+    }
+  }
 
   test("copy annotations back from child campaigns") {
     check {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -65,7 +65,9 @@ class StacExportDaoSpec
             "Sent and inserted StacExport taskStatuses should be the same"
           )
           assert(
-            se.annotationProjectId.map(_ == seCreate.annotationProjectId).getOrElse(false),
+            se.annotationProjectId
+              .map(_ == seCreate.annotationProjectId)
+              .getOrElse(false),
             "Sent and inserted StacExport annotation project ids should be the same"
           )
           true


### PR DESCRIPTION
## Overview

This pr adds the endpoint `/campaigns/{lesson_campaign_id}/random-review-task` which returns a task of type `Review` when possible.

There are some conditions on getting a task back:
  - if a user has already validated a parent task, the endpoint will not return a review task for it
  - if a parent task has already been validated 3 times, the endpoint will not return a review task for it

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Notes

It just occurred to me while writing out this PR that maybe we don't need to check for the number of times a task has been validated since that could be controlled by only creating a certain number of review tasks and if they are all validated, they would not be returned. Thoughts?

## Testing Instructions

- Verify that the tests are sensible
- CI
