### PR TITLE
Make campaign task endpoint returns only labeled tasks

### DIFF
--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -262,7 +262,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
         AND task_type = ${TaskType.Review.toString}::task_type
         AND annotation_projects.campaign_id IN (select id from candidate_campaigns)
         AND (locked_by = ${user.id} OR locked_by IS NULL)
-        AND status = ${TaskStatus.Labeled.toString}::task_status
+        AND tasks.status = ${TaskStatus.Labeled.toString}::task_status
       ORDER BY RANDOM() LIMIT 1;
     """
       .query[Task.TaskWithCampaign]

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -262,6 +262,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
         AND task_type = ${TaskType.Review.toString}::task_type
         AND annotation_projects.campaign_id IN (select id from candidate_campaigns)
         AND (locked_by = ${user.id} OR locked_by IS NULL)
+        AND status = ${TaskStatus.Labeled.toString}::task_status
       ORDER BY RANDOM() LIMIT 1;
     """
       .query[Task.TaskWithCampaign]


### PR DESCRIPTION
## Overview

This PR makes a small adjustment so that only tasks with a status of `LABELED` are returned.

Prior to this, the query works properly to return a child task of tasks that still need a review, but the query missed on ensuring that the child task returned was not one that was already validated.

I attempted to modify tests to test this but it turned out to be harder than I thought and maybe not worth it given time constraints.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

The query should make more sense now...

🤷‍♂️ 
