### PR TITLE
Include task statuses in STAC label items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+- STAC label items now include the task statuses in a `groundwork:taskStatuses` property [#5490](https://github.com/raster-foundry/raster-foundry/pull/5490)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/batch/src/main/scala/stacExport/DatabaseIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/DatabaseIO.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.batch.stacExport
 
-import com.rasterfoundry.datamodel.TaskStatus
 import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel.TaskStatus
 
 import cats.data._
 import cats.implicits._

--- a/app-backend/batch/src/main/scala/stacExport/DatabaseIO.scala
+++ b/app-backend/batch/src/main/scala/stacExport/DatabaseIO.scala
@@ -1,5 +1,6 @@
 package com.rasterfoundry.batch.stacExport
 
+import com.rasterfoundry.datamodel.TaskStatus
 import com.rasterfoundry.database._
 
 import cats.data._
@@ -82,7 +83,8 @@ object DatabaseIO {
               tasks,
               tasksGeomExtent,
               annotations,
-              labelItemPropsThin
+              labelItemPropsThin,
+              taskStatuses map { TaskStatus.fromString }
             )
           )
         }

--- a/app-backend/batch/src/main/scala/stacExport/ExportData.scala
+++ b/app-backend/batch/src/main/scala/stacExport/ExportData.scala
@@ -11,5 +11,6 @@ case class ExportData(
     tasks: List[Task],
     taskGeomExtent: UnionedGeomExtent,
     annotations: Json,
-    labelItemExtension: LabelItemExtension
+    labelItemExtension: LabelItemExtension,
+    taskStatuses: List[TaskStatus]
 )

--- a/app-backend/batch/src/main/scala/stacExport/Utils.scala
+++ b/app-backend/batch/src/main/scala/stacExport/Utils.scala
@@ -143,7 +143,8 @@ object Utils {
         "label:tasks" -> sceneTaskAnnotation.labelItemExtension.tasks.asJson,
         "label:methods" -> sceneTaskAnnotation.labelItemExtension.methods.asJson,
         "label:overviews" -> sceneTaskAnnotation.labelItemExtension.overviews.asJson,
-        "datetime" -> dateTime.asJson
+        "datetime" -> dateTime.asJson,
+        "groundwork:taskStatuses" -> sceneTaskAnnotation.taskStatuses.asJson
       )
     )
     val labelDataRelLink = "./data.geojson"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     env_file: .env
     environment:
       - HIKARI_LOG_LEVEL=WARN
-      - RF_LOG_LEVEL=DEBUG
+      - RF_LOG_LEVEL=INFO
       - TILE_SERVER_LOCATION
       - COURSIER_CACHE=/root/.coursier
       - BACKSPLASH_ENABLE_MULTITIFF=false


### PR DESCRIPTION
## Overview

This PR makes it so that we can see the exported task statuses in our label items.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

This should help us in the future if we get confused about geometries. I was confused about whether the geometry in the STAC export was supposed to refer just to the labeled tasks, but the Groundwork UI doesn't specify any statuses so we're exporting all the tasks.

## Testing Instructions

- create a STAC export with your local Groundwork
- `./scripts/console batch "java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <your export ID>"
- download the export (you can find it with a search for `under prefix` in the logs)
- examine the label item's `groundwork:taskStatuses` property
- set a specific status in the db -- `update stac_exports set task_statuses = '{ "LABELED" }' where id = '<your id>';`
- rerun the exports, download it again, and check the statuses in the label item

Closes #5485 
