### PR TITLE
Update annotation project share for validation use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- Update annotation project share endpoint for validation use case [#5452](https://github.com/raster-foundry/raster-foundry/pull/5452)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -137,11 +137,9 @@ trait AnnotationProjectPermissionRoutes
       ActionType.Validate
     )
     actionTypeOpt match {
-      case Some(actionType) if actionType == ActionType.Validate =>
+      case Some(ActionType.Validate) =>
         default :+ annotate :+ validate
-      case Some(actionType) if actionType == ActionType.Annotate =>
-        default :+ annotate
-      case None =>
+      case Some(ActionType.Annotate) | None =>
         default :+ annotate
       case _ =>
         default
@@ -374,12 +372,12 @@ trait AnnotationProjectPermissionRoutes
       user
     ) {
       entity(as[UserShareInfo]) { userByEmail =>
-        authorizeAsync {
+        authorize {
           (userByEmail.actionType match {
             case Some(ActionType.Annotate) | Some(ActionType.Validate) | None =>
-              true.pure[ConnectionIO]
-            case _ => false.pure[ConnectionIO]
-          }).transact(xa).unsafeToFuture()
+              true
+            case _ => false
+          })
         } {
           complete {
             Auth0Service.getManagementBearerToken flatMap { managementToken =>

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -457,7 +457,7 @@ trait AnnotationProjectPermissionRoutes
                             .addPermission(projectId, acr)
                         }).transact(xa) <* (
                           canUserAnnotateIO flatMap {
-                            case true =>
+                            case false =>
                               shareNotify(
                                 existingUser,
                                 user,

--- a/app-backend/datamodel/src/main/scala/ActionType.scala
+++ b/app-backend/datamodel/src/main/scala/ActionType.scala
@@ -16,6 +16,7 @@ object ActionType {
   case object Export extends ActionType("EXPORT")
   case object Download extends ActionType("DOWNLOAD")
   case object Create extends ActionType("CREATE")
+  case object Validate extends ActionType("VALIDATE")
 
   def fromString(s: String): ActionType = s.toUpperCase match {
     case "VIEW"       => View
@@ -26,6 +27,7 @@ object ActionType {
     case "EXPORT"     => Export
     case "DOWNLOAD"   => Download
     case "CREATE"     => Create
+    case "VALIDATE"   => Validate
     case _            => throw new Exception(s"Invalid ActionType: ${s}")
   }
 

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -252,7 +252,7 @@ object User {
   }
 }
 
-@JsonCodec final case class UserEmail(email: String)
+@JsonCodec final case class UserShareInfo(email: String, actionType: ActionType)
 
 @JsonCodec final case class UserThin(
     id: String,

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -252,7 +252,11 @@ object User {
   }
 }
 
-@JsonCodec final case class UserShareInfo(email: String, actionType: ActionType)
+@JsonCodec final case class UserShareInfo(
+    email: String,
+    actionType: Option[ActionType] = None,
+    silent: Option[Boolean] = None
+)
 
 @JsonCodec final case class UserThin(
     id: String,

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-              )
+                )
             )
         }.flatten,
         "vector",
@@ -493,7 +493,7 @@ object AnnotationProjectDao
                   Some(userId),
                   ActionType.Annotate
                 )
-            )
+              )
           )
         AnnotationProjectDao.addPermissionsMany(
           project.id,
@@ -501,4 +501,43 @@ object AnnotationProjectDao
         )
       }
     } yield projects
+
+  /*
+    If no action specified, we see it as just assigning Annotate action
+    If the action param is Annotate, the existing Validate action, if any, needs to be removed
+    If the action param is Validate, existing actions should stay untouched
+   */
+  def handleSharedPermissions(
+      projectId: UUID,
+      userId: String,
+      acrs: List[ObjectAccessControlRule],
+      actionTypeOpt: Option[ActionType]
+  ): ConnectionIO[List[List[ObjectAccessControlRule]]] =
+    actionTypeOpt match {
+      case Some(ActionType.Annotate) | None =>
+        for {
+          permissions <- getPermissions(projectId)
+          permissionsToKeep = permissions collect {
+            case p
+                if p.subjectId != Some(userId) && p.actionType != ActionType.Validate =>
+              p
+          }
+          _ <- permissionsToKeep match {
+            case Nil => deletePermissions(projectId)
+            case ps if ps.toSet != permissions.toSet =>
+              replacePermissions(projectId, ps) map { _ =>
+                permissions.size - ps.size
+              }
+            case _ =>
+              0.pure[ConnectionIO]
+          }
+          resultedPermissions <- acrs traverse { acr =>
+            addPermission(projectId, acr)
+          }
+        } yield resultedPermissions
+      case _ =>
+        acrs traverse { acr =>
+          addPermission(projectId, acr)
+        }
+    }
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -361,7 +361,7 @@ object AnnotationProjectDao
                 StacLabelItemProperties.StacLabelItemClasses(
                   group.name,
                   classes.map(_.name)
-                )
+              )
             )
         }.flatten,
         "vector",
