### PR TITLE
URL decode ingest location for new scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### Fixed
 
 - Apply single band settings to project default layer upon project create [#5454](https://github.com/raster-foundry/raster-foundry/pull/5454)
-- Switched to GDALRasterSource in COG scene posts to fetch metadata without timeouts [#5459](https://github.com/raster-foundry/raster-foundry/pull/5459)
+- Switched to GDALRasterSource in COG scene posts to fetch metadata without timeouts [#5459](https://github.com/raster-foundry/raster-foundry/pull/5459), [#5460](https://github.com/raster-foundry/raster-foundry/pull/5460)
 
 ### Security
 

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -28,6 +28,8 @@ import io.circe.syntax._
 
 import scala.concurrent.ExecutionContext
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 
 trait SceneRoutes
@@ -127,7 +129,10 @@ trait SceneRoutes
     authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
       entity(as[Scene.Create]) { newScene =>
         val rasterSourceOption =
-          newScene.ingestLocation.map(location => GDALRasterSource(location))
+          newScene.ingestLocation.map(
+            location =>
+              GDALRasterSource(URLDecoder.decode(location, UTF_8.toString))
+          )
         val tileFootprint = (
           newScene.sceneType,
           newScene.tileFootprint

--- a/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
@@ -17,6 +17,8 @@ import geotrellis.raster.histogram.Histogram
 import geotrellis.raster.io.json.HistogramJsonFormats
 import io.circe.syntax._
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 
 object HistogramBackfill
@@ -74,7 +76,9 @@ object HistogramBackfill
       ingestLocation: String
   ): Option[Array[Histogram[Double]]] = {
     logger.info(s"Fetching histogram for scene at $ingestLocation")
-    val rasterSource = GDALRasterSource(ingestLocation)
+    val rasterSource = GDALRasterSource(
+      URLDecoder.decode(ingestLocation, UTF_8.toString())
+    )
     val histO = CogUtils.histogramFromUri(rasterSource)
     if (histO.isEmpty) {
       logger.info(s"Fetching histogram for scene at $ingestLocation failed")


### PR DESCRIPTION
## Overview

`GDALRasterSource` handles URIs in a slightly different manner and requires that we decode ingest location.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
