### PR TITLE
Move all CogUtils RasterSource interaction onto a blocker

### DIFF
--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -320,6 +320,7 @@ lazy val common = project
       Dependencies.awsCoreSdk,
       Dependencies.awsS3,
       Dependencies.catsCore,
+      Dependencies.catsEffect,
       Dependencies.catsScalacheck,
       Dependencies.chronoscala,
       Dependencies.circeCore,


### PR DESCRIPTION
## Overview

This PR wraps calls in `CogUtils` in `F` and transforms `CogUtils` from an object into a class that demands a [`Blocker`](https://typelevel.org/cats-effect/datatypes/contextshift.html). I don't know for certain that it's going to solve All of Our Problems :tm: but it at least will move the `GDALRasterSource` calls off the main thread which uh freaks me out a bit and Seems Bad :tm: in light of the server seemingly locking up and falling over.

There's also a `test/` branch building so we can test in staging to see if this fixes things.

**NB**: this did not fix the problem with the API server falling over, but it's probably still a good thing to do

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- How to test this PR
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as bundling scripts, restarting services, etc.
- Include test case, and expected output

(maybe) Closes azavea/raster-foundry-platform#1074