### PR TITLE
Return before task grid is ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Moved task grid creation into a background task [#5476](https://github.com/raster-foundry/raster-foundry/pull/5476)
+
 ### Deprecated
 
 ### Removed

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -10,12 +10,18 @@ import com.rasterfoundry.datamodel._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server._
 import cats.effect.IO
+import cats.implicits._
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 
+import scala.concurrent.ExecutionContext
+
 import java.util.UUID
+import java.util.concurrent.Executors
+import cats.effect.Blocker
 
 trait AnnotationProjectTaskRoutes
     extends CommonHandlers
@@ -23,6 +29,16 @@ trait AnnotationProjectTaskRoutes
     with Authentication
     with PaginationDirectives
     with QueryParametersCommon {
+
+  val taskGridContext = ExecutionContext.fromExecutor(
+    Executors.newFixedThreadPool(
+      4,
+      new ThreadFactoryBuilder().setNameFormat("task-grid-%d").build()
+    )
+  )
+
+  val taskGridContextShift = IO.contextShift(taskGridContext)
+  val taskGridBlocker = Blocker.liftExecutionContext(taskGridContext)
 
   val xa: Transactor[IO]
 
@@ -143,22 +159,27 @@ trait AnnotationProjectTaskRoutes
       } {
         entity(as[Task.TaskGridFeatureCreate]) { tgf =>
           complete(
-            StatusCodes.Created,
-            TaskDao
-              .insertTasksByGrid(
-                Task
-                  .TaskPropertiesCreate(
-                    TaskStatus.Unlabeled,
-                    projectId,
-                    None,
-                    None,
-                    None,
-                    None
-                  ),
-                tgf,
-                user
-              )
-              .transact(xa)
+            StatusCodes.Accepted,
+            taskGridBlocker
+              .blockOn(
+                TaskDao
+                  .insertTasksByGrid(
+                    Task
+                      .TaskPropertiesCreate(
+                        TaskStatus.Unlabeled,
+                        projectId,
+                        None,
+                        None,
+                        None,
+                        None
+                      ),
+                    tgf,
+                    user
+                  )
+                  .transact(xa)
+                  .start(taskGridContextShift)
+              )(taskGridContextShift)
+              .void
               .unsafeToFuture
           )
         }

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -9,6 +9,7 @@ import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server._
+import cats.effect.Blocker
 import cats.effect.IO
 import cats.implicits._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -21,7 +22,6 @@ import scala.concurrent.ExecutionContext
 
 import java.util.UUID
 import java.util.concurrent.Executors
-import cats.effect.Blocker
 
 trait AnnotationProjectTaskRoutes
     extends CommonHandlers

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -31,8 +31,7 @@ trait AnnotationProjectTaskRoutes
     with QueryParametersCommon {
 
   val taskGridContext = ExecutionContext.fromExecutor(
-    Executors.newFixedThreadPool(
-      4,
+    Executors.newCachedThreadPool(
       new ThreadFactoryBuilder().setNameFormat("task-grid-%d").build()
     )
   )

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -274,6 +274,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       annotationProjectO <- AnnotationProjectDao.getById(
         taskProperties.annotationProjectId
       )
+      _ <- debug(
+        s"Got annotation project for ${taskProperties.annotationProjectId}"
+      )
       geomO <- (taskGridFeatureCreate.geometry, annotationProjectO) match {
         case (Some(g), _) => Option(g).pure[ConnectionIO]
         case (_, Some(annotationProject)) =>
@@ -315,6 +318,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       } getOrElse {
         0.pure[ConnectionIO]
       }
+      _ <- debug(s"Inserted $gridInsert tasks")
       _ <- annotationProjectO traverse { annotationProject =>
         AnnotationProjectDao.update(
           annotationProject.copy(taskSizeMeters = taskSizeO, aoi = geomO),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     env_file: .env
     environment:
       - HIKARI_LOG_LEVEL=WARN
-      - RF_LOG_LEVEL=WARN
+      - RF_LOG_LEVEL=DEBUG
       - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
       - BACKSPLASH_ENABLE_MULTITIFF=false

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3502,11 +3502,11 @@ paths:
           schema:
             $ref: "#/definitions/TaskGridCreate"
       responses:
-        201:
-          description: "Task grid was successfully created"
+        202:
+          description: "Task grid creation in progress"
           schema:
-            type: integer
-            description: Number of tasks created
+            type: object
+            description: "An empty object corresponding to a successful request"
         400:
           description: "Task grid could not be created. The provided parameters were likely invalid"
           schema:


### PR DESCRIPTION
## Overview

This PR moves the wait for the task grid into a blocker. This way it doesn't really matter how big the task grid area is, you'll get a response pretty quickly and later the server will finish what it's up to.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated

### Notes

The log message for tasks having been inserted shows up in the transactor pool, so I think it's probably the case that the fixed
thread pool in use in `AnnotationProjectTaskRoutes` creates four threads that largely just hang out and wait on db responses. I think that's probably fine.

Also, I picked a fixed thread pool because that's what we do for scenes, but maybe since these threads are just going to be hanging out waiting for database IO it should be a cached thread pool. (Unlike the scenes work, where we're doing more work to read data from S3 and calculate histograms, etc.) I think as long as it's in the background / not in the main thread pool it won't hurt anything. 🤔 I'm gonna change it. I'm gonna change it right now.

I'm not sure what all depends on the shape of this endpoint's response and I won't bother speculating here, but I'd expect to break staging sites in the very short-term.

## Testing Instructions

- assemble api server
- set the api server log level to `DEBUG` in `docker-compose.yml`
- `./scripts/server`
- here's a nice geojson feature for you to use. It's a large area in Nevada, where a task size of 500m creates lots of tasks. save it in `tfc.json`:

```json
{
      "type": "Feature",
      "properties": {
          "sizeMeters": 500
      },
      "geometry": {
        "type": "Polygon",
        "coordinates": [
          [
            [
              -118.20190429687501,
              34.617387052407175
            ],
            [
              -117.80364990234375,
              34.617387052407175
            ],
            [
              -117.80364990234375,
              34.908457853981375
            ],
            [
              -118.20190429687501,
              34.908457853981375
            ],
            [
              -118.20190429687501,
              34.617387052407175
            ]
          ]
        ]
      }
    }
```
- get a bearer token. You can do this using the "RF Dev user refresh token" from Lastpass -- `echo '{"refresh_token": "zw8bpslWeweB3RV0gPvmYirWb8YQd7cB4pMbVvldEEW51"}' | http :9100/api/tokens`
- `export JWT_AUTH_TOKEN=<your bearer token>`
- `cat tfc.json | http --auth-type=jwt ":9100/api/annotation-projects/13dd152a-db3a-45f7-ba6b-c7274e679351/tasks/grid"` -- this is a sample annotation project, so if you really want it back, you can reload development data after testing this
- you should get an empty response with a 202 status back pretty quickly
- after a little bit, you should see a DEBUG message about how many tasks were inserted in the API logs
- extra credit / for fun: shrink the task edge in meters by a factor of 5 (expect 25x more tasks) and see how long it takes to create the grid

Closes #5475 
