### PR TITLE
Accept campaignId query parameter on listStac endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - STAC label items now include the task statuses in a `groundwork:taskStatuses` property [#5490](https://github.com/raster-foundry/raster-foundry/pull/5490)
 - Tasks can be listed by campaign [#5494](https://github.com/raster-foundry/raster-foundry/pull/5494)
 - Campaigns can be shared with only an email [#5495](https://github.com/raster-foundry/raster-foundry/pull/5495)
+- Campaign IDs can be used to filter STAC exports [#5498](https://github.com/raster-foundry/raster-foundry/pull/5498)
 
 ### Changed
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -204,7 +204,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         searchParams &
         parameters(
           'exportStatus.as[String].?,
-          'annotationProjectId.as[UUID].?
+          'annotationProjectId.as[UUID].?,
+          'campaignId.as[UUID].?
         )
     ).as(StacExportQueryParameters.apply _)
 

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -997,7 +997,15 @@ object Generators extends ArbitraryInstances {
   private def taskStatusListGen: Gen[List[TaskStatus]] =
     Gen.oneOf(0, 5) flatMap { Gen.listOfN(_, taskStatusGen) }
 
-  private val stacExportGenTup =
+  private val stacAnnotationExportGenTup =
+    (
+      nonEmptyStringGen,
+      Gen.const(StacExportLicense(Proprietary(), Some("http://example.com"))),
+      taskStatusListGen,
+      uuidGen
+    )
+
+  private val stacCampaignExportGenTup =
     (
       nonEmptyStringGen,
       Gen.const(StacExportLicense(Proprietary(), Some("http://example.com"))),
@@ -1007,10 +1015,10 @@ object Generators extends ArbitraryInstances {
 
   private def stacAnnotationProjectExportGen
       : Gen[StacExport.AnnotationProjectExport] =
-    stacExportGenTup.mapN(StacExport.AnnotationProjectExport.apply)
+    stacAnnotationExportGenTup.mapN(StacExport.AnnotationProjectExport.apply)
 
   private def stacCampaignExportGen: Gen[StacExport.CampaignExport] =
-    stacExportGenTup.mapN(StacExport.CampaignExport.apply)
+    stacCampaignExportGenTup.mapN(StacExport.CampaignExport.apply)
 
   private def stacExportQueryParametersGen: Gen[StacExportQueryParameters] =
     Gen.const(StacExportQueryParameters())

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -664,7 +664,8 @@ final case class StacExportQueryParameters(
     ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
     searchParams: SearchQueryParameters = SearchQueryParameters(),
     exportStatus: Option[String] = None,
-    annotationProjectId: Option[UUID] = None
+    annotationProjectId: Option[UUID] = None,
+    campaignId: Option[UUID] = None
 )
 
 object StacExportQueryParameters {

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -426,6 +426,9 @@ trait Filterables extends RFMeta with LazyLogging {
             },
             params.annotationProjectId map { qp =>
               fr"annotation_project_id = ${qp}"
+            },
+            params.campaignId map { qp =>
+              fr"campaign_id = ${qp}"
             }
           )
     }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -441,6 +441,15 @@ trait PropTestHelpers {
       annotationProjectId = project.id
     )
 
+  def fixupCampaignExportCreate(
+      campaignExport: StacExport.CampaignExport,
+      campaign: Campaign
+  ): StacExport.CampaignExport = {
+    campaignExport.copy(
+      campaignId = campaign.id
+    )
+  }
+
   def createChildTaskCreateFC(
       parentTask: Task.TaskFeature,
       childStatus: TaskStatus,


### PR DESCRIPTION
## Overview

This PR adds support for the `campaignId` query parameter on the `listStacExport` endpoint. It appears as though the database is already setup with support for campaign IDs, so all that was required here was passing parameters through.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated
- [x] New tables and queries have appropriate indices added
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Notes

First time PRing against this project in a while. Might be good to double check that I'm making all and only necessary changes.

## Testing Instructions

Run tests or try adding a `campaignId` query parameter on a STAC list request.

Closes https://github.com/raster-foundry/annotate/issues/975 (not sure how to close in another repo)
