### PR TITLE
Copy child campaign projects' labels to parent campaigns projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Campaigns can copy labels back from their children's annotation projects [#5436](https://github.com/raster-foundry/raster-foundry/pull/5436)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -218,3 +218,4 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/permissions,campaigns:share,delete
 /api/campaigns/{campaignId}/clone,campaigns:clone,post
 /api/campaigns/{campaignId}/clone-owners,campaigns:clone,get
+/api/campaigns/{campaignId}/retrieve-child-labels,campaigns:clone,post

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -144,7 +144,7 @@ lazy val publishSettings = Seq(
   organization := "com.rasterfoundry",
   organizationName := "Raster Foundry",
   organizationHomepage := Some(new URL("https://rasterfoundry.azavea.com/")),
-  description := "A platform to find, combine and analyze earth imagery at any scale.",
+  description := "A platform to find, combine and analyze earth imagery at any scale."
 ) ++ sonatypeSettings ++ credentialSettings
 
 lazy val sonatypeSettings = Seq(
@@ -216,7 +216,7 @@ lazy val apiSettings = sharedSettings ++ Seq(
   fork in run := true,
   connectInput in run := true,
   cancelable in Global := true,
-  resolvers += Resolver.bintrayRepo("azavea", "maven"),
+  resolvers += Resolver.bintrayRepo("azavea", "maven")
 )
 
 lazy val apiDependencies = Seq(
@@ -411,6 +411,7 @@ lazy val db = project
       Dependencies.jts,
       Dependencies.mamlJvm,
       Dependencies.monocleCore % "test",
+      Dependencies.newtype,
       Dependencies.postgis,
       Dependencies.postgres,
       Dependencies.refined,

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1104,7 +1104,9 @@ object Generators extends ArbitraryInstances {
       Gen.listOfN(3, labelClassGroupGen),
       annotationProjectStatusGen,
       Gen.const(None),
-      Gen.const(None)
+      // always generate a timestamp -- copying child project labels back requires one,
+      // and it doesn't hurt anything else to have one
+      Gen.const(Some(Timestamp.valueOf(LocalDate.now.atStartOfDay)))
     ).mapN(AnnotationProject.Create.apply _)
 
   private def annotationLabelWithClassesCreateGen

--- a/app-backend/db/src/main/resources/migrations/V57__add_breadcrumb_tables_for_project_copying.sql
+++ b/app-backend/db/src/main/resources/migrations/V57__add_breadcrumb_tables_for_project_copying.sql
@@ -2,3 +2,9 @@ CREATE TABLE public.label_class_history (
     parent_label_class_id uuid not null,
     child_label_class_id uuid not null
 );
+
+CREATE INDEX IF NOT EXISTS label_class_history_parent_label_class_id_idx
+ON public.label_class_history (parent_label_class_id);
+
+CREATE INDEX IF NOT EXISTS label_class_history_child_label_class_id_idx
+ON public.label_class_history (child_label_class_id);

--- a/app-backend/db/src/main/resources/migrations/V57__add_breadcrumb_tables_for_project_copying.sql
+++ b/app-backend/db/src/main/resources/migrations/V57__add_breadcrumb_tables_for_project_copying.sql
@@ -1,0 +1,4 @@
+CREATE TABLE public.label_class_history (
+    parent_label_class_id uuid not null,
+    child_label_class_id uuid not null
+);

--- a/app-backend/db/src/main/resources/migrations/V57__add_breadcrumb_tables_for_project_copying.sql
+++ b/app-backend/db/src/main/resources/migrations/V57__add_breadcrumb_tables_for_project_copying.sql
@@ -1,6 +1,6 @@
 CREATE TABLE public.label_class_history (
-    parent_label_class_id uuid not null,
-    child_label_class_id uuid not null
+    parent_label_class_id uuid not null references annotation_label_classes (id),
+    child_label_class_id uuid not null references annotation_label_classes (id)
 );
 
 CREATE INDEX IF NOT EXISTS label_class_history_parent_label_class_id_idx

--- a/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
@@ -33,16 +33,16 @@ object AnnotationLabelClassDao extends Dao[AnnotationLabelClass] {
       parent: Option[AnnotationLabelClass]
   ): ConnectionIO[AnnotationLabelClass] =
     for {
-      newLabel <- (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+      newLabelClass <- (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
         fr"""VALUES (
         uuid_generate_v4(), ${classCreate.name}, ${annotationLabelGroup.id},
         ${classCreate.colorHexCode}, ${classCreate.default}, ${classCreate.determinant},
         ${classCreate.index}, ${classCreate.geometryType}, ${classCreate.description}
       )""").update.withUniqueGeneratedKeys[AnnotationLabelClass](fieldNames: _*)
       _ <- parent traverse { parentClass =>
-        fr"INSERT INTO label_class_history VALUES (${parentClass.id}, ${newLabel.id})".update.run
+        fr"INSERT INTO label_class_history VALUES (${parentClass.id}, ${newLabelClass.id})".update.run
       }
-    } yield newLabel
+    } yield newLabelClass
 
   def listAnnotationLabelClassByGroupId(
       groupId: UUID

--- a/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.database
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
 
+import cats.implicits._
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
@@ -28,15 +29,20 @@ object AnnotationLabelClassDao extends Dao[AnnotationLabelClass] {
 
   def insertAnnotationLabelClass(
       classCreate: AnnotationLabelClass.Create,
-      annotationLabelGroup: AnnotationLabelClassGroup
-  ): ConnectionIO[AnnotationLabelClass] = {
-    (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
-      fr"""VALUES (
+      annotationLabelGroup: AnnotationLabelClassGroup,
+      parent: Option[AnnotationLabelClass]
+  ): ConnectionIO[AnnotationLabelClass] =
+    for {
+      newLabel <- (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+        fr"""VALUES (
         uuid_generate_v4(), ${classCreate.name}, ${annotationLabelGroup.id},
         ${classCreate.colorHexCode}, ${classCreate.default}, ${classCreate.determinant},
         ${classCreate.index}, ${classCreate.geometryType}, ${classCreate.description}
       )""").update.withUniqueGeneratedKeys[AnnotationLabelClass](fieldNames: _*)
-  }
+      _ <- parent traverse { parentClass =>
+        fr"INSERT INTO label_class_history VALUES (${parentClass.id}, ${newLabel.id})".update.run
+      }
+    } yield newLabel
 
   def listAnnotationLabelClassByGroupId(
       groupId: UUID

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -1,6 +1,7 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.database.types._
 import com.rasterfoundry.datamodel._
 
 import cats.data._

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -227,17 +227,13 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
         SELECT id, array_agg(annotation_class_id) as class_ids
         FROM source_labels_with_classes GROUP BY id
       ),
-      new_labels AS (
-        SELECT uuid_generate_v4() as id, created_at, created_by,
-               ${parentAnnotationProjectId.parentAnnotationProjectId} as annotation_project_id,
-               ${parentTask.id} as annotation_task_id,
-               geometry, description
-        FROM source_labels
-      ),
       new_labels_insert AS (
         INSERT INTO annotation_labels (
-          SELECT id, created_at, created_by, annotation_project_id, annotation_task_id, geometry, description
-          FROM new_labels
+          SELECT uuid_generate_v4() as id, created_at, created_by,
+                 ${parentAnnotationProjectId.parentAnnotationProjectId} as annotation_project_id,
+                 ${parentTask.id} as annotation_task_id,
+                 geometry, description
+          FROM source_labels
         )
       ),
       unnested as (

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -195,4 +195,53 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       ).asJson
     fcIo.value
   }
+
+  def copyProjectAnnotations(
+      childAnnotationProjectId: ChildAnnotationProjectId,
+      parentAnnotationProjectId: ParentAnnotationProjectId
+  ): ConnectionIO[Unit] =
+    for {
+      parentTask <- TaskDao.query
+        .filter(
+          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+        )
+        .select
+      _ <- fr"""
+      WITH source_labels_with_classes AS (
+        SELECT * FROM
+          (annotation_labels JOIN annotation_labels_annotation_label_classes ON
+             annotation_labels.id = annotation_labels_annotation_label_classes.annotation_label_id)
+        WHERE
+          annotation_project_id = ${childAnnotationProjectId.childAnnotationProjectId}
+      ),
+      grouped AS (
+        SELECT id, created_at, created_by, annotation_project_id, annotation_task_id,
+               geometry, description, array_agg(label_class_id) as class_ids
+        FROM source_labels_with_classes GROUP BY id
+      ),
+      new_labels AS (
+        SELECT uuid_generate_v4(), created_at, created_by,
+               ${parentAnnotationProjectId.parentAnnotationProjectId}, ${parentTask.id},
+               geometry, description, class_ids
+        FROM grouped
+      ),
+      new_labels_insert AS (
+        INSERT INTO annotation_labels (
+          SELECT id, created_at, created_by, annotation_project_id, annotation_task_id, geometry, description
+          FROM new_labels
+        )
+      ),
+      unnested as (
+        SELECT id, unnest(class_ids) as class_id FROM new_labels
+      )
+      INSERT INTO annotation_labels_annotation_label_classes (
+        SELECT id, parent_label_class_id
+        FROM unnested JOIN label_class_history
+        ON unnested.class_id = label_class_history.child_label_class_id
+      )
+      """.update.run
+      // ^^ works fine to create new labels... but how to get their classes?
+      // thinking through maybe a temp table strategy? i don't know how to keep the label
+      // join information around. maybe i can do it with CTEs if I think harder about it
+    } yield ()
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",
@@ -450,7 +450,8 @@ object AnnotationProjectDao
                 }
               ),
               annotationProjectCopy,
-              0
+              0,
+              labelClasses
             )
         } yield newClassGroup
       }
@@ -493,7 +494,7 @@ object AnnotationProjectDao
                     Some(user.id),
                     ActionType.Annotate
                   )
-              )
+                )
             )
           AnnotationProjectDao.addPermissionsMany(
             project.id,

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",
@@ -494,7 +494,7 @@ object AnnotationProjectDao
                     Some(user.id),
                     ActionType.Annotate
                   )
-                )
+              )
             )
           AnnotationProjectDao.addPermissionsMany(
             project.id,

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -9,8 +9,8 @@ import doobie.implicits._
 import doobie.implicits.javasql._
 import doobie.postgres.implicits._
 
-import java.util.UUID
 import java.sql.Timestamp
+import java.util.UUID
 
 object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
 

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -206,7 +206,9 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       }
     }
 
-  def retrieveChildCampaignAnnotations(campaignId: UUID): ConnectionIO[Unit] =
+  def retrieveChildCampaignAnnotations(
+      campaignId: UUID
+  ): ConnectionIO[List[(UUID, UUID)]] =
     for {
       childCampaigns <- getChildren(campaignId)
       parentProjects <- AnnotationProjectDao.listByCampaign(campaignId)
@@ -227,7 +229,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       childParentMapping = childParentMappings.combineAll
       // now we have a map of child annotation projects to parent annotation projects,
       // so we no longer care about campaigns
-      _ <- childParentMapping traverse {
+      result <- childParentMapping traverse {
         case (
             childId,
             parentId
@@ -237,5 +239,5 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
             parentId
           )
       }
-    } yield (())
+    } yield result.flatten
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -208,7 +208,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
 
   def retrieveChildCampaignAnnotations(
       campaignId: UUID
-  ): ConnectionIO[List[(UUID, UUID)]] =
+  ): ConnectionIO[Unit] =
     for {
       childCampaigns <- getChildren(campaignId)
       parentProjects <- AnnotationProjectDao.listByCampaign(campaignId)
@@ -229,15 +229,9 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       childParentMapping = childParentMappings.combineAll
       // now we have a map of child annotation projects to parent annotation projects,
       // so we no longer care about campaigns
-      result <- childParentMapping traverse {
-        case (
-            childId,
-            parentId
-            ) =>
-          AnnotationLabelDao.copyProjectAnnotations(
-            childId,
-            parentId
-          )
+      _ <- childParentMapping traverse {
+        case (childId, parentId) =>
+          AnnotationLabelDao.copyProjectAnnotations(childId, parentId)
       }
-    } yield result.flatten
+    } yield ()
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -1,6 +1,7 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.database.types._
 import com.rasterfoundry.datamodel._
 
 import cats.implicits._

--- a/app-backend/db/src/main/scala/package.scala
+++ b/app-backend/db/src/main/scala/package.scala
@@ -5,8 +5,16 @@ import com.rasterfoundry.database.meta.RFMeta
 import com.rasterfoundry.datamodel.Credential
 
 import doobie.Meta
+import io.estatico.newtype.macros.newtype
+
+import java.util.UUID
 
 package object database {
+
+  // to differentiate copy operations between parent and child annotation projects
+  @newtype case class ParentAnnotationProjectId(parentAnnotationProjectId: UUID)
+  @newtype case class ChildAnnotationProjectId(childAnnotationProjectId: UUID)
+
   object Implicits extends RFMeta with Filterables {
     def fromString(s: String): Credential = {
       Credential.apply(Some(s))

--- a/app-backend/db/src/main/scala/package.scala
+++ b/app-backend/db/src/main/scala/package.scala
@@ -5,15 +5,8 @@ import com.rasterfoundry.database.meta.RFMeta
 import com.rasterfoundry.datamodel.Credential
 
 import doobie.Meta
-import io.estatico.newtype.macros.newtype
-
-import java.util.UUID
 
 package object database {
-
-  // to differentiate copy operations between parent and child annotation projects
-  @newtype case class ParentAnnotationProjectId(parentAnnotationProjectId: UUID)
-  @newtype case class ChildAnnotationProjectId(childAnnotationProjectId: UUID)
 
   object Implicits extends RFMeta with Filterables {
     def fromString(s: String): Credential = {

--- a/app-backend/db/src/main/scala/types.scala
+++ b/app-backend/db/src/main/scala/types.scala
@@ -1,0 +1,12 @@
+package com.rasterfoundry.database
+
+import io.estatico.newtype.macros.newtype
+
+import java.util.UUID
+
+@SuppressWarnings(Array("AsInstanceOf"))
+object types {
+  // to differentiate copy operations between parent and child annotation projects
+  @newtype case class ParentAnnotationProjectId(parentAnnotationProjectId: UUID)
+  @newtype case class ChildAnnotationProjectId(childAnnotationProjectId: UUID)
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -1,14 +1,17 @@
 package com.rasterfoundry.database
 
 import com.rasterfoundry.common.Generators.Implicits._
+import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
 
 import cats.implicits._
 import doobie.implicits._
+import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
+import scala.util.Random
 
 class CampaignDaoSpec
     extends AnyFunSuite
@@ -509,6 +512,93 @@ class CampaignDaoSpec
           true
         }
       )
+    }
+  }
+
+  test("copy annotations back from child campaigns") {
+    check {
+      forAll {
+        (
+            users: (User.Create, User.Create),
+            sourceCampaignCreate: Campaign.Create,
+            sourceAnnotationProject: AnnotationProject.Create,
+            sourceTaskFeature: Task.TaskFeatureCreate,
+            childLabels: List[AnnotationLabelWithClasses.Create]
+        ) =>
+          {
+            val (parentUser, childUser) = users
+            val retrievalIO = for {
+              dbParentUser <- UserDao.create(parentUser)
+              dbParentCampaign <- CampaignDao.insertCampaign(
+                sourceCampaignCreate.copy(parentCampaignId = None),
+                dbParentUser
+              )
+              dbParentAnnotationProject <- AnnotationProjectDao.insert(
+                sourceAnnotationProject.copy(
+                  campaignId = Some(dbParentCampaign.id)
+                ),
+                dbParentUser
+              )
+              _ <- TaskDao.insertTasks(
+                Task.TaskFeatureCollectionCreate(
+                  _type = "FeatureCollection",
+                  features = List(
+                    sourceTaskFeature.copy(
+                      properties = sourceTaskFeature.properties.copy(
+                        annotationProjectId = dbParentAnnotationProject.id
+                      )
+                    )
+                  )
+                ),
+                dbParentUser
+              )
+              dbChildUser <- UserDao.create(childUser)
+              dbChildCampaign <- CampaignDao.copyCampaign(
+                dbParentCampaign.id,
+                dbChildUser
+              )
+              childProject <- AnnotationProjectDao.listByCampaign(
+                dbChildCampaign.id
+              ) map { _.head }
+              childProjectWithRelated <- AnnotationProjectDao
+                .getWithRelatedById(childProject.id) map { _.get }
+              childClasses = childProjectWithRelated.labelClassGroups flatMap {
+                _.labelClasses
+              } map { _.id }
+              childTask <- TaskDao.query
+                .filter(fr"annotation_project_id = ${childProject.id}")
+                .select
+              childInserted <- AnnotationLabelDao.insertAnnotations(
+                childProject.id,
+                childTask.id,
+                childLabels map { labelCreate =>
+                  labelCreate.copy(
+                    annotationLabelClasses =
+                      Random.shuffle(childClasses).take(1)
+                  )
+                },
+                dbChildUser
+              )
+              _ <- CampaignDao.retrieveChildCampaignAnnotations(
+                dbParentCampaign.id
+              )
+              labelCountOnParentProject <- AnnotationLabelDao.query
+                .filter(
+                  fr"annotation_project_id = ${dbParentAnnotationProject.id}"
+                )
+                .count
+            } yield (childInserted, labelCountOnParentProject)
+
+            val (childInsertedLabels, parentLabelCount) =
+              retrievalIO.transact(xa).unsafeRunSync
+
+            assert(
+              parentLabelCount.toInt == childInsertedLabels.length,
+              "Parent project has the same count of labels as the child project"
+            )
+            true
+          }
+      }
     }
   }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -581,10 +581,9 @@ class CampaignDaoSpec
                 },
                 dbChildUser
               )
-              result <- CampaignDao.retrieveChildCampaignAnnotations(
+              _ <- CampaignDao.retrieveChildCampaignAnnotations(
                 dbParentCampaign.id
               )
-              _ <- warn(s"label class mapping after copy: ${result}")
               labelCountOnParentProject <- AnnotationLabelDao.query
                 .filter(
                   fr"annotation_project_id = ${dbParentAnnotationProject.id}"
@@ -598,9 +597,6 @@ class CampaignDaoSpec
             assert(
               parentLabelCount == childInsertedLabels.length,
               "Parent project has the same count of labels as the child project"
-            )
-            println(
-              s"Passed with ($parentLabelCount, ${childInsertedLabels.length}) results"
             )
             true
           }


### PR DESCRIPTION
## Overview

This PR makes it so that we can copy labels and label classes from children campaigns' projects to their parents campaigns' projects (matching on `capturedAt` date).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] New tables and queries have appropriate indices added
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Notes

Ooh boy is this brittle. It depends on our using the `capturedAt` field in a particular way to indicate special kinds of projects, which Feels Bad :tm:. 

## Testing Instructions

- verify that test in `CampaignDaoSpec` makes sense
- see if you can come up with anything else I could assert about it -- it makes me a bit nervous that it's just a length check
