### PR TITLE
Add review status to tasks; Update MVTLayerDao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Added `review_status` to tasks, added a DB trigger to update this field when children task reviews change [#5478](https://github.com/raster-foundry/raster-foundry/pull/5478)
+
 ### Changed
 
 - Moved task grid creation into a background task [#5476](https://github.com/raster-foundry/raster-foundry/pull/5476)

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -987,6 +987,7 @@ object Generators extends ArbitraryInstances {
         taskTypeGen map { Some(_) }
       )
       reviews <- Gen.const(None)
+      reviewStatus <- Gen.const(None)
     } yield {
       Task.TaskPropertiesCreate(
         status,
@@ -994,7 +995,8 @@ object Generators extends ArbitraryInstances {
         note,
         taskType,
         None,
-        reviews
+        reviews,
+        reviewStatus
       )
     }
 

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -986,10 +986,7 @@ object Generators extends ArbitraryInstances {
         Gen.const(None),
         taskTypeGen map { Some(_) }
       )
-      reviews <- Gen.oneOf(
-        Gen.const(None),
-        Gen.const(().asJson) map { Some(_) }
-      )
+      reviews <- Gen.const(None)
     } yield {
       Task.TaskPropertiesCreate(
         status,

--- a/app-backend/datamodel/src/main/scala/LabelVoteType.scala
+++ b/app-backend/datamodel/src/main/scala/LabelVoteType.scala
@@ -1,0 +1,29 @@
+package com.rasterfoundry.datamodel
+
+import cats.syntax.either._
+import io.circe._
+
+sealed abstract class LabelVoteType(val repr: String) {
+  override def toString = repr
+}
+
+object LabelVoteType {
+  case object Pass extends LabelVoteType("PASS")
+  case object Fail extends LabelVoteType("FAIL")
+
+  def fromString(s: String): LabelVoteType = s.toUpperCase match {
+    case "PASS" => Pass
+    case "FAIL" => Fail
+    case _      => throw new Exception(s"Invalid string: $s")
+  }
+
+  implicit val labelVoteTypeEncoder: Encoder[LabelVoteType] =
+    Encoder.encodeString.contramap[LabelVoteType](_.toString)
+
+  implicit val labelVoteTypeDecoder: Decoder[LabelVoteType] =
+    Decoder.decodeString.emap { str =>
+      Either
+        .catchNonFatal(fromString(str))
+        .leftMap(_ => "LabelVoteType")
+    }
+}

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -15,6 +15,7 @@ import java.util.UUID
 @JsonCodec
 final case class Review(
     vote: LabelVoteType,
+    userName: String,
     description: Option[String]
 )
 
@@ -31,7 +32,8 @@ case class Task(
     annotationProjectId: UUID,
     taskType: TaskType,
     parentTaskId: Option[UUID],
-    reviews: Map[UUID, Review]
+    reviews: Map[UUID, Review],
+    reviewStatus: Option[TaskReviewStatus]
 ) {
   def toGeoJSONFeature(actions: List[TaskActionStamp]): Task.TaskFeature = {
     Task.TaskFeature(
@@ -70,7 +72,8 @@ case class Task(
       statusNote,
       this.taskType,
       this.parentTaskId,
-      this.reviews
+      this.reviews,
+      this.reviewStatus
     )
   }
 
@@ -89,6 +92,7 @@ case class Task(
       this.taskType,
       this.parentTaskId,
       this.reviews,
+      this.reviewStatus,
       campaignId
     )
   }
@@ -110,7 +114,8 @@ object Task {
       note: Option[NonEmptyString],
       taskType: TaskType,
       parentTaskId: Option[UUID],
-      reviews: Map[UUID, Review]
+      reviews: Map[UUID, Review],
+      reviewStatus: Option[TaskReviewStatus]
   ) {
     def toCreate: TaskPropertiesCreate = {
       TaskPropertiesCreate(
@@ -143,6 +148,7 @@ object Task {
       taskType: TaskType,
       parentTaskId: Option[UUID],
       reviews: Map[UUID, Review],
+      reivewStatus: Option[TaskReviewStatus],
       campaignId: UUID
   ) {
     def toTask: Task = {
@@ -159,7 +165,8 @@ object Task {
         this.annotationProjectId,
         this.taskType,
         this.parentTaskId,
-        this.reviews
+        this.reviews,
+        this.reivewStatus
       )
     }
 
@@ -187,6 +194,7 @@ object Task {
         this.taskType,
         this.parentTaskId,
         this.reviews,
+        this.reivewStatus,
         this.campaignId
       )
     }
@@ -217,14 +225,15 @@ object Task {
       taskType: TaskType,
       parentTaskId: Option[UUID],
       reviews: Map[UUID, Review],
+      reviewStatus: Option[TaskReviewStatus] = None,
       campaignId: UUID
   )
 
   object TaskPropertiesWithCampaign {
     implicit val encTaskPropertiesWithCampaign
-      : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
+        : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
     implicit val decTaskPropertiesWithCamapgin
-      : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
+        : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
   }
 
   final case class TaskPropertiesCreate(
@@ -233,7 +242,8 @@ object Task {
       note: Option[NonEmptyString],
       taskType: Option[TaskType],
       parentTaskId: Option[UUID],
-      reviews: Option[Map[UUID, Review]]
+      reviews: Option[Map[UUID, Review]],
+      reviewStatus: Option[TaskReviewStatus] = None
   )
 
   object TaskPropertiesCreate {
@@ -314,7 +324,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-        )
+          )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -331,12 +341,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-      : Decoder[TaskFeatureCollectionCreate] =
+        : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-      : Encoder[TaskFeatureCollectionCreate] =
+        : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -348,10 +358,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-      : Encoder[TaskGridCreateProperties] =
+        : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-      : Decoder[TaskGridCreateProperties] =
+        : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -222,9 +222,9 @@ object Task {
 
   object TaskPropertiesWithCampaign {
     implicit val encTaskPropertiesWithCampaign
-        : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
+      : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
     implicit val decTaskPropertiesWithCamapgin
-        : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
+      : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
   }
 
   final case class TaskPropertiesCreate(
@@ -314,7 +314,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-          )
+        )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -331,12 +331,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-        : Decoder[TaskFeatureCollectionCreate] =
+      : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-        : Encoder[TaskFeatureCollectionCreate] =
+      : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -348,10 +348,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-        : Encoder[TaskGridCreateProperties] =
+      : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-        : Decoder[TaskGridCreateProperties] =
+      : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -12,6 +12,12 @@ import io.circe.refined._
 import java.sql.Timestamp
 import java.util.UUID
 
+@JsonCodec
+final case class Review(
+    vote: LabelVoteType,
+    description: Option[String]
+)
+
 case class Task(
     id: UUID,
     createdAt: Timestamp,
@@ -25,7 +31,7 @@ case class Task(
     annotationProjectId: UUID,
     taskType: TaskType,
     parentTaskId: Option[UUID],
-    reviews: Json
+    reviews: Map[UUID, Review]
 ) {
   def toGeoJSONFeature(actions: List[TaskActionStamp]): Task.TaskFeature = {
     Task.TaskFeature(
@@ -104,7 +110,7 @@ object Task {
       note: Option[NonEmptyString],
       taskType: TaskType,
       parentTaskId: Option[UUID],
-      reviews: Json
+      reviews: Map[UUID, Review]
   ) {
     def toCreate: TaskPropertiesCreate = {
       TaskPropertiesCreate(
@@ -136,7 +142,7 @@ object Task {
       annotationProjectId: UUID,
       taskType: TaskType,
       parentTaskId: Option[UUID],
-      reviews: Json,
+      reviews: Map[UUID, Review],
       campaignId: UUID
   ) {
     def toTask: Task = {
@@ -210,15 +216,15 @@ object Task {
       note: Option[NonEmptyString],
       taskType: TaskType,
       parentTaskId: Option[UUID],
-      reviews: Json,
+      reviews: Map[UUID, Review],
       campaignId: UUID
   )
 
   object TaskPropertiesWithCampaign {
     implicit val encTaskPropertiesWithCampaign
-      : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
+        : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
     implicit val decTaskPropertiesWithCamapgin
-      : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
+        : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
   }
 
   final case class TaskPropertiesCreate(
@@ -227,7 +233,7 @@ object Task {
       note: Option[NonEmptyString],
       taskType: Option[TaskType],
       parentTaskId: Option[UUID],
-      reviews: Option[Json]
+      reviews: Option[Map[UUID, Review]]
   )
 
   object TaskPropertiesCreate {
@@ -308,7 +314,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-        )
+          )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -325,12 +331,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-      : Decoder[TaskFeatureCollectionCreate] =
+        : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-      : Encoder[TaskFeatureCollectionCreate] =
+        : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -342,10 +348,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-      : Encoder[TaskGridCreateProperties] =
+        : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-      : Decoder[TaskGridCreateProperties] =
+        : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -231,9 +231,9 @@ object Task {
 
   object TaskPropertiesWithCampaign {
     implicit val encTaskPropertiesWithCampaign
-        : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
+      : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
     implicit val decTaskPropertiesWithCamapgin
-        : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
+      : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
   }
 
   final case class TaskPropertiesCreate(
@@ -324,7 +324,7 @@ object Task {
           (
             tfc._type,
             tfc.features
-          )
+        )
       )
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
@@ -341,12 +341,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-        : Decoder[TaskFeatureCollectionCreate] =
+      : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-        : Encoder[TaskFeatureCollectionCreate] =
+      : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(
         tfc => (tfc._type, tfc.features)
       )
@@ -358,10 +358,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-        : Encoder[TaskGridCreateProperties] =
+      : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-        : Decoder[TaskGridCreateProperties] =
+      : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 

--- a/app-backend/datamodel/src/main/scala/TaskReviewStatus.scala
+++ b/app-backend/datamodel/src/main/scala/TaskReviewStatus.scala
@@ -1,0 +1,32 @@
+package com.rasterfoundry.datamodel
+
+import cats.syntax.either._
+import io.circe._
+
+sealed abstract class TaskReviewStatus(val repr: String) {
+  override def toString = repr
+}
+
+object TaskReviewStatus {
+  case object ReviewPending extends TaskReviewStatus("REVIEW_PENDING")
+  case object ReviewValidated extends TaskReviewStatus("REVIEW_VALIDATED")
+  case object ReviewNeedsAttention
+      extends TaskReviewStatus("REVIEW_NEEDS_ATTENTION")
+
+  def fromString(s: String): TaskReviewStatus = s.toUpperCase match {
+    case "REVIEW_PENDING"         => ReviewPending
+    case "REVIEW_VALIDATED"       => ReviewValidated
+    case "REVIEW_NEEDS_ATTENTION" => ReviewNeedsAttention
+    case _                        => throw new Exception(s"Invalid string: $s")
+  }
+
+  implicit val taskReviewStatusEncoder: Encoder[TaskReviewStatus] =
+    Encoder.encodeString.contramap[TaskReviewStatus](_.toString)
+
+  implicit val taskReviewStatusDecoder: Decoder[TaskReviewStatus] =
+    Decoder.decodeString.emap { str =>
+      Either
+        .catchNonFatal(fromString(str))
+        .leftMap(_ => "TaskReviewStatus")
+    }
+}

--- a/app-backend/db/src/main/resources/migrations/V61__add_review_status.sql
+++ b/app-backend/db/src/main/resources/migrations/V61__add_review_status.sql
@@ -96,12 +96,13 @@ FROM
   ) review_task_checks
 WHERE tasks.id = review_task_checks.id;
 
--- REVIEW_PENDING:
--- if any review task has '{}' as reviews
--- REVIEW_NEEDS_ATTENTION:
--- if there is one "FAIL" vote in a review
--- REVIEW_VALIDATED:
--- if the label task is validated, or if all review votes are "PASS"
+-- Pending review:
+-- if there is still any task with '{}' in the reviews field.
+-- Needs attention:
+-- if none of the review is '{}', and there is at least one "fail" vote
+-- Validated
+-- If none of the review is '{}', and there is no "fail" vote;
+-- or, the label task itself is validated
 CREATE OR REPLACE FUNCTION UPDATE_TASK_REVIEW_STATUS ()
   RETURNS TRIGGER
   AS $BODY$

--- a/app-backend/db/src/main/resources/migrations/V61__add_review_status.sql
+++ b/app-backend/db/src/main/resources/migrations/V61__add_review_status.sql
@@ -1,0 +1,116 @@
+CREATE TYPE public.label_vote_type AS ENUM (
+  'PASS',
+  'FAIL'
+);
+
+CREATE TYPE public.review_status AS ENUM (
+  'REVIEW_PENDING',
+  'REVIEW_VALIDATED',
+  'REVIEW_NEEDS_ATTENTION'
+);
+
+ALTER TABLE public.tasks
+  ADD COLUMN review_status review_status DEFAULT NULL;
+
+-- empty jsonb value should be written down as '{}'
+-- there are some task records written by wrong review values
+
+UPDATE
+  tasks
+SET
+  reviews = '{}'
+WHERE
+  reviews = '"{}"';
+
+-- TODO: add an initial update query to fill in the reviewStatus field
+-- REVIEW_PENDING:
+-- if any review task has '{}' as reviews
+-- REVIEW_NEEDS_ATTENTION:
+-- if there is one "FAIL" vote in a review
+-- REVIEW_VALIDATED:
+-- if the label task is validated, or if all review votes are "PASS"
+
+CREATE OR REPLACE FUNCTION UPDATE_TASK_REVIEW_STATUS ()
+  RETURNS TRIGGER
+  AS $BODY$
+DECLARE
+  op_parent_task_id uuid;
+  op_task_type task_type;
+BEGIN
+  IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN
+    op_parent_task_id := NEW.parent_task_id;
+    op_task_type := NEW.task_type;
+  ELSE
+    op_parent_task_id := OLD.parent_task_id;
+    op_task_type := OLD.task_type;
+  END IF;
+  IF op_parent_task_id IS NOT NULL AND op_task_type = 'REVIEW' THEN
+    WITH review_task_checks AS (
+      SELECT
+        EXISTS (
+          SELECT
+            id
+          FROM
+            tasks
+          WHERE
+            parent_task_id = op_parent_task_id
+            AND reviews = '{}') has_empty_review,
+        EXISTS (
+          SELECT
+            *
+          FROM (
+            SELECT
+              jsonb_extract_path_text(reviews.value, 'vote') AS vote
+            FROM
+              tasks t,
+              jsonb_each(t.reviews) AS reviews
+          WHERE
+            parent_task_id = op_parent_task_id) AS a
+        WHERE
+          a.vote = 'FAIL') has_down_vote,
+        EXISTS (
+          SELECT
+            *
+          FROM
+            tasks
+          WHERE
+            status = 'VALIDATED'
+            AND id = op_parent_task_id) is_validated,
+          NOT EXISTS (
+            SELECT
+              *
+            FROM (
+              SELECT
+                jsonb_extract_path_text(reviews.value, 'vote') AS vote
+            FROM
+              tasks t,
+              jsonb_each(t.reviews) AS reviews
+            WHERE
+              parent_task_id = op_parent_task_id) AS a
+          WHERE
+            a.vote = 'FAIL') no_down_vote)
+    UPDATE
+      tasks
+    SET
+      review_status = CASE WHEN (review_task_checks.has_empty_review) THEN
+        'REVIEW_PENDING'
+      WHEN (review_task_checks.has_down_vote) THEN
+        'REVIEW_NEEDS_ATTENTION'
+      WHEN (review_task_checks.is_validated
+        OR review_task_checks.no_down_vote) THEN
+        'REVIEW_VALIDATED'
+      ELSE
+        NULL
+      WHERE
+        id = op_parent_task_id;
+      END IF;
+    RETURN NULL;
+END;
+$BODY$
+LANGUAGE 'plpgsql';
+
+CREATE TRIGGER update_task_review_status
+  AFTER INSERT OR UPDATE OR DELETE ON tasks
+  FOR EACH ROW
+  EXECUTE PROCEDURE UPDATE_TASK_REVIEW_STATUS ();
+

--- a/app-backend/db/src/main/resources/migrations/V61__add_review_status.sql
+++ b/app-backend/db/src/main/resources/migrations/V61__add_review_status.sql
@@ -1,35 +1,107 @@
+-- vote types for each label
 CREATE TYPE public.label_vote_type AS ENUM (
   'PASS',
   'FAIL'
 );
 
+-- review status of each "label" task
 CREATE TYPE public.review_status AS ENUM (
   'REVIEW_PENDING',
   'REVIEW_VALIDATED',
   'REVIEW_NEEDS_ATTENTION'
 );
 
+-- add a review_status colum to tasks table
 ALTER TABLE public.tasks
   ADD COLUMN review_status review_status DEFAULT NULL;
 
 -- empty jsonb value should be written down as '{}'
 -- there are some task records written by wrong review values
+UPDATE tasks
+SET reviews = '{}'
+WHERE reviews = '"{}"';
 
-UPDATE
-  tasks
-SET
-  reviews = '{}'
-WHERE
-  reviews = '"{}"';
+-- a function to return review status criteria by task id
+CREATE OR REPLACE FUNCTION GET_TASK_REVIEW_STATUS_BY_ID (
+  task_id uuid
+)
+RETURNS table (
+  id uuid,
+  has_empty_review boolean,
+  has_down_vote boolean,
+  no_down_vote boolean,
+  is_validated boolean
+) AS
+$func$
+BEGIN
+  RETURN QUERY
+    WITH validated_label_task AS (
+      SELECT
+        *
+      FROM
+        tasks t
+      WHERE
+        status = 'VALIDATED'
+        AND t.id = task_id
+    ),
+    empty_reviews AS (
+      SELECT
+        t.id
+      FROM
+        tasks t
+      WHERE
+        parent_task_id = task_id
+        AND reviews = '{}'
+    ),
+    review_votes AS (
+      SELECT
+        jsonb_extract_path_text(reviews.value, 'vote') AS vote
+      FROM
+        tasks t,
+        jsonb_each(t.reviews) AS reviews
+      WHERE
+        parent_task_id = task_id
+    )
+    SELECT
+      task_id AS id,
+      EXISTS (SELECT * FROM empty_reviews) has_empty_review,
+      EXISTS (SELECT * FROM review_votes WHERE vote = 'FAIL') has_down_vote,
+      NOT EXISTS (SELECT * FROM review_votes WHERE vote = 'FAIL') no_down_vote,
+      EXISTS (SELECT* FROM validated_label_task) is_validated;
+END;
+$func$
+LANGUAGE 'plpgsql';
 
--- TODO: add an initial update query to fill in the reviewStatus field
+-- an initial update query to fill in the reviewStatus field
+UPDATE tasks
+SET review_status = CASE WHEN (review_task_checks.has_empty_review) THEN
+    'REVIEW_PENDING'::review_status
+  WHEN (review_task_checks.has_down_vote) THEN
+    'REVIEW_NEEDS_ATTENTION'::review_status
+  WHEN (review_task_checks.is_validated
+    OR review_task_checks.no_down_vote) THEN
+    'REVIEW_VALIDATED'::review_status
+  ELSE
+    NULL
+  END
+FROM
+  (
+    SELECT task_criteria.*
+    FROM (
+      SELECT DISTINCT parent_task_id AS id
+      FROM tasks
+      WHERE parent_task_id IS NOT NULL
+    ) as tasks_to_update,
+    GET_TASK_REVIEW_STATUS_BY_ID(tasks_to_update.id) AS task_criteria
+  ) review_task_checks
+WHERE tasks.id = review_task_checks.id;
+
 -- REVIEW_PENDING:
 -- if any review task has '{}' as reviews
 -- REVIEW_NEEDS_ATTENTION:
 -- if there is one "FAIL" vote in a review
 -- REVIEW_VALIDATED:
 -- if the label task is validated, or if all review votes are "PASS"
-
 CREATE OR REPLACE FUNCTION UPDATE_TASK_REVIEW_STATUS ()
   RETURNS TRIGGER
   AS $BODY$
@@ -45,72 +117,40 @@ BEGIN
     op_task_type := OLD.task_type;
   END IF;
   IF op_parent_task_id IS NOT NULL AND op_task_type = 'REVIEW' THEN
-    WITH review_task_checks AS (
-      SELECT
-        EXISTS (
-          SELECT
-            id
-          FROM
-            tasks
-          WHERE
-            parent_task_id = op_parent_task_id
-            AND reviews = '{}') has_empty_review,
-        EXISTS (
-          SELECT
-            *
-          FROM (
-            SELECT
-              jsonb_extract_path_text(reviews.value, 'vote') AS vote
-            FROM
-              tasks t,
-              jsonb_each(t.reviews) AS reviews
-          WHERE
-            parent_task_id = op_parent_task_id) AS a
-        WHERE
-          a.vote = 'FAIL') has_down_vote,
-        EXISTS (
-          SELECT
-            *
-          FROM
-            tasks
-          WHERE
-            status = 'VALIDATED'
-            AND id = op_parent_task_id) is_validated,
-          NOT EXISTS (
-            SELECT
-              *
-            FROM (
-              SELECT
-                jsonb_extract_path_text(reviews.value, 'vote') AS vote
-            FROM
-              tasks t,
-              jsonb_each(t.reviews) AS reviews
-            WHERE
-              parent_task_id = op_parent_task_id) AS a
-          WHERE
-            a.vote = 'FAIL') no_down_vote)
-    UPDATE
-      tasks
-    SET
-      review_status = CASE WHEN (review_task_checks.has_empty_review) THEN
-        'REVIEW_PENDING'
+    UPDATE tasks
+    SET review_status = CASE WHEN (review_task_checks.has_empty_review) THEN
+        'REVIEW_PENDING'::review_status
       WHEN (review_task_checks.has_down_vote) THEN
-        'REVIEW_NEEDS_ATTENTION'
+        'REVIEW_NEEDS_ATTENTION'::review_status
       WHEN (review_task_checks.is_validated
         OR review_task_checks.no_down_vote) THEN
-        'REVIEW_VALIDATED'
+        'REVIEW_VALIDATED'::review_status
       ELSE
         NULL
-      WHERE
-        id = op_parent_task_id;
-      END IF;
-    RETURN NULL;
+      END
+    FROM (
+      SELECT * from GET_TASK_REVIEW_STATUS_BY_ID(op_parent_task_id)
+    ) AS review_task_checks
+    WHERE review_task_checks.id = tasks.id;
+
+  END IF;
+  RETURN NULL;
 END;
 $BODY$
 LANGUAGE 'plpgsql';
 
+-- create a trigger for updating task review
 CREATE TRIGGER update_task_review_status
-  AFTER INSERT OR UPDATE OR DELETE ON tasks
+  AFTER UPDATE OF reviews OR INSERT OR DELETE ON tasks
   FOR EACH ROW
   EXECUTE PROCEDURE UPDATE_TASK_REVIEW_STATUS ();
 
+-- update a previous trigger on task summary
+DROP TRIGGER IF EXISTS update_annotation_project_task_summary 
+ON tasks;
+
+CREATE TRIGGER update_annotation_project_task_summary
+  AFTER UPDATE OF status OR INSERT OR DELETE
+  ON tasks
+  FOR EACH ROW
+  EXECUTE PROCEDURE UPDATE_PROJECT_TASK_SUMMARY();

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -33,7 +33,8 @@ object MVTLayerDao {
             geometry,
             ST_TileEnvelope(${z},${x},${y})
           ) AND
-          annotation_project_id = ${annotationProjectId}
+          annotation_project_id = ${annotationProjectId} AND
+          task_type = 'LABEL'::task_type
       )
     SELECT ST_AsMVT(mvtgeom.*) FROM mvtgeom;""".query[Array[Byte]]
 

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -14,7 +14,6 @@ import doobie.postgres.implicits._
 import doobie.refined.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
 import geotrellis.vector.{Geometry, Projected}
-import io.circe.syntax._
 import shapeless._
 
 import scala.concurrent.duration._
@@ -227,12 +226,12 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       user: User
   ): Fragment = {
     val t = tfc.properties.taskType.getOrElse(TaskType.fromString("LABEL"))
-    val r = tfc.properties.reviews.getOrElse("{}".asJson)
+    val r = tfc.properties.reviews.getOrElse(Map[UUID, Review]())
     fr"""(
         ${UUID.randomUUID}, ${Timestamp.from(Instant.now)}, ${user.id}, ${Timestamp
       .from(Instant.now)},
         ${user.id}, ${tfc.properties.status}, null, null, ${tfc.geometry},
-        ${tfc.properties.annotationProjectId}, ${t}, ${tfc.properties.parentTaskId}, ${r}::jsonb
+        ${tfc.properties.annotationProjectId}, ${t}, ${tfc.properties.parentTaskId}, ${r}
     )"""
   }
 
@@ -581,7 +580,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
                 None,
                 TaskType.Label,
                 None,
-                "{}".asJson
+                Map[UUID, Review]()
                 // since this is a fake task feature that exists I think for the purpose of
                 // providing a geojson interface over the task status geom summary,
                 // it's fine to pretend that the note is always None

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -303,7 +303,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           ${taskProperties.annotationProjectId},
           ${TaskType.Label.toString()}::task_type,
           null,
-          '{}'::jsonb
+          '{}'::jsonb,
+          null
         FROM (
           SELECT (
             ST_Dump(

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -12,6 +12,7 @@ import io.circe._
 import io.circe.syntax._
 
 import scala.reflect.runtime.universe.TypeTag
+
 import java.util.UUID
 
 object CirceJsonbMeta {
@@ -29,7 +30,7 @@ trait CirceJsonbMeta {
       Json.obj(
         ("width", a.width.asJson),
         ("height", a.height.asJson)
-      )
+    )
 
   implicit val cellSizeDecoder: Decoder[CellSize] = (c: HCursor) =>
     for {
@@ -37,7 +38,7 @@ trait CirceJsonbMeta {
       height <- c.downField("height").as[Double]
     } yield {
       new CellSize(width, height)
-    }
+  }
 
   implicit val gridExtentMeta: Meta[GridExtent[Long]] =
     CirceJsonbMeta[GridExtent[Long]]
@@ -110,11 +111,11 @@ trait CirceJsonbMeta {
     CirceJsonbMeta[List[TileLayer]]
 
   implicit val annotationProjectLabelGroupsMeta
-      : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
+    : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
     CirceJsonbMeta[List[AnnotationLabelClassGroup.WithLabelClasses]]
 
   implicit val annotationProjectTaskStatusSummaryMeta
-      : Meta[Option[Map[String, Int]]] =
+    : Meta[Option[Map[String, Int]]] =
     CirceJsonbMeta[Option[Map[String, Int]]]
 
   implicit val campaignStatusMeta: Meta[Map[String, Int]] =

--- a/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
+++ b/app-backend/db/src/main/scala/meta/CirceJsonbMeta.scala
@@ -12,6 +12,7 @@ import io.circe._
 import io.circe.syntax._
 
 import scala.reflect.runtime.universe.TypeTag
+import java.util.UUID
 
 object CirceJsonbMeta {
   def apply[Type: TypeTag: Encoder: Decoder] = {
@@ -28,7 +29,7 @@ trait CirceJsonbMeta {
       Json.obj(
         ("width", a.width.asJson),
         ("height", a.height.asJson)
-    )
+      )
 
   implicit val cellSizeDecoder: Decoder[CellSize] = (c: HCursor) =>
     for {
@@ -36,7 +37,7 @@ trait CirceJsonbMeta {
       height <- c.downField("height").as[Double]
     } yield {
       new CellSize(width, height)
-  }
+    }
 
   implicit val gridExtentMeta: Meta[GridExtent[Long]] =
     CirceJsonbMeta[GridExtent[Long]]
@@ -109,13 +110,16 @@ trait CirceJsonbMeta {
     CirceJsonbMeta[List[TileLayer]]
 
   implicit val annotationProjectLabelGroupsMeta
-    : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
+      : Meta[List[AnnotationLabelClassGroup.WithLabelClasses]] =
     CirceJsonbMeta[List[AnnotationLabelClassGroup.WithLabelClasses]]
 
   implicit val annotationProjectTaskStatusSummaryMeta
-    : Meta[Option[Map[String, Int]]] =
+      : Meta[Option[Map[String, Int]]] =
     CirceJsonbMeta[Option[Map[String, Int]]]
 
   implicit val campaignStatusMeta: Meta[Map[String, Int]] =
     CirceJsonbMeta[Map[String, Int]]
+
+  implicit val taskReviewsMeta: Meta[Map[UUID, Review]] =
+    CirceJsonbMeta[Map[UUID, Review]]
 }

--- a/app-backend/db/src/main/scala/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/meta/EnumMeta.scala
@@ -120,4 +120,11 @@ trait EnumMeta {
       TaskType.fromString,
       _.repr
     )
+
+  implicit val taskReviewStatusMeta: Meta[TaskReviewStatus] =
+    pgEnumString(
+      "review_status",
+      TaskReviewStatus.fromString,
+      _.repr
+    )
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -443,4 +443,46 @@ trait PropTestHelpers {
       owner = Some(user.id)
     )
 
+  def createChildTaskCreateFC(
+      parentTask: Task.TaskFeature,
+      childStatus: TaskStatus,
+      taskType: Option[TaskType],
+      reviews: Option[Map[UUID, Review]] = None
+  ): Task.TaskFeatureCollectionCreate = Task.TaskFeatureCollectionCreate(
+    _type = "FeatureCollection",
+    features = List(
+      Task.TaskFeatureCreate(
+        properties = Task.TaskPropertiesCreate(
+          status = childStatus,
+          annotationProjectId = parentTask.properties.annotationProjectId,
+          note = parentTask.properties.note,
+          taskType = taskType,
+          parentTaskId = Some(parentTask.id),
+          reviews = reviews
+        ),
+        geometry = parentTask.geometry
+      )
+    )
+  )
+
+  def addReviewToTaskCreate(
+      feature: Task.TaskFeature,
+      vote: LabelVoteType
+  ): Task.TaskFeatureCreate =
+    Task.TaskFeatureCreate(
+      properties = feature.properties.toCreate
+        .copy(
+          reviews = Some(
+            Map(
+              UUID.randomUUID -> Review(
+                vote = vote,
+                userName = UUID.randomUUID.toString,
+                description = None
+              )
+            )
+          )
+        ),
+      geometry = feature.geometry
+    )
+
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -465,7 +465,7 @@ trait PropTestHelpers {
     )
   )
 
-  def addReviewToTaskCreate(
+  def setReviewToTaskCreate(
       feature: Task.TaskFeature,
       vote: LabelVoteType
   ): Task.TaskFeatureCreate =

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -1637,37 +1637,49 @@ class TaskDaoSpec
               pAfterCOneUpdate,
               pAfterCTwoUpdate,
               pAfterCThreeUpdate,
-              pAfterCTwoUpdateWPass
-            ) =
-              connIO.transact(xa).unsafeRunSync
+              pAfterCTwoUpdatePass
+            ) = connIO.transact(xa).unsafeRunSync
 
             assert(
               pAfterCInsert
-                .map(t => t.reviewStatus === TaskReviewStatus.ReviewPending)
+                .map(
+                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
+                )
                 .toSet === Set(true),
               "Parent task review status is pending after inserting children tasks"
             )
             assert(
               pAfterCOneUpdate
-                .map(t => t.reviewStatus === TaskReviewStatus.ReviewPending)
+                .map(
+                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
+                )
                 .toSet === Set(true),
               "Parent task review status is pending after 1 out of 3 children tasks has reviews"
             )
             assert(
               pAfterCTwoUpdate
-                .map(t => t.reviewStatus === TaskReviewStatus.ReviewPending)
+                .map(
+                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
+                )
                 .toSet === Set(true),
               "Parent task review status is pending after 2 out of 3 children tasks has reviews"
             )
             assert(
               pAfterCThreeUpdate
-                .map(t => t.reviewStatus === TaskReviewStatus.ReviewNeedsAttention)
+                .map(
+                  t =>
+                    t.reviewStatus == Some(
+                      TaskReviewStatus.ReviewNeedsAttention
+                    )
+                )
                 .toSet === Set(true),
               "Parent task review status is needs attention after 3 out of 3 children tasks has reviews"
-            ) 
+            )
             assert(
-              pAfterCTwoUpdateWPass
-                .map(t => t.reviewStatus === TaskReviewStatus.ReviewValidated)
+              pAfterCTwoUpdatePass
+                .map(
+                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewValidated)
+                )
                 .toSet === Set(true),
               "Parent task review status is validated after all 3 children tasks have Pass votes"
             )


### PR DESCRIPTION
## Overview

This PR:
- improves type of `reviews` field on `tasks`
- adds `review_status` field, which is optional, to `tasks`
- updates the method for getting task grid as MVT layer to include only `LABEL` type of tasks
- adds a DB trigger so that `review_status` on `LABEL` tasks will update based on changes in `reviews` field on the corresponding `REVIEW` tasks.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should pass
- Make sure the tests make sense
