### PR TITLE
Add simplified sharing endpoints for campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 - Tasks can be listed by campaign [#5494](https://github.com/raster-foundry/raster-foundry/pull/5494)
+- Campaigns can be shared with only an email [#5495](https://github.com/raster-foundry/raster-foundry/pull/5495)
 
 ### Changed
 

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -222,3 +222,6 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/random-review-task,campaigns:read,get
 /api/campaigns/{campaignId}/retrieve-child-labels,campaigns:clone,post
 /api/campaigns/{campaignId}/tasks,campaigns:read,get
+/api/campaigns/{campaignId}/share,campaigns:share,post
+/api/campaigns/{campaignId}/share,campaigns:share,get
+/api/campaigns/{campaignId}/share/{userId},campaigns:read,delete

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.api.annotationProject
 
 import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.user.Auth0Service
-import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
+import com.rasterfoundry.api.utils.IntercomNotifications
 import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
 
@@ -24,7 +24,6 @@ trait AnnotationProjectPermissionRoutes
     extends CommonHandlers
     with Directives
     with Authentication
-    with Config
     with IntercomNotifications {
 
   val xa: Transactor[IO]

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -2,23 +2,19 @@ package com.rasterfoundry.api.annotationProject
 
 import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.user.Auth0Service
-import com.rasterfoundry.api.utils.{Config, ManagementBearerToken}
+import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
 import com.rasterfoundry.database._
-import com.rasterfoundry.database.notification.Notify
 import com.rasterfoundry.datamodel._
-import com.rasterfoundry.notification.intercom.Model._
-import com.rasterfoundry.notification.intercom._
 
 import akka.http.scaladsl.server._
 import cats.data.OptionT
-import cats.effect.{Async, ContextShift, IO}
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
-import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 import scala.concurrent.Future
 
@@ -28,123 +24,12 @@ trait AnnotationProjectPermissionRoutes
     extends CommonHandlers
     with Directives
     with Authentication
-    with Config {
+    with Config
+    with IntercomNotifications {
 
   val xa: Transactor[IO]
 
-  val getBackend = for {
-    backendRef <- Async.memoize {
-      AsyncHttpClientCatsBackend[IO]()
-    }
-    backend <- backendRef
-  } yield backend
-
   implicit val contextShift: ContextShift[IO]
-  private val intercomNotifierIO = for {
-    backend <- getBackend
-    notifier = new LiveIntercomNotifier[IO](backend)
-  } yield notifier
-
-  private def getSharer(sharingUser: User): String =
-    if (sharingUser.email != "") {
-      sharingUser.email
-    } else if (sharingUser.personalInfo.email != "") {
-      sharingUser.personalInfo.email
-    } else {
-      sharingUser.name
-    }
-
-  private def shareNotify(
-      sharedUser: User,
-      sharingUser: User,
-      annotationProjectId: UUID
-  ): IO[Either[Throwable, Unit]] =
-    intercomNotifierIO flatMap { intercomNotifier =>
-      intercomNotifier
-        .notifyUser(
-          intercomToken,
-          intercomAdminId,
-          ExternalId(sharedUser.id),
-          Message(s"""
-        | ${getSharer(sharingUser)} has shared a project with you!
-        | ${groundworkUrlBase}/app/projects/${annotationProjectId}/overview
-        | """.trim.stripMargin)
-        )
-        .attempt
-    }
-
-  private def shareNotifyNewUser(
-      bearerToken: ManagementBearerToken,
-      sharingUser: User,
-      newUserEmail: String,
-      newUserId: String,
-      sharingUserPlatform: Platform,
-      annotationProject: AnnotationProject
-  ): Future[Unit] = {
-    val subject =
-      s"""You've been invited to join the "${annotationProject.name}" project on GroundWork!"""
-    (for {
-      ticket <- IO.fromFuture {
-        IO {
-          Auth0Service.createPasswordChangeTicket(
-            bearerToken,
-            s"$groundworkUrlBase/app/login",
-            newUserId
-          )
-        }
-      }
-      (messageRich, messagePlain) = Notifications.getInvitationMessage(
-        getSharer(sharingUser),
-        annotationProject,
-        ticket
-      )
-      _ <- Notify
-        .sendEmail(
-          sharingUserPlatform.publicSettings,
-          sharingUserPlatform.privateSettings,
-          newUserEmail,
-          subject,
-          messageRich.underlying,
-          messagePlain.underlying
-        )
-    } yield ()).attempt.void.unsafeToFuture
-  }
-
-  def getDefaultShare(
-      user: User,
-      actionTypeOpt: Option[ActionType] = None
-  ): List[ObjectAccessControlRule] = {
-    val default = List(
-      ObjectAccessControlRule(
-        SubjectType.User,
-        Some(user.id),
-        ActionType.View
-      ),
-      ObjectAccessControlRule(
-        SubjectType.User,
-        Some(user.id),
-        ActionType.Export
-      )
-    )
-    val annotate = ObjectAccessControlRule(
-      SubjectType.User,
-      Some(user.id),
-      ActionType.Annotate
-    )
-    val validate = ObjectAccessControlRule(
-      SubjectType.User,
-      Some(user.id),
-      ActionType.Validate
-    )
-    actionTypeOpt match {
-      case Some(ActionType.Validate) =>
-        default :+ annotate :+ validate
-      case Some(ActionType.Annotate) | None =>
-        default :+ annotate
-      case _ =>
-        default
-    }
-  }
 
   def listPermissions(projectId: UUID): Route = authenticate { user =>
     authorizeScope(
@@ -208,13 +93,19 @@ trait AnnotationProjectPermissionRoutes
           complete {
             (AnnotationProjectDao
               .replacePermissions(projectId, acrList)
-              .transact(xa) <* (distinctUserIds traverse { userId =>
-              // it's safe to do this unsafely because we know the user exists from
-              // the isValidPermission check
-              UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
-                sharedUser =>
-                  shareNotify(sharedUser, user, projectId)
-              }
+              .transact(xa) <* (AnnotationProjectDao
+              .unsafeGetById(
+                projectId
+              )
+              .transact(xa) flatMap { annotationProject =>
+              (distinctUserIds traverse { userId =>
+                // it's safe to do this unsafely because we know the user exists from
+                // the isValidPermission check
+                UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                  sharedUser =>
+                    shareNotify(sharedUser, user, annotationProject, "project")
+                }
+              })
             })).unsafeToFuture
           }
         }
@@ -251,13 +142,23 @@ trait AnnotationProjectPermissionRoutes
           complete {
             (AnnotationProjectDao
               .addPermission(projectId, acr)
-              .transact(xa) <*
-              (acr.getUserId traverse { userId =>
-                UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
-                  sharedUser =>
-                    shareNotify(sharedUser, user, projectId)
+              .transact(xa) <* (
+              AnnotationProjectDao
+                .unsafeGetById(projectId)
+                .transact(xa) flatMap { annotationProject =>
+                acr.getUserId traverse { userId =>
+                  UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                    sharedUser =>
+                      shareNotify(
+                        sharedUser,
+                        user,
+                        annotationProject,
+                        "project"
+                      )
+                  }
                 }
-              })).unsafeToFuture
+              }
+            )).unsafeToFuture
           }
         }
       }
@@ -440,7 +341,9 @@ trait AnnotationProjectPermissionRoutes
                               userByEmail.email,
                               newUser.id,
                               userPlatform,
-                              annotationProject
+                              annotationProject,
+                              "project",
+                              Notifications.getInvitationMessage
                             )
                           } else {
                             Future.unit
@@ -475,11 +378,16 @@ trait AnnotationProjectPermissionRoutes
                           // if silent param is not provided, we notify
                           userByEmail.silent match {
                             case Some(false) | None =>
-                              shareNotify(
-                                existingUser,
-                                user,
-                                projectId
-                              )
+                              AnnotationProjectDao
+                                .unsafeGetById(projectId)
+                                .transact(xa) flatMap { annotationProject =>
+                                shareNotify(
+                                  existingUser,
+                                  user,
+                                  annotationProject,
+                                  "project"
+                                )
+                              }
                             case _ => IO.pure(())
                           }
                         )).unsafeToFuture

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -15,11 +15,11 @@ import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
+import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 import scala.concurrent.Future
 
 import java.util.UUID
