### PR TITLE
Cleanup behemoth task queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Filtered locked tasks out of random tasks endpoint [#5442](https://github.com/raster-foundry/raster-foundry/pull/5442)
+- Prevented `label_class_history` from blocking annotation project deletion [#5442](https://github.com/raster-foundry/raster-foundry/pull/5442)
+
 ### Security
 
 ## [1.44.1](https://github.com/raster-foundry/raster-foundry/compare/1.44.0...1.44.1)

--- a/app-backend/db/src/main/resources/migrations/V58__add_cascade_delete_to_breadcrumbs.sql
+++ b/app-backend/db/src/main/resources/migrations/V58__add_cascade_delete_to_breadcrumbs.sql
@@ -1,0 +1,7 @@
+ALTER TABLE label_class_history
+  DROP CONSTRAINT "label_class_history_child_label_class_id_fkey",
+  ADD CONSTRAINT "label_class_history_child_label_class_id_fkey"
+    FOREIGN KEY (child_label_class_id) REFERENCES annotation_label_classes(id) ON DELETE CASCADE,
+  DROP CONSTRAINT "label_class_history_parent_label_class_id_fkey",
+  ADD CONSTRAINT "label_class_history_parent_label_class_id_fkey"
+    FOREIGN KEY (parent_label_class_id) REFERENCES annotation_label_classes(id) ON DELETE CASCADE;

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -261,6 +261,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
         AND parent_task_id IS NOT NULL
         AND task_type = ${TaskType.Review.toString}::task_type
         AND annotation_projects.campaign_id IN (select id from candidate_campaigns)
+        AND (locked_by = ${user.id} OR locked_by IS NULL)
       ORDER BY RANDOM() LIMIT 1;
     """
       .query[Task.TaskWithCampaign]


### PR DESCRIPTION
## Overview

This PR adds two optimizations discovered in testing:

- the random task endpoint should only return _unlocked_ tasks
- the `label_class_history` table shouldn't block deletes of annotation projects

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

- good to go with CI unless underlying cleanup goals change

Closes azavea/raster-foundry-platform#1054
