### PR TITLE
Apply single band settings to project default layer on project create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Apply single band settings to project default layer upon project create [#5454](https://github.com/raster-foundry/raster-foundry/pull/5454)
+
 ### Security
 
 ## [1.47.0](https://github.com/raster-foundry/raster-foundry/compare/1.46.1...1.47.0)
@@ -32,11 +34,13 @@
 ## [1.46.0](https://github.com/raster-foundry/raster-foundry/compare/1.45.0...1.46.0)
 
 ### Fixed
+
 - Fixed tile rendering by updating GeoTrellis to 3.4.1 [#5449](https://github.com/raster-foundry/raster-foundry/pull/5449)
 
 ## [1.45.0(https://github.com/raster-foundry/raster-foundry/compare/1.44.2...1.45.0)
 
 ### Added
+
 - Add support for campaign resource links [#5445](https://github.com/raster-foundry/raster-foundry/pull/5445)
 
 ### Changed
@@ -48,7 +52,6 @@
 
 - Copied back labels should be associated with label classes [#5448](https://github.com/raster-foundry/raster-foundry/pull/5448)
 - `load_development_data --create` should correctly provide a time format parameter [#5448](https://github.com/raster-foundry/raster-foundry/pull/5448)
-
 
 ## [1.44.2](https://github.com/raster-foundry/raster-foundry/compare/1.44.1...1.44.2)
 
@@ -73,7 +76,6 @@
 ### Fixed
 
 - Fix Maven Central release pipeline hanging behavior [#5438](https://github.com/raster-foundry/raster-foundry/pull/5438)
-
 
 ## [1.43.0](https://github.com/raster-foundry/raster-foundry/compare/1.42.0...1.43.0)
 

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -118,20 +118,20 @@ object ProjectDao
     for {
       defaultProjectLayer <- ProjectLayerDao.insertProjectLayer(
         ProjectLayer(
-          UUID.randomUUID(),
-          now,
-          now,
-          "Project default layer",
-          None,
-          "#738FFC",
-          None,
-          None,
-          None,
-          None,
-          false,
-          None,
-          None,
-          None
+          UUID.randomUUID(), //id
+          now, // createdAt
+          now, // modifiedAt
+          "Project default layer", //name
+          None, // projectId
+          "#738FFC", // colorGroupHex
+          None, // smartLayerId
+          None, // rangeStart
+          None, // rangeEnd
+          None, // geometry
+          newProject.isSingleBand, //isSingleBand
+          newProject.singleBandOptions, // singleBandOptions
+          None, // overviewsLocation
+          None // minZoomLevel
         )
       )
       project <- (fr"INSERT INTO" ++ tableF ++ fr"""

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/ProjectDaoSpec.scala
@@ -41,9 +41,13 @@ class ProjectDaoSpec
                 platform,
                 project
               )
-            } yield dbProject
-            val insertedProject =
+              dbProjectLayer <- ProjectLayerDao.unsafeGetProjectLayerById(
+                dbProject.defaultLayerId
+              )
+            } yield (dbProject, dbProjectLayer)
+            val (insertedProject, insertedDefaultLayer) =
               projInsertIO.transact(xa).unsafeRunSync
+
             insertedProject.name == project.name &&
             insertedProject.description == project.description &&
             insertedProject.visibility == project.visibility &&
@@ -52,7 +56,9 @@ class ProjectDaoSpec
             insertedProject.aoiCadenceMillis == project.aoiCadenceMillis &&
             insertedProject.tags == project.tags &&
             insertedProject.isSingleBand == project.isSingleBand &&
-            insertedProject.singleBandOptions == project.singleBandOptions
+            insertedProject.singleBandOptions == project.singleBandOptions &&
+            insertedProject.isSingleBand == insertedDefaultLayer.isSingleBand &&
+            insertedProject.singleBandOptions == insertedDefaultLayer.singleBandOptions
           }
       }
     }


### PR DESCRIPTION
## Overview

This PR updates the insert method for `ProjectDao` so that the single-band related settings from `Project.Create` are applied to the default project layer as well, since backsplash reads the mosaic definitions from layers in the `layerStore` (which makes sense).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should pass
- assemble your api jar
- grab a token and run the following to create a single band project:
```
curl --location --request POST 'http://localhost:9091/api/projects' \
--header 'Authorization: Bearer <your token>' \
--header 'Content-Type: application/json' \
--data-raw '{
  "name": "Test Single Band",
  "description": "",
  "visibility": "PRIVATE",
  "tileVisibility": "PUBLIC",
  "tags": [],
  "isAOIProject": false,
  "isSingleBand": true,
  "singleBandOptions": {
    "band": 0,
    "dataType": "SEQUENTIAL",
    "colorBins": 0,
    "colorScheme": [
      "#000000",
      "#FFFFFF"
    ],
    "legendOrientation": "left",
    "extraNoData": []
  }
}'
```
- From the frontend, add a single-band COG image to this project
- After closing the modal, the scene should load with no problem

Closes https://github.com/raster-foundry/raster-foundry/issues/5451
