### PR TITLE
Return empty tiles for low zooms when appropriate

### DIFF
--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -34,8 +34,8 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
 
   val streamConcurrency = Config.parallelism.streamConcurrency
 
-  // To be used when folding over/merging tiles
   val invisiCellType = IntUserDefinedNoDataCellType(0)
+
   val invisiTile = IntUserDefinedNoDataArrayTile(
     Array.fill(65536)(0),
     256,
@@ -130,7 +130,9 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
             extent
           )
         case someTiles =>
-          val outTile = someTiles.foldLeft(MultibandTile(invisiTile))(
+          val outTile = someTiles.foldLeft(
+            MultibandTile(invisiTile)
+          )(
             (baseTile: MultibandTile, triple2: MBTTriple) =>
               interpretAsFallback(baseTile, firstNd) merge interpretAsFallback(
                 triple2._1,
@@ -225,7 +227,14 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
     mergeTiles(ioMBT).map {
       case Some(t) => Raster(t, extent)
       case _ =>
-        Raster(MultibandTile(invisiTile, invisiTile, invisiTile), extent)
+        Raster(
+          MultibandTile(
+            invisiTile,
+            invisiTile,
+            invisiTile
+          ),
+          extent
+        )
     }
   }
 
@@ -255,7 +264,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
               case Some(t) => Raster(t, extent)
               case _ =>
                 Raster(
-                  MultibandTile(invisiTile, invisiTile, invisiTile),
+                  MultibandTile(
+                    invisiTile,
+                    invisiTile,
+                    invisiTile
+                  ),
                   extent
                 )
             }
@@ -297,7 +310,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
               IO.pure(
                 ProjectedRaster(
                   Raster(
-                    MultibandTile(invisiTile, invisiTile, invisiTile),
+                    MultibandTile(
+                      invisiTile,
+                      invisiTile,
+                      invisiTile
+                    ),
                     Extent(0, 0, 256, 256)
                   ),
                   WebMercator
@@ -321,9 +338,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
     logger.debug(
       s"Retrieving Histograms for ${relevant.imageId} from histogram store"
     )
-    histStore.layerHistogram(relevant.imageId,
-                             relevant.subsetBands,
-                             tracingContext)
+    histStore.layerHistogram(
+      relevant.imageId,
+      relevant.subsetBands,
+      tracingContext
+    )
   }
 
   // We need to be able to pass information about whether scenes should paint themselves while
@@ -407,7 +426,9 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                             case Some(mbTile) =>
                               Some(
                                 Raster(
-                                  mbTile.interpretAs(invisiCellType),
+                                  mbTile.interpretAs(
+                                    invisiCellType
+                                  ),
                                   extent
                                 )
                               )
@@ -421,7 +442,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                     case Some(r) => r
                     case _ =>
                       Raster(
-                        MultibandTile(invisiTile, invisiTile, invisiTile),
+                        MultibandTile(
+                          invisiTile,
+                          invisiTile,
+                          invisiTile
+                        ),
                         extent
                       )
                   })
@@ -445,7 +470,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                           case Some(mbt) =>
                             ColorRampMosaic.colorTile(mbt, histograms, opts)
                           case _ =>
-                            MultibandTile(invisiTile, invisiTile, invisiTile)
+                            MultibandTile(
+                              invisiTile,
+                              invisiTile,
+                              invisiTile
+                            )
                         }
                       case _ =>
                         IO.raiseError(
@@ -461,7 +490,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                   case Some(r) => Raster(r, extent)
                   case _ =>
                     Raster(
-                      MultibandTile(invisiTile, invisiTile, invisiTile),
+                      MultibandTile(
+                        invisiTile,
+                        invisiTile,
+                        invisiTile
+                      ),
                       extent
                     )
                 }
@@ -500,7 +533,11 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                       case Some(r) => r
                       case _ =>
                         Raster(
-                          MultibandTile(invisiTile, invisiTile, invisiTile),
+                          MultibandTile(
+                            invisiTile,
+                            invisiTile,
+                            invisiTile
+                          ),
                           extent
                         )
                     }


### PR DESCRIPTION
## Overview

This PR preempts reading any imagery if an image's data footprint doesn't have an area 3.9x the size of the pixel area at the requested zoom level. I chose 3.9 because it's slightly below 4, and if an image can fill a 2x2 pixel grid, then _I guess_ we should bother rendering it (I'm not sold on this argument at all / I think the threshold could be higher). Arguably this should just be a configurable value.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible.

## Notes

For one of the sample NAIP images in Nebraska, I'm consistently timing out in the first zoom levels where I attempt to read. In both higher and lower zooms it's fine. I have no idea why but I've done so little that I feel like it has to be unrelated to what I've done here.

## Testing Instructions

- assemble backsplash
- fire up your servers
- set `tile_visibility = 'PUBLIC'` for project `cf0fcb49-ffa7-4337-ab0f-af968f1aa812` in your database
- put `http://localhost:8081/cf0fcb49-ffa7-4337-ab0f-af968f1aa812/{z}/{x}/{y}` into a map layer in QGIS or geojson.io or wherever you like to view TMS layers (or check out "Sample Project" in local groundwork if you have that set up)
- zoom out a little bit at a time -- once the image vanishes, you should see a log line from Jaeger with `invisiTile` in it
- steal a request from a copy of the bad project in staging and replace its TMS triple with 0/0/0
- make that request -- it should be fast instead of sad and slow
- make sure traces make sense to you https://console.aws.amazon.com/xray/home?region=us-east-1#/analytics?timeRange=2020-09-03T21:28:00.000Z~2020-09-03T21:33:00.000Z -- in particular, note that low zoom levels are near the bottom of the trace list sorted by latency instead of at the top like they normally are

Closes #5469 