-import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 trait AnnotationProjectPermissionRoutes
     extends CommonHandlers

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.api.campaign
 
 import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.user.Auth0Service
-import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
+import com.rasterfoundry.api.utils.IntercomNotifications
 import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
 
@@ -24,7 +24,6 @@ trait CampaignPermissionRoutes
     extends CommonHandlers
     with Directives
     with Authentication
-    with Config
     with IntercomNotifications {
 
   implicit val contextShift: ContextShift[IO]
@@ -229,10 +228,10 @@ trait CampaignPermissionRoutes
       authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
         if (user.id == deleteId) {
           authorizeAuthResultAsync {
-            AnnotationProjectDao
+            CampaignDao
               .authorized(
                 user,
-                ObjectType.AnnotationProject,
+                ObjectType.Campaign,
                 campaignId,
                 ActionType.View
               )
@@ -241,10 +240,10 @@ trait CampaignPermissionRoutes
           }
         } else {
           authorizeAuthResultAsync {
-            AnnotationProjectDao
+            CampaignDao
               .authorized(
                 user,
-                ObjectType.AnnotationProject,
+                ObjectType.Campaign,
                 campaignId,
                 ActionType.Edit
               )

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -1,23 +1,32 @@
 package com.rasterfoundry.api.campaign
 
 import com.rasterfoundry.akkautil._
+import com.rasterfoundry.api.user.Auth0Service
+import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
 import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
-
 import akka.http.scaladsl.server._
-import cats.effect.IO
+import cats.data.OptionT
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import io.circe.syntax._
+
+import scala.concurrent.Future
 
 import java.util.UUID
 
 trait CampaignPermissionRoutes
     extends CommonHandlers
     with Directives
-    with Authentication {
+    with Authentication
+    with Config
+    with IntercomNotifications {
+
+  implicit val contextShift: ContextShift[IO]
 
   val xa: Transactor[IO]
 
@@ -77,11 +86,32 @@ trait CampaignPermissionRoutes
               })
             }).transact(xa).unsafeToFuture()
           } {
+            val distinctUserIds =
+              acrList
+                .foldMap(acr => acr.getUserId map { Set(_) })
+                .combineAll
+                .toList
             complete {
-              CampaignDao
+              (CampaignDao
                 .replacePermissions(campaignId, acrList)
-                .transact(xa)
-                .unsafeToFuture
+                .transact(xa) <* (
+                CampaignDao
+                  .unsafeGetCampaignById(campaignId)
+                  .transact(xa) flatMap { campaign =>
+                  distinctUserIds traverse { userId =>
+                    UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                      sharedUser =>
+                        shareNotify(
+                          sharedUser,
+                          user,
+                          campaign,
+                          "campaign"
+                        )
+                    }
+
+                  }
+                }
+              )).unsafeToFuture
             }
           }
         }
