### PR TITLE
Associate label class groups with campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
+
 ## [Unreleased](https://github.com/raster-foundry/raster-foundry/tree/develop)
 
 ### Added
@@ -9,6 +10,8 @@
 - Campaign IDs can be used to filter STAC exports [#5498](https://github.com/raster-foundry/raster-foundry/pull/5498)
 
 ### Changed
+
+- Campaigns are now optionally associated with `AnnotationLabelClassGroup`s and return associated groups from `/campaign` endpoints [#5500](https://github.com/raster-foundry/raster-foundry/pull/5500)
 
 ### Deprecated
 

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -187,7 +187,7 @@ trait CampaignRoutes
         rejectEmptyResponse {
           complete {
             CampaignDao
-              .getCampaignById(campaignId)
+              .getCampaignWithRelatedById(campaignId)
               .transact(xa)
               .unsafeToFuture
           }

--- a/app-backend/datamodel/src/main/scala/AnnotationLabelClassGroup.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabelClassGroup.scala
@@ -8,7 +8,8 @@ import java.util.UUID
 final case class AnnotationLabelClassGroup(
     id: UUID,
     name: String,
-    annotationProjectId: UUID,
+    annotationProjectId: Option[UUID],
+    campaignId: Option[UUID],
     index: Int
 ) {
   def withLabelClasses(
@@ -18,6 +19,7 @@ final case class AnnotationLabelClassGroup(
       id,
       name,
       annotationProjectId,
+      campaignId,
       index,
       classes
     )
@@ -43,7 +45,8 @@ object AnnotationLabelClassGroup {
   final case class WithLabelClasses(
       id: UUID,
       name: String,
-      annotationProjectId: UUID,
+      annotationProjectId: Option[UUID],
+      campaignId: Option[UUID],
       index: Int,
       labelClasses: List[AnnotationLabelClass]
   )

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -25,14 +25,26 @@ final case class Campaign(
     resourceLink: Option[String] = None
 ) {
   def withRelated(
-    labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
+      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
   ): Campaign.WithRelated = {
     Campaign.WithRelated(
-      id, createdAt, owner, name, campaignType,
-      description, videoLink, partnerName,
-      partnerLogo, parentCampaignId, continent,
-      tags, childrenCount, projectStatuses,
-      isActive, resourceLink, labelClassGroups
+      id,
+      createdAt,
+      owner,
+      name,
+      campaignType,
+      description,
+      videoLink,
+      partnerName,
+      partnerLogo,
+      parentCampaignId,
+      continent,
+      tags,
+      childrenCount,
+      projectStatuses,
+      isActive,
+      resourceLink,
+      labelClassGroups
     )
   }
 }
@@ -69,23 +81,23 @@ object Campaign {
   }
 
   final case class WithRelated(
-    id: UUID,
-    createdAt: Timestamp,
-    owner: String,
-    name: String,
-    campaignType: AnnotationProjectType,
-    description: Option[String] = None,
-    videoLink: Option[String] = None,
-    partnerName: Option[String] = None,
-    partnerLogo: Option[String] = None,
-    parentCampaignId: Option[UUID] = None,
-    continent: Option[Continent] = None,
-    tags: List[String] = List.empty,
-    childrenCount: Int,
-    projectStatuses: Map[String, Int],
-    isActive: Boolean,
-    resourceLink: Option[String] = None,
-    labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
+      id: UUID,
+      createdAt: Timestamp,
+      owner: String,
+      name: String,
+      campaignType: AnnotationProjectType,
+      description: Option[String] = None,
+      videoLink: Option[String] = None,
+      partnerName: Option[String] = None,
+      partnerLogo: Option[String] = None,
+      parentCampaignId: Option[UUID] = None,
+      continent: Option[Continent] = None,
+      tags: List[String] = List.empty,
+      childrenCount: Int,
+      projectStatuses: Map[String, Int],
+      isActive: Boolean,
+      resourceLink: Option[String] = None,
+      labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
   )
 
   object WithRelated {

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -23,7 +23,19 @@ final case class Campaign(
     projectStatuses: Map[String, Int],
     isActive: Boolean,
     resourceLink: Option[String] = None
-)
+) {
+  def withRelated(
+    labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
+  ): Campaign.WithRelated = {
+    Campaign.WithRelated(
+      id, createdAt, owner, name, campaignType,
+      description, videoLink, partnerName,
+      partnerLogo, parentCampaignId, continent,
+      tags, childrenCount, projectStatuses,
+      isActive, resourceLink, labelClassGroups
+    )
+  }
+}
 
 object Campaign {
   implicit val encCampaign: Encoder[Campaign] = deriveEncoder
@@ -54,5 +66,30 @@ object Campaign {
 
   object Clone {
     implicit val decClone: Decoder[Clone] = deriveDecoder
+  }
+
+  final case class WithRelated(
+    id: UUID,
+    createdAt: Timestamp,
+    owner: String,
+    name: String,
+    campaignType: AnnotationProjectType,
+    description: Option[String] = None,
+    videoLink: Option[String] = None,
+    partnerName: Option[String] = None,
+    partnerLogo: Option[String] = None,
+    parentCampaignId: Option[UUID] = None,
+    continent: Option[Continent] = None,
+    tags: List[String] = List.empty,
+    childrenCount: Int,
+    projectStatuses: Map[String, Int],
+    isActive: Boolean,
+    resourceLink: Option[String] = None,
+    labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
+  )
+
+  object WithRelated {
+    implicit val encRelated: Encoder[WithRelated] = deriveEncoder
+    implicit val decRelated: Decoder[WithRelated] = deriveDecoder
   }
 }

--- a/app-backend/db/src/main/resources/migrations/V63__add_campaigns_to_label_class_groups.sql
+++ b/app-backend/db/src/main/resources/migrations/V63__add_campaigns_to_label_class_groups.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.annotation_label_class_groups
+ALTER COLUMN annotation_project_id DROP NOT NULL,
+ADD COLUMN campaign_id UUID REFERENCES campaigns(id);

--- a/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
@@ -27,7 +27,8 @@ object AnnotationLabelClassGroupDao
     val index = groupCreate.index getOrElse indexFallback
     val groupIO = (fr"INSERT INTO" ++ tableF ++ fr"""
       (id, name, annotation_project_id, campaign_id, idx) VALUES (
-        uuid_generate_v4(), ${groupCreate.name}, ${annotationProject.map(_.id)}, ${campaign.map(_.id)}, ${index}
+        uuid_generate_v4(), ${groupCreate.name}, ${annotationProject.map(_.id)}, ${campaign
+      .map(_.id)}, ${index}
       )""").update.withUniqueGeneratedKeys[AnnotationLabelClassGroup](
       "id",
       "name",

--- a/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
@@ -15,22 +15,24 @@ object AnnotationLabelClassGroupDao
   val tableName = "annotation_label_class_groups"
 
   def selectF: Fragment =
-    fr"SELECT id, name, annotation_project_id, idx FROM" ++ tableF
+    fr"SELECT id, name, annotation_project_id, campaign_id, idx FROM" ++ tableF
 
   def insertAnnotationLabelClassGroup(
       groupCreate: AnnotationLabelClassGroup.Create,
-      annotationProject: AnnotationProject,
+      annotationProject: Option[AnnotationProject],
+      campaign: Option[Campaign],
       indexFallback: Int,
       parentAnnotationLabelClasses: List[AnnotationLabelClass] = Nil
   ): ConnectionIO[AnnotationLabelClassGroup.WithLabelClasses] = {
     val index = groupCreate.index getOrElse indexFallback
     val groupIO = (fr"INSERT INTO" ++ tableF ++ fr"""
-      (id, name, annotation_project_id, idx) VALUES (
-        uuid_generate_v4(), ${groupCreate.name}, ${annotationProject.id}, ${index}
+      (id, name, annotation_project_id, campaign_id, idx) VALUES (
+        uuid_generate_v4(), ${groupCreate.name}, ${annotationProject.map(_.id)}, ${campaign.map(_.id)}, ${index}
       )""").update.withUniqueGeneratedKeys[AnnotationLabelClassGroup](
       "id",
       "name",
       "annotation_project_id",
+      "campaign_id",
       "idx"
     )
     for {
@@ -64,8 +66,21 @@ object AnnotationLabelClassGroupDao
     )).query[AnnotationLabelClassGroup].to[List]
   }
 
+  def listByCampaignId(
+      campaignId: UUID
+  ): ConnectionIO[List[AnnotationLabelClassGroup]] = {
+    (selectF ++ Fragments.whereAndOpt(
+      Some(fr"campaign_id = ${campaignId}")
+    )).query[AnnotationLabelClassGroup].to[List]
+  }
+
   def deleteByProjectId(
       projectId: UUID
   ): ConnectionIO[Int] =
     query.filter(fr"annotation_project_id = $projectId").delete
+
+  def deleteByCampaignId(
+      campaignId: UUID
+  ): ConnectionIO[Int] =
+    query.filter(fr"campaignId = $campaignId").delete
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -172,7 +172,8 @@ object AnnotationProjectDao
         case (classGroup, idx) =>
           AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
             classGroup,
-            annotationProject,
+            Some(annotationProject),
+            None,
             idx
           )
       }
@@ -479,7 +480,8 @@ object AnnotationProjectDao
                   )
                 }
               ),
-              annotationProjectCopy,
+              Some(annotationProjectCopy),
+              None,
               0,
               labelClasses
             )

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -94,7 +94,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       .flatMap(toWithRelated)
 
   def toWithRelated(
-    campaignsPage: PaginatedResponse[Campaign]
+      campaignsPage: PaginatedResponse[Campaign]
   ): ConnectionIO[PaginatedResponse[Campaign.WithRelated]] =
     campaignsPage.results.toList.toNel match {
       case Some(campaigns) =>


### PR DESCRIPTION
## Overview

This PR optionally associates `AnnotationLabelClassGroup`s with `Campaign`s and makes `AnnotationProject` associations optional as well. Additionally, campaign-associated `AnnotationLabelClassGroup`s are now returned via `/campaign` endpoints

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated
- [x] New tables and queries have appropriate indices added
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv


## Testing Instructions

These changes are largely covered by existing tests

Closes https://github.com/raster-foundry/annotate/issues/988
