### PR TITLE
Allow listing tasks for campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Added
 
+- Tasks can be listed by campaign [#5494](https://github.com/raster-foundry/raster-foundry/pull/5494)
+
 ### Changed
 
 ### Deprecated

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -221,3 +221,4 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/clone-owners,campaigns:clone,get
 /api/campaigns/{campaignId}/random-review-task,campaigns:read,get
 /api/campaigns/{campaignId}/retrieve-child-labels,campaigns:clone,post
+/api/campaigns/{campaignId}/tasks,campaigns:read,get

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -60,22 +60,15 @@ trait AnnotationProjectTaskRoutes
           (withPagination & taskQueryParameters) { (page, taskParams) =>
             complete {
               (
-                taskParams.format match {
-                  case Some(format) if format.toUpperCase == "SUMMARY" =>
-                    TaskDao.listTaskGeomByStatus(
-                      user,
-                      projectId,
-                      taskParams.status
-                    )
-                  case _ =>
-                    TaskDao
-                      .listTasks(
-                        taskParams,
-                        projectId,
-                        page
-                      )
-                }
-              ).transact(xa).unsafeToFuture
+                TaskDao
+                  .listTasks(
+                    taskParams,
+                    projectId,
+                    page
+                  )
+                )
+                .transact(xa)
+                .unsafeToFuture
             }
           }
         }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -187,7 +187,6 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
       'actionEndTime.as(deserializerTimestamp).?,
       'actionMinCount.as[Int].?,
       'actionMaxCount.as[Int].?,
-      'format.as[String].?,
       'taskType.as(deserializerTaskType).?
     ).as(TaskQueryParameters.apply _)
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -652,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -669,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -683,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -704,10 +704,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -90,10 +90,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +145,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +177,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +205,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -260,10 +260,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -336,10 +336,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +353,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +380,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +420,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +446,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +459,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +496,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +536,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +552,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +571,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -638,7 +638,6 @@ final case class TaskQueryParameters(
     actionEndTime: Option[Timestamp] = None,
     actionMinCount: Option[Int] = None,
     actionMaxCount: Option[Int] = None,
-    format: Option[String] = None,
     taskType: Option[TaskType] = None
 ) {
   val bboxPolygon: Option[Seq[Projected[Polygon]]] =
@@ -653,10 +652,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -670,10 +669,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -684,10 +683,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -705,10 +704,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 


### PR DESCRIPTION
## Overview

This PR:

- adds a `/api/campaigns/<campaignId>/tasks` endpoint that accepts all the task query parameters
- removes the `format=summary` query parameter for task lists, since we no longer use it now that we have the MVT endpoint

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- confirm tests make sense

Closes raster-foundry/annotate#976
