### PR TITLE
Copied back labels should have classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Fixed
 
+- Copied back labels should be associated with label classes [#5448](https://github.com/raster-foundry/raster-foundry/pull/5448)
+- `load_development_data --create` should correctly provide a time format parameter [#5448](https://github.com/raster-foundry/raster-foundry/pull/5448)
+
 ### Security
 
 ## [1.44.2](https://github.com/raster-foundry/raster-foundry/compare/1.44.1...1.44.2)

--- a/scripts/load_development_data
+++ b/scripts/load_development_data
@@ -23,7 +23,7 @@ and overwrites the existing dump.
 function create_database_backup() {
     if [ -f data/database.pgdump ]; then
         echo "Renaming old database dump"
-        HASH=$(date + '%N')
+        HASH=$(date +%N)
         mv "data/database.pgdump" "data/database.pgdump.${HASH}"
     fi
     echo "Creating new dev database dump"


### PR DESCRIPTION
## Overview

This PR:

- fixes the `--create` flag behavior in `load_development_data`
- makes it so that the copied back labels from child annotation projects get the correct label classes associated with them

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Any new SQL strings have tests ( 😭 )

## Testing Instructions

- to be sent separately because speaking in code is hard