### PR TITLE
Add GeoTiff info on COG post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Creating a scene from a COG eagerly fetches GeoTiff information [#5473](https://github.com/raster-foundry/raster-foundry/pull/5473)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -16,7 +16,7 @@ import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Route
-import cats.effect.{Blocker, IO}
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
@@ -46,6 +46,8 @@ trait SceneRoutes
 
   implicit val ec: ExecutionContext
 
+  implicit val contextShift: ContextShift[IO]
+
   val rasterIOContext = ExecutionContext.fromExecutor(
     Executors.newFixedThreadPool(
       4,
@@ -53,11 +55,9 @@ trait SceneRoutes
     )
   )
 
-  implicit val rasterIOContextShift = IO.contextShift(rasterIOContext)
+  val rasterIOContextShift = IO.contextShift(rasterIOContext)
 
-  val blocker = Blocker.liftExecutionContext(rasterIOContext)
-
-  val cogUtils = new CogUtils[IO](blocker)
+  val cogUtils = new CogUtils[IO](rasterIOContextShift, rasterIOContext)
 
   val xa: Transactor[IO]
 
@@ -127,389 +127,425 @@ trait SceneRoutes
       }
   }
 
-  def listScenes: Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
-      (withPagination & sceneQueryParameters) { (page, sceneParams) =>
-        complete {
-          SceneWithRelatedDao
-            .listAuthorizedScenes(page, sceneParams, user)
-            .transact(xa)
-            .unsafeToFuture
+  def listScenes: Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
+        (withPagination & sceneQueryParameters) { (page, sceneParams) =>
+          complete {
+            SceneWithRelatedDao
+              .listAuthorizedScenes(page, sceneParams, user)
+              .transact(xa)
+              .unsafeToFuture
+          }
         }
       }
     }
-  }
 
