### PR TITLE
Refactor bulk create user endpoint to use Auth0's bulk endpoint

### DIFF
--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -33,6 +33,8 @@ auth0 {
   groundworkConnectionName = ${?AUTH0_GROUNDWORK_CONNECTION_NAME}
 
   anonymizedUserCreateConnectionName = ${?AUTH0_ANONYMIZED_CONNECTION_NAME}
+
+  anonymizedUserCreateConnectionId = ${?AUTH0_ANONYMIZED_CONNECTION_ID}
 }
 
 client {

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -364,7 +364,7 @@ object Auth0Service extends Config with LazyLogging {
     if (jobComplete) {
       Future.successful(Right(jobId))
     } else if (numTries > 15) {
-      Future {
+      Future.failed {
         val e =
           BulkJobProcessTimeout("Exhausted tries when bulk creating users")
         logger.error(e.error)

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -362,7 +362,7 @@ object Auth0Service extends Config with LazyLogging {
       bearerToken: ManagementBearerToken
   ): Future[Either[BulkCreateError, String]] = {
     if (jobComplete) {
-      Future(Right(jobId))
+      Future.successful(Right(jobId))
     } else if (numTries > 15) {
       Future {
         val e =

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -289,7 +289,7 @@ trait UserRoutes
       entity(as[UserBulkCreate]) { userBulkCreate =>
         complete {
           val names = PseudoUsernameService.createPseudoNames(
-            userBulkCreate.count,
+            userBulkCreate.count.value,
             userBulkCreate.peudoUserNameType
           )
 

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -29,6 +29,8 @@ trait Config {
     auth0Config.getString("groundworkConnectionName")
   val auth0AnonymizedConnectionName =
     auth0Config.getString("anonymizedUserCreateConnectionName")
+  val auth0AnonymizedConnectionId =
+    auth0Config.getString("anonymizedUserCreateConnectionId")
 
   val clientEnvironment = clientConfig.getString("clientEnvironment")
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -260,10 +260,13 @@ lazy val apiDependencies = Seq(
   Dependencies.scalatest,
   Dependencies.shapeless,
   Dependencies.sourceCode,
+  Dependencies.sttpAkka,
   Dependencies.sttpAsyncBackend,
   Dependencies.sttpCatsBackend,
+  Dependencies.sttpCirce,
   Dependencies.sttpCore,
-  Dependencies.sttpAkka,
+  Dependencies.sttpJson,
+  Dependencies.sttpModel,
   Dependencies.typesafeConfig
 )
 

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -220,6 +220,8 @@ lazy val apiSettings = sharedSettings ++ Seq(
 )
 
 lazy val apiDependencies = Seq(
+  Dependencies.bcrypt,
+  Dependencies.betterFiles,
   Dependencies.akkaActor,
   Dependencies.akkaCirceJson,
   Dependencies.akkaHttp,
@@ -261,6 +263,7 @@ lazy val apiDependencies = Seq(
   Dependencies.sttpAsyncBackend,
   Dependencies.sttpCatsBackend,
   Dependencies.sttpCore,
+  Dependencies.sttpAkka,
   Dependencies.typesafeConfig
 )
 

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -1,9 +1,13 @@
 package com.rasterfoundry.datamodel
 
 import cats.syntax.either._
+import eu.timepit.refined._
+import eu.timepit.refined.api._
+import eu.timepit.refined.numeric._
 import io.circe._
 import io.circe.generic.JsonCodec
 import io.circe.generic.semiauto._
+import io.circe.refined._
 
 import java.net.{URI, URLEncoder}
 import java.security.InvalidParameterException
@@ -260,7 +264,7 @@ object UserThin {
 }
 
 case class UserBulkCreate(
-    count: Int,
+    count: Int Refined Interval.Closed[W.`1`.T, W.`40`.T],
     peudoUserNameType: PseudoUsernameType,
     organizationId: UUID,
     platformId: UUID,

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -19,6 +19,7 @@ object Version {
   val awsSdkV2Version = "2.12.0"
   val awsXrayRecorder = "2.3.0"
   val betterFiles = "3.4.0"
+  val bcrypt = "4.1"
   val caffeine = "2.3.5"
   val cats = "2.1.1"
   val catsEffect = "2.1.2"
@@ -112,6 +113,7 @@ object Dependencies {
   val awsS3SdkV2 = "software.amazon.awssdk" % "s3" % Version.awsSdkV2Version
   val awsUtilsSdkV2 = "software.amazon.awssdk" % "utils" % Version.awsSdkV2Version
   val betterFiles = "com.github.pathikrit" %% "better-files" % Version.betterFiles
+  val bcrypt = "com.github.t3hnar" %% "scala-bcrypt" % Version.bcrypt
   val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % Version.caffeine
   val catsCore = "org.typelevel" %% "cats-core" % Version.cats
   val catsEffect = "org.typelevel" %% "cats-effect" % Version.catsEffect
@@ -213,6 +215,7 @@ object Dependencies {
   val spire = "org.typelevel" %% "spire" % Version.spire
   val spireMath = "org.spire-math" %% "spire" % Version.spireMath
   val sttpModel = "com.softwaremill.sttp.model" %% "core" % Version.sttpModel
+  val sttpAkka = "com.softwaremill.sttp.client" %% "akka-http-backend" % Version.sttp
   val sttpAsyncBackend = "com.softwaremill.sttp.client" %% "async-http-client-backend" % Version.sttp
   val sttpCatsBackend = "com.softwaremill.sttp.client" %% "async-http-client-backend-cats" % Version.sttp
   val sttpCirce = "com.softwaremill.sttp.client" %% "circe" % Version.sttp

--- a/nginx/etc/nginx/conf.d/api.conf
+++ b/nginx/etc/nginx/conf.d/api.conf
@@ -20,6 +20,16 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
+    location /api/users/bulk-create {
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_redirect off;
+
+        proxy_pass http://api-server-upstream;
+    }
+
     location /api/shapes/upload {
         client_max_body_size 20m;
         include /etc/nginx/includes/proxy-settings.conf;


### PR DESCRIPTION
## Overview

This updates the bulk create endpoint to use the Auth0 import user's job so that we can create a larger amount of users without being rate-limited.

I was able to pretty consistently create 50 users at a time with this setup. Anything more than that and I would hit a 20 second timeout (that we have set in akka). So we probably want to limit the frontend to that amount.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

## Notes

A new environment variable is required for server startup. There is a related PR incoming in the deployment repository for that.

## Testing Instructions

- Pull down an updated `.env` because there is now a new setting
- Assemble the API server
- Rebuild the `nginx-api` container: `docker-compose build nginx-api`
- Save the following `json` in a file:
```
{
    "count": 50,
    "peudoUserNameType": "POKEMON",
    "organizationId": "dfac6307-b5ef-43f7-beda-b9f208bb7726",
    "platformId": "31277626-968b-4e40-840b-559d9c67863c",
    "campaignId": null,
    "grantAccessToParentCampaignOwner": false,
    "grantAccessToChildrenCampaignOwner": false
}
```
- Ensure your user development user has the scope to use the bulk endpoint: `users:bulkCreate`
- Save a JWT token in your shell so that you can run the following: `cat sample-bulk.json | http :9091/api/users/bulk-create --auth-type=jwt`
