### PR TITLE
Fix Maven Central release pipeline hanging behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fix Maven Central release pipeline hanging behavior [#5438](https://github.com/raster-foundry/raster-foundry/pull/5438)
+
 ### Security
 
 ## [1.42.0](https://github.com/raster-foundry/raster-foundry/compare/1.41.0...1.42.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node {
 
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\// || env.BRANCH_NAME == 'PR-5438') {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\//) {
         env.RF_DEPLOYMENT_BRANCH = 'develop'
         env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
 
@@ -65,29 +65,29 @@ node {
       // Also, use the container image revision referenced above to
       // cycle in the newest version of the application into Amazon
       // ECS.
-      // stage('infra') {
-      //   // Use `git` to get the primary repository's current commmit SHA and
-      //   // set it as the value of the `GIT_COMMIT` environment variable.
-      //   env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+      stage('infra') {
+        // Use `git` to get the primary repository's current commmit SHA and
+        // set it as the value of the `GIT_COMMIT` environment variable.
+        env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
 
-      //   checkout scm: [$class: 'GitSCM',
-      //                  branches: [[name: env.RF_DEPLOYMENT_BRANCH]],
-      //                  extensions: [[$class: 'RelativeTargetDirectory',
-      //                                relativeTargetDir: 'raster-foundry-deployment']],
-      //                  userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
-      //                                       url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
+        checkout scm: [$class: 'GitSCM',
+                       branches: [[name: env.RF_DEPLOYMENT_BRANCH]],
+                       extensions: [[$class: 'RelativeTargetDirectory',
+                                     relativeTargetDir: 'raster-foundry-deployment']],
+                       userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
+                                            url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
 
-      //   dir('raster-foundry-deployment') {
-      //     wrap([$class: 'AnsiColorBuildWrapper']) {
-      //       sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
-      //       withCredentials([[$class: 'StringBinding',
-      //                         credentialsId: 'ROLLBAR_ACCESS_TOKEN',
-      //                         variable: 'ROLLBAR_ACCESS_TOKEN']]) {
-      //         sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
-      //       }
-      //     }
-      //   }
-      // }
+        dir('raster-foundry-deployment') {
+          wrap([$class: 'AnsiColorBuildWrapper']) {
+            sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+            withCredentials([[$class: 'StringBinding',
+                              credentialsId: 'ROLLBAR_ACCESS_TOKEN',
+                              variable: 'ROLLBAR_ACCESS_TOKEN']]) {
+              sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+            }
+          }
+        }
+      }
     }
   } catch (err) {
     // Some exception was raised in the `try` block above. Assemble

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ node {
 
     env.RF_SETTINGS_BUCKET = 'rasterfoundry-staging-config-us-east-1'
 
-    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\//) {
+    if (env.BRANCH_NAME == 'develop' || env.BRANCH_NAME =~ /test\// || env.BRANCH_NAME =~ /hotfix\// || env.BRANCH_NAME == 'PR-5438') {
         env.RF_DEPLOYMENT_BRANCH = 'develop'
         env.RF_DEPLOYMENT_ENVIRONMENT = "Staging"
 
@@ -65,29 +65,29 @@ node {
       // Also, use the container image revision referenced above to
       // cycle in the newest version of the application into Amazon
       // ECS.
-      stage('infra') {
-        // Use `git` to get the primary repository's current commmit SHA and
-        // set it as the value of the `GIT_COMMIT` environment variable.
-        env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
+      // stage('infra') {
+      //   // Use `git` to get the primary repository's current commmit SHA and
+      //   // set it as the value of the `GIT_COMMIT` environment variable.
+      //   env.GIT_COMMIT = sh(returnStdout: true, script: 'git rev-parse --short HEAD').trim()
 
-        checkout scm: [$class: 'GitSCM',
-                       branches: [[name: env.RF_DEPLOYMENT_BRANCH]],
-                       extensions: [[$class: 'RelativeTargetDirectory',
-                                     relativeTargetDir: 'raster-foundry-deployment']],
-                       userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
-                                            url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
+      //   checkout scm: [$class: 'GitSCM',
+      //                  branches: [[name: env.RF_DEPLOYMENT_BRANCH]],
+      //                  extensions: [[$class: 'RelativeTargetDirectory',
+      //                                relativeTargetDir: 'raster-foundry-deployment']],
+      //                  userRemoteConfigs: [[credentialsId: '3bc1e878-814a-43d1-864e-2e378ebddb0f',
+      //                                       url: 'https://github.com/azavea/raster-foundry-deployment.git']]]
 
-        dir('raster-foundry-deployment') {
-          wrap([$class: 'AnsiColorBuildWrapper']) {
-            sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
-            withCredentials([[$class: 'StringBinding',
-                              credentialsId: 'ROLLBAR_ACCESS_TOKEN',
-                              variable: 'ROLLBAR_ACCESS_TOKEN']]) {
-              sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
-            }
-          }
-        }
-      }
+      //   dir('raster-foundry-deployment') {
+      //     wrap([$class: 'AnsiColorBuildWrapper']) {
+      //       sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
+      //       withCredentials([[$class: 'StringBinding',
+      //                         credentialsId: 'ROLLBAR_ACCESS_TOKEN',
+      //                         variable: 'ROLLBAR_ACCESS_TOKEN']]) {
+      //         sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra apply'
+      //       }
+      //     }
+      //   }
+      // }
     }
   } catch (err) {
     // Some exception was raised in the `try` block above. Assemble

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -19,7 +19,7 @@ node {
     stage('checkout') {
       checkout([
         $class: 'GitSCM',
-        branches: [[name: '371a92f1a']],
+        branches: [[name: params.RELEASE_TAG]],
         extensions: scm.extensions + [[$class: 'CloneOption', noTags: false, reference: '', shallow: false]],
         userRemoteConfigs: scm.userRemoteConfigs
       ])

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -62,7 +62,7 @@ node {
                         --recv-keys ${GPG_KEY_ID} &&
                     echo ${GPG_KEY} | base64 -d >signing_key.asc &&
                     gpg --import signing_key.asc &&
-                    ./sbt ';set version in ThisBuild := \\"${params.RELEASE_TAG}\\";publish;sonatypeBundleRelease'
+                    ./sbt ';set version in ThisBuild := \\"${params.RELEASE_TAG}\\";sonatypeBundleClean;publish;sonatypeBundleRelease'
                 "
           """
         }

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -19,7 +19,7 @@ node {
     stage('checkout') {
       checkout([
         $class: 'GitSCM',
-        branches: [[name: 'cb4ba12']],
+        branches: [[name: '371a92f1a']],
         extensions: scm.extensions + [[$class: 'CloneOption', noTags: false, reference: '', shallow: false]],
         userRemoteConfigs: scm.userRemoteConfigs
       ])

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -19,7 +19,7 @@ node {
     stage('checkout') {
       checkout([
         $class: 'GitSCM',
-        branches: [[name: params.RELEASE_TAG]],
+        branches: [[name: 'cb4ba12']],
         extensions: scm.extensions + [[$class: 'CloneOption', noTags: false, reference: '', shallow: false]],
         userRemoteConfigs: scm.userRemoteConfigs
       ])

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -11,7 +11,7 @@ node {
         regex: /^\d+\.\d+\.\d+$/]
     ])
   ])
-    
+
   try {
     env.AWS_DEFAULT_REGION = "us-east-1"
 
@@ -52,7 +52,7 @@ node {
         wrap([$class: 'AnsiColorBuildWrapper']) {
           sh """#!/bin/bash
             docker-compose \
-                -f "${DIR}/../docker-compose.test.yml" \
+                -f docker-compose.test.yml \
                 run --rm --no-deps --entrypoint "bash -c" \
                 -e SONATYPE_USERNAME="${SONATYPE_USERNAME}" \
                 -e SONATYPE_PASSWORD="${SONATYPE_PASSWORD}" \
@@ -62,13 +62,13 @@ node {
                         --recv-keys ${GPG_KEY_ID} &&
                     echo ${GPG_KEY} | base64 -d >signing_key.asc &&
                     gpg --import signing_key.asc &&
-                    ./sbt ";sonatypeOpen ${BUILD_NUMBER};publish;sonatypeRelease"
+                    ./sbt ';set version in ThisBuild := \\"${params.RELEASE_TAG}\\";publishSigned;sonatypeBundleRelease'
                 "
           """
         }
       }
     }
-    
+
     slackMessage = "*<https://github.com/raster-foundry/raster-foundry/tree/${params.RELEASE_TAG}|${params.RELEASE_TAG}>* deployed to Maven Central :tada:"
     slackSend color: 'warning', message: slackMessage
   } catch(err) {

--- a/Jenkinsfile.central
+++ b/Jenkinsfile.central
@@ -62,7 +62,7 @@ node {
                         --recv-keys ${GPG_KEY_ID} &&
                     echo ${GPG_KEY} | base64 -d >signing_key.asc &&
                     gpg --import signing_key.asc &&
-                    ./sbt ';set version in ThisBuild := \\"${params.RELEASE_TAG}\\";publishSigned;sonatypeBundleRelease'
+                    ./sbt ';set version in ThisBuild := \\"${params.RELEASE_TAG}\\";publish;sonatypeBundleRelease'
                 "
           """
         }

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -694,7 +694,6 @@ lazy val backsplashServer =
 lazy val http4sUtil = Project("http4s-util", file("http4s-util"))
   .dependsOn(db)
   .settings(sharedSettings: _*)
-  .settings(publishSettings)
   .settings({
     libraryDependencies ++= Seq(
       Dependencies.awsXrayRecorder,
@@ -732,7 +731,6 @@ lazy val http4sUtil = Project("http4s-util", file("http4s-util"))
 lazy val notification = Project("notification", file("notification"))
   .dependsOn(datamodel)
   .settings(sharedSettings: _*)
-  .settings(publishSettings)
   .settings({
     libraryDependencies ++= Seq(
       Dependencies.apacheCommonsEmail,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -15,6 +15,21 @@ cancelable in Global := true
 
 onChangedBuildSource := ReloadOnSourceChanges
 
+scapegoatVersion in ThisBuild := "1.3.8"
+
+scalaVersion in ThisBuild := Version.scala
+
+// We are overriding the default behavior of sbt-git which, by default,
+// only appends the `-SNAPSHOT` suffix if there are uncommitted
+// changes in the workspace.
+version in ThisBuild := {
+  if (git.gitHeadCommit.value.isEmpty) "dev"
+  else if (git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value)
+    git.gitDescribedVersion.value.get + "-SNAPSHOT"
+  else
+    git.gitDescribedVersion.value.get
+}
+
 val scalaOptions = Seq(
   "-deprecation",
   "-unchecked",
@@ -38,24 +53,10 @@ val scalaOptions = Seq(
   "100"
 )
 
-scalaVersion in ThisBuild := Version.scala
-
 /**
   * Shared settings across all subprojects
   */
 lazy val sharedSettings = Seq(
-  // We are overriding the default behavior of sbt-git which, by default,
-  // only appends the `-SNAPSHOT` suffix if there are uncommitted
-  // changes in the workspace.
-  version := {
-    if (git.gitHeadCommit.value.isEmpty) "dev"
-    else if (git.gitCurrentTags.value.isEmpty || git.gitUncommittedChanges.value)
-      git.gitDescribedVersion.value.get + "-SNAPSHOT"
-    else
-      git.gitDescribedVersion.value.get
-  },
-  scapegoatVersion in ThisBuild := "1.3.8",
-  scalaVersion in ThisBuild := Version.scala,
   unusedCompileDependenciesFilter -= moduleFilter(
     "com.sksamuel.scapegoat",
     "scalac-scapegoat-plugin"

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -168,7 +168,7 @@ lazy val sonatypeSettings = Seq(
   licenses := Seq(
     "Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt")
   ),
-  publishTo := sonatypePublishTo.value
+  publishTo := sonatypePublishToBundle.value
 )
 
 lazy val credentialSettings = Seq(


### PR DESCRIPTION
## Overview

- Define `version` in [`ThisBuild`](https://www.scala-sbt.org/1.x/docs/Scopes.html#Scoping+by+the+subproject+axis) scope so that we can override it in Jenkinsfile.central
- Use sbt-sonatype [3.x workflow](https://github.com/xerial/sbt-sonatype#publishing-your-artifact)

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

See that snapshot publishing still works: http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry/job/raster-foundry/view/change-requests/job/PR-5438/6/console

See that the 1.42.0 release was successful: http://jenkins.staging.rasterfoundry.com/job/Raster%20Foundry%20Release%20Pipelines/job/Raster%20Foundry%20Maven%20Central%20Release%20Pipeline/95/console

Resolves #5433 