-  def createScene: Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
-      entity(as[Scene.Create]) { newScene =>
-        val rasterSourceOption =
-          newScene.ingestLocation.map(
-            location =>
+  def createScene: Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
+        entity(as[Scene.Create]) { newScene =>
+          val rasterSourceOption =
+            newScene.ingestLocation.map(location =>
               GDALRasterSource(URLDecoder.decode(location, UTF_8.toString))
-          )
-        val tileFootprintIO = (
-          newScene.sceneType,
-          newScene.tileFootprint
-        ) match {
-          case (Some(SceneType.COG), None) => {
-            logger.info(s"Generating Footprint for Newly Added COG")
-            rasterSourceOption traverse { rs =>
-              cogUtils.getTiffExtent(rs)
-            }
-          }
-          case (_, tf @ Some(_)) => {
-            logger.info("Not generating footprint, already exists")
-            IO.pure(tf)
-          }
-          case _ => IO.pure(None)
-        }
-
-        val histogramIO: IO[Option[Array[Histogram[Double]]]] =
-          (newScene.sceneType) match {
-            case Some(SceneType.COG) =>
-              rasterSourceOption
-                .traverse(rs => cogUtils.histogramFromUri(rs)) map { _.flatten }
-            case _ => IO.pure(Option.empty)
-          }
-
-        val dataFootprintIO = tileFootprintIO map { tf =>
-          (tf, newScene.dataFootprint) match {
-            case (Some(_), None) => tf
-            case _               => newScene.dataFootprint
-          }
-        }
-
-        val insertFut = for {
-          histogram <- histogramIO.unsafeToFuture
-          (tileFootprint, dataFootprint) <- (tileFootprintIO, dataFootprintIO).tupled.unsafeToFuture
-          updatedScene = newScene
-            .copy(
-              dataFootprint = dataFootprint,
-              tileFootprint = tileFootprint,
-              statusFields = newScene.statusFields.copy(
-                ingestStatus = IngestStatus.NotIngested
-              )
             )
-          sceneInsert = (
-            histogram,
+          val tileFootprintIO = (
             newScene.sceneType,
-            !newScene.ingestLocation.isEmpty
+            newScene.tileFootprint
           ) match {
-            case (Some(hist), Some(SceneType.COG), true) =>
-              for {
-                insertedScene <- SceneDao.insert(updatedScene, user)
-                _ <- LayerAttributeDao
-                  .insertLayerAttribute(
-                    LayerAttribute(
-                      insertedScene.id.toString,
-                      0,
-                      "histogram",
-                      hist.asJson
-                    )
-                  )
-                  .attempt map {
-                  _.toOption
-                }
-              } yield insertedScene
-            case (_, _, false) =>
-              SceneDao.insert(updatedScene, user)
-            case _ =>
-              throw new IllegalArgumentException(
-                "Unable to generate histograms for scene. Please verify that appropriate " ++
-                  "overviews exist. Histogram generation requires an overview smaller than 600x600."
-              )
-          }
-          histogramAndInsertFut <- sceneInsert.transact(xa).unsafeToFuture
-          _ <- (newScene.ingestLocation traverse { uri =>
-            cogUtils.getGeoTiffInfo(uri) flatMap { geotiffInfo =>
-              (SceneDao
-                .updateSceneGeoTiffInfo(geotiffInfo, histogramAndInsertFut.id)
-                *> SceneDao.update(
-                  histogramAndInsertFut
-                    .copy(
-                      statusFields = histogramAndInsertFut.statusFields
-                        .copy(ingestStatus = IngestStatus.Ingested)
-                    )
-                    .toScene,
-                  histogramAndInsertFut.id,
-                  user
-                ))
-                .transact(xa)
-            }
-          }).attempt.start.unsafeToFuture
-        } yield histogramAndInsertFut
-
-        onSuccess(insertFut) { scene =>
-          if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested)
-            kickoffSceneIngest(scene.id)
-          complete((StatusCodes.Created, scene))
-        }
-      }
-    }
-  }
-
-  def getScene(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
-      authorizeAsync {
-        SceneDao
-          .authQuery(user, ObjectType.Scene)
-          .filter(sceneId)
-          .exists
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        rejectEmptyResponse {
-          complete {
-            SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def updateScene(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Update, None), user) {
-      authorizeAuthResultAsync {
-        SceneDao
-          .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[Scene]) { updatedScene =>
-          onSuccess(
-            SceneDao
-              .update(updatedScene, sceneId, user)
-              .transact(xa)
-              .unsafeToFuture
-          ) {
-            completeSingleOrNotFound(_)
-          }
-        }
-      }
-    }
-  }
-
-  def deleteScene(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Delete, None), user) {
-      authorizeAuthResultAsync {
-        SceneDao
-          .authorized(user, ObjectType.Scene, sceneId, ActionType.Delete)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        val response = for {
-          result <- SceneDao.query.filter(sceneId).delete.transact(xa)
-          _ <- SceneDao.deleteCache(sceneId).transact(xa)
-        } yield result
-        onSuccess(response.unsafeToFuture) {
-          completeSingleOrNotFound
-        }
-      }
-    }
-  }
-
-  def getDownloadUrl(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Download, None), user) {
-      authorizeAuthResultAsync {
-        SceneWithRelatedDao
-          .authorized(user, ObjectType.Scene, sceneId, ActionType.Download)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
-        ) { scene =>
-          complete {
-            val retrievedScene = scene.getOrElse {
-              throw new Exception(
-                "Scene does not exist or is not accessible by this user"
-              )
-            }
-            val s3Client = S3()
-            val whitelist = List(s"s3://$dataBucket")
-            (retrievedScene.sceneType, retrievedScene.ingestLocation) match {
-              case (Some(SceneType.COG), Some(ingestLocation)) =>
-                val signedUrl = s3Client.maybeSignUri(ingestLocation, whitelist)
-                List(
-                  Image.Downloadable(
-                    s"${sceneId}_COG.tif",
-                    s"$ingestLocation",
-                    signedUrl
-                  )
-                )
-              case _ =>
-                retrievedScene.images map { image =>
-                  val downloadUri: String =
-                    s3Client.maybeSignUri(image.sourceUri, whitelist)
-                  image.toDownloadable(downloadUri)
-                }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  def listScenePermissions(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        SceneDao
-          .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          SceneDao
-            .getPermissions(sceneId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def replaceScenePermissions(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
-        authorizeAsync {
-          (
-            SceneDao
-              .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit) map {
-              _.toBoolean
-            },
-            acrList traverse { acr =>
-              SceneDao.isValidPermission(acr, user)
-            } map {
-              _.foldLeft(true)(_ && _)
-            } map {
-              case true =>
-                SceneDao.isReplaceWithinScopedLimit(
-                  Domain.Scenes,
-                  user,
-                  acrList
-                )
-              case _ => false
-            }
-          ).tupled
-            .map({ authTup =>
-              authTup._1 && authTup._2
-            })
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            SceneDao
-              .replacePermissions(sceneId, acrList)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def addScenePermission(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
-      entity(as[ObjectAccessControlRule]) { acr =>
-        authorizeAsync {
-          (
-            SceneDao
-              .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit) map {
-              _.toBoolean
-            },
-            SceneDao.isValidPermission(acr, user)
-          ).tupled
-            .map(authTup => authTup._1 && authTup._2)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            SceneDao
-              .addPermission(sceneId, acr)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def listUserSceneActions(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAsync {
-        SceneDao
-          .authQuery(user, ObjectType.Scene)
-          .filter(sceneId)
-          .exists
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          SceneWithRelatedDao
-            .unsafeGetScene(sceneId)
-            .transact(xa)
-            .unsafeToFuture
-        ) { scene =>
-          scene.owner == user.id match {
-            case true => complete(List("*"))
-            case false =>
-              complete {
-                SceneDao
-                  .listUserActions(user, sceneId)
-                  .transact(xa)
-                  .unsafeToFuture
+            case (Some(SceneType.COG), None) => {
+              logger.info(s"Generating Footprint for Newly Added COG")
+              rasterSourceOption traverse { rs =>
+                cogUtils.getTiffExtent(rs)
               }
+            }
+            case (_, tf @ Some(_)) => {
+              logger.info("Not generating footprint, already exists")
+              IO.pure(tf)
+            }
+            case _ => IO.pure(None)
+          }
+
+          val histogramIO: IO[Option[Array[Histogram[Double]]]] =
+            (newScene.sceneType) match {
+              case Some(SceneType.COG) =>
+                rasterSourceOption
+                  .traverse(rs => cogUtils.histogramFromUri(rs)) map {
+                  _.flatten
+                }
+              case _ => IO.pure(Option.empty)
+            }
+
+          val dataFootprintIO = tileFootprintIO map { tf =>
+            (tf, newScene.dataFootprint) match {
+              case (Some(_), None) => tf
+              case _               => newScene.dataFootprint
+            }
+          }
+
+          val insertFut = for {
+            histogram <- histogramIO.unsafeToFuture
+            (tileFootprint, dataFootprint) <-
+              (tileFootprintIO, dataFootprintIO).tupled.unsafeToFuture
+            updatedScene =
+              newScene
+                .copy(
+                  dataFootprint = dataFootprint,
+                  tileFootprint = tileFootprint,
+                  statusFields = newScene.statusFields.copy(
+                    ingestStatus = IngestStatus.NotIngested
+                  )
+                )
+            sceneInsert = (
+                histogram,
+                newScene.sceneType,
+                !newScene.ingestLocation.isEmpty
+            ) match {
+              case (Some(hist), Some(SceneType.COG), true) =>
+                for {
+                  insertedScene <- SceneDao.insert(updatedScene, user)
+                  _ <-
+                    LayerAttributeDao
+                      .insertLayerAttribute(
+                        LayerAttribute(
+                          insertedScene.id.toString,
+                          0,
+                          "histogram",
+                          hist.asJson
+                        )
+                      )
+                      .attempt map {
+                      _.toOption
+                    }
+                } yield insertedScene
+              case (_, _, false) =>
+                SceneDao.insert(updatedScene, user)
+              case _ =>
+                throw new IllegalArgumentException(
+                  "Unable to generate histograms for scene. Please verify that appropriate " ++
+                    "overviews exist. Histogram generation requires an overview smaller than 600x600."
+                )
+            }
+            histogramAndInsertFut <- sceneInsert.transact(xa).unsafeToFuture
+            _ <- (newScene.ingestLocation traverse { uri =>
+                cogUtils.getGeoTiffInfo(uri) flatMap { geotiffInfo =>
+                  (SceneDao
+                    .updateSceneGeoTiffInfo(
+                      geotiffInfo,
+                      histogramAndInsertFut.id
+                    )
+                    *> SceneDao.update(
+                      histogramAndInsertFut
+                        .copy(
+                          statusFields = histogramAndInsertFut.statusFields
+                            .copy(ingestStatus = IngestStatus.Ingested)
+                        )
+                        .toScene,
+                      histogramAndInsertFut.id,
+                      user
+                    ))
+                    .transact(xa)
+                }
+              }).attempt.start.unsafeToFuture
+          } yield histogramAndInsertFut
+
+          onSuccess(insertFut) { scene =>
+            if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested)
+              kickoffSceneIngest(scene.id)
+            complete((StatusCodes.Created, scene))
           }
         }
       }
     }
-  }
 
-  def deleteScenePermissions(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
-      authorizeAuthResultAsync {
-        SceneDao
-          .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
+  def getScene(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
+        authorizeAsync {
           SceneDao
-            .deletePermissions(sceneId)
+            .authQuery(user, ObjectType.Scene)
+            .filter(sceneId)
+            .exists
             .transact(xa)
             .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def getSceneDatasource(sceneId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Datasources, Action.Read, None), user) {
-      authorizeAsync {
-        SceneDao
-          .authQuery(user, ObjectType.Scene)
-          .filter(sceneId)
-          .exists
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          DatasourceDao.getSceneDatasource(sceneId).transact(xa).unsafeToFuture
-        ) { datasourceO =>
-          complete {
-            datasourceO
+        } {
+          rejectEmptyResponse {
+            complete {
+              SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
+            }
           }
         }
       }
     }
-  }
+
+  def updateScene(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Update, None), user) {
+        authorizeAuthResultAsync {
+          SceneDao
+            .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[Scene]) { updatedScene =>
+            onSuccess(
+              SceneDao
+                .update(updatedScene, sceneId, user)
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              completeSingleOrNotFound(_)
+            }
+          }
+        }
+      }
+    }
+
+  def deleteScene(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Delete, None), user) {
+        authorizeAuthResultAsync {
+          SceneDao
+            .authorized(user, ObjectType.Scene, sceneId, ActionType.Delete)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          val response = for {
+            result <- SceneDao.query.filter(sceneId).delete.transact(xa)
+            _ <- SceneDao.deleteCache(sceneId).transact(xa)
+          } yield result
+          onSuccess(response.unsafeToFuture) {
+            completeSingleOrNotFound
+          }
+        }
+      }
+    }
+
+  def getDownloadUrl(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Download, None), user) {
+        authorizeAuthResultAsync {
+          SceneWithRelatedDao
+            .authorized(user, ObjectType.Scene, sceneId, ActionType.Download)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess(
+            SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
+          ) { scene =>
+            complete {
+              val retrievedScene = scene.getOrElse {
+                throw new Exception(
+                  "Scene does not exist or is not accessible by this user"
+                )
+              }
+              val s3Client = S3()
+              val whitelist = List(s"s3://$dataBucket")
+              (retrievedScene.sceneType, retrievedScene.ingestLocation) match {
+                case (Some(SceneType.COG), Some(ingestLocation)) =>
+                  val signedUrl =
+                    s3Client.maybeSignUri(ingestLocation, whitelist)
+                  List(
+                    Image.Downloadable(
+                      s"${sceneId}_COG.tif",
+                      s"$ingestLocation",
+                      signedUrl
+                    )
+                  )
+                case _ =>
+                  retrievedScene.images map { image =>
+                    val downloadUri: String =
+                      s3Client.maybeSignUri(image.sourceUri, whitelist)
+                    image.toDownloadable(downloadUri)
+                  }
+              }
+            }
+          }
+        }
+      }
+    }
+
+  def listScenePermissions(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          SceneDao
+            .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            SceneDao
+              .getPermissions(sceneId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
+
+  def replaceScenePermissions(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
+        entity(as[List[ObjectAccessControlRule]]) { acrList =>
+          authorizeAsync {
+            (
+              SceneDao
+                .authorized(
+                  user,
+                  ObjectType.Scene,
+                  sceneId,
+                  ActionType.Edit
+                ) map {
+                _.toBoolean
+              },
+              acrList traverse { acr =>
+                SceneDao.isValidPermission(acr, user)
+              } map {
+                _.foldLeft(true)(_ && _)
+              } map {
+                case true =>
+                  SceneDao.isReplaceWithinScopedLimit(
+                    Domain.Scenes,
+                    user,
+                    acrList
+                  )
+                case _ => false
+              }
+            ).tupled
+              .map({ authTup =>
+                authTup._1 && authTup._2
+              })
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              SceneDao
+                .replacePermissions(sceneId, acrList)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+      }
+    }
+
+  def addScenePermission(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
+        entity(as[ObjectAccessControlRule]) { acr =>
+          authorizeAsync {
+            (
+              SceneDao
+                .authorized(
+                  user,
+                  ObjectType.Scene,
+                  sceneId,
+                  ActionType.Edit
+                ) map {
+                _.toBoolean
+              },
+              SceneDao.isValidPermission(acr, user)
+            ).tupled
+              .map(authTup => authTup._1 && authTup._2)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              SceneDao
+                .addPermission(sceneId, acr)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+      }
+    }
+
+  def listUserSceneActions(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAsync {
+          SceneDao
+            .authQuery(user, ObjectType.Scene)
+            .filter(sceneId)
+            .exists
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess(
+            SceneWithRelatedDao
+              .unsafeGetScene(sceneId)
+              .transact(xa)
+              .unsafeToFuture
+          ) { scene =>
+            scene.owner == user.id match {
+              case true => complete(List("*"))
+              case false =>
+                complete {
+                  SceneDao
+                    .listUserActions(user, sceneId)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+            }
+          }
+        }
+      }
+    }
+
+  def deleteScenePermissions(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
+        authorizeAuthResultAsync {
+          SceneDao
+            .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            SceneDao
+              .deletePermissions(sceneId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
+
+  def getSceneDatasource(sceneId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Datasources, Action.Read, None),
+        user
+      ) {
+        authorizeAsync {
+          SceneDao
+            .authQuery(user, ObjectType.Scene)
+            .filter(sceneId)
+            .exists
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess(
+            DatasourceDao
+              .getSceneDatasource(sceneId)
+              .transact(xa)
+              .unsafeToFuture
+          ) { datasourceO =>
+            complete {
+              datasourceO
+            }
+          }
+        }
+      }
+    }
 
   def getSentinelMetadata(sceneId: UUID, metadataUrl: String): Route =
     authenticate { user =>

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.backsplash
 
-import com.rasterfoundry.common.{BacksplashGeoTiffInfo, BacksplashGeotiffReader}
 import com.rasterfoundry.common.color._
+import com.rasterfoundry.common.{BacksplashGeoTiffInfo, BacksplashGeotiffReader}
 import com.rasterfoundry.database.SceneDao
 import com.rasterfoundry.database.util.{Cache => DBCache}
 import com.rasterfoundry.datamodel.{SceneMetadataFields, SingleBandOptions}

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.backsplash
 
-import com.rasterfoundry.common.BacksplashGeoTiffInfo
+import com.rasterfoundry.common.{BacksplashGeoTiffInfo, BacksplashGeotiffReader}
 import com.rasterfoundry.common.color._
 import com.rasterfoundry.database.SceneDao
 import com.rasterfoundry.database.util.{Cache => DBCache}
@@ -102,7 +102,7 @@ final case class BacksplashGeotiff(
             }
           }
           reader <- child.span("getByteReader") use { _ =>
-            IO(getByteReader(uri))
+            IO(BacksplashGeotiffReader.getByteReader(uri))
           }
           gtInfo <- child.span("toGeotiffInfo") use { _ =>
             IO(info.toGeotiffInfo(reader))

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -2,7 +2,6 @@ package com.rasterfoundry
 
 import cats.effect._
 import com.colisweb.tracing.core.TracingContext
-
 import io.circe.KeyEncoder
 import org.http4s.Request
 import org.http4s.util.CaseInsensitiveString

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/package.scala
@@ -1,19 +1,11 @@
 package com.rasterfoundry
 
 import cats.effect._
-import com.amazonaws.services.s3.AmazonS3URI
 import com.colisweb.tracing.core.TracingContext
-import geotrellis.store.s3.util.S3RangeReader
-import geotrellis.util.{FileRangeReader, HttpRangeReader, StreamingByteReader}
+
 import io.circe.KeyEncoder
-import org.apache.http.client.utils.URLEncodedUtils
 import org.http4s.Request
 import org.http4s.util.CaseInsensitiveString
-import software.amazon.awssdk.services.s3.S3Client
-
-import java.net.{URI, URL}
-import java.nio.charset.Charset
-import java.nio.file.Paths
 
 package object backsplash {
 
@@ -37,47 +29,5 @@ package object backsplash {
         case _       => ""
       }
     }
-  }
-
-  /** AWS' S3 client has an internal connection pool, in order to maximize throughput
-    * we try to reuse it and only instantiate one
-    *
-    */
-  lazy val s3Client = S3Client.builder().build()
-
-  /** Replicates byte reader functionality in GeoTrellis that we don't get
-    * access to
-    *
-    * @param uri
-    * @return
-    */
-  def getByteReader(uri: String): StreamingByteReader = {
-
-    val javaURI = new URI(uri)
-    val noQueryParams =
-      URLEncodedUtils.parse(uri, Charset.forName("UTF-8")).isEmpty
-
-    val rr = javaURI.getScheme match {
-      case null =>
-        FileRangeReader(Paths.get(uri).toFile)
-
-      case "file" =>
-        FileRangeReader(Paths.get(javaURI).toFile)
-
-      case "http" | "https" if noQueryParams =>
-        HttpRangeReader(new URL(uri))
-
-      case "http" | "https" =>
-        new HttpRangeReader(new URL(uri), false)
-
-      case "s3" =>
-        val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))
-        S3RangeReader(s3Uri.getBucket, s3Uri.getKey, s3Client)
-
-      case scheme =>
-        throw new IllegalArgumentException(
-          s"Unable to read scheme $scheme at $uri")
-    }
-    new StreamingByteReader(rr, 128000)
   }
 }

--- a/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/HistogramBackfill.scala
@@ -42,9 +42,9 @@ object HistogramBackfill
 
   val name = "cog-histogram-backfill"
 
-  def getScenesToBackfill(implicit
-      xa: Transactor[IO]
-  ): IO[List[List[CogTuple]]] = {
+  def getScenesToBackfill(
+      implicit
+      xa: Transactor[IO]): IO[List[List[CogTuple]]] = {
     logger.info("Finding COG scenes without histograms in layer_attributes")
     fr"""select
            id, ingest_location
@@ -65,9 +65,9 @@ object HistogramBackfill
 
   // presence of the ingest location is guaranteed by the filter in the sql string
   @SuppressWarnings(Array("OptionGet"))
-  def insertHistogramLayerAttribute(cogTuple: CogTuple)(implicit
-      xa: Transactor[IO]
-  ): IO[Option[LayerAttribute]] = {
+  def insertHistogramLayerAttribute(cogTuple: CogTuple)(
+      implicit
+      xa: Transactor[IO]): IO[Option[LayerAttribute]] = {
     val histogram = getSceneHistogram(cogTuple._2.get)
     histogram flatMap { hist =>
       LayerAttributeDao

--- a/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
+++ b/app-backend/batch/src/main/scala/cogMetadata/RasterSourceMetadataBackfill.scala
@@ -1,8 +1,11 @@
 package com.rasterfoundry.batch.cogMetadata
 
-import com.rasterfoundry.backsplash.BacksplashGeotiffReader
 import com.rasterfoundry.batch.Job
-import com.rasterfoundry.common.{BacksplashGeoTiffInfo, RollbarNotifier}
+import com.rasterfoundry.common.{
+  BacksplashGeoTiffInfo,
+  BacksplashGeotiffReader,
+  RollbarNotifier
+}
 import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.{RasterSourceMetadataDao, SceneDao}
 import com.rasterfoundry.datamodel.RasterSourceMetadata

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -323,6 +323,7 @@ lazy val common = project
       Dependencies.awsCoreSdk,
       Dependencies.awsS3,
       Dependencies.catsCore,
+      Dependencies.catsEffect,
       Dependencies.catsScalacheck,
       Dependencies.chronoscala,
       Dependencies.circeCore,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -336,6 +336,7 @@ lazy val common = project
       Dependencies.geotrellisGdal,
       Dependencies.geotrellisProj4,
       Dependencies.geotrellisRaster,
+      Dependencies.geotrellisS3,
       Dependencies.geotrellisStore,
       Dependencies.geotrellisUtil,
       Dependencies.geotrellisVector,

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -322,6 +322,8 @@ lazy val common = project
       Dependencies.awsBatchSdk,
       Dependencies.awsCoreSdk,
       Dependencies.awsS3,
+      Dependencies.awsUtilsSdkV2,
+      Dependencies.awsS3SdkV2,
       Dependencies.catsCore,
       Dependencies.catsEffect,
       Dependencies.catsScalacheck,
@@ -349,7 +351,9 @@ lazy val common = project
       Dependencies.scalaCheck,
       Dependencies.shapeless,
       Dependencies.spireMath,
-      Dependencies.typesafeConfig
+      Dependencies.typesafeConfig,
+      "org.apache.httpcomponents" % "httpclient" % "4.5.9",
+      "org.apache.httpcomponents" % "httpcore" % "4.4.11"
     ) ++ loggingDependencies
   })
 
@@ -565,9 +569,6 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
   .settings(
     fork in run := true,
     libraryDependencies ++= Seq(
-      Dependencies.awsS3,
-      Dependencies.awsUtilsSdkV2,
-      Dependencies.awsS3SdkV2,
       Dependencies.catsCore,
       Dependencies.catsEffect,
       Dependencies.catsFree,
@@ -580,7 +581,6 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
       Dependencies.geotrellisLayer,
       Dependencies.geotrellisProj4,
       Dependencies.geotrellisRaster,
-      Dependencies.geotrellisS3,
       Dependencies.geotrellisServer,
       Dependencies.geotrellisUtil,
       Dependencies.geotrellisVector,
@@ -596,9 +596,7 @@ lazy val backsplashCore = Project("backsplash-core", file("backsplash-core"))
       Dependencies.scalacacheCore,
       Dependencies.spatial4j,
       Dependencies.spireMath,
-      Dependencies.typesafeConfig,
-      "org.apache.httpcomponents" % "httpclient" % "4.5.9",
-      "org.apache.httpcomponents" % "httpcore" % "4.4.11"
+      Dependencies.typesafeConfig
     ) ++ loggingDependencies,
     addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6"),
     addCompilerPlugin(

--- a/app-backend/common/src/main/scala/BacksplashGeotiffReader.scala
+++ b/app-backend/common/src/main/scala/BacksplashGeotiffReader.scala
@@ -11,13 +11,13 @@ import geotrellis.raster.io.geotiff.reader.{
 import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.io.geotiff.util._
 import geotrellis.store.s3.util.S3RangeReader
+import geotrellis.util.ByteReader
 import geotrellis.util.{
   ByteReader,
   FileRangeReader,
   HttpRangeReader,
   StreamingByteReader
 }
-import geotrellis.util.ByteReader
 import org.apache.http.client.utils.URLEncodedUtils
 import software.amazon.awssdk.services.s3.S3Client
 

--- a/app-backend/common/src/main/scala/BacksplashGeotiffReader.scala
+++ b/app-backend/common/src/main/scala/BacksplashGeotiffReader.scala
@@ -206,9 +206,6 @@ object BacksplashGeotiffReader extends LazyLogging {
   def getGeotiffInfo(uri: String): BacksplashGeoTiffInfo = {
     val reader = getByteReader(uri)
     val geoTiffInfo = GeoTiffInfo.read(reader, true, true)
-    logger.debug(
-      s"Some Geotiff Info for $uri: COMPRESSION: ${geoTiffInfo.compression} SEGMENT LAYOUT: ${geoTiffInfo.segmentLayout}"
-    )
     val tiffTags = NEL.fromListUnsafe(getAllTiffTags(reader, true))
     BacksplashGeoTiffInfo.fromGeotiffInfo(geoTiffInfo, tiffTags)
   }

--- a/app-backend/common/src/main/scala/BacksplashGeotiffReader.scala
+++ b/app-backend/common/src/main/scala/BacksplashGeotiffReader.scala
@@ -1,8 +1,7 @@
-package com.rasterfoundry.backsplash
-
-import com.rasterfoundry.common.BacksplashGeoTiffInfo
+package com.rasterfoundry.common
 
 import cats.data.{NonEmptyList => NEL}
+import com.amazonaws.services.s3.AmazonS3URI
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.raster.io.geotiff._
 import geotrellis.raster.io.geotiff.reader.{
@@ -11,13 +10,68 @@ import geotrellis.raster.io.geotiff.reader.{
 }
 import geotrellis.raster.io.geotiff.tags.TiffTags
 import geotrellis.raster.io.geotiff.util._
+import geotrellis.store.s3.util.S3RangeReader
+import geotrellis.util.{
+  ByteReader,
+  FileRangeReader,
+  HttpRangeReader,
+  StreamingByteReader
+}
 import geotrellis.util.ByteReader
+import org.apache.http.client.utils.URLEncodedUtils
+import software.amazon.awssdk.services.s3.S3Client
 
 import scala.collection.mutable.ListBuffer
 
+import java.net.{URI, URL}
 import java.nio.ByteOrder
+import java.nio.charset.Charset
+import java.nio.file.Paths
 
 object BacksplashGeotiffReader extends LazyLogging {
+
+  /** AWS' S3 client has an internal connection pool, in order to maximize throughput
+    * we try to reuse it and only instantiate one
+    *
+    */
+  private lazy val s3Client = S3Client.builder().build()
+
+  /** Replicates byte reader functionality in GeoTrellis that we don't get
+    * access to
+    *
+    * @param uri
+    * @return
+    */
+  def getByteReader(uri: String): StreamingByteReader = {
+
+    val javaURI = new URI(uri)
+    val noQueryParams =
+      URLEncodedUtils.parse(uri, Charset.forName("UTF-8")).isEmpty
+
+    val rr = javaURI.getScheme match {
+      case null =>
+        FileRangeReader(Paths.get(uri).toFile)
+
+      case "file" =>
+        FileRangeReader(Paths.get(javaURI).toFile)
+
+      case "http" | "https" if noQueryParams =>
+        HttpRangeReader(new URL(uri))
+
+      case "http" | "https" =>
+        new HttpRangeReader(new URL(uri), false)
+
+      case "s3" =>
+        val s3Uri = new AmazonS3URI(java.net.URLDecoder.decode(uri, "UTF-8"))
+        S3RangeReader(s3Uri.getBucket, s3Uri.getKey, s3Client)
+
+      case scheme =>
+        throw new IllegalArgumentException(
+          s"Unable to read scheme $scheme at $uri"
+        )
+    }
+    new StreamingByteReader(rr, 128000)
+  }
 
   import GeoTiffReader.geoTiffMultibandTile
 

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -1,9 +1,11 @@
 package com.rasterfoundry.common.utils
 
+import com.rasterfoundry.common.{BacksplashGeoTiffInfo, BacksplashGeotiffReader}
+
 import cats.effect.{Blocker, ContextShift, Sync}
+import cats.syntax.functor._
 import com.typesafe.scalalogging.LazyLogging
 import geotrellis.proj4._
-import geotrellis.raster._
 import geotrellis.raster._
 import geotrellis.raster.gdal.GDALRasterSource
 import geotrellis.raster.io.geotiff.OverviewStrategy
@@ -17,7 +19,7 @@ class CogUtils[F[_]: Sync](
 
   def getTiffExtent(
       rasterSource: GDALRasterSource
-  ): F[Projected[MultiPolygon]] = blocker.delay {
+  ): F[Projected[MultiPolygon]] = Sync[F].delay {
     Projected(
       MultiPolygon(
         rasterSource.extent
@@ -31,7 +33,7 @@ class CogUtils[F[_]: Sync](
   def histogramFromUri(
       rasterSource: GDALRasterSource,
       buckets: Int = 80
-  ): F[Option[Array[Histogram[Double]]]] = blocker.delay {
+  ): F[Option[Array[Histogram[Double]]]] = Sync[F].delay {
     val largestCellSize = rasterSource.resolutions
       .maxBy(_.resolution)
 
@@ -47,4 +49,13 @@ class CogUtils[F[_]: Sync](
 
   }
 
+  def getGeoTiffInfo(
+      uri: String
+  ): F[BacksplashGeoTiffInfo] =
+    blocker.delay(
+      BacksplashGeotiffReader.getGeotiffInfo(uri)
+    ) map { data =>
+      logger.debug(s"Got backsplash geotiff info for $uri")
+      data
+    }
 }

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -11,50 +11,55 @@ import geotrellis.raster.gdal.GDALRasterSource
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector._
+import scala.concurrent.ExecutionContext
 
 class CogUtils[F[_]: Sync](
-    blocker: Blocker
-)(implicit contextShift: ContextShift[F])
-    extends LazyLogging {
+    contextShift: ContextShift[F],
+    executionContext: ExecutionContext
+) extends LazyLogging {
+
+  val blocker = Blocker.liftExecutionContext(executionContext)
 
   def getTiffExtent(
       rasterSource: GDALRasterSource
-  ): F[Projected[MultiPolygon]] = Sync[F].delay {
-    Projected(
-      MultiPolygon(
-        rasterSource.extent
-          .reproject(rasterSource.crs, WebMercator)
-          .toPolygon()
-      ),
-      3857
-    )
-  }
+  ): F[Projected[MultiPolygon]] =
+    Sync[F].delay {
+      Projected(
+        MultiPolygon(
+          rasterSource.extent
+            .reproject(rasterSource.crs, WebMercator)
+            .toPolygon()
+        ),
+        3857
+      )
+    }
 
   def histogramFromUri(
       rasterSource: GDALRasterSource,
       buckets: Int = 80
-  ): F[Option[Array[Histogram[Double]]]] = Sync[F].delay {
-    val largestCellSize = rasterSource.resolutions
-      .maxBy(_.resolution)
+  ): F[Option[Array[Histogram[Double]]]] =
+    Sync[F].delay {
+      val largestCellSize = rasterSource.resolutions
+        .maxBy(_.resolution)
 
-    val resampleTarget = TargetCellSize(largestCellSize)
-    rasterSource
-      .resample(
-        resampleTarget,
-        ResampleMethod.DEFAULT,
-        OverviewStrategy.DEFAULT
-      )
-      .read
-      .map(_.tile.bands.map(_.histogramDouble(buckets)).toArray)
+      val resampleTarget = TargetCellSize(largestCellSize)
+      rasterSource
+        .resample(
+          resampleTarget,
+          ResampleMethod.DEFAULT,
+          OverviewStrategy.DEFAULT
+        )
+        .read
+        .map(_.tile.bands.map(_.histogramDouble(buckets)).toArray)
 
-  }
+    }
 
   def getGeoTiffInfo(
       uri: String
   ): F[BacksplashGeoTiffInfo] =
     blocker.delay(
       BacksplashGeotiffReader.getGeotiffInfo(uri)
-    ) map { data =>
+    )(Sync[F], contextShift) map { data =>
       logger.debug(s"Got backsplash geotiff info for $uri")
       data
     }

--- a/app-backend/common/src/main/scala/utils/CogUtils.scala
+++ b/app-backend/common/src/main/scala/utils/CogUtils.scala
@@ -11,6 +11,7 @@ import geotrellis.raster.gdal.GDALRasterSource
 import geotrellis.raster.io.geotiff.OverviewStrategy
 import geotrellis.raster.resample.ResampleMethod
 import geotrellis.vector._
+
 import scala.concurrent.ExecutionContext
 
 class CogUtils[F[_]: Sync](

--- a/app-backend/db/src/main/scala/SceneDao.scala
+++ b/app-backend/db/src/main/scala/SceneDao.scala
@@ -166,9 +166,11 @@ object SceneDao
   def updateSceneGeoTiffInfo(
       bsi: BacksplashGeoTiffInfo,
       id: UUID
-  ): ConnectionIO[Int] = {
-    fr"""UPDATE scenes SET backsplash_geotiff_info = ${bsi} WHERE id = ${id}""".update.run
-  }
+  ): ConnectionIO[Int] =
+    fr"""
+    UPDATE scenes
+    SET backsplash_geotiff_info = ${bsi}, ingest_status = ${IngestStatus.Ingested: IngestStatus}
+    WHERE id = ${id}""".update.run
 
   @SuppressWarnings(Array("CollectionIndexOnNonIndexedSeq"))
   def insertMaybe(


### PR DESCRIPTION
## Overview

This PR makes it so that we spin off fetching GeoTiff info for new COGs that have been posted into a separate thread that doesn't block the server's response. It picks up the `Blocker` added in #5465 and uses it to get the GeoTiffInfo and moves the GDALRasterSource calls out of that blocker and back into the default execution context (but still wrapped in `F`).

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Here's a nice json for you -- save it in `scene.json`

```json
{
	"id": null,
	"visibility": "PRIVATE",
	"tags": [],
	"datasource": "e4d1b0a0-99ee-493d-8548-53df8e20d2aa",
	"sceneMetadata": {},
	"name": "Test scene",
	"owner": null,
	"tileFootprint": null,
	"dataFootprint": null,
	"metadataFiles": [],
	"images": [],
	"thumbnails": [],
	"ingestLocation": "s3://rasterfoundry-development-data-us-east-1/cog-pa_m_4208063_sw_17_1_20150727.tif",
	"filterFields": {},
	"statusFields": {
		"ingestStatus": "NOTINGESTED",
		"thumbnailStatus": "SUCCESS",
		"boundaryStatus": "SUCCESS"
	},
	"sceneType": "COG"
}
```
- assemble api server and tile server
- set the `api-server` service's log level to DEBUG in docker-compose
- `./scripts/server`
- Copy the "RF Dev user refresh token" from Lastpass
- `echo {"refresh_token": "the refresh token"} | http :9100/api/tokens`
- `export JWT_AUTH_TOKEN=<the id_token that you got back>`
- `cat scene.json | http --auth-type=jwt :9100/api/scenes`
- note that in your response the scene is not ingested
- but also note in the logs that within not very long, you see a nice log message from the `geotiffinfo` thread pool letting you know that it got info for that URI
- now request the scene by id -- `http --auth-type=jwt :9100/api/scenes/<your scene id> | jq .statusFields`
- it should now show as INGESTED

Closes #5466 

Closes #5465 