### PR TITLE
Construct histogram from smallest overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Improve histogram generation when COGs are POSTed to the scenes endopint [#5444](https://github.com/raster-foundry/raster-foundry/pull/5444)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed
 
-- Improve histogram generation when COGs are POSTed to the scenes endopint [#5444](https://github.com/raster-foundry/raster-foundry/pull/5444)
+- Improve histogram generation when COGs are POSTed to the scenes endpoint [#5444](https://github.com/raster-foundry/raster-foundry/pull/5444)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -451,7 +451,8 @@ object Auth0Service extends Config with LazyLogging {
           .multipartBody(
             multipart("upsert", true),
             multipart("connection_id", auth0AnonymizedConnectionId),
-            multipartFile("users", tempFile.path)
+            multipartFile("users", tempFile.path),
+            multipart("send_completion_email", true)
           )
           .response(asJson[ImportResponse])
           .post(uri"https://$auth0Domain/api/v2/jobs/users-imports")

--- a/app-backend/api/src/main/scala/user/Auth0User.scala
+++ b/app-backend/api/src/main/scala/user/Auth0User.scala
@@ -452,7 +452,7 @@ object Auth0Service extends Config with LazyLogging {
             multipart("upsert", true),
             multipart("connection_id", auth0AnonymizedConnectionId),
             multipartFile("users", tempFile.path),
-            multipart("send_completion_email", true)
+            multipart("send_completion_email", false)
           )
           .response(asJson[ImportResponse])
           .post(uri"https://$auth0Domain/api/v2/jobs/users-imports")

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import geotrellis.proj4._
 import geotrellis.raster._
 import geotrellis.raster.geotiff.GeoTiffRasterSource
-import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.vector.Projected
 import geotrellis.vector._
 

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -24,17 +24,16 @@ object CogUtils extends LazyLogging {
       uri: String,
       buckets: Int = 80
   ): Option[Array[Histogram[Double]]] = {
-    // use the resolution that's closest to 100,000 pixels and not greater than 400,000 pixels
-    // this must fit in a request/response cycle. A 500x500 overview is reasonable, and that adds
-    // up to 250,000 pixels
-    // We may need to adjust this number depending on how fast our API is able to process it, these
-    // numbers are based off local testing
+    // Get the smallest overview and calculate histogrm from that
     val rasterSource = GeoTiffRasterSource(uri)
     logger.debug(s"Base cell size is: ${rasterSource.cellSize}")
-    val targetCellSize = TargetCellSize(rasterSource.resolutions.sortBy(_.height).max)
+    val targetCellSize = TargetCellSize(
+      rasterSource.resolutions.sortBy(_.height).max)
 
     rasterSource
-      .resample(targetCellSize, ResampleMethods.NearestNeighbor, OverviewStrategy.DEFAULT)
+      .resample(targetCellSize,
+                ResampleMethods.NearestNeighbor,
+                OverviewStrategy.DEFAULT)
       .read()
       .map(_.tile.histogramDouble(buckets))
   }


### PR DESCRIPTION
## Overview

Simplifies histogram generation when a COG is POSTed by always using the smallest overview to calculate histograms.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Take a tiff and upload it to a project
- Verify that it does not time out

Closes #5443 
