### PR TITLE
Add more username types for bulk-creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
+
 - Add validation specific endpoint [#5453](https://github.com/raster-foundry/raster-foundry/pull/5453)
+- Added three additional categories for usernames when bulk-creating [#5458](https://github.com/raster-foundry/raster-foundry/pull/5458)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/user/PseudoUsernameService.scala
+++ b/app-backend/api/src/main/scala/user/PseudoUsernameService.scala
@@ -4,9 +4,201 @@ import com.rasterfoundry.datamodel.PseudoUsernameType
 
 import com.github.javafaker._
 
+import scala.util.Random
+
 import java.util.UUID
 
 object PseudoUsernameService {
+
+  private val moonsOfJupiter = List(
+    "Adrastea",
+    "Aitne",
+    "Amalthea",
+    "Ananke",
+    "Aoede",
+    "Arche",
+    "Autonoe",
+    "Callirrhoe",
+    "Callisto",
+    "Carme",
+    "Carpo",
+    "Chaldene",
+    "Cyllene",
+    "Dia",
+    "Elara",
+    "Erinome",
+    "Eukelade",
+    "Euanthe",
+    "Euporie",
+    "Europa",
+    "Eurydome",
+    "Ganymede",
+    "Harpalyke",
+    "Hegemone",
+    "Helike",
+    "Hermippe",
+    "Herse",
+    "Himalia",
+    "Io",
+    "Iocaste",
+    "Isonoe",
+    "Kale",
+    "Kallichore",
+    "Kalyke",
+    "Kore",
+    "Leda",
+    "Lysithea",
+    "Mneme",
+    "Orthosie",
+    "Pasiphae",
+    "Pasithee",
+    "Praxidike",
+    "Sinope",
+    "Sponde",
+    "Thebe",
+    "Themisto",
+    "Taygete",
+    "Thelxinoe",
+    "Thyone",
+    "S/2003 J2",
+    "S/2003 J3",
+    "S/2003 J4",
+    "S/2003 J5",
+    "S/2003 J9",
+    "S/2003 J10",
+    "S/2003 J12",
+    "S/2003 J15",
+    "S/2003 J16",
+    "S/2003 J18",
+    "S/2003 J19",
+    "S/2003 J23",
+    "S/2011 J1",
+    "S/2011 J2"
+  )
+
+  private val animalAstronauts = List(
+    "Albert",
+    "Yorick",
+    "Patricia",
+    "Mike",
+    "Gordo",
+    "Able",
+    "Baker",
+    "Sam",
+    "Miss Sam",
+    "Ham",
+    "Goliath",
+    "Enos",
+    "Bonnie",
+    "Abrek",
+    "Bion",
+    "Verny",
+    "Gordy",
+    "Yerosha",
+    "Dryoma",
+    "Zhakonya",
+    "Zabiyaka",
+    "Krosh",
+    "Ivasha",
+    "Lapik",
+    "Multik",
+    "Dezik",
+    "Lisa",
+    "Smelaya",
+    "Malyshka",
+    "ZIB",
+    "Albina",
+    "Dymka",
+    "Modnista",
+    "Kozyavka",
+    "Laika",
+    "Bars",
+    "Lisichka",
+    "Belka",
+    "Strelka",
+    "Pchelka",
+    "Muska",
+    "Damka",
+    "Krasavka",
+    "Zvezdochka",
+    "Veterok",
+    "Mildred",
+    "Albert",
+    "Laska",
+    "Wilkie",
+    "Felicette",
+    "Anita",
+    "Arabella"
+  )
+
+  private val earthNames = List(
+    "Terra",
+    "Tierra",
+    "Terre",
+    "Pamant",
+    "Tiere",
+    "Tiara",
+    "Terrinu",
+    "Jord",
+    "Aarde",
+    "Erde",
+    "Earth",
+    "Erd",
+    "Talamh",
+    "Ierde",
+    "Buedem",
+    "Zemlja",
+    "Ziemia",
+    "Ziamli",
+    "Zeme",
+    "Domhain",
+    "Talamh",
+    "Cre",
+    "Tir",
+    "Daeaer",
+    "Douar",
+    "Yeryuzu",
+    "Ge",
+    "Maa",
+    "Toke",
+    "Yerkir",
+    "Yerger",
+    "Kedin",
+    "Erkir",
+    "Zamin",
+    "Bhim",
+    "Palal",
+    "Mati",
+    "Mitti",
+    "Prithbi",
+    "Zamin",
+    "Metsu",
+    "Xak",
+    "Dunia",
+    "Ile aye",
+    "Duniya",
+    "Uwa",
+    "Umhlaba",
+    "Pasi",
+    "Midiri",
+    "Ard",
+    "Eretz",
+    "Lafa",
+    "Diqiu",
+    "Kambharmyay",
+    "Prthvi",
+    "Jigu",
+    "Chikyu",
+    "Trai dat",
+    "Phendei",
+    "Lok",
+    "Aephndin olk",
+    "Vanua",
+    "Yuta",
+    "Lupa",
+    "Bumi",
+    "Pumi"
+  )
 
   def createPseudoName(peudoUserNameType: PseudoUsernameType): String = {
     val uuidSegments = UUID.randomUUID
@@ -15,7 +207,9 @@ object PseudoUsernameService {
       .toIndexedSeq
     val uuidSegOne = uuidSegments(1)
     val uuidSegTwo = uuidSegments(2)
-    val faker = new Faker();
+    val faker = new Faker()
+    val random = new Random
+
     (peudoUserNameType match {
       case PseudoUsernameType.GameOfThrones =>
         s"${faker.gameOfThrones().character()} ${uuidSegOne} ${uuidSegTwo}"
@@ -35,6 +229,12 @@ object PseudoUsernameService {
         s"${faker.superhero().prefix()} ${faker
           .superhero()
           .descriptor()} ${uuidSegOne} ${uuidSegTwo}"
+      case PseudoUsernameType.AnimalAstronauts =>
+        s"${animalAstronauts(random.nextInt(animalAstronauts.length))} ${uuidSegOne} ${uuidSegTwo}"
+      case PseudoUsernameType.MoonsOfJupiter =>
+        s"${moonsOfJupiter(random.nextInt(moonsOfJupiter.length))} ${uuidSegOne} ${uuidSegTwo}"
+      case PseudoUsernameType.EarthNames =>
+        s"${earthNames(random.nextInt(earthNames.length))} ${uuidSegOne} ${uuidSegTwo}"
     }).replaceAll("\\s", "-").toLowerCase().capitalize
   }
 

--- a/app-backend/api/src/main/scala/user/PseudoUsernameService.scala
+++ b/app-backend/api/src/main/scala/user/PseudoUsernameService.scala
@@ -200,6 +200,7 @@ object PseudoUsernameService {
     "Pumi"
   )
 
+  @SuppressWarnings(Array("CollectionIndexOnNonIndexedSeq"))
   def createPseudoName(peudoUserNameType: PseudoUsernameType): String = {
     val uuidSegments = UUID.randomUUID
       .toString()

--- a/app-backend/datamodel/src/main/scala/PseudoUsernameType.scala
+++ b/app-backend/datamodel/src/main/scala/PseudoUsernameType.scala
@@ -16,6 +16,9 @@ object PseudoUsernameType {
   case object RickAndMorty extends PseudoUsernameType("RICK_AND_MORTY")
   case object StarTrek extends PseudoUsernameType("STAR_TREK")
   case object SuperHero extends PseudoUsernameType("SUPER_HERO")
+  case object MoonsOfJupiter extends PseudoUsernameType("MOONS_OF_JUPITER")
+  case object AnimalAstronauts extends PseudoUsernameType("ANIMAL_ASTRONAUTS")
+  case object EarthNames extends PseudoUsernameType("EARTH_NAMES")
 
   def fromString(s: String): PseudoUsernameType = s.toUpperCase match {
     case "GAME_OF_THRONES"   => GameOfThrones
@@ -26,6 +29,9 @@ object PseudoUsernameType {
     case "RICK_AND_MORTY"    => RickAndMorty
     case "STAR_TREK"         => StarTrek
     case "SUPER_HERO"        => SuperHero
+    case "MOONS_OF_JUPITER"  => MoonsOfJupiter
+    case "ANIMAL_ASTRONAUTS" => AnimalAstronauts
+    case "EARTH_NAMES"       => EarthNames
     case _                   => throw new Exception(s"Invalid string: $s")
   }
 


### PR DESCRIPTION
## Overview

This PR adds three more categories of user-names to the `PseudoUsernameService`:
  - `MoonsOfJupiter`
  - `AnimalAstronauts`
  - `EarthNames`

This still adds UUID segments to the usernames and keeps the old categories around for deployment independence.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Use the corresponding PR in another repo to test this
