### PR TITLE
Add task status summaries and image counts to campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Changed
 
 - Campaigns are now optionally associated with `AnnotationLabelClassGroup`s and return associated groups from `/campaign` endpoints [#5500](https://github.com/raster-foundry/raster-foundry/pull/5500)
+- Campaigns now include image counts and task status summaries [#5501](https://github.com/raster-foundry/raster-foundry/pull/5501)
 
 ### Deprecated
 

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -22,7 +22,9 @@ final case class Campaign(
     childrenCount: Int,
     projectStatuses: Map[String, Int],
     isActive: Boolean,
-    resourceLink: Option[String] = None
+    resourceLink: Option[String] = None,
+    taskStatusSummary: Map[String, Int],
+    imageCount: Int = 0
 ) {
   def withRelated(
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses]
@@ -44,7 +46,9 @@ final case class Campaign(
       projectStatuses,
       isActive,
       resourceLink,
-      labelClassGroups
+      labelClassGroups,
+      taskStatusSummary,
+      imageCount
     )
   }
 }
@@ -98,6 +102,8 @@ object Campaign {
       isActive: Boolean,
       resourceLink: Option[String] = None,
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
+      taskStatusSummary: Map[String, Int],
+      imageCount: Int = 0
   )
 
   object WithRelated {

--- a/app-backend/db/src/main/resources/migrations/V64__add_campaign_status_trigger.sql
+++ b/app-backend/db/src/main/resources/migrations/V64__add_campaign_status_trigger.sql
@@ -1,0 +1,104 @@
+-- add column to track task status of campaigns and populate data from existing
+-- campaign projects
+
+ALTER TABLE
+  public.campaigns
+ADD
+  COLUMN task_status_summary jsonb DEFAULT '{"FLAGGED": 0, "INVALID": 0, "LABELED": 0, "UNLABELED": 0, "VALIDATED": 0, "LABELING_IN_PROGRESS": 0, "VALIDATION_IN_PROGRESS": 0}' :: jsonb NOT NULL;
+
+UPDATE
+    campaigns
+SET
+    task_status_summary = campaign_status.task_status_summary
+FROM
+    (
+        SELECT
+            campaign_id,
+            json_object_agg(k, v) task_status_summary
+        FROM
+            (
+                SELECT
+                    annotation_projects.campaign_id,
+                    task_summary.key k,
+                    sum(task_summary.value :: integer) v
+                FROM
+                    annotation_projects
+                    JOIN jsonb_each_text(annotation_projects.task_status_summary) task_summary ON true
+                WHERE
+                    campaign_id IS NOT NULL
+                GROUP BY
+                    campaign_id,
+                    key
+                ORDER BY
+                    k
+            ) campaign_summary
+        GROUP BY
+            campaign_id
+    ) campaign_status
+WHERE
+    campaigns.id = campaign_status.campaign_id;
+
+CREATE
+OR REPLACE FUNCTION UPDATE_CAMPAIGN_TASK_STATUSES() RETURNS trigger AS $BODY$ DECLARE op_campaign_id uuid;
+
+BEGIN -- the NEW variable holds row for INSERT/UPDATE operations
+-- the OLD variable holds row for DELETE operations
+-- store the campaign ID from the annotation project update
+IF TG_OP = 'UPDATE'
+OR TG_OP = 'INSERT' THEN op_campaign_id := NEW.campaign_id;
+
+ELSE op_campaign_id := OLD.campaign_id;
+
+END IF;
+
+-- update status for the parent campaign
+IF op_campaign_id IS NOT NULL THEN
+UPDATE
+  public.campaigns
+SET
+  task_status_summary = campaign_status.task_status_summary
+FROM
+  (
+    SELECT
+      campaign_id,
+      json_object_agg(status_label, status_count) task_status_summary
+    FROM
+      (
+        SELECT
+          annotation_projects.campaign_id,
+          task_summary.key status_label,
+          sum(task_summary.value :: integer) status_count
+        FROM
+          annotation_projects
+          JOIN jsonb_each_text(annotation_projects.task_status_summary) task_summary ON true
+        WHERE
+          campaign_id = op_campaign_id
+        GROUP BY
+          campaign_id,
+          key
+        ORDER BY
+          status_label
+      ) campaign_summary
+    GROUP BY
+      campaign_id
+  ) campaign_status
+WHERE
+  id = op_campaign_id;
+
+END IF;
+
+-- result is ignored since this is an AFTER trigger
+RETURN NULL;
+
+END;
+
+$BODY$ LANGUAGE 'plpgsql';
+
+CREATE TRIGGER update_campaign_task_statuses
+AFTER
+UPDATE
+  OF task_status_summary
+  OR DELETE
+  OR
+INSERT
+  ON annotation_projects FOR EACH ROW EXECUTE PROCEDURE UPDATE_CAMPAIGN_TASK_STATUSES();


### PR DESCRIPTION
## Overview

This adds two fields to campaigns when they're returned from the database:
 - task status summary: an aggregation of task status summaries from all annotation projects that belong to a campaign
 - image count: the number of annotation projects that belong to a campaign

The summary is updated via a trigger which is fired any time that the summary of an annotation project is updated. This is adapted from the trigger already present on annotation projects for updating summary fields

The image count is obtained via a join from the select for annotation projects. This is a left outer join in order to preserve any nulls (campaigns without any annotation projects). All nulls are replaced with a `0`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
~- [ ] New tables and queries have appropriate indices added~
~- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [x] Any new SQL strings have tests
~- [ ] Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

I think the easiest way to test the task status summary is via direct SQL queries.

- run migrations (`./scripts/migrate`) -- alternatively, if you have heavily manipulated data from the development database, run `./scripts/load-development-data`
- make a query to check the task summary for a set of annotation projects in a campaign:
```
select task_status_summary from annotation_projects where campaign_id = '402e753b-93f4-4046-8a1e-77511ad30e2e';
```
- note that there are only 3 tasks, all are unlabeled, and check that this matches the summary for the campaign:
```
select task_status_summary from campaigns where id = '402e753b-93f4-4046-8a1e-77511ad30e2e';
```
- update one task status summary of the annotation projects in that campaign:
```
update annotation_projects 
set task_status_summary = '{"FLAGGED": 0, "INVALID": 0, "LABELED": 0, "UNLABELED": 0, "VALIDATED": 1, "LABELING_IN_PROGRESS": 0, "VALIDATION_IN_PROGRESS": 0}' 
where id = 'eaa72925-e18e-4ea0-bf8d-b27d2dfb5100';
```
- query again for the campaign summary and verify that it has updated successfully
```
select task_status_summary from campaigns where id = '402e753b-93f4-4046-8a1e-77511ad30e2e';
```
- to test the image counts match up as expected you will need to use the API -- obtain a JWT auth token and set it to the environment variable `JWT_AUTH_TOKEN`
- start your API server
- make a request for a campaign: `http :9100/api/campaigns/b78bc4ff-6ef9-4fae-ba03-77ce33e85f03 --auth=jwt`
- via sql - make sure the image count from the API matches how many annotation projects are in that campaign: `select count(*) from annotation_projects where campaign_id = 'b78bc4ff-6ef9-4fae-ba03-77ce33e85f03';`

Closes https://github.com/raster-foundry/annotate/issues/987
