### PR TITLE
filter to a list of candidate campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Random tasks can only be drawn from sibling projects [#5440](https://github.com/raster-foundry/raster-foundry/pull/5440)
+
 ### Security
 
 ## [1.44.0](https://github.com/raster-foundry/raster-foundry/compare/1.43.0...1.44.0)


### PR DESCRIPTION
## Overview

This PR limits returned tasks from the random tasks endpoint to tasks in projects in campaigns that share a parent but that are not owned by the requesting user.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Any new SQL strings have tests (😢)

### Notes

This is _really_ hard to test, given the number of things that need to be produced to create a test case. I think it should be tested in practice instead of in an automated way. Also, the testing pain here makes me concerned in a broader sense.

## Testing Instructions

- 😢 