@@ -493,7 +493,7 @@ object AnnotationProjectDao
                   Some(userId),
                   ActionType.Annotate
                 )
-              )
+            )
           )
         AnnotationProjectDao.addPermissionsMany(
           project.id,

--- a/app-backend/project/plugins.sbt
+++ b/app-backend/project/plugins.sbt
@@ -20,4 +20,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
 
 addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.0-RC1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.3")
+
+addSbtPlugin("org.scalameta" % "sbt-metals" % "0.7.6")


### PR DESCRIPTION
## Overview

This PR adds a new `ActionType.Validate` and updates the annotation project share endpoint:
- the endpoint now takes two other optional params, `actionType` and `silent` - the former specifies if to `ActionType.Annotate` or `ActionType.Validate`; the latter specifies if to send email notification to new user or send intercom message to existing user
- if `ActionType.Annotate` is passed to `actionType` param, the endpoint removes any existing `ActionType.Validate` permission for the user with the specified email; if `ActionType.Validate`, it adds `ANNOTATE` and `VALIDATE`
- `actionType` and `silent` params are optional, so when posting, it is ok to ignore these two fields and just post the `email` field -- this will work like just assigning users to `ANNOTATE` and send notifications, which is for backward compatibility

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

### Notes

The latest pgdump seems to miss the sample GW project mentioned in the `.env`, so I created a new db dump, uploaded it, and updated the env file on S3. I also updated the local db platform settings from the staging RF platform, so that email sending in local servers should work the same as that of staging.

Another thing I noticed is that intercom message sending does not work well for me locally, but it does not block the tests for the updates in this PR, I think.

## Testing Instructions

- `aws s3 cp s3://rasterfoundry-development-config-us-east-1/.env .env --profile=<your profile name, mine is raster-foundry>`
- `./scripts/load_development_data --download`
- compile your api server jar and spin up servers
- grab a token `<your token>`
- Share the sample project with `<an email address>` that you have access to, so you will see an email. This is to mock the use case on frontend, where you put in an email address and click "Share"
```
curl --location --request POST 'http://localhost:9091/api/annotation-projects/48e7cbd3-3395-4df3-ae05-1d698ee38bee/share' \
--header 'Authorization: Bearer <your token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "<an email address>"
}'
```
- Check in the DB that you have something like the following:
```
rasterfoundry=# select acrs from annotation_projects where id = '48e7cbd3-3395-4df3-ae05-1d698ee38bee';
                                                                acrs                                                                
------------------------------------------------------------------------------------------------------------------------------------
 {USER;<id>;VIEW,USER;<id>;EXPORT,USER;<id>;ANNOTATE}
(1 row)
```
- Now give this user `VALIDATE` power silently. This is to mock the use case on the frontend where you select `Validate` option in the dropdown next to a user you've shared the project with:
```
curl --location --request POST 'http://localhost:9091/api/annotation-projects/48e7cbd3-3395-4df3-ae05-1d698ee38bee/share' \
--header 'Authorization: Bearer <your token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "<an email address>",
    "actionType": "VALIDATE",
    "silent": true
}'
```
- Check in the DB that you have something like the following:
```
rasterfoundry=# select acrs from annotation_projects where id = '48e7cbd3-3395-4df3-ae05-1d698ee38bee';
                                                                acrs                                                                
------------------------------------------------------------------------------------------------------------------------------------
 {USER;<id>;VIEW,USER;<id>;EXPORT,USER;<id>;ANNOTATE,USER;<id>;VALIDATE}
(1 row)
```
- Now give this user only `ANNOTATE` power silently. This is to mock the use case on the frontend where you select `Annotate` option in the dropdown next to a user you've shared the project with after you decide you want the user to only label stuffs but cannot review stuffs:
```
curl --location --request POST 'http://localhost:9091/api/annotation-projects/48e7cbd3-3395-4df3-ae05-1d698ee38bee/share' \
--header 'Authorization: Bearer <your token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "<an email address>",
    "actionType": "ANNOTATE",
    "silent": true
}'
```
- Check in the DB that you have something like the following:
```
rasterfoundry=# select acrs from annotation_projects where id = '48e7cbd3-3395-4df3-ae05-1d698ee38bee';
                                                                acrs                                                                
------------------------------------------------------------------------------------------------------------------------------------
 {USER;<id>;VIEW,USER;<id>;EXPORT,USER;<id>;ANNOTATE}
(1 row)
```
Closes https://github.com/raster-foundry/annotate/issues/942