@@ -115,10 +145,25 @@ trait CampaignPermissionRoutes
           }).transact(xa).unsafeToFuture()
         } {
           complete {
-            CampaignDao
+            (CampaignDao
               .addPermission(campaignId, acr)
-              .transact(xa)
-              .unsafeToFuture
+              .transact(xa) <* (
+              CampaignDao
+                .unsafeGetCampaignById(campaignId)
+                .transact(xa) flatMap { campaign =>
+                acr.getUserId traverse { userId =>
+                  UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                    sharedUser =>
+                      shareNotify(
+                        sharedUser,
+                        user,
+                        campaign,
+                        "campaign"
+                      )
+                  }
+                }
+              }
+            )).unsafeToFuture
           }
         }
       }
@@ -152,4 +197,213 @@ trait CampaignPermissionRoutes
       }
   }
 
+  def listCampaignShares(campaignId: UUID): Route = authenticate { user =>
+    authorizeScope(
+      ScopedAction(Domain.Campaigns, Action.Share, None),
+      user
+    ) {
+      authorizeAuthResultAsync {
+        CampaignDao
+          .authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            ActionType.Edit
+          )
+          .transact(xa)
+          .unsafeToFuture
+      } {
+        complete {
+          CampaignDao
+            .getSharedUsers(campaignId)
+            .transact(xa)
+            .unsafeToFuture
+        }
+      }
+    }
+  }
+
+  def deleteCampaignShare(campaignId: UUID, deleteId: String): Route =
+    authenticate { user =>
+      authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
+        if (user.id == deleteId) {
+          authorizeAuthResultAsync {
+            AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                campaignId,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          }
+        } else {
+          authorizeAuthResultAsync {
+            AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                campaignId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+        {
+          complete {
+            CampaignDao
+              .deleteSharedUser(campaignId, deleteId)
+              .map(c => if (c > 0) 1 else 0)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
+
+  def shareCampaign(campaignId: UUID): Route =
+    authenticate { user =>
+      val shareCount =
+        CampaignDao
+          .getShareCount(campaignId, user.id)
+          .transact(xa)
+          .unsafeToFuture
+
+      authorizeScopeLimit(
+        shareCount,
+        Domain.Campaigns,
+        Action.Share,
+        user
+      ) {
+        entity(as[UserShareInfo]) { userByEmail =>
+          authorize {
+            (userByEmail.actionType match {
+              case Some(ActionType.Annotate) | Some(ActionType.Validate) |
+                  None =>
+                true
+              case _ => false
+            })
+          } {
+            complete {
+              Auth0Service.getManagementBearerToken flatMap { managementToken =>
+                for {
+                  // Everything has to be Futures here because of methods in akka-http / Auth0Service
+                  users <- UserDao
+                    .findUsersByEmail(userByEmail.email)
+                    .transact(xa)
+                    .unsafeToFuture
+                  userPlatform <- UserDao
+                    .unsafeGetUserPlatform(user.id)
+                    .transact(xa)
+                    .unsafeToFuture
+                  campaignO <- CampaignDao
+                    .getCampaignById(campaignId)
+                    .transact(xa)
+                    .unsafeToFuture
+                  permissions <- users match {
+                    case Nil =>
+                      for {
+                        auth0User <- OptionT {
+                          Auth0Service.findGroundworkUser(
+                            userByEmail.email,
+                            managementToken
+                          )
+                        } getOrElseF {
+                          Auth0Service
+                            .createGroundworkUser(
+                              userByEmail.email,
+                              managementToken
+                            )
+                        }
+                        newUserOpt <- (auth0User.user_id traverse { userId =>
+                          for {
+                            user <- UserDao.create(
+                              User.Create(
+                                userId,
+                                email = userByEmail.email,
+                                scope = Scopes.GroundworkUser
+                              )
+                            )
+                            _ <- UserGroupRoleDao.createDefaultRoles(user)
+                            _ <- AnnotationProjectDao.copyProject(
+                              UUID.fromString(groundworkSampleProject),
+                              user
+                            )
+                          } yield user
+                        }).transact(xa).unsafeToFuture
+                        acrs = newUserOpt map { newUser =>
+                          getDefaultShare(newUser, userByEmail.actionType)
+                        } getOrElse Nil
+                        _ <- (newUserOpt, campaignO).tupled traverse {
+                          case (newUser, campaign) =>
+                            // if silent param is not provided, we notify
+                            val isSilent = userByEmail.silent.getOrElse(false)
+                            if (!isSilent) {
+                              shareNotifyNewUser(
+                                managementToken,
+                                user,
+                                userByEmail.email,
+                                newUser.id,
+                                userPlatform,
+                                campaign,
+                                "campaign",
+                                Notifications.getInvitationMessage
+                              )
+                            } else {
+                              Future.unit
+                            }
+                        }
+                        // this is not an existing user,
+                        // there is no project specific ACR yet,
+                        // so no need to remove Validate action if only want Annotate
+                        dbAcrs <- (acrs traverse { acr =>
+                          CampaignDao
+                            .addPermission(campaignId, acr)
+                        }).transact(xa).unsafeToFuture
+                      } yield dbAcrs
+                    case existingUsers =>
+                      existingUsers traverse { existingUser =>
+                        val acrs =
+                          getDefaultShare(existingUser, userByEmail.actionType)
+                        Auth0Service
+                          .addUserMetadata(
+                            existingUser.id,
+                            managementToken,
+                            Map("app_metadata" -> Map("annotateApp" -> true)).asJson
+                          ) *>
+                          (CampaignDao
+                            .handleSharedPermissions(
+                              campaignId,
+                              existingUser.id,
+                              acrs,
+                              userByEmail.actionType
+                            )
+                            .transact(xa) <* (
+                            // if silent param is not provided, we notify
+                            userByEmail.silent match {
+                              case Some(false) | None =>
+                                CampaignDao
+                                  .unsafeGetCampaignById(campaignId)
+                                  .transact(xa) flatMap { campaign =>
+                                  shareNotify(
+                                    existingUser,
+                                    user,
+                                    campaign,
+                                    "campaign"
+                                  )
+                                }
+                              case _ => IO.pure(())
+                            }
+                          )).unsafeToFuture
+                      } map { _.flatten }
+                  }
+                } yield permissions
+              }
+            }
+          }
+        }
+      }
+    }
 }

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -5,6 +5,7 @@ import com.rasterfoundry.api.user.Auth0Service
 import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
 import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
+
 import akka.http.scaladsl.server._
 import cats.data.OptionT
 import cats.effect.{ContextShift, IO}

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -15,11 +15,11 @@ import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
+import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 import scala.concurrent.Future
 
 import java.util.UUID
-import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 trait CampaignPermissionRoutes
     extends CommonHandlers

--- a/app-backend/api/src/main/scala/campaign/Notifications.scala
+++ b/app-backend/api/src/main/scala/campaign/Notifications.scala
@@ -1,0 +1,85 @@
+package com.rasterfoundry.api.campaign
+
+import com.rasterfoundry.api.user.PasswordResetTicket
+import com.rasterfoundry.datamodel.Campaign
+import com.rasterfoundry.notification.email.Model._
+
+object Notifications {
+  def getInvitationMessage(
+      sharingUserEmail: String,
+      campaign: Campaign,
+      passwordResetTicket: PasswordResetTicket
+  ): (HtmlBody, PlainBody) = {
+    val richBody = HtmlBody(s"""
+<html>
+  <head>
+    <style type="text/css">
+      @import url(https://use.typekit.net/yrj5flr.css);.ExternalClass,.ExternalClass div,.ExternalClass font,.ExternalClass p,.ExternalClass span,.ExternalClass td,img{line-height:100%}#outlook a{padding:0}.ExternalClass,.ReadMsgBody{width:100%}a,blockquote,body,li,p,table,td{-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}table,td{mso-table-lspace:0;mso-table-rspace:0}img{-ms-interpolation-mode:bicubic;border:0;height:auto;outline:0;text-decoration:none}table{border-collapse:collapse!important}#bodyCell,#bodyTable,body{height:100%!important;margin:0;padding:0;font-family:proxima-nova,sans-serif}#bodyCell{padding:20px}#bodyTable{width:600px}@media only screen and (max-width:480px){#bodyTable,body{width:100%!important}a,blockquote,body,li,p,table,td{-webkit-text-size-adjust:none!important}body{min-width:100%!important}#bodyTable{max-width:600px!important}#signIn{max-width:280px!important}}
+    </style>
+  </head>
+  <body>
+    <center>
+      <table
+        style='width: 600px;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 0;font-family: proxima-nova, sans-serif;border-collapse: collapse !important;height: 100% !important;'
+        align="center"
+        border="0"
+        cellpadding="0"
+        cellspacing="0"
+        height="100%"
+        width="100%"
+        id="bodyTable"
+      >
+        <tr>
+          <td
+            align="center"
+            valign="top"
+            id="bodyCell"
+            style='-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: proxima-nova, sans-serif;;height: 100% !important;'
+          >
+            <div class="main">
+              <p
+                style="text-align: center;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; margin-bottom: 30px;"
+              >
+                <img
+                  src="https://groundwork.azavea.com/assets/img/groundwork_logo_email_2x.png"
+                  width="200"
+                  alt="GroundWork"
+                  style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;"
+                />
+              </p>
+
+              <h1>Collaboration request</h1>
+
+              <p>
+                <strong>${sharingUserEmail}</strong> needs your help! They've invited you to be a collaborator on their labeling campaign <strong>${campaign.name}</strong>
+              </p>
+
+              <p>
+                <a href="${passwordResetTicket.ticket}">Create an account and accept their invitation.</a>
+              </p>
+
+              <p>GroundWork is an image annotation tool designed for working with geospatial data like satellite, drone, and aerial imagery.</p>
+
+              <br /><br />
+              <hr style="border: 2px solid #EAEEF3; border-bottom: 0; margin: 20px 0;" />
+              <p style="text-align: center;color: #A9B3BC;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;">
+                If you do not know ${sharingUserEmail}, please ignore this request.
+              </p>
+            </div>
+          </td>
+        </tr>
+      </table>
+    </center>
+  </body>
+</html>
+""")
+    val plainBody = PlainBody(s"""
+    | ${sharingUserEmail} needs your help! They've invited you to be a collaborator on their labeling campaign ${campaign.name} in Groundwork.
+    |
+    | Groundwork is an image annotation tool designed for working with geospatial data like satellite, drone, and aerial imagery.
+    |
+    | Made by your friends at Azavea.
+    | """.trim.stripMargin)
+    (richBody, plainBody)
+  }
+}

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -112,6 +112,18 @@ trait CampaignRoutes
           pathEndOrSingleSlash {
             get {
               listCampaignTasks(campaignId)
+        } ~ pathPrefix("share") {
+          pathEndOrSingleSlash {
+            get {
+              listCampaignShares(campaignId)
+            } ~ post {
+              shareCampaign(campaignId)
+            }
+          } ~ pathPrefix(Segment) { deleteId =>
+            pathEndOrSingleSlash {
+              delete {
+                deleteCampaignShare(campaignId, deleteId)
+              }
             }
           }
         }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -112,19 +112,19 @@ trait CampaignRoutes
           pathEndOrSingleSlash {
             get {
               listCampaignTasks(campaignId)
-            } ~ pathPrefix("share") {
-              pathEndOrSingleSlash {
-                get {
-                  listCampaignShares(campaignId)
-                } ~ post {
-                  shareCampaign(campaignId)
-                }
-              } ~ pathPrefix(Segment) { deleteId =>
-                pathEndOrSingleSlash {
-                  delete {
-                    deleteCampaignShare(campaignId, deleteId)
-                  }
-                }
+            }
+          }
+        } ~ pathPrefix("share") {
+          pathEndOrSingleSlash {
+            get {
+              listCampaignShares(campaignId)
+            } ~ post {
+              shareCampaign(campaignId)
+            }
+          } ~ pathPrefix(Segment) { deleteId =>
+            pathEndOrSingleSlash {
+              delete {
+                deleteCampaignShare(campaignId, deleteId)
               }
             }
           }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -112,381 +112,392 @@ trait CampaignRoutes
           pathEndOrSingleSlash {
             get {
               listCampaignTasks(campaignId)
-        } ~ pathPrefix("share") {
-          pathEndOrSingleSlash {
-            get {
-              listCampaignShares(campaignId)
-            } ~ post {
-              shareCampaign(campaignId)
-            }
-          } ~ pathPrefix(Segment) { deleteId =>
-            pathEndOrSingleSlash {
-              delete {
-                deleteCampaignShare(campaignId, deleteId)
+            } ~ pathPrefix("share") {
+              pathEndOrSingleSlash {
+                get {
+                  listCampaignShares(campaignId)
+                } ~ post {
+                  shareCampaign(campaignId)
+                }
+              } ~ pathPrefix(Segment) { deleteId =>
+                pathEndOrSingleSlash {
+                  delete {
+                    deleteCampaignShare(campaignId, deleteId)
+                  }
+                }
               }
             }
           }
         }
-      }
-  }
 
-  def listCampaigns: Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Read, None),
-      user
-    ) {
-      (withPagination & campaignQueryParameters) { (page, campaignQP) =>
-        complete {
-          CampaignDao
-            .listCampaigns(page, campaignQP, user)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def createCampaign: Route = authenticate { user =>
-    authorizeScopeLimit(
-      CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
-      Domain.Campaigns,
-      Action.Create,
-      user
-    ) {
-      entity(as[Campaign.Create]) { newCampaign =>
-        onSuccess(
-          CampaignDao
-            .insertCampaign(newCampaign, user)
-            .transact(xa)
-            .unsafeToFuture
-        ) { campaign =>
-          complete((StatusCodes.Created, campaign))
-        }
-      }
-    }
-  }
-
-  def getCampaign(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Read, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        CampaignDao
-          .authorized(
-            user,
-            ObjectType.Campaign,
-            campaignId,
-            ActionType.View
-          )
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        rejectEmptyResponse {
-          complete {
-            CampaignDao
-              .getCampaignById(campaignId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def updateCampaign(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Update, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        CampaignDao
-          .authorized(
-            user,
-            ObjectType.Campaign,
-            campaignId,
-            ActionType.Edit
-          )
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[Campaign]) { updatedCampaign =>
-          onSuccess(
-            CampaignDao
-              .updateCampaign(
-                updatedCampaign,
-                campaignId
-              )
-              .transact(xa)
-              .unsafeToFuture
+        def listCampaigns: Route = authenticate { user =>
+          authorizeScope(
+            ScopedAction(Domain.Campaigns, Action.Read, None),
+            user
           ) {
-            completeSingleOrNotFound
+            (withPagination & campaignQueryParameters) { (page, campaignQP) =>
+              complete {
+                CampaignDao
+                  .listCampaigns(page, campaignQP, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
           }
         }
-      }
-    }
-  }
 
-  def deleteCampaign(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Delete, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        CampaignDao
-          .authorized(
-            user,
-            ObjectType.Campaign,
-            campaignId,
-            ActionType.Delete
-          )
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          CampaignDao
-            .deleteCampaign(campaignId, user)
-            .transact(xa)
-            .unsafeToFuture
-        ) {
-          completeSingleOrNotFound
+        def createCampaign: Route = authenticate { user =>
+          authorizeScopeLimit(
+            CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
+            Domain.Campaigns,
+            Action.Create,
+            user
+          ) {
+            entity(as[Campaign.Create]) { newCampaign =>
+              onSuccess(
+                CampaignDao
+                  .insertCampaign(newCampaign, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) { campaign =>
+                complete((StatusCodes.Created, campaign))
+              }
+            }
+          }
         }
-      }
-    }
-  }
 
-  def cloneCampaign(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Clone, None),
-      user
-    ) {
-      authorizeAsync {
-        (
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            ) map {
-            _.toBoolean
-          },
-          CampaignDao.isActiveCampaign(campaignId)
-        ).tupled
-          .map({ authTup =>
-            authTup._1 && authTup._2
-          })
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[Campaign.Clone]) { campaignClone =>
-          onSuccess(
-            (campaignClone.grantAccessToParentCampaignOwner match {
-              case false =>
-                CampaignDao.copyCampaign(
-                  campaignId,
+        def getCampaign(campaignId: UUID): Route = authenticate { user =>
+          authorizeScope(
+            ScopedAction(Domain.Campaigns, Action.Read, None),
+            user
+          ) {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
                   user,
-                  Some(campaignClone.tags),
-                  campaignClone.copyResourceLink
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.View
                 )
-              case true =>
-                for {
-                  copiedCampaign <- CampaignDao.copyCampaign(
-                    campaignId,
-                    user,
-                    Some(campaignClone.tags),
-                    campaignClone.copyResourceLink
-                  )
-                  copiedProjects <- AnnotationProjectDao.listByCampaign(
-                    copiedCampaign.id
-                  )
-                  originalCampaignO <- CampaignDao.getCampaignById(campaignId)
-                  originalCampaignOwnerO = originalCampaignO map { _.owner }
-                  _ <- CampaignDao.addPermission(
-                    copiedCampaign.id,
-                    ObjectAccessControlRule(
-                      SubjectType.User,
-                      originalCampaignOwnerO,
-                      ActionType.View
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              rejectEmptyResponse {
+                complete {
+                  CampaignDao
+                    .getCampaignById(campaignId)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+              }
+            }
+          }
+        }
+
+        def updateCampaign(campaignId: UUID): Route = authenticate { user =>
+          authorizeScope(
+            ScopedAction(Domain.Campaigns, Action.Update, None),
+            user
+          ) {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.Edit
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              entity(as[Campaign]) { updatedCampaign =>
+                onSuccess(
+                  CampaignDao
+                    .updateCampaign(
+                      updatedCampaign,
+                      campaignId
                     )
+                    .transact(xa)
+                    .unsafeToFuture
+                ) {
+                  completeSingleOrNotFound
+                }
+              }
+            }
+          }
+        }
+
+        def deleteCampaign(campaignId: UUID): Route = authenticate { user =>
+          authorizeScope(
+            ScopedAction(Domain.Campaigns, Action.Delete, None),
+            user
+          ) {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.Delete
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              onSuccess(
+                CampaignDao
+                  .deleteCampaign(campaignId, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) {
+                completeSingleOrNotFound
+              }
+            }
+          }
+        }
+
+        def cloneCampaign(campaignId: UUID): Route = authenticate { user =>
+          authorizeScope(
+            ScopedAction(Domain.Campaigns, Action.Clone, None),
+            user
+          ) {
+            authorizeAsync {
+              (
+                CampaignDao
+                  .authorized(
+                    user,
+                    ObjectType.Campaign,
+                    campaignId,
+                    ActionType.View
+                  ) map {
+                  _.toBoolean
+                },
+                CampaignDao.isActiveCampaign(campaignId)
+              ).tupled
+                .map({ authTup =>
+                  authTup._1 && authTup._2
+                })
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              entity(as[Campaign.Clone]) { campaignClone =>
+                onSuccess(
+                  (campaignClone.grantAccessToParentCampaignOwner match {
+                    case false =>
+                      CampaignDao.copyCampaign(
+                        campaignId,
+                        user,
+                        Some(campaignClone.tags),
+                        campaignClone.copyResourceLink
+                      )
+                    case true =>
+                      for {
+                        copiedCampaign <- CampaignDao.copyCampaign(
+                          campaignId,
+                          user,
+                          Some(campaignClone.tags),
+                          campaignClone.copyResourceLink
+                        )
+                        copiedProjects <- AnnotationProjectDao.listByCampaign(
+                          copiedCampaign.id
+                        )
+                        originalCampaignO <- CampaignDao.getCampaignById(
+                          campaignId
+                        )
+                        originalCampaignOwnerO = originalCampaignO map {
+                          _.owner
+                        }
+                        _ <- CampaignDao.addPermission(
+                          copiedCampaign.id,
+                          ObjectAccessControlRule(
+                            SubjectType.User,
+                            originalCampaignOwnerO,
+                            ActionType.View
+                          )
+                        )
+                        _ <- copiedProjects traverse { project =>
+                          AnnotationProjectDao.addPermissionsMany(
+                            project.id,
+                            List(
+                              ObjectAccessControlRule(
+                                SubjectType.User,
+                                originalCampaignOwnerO,
+                                ActionType.View
+                              ),
+                              ObjectAccessControlRule(
+                                SubjectType.User,
+                                originalCampaignOwnerO,
+                                ActionType.Annotate
+                              )
+                            )
+                          )
+                        }
+                      } yield copiedCampaign
+                  }).transact(xa).unsafeToFuture
+                ) { campaign =>
+                  complete((StatusCodes.Created, campaign))
+                }
+              }
+            }
+          }
+        }
+
+        def listCampaignUserActions(campaignId: UUID): Route = authenticate {
+          user =>
+            authorizeScope(
+              ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
+              user
+            ) {
+              authorizeAuthResultAsync {
+                CampaignDao
+                  .authorized(
+                    user,
+                    ObjectType.Campaign,
+                    campaignId,
+                    ActionType.View
                   )
-                  _ <- copiedProjects traverse { project =>
-                    AnnotationProjectDao.addPermissionsMany(
-                      project.id,
-                      List(
-                        ObjectAccessControlRule(
-                          SubjectType.User,
-                          originalCampaignOwnerO,
-                          ActionType.View
-                        ),
-                        ObjectAccessControlRule(
-                          SubjectType.User,
-                          originalCampaignOwnerO,
-                          ActionType.Annotate
+                  .transact(xa)
+                  .unsafeToFuture
+              } {
+                user.isSuperuser match {
+                  case true => complete(List("*"))
+                  case false =>
+                    onSuccess(
+                      CampaignDao
+                        .getCampaignById(campaignId)
+                        .transact(xa)
+                        .unsafeToFuture
+                    ) { campaignO =>
+                      complete {
+                        (campaignO traverse { campaign =>
+                          campaign.owner == user.id match {
+                            case true => List("*").pure[ConnectionIO]
+                            case false =>
+                              CampaignDao
+                                .listUserActions(user, campaignId)
+                          }
+                        } map { _.getOrElse(List[String]()) })
+                          .transact(xa)
+                          .unsafeToFuture()
+                      }
+                    }
+                }
+              }
+            }
+        }
+
+        def listCampaignCloneOwners(campaignId: UUID): Route = authenticate {
+          user =>
+            authorizeScope(
+              ScopedAction(Domain.Campaigns, Action.Clone, None),
+              user
+            ) {
+              authorizeAuthResultAsync {
+                CampaignDao
+                  .authorized(
+                    user,
+                    ObjectType.Campaign,
+                    campaignId,
+                    ActionType.Edit
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              } {
+                complete {
+                  CampaignDao
+                    .getCloneOwners(campaignId)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+              }
+            }
+        }
+
+        def getReviewTask(campaignId: UUID): Route = authenticate { user =>
+          authorizeScope(
+            ScopedAction(Domain.Campaigns, Action.Read, None),
+            user
+          ) {
+            authorizeAsync {
+              CampaignDao
+                .isActiveCampaign(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              complete {
+                CampaignDao
+                  .randomReviewTask(
+                    campaignId,
+                    user
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+
+          }
+        }
+
+        def retrieveChildCampaignLabels(campaignId: UUID): Route =
+          authenticate { user =>
+            authorizeScope(
+              ScopedAction(Domain.Campaigns, Action.Clone, None),
+              user
+            ) {
+              authorizeAuthResultAsync {
+                CampaignDao
+                  .authorized(
+                    user,
+                    ObjectType.Campaign,
+                    campaignId,
+                    ActionType.Edit
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              } {
+                onSuccess {
+                  CampaignDao
+                    .retrieveChildCampaignAnnotations(campaignId)
+                    .transact(xa)
+                    .unsafeToFuture
+                } { complete(StatusCodes.NoContent) }
+              }
+            }
+          }
+
+        def listCampaignTasks(campaignId: UUID): Route =
+          authenticate { user =>
+            authorizeScope(
+              ScopedAction(Domain.Campaigns, Action.Read, None),
+              user
+            ) {
+              authorizeAuthResultAsync(
+                CampaignDao
+                  .authorized(
+                    user,
+                    ObjectType.Campaign,
+                    campaignId,
+                    ActionType.View
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              ) {
+                (withPagination & taskQueryParameters) { (page, taskParams) =>
+                  complete {
+                    (
+                      TaskDao
+                        .listCampaignTasks(
+                          taskParams,
+                          campaignId,
+                          page
                         )
                       )
-                    )
+                      .transact(xa)
+                      .unsafeToFuture
                   }
-                } yield copiedCampaign
-            }).transact(xa).unsafeToFuture
-          ) { campaign =>
-            complete((StatusCodes.Created, campaign))
-          }
-        }
-      }
-    }
-  }
-
-  def listCampaignUserActions(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        CampaignDao
-          .authorized(
-            user,
-            ObjectType.Campaign,
-            campaignId,
-            ActionType.View
-          )
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        user.isSuperuser match {
-          case true => complete(List("*"))
-          case false =>
-            onSuccess(
-              CampaignDao
-                .getCampaignById(campaignId)
-                .transact(xa)
-                .unsafeToFuture
-            ) { campaignO =>
-              complete {
-                (campaignO traverse { campaign =>
-                  campaign.owner == user.id match {
-                    case true => List("*").pure[ConnectionIO]
-                    case false =>
-                      CampaignDao
-                        .listUserActions(user, campaignId)
-                  }
-                } map { _.getOrElse(List[String]()) })
-                  .transact(xa)
-                  .unsafeToFuture()
+                }
               }
             }
-        }
-      }
-    }
-  }
-
-  def listCampaignCloneOwners(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Clone, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        CampaignDao
-          .authorized(
-            user,
-            ObjectType.Campaign,
-            campaignId,
-            ActionType.Edit
-          )
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          CampaignDao
-            .getCloneOwners(campaignId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def getReviewTask(campaignId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.Campaigns, Action.Read, None),
-      user
-    ) {
-      authorizeAsync {
-        CampaignDao
-          .isActiveCampaign(campaignId)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          CampaignDao
-            .randomReviewTask(
-              campaignId,
-              user
-            )
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-
-    }
-  }
-
-  def retrieveChildCampaignLabels(campaignId: UUID): Route = authenticate {
-    user =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Clone, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess {
-            CampaignDao
-              .retrieveChildCampaignAnnotations(campaignId)
-              .transact(xa)
-              .unsafeToFuture
-          } { complete(StatusCodes.NoContent) }
-        }
-      }
-  }
-
-  def listCampaignTasks(campaignId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
-        authorizeAuthResultAsync(
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        ) {
-          (withPagination & taskQueryParameters) { (page, taskParams) =>
-            complete {
-              (
-                TaskDao
-                  .listCampaignTasks(
-                    taskParams,
-                    campaignId,
-                    page
-                  )
-                )
-                .transact(xa)
-                .unsafeToFuture
-            }
           }
-        }
       }
-    }
+  }
 }

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -50,7 +50,7 @@ trait ProjectRoutes
 
   val xa: Transactor[IO]
 
-  implicit val contextShift: ContextShift[IO]
+  implicit def contextShift: ContextShift[IO]
   val projectRoutes: Route = handleExceptions(userExceptionHandler) {
     pathEndOrSingleSlash {
       get {

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -42,7 +42,7 @@ trait SceneRoutes
 
   implicit val ec: ExecutionContext
 
-  implicit val contextShift: ContextShift[IO]
+  implicit def contextShift: ContextShift[IO]
 
   val rasterIOContext = ExecutionContext.fromExecutor(
     Executors.newFixedThreadPool(

--- a/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
+++ b/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
@@ -1,0 +1,135 @@
+package com.rasterfoundry.api.utils
+
+import com.rasterfoundry.datamodel._
+
+import cats.effect.{Async, ContextShift, IO}
+import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
+import com.rasterfoundry.api.user.{Auth0Service, PasswordResetTicket}
+import com.rasterfoundry.notification.email.Model.{HtmlBody, PlainBody}
+
+import scala.concurrent.Future
+import java.{util => ju}
+import com.rasterfoundry.notification.intercom.LiveIntercomNotifier
+import com.rasterfoundry.notification.intercom.Model.{ExternalId, Message}
+import com.rasterfoundry.database.notification.Notify
+
+trait IntercomNotifications extends Config {
+  implicit val contextShift: ContextShift[IO]
+
+  private val intercomNotifierIO = for {
+    backend <- getBackend
+    notifier = new LiveIntercomNotifier[IO](backend)
+  } yield notifier
+
+  def getDefaultShare(
+      user: User,
+      actionTypeOpt: Option[ActionType] = None
+  ): List[ObjectAccessControlRule] = {
+    val default = List(
+      ObjectAccessControlRule(
+        SubjectType.User,
+        Some(user.id),
+        ActionType.View
+      ),
+      ObjectAccessControlRule(
+        SubjectType.User,
+        Some(user.id),
+        ActionType.Export
+      )
+    )
+    val annotate = ObjectAccessControlRule(
+      SubjectType.User,
+      Some(user.id),
+      ActionType.Annotate
+    )
+    val validate = ObjectAccessControlRule(
+      SubjectType.User,
+      Some(user.id),
+      ActionType.Validate
+    )
+    actionTypeOpt match {
+      case Some(ActionType.Validate) =>
+        default :+ annotate :+ validate
+      case Some(ActionType.Annotate) | None =>
+        default :+ annotate
+      case _ =>
+        default
+    }
+  }
+
+  def getSharer(sharingUser: User): String =
+    if (sharingUser.email != "") {
+      sharingUser.email
+    } else if (sharingUser.personalInfo.email != "") {
+      sharingUser.personalInfo.email
+    } else {
+      sharingUser.name
+    }
+
+  val getBackend = for {
+    backendRef <- Async.memoize {
+      AsyncHttpClientCatsBackend[IO]()
+    }
+    backend <- backendRef
+  } yield backend
+
+  def shareNotify[T <: { val id: ju.UUID }](
+      sharedUser: User,
+      sharingUser: User,
+      value: T,
+      valueType: String
+  ): IO[Either[Throwable, Unit]] =
+    intercomNotifierIO flatMap { intercomNotifier =>
+      intercomNotifier
+        .notifyUser(
+          intercomToken,
+          intercomAdminId,
+          ExternalId(sharedUser.id),
+          Message(s"""
+        | ${getSharer(sharingUser)} has shared a $valueType with you!
+        | ${groundworkUrlBase}/app/${valueType}s/${value.id}/overview
+        | """.trim.stripMargin)
+        )
+        .attempt
+    }
+
+  def shareNotifyNewUser[T <: { val name: String }](
+      bearerToken: ManagementBearerToken,
+      sharingUser: User,
+      newUserEmail: String,
+      newUserId: String,
+      sharingUserPlatform: Platform,
+      value: T,
+      valueType: String,
+      getMessages: (String, T, PasswordResetTicket) => (HtmlBody, PlainBody)
+  ): Future[Unit] = {
+    val subject =
+      s"""You've been invited to join the "${value.name}" $valueType on GroundWork!"""
+    (for {
+      ticket <- IO.fromFuture {
+        IO {
+          Auth0Service.createPasswordChangeTicket(
+            bearerToken,
+            s"$groundworkUrlBase/app/login",
+            newUserId
+          )
+        }
+      }
+      (messageRich, messagePlain) = getMessages(
+        getSharer(sharingUser),
+        value,
+        ticket
+      )
+      _ <- Notify
+        .sendEmail(
+          sharingUserPlatform.publicSettings,
+          sharingUserPlatform.privateSettings,
+          newUserEmail,
+          subject,
+          messageRich.underlying,
+          messagePlain.underlying
+        )
+    } yield ()).attempt.void.unsafeToFuture
+  }
+
+}

--- a/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
+++ b/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
@@ -1,17 +1,18 @@
 package com.rasterfoundry.api.utils
 
+import com.rasterfoundry.api.user.{Auth0Service, PasswordResetTicket}
+import com.rasterfoundry.database.notification.Notify
 import com.rasterfoundry.datamodel._
+import com.rasterfoundry.notification.email.Model.{HtmlBody, PlainBody}
+import com.rasterfoundry.notification.intercom.LiveIntercomNotifier
+import com.rasterfoundry.notification.intercom.Model.{ExternalId, Message}
 
 import cats.effect.{Async, ContextShift, IO}
 import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
-import com.rasterfoundry.api.user.{Auth0Service, PasswordResetTicket}
-import com.rasterfoundry.notification.email.Model.{HtmlBody, PlainBody}
 
 import scala.concurrent.Future
+
 import java.{util => ju}
-import com.rasterfoundry.notification.intercom.LiveIntercomNotifier
-import com.rasterfoundry.notification.intercom.Model.{ExternalId, Message}
-import com.rasterfoundry.database.notification.Notify
 
 trait IntercomNotifications extends Config {
   implicit val contextShift: ContextShift[IO]


### PR DESCRIPTION
## Overview

This PR adds simple sharing endpoints for campaigns. It abstracts the sharing functionality into an `IntercomNotifications` trait that we can re-use, but it doesn't abstract the procedure to actually do the sharing, so there's a lot of copy-pasta.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- I think tests are fine? I think we'll have a better idea of how this works once we need to use it

Closes raster-foundry/annotate#973
