### PR TITLE
Don't panic if intercom API interaction fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Failed Intercom API interaction no longer throws an exception [#5468](https://github.com/raster-foundry/raster-foundry/pull/5468)
+
 ### Deprecated
 
 ### Removed

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -73,6 +73,10 @@ lazy val sharedSettings = Seq(
     "org.slf4j",
     "slf4j-api"
   ),
+  unusedCompileDependenciesFilter -= moduleFilter(
+    "org.slf4j",
+    "slf4j-api"
+  ),
   // Try to keep logging sane and make sure to use slf4j + logback
   excludeDependencies ++= Seq(
     "log4j" % "log4j",
@@ -293,7 +297,6 @@ lazy val apiIntegrationTest = project
     libraryDependencies ++= Seq(
       Dependencies.scalaCsv % "test",
       Dependencies.sttpCore % "test",
-      Dependencies.sttpJson % "test",
       Dependencies.sttpCirce % "test",
       Dependencies.sttpOkHttpBackend % "test",
       Dependencies.scalatest
@@ -487,6 +490,7 @@ lazy val batch = project
       Dependencies.scalatest,
       Dependencies.scopt,
       Dependencies.shapeless,
+      Dependencies.slf4j,
       Dependencies.sourceCode,
       Dependencies.spireMath,
       Dependencies.stac4s,
@@ -757,7 +761,6 @@ lazy val notification = Project("notification", file("notification"))
       Dependencies.log4catsSlf4j,
       Dependencies.newtype,
       Dependencies.sttpCore,
-      Dependencies.sttpJson,
       Dependencies.sttpAsyncBackend,
       Dependencies.sttpCirce,
       Dependencies.sttpModel

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/NotifyIntercom.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/NotifyIntercom.scala
@@ -45,7 +45,12 @@ class LiveIntercomNotifier[F[_]: Sync](
           .header("Accept", "application/json")
           .post(uri)
           .body(MessagePost(adminId, userId, msg))
-          .send()
+          .send() flatMap { resp =>
+        resp.body match {
+          case Left(err) => Logger[F].error(err)
+          case _         => ().pure[F]
+        }
+      }
 
     resp.void
   }


### PR DESCRIPTION
## Overview

This PR fixes two things in sending Intercom notifications:

- it doesn't bother attempting to decode the response as json
- it fixes the logging dependencies so that logs actually get printed

Separately, I fixed a configuration value in the dev `.env`, staging tfvars, and production tfvars.

What was wrong was:

- our configuration value was wrong, since someone deleted the Intercom admin user whose ID we were using
- that meant that we couldn't decode the response as the json we expected
- and sttp for some reason throws a NPE in that case (lol)

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

I don't know if the batch job should exit with an error status if notification fails. It's unclear to me the extent to which we think this error is ignorable.

## Testing Instructions

- pull the env down again: `RF_SETTINGS_BUCKET=rasterfoundry-development-config-us-east-1 ./scripts/bootstrap --env`
- assemble the batch jar: `pushd app-backend && ./sbt batch/assembly && popd`
- `./scripts/console batch bash`
- find the user id from a staging user you can log in as
- from the batch container, send them a notification: `RF_LOG_LEVEL=DEBUG java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main notify-intercom "<the real staging user id>" "what's up pal"`
- find your user in the staging workspace in Intercom and confirm that whatever message you sent is present
- `export INTERCOM_ADMIN_ID=1234567` to simulate the previous configuration error
- try to send the notification to your user again -- it should fail and you should see an error, but the exit status should be 0

Closes raster-foundry/annotate#956