### PR TITLE
Use campaign authorization for annotation projects in /campaign/ routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Moved task grid creation into a background task [#5476](https://github.com/raster-foundry/raster-foundry/pull/5476)
 - Hand-rolled cogification commands have been replaced with `gdal_translate -of COG` [#5477](https://github.com/raster-foundry/raster-foundry/pull/5477)
+- Annotation projects requested for campaigns use campaign authorization [#5481](https://github.com/raster-foundry/raster-foundry/pull/5481)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -2,8 +2,8 @@ package com.rasterfoundry.api.campaign
 
 import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
-import com.rasterfoundry.database._
 import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.server._

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -3,10 +3,12 @@ package com.rasterfoundry.api.campaign
 import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
 import com.rasterfoundry.database._
+import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.server._
 import cats.effect.IO
+import cats.syntax.apply._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
@@ -28,20 +30,26 @@ trait CampaignProjectRoutes
       user
     ) {
       authorizeAsync {
-        CampaignDao
-          .isActiveCampaign(campaignId)
-          .transact(xa)
-          .unsafeToFuture
+        (
+          CampaignDao
+            .isActiveCampaign(campaignId),
+          CampaignDao.authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.View
+          )
+        ).tupled.transact(xa).unsafeToFuture map {
+          case (true, AuthSuccess(_)) => true
+          case _                      => false
+        }
       } {
         (withPagination & annotationProjectQueryParameters) {
           (page, annotationProjectQP) =>
             complete {
-              AnnotationProjectDao
-                .listProjects(
-                  page,
-                  annotationProjectQP.copy(campaignId = Some(campaignId)),
-                  user
-                )
+              AnnotationProjectDao.query
+                .filter(annotationProjectQP.copy(campaignId = Some(campaignId)))
+                .page(page)
                 .transact(xa)
                 .unsafeToFuture
             }
@@ -50,4 +58,44 @@ trait CampaignProjectRoutes
 
     }
   }
+
+  def getCampaignProject(campaignId: UUID, annotationProjectId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+        user
+      ) {
+        authorizeAsync {
+          (
+            CampaignDao.isActiveCampaign(campaignId),
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.View
+              ),
+            AnnotationProjectDao.authorized(
+              user,
+              ObjectType.AnnotationProject,
+              annotationProjectId,
+              ActionType.View
+            )
+          ).tupled.transact(xa).unsafeToFuture map {
+            case (true, campaignResult, annotationProjectResult) =>
+              campaignResult.toBoolean || annotationProjectResult.toBoolean
+            case _ => false
+          }
+        } {
+          complete {
+            AnnotationProjectDao
+              .listByCampaignQB(campaignId)
+              .filter(annotationProjectId)
+              .selectOption
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
 }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -97,6 +97,10 @@ trait CampaignRoutes
               get {
                 listCampaignProjects(campaignId)
               }
+            } ~ pathPrefix(JavaUUID) { projectId =>
+              pathEndOrSingleSlash {
+                getCampaignProject(campaignId, projectId)
+              }
             }
           } ~ pathPrefix("actions") {
           pathEndOrSingleSlash {

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -366,7 +366,7 @@ object AnnotationProjectDao
                   LabelClassClasses.NamedLabelClasses(
                     classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
                   )
-                )
+              )
             )
         },
         "Label Item",
@@ -526,7 +526,7 @@ object AnnotationProjectDao
                   Some(userId),
                   ActionType.Annotate
                 )
-              )
+            )
           )
         AnnotationProjectDao.addPermissionsMany(
           project.id,

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -366,7 +366,7 @@ object AnnotationProjectDao
                   LabelClassClasses.NamedLabelClasses(
                     classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
                   )
-              )
+                )
             )
         },
         "Label Item",
@@ -497,8 +497,11 @@ object AnnotationProjectDao
     } yield annotationProjectCopy
   }
 
+  def listByCampaignQB(campaignId: UUID) =
+    query.filter(fr"campaign_id = $campaignId")
+
   def listByCampaign(campaignId: UUID): ConnectionIO[List[AnnotationProject]] =
-    query.filter(fr"campaign_id = $campaignId").list
+    listByCampaignQB(campaignId).list
 
   def assignUsersToProjectsByCampaign(
       campaignId: UUID,
@@ -523,7 +526,7 @@ object AnnotationProjectDao
                   Some(userId),
                   ActionType.Annotate
                 )
-            )
+              )
           )
         AnnotationProjectDao.addPermissionsMany(
           project.id,


### PR DESCRIPTION
## Overview

This PR makes the routes for listing annotation projects and getting an annotation project _behind `/campaigns/id/projects`_ use campaign authorization instead of annotation project authorization.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I opted for "instead of" rather than "in addition to" because I thought the desired behavior on the detail route if you're authorized for the project but not the campaign was pretty unclear. I can be talked into changing it to "in addition to" though.

I had a lot of trouble testing locally. When I create a user in the dev tenant locally I end up getting a bunch of 500s from the API server, which made it really tough to get a second user to log in as to make things work.

## Testing Instructions

- inspection I guess. You should be able to verify that:
  - [ ] for the list endpoint, we're ignoring the auth information in the annotation projects table for the user and just making sure everything's in the campaign that we know the user is allowed to view
  - [ ] for the detail endpoint:
    - [ ] when the user can't view the campaign or the campaign is inactive, they shouldn't be authorized
    - [ ] if they're authorized to view the campaign but the project isn't in that campaign (or doesn't exist), they should not get a project back

Closes raster-foundry/annotate#972