### PR TITLE
Update annotation project update endpoint. Update status DB trigger

### DIFF
--- a/app-backend/db/src/main/resources/migrations/V60__Update_annotation_project_status_trigger.sql
+++ b/app-backend/db/src/main/resources/migrations/V60__Update_annotation_project_status_trigger.sql
@@ -1,0 +1,49 @@
+DROP TRIGGER IF EXISTS update_campaign_project_statuses 
+ON annotation_projects;
+
+CREATE OR REPLACE FUNCTION UPDATE_CAMPAIGN_PROJECT_STATUSES()
+  RETURNS trigger AS
+$BODY$
+DECLARE
+  op_campaign_id uuid;
+BEGIN
+  -- the NEW variable holds row for INSERT/UPDATE operations
+  -- the OLD variable holds row for DELETE operations
+  -- store the campaign ID from the annotation project update
+  IF TG_OP = 'UPDATE' THEN
+    op_campaign_id := NEW.campaign_id;
+  ELSE
+    op_campaign_id := OLD.campaign_id;
+  END IF;
+  -- update status for the parent campaign
+  IF op_campaign_id IS NOT NULL THEN
+    UPDATE public.campaigns
+    SET project_statuses = annotation_project_statuses.project_status
+    FROM (
+      SELECT
+      CREATE_CAMPAIGN_PROJECT_STATUSES(
+        jsonb_object_agg(
+          statuses.status,
+          statuses.status_count
+        )
+      ) AS project_status
+      FROM (
+        SELECT status, COUNT(id) AS status_count
+        FROM public.annotation_projects
+        WHERE campaign_id = op_campaign_id
+        GROUP BY status
+      ) statuses
+    ) AS annotation_project_statuses
+    WHERE id = op_campaign_id;
+  END IF;
+  -- result is ignored since this is an AFTER trigger
+  RETURN NULL;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+CREATE TRIGGER update_campaign_project_statuses
+  AFTER UPDATE OF status OR DELETE
+  ON annotation_projects
+  FOR EACH ROW
+  EXECUTE PROCEDURE UPDATE_CAMPAIGN_PROJECT_STATUSES();

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -299,7 +299,9 @@ object AnnotationProjectDao
       validators_team_id = ${project.validatorsTeamId},
       task_size_meters= ${project.taskSizeMeters},
       aoi = ${project.aoi},
-      status = ${project.status}
+      status = ${project.status},
+      campaign_id = ${project.campaignId},
+      captured_at = ${project.capturedAt}
     WHERE
       id = $id
     """).update.run;

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationProjectDaoSpec.scala
@@ -302,6 +302,16 @@ class AnnotationProjectDaoSpec
             "Readiness was updated"
           )
 
+          assert(
+            afterUpdate.campaignId == annotationProjectUpdate.campaignId,
+            "Readiness was updated"
+          )
+
+          assert(
+            afterUpdate.capturedAt == annotationProjectUpdate.capturedAt,
+            "Readiness was updated"
+          )
+
           true
         }
       )


### PR DESCRIPTION
## Overview

This PR:
- updates the annotation project update dao method so that it accepts updating the `campaign_id` and the `captured_at` field
- updates the DB trigger listening to change of `annotation_projects` so that the associated `campaign`'s `project_statuses` is in-sync. We used to only listen to `UPDATE OF status`, now we listen to `DELETE` as well

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should cover the testing of both the dao method update and the DB trigger update
- Make sure the code change makes sense to you

Closes https://github.com/azavea/earthrise/issues/135
