### PR TITLE
Use non-decoded URLs for the GeoTiffRasterSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Fixed
 
+- Fixed a URL decoding bug that caused imagery to be unavailable after upload processing [#5492](https://github.com/raster-foundry/raster-foundry/pull/5492)
+
 ### Security
 
 ## [1.52.0](https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0)

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -27,8 +27,6 @@ import io.circe.syntax._
 
 import scala.concurrent.ExecutionContext
 
-import java.net.URLDecoder
-import java.nio.charset.StandardCharsets.UTF_8
 import java.util.UUID
 import java.util.concurrent.Executors
 
@@ -145,11 +143,10 @@ trait SceneRoutes
         entity(as[Scene.Create]) { newScene =>
           val metadataIO = (sceneId: UUID) => {
             newScene.ingestLocation traverse { location =>
-              val decodedUri = URLDecoder.decode(location, UTF_8.toString)
               (
-                cogUtils.getGeoTiffInfo(decodedUri),
-                cogUtils.histogramFromUri(decodedUri),
-                cogUtils.getTiffExtent(decodedUri)
+                cogUtils.getGeoTiffInfo(location),
+                cogUtils.histogramFromUri(location),
+                cogUtils.getTiffExtent(location)
               ).tupled flatMap {
                 case (geotiffInfo, histogram, footprint) =>
                   ((LayerAttributeDao


### PR DESCRIPTION
## Overview

GeoTiffRasterSources and GDALRasterSources have different ideas about encoded URLs. This PR (which I'm opening on behalf on @notthatbreezy because he's busy) uses the non-decoded URL to get all the scene metadata. It fixes a broken production situation where no one can see scenes that they upload since 1.52.0.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

I just ran this upload based on the deployed staging branch

![image](https://user-images.githubusercontent.com/5702984/95895128-68fa3800-0d47-11eb-84e6-519f6ea3f121.png)

## Testing Instructions

- do an upload in staging GW

Closes #5491 

Closes raster-foundry/annotate#1037
