### PR TITLE
Add Parameter to Disable Color Correction and Fix Tag Parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Removed
 
 ### Fixed
+- Fixed a tiff tag parsing bug and allow for disabling color correction via a query parameter [#5455](https://github.com/raster-foundry/raster-foundry/pull/5455)
 
 ### Security
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashGeotiffReader.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashGeotiffReader.scala
@@ -105,21 +105,27 @@ object BacksplashGeotiffReader extends LazyLogging {
             case Tiff =>
               var ifdOffset = byteReader.getInt
               while (ifdOffset > 0) {
-                val ifdTiffTags = TiffTags.read(byteReader, ifdOffset)(IntTiffTagOffsetSize)
+                val ifdTiffTags =
+                  TiffTags.read(byteReader, ifdOffset)(IntTiffTagOffsetSize)
                 // TIFF Reader supports only overviews at this point
                 // Overview is a reduced-resolution IFD
-                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType.flatMap(NewSubfileType.fromCode)
-                if(subfileType.contains(ReducedImage)) tiffTagsBuffer += ifdTiffTags
+                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType
+                  .flatMap(NewSubfileType.fromCode)
+                if (subfileType.contains(ReducedImage))
+                  tiffTagsBuffer += ifdTiffTags
                 ifdOffset = byteReader.getInt
               }
             case _ =>
               var ifdOffset = byteReader.getLong
               while (ifdOffset > 0) {
-               val ifdTiffTags = TiffTags.read(byteReader, ifdOffset)(LongTiffTagOffsetSize)
+                val ifdTiffTags =
+                  TiffTags.read(byteReader, ifdOffset)(LongTiffTagOffsetSize)
                 // TIFF Reader supports only overviews at this point
                 // Overview is a reduced-resolution IFD
-                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType.flatMap(NewSubfileType.fromCode)
-                if(subfileType.contains(ReducedImage)) tiffTagsBuffer += ifdTiffTags
+                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType
+                  .flatMap(NewSubfileType.fromCode)
+                if (subfileType.contains(ReducedImage))
+                  tiffTagsBuffer += ifdTiffTags
                 ifdOffset = byteReader.getLong
               }
           }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashGeotiffReader.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashGeotiffReader.scala
@@ -105,17 +105,21 @@ object BacksplashGeotiffReader extends LazyLogging {
             case Tiff =>
               var ifdOffset = byteReader.getInt
               while (ifdOffset > 0) {
-                tiffTagsBuffer += TiffTags.read(byteReader, ifdOffset.toLong)(
-                  IntTiffTagOffsetSize
-                )
+                val ifdTiffTags = TiffTags.read(byteReader, ifdOffset)(IntTiffTagOffsetSize)
+                // TIFF Reader supports only overviews at this point
+                // Overview is a reduced-resolution IFD
+                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType.flatMap(NewSubfileType.fromCode)
+                if(subfileType.contains(ReducedImage)) tiffTagsBuffer += ifdTiffTags
                 ifdOffset = byteReader.getInt
               }
             case _ =>
               var ifdOffset = byteReader.getLong
               while (ifdOffset > 0) {
-                tiffTagsBuffer += TiffTags.read(byteReader, ifdOffset)(
-                  LongTiffTagOffsetSize
-                )
+               val ifdTiffTags = TiffTags.read(byteReader, ifdOffset)(LongTiffTagOffsetSize)
+                // TIFF Reader supports only overviews at this point
+                // Overview is a reduced-resolution IFD
+                val subfileType = ifdTiffTags.nonBasicTags.newSubfileType.flatMap(NewSubfileType.fromCode)
+                if(subfileType.contains(ReducedImage)) tiffTagsBuffer += ifdTiffTags
                 ifdOffset = byteReader.getLong
               }
           }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -52,6 +52,7 @@ final case class BacksplashGeotiff(
     mask: Option[MultiPolygon],
     footprint: MultiPolygon,
     metadata: SceneMetadataFields,
+    disableAutoCorrect: Option[Boolean],
     xa: Transactor[IO]
 ) extends LazyLogging
     with BacksplashImage[IO] {
@@ -203,6 +204,7 @@ sealed trait BacksplashImage[F[_]] extends LazyLogging {
   val projectLayerId: UUID
   val mask: Option[MultiPolygon]
   val metadata: SceneMetadataFields
+  val disableAutoCorrect: Option[Boolean]
 
   val enableGDAL = Config.RasterSource.enableGDAL
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -198,18 +198,20 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                   .span("renderMosaicMultiband.colorCorrect") use {
                   _ =>
                     IO {
-                      im map { mbTile =>
-                        val noDataValue = getNoDataValue(mbTile.cellType)
-                        logger.debug(
-                          s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
-                        )
-                        relevant.corrections.colorCorrect(
-                          mbTile,
-                          hists,
-                          relevant.metadata.noDataValue orElse noDataValue orElse Some(
-                            0
+                      im map {
+                        mbTile =>
+                          val noDataValue = getNoDataValue(mbTile.cellType)
+                          logger.debug(
+                            s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
                           )
-                        )
+                          relevant.corrections.colorCorrect(
+                            mbTile,
+                            hists,
+                            relevant.metadata.noDataValue orElse noDataValue orElse Some(
+                              0
+                            ),
+                            relevant.disableAutoCorrect
+                          )
                       }
                     }
                 }
@@ -394,7 +396,8 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                                 relevant.corrections.colorCorrect(
                                   mbTile,
                                   hists,
-                                  None
+                                  None,
+                                  relevant.disableAutoCorrect
                                 )
                               }
                             }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
@@ -79,6 +79,8 @@ object Parameters {
       extends OptionalQueryParamDecoderMatcher[String]("tag")
   object VoidCacheQueryParamMatcher
       extends QueryParamDecoderMatcher[Boolean]("voidCache")
+  object DisableAutoCorrectionQueryParamDecoder
+      extends OptionalQueryParamDecoderMatcher[Boolean]("disableAutoCorrect")
   object ZoomQueryParamMatcher extends QueryParamDecoderMatcher[Int]("zoom")
   object BrightnessFloorQueryParamMatcher
       extends OptionalQueryParamDecoderMatcher[Int]("floor")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
@@ -22,6 +22,7 @@ import java.util.UUID
       window: Option[Projected[Polygon]],
       bandOverride: Option[BandOverride],
       imageSubset: Option[NEL[UUID]],
+      disableAutoCorrect: Option[Boolean],
       tracingContext: TracingContext[IO] = NoOpTracingContext[IO]("no-op-read")
   ): BacksplashMosaic
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -39,6 +39,7 @@ class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
                                 None,
                                 None,
                                 None,
+                                None,
                                 NoOpTracingContext[IO]("no-op-read"))
             } map {
               case (tracingContext, bsiList) =>
@@ -60,6 +61,7 @@ class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
             s"${layerId.toString}_${bandActual}" -> (
               layerStore
                 .read(layerId,
+                      None,
                       None,
                       None,
                       None,

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
@@ -35,6 +35,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
   private def mosaicDefinitionToImage(
       mosaicDefinition: MosaicDefinition,
       bandOverride: Option[BandOverride],
+      disableAutoCorrect: Option[Boolean],
       projId: UUID
   ): BacksplashImage[IO] = {
     val singleBandOptions =
@@ -89,6 +90,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
       mosaicDefinition.mask,
       footprint,
       mosaicDefinition.sceneMetadataFields,
+      disableAutoCorrect,
       xa
     )
   }
@@ -101,6 +103,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
           window: Option[Projected[Polygon]],
           bandOverride: Option[BandOverride],
           imageSubset: Option[NEL[UUID]],
+          disableAutoCorrect: Option[Boolean],
           tracingContext: TracingContext[IO]
       ): BacksplashMosaic = {
         val tags = Map("sceneId" -> projId.toString)
@@ -137,6 +140,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
                     None, // not adding the mask here, since out of functional scope for md to image
                     footprint,
                     scene.metadataFields,
+                    disableAutoCorrect,
                     xa
                   )
                 )
@@ -156,6 +160,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
           window: Option[Projected[Polygon]],
           bandOverride: Option[BandOverride],
           imageSubset: Option[NEL[UUID]],
+          disableAutoCorrect: Option[Boolean],
           tracingContext: TracingContext[IO]
       ): BacksplashMosaic = {
         val tags = Map("projectId" -> projId.toString)
@@ -177,7 +182,10 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
             }
           } yield {
             (tracingContext, mosaicDefinitions map { md =>
-              mosaicDefinitionToImage(md, bandOverride, projId)
+              mosaicDefinitionToImage(md,
+                                      bandOverride,
+                                      disableAutoCorrect,
+                                      projId)
             })
           }
         }

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -26,12 +26,6 @@ object CogUtils extends LazyLogging {
   ): Option[Array[Histogram[Double]]] = {
     // Get the smallest overview and calculate histogram from that
     val rasterSource = GeoTiffRasterSource(uri)
-    val bandCount = rasterSource.bandCount
-    logger.debug(s"Base cell size is: ${rasterSource.cellSize}")
-    // This is to workaround https://github.com/locationtech/geotrellis/issues/3269
-    // where not all overviews are actually overviews
-    val lastOverview =
-      rasterSource.tiff.overviews.filter(_.bandCount == bandCount).lastOption
-    lastOverview.map(_.tile.bands.map(_.histogramDouble(buckets)).toArray)
+    rasterSource.tiff.overviews.lastOption.map(_.tile.bands.map(_.histogramDouble(buckets)).toArray)
   }
 }

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -26,6 +26,7 @@ object CogUtils extends LazyLogging {
   ): Option[Array[Histogram[Double]]] = {
     // Get the smallest overview and calculate histogram from that
     val rasterSource = GeoTiffRasterSource(uri)
-    rasterSource.tiff.overviews.lastOption.map(_.tile.bands.map(_.histogramDouble(buckets)).toArray)
+    rasterSource.tiff.overviews.lastOption
+      .map(_.tile.bands.map(_.histogramDouble(buckets)).toArray)
   }
 }


### PR DESCRIPTION
## Overview

There are two fixes for bugs that were uncovered last week.

First - the tiff overview tag parsing now matches what is in GeoTrellis. This prevents accidentally identifying per dataset masks as overviews that can be rendered which introduced some rendering bugs.

Second - this adds a parameter to tile requests that allows for disabling auto color correction. This prevents image distortion when a user has already applied some corrections to their imagery and does not want the server to apply any changes.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

With color correction enabled: 
![image](https://user-images.githubusercontent.com/898060/88579962-eb147380-d018-11ea-9433-822c9453abbe.png)

With color correction disabled via query parameter:
![image](https://user-images.githubusercontent.com/898060/88580088-18612180-d019-11ea-88f0-e148b5c88e63.png)

## Testing Instructions

- Upload a COG that you'd like to compare before/after disabling color correction
- Go to the "publish" page of the project you uploaded the COG to, make project public, and copy the ZXY URL
- Strip off any existing query parameters to the project and add `disableAutoCorrect=true` to the ZXY URL template
- Go to [geojson.io](geojson.io) and add a layer with the ZXY URL template
- Compare this non-corrected image to the one displayed in the UI
