### PR TITLE
Fix bug in drawing random review task from a campaign

### DIFF
--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -244,7 +244,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
         GROUP BY parent_tasks.id
         HAVING SUM(r.reviewed) >= 1
       )
-      SELECT *, annotation_projects.campaign_id
+      SELECT tasks.*, annotation_projects.campaign_id
       FROM tasks
       JOIN annotation_projects
         ON tasks.annotation_project_id = annotation_projects.id


### PR DESCRIPTION
## Overview

`select *, annotation_projects.campaign_id ...` is changed to `select tasks.*, annotation_projects.campaign_id ...` in this PR, since the former selects all columns from `tasks` and `annotation_projects`, plus `annotation_projects.campaign_id`, and that mapping is based on types, so the annotation project ID would naturally be piped into our new data model (`annotation_projects.id` and `annotation_projects.campaign_id` are both `UUID`s), so, yea.

## Testing Instructions

- 🤷‍♂️ 


