### PR TITLE
Validation specific endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+- Add validation specific endpoint [#5453](https://github.com/raster-foundry/raster-foundry/pull/5453)
 
 ### Changed
 - Update annotation project share endpoint for validation use case [#5452](https://github.com/raster-foundry/raster-foundry/pull/5452)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -42,6 +42,7 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:read,get
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:deleteAnnotation,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/children,annotationProjects:readTasks,get
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/validate,annotationProjects:createAnnotation,post
 /api/licenses/,licenses:read,get
 /api/licenses/{licenseID},licenses:read,get
 /api/map-tokens/,mapTokens:read,get

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -42,7 +42,7 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:read,get
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:deleteAnnotation,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/children,annotationProjects:readTasks,get
-/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/validate,annotationProjects:createAnnotation,post
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/validate/,annotationProjects:createAnnotation,post
 /api/licenses/,licenses:read,get
 /api/licenses/{licenseID},licenses:read,get
 /api/map-tokens/,mapTokens:read,get

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -363,7 +363,14 @@ trait AnnotationProjectTaskRoutes
                 projectId,
                 ActionType.Annotate
               )
-            auth2 <- TaskDao.hasStatus(
+            auth2 <- AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Validate
+              )
+            auth3 <- TaskDao.hasStatus(
               taskId,
               List(
                 TaskStatus.Unlabeled,
@@ -372,7 +379,7 @@ trait AnnotationProjectTaskRoutes
               )
             )
           } yield {
-            auth1.toBoolean && auth2
+            (auth1.toBoolean || auth2.toBoolean) && auth3
           }).transact(xa).unsafeToFuture
         } {
           entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) { fc =>

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -348,125 +348,85 @@ trait AnnotationProjectTaskRoutes
       }
   }
 
-  def addTaskLabels(projectId: UUID, taskId: UUID): Route = authenticate {
-    user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          (for {
-            auth1 <- AnnotationProjectDao
-              .authorized(
-                user,
-                ObjectType.AnnotationProject,
-                projectId,
-                ActionType.Annotate
-              )
-            auth2 <- AnnotationProjectDao
-              .authorized(
-                user,
-                ObjectType.AnnotationProject,
-                projectId,
-                ActionType.Validate
-              )
-            auth3 <- TaskDao.hasStatus(
-              taskId,
-              List(
-                TaskStatus.Unlabeled,
-                TaskStatus.LabelingInProgress,
-                TaskStatus.Labeled
-              )
-            )
-          } yield {
-            (auth1.toBoolean || auth2.toBoolean) && auth3
-          }).transact(xa).unsafeToFuture
-        } {
-          entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) { fc =>
-            val annotationLabelWithClassesCreate = fc.features map {
-              _.toAnnotationLabelWithClassesCreate
-            }
-            onSuccess(
-              AnnotationLabelDao
-                .insertAnnotations(
-                  projectId,
-                  taskId,
-                  annotationLabelWithClassesCreate.toList,
-                  user
-                )
-                .transact(xa)
-                .unsafeToFuture
-                .map { annotations: List[AnnotationLabelWithClasses] =>
-                  fromSeqToFeatureCollection[
-                    AnnotationLabelWithClasses,
-                    AnnotationLabelWithClasses.GeoJSON
-                  ](
-                    annotations
-                  )
-                }
-            ) { createdAnnotation =>
-              complete((StatusCodes.Created, createdAnnotation))
-            }
-          }
-        }
-      }
-  }
+  def addTaskLabels(projectId: UUID, taskId: UUID): Route =
+    addLabels(
+      projectId,
+      taskId,
+      ActionType.Annotate,
+      List(
+        TaskStatus.Unlabeled,
+        TaskStatus.LabelingInProgress,
+        TaskStatus.Labeled
+      )
+    )
 
-  def validateTaskLabels(projectId: UUID, taskId: UUID): Route = authenticate {
-    user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          (for {
-            auth1 <- AnnotationProjectDao
-              .authorized(
-                user,
-                ObjectType.AnnotationProject,
-                projectId,
-                ActionType.Validate
-              )
-            auth2 <- TaskDao.hasStatus(
-              taskId,
-              List(
-                TaskStatus.Labeled,
-                TaskStatus.ValidationInProgress,
-                TaskStatus.Validated
-              )
+  def validateTaskLabels(projectId: UUID, taskId: UUID): Route =
+    addLabels(
+      projectId,
+      taskId,
+      ActionType.Validate,
+      List(
+        TaskStatus.Labeled,
+        TaskStatus.ValidationInProgress,
+        TaskStatus.Validated
+      )
+    )
+
+  private def addLabels(
+      projectId: UUID,
+      taskId: UUID,
+      actionType: ActionType,
+      requiredStatuses: List[TaskStatus]
+  ): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+      user
+    ) {
+      authorizeAsync {
+        (for {
+          auth1 <- AnnotationProjectDao
+            .authorized(
+              user,
+              ObjectType.AnnotationProject,
+              projectId,
+              actionType
             )
-          } yield {
-            auth1.toBoolean && auth2
-          }).transact(xa).unsafeToFuture
-        } {
-          entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) { fc =>
-            val annotationLabelWithClassesCreate = fc.features map {
-              _.toAnnotationLabelWithClassesCreate
-            }
-            onSuccess(
-              AnnotationLabelDao
-                .insertAnnotations(
-                  projectId,
-                  taskId,
-                  annotationLabelWithClassesCreate.toList,
-                  user
+          auth2 <- TaskDao.hasStatus(
+            taskId,
+            requiredStatuses
+          )
+        } yield {
+          auth1.toBoolean && auth2
+        }).transact(xa).unsafeToFuture
+      } {
+        entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) { fc =>
+          val annotationLabelWithClassesCreate = fc.features map {
+            _.toAnnotationLabelWithClassesCreate
+          }
+          onSuccess(
+            AnnotationLabelDao
+              .insertAnnotations(
+                projectId,
+                taskId,
+                annotationLabelWithClassesCreate.toList,
+                user
+              )
+              .transact(xa)
+              .unsafeToFuture
+              .map { annotations: List[AnnotationLabelWithClasses] =>
+                fromSeqToFeatureCollection[
+                  AnnotationLabelWithClasses,
+                  AnnotationLabelWithClasses.GeoJSON
+                ](
+                  annotations
                 )
-                .transact(xa)
-                .unsafeToFuture
-                .map { annotations: List[AnnotationLabelWithClasses] =>
-                  fromSeqToFeatureCollection[
-                    AnnotationLabelWithClasses,
-                    AnnotationLabelWithClasses.GeoJSON
-                  ](
-                    annotations
-                  )
-                }
-            ) { createdAnnotation =>
-              complete((StatusCodes.Created, createdAnnotation))
-            }
+              }
+          ) { createdAnnotation =>
+            complete((StatusCodes.Created, createdAnnotation))
           }
         }
       }
+    }
   }
 
   def deleteTaskLabels(projectId: UUID, task: UUID): Route =

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -117,20 +117,25 @@ trait AnnotationProjectRoutes
                       unlockTask(projectId, taskId)
                     }
                   }
