### PR TITLE
Add support for campaign resource links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Add support for campaign resource links [#5445](https://github.com/raster-foundry/raster-foundry/pull/5445)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -264,14 +264,16 @@ trait CampaignRoutes
                 CampaignDao.copyCampaign(
                   campaignId,
                   user,
-                  Some(campaignClone.tags)
+                  Some(campaignClone.tags),
+                  campaignClone.copyResourceLink
                 )
               case true =>
                 for {
                   copiedCampaign <- CampaignDao.copyCampaign(
                     campaignId,
                     user,
-                    Some(campaignClone.tags)
+                    Some(campaignClone.tags),
+                    campaignClone.copyResourceLink
                   )
                   copiedProjects <- AnnotationProjectDao.listByCampaign(
                     copiedCampaign.id

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1140,12 +1140,14 @@ object Generators extends ArbitraryInstances {
       Gen.option(nonEmptyStringGen),
       Gen.option(uuidGen),
       Gen.option(continentGen),
-      stringListGen
+      stringListGen,
+      Gen.option(nonEmptyStringGen)
     ).mapN(Campaign.Create.apply _)
 
   private def campaignCloneGen: Gen[Campaign.Clone] =
     (
       stringListGen,
+      arbitrary[Boolean],
       arbitrary[Boolean]
     ).mapN(Campaign.Clone.apply _)
 

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -21,7 +21,8 @@ final case class Campaign(
     tags: List[String] = List.empty,
     childrenCount: Int,
     projectStatuses: Map[String, Int],
-    isActive: Boolean
+    isActive: Boolean,
+    resourceLink: Option[String] = None
 )
 
 object Campaign {
@@ -37,7 +38,8 @@ object Campaign {
       partnerLogo: Option[String] = None,
       parentCampaignId: Option[UUID] = None,
       continent: Option[Continent] = None,
-      tags: List[String] = List.empty
+      tags: List[String] = List.empty,
+      resourceLink: Option[String] = None
   )
 
   object Create {
@@ -46,7 +48,8 @@ object Campaign {
 
   final case class Clone(
       tags: List[String] = List.empty,
-      grantAccessToParentCampaignOwner: Boolean = false
+      grantAccessToParentCampaignOwner: Boolean = false,
+      copyResourceLink: Boolean = false
   )
 
   object Clone {

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -270,7 +270,8 @@ case class UserBulkCreate(
     platformId: UUID,
     campaignId: Option[UUID] = None,
     grantAccessToParentCampaignOwner: Boolean = false,
-    grantAccessToChildrenCampaignOwner: Boolean = false
+    grantAccessToChildrenCampaignOwner: Boolean = false,
+    copyResourceLink: Boolean = false
 )
 
 object UserBulkCreate {

--- a/app-backend/db/src/main/resources/migrations/V59__add_resource_link_to_campaigns.sql
+++ b/app-backend/db/src/main/resources/migrations/V59__add_resource_link_to_campaigns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.campaigns
+ADD COLUMN resource_link text;

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -333,7 +333,12 @@ object UserDao extends Dao[User] with Sanitization {
         Some(userBulkCreate.organizationId)
       )
       copiedCampaignO <- userBulkCreate.campaignId traverse { campaignId =>
-        CampaignDao.copyCampaign(campaignId, user)
+        CampaignDao.copyCampaign(
+          campaignId,
+          user,
+          None,
+          userBulkCreate.copyResourceLink
+        )
       }
     } yield UserWithCampaign(user, copiedCampaignO)
 


### PR DESCRIPTION
## Overview

This PR adds support for campaign resource links -- a URL that points to some documentation resource for campaigns. This includes:
- a migration to add a text field `resource_link` to the campaigns table
- updates to campaign data-models
- updates to the campaign copy method so that a consumer can opt-in to copying the resource link to cloned campaigns
- updates to the expected structure of `Campaign.Clone` and `UserBulkCreate` to include a new field: `copyResourceLink: Boolean` which defaults to `false`. This allows requests to `/campaigns/{id}/clone` and `users/bulk-create` to specify if the resulting campaign copies should copy the resource link
- updates to the campaign tests to verify that the resource link is only copied when desired

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Ensure that the added test makes sense
- CI
