### PR TITLE
Update user bulk create endpoint to fix ACR assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Fixed the ACR assignment issue on the user bulk creation endpoint [#5450](https://github.com/raster-foundry/raster-foundry/pull/5450)
+
 ### Security
 
 ## [1.46.0](https://github.com/raster-foundry/raster-foundry/compare/1.45.0...1.46.0)

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",
@@ -493,7 +493,7 @@ object AnnotationProjectDao
                   Some(userId),
                   ActionType.Annotate
                 )
-              )
+            )
           )
         AnnotationProjectDao.addPermissionsMany(
           project.id,

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",
@@ -472,35 +472,33 @@ object AnnotationProjectDao
 
   def assignUsersToProjectsByCampaign(
       campaignId: UUID,
-      usersO: Option[List[User]]
+      userIds: List[String]
   ): ConnectionIO[List[AnnotationProject]] =
     for {
       projects <- AnnotationProjectDao.listByCampaign(
         campaignId
       )
       _ <- projects traverse { project =>
-        usersO traverse { users =>
-          val rules =
-            users.foldLeft(List[ObjectAccessControlRule]())(
-              (acc, user) =>
-                acc ++ List(
-                  ObjectAccessControlRule(
-                    SubjectType.User,
-                    Some(user.id),
-                    ActionType.View
-                  ),
-                  ObjectAccessControlRule(
-                    SubjectType.User,
-                    Some(user.id),
-                    ActionType.Annotate
-                  )
+        val rules =
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
               )
-            )
-          AnnotationProjectDao.addPermissionsMany(
-            project.id,
-            rules
           )
-        }
+        AnnotationProjectDao.addPermissionsMany(
+          project.id,
+          rules
+        )
       }
     } yield projects
 }


### PR DESCRIPTION
## Overview

This PR updates the user bulk create endpoint so that **all** child campaign owners have access to all child campaigns (and annotation projects), no matter in which batch the users are added in.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests (YES! 😭  FINALLY)
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should test our use case, so take a close look to the property tests