-                } ~
-                  pathPrefix("labels") {
-                    pathEndOrSingleSlash {
-                      get {
-                        listTaskLabels(projectId, taskId)
+                } ~ pathPrefix("labels") {
+                  pathEndOrSingleSlash {
+                    get {
+                      listTaskLabels(projectId, taskId)
+                    } ~
+                      post {
+                        addTaskLabels(projectId, taskId)
                       } ~
-                        post {
-                          addTaskLabels(projectId, taskId)
-                        } ~
-                        delete {
-                          deleteTaskLabels(projectId, taskId)
-                        }
+                      delete {
+                        deleteTaskLabels(projectId, taskId)
+                      }
+                  }
+                } ~ pathPrefix("validate") {
+                  pathEndOrSingleSlash {
+                    post {
+                      validateTaskLabels(projectId, taskId)
                     }
-                  } ~ pathPrefix("children") {
+                  }
+                } ~ pathPrefix("children") {
                   pathEndOrSingleSlash {
                     get {
                       children(projectId, taskId)

--- a/app-backend/datamodel/src/main/scala/User.scala
+++ b/app-backend/datamodel/src/main/scala/User.scala
@@ -263,8 +263,26 @@ object User {
     email: String,
     profileImageUri: String
 )
+
 object UserThin {
   def fromUser(user: User) = UserThin(user.id, user.email, user.profileImageUri)
+}
+
+@JsonCodec final case class UserThinWithActionType(
+    id: String,
+    email: String,
+    profileImageUri: String,
+    actionType: ActionType
+)
+
+object UserThinWithActionType {
+  def fromUser(user: User, actionType: ActionType) =
+    UserThinWithActionType(
+      user.id,
+      user.email,
+      user.profileImageUri,
+      actionType
+    )
 }
 
 case class UserBulkCreate(

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -333,6 +333,13 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       case _          => true
     }
 
+  def hasStatus(
+      taskId: UUID,
+      statuses: List[TaskStatus]
+  ): ConnectionIO[Boolean] =
+    getTaskById(taskId)
+      .map(_.exists(task => statuses.contains(task.status)))
+
   def lockTask(
       taskId: UUID
   )(user: User): ConnectionIO[Option[Task.TaskFeature]] =


### PR DESCRIPTION
## Overview

This PR makes changes to the backend to further support validation. From the issue:

- a new endpoint for a task that handles validation:` /annotation-projects/{id}/tasks/{id}/validate` that takes a POST request which contains the feature-collection of labels for that task.
- requires the current status of the task to be one of LABELED, VALIDATION_IN_PROGRESS, or VALIDATED. The end statuses (LABELED and VALIDATED) are included here because sometimes the DB and the front-end are not perfectly in-sync and this seems like a bad time to be overly specific. This endpoint should require a ActionType.Validate permission for the project
- updates the existing labeling endpoint `/annotation-projects/{id}/tasks/{id}/labels` so that the POST is only applied if the status of the task is one of UNLABELED, LABELING_IN_PROGRESS, or LABELED.


### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new endpoints have scope validation and are included in the integration test csv


## Testing Instructions

- spin up the branch locally
- adjust the front-end of groundwork to point to your local server
- for a sample project, verify that labeling works as you'd expect
- return to a labeled task and modify the URL: replace `label` with `validate`
- open dev-tools to see requests
- confirm (validate) the task and verify that the request to the `labels` endpoint is rejected (the status of the task should cause it to fail)
- copy the cURL command of the failed request and paste it somewhere
- switch the URL back to `label` and grab a fresh unlabeled task and copy the id (keep the window around)
- use the cURL command as a template, modify it to target the ` /annotation-projects/{id}/tasks/{id}/validate` endpoint with the task id you got from the previous step -- verify that the request is rejected (the status should cause it to fail)
- return to GW and label the task and confirm it
- run the cURL command again and this time it should go through
