### PR TITLE
Include user_id in trace tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add validation specific endpoint [#5453](https://github.com/raster-foundry/raster-foundry/pull/5453)
 - Added three additional categories for usernames when bulk-creating [#5458](https://github.com/raster-foundry/raster-foundry/pull/5458)
+- Included user IDs in traces [#5464](https://github.com/raster-foundry/raster-foundry/pull/5464)
 
 ### Changed
 

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
@@ -86,7 +86,8 @@ object TracedHTTPRoutes {
         val responseOptionWithTags = routes.run(tracedRequest) semiflatMap {
           response =>
             val traceTags = Map(
-              "http_status" -> response.status.code.toString
+              "http_status" -> response.status.code.toString,
+              "user_id" -> authedReq.context.id
             ) ++ tags ++
               response.headers.toList
                 .map(h => (s"response_header_${h.name}" -> h.value))

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/TracedHTTPRoutes.scala
@@ -69,7 +69,8 @@ object TracedHTTPRoutes {
       val tags = Map(
         "http_method" -> req.method.name,
         "request_url" -> req.uri.path,
-        "environment" -> Config.environment
+        "environment" -> Config.environment,
+        "user_id" -> authedReq.context.id
       ) combine {
         getTraceId(req)
       } combine {
@@ -86,8 +87,7 @@ object TracedHTTPRoutes {
         val responseOptionWithTags = routes.run(tracedRequest) semiflatMap {
           response =>
             val traceTags = Map(
-              "http_status" -> response.status.code.toString,
-              "user_id" -> authedReq.context.id
+              "http_status" -> response.status.code.toString
             ) ++ tags ++
               response.headers.toList
                 .map(h => (s"response_header_${h.name}" -> h.value))


### PR DESCRIPTION
## Overview

This PR includes user ids in trace tags. ~I think since everything's running through our fancy request wrapper that this will get them into xray also, but I'll want to test in staging to be sure. I'm waiting a bit so I don't interrupt QA.~ [verified](https://console.aws.amazon.com/xray/home?region=us-east-1#/traces/1-5f459f1d-5bea70bad639fac48b137604/raw)

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundr/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

![image](https://user-images.githubusercontent.com/5702984/90932392-c9aa6b80-e3bb-11ea-9c23-94d73e13b610.png)

## Notes

Please don't ask me how long it took me to debug why I wasn't seeing the user id after the first commit

## Testing Instructions

- check out the linked trace from when I pushed a `test/` branch a minute ago above (or you can find it [here](https://console.aws.amazon.com/xray/home?region=us-east-1#/traces/1-5f459f1d-5bea70bad639fac48b137604/raw)) and look for `user_id` in the annotations
- extra credit for local if you're feeling like it:
  - assemble backsplash server
  - generate some tile requests however you want -- Groundwork, geojson.io, RF frontend...
  - look at the Jaeger UI at localhost:16686, click on a trace, click on tags... and check out the user id

Closes #5431 