### PR TITLE
Allow users to split tasks with the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Tasks can be listed by campaign [#5494](https://github.com/raster-foundry/raster-foundry/pull/5494)
 - Campaigns can be shared with only an email [#5495](https://github.com/raster-foundry/raster-foundry/pull/5495)
 - Campaign IDs can be used to filter STAC exports [#5498](https://github.com/raster-foundry/raster-foundry/pull/5498)
+- API support for splitting tasks [#5502](https://github.com/raster-foundry/raster-foundry/pull/5502)
 
 ### Changed
 

--- a/app-backend/.scalafmt.conf
+++ b/app-backend/.scalafmt.conf
@@ -1,3 +1,1 @@
-version=2.0.0-RC4
-
-rewrite.rules = [SortImports]
+version = "2.6.4"

--- a/app-backend/.scalafmt.conf
+++ b/app-backend/.scalafmt.conf
@@ -1,1 +1,3 @@
 version = "2.6.4"
+
+rewrite.rules = [SortImports]

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -43,6 +43,7 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:deleteAnnotation,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/children,annotationProjects:readTasks,get
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/validate/,annotationProjects:createAnnotation,post
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/split/,annotationProjects:readTasks,post
 /api/licenses/,licenses:read,get
 /api/licenses/{licenseID},licenses:read,get
 /api/map-tokens/,mapTokens:read,get

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -177,7 +177,7 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
 
   def taskQueryParameters =
     parameters(
-      'status.as[TaskStatus].?,
+      'status.as[TaskStatus].*,
       'locked.as[Boolean].?,
       'lockedBy.as[String].?,
       'bbox.as[String].*,

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -49,30 +49,33 @@ object Generators extends ArbitraryInstances {
   private def groupRoleGen: Gen[GroupRole] =
     Gen.oneOf(GroupRole.Admin, GroupRole.Member)
 
-  private def subjectTypeGen: Gen[SubjectType] = Gen.oneOf(
-    SubjectType.All,
-    SubjectType.Platform,
-    SubjectType.Organization,
-    SubjectType.Team,
-    SubjectType.User
-  )
+  private def subjectTypeGen: Gen[SubjectType] =
+    Gen.oneOf(
+      SubjectType.All,
+      SubjectType.Platform,
+      SubjectType.Organization,
+      SubjectType.Team,
+      SubjectType.User
+    )
 
-  private def actionTypeGen: Gen[ActionType] = Gen.oneOf(
-    ActionType.View,
-    ActionType.Edit,
-    ActionType.Deactivate,
-    ActionType.Delete,
-    ActionType.Annotate,
-    ActionType.Export,
-    ActionType.Download
-  )
+  private def actionTypeGen: Gen[ActionType] =
+    Gen.oneOf(
+      ActionType.View,
+      ActionType.Edit,
+      ActionType.Deactivate,
+      ActionType.Delete,
+      ActionType.Annotate,
+      ActionType.Export,
+      ActionType.Download
+    )
 
-  private def annotationQualityGen: Gen[AnnotationQuality] = Gen.oneOf(
-    AnnotationQuality.Yes,
-    AnnotationQuality.No,
-    AnnotationQuality.Miss,
-    AnnotationQuality.Unsure
-  )
+  private def annotationQualityGen: Gen[AnnotationQuality] =
+    Gen.oneOf(
+      AnnotationQuality.Yes,
+      AnnotationQuality.No,
+      AnnotationQuality.Miss,
+      AnnotationQuality.Unsure
+    )
 
   private def visibilityGen: Gen[Visibility] =
     Gen.oneOf(Visibility.Public, Visibility.Organization, Visibility.Private)
@@ -85,7 +88,8 @@ object Generators extends ArbitraryInstances {
       (6, TaskStatus.ValidationInProgress),
       (1, TaskStatus.Validated),
       (6, TaskStatus.Flagged),
-      (1, TaskStatus.Invalid)
+      (1, TaskStatus.Invalid),
+      (1, TaskStatus.Split)
     )
 
   private def taskTypeGen: Gen[TaskType] =
@@ -112,37 +116,41 @@ object Generators extends ArbitraryInstances {
   private def sceneTypeGen: Gen[SceneType] =
     Gen.oneOf(SceneType.Avro, SceneType.COG)
 
-  private def credentialGen: Gen[Credential] = possiblyEmptyStringGen flatMap {
-    Credential.fromString
-  }
+  private def credentialGen: Gen[Credential] =
+    possiblyEmptyStringGen flatMap {
+      Credential.fromString
+    }
 
   // This is fine not to test the max value --
   private def rawDataBytesGen: Gen[Long] = Gen.choose(0L, 100000L)
 
-  private def bandDataTypeGen: Gen[BandDataType] = Gen.oneOf(
-    BandDataType.Diverging,
-    BandDataType.Sequential,
-    BandDataType.Categorical
-  )
+  private def bandDataTypeGen: Gen[BandDataType] =
+    Gen.oneOf(
+      BandDataType.Diverging,
+      BandDataType.Sequential,
+      BandDataType.Categorical
+    )
 
   private def uuidGen: Gen[UUID] = Gen.delay(UUID.randomUUID)
 
-  private def jobStatusGen: Gen[JobStatus] = Gen.oneOf(
-    JobStatus.Uploading,
-    JobStatus.Success,
-    JobStatus.Failure,
-    JobStatus.PartialFailure,
-    JobStatus.Queued,
-    JobStatus.Processing
-  )
+  private def jobStatusGen: Gen[JobStatus] =
+    Gen.oneOf(
+      JobStatus.Uploading,
+      JobStatus.Success,
+      JobStatus.Failure,
+      JobStatus.PartialFailure,
+      JobStatus.Queued,
+      JobStatus.Processing
+    )
 
-  private def ingestStatusGen: Gen[IngestStatus] = Gen.oneOf(
-    IngestStatus.NotIngested,
-    IngestStatus.ToBeIngested,
-    IngestStatus.Ingesting,
-    IngestStatus.Ingested,
-    IngestStatus.Failed
-  )
+  private def ingestStatusGen: Gen[IngestStatus] =
+    Gen.oneOf(
+      IngestStatus.NotIngested,
+      IngestStatus.ToBeIngested,
+      IngestStatus.Ingesting,
+      IngestStatus.Ingested,
+      IngestStatus.Failed
+    )
 
   private def annotationProjectStatusGen: Gen[AnnotationProjectStatus] =
     Gen.oneOf(
@@ -155,25 +163,30 @@ object Generators extends ArbitraryInstances {
       AnnotationProjectStatus.ImageIngestionFailure
     )
 
-  private def tileLayerTypeGen: Gen[TileLayerType] = Gen.oneOf(
-    TileLayerType.MVT,
-    TileLayerType.TMS
-  )
+  private def tileLayerTypeGen: Gen[TileLayerType] =
+    Gen.oneOf(
+      TileLayerType.MVT,
+      TileLayerType.TMS
+    )
 
-  private def annotationProjectTypeGen: Gen[AnnotationProjectType] = Gen.oneOf(
-    AnnotationProjectType.Segmentation,
-    AnnotationProjectType.Classification,
-    AnnotationProjectType.Detection
-  )
+  private def annotationProjectTypeGen: Gen[AnnotationProjectType] =
+    Gen.oneOf(
+      AnnotationProjectType.Segmentation,
+      AnnotationProjectType.Classification,
+      AnnotationProjectType.Detection
+    )
 
   private def shapePropertiesGen: Gen[ShapeProperties] =
     for {
       timeField <- timestampIn2016Gen
       userField <- nonEmptyStringGen
       name <- nonEmptyStringGen
-      description <- Gen.oneOf(Gen.const(None), nonEmptyStringGen map {
-        Some(_)
-      })
+      description <- Gen.oneOf(
+        Gen.const(None),
+        nonEmptyStringGen map {
+          Some(_)
+        }
+      )
     } yield {
       ShapeProperties(
         timeField,
@@ -188,23 +201,25 @@ object Generators extends ArbitraryInstances {
   private def thumbnailSizeGen: Gen[ThumbnailSize] =
     Gen.oneOf(ThumbnailSize.Small, ThumbnailSize.Large, ThumbnailSize.Square)
 
-  private def uploadStatusGen: Gen[UploadStatus] = Gen.oneOf(
-    UploadStatus.Created,
-    UploadStatus.Uploading,
-    UploadStatus.Uploaded,
-    UploadStatus.Queued,
-    UploadStatus.Processing,
-    UploadStatus.Complete,
-    UploadStatus.Failed,
-    UploadStatus.Aborted
-  )
+  private def uploadStatusGen: Gen[UploadStatus] =
+    Gen.oneOf(
+      UploadStatus.Created,
+      UploadStatus.Uploading,
+      UploadStatus.Uploaded,
+      UploadStatus.Queued,
+      UploadStatus.Processing,
+      UploadStatus.Complete,
+      UploadStatus.Failed,
+      UploadStatus.Aborted
+    )
 
-  private def uploadTypeGen: Gen[UploadType] = Gen.oneOf(
-    UploadType.Dropbox,
-    UploadType.S3,
-    UploadType.Local,
-    UploadType.Planet
-  )
+  private def uploadTypeGen: Gen[UploadType] =
+    Gen.oneOf(
+      UploadType.Dropbox,
+      UploadType.S3,
+      UploadType.Local,
+      UploadType.Planet
+    )
 
   private def fileTypeGen: Gen[FileType] =
     Gen.oneOf(FileType.Geotiff, FileType.GeotiffWithMetadata)
@@ -289,13 +304,13 @@ object Generators extends ArbitraryInstances {
       name <- nonEmptyStringGen
       visibility <- visibilityGen
       orgStatus <- orgStatusGen
-    } yield
-      Organization
-        .Create(name, UUID.randomUUID, Some(visibility), orgStatus)
+    } yield Organization
+      .Create(name, UUID.randomUUID, Some(visibility), orgStatus)
 
-  private def organizationGen: Gen[Organization] = organizationCreateGen map {
-    _.toOrganization(true)
-  }
+  private def organizationGen: Gen[Organization] =
+    organizationCreateGen map {
+      _.toOrganization(true)
+    }
 
   private def shapeCreateGen: Gen[Shape.Create] =
     for {
@@ -387,18 +402,17 @@ object Generators extends ArbitraryInstances {
       owner <- stringOptionGen
       resolutionMeters <- Gen.choose(0.25f, 1000f)
       metadataFiles <- stringListGen
-    } yield
-      Image.Create(
-        rawDataBytes,
-        visibility,
-        filename,
-        sourceUri,
-        scene,
-        imageMetadata,
-        owner,
-        resolutionMeters,
-        metadataFiles
-      )
+    } yield Image.Create(
+      rawDataBytes,
+      visibility,
+      filename,
+      sourceUri,
+      scene,
+      imageMetadata,
+      owner,
+      resolutionMeters,
+      metadataFiles
+    )
 
   private def imageBandedGen: Gen[Image.Banded] =
     for {
@@ -412,19 +426,18 @@ object Generators extends ArbitraryInstances {
       resolutionMeters <- Gen.choose(0.25f, 1000f)
       metadataFiles <- stringListGen
       bands <- Gen.listOf[Band.Create](bandCreateGen)
-    } yield
-      Image.Banded(
-        rawDataBytes,
-        visibility,
-        filename,
-        sourceUri,
-        owner,
-        scene,
-        imageMetadata,
-        resolutionMeters,
-        metadataFiles,
-        bands
-      )
+    } yield Image.Banded(
+      rawDataBytes,
+      visibility,
+      filename,
+      sourceUri,
+      owner,
+      scene,
+      imageMetadata,
+      resolutionMeters,
+      metadataFiles,
+      bands
+    )
   private def imageGen: Gen[Image] =
     for {
       imCreate <- imageCreateGen
@@ -471,18 +484,42 @@ object Generators extends ArbitraryInstances {
 
   private def sceneFilterFieldsGen: Gen[SceneFilterFields] =
     for {
-      cloudCover <- Gen.frequency((1, None), (10, Gen.choose(0.0f, 1.0f) map {
-        Some(_)
-      }))
-      acquisitionDate <- Gen.frequency((1, None), (10, timestampIn2016Gen map {
-        Some(_)
-      }))
-      sunAzimuth <- Gen.frequency((1, None), (10, Gen.choose(0f, 360f) map {
-        Some(_)
-      }))
-      sunElevation <- Gen.frequency((1, None), (10, Gen.choose(0f, 90f) map {
-        Some(_)
-      }))
+      cloudCover <- Gen.frequency(
+        (1, None),
+        (
+          10,
+          Gen.choose(0.0f, 1.0f) map {
+            Some(_)
+          }
+        )
+      )
+      acquisitionDate <- Gen.frequency(
+        (1, None),
+        (
+          10,
+          timestampIn2016Gen map {
+            Some(_)
+          }
+        )
+      )
+      sunAzimuth <- Gen.frequency(
+        (1, None),
+        (
+          10,
+          Gen.choose(0f, 360f) map {
+            Some(_)
+          }
+        )
+      )
+      sunElevation <- Gen.frequency(
+        (1, None),
+        (
+          10,
+          Gen.choose(0f, 90f) map {
+            Some(_)
+          }
+        )
+      )
     } yield {
       SceneFilterFields(cloudCover, acquisitionDate, sunAzimuth, sunElevation)
     }
@@ -755,10 +792,14 @@ object Generators extends ArbitraryInstances {
       subjectId <- uuidGen
       actionType <- actionTypeGen
     } yield {
-      ObjectAccessControlRule(subjectType, subjectType match {
-        case SubjectType.All => None
-        case _               => Some(subjectId.toString)
-      }, actionType)
+      ObjectAccessControlRule(
+        subjectType,
+        subjectType match {
+          case SubjectType.All => None
+          case _               => Some(subjectId.toString)
+        },
+        actionType
+      )
     }
 
   private def toolCreateGen: Gen[Tool.Create] =
@@ -816,27 +857,27 @@ object Generators extends ArbitraryInstances {
 
   private def exportOptionGen: Gen[ExportOptions] =
     for {
-      mask: Option[Projected[MultiPolygon]] <- projectedMultiPolygonGen3857 map {
-        Some(_)
-      }
+      mask: Option[Projected[MultiPolygon]] <-
+        projectedMultiPolygonGen3857 map {
+          Some(_)
+        }
       resolution <- arbitrary[Int]
       rasterSize <- arbitrary[Option[Int]]
       crop <- arbitrary[Boolean]
       raw <- arbitrary[Boolean]
       bands <- arbitrary[Option[Seq[Int]]]
       operation <- nonEmptyStringGen
-    } yield
-      ExportOptions(
-        mask,
-        resolution,
-        crop,
-        raw,
-        bands,
-        rasterSize,
-        Some(3857),
-        new URI(""),
-        operation
-      )
+    } yield ExportOptions(
+      mask,
+      resolution,
+      crop,
+      raw,
+      bands,
+      rasterSize,
+      Some(3857),
+      new URI(""),
+      operation
+    )
 
   private def exportCreateGen: Gen[Export.Create] =
     for {
@@ -889,10 +930,11 @@ object Generators extends ArbitraryInstances {
       )
     }
 
-  private def metricEventGen: Gen[MetricEvent] = Gen.oneOf(
-    projectMosaicEventGen.widen,
-    analysisEventGen.widen
-  )
+  private def metricEventGen: Gen[MetricEvent] =
+    Gen.oneOf(
+      projectMosaicEventGen.widen,
+      analysisEventGen.widen
+    )
 
   private def projectMosaicEventGen: Gen[ProjectLayerMosaicEvent] =
     for {
@@ -900,15 +942,22 @@ object Generators extends ArbitraryInstances {
       projectLayerId <- uuidGen
       projectOwner <- nonEmptyStringGen
       referer <- nonEmptyStringGen
-    } yield
-      ProjectLayerMosaicEvent(projectId, projectLayerId, projectOwner, referer)
+    } yield ProjectLayerMosaicEvent(
+      projectId,
+      projectLayerId,
+      projectOwner,
+      referer
+    )
 
   private def analysisEventGen: Gen[AnalysisEvent] =
     for {
       (projectId, projectLayerId) <- Gen.oneOf(
-        (uuidGen map { Some(_) }, uuidGen map {
-          Some(_)
-        }).tupled,
+        (
+          uuidGen map { Some(_) },
+          uuidGen map {
+            Some(_)
+          }
+        ).tupled,
         Gen.const((None, None))
       )
       analysisId <- uuidGen
@@ -918,15 +967,14 @@ object Generators extends ArbitraryInstances {
       )
       analysisOwner <- nonEmptyStringGen
       referer <- nonEmptyStringGen
-    } yield
-      AnalysisEvent(
-        projectId,
-        projectLayerId,
-        analysisId,
-        nodeId,
-        analysisOwner,
-        referer
-      )
+    } yield AnalysisEvent(
+      projectId,
+      projectLayerId,
+      analysisId,
+      nodeId,
+      analysisOwner,
+      referer
+    )
 
   private def metricGen: Gen[Metric] =
     for {
@@ -940,13 +988,14 @@ object Generators extends ArbitraryInstances {
     for {
       status <- Gen.const[TaskStatus](TaskStatus.Unlabeled)
       annotationProjectId <- uuidGen
-      note <- if (status == TaskStatus.Flagged) {
-        nonEmptyStringGen map { s =>
-          Some(NonEmptyString.unsafeFrom(s))
+      note <-
+        if (status == TaskStatus.Flagged) {
+          nonEmptyStringGen map { s =>
+            Some(NonEmptyString.unsafeFrom(s))
+          }
+        } else {
+          Gen.const(None)
         }
-      } else {
-        Gen.const(None)
-      }
       taskType <- Gen.oneOf(
         Gen.const(None),
         taskTypeGen map { Some(_) }
@@ -1123,26 +1172,30 @@ object Generators extends ArbitraryInstances {
     ).mapN(Campaign.Clone.apply _)
 
   object Implicits {
-    implicit def arbCredential: Arbitrary[Credential] = Arbitrary {
-      credentialGen
-    }
+    implicit def arbCredential: Arbitrary[Credential] =
+      Arbitrary {
+        credentialGen
+      }
 
-    implicit def arbPageRequest: Arbitrary[PageRequest] = Arbitrary {
-      pageRequestGen
-    }
+    implicit def arbPageRequest: Arbitrary[PageRequest] =
+      Arbitrary {
+        pageRequestGen
+      }
 
     implicit def arbCombinedSceneQueryParams
-        : Arbitrary[CombinedSceneQueryParams] = Arbitrary {
-      combinedSceneQueryParamsGen
-    }
+        : Arbitrary[CombinedSceneQueryParams] =
+      Arbitrary {
+        combinedSceneQueryParamsGen
+      }
 
     implicit def arbProjectsceneQueryParameters
         : Arbitrary[ProjectSceneQueryParameters] =
       Arbitrary { projectSceneQueryParametersGen }
 
-    implicit def arbAnnotationCreate: Arbitrary[Annotation.Create] = Arbitrary {
-      annotationCreateGen
-    }
+    implicit def arbAnnotationCreate: Arbitrary[Annotation.Create] =
+      Arbitrary {
+        annotationCreateGen
+      }
 
     implicit def arbListAnnotationCreate: Arbitrary[List[Annotation.Create]] =
       Arbitrary {
@@ -1152,20 +1205,23 @@ object Generators extends ArbitraryInstances {
     implicit def arbAnnotationGroupCreate: Arbitrary[AnnotationGroup.Create] =
       Arbitrary { annotationGroupCreateGen }
 
-    implicit def arbOrganization: Arbitrary[Organization] = Arbitrary {
-      organizationGen
-    }
+    implicit def arbOrganization: Arbitrary[Organization] =
+      Arbitrary {
+        organizationGen
+      }
 
-    implicit def arbExport: Arbitrary[Export.Create] = Arbitrary {
-      exportCreateGen
-    }
+    implicit def arbExport: Arbitrary[Export.Create] =
+      Arbitrary {
+        exportCreateGen
+      }
 
     implicit def arbOrganizationCreate: Arbitrary[Organization.Create] =
       Arbitrary { organizationCreateGen }
 
-    implicit def arbUserCreate: Arbitrary[User.Create] = Arbitrary {
-      userCreateGen
-    }
+    implicit def arbUserCreate: Arbitrary[User.Create] =
+      Arbitrary {
+        userCreateGen
+      }
 
     implicit def arbUser: Arbitrary[User] = Arbitrary { userGen }
 
@@ -1173,93 +1229,108 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbImage: Arbitrary[Image] = Arbitrary { imageGen }
 
-    implicit def arbImageCreate: Arbitrary[Image.Create] = Arbitrary {
-      imageCreateGen
-    }
+    implicit def arbImageCreate: Arbitrary[Image.Create] =
+      Arbitrary {
+        imageCreateGen
+      }
 
-    implicit def arbImageBanded: Arbitrary[Image.Banded] = Arbitrary {
-      imageBandedGen
-    }
+    implicit def arbImageBanded: Arbitrary[Image.Banded] =
+      Arbitrary {
+        imageBandedGen
+      }
 
-    implicit def arbProjectCreate: Arbitrary[Project.Create] = Arbitrary {
-      projectCreateGen
-    }
+    implicit def arbProjectCreate: Arbitrary[Project.Create] =
+      Arbitrary {
+        projectCreateGen
+      }
 
     implicit def arbProject: Arbitrary[Project] = Arbitrary { projectGen }
 
-    implicit def arbSceneCreate: Arbitrary[Scene.Create] = Arbitrary {
-      sceneCreateGen
-    }
+    implicit def arbSceneCreate: Arbitrary[Scene.Create] =
+      Arbitrary {
+        sceneCreateGen
+      }
 
-    implicit def arbShapeCreate: Arbitrary[Shape.Create] = Arbitrary {
-      shapeCreateGen
-    }
+    implicit def arbShapeCreate: Arbitrary[Shape.Create] =
+      Arbitrary {
+        shapeCreateGen
+      }
 
-    implicit def arbShapeGeoJSON: Arbitrary[Shape.GeoJSON] = Arbitrary {
-      shapeGeoJSONGen
-    }
+    implicit def arbShapeGeoJSON: Arbitrary[Shape.GeoJSON] =
+      Arbitrary {
+        shapeGeoJSONGen
+      }
 
-    implicit def arbListSceneCreate: Arbitrary[List[Scene.Create]] = Arbitrary {
-      Gen.oneOf(
-        // 11 is one more than the size of the pageRequest that we'll generate, so this allows
-        // testing paging and counting correctly
-        Gen.listOfN(11, sceneCreateGen),
-        Gen.listOfN(7, sceneCreateGen),
-        Gen.listOfN(0, sceneCreateGen)
-      )
-    }
+    implicit def arbListSceneCreate: Arbitrary[List[Scene.Create]] =
+      Arbitrary {
+        Gen.oneOf(
+          // 11 is one more than the size of the pageRequest that we'll generate, so this allows
+          // testing paging and counting correctly
+          Gen.listOfN(11, sceneCreateGen),
+          Gen.listOfN(7, sceneCreateGen),
+          Gen.listOfN(0, sceneCreateGen)
+        )
+      }
 
     implicit def arbThumbnail: Arbitrary[Thumbnail] = Arbitrary { thumbnailGen }
 
-    implicit def arbDatasourceCreate: Arbitrary[Datasource.Create] = Arbitrary {
-      datasourceCreateGen
-    }
+    implicit def arbDatasourceCreate: Arbitrary[Datasource.Create] =
+      Arbitrary {
+        datasourceCreateGen
+      }
 
-    implicit def arbUploadCreate: Arbitrary[Upload.Create] = Arbitrary {
-      uploadCreateGen
-    }
+    implicit def arbUploadCreate: Arbitrary[Upload.Create] =
+      Arbitrary {
+        uploadCreateGen
+      }
 
     implicit def arbGeojsonUploadCreate: Arbitrary[GeojsonUpload.Create] =
       Arbitrary {
         geojsonUploadCreateGen
       }
 
-    implicit def arbLayerAttribute: Arbitrary[LayerAttribute] = Arbitrary {
-      layerAttributeGen
-    }
+    implicit def arbLayerAttribute: Arbitrary[LayerAttribute] =
+      Arbitrary {
+        layerAttributeGen
+      }
 
     implicit def arbListLayerAttribute: Arbitrary[List[LayerAttribute]] =
       Arbitrary {
         layerAttributesWithSameLayerNameGen
       }
 
-    implicit def arbTeamCreate: Arbitrary[Team.Create] = Arbitrary {
-      teamCreateGen
-    }
+    implicit def arbTeamCreate: Arbitrary[Team.Create] =
+      Arbitrary {
+        teamCreateGen
+      }
 
     implicit def arbTeam: Arbitrary[Team] = Arbitrary { teamGen }
 
     implicit def arbUserGroupRoleCreate: Arbitrary[UserGroupRole.Create] =
       Arbitrary { userGroupRoleCreateGen }
 
-    implicit def arbGroupRoleCreate: Arbitrary[GroupRole] = Arbitrary {
-      groupRoleGen
-    }
+    implicit def arbGroupRoleCreate: Arbitrary[GroupRole] =
+      Arbitrary {
+        groupRoleGen
+      }
 
     implicit def arbPlatform: Arbitrary[Platform] = Arbitrary { platformGen }
 
     implicit def arbUserOrgPlatform
-        : Arbitrary[(User.Create, Organization.Create, Platform)] = Arbitrary {
-      userOrgPlatformGen
-    }
+        : Arbitrary[(User.Create, Organization.Create, Platform)] =
+      Arbitrary {
+        userOrgPlatformGen
+      }
 
-    implicit def arbUserJwtFields: Arbitrary[User.JwtFields] = Arbitrary {
-      userJwtFieldsGen
-    }
+    implicit def arbUserJwtFields: Arbitrary[User.JwtFields] =
+      Arbitrary {
+        userJwtFieldsGen
+      }
 
-    implicit def arbUserVisibility: Arbitrary[UserVisibility] = Arbitrary {
-      userVisibilityGen
-    }
+    implicit def arbUserVisibility: Arbitrary[UserVisibility] =
+      Arbitrary {
+        userVisibilityGen
+      }
 
     implicit def arbSearchQueryParameters: Arbitrary[SearchQueryParameters] =
       Arbitrary { searchQueryParametersGen }
@@ -1306,28 +1377,33 @@ object Generators extends ArbitraryInstances {
     }
 
     implicit def arbAnnotationQueryParameters
-        : Arbitrary[AnnotationQueryParameters] = Arbitrary {
-      annotationQueryParametersGen
-    }
+        : Arbitrary[AnnotationQueryParameters] =
+      Arbitrary {
+        annotationQueryParametersGen
+      }
 
-    implicit def arbMetric: Arbitrary[Metric] = Arbitrary {
-      metricGen
-    }
+    implicit def arbMetric: Arbitrary[Metric] =
+      Arbitrary {
+        metricGen
+      }
 
-    implicit def arbNEL[T: Arbitrary]: Arbitrary[NEL[T]] = Arbitrary {
-      for {
-        h <- arbitrary[T]
-        t <- arbitrary[List[T]]
-      } yield { NEL(h, t) }
-    }
+    implicit def arbNEL[T: Arbitrary]: Arbitrary[NEL[T]] =
+      Arbitrary {
+        for {
+          h <- arbitrary[T]
+          t <- arbitrary[List[T]]
+        } yield { NEL(h, t) }
+      }
 
-    implicit def arbTaskStatus: Arbitrary[TaskStatus] = Arbitrary {
-      taskStatusGen
-    }
+    implicit def arbTaskStatus: Arbitrary[TaskStatus] =
+      Arbitrary {
+        taskStatusGen
+      }
 
-    implicit def arbTaskType: Arbitrary[TaskType] = Arbitrary {
-      taskTypeGen
-    }
+    implicit def arbTaskType: Arbitrary[TaskType] =
+      Arbitrary {
+        taskTypeGen
+      }
 
     implicit def arbTaskFeatureCreate: Arbitrary[Task.TaskFeatureCreate] =
       Arbitrary {
@@ -1381,9 +1457,10 @@ object Generators extends ArbitraryInstances {
         tileLayerCreateGen
       }
 
-    implicit def arbContinent: Arbitrary[Continent] = Arbitrary {
-      continentGen
-    }
+    implicit def arbContinent: Arbitrary[Continent] =
+      Arbitrary {
+        continentGen
+      }
 
     implicit def arbCampaignCreate: Arbitrary[Campaign.Create] =
       Arbitrary {

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -91,10 +91,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -146,7 +146,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -178,10 +178,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -206,10 +206,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -261,10 +261,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -337,10 +337,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -354,10 +354,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -381,10 +381,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -421,10 +421,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -447,10 +447,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -460,10 +460,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -497,10 +497,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -537,10 +537,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -553,10 +553,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -572,10 +572,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -653,10 +653,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -671,10 +671,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -685,10 +685,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -706,10 +706,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -63,18 +63,19 @@ final case class SceneQueryParameters(
   val bboxPolygon: Option[Seq[Projected[Polygon]]] =
     BboxUtil.toBboxPolygon(bbox)
 
-  val pointGeom: Option[Projected[Point]] = try {
-    point.map { s =>
-      val Array(x, y) = s.split(",")
-      Projected(Point(x.toDouble, y.toDouble), 4326)
-        .reproject(LatLng, WebMercator)(3857)
+  val pointGeom: Option[Projected[Point]] =
+    try {
+      point.map { s =>
+        val Array(x, y) = s.split(",")
+        Projected(Point(x.toDouble, y.toDouble), 4326)
+          .reproject(LatLng, WebMercator)(3857)
+      }
+    } catch {
+      case e: Exception =>
+        throw new IllegalArgumentException(
+          "Both coordinate parameters of point (x, y) must be specified"
+        ).initCause(e)
     }
-  } catch {
-    case e: Exception =>
-      throw new IllegalArgumentException(
-        "Both coordinate parameters of point (x, y) must be specified"
-      ).initCause(e)
-  }
 }
 
 object SceneQueryParameters {
@@ -90,10 +91,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -145,7 +146,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -177,10 +178,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -205,10 +206,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -249,10 +250,10 @@ object OwnerQueryParameters {
 }
 
 /** Query parameters to filter by ownership type:
-  *- owned by the requesting user only: owned
-  *- shared to the requesting user due to group membership: inherited
-  *- shared to the requesting user directly, across platform, or due to group membership: shared
-  *- both the above: none, this is default
+  * - owned by the requesting user only: owned
+  * - shared to the requesting user due to group membership: inherited
+  * - shared to the requesting user directly, across platform, or due to group membership: shared
+  * - both the above: none, this is default
   */
 final case class OwnershipTypeQueryParameters(
     ownershipType: Option[String] = None
@@ -260,14 +261,14 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
-/** Query parameters to filter by group membership*/
+/** Query parameters to filter by group membership */
 final case class GroupQueryParameters(
     groupType: Option[GroupType] = None,
     groupId: Option[UUID] = None
@@ -336,10 +337,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -353,10 +354,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -380,10 +381,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -420,10 +421,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -446,10 +447,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -459,10 +460,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -496,10 +497,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -536,10 +537,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -552,10 +553,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -571,10 +572,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -628,7 +629,7 @@ final case class MetricQueryParameters(
 )
 
 final case class TaskQueryParameters(
-    status: Option[TaskStatus] = None,
+    status: Iterable[TaskStatus] = Nil,
     locked: Option[Boolean] = None,
     lockedBy: Option[String] = None,
     bbox: Iterable[String] = Seq.empty,
@@ -652,10 +653,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -670,10 +671,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -684,10 +685,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -705,10 +706,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 

--- a/app-backend/datamodel/src/main/scala/TaskStatus.scala
+++ b/app-backend/datamodel/src/main/scala/TaskStatus.scala
@@ -15,16 +15,19 @@ object TaskStatus {
   case object Validated extends TaskStatus("VALIDATED")
   case object Flagged extends TaskStatus("FLAGGED")
   case object Invalid extends TaskStatus("INVALID")
+  case object Split extends TaskStatus("SPLIT")
 
-  def fromString(s: String): TaskStatus = s.toUpperCase match {
-    case "UNLABELED"              => Unlabeled
-    case "LABELING_IN_PROGRESS"   => LabelingInProgress
-    case "LABELED"                => Labeled
-    case "VALIDATION_IN_PROGRESS" => ValidationInProgress
-    case "VALIDATED"              => Validated
-    case "FLAGGED"                => Flagged
-    case "INVALID"                => Invalid
-  }
+  def fromString(s: String): TaskStatus =
+    s.toUpperCase match {
+      case "UNLABELED"              => Unlabeled
+      case "LABELING_IN_PROGRESS"   => LabelingInProgress
+      case "LABELED"                => Labeled
+      case "VALIDATION_IN_PROGRESS" => ValidationInProgress
+      case "VALIDATED"              => Validated
+      case "FLAGGED"                => Flagged
+      case "INVALID"                => Invalid
+      case "SPLIT"                  => Split
+    }
 
   implicit val taskStatusEncoder: Encoder[TaskStatus] =
     Encoder.encodeString.contramap[TaskStatus](_.toString)

--- a/app-backend/db/src/main/resources/migrations/V65__Add_split_to_task_statuses.sql
+++ b/app-backend/db/src/main/resources/migrations/V65__Add_split_to_task_statuses.sql
@@ -1,0 +1,1 @@
+ALTER TYPE task_status ADD VALUE "SPLIT";

--- a/app-backend/db/src/main/resources/migrations/V65__Add_split_to_task_statuses.sql
+++ b/app-backend/db/src/main/resources/migrations/V65__Add_split_to_task_statuses.sql
@@ -1,1 +1,1 @@
-ALTER TYPE task_status ADD VALUE "SPLIT";
+ALTER TYPE task_status ADD VALUE 'SPLIT';

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -35,7 +35,7 @@ object MVTLayerDao {
           ) AND
           annotation_project_id = ${annotationProjectId} AND
           task_type = 'LABEL'::task_type AND
-          task_status <> 'SPLIT'
+          status <> 'SPLIT'
       )
     SELECT ST_AsMVT(mvtgeom.*) FROM mvtgeom;""".query[Array[Byte]]
 
@@ -65,7 +65,8 @@ object MVTLayerDao {
           annotation_label_classes.name,
           annotation_label_classes.color_hex_code
         FROM
-          (annotation_labels JOIN annotation_labels_annotation_label_classes on
+          (annotation_labels join (select id, status from tasks) tasks on annotation_labels.annotation_task_id = tasks.id
+           JOIN annotation_labels_annotation_label_classes on
            annotation_labels.id = annotation_labels_annotation_label_classes.annotation_label_id) join_table_join
           JOIN annotation_label_classes on join_table_join.annotation_class_id = annotation_label_classes.id
         WHERE
@@ -74,6 +75,7 @@ object MVTLayerDao {
             ST_TileEnvelope(${z},${x},${y})
           )
           AND join_table_join.annotation_project_id = ${annotationProjectId}
+          AND status <> 'SPLIT'
       )
     SELECT ST_AsMVT(mvtgeom.*) FROM mvtgeom;""".query[Array[Byte]]
   }

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -34,7 +34,8 @@ object MVTLayerDao {
             ST_TileEnvelope(${z},${x},${y})
           ) AND
           annotation_project_id = ${annotationProjectId} AND
-          task_type = 'LABEL'::task_type
+          task_type = 'LABEL'::task_type AND
+          task_status <> 'SPLIT'
       )
     SELECT ST_AsMVT(mvtgeom.*) FROM mvtgeom;""".query[Array[Byte]]
 

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -934,7 +934,12 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
               .toProperties(Nil)
               .toCreate
               .copy(
-                parentTaskId = Some(taskId)
+                parentTaskId = Some(taskId),
+                status = task.status match {
+                  case TaskStatus.ValidationInProgress => TaskStatus.Labeled
+                  case TaskStatus.LabelingInProgress   => TaskStatus.Unlabeled
+                  case s                               => s
+                }
               )
             Task.TaskFeatureCreate(
               taskPropertiesCreate,

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -264,7 +264,6 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           query
             .filter(queryParams)
             .filter(fr"annotation_project_id = $annotationProjectId")
-            .filter(fr"parent_task_id IS NULL")
             .page(pageRequest)
       }
       withActions <- paginatedResponse.results.toList traverse { task =>

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -346,10 +346,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO =
-        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-          _.taskSizeMeters
-        })
+      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+        _.taskSizeMeters
+      })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -749,21 +748,19 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
     for {
       _ <- info("Expiring stuck tasks")
       defaultUser <- UserDao.unsafeGetUserById("default")
-      stuckLockedTasks <-
-        query
-          .filter(
-            fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-          )
-          .list
-      stuckUnlockedTasks <-
-        query
-          .filter(
-            fr"""
+      stuckLockedTasks <- query
+        .filter(
+          fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+        )
+        .list
+      stuckUnlockedTasks <- query
+        .filter(
+          fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
-          )
-          .list
+        )
+        .list
       _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
         projectIdsList =>
           val projectIdsSet = projectIdsList.toNes
@@ -818,10 +815,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <-
-        query
-          .filter(fr"parent_task_id = $taskId")
-          .page(pageRequest)
+      paginatedResponse <- query
+        .filter(fr"parent_task_id = $taskId")
+        .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -946,8 +942,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-              reassociateLabelF(taskId, taskFeature.id).update.run
-            }).void
+            reassociateLabelF(taskId, taskFeature.id).update.run
+          }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -346,9 +346,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-        _.taskSizeMeters
-      })
+      taskSizeO =
+        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+          _.taskSizeMeters
+        })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -748,19 +749,21 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
     for {
       _ <- info("Expiring stuck tasks")
       defaultUser <- UserDao.unsafeGetUserById("default")
-      stuckLockedTasks <- query
-        .filter(
-          fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-        )
-        .list
-      stuckUnlockedTasks <- query
-        .filter(
-          fr"""
+      stuckLockedTasks <-
+        query
+          .filter(
+            fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+          )
+          .list
+      stuckUnlockedTasks <-
+        query
+          .filter(
+            fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
-        )
-        .list
+          )
+          .list
       _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
         projectIdsList =>
           val projectIdsSet = projectIdsList.toNes
@@ -815,9 +818,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <- query
-        .filter(fr"parent_task_id = $taskId")
-        .page(pageRequest)
+      paginatedResponse <-
+        query
+          .filter(fr"parent_task_id = $taskId")
+          .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -858,6 +862,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
          on annotation_labels.id = annotation_labels_annotation_label_classes.annotation_label_id,
        new_task
        where tasks.id = $oldTaskId
+       and st_intersects(annotation_labels.geometry, new_task.geometry)
       ),
     -- insert into labels and label classes from the old view
     label_insert as
@@ -942,8 +947,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-            reassociateLabelF(taskId, taskFeature.id).update.run
-          }).void
+              reassociateLabelF(taskId, taskFeature.id).update.run
+            }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split

--- a/app-backend/db/src/main/scala/filters/Filters.scala
+++ b/app-backend/db/src/main/scala/filters/Filters.scala
@@ -53,29 +53,23 @@ object Filters {
       timestampParams: TimestampQueryParameters
   ): List[Option[Fragment]] = {
     val f1 = timestampParams.minCreateDatetime.map(minCreate =>
-      fr"created_at > $minCreate"
-    )
+      fr"created_at > $minCreate")
     val f2 = timestampParams.maxCreateDatetime.map(maxCreate =>
-      fr"created_at < $maxCreate"
-    )
+      fr"created_at < $maxCreate")
     val f3 = timestampParams.minModifiedDatetime.map(minMod =>
-      fr"modified_at > $minMod"
-    )
+      fr"modified_at > $minMod")
     val f4 = timestampParams.maxModifiedDatetime.map(maxMod =>
-      fr"modified_at < $maxMod"
-    )
+      fr"modified_at < $maxMod")
     List(f1, f2, f3, f4)
   }
 
   def imageQP(imageParams: ImageQueryParameters): List[Option[Fragment]] = {
     val f1 =
       imageParams.minRawDataBytes.map(minBytes =>
-        fr"raw_data_bytes > $minBytes"
-      )
+        fr"raw_data_bytes > $minBytes")
     val f2 =
       imageParams.maxRawDataBytes.map(maxBytes =>
-        fr"raw_data_bytes < $maxBytes"
-      )
+        fr"raw_data_bytes < $maxBytes")
     val f3 =
       imageParams.minResolution.map(minRes => fr"resolution_meters > $minRes")
     val f4 =
@@ -176,11 +170,11 @@ object Filters {
     )
   }
 
-  def taskQP(taskQP: TaskQueryParameters)(implicit
+  def taskQP(taskQP: TaskQueryParameters)(
+      implicit
       putTaskStatus: Put[TaskStatus],
       putTaskType: Put[TaskType],
-      putGeom: Put[Projected[Polygon]]
-  ): List[Option[Fragment]] =
+      putGeom: Put[Projected[Polygon]]): List[Option[Fragment]] =
     List(
       taskQP.status.toList.toNel map { qp =>
         Fragments.in(fr"status", qp)
@@ -198,8 +192,7 @@ object Filters {
       taskQP.bboxPolygon match {
         case Some(bboxPolygons) =>
           val fragments = bboxPolygons.map(bbox =>
-            fr"(_ST_Intersects(geometry, ${bbox}) AND geometry && ${bbox})"
-          )
+            fr"(_ST_Intersects(geometry, ${bbox}) AND geometry && ${bbox})")
           Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
         case _ => None
       },

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -52,18 +52,19 @@ trait PropTestHelpers {
         false
       )
       (dbOrg, dbUser) = orgAndUser
-      _ <- if (doUserGroupRole)
-        UserGroupRoleDao.create(
-          UserGroupRole
-            .Create(
-              dbUser.id,
-              GroupType.Platform,
-              dbPlatform.id,
-              GroupRole.Member
-            )
-            .toUserGroupRole(dbUser, MembershipStatus.Approved)
-        )
-      else ().pure[ConnectionIO]
+      _ <-
+        if (doUserGroupRole)
+          UserGroupRoleDao.create(
+            UserGroupRole
+              .Create(
+                dbUser.id,
+                GroupType.Platform,
+                dbPlatform.id,
+                GroupRole.Member
+              )
+              .toUserGroupRole(dbUser, MembershipStatus.Approved)
+          )
+        else ().pure[ConnectionIO]
     } yield { (dbUser, dbOrg, dbPlatform) }
 
   def insertUserOrgPlatProject(
@@ -113,18 +114,19 @@ trait PropTestHelpers {
     for {
       orgInsert <- OrganizationDao.createOrganization(org)
       userInsert <- UserDao.create(user)
-      _ <- if (doUserGroupRole)
-        UserGroupRoleDao.create(
-          UserGroupRole
-            .Create(
-              userInsert.id,
-              GroupType.Organization,
-              orgInsert.id,
-              GroupRole.Member
-            )
-            .toUserGroupRole(userInsert, MembershipStatus.Approved)
-        )
-      else ().pure[ConnectionIO]
+      _ <-
+        if (doUserGroupRole)
+          UserGroupRoleDao.create(
+            UserGroupRole
+              .Create(
+                userInsert.id,
+                GroupType.Organization,
+                orgInsert.id,
+                GroupRole.Member
+              )
+              .toUserGroupRole(userInsert, MembershipStatus.Approved)
+          )
+        else ().pure[ConnectionIO]
     } yield (orgInsert, userInsert)
   }
 
@@ -273,7 +275,12 @@ trait PropTestHelpers {
   }
 
   def fixUpProjMiscInsert(
-      userTeamOrgPlat: (User.Create, Team.Create, Organization.Create, Platform),
+      userTeamOrgPlat: (
+          User.Create,
+          Team.Create,
+          Organization.Create,
+          Platform
+      ),
       project: Project.Create
   ): ConnectionIO[(Project, (User, Team, Organization, Platform))] = {
     val (user, team, org, platform) = userTeamOrgPlat
@@ -301,9 +308,13 @@ trait PropTestHelpers {
       project: Option[Project],
       analysis: Option[ToolRun]
   ): MapToken.Create =
-    mapTokenCreate.copy(project = project map { _.id }, toolRun = analysis map {
-      _.id
-    }, owner = Some(user.id))
+    mapTokenCreate.copy(
+      project = project map { _.id },
+      toolRun = analysis map {
+        _.id
+      },
+      owner = Some(user.id)
+    )
 
   def fixupTaskFeaturesCollection(
       tfc: Task.TaskFeatureCollectionCreate,
@@ -386,52 +397,53 @@ trait PropTestHelpers {
       validateTeamId: UUID,
       labelsOption: Option[List[(UUID, String, UUID)]] = None,
       labelGroupsOption: Option[Map[UUID, String]] = None
-  ): ProjectExtras = (labelsOption, labelGroupsOption) match {
-    case (Some(labels), Some(labelGroups)) =>
-      val createdLabels = labels.map(label => {
-        ProjectExtrasAnnotateLabel(
-          label._2,
-          label._1,
-          "red",
-          label._3,
-          false
+  ): ProjectExtras =
+    (labelsOption, labelGroupsOption) match {
+      case (Some(labels), Some(labelGroups)) =>
+        val createdLabels = labels.map(label => {
+          ProjectExtrasAnnotateLabel(
+            label._2,
+            label._1,
+            "red",
+            label._3,
+            false
+          )
+        })
+        ProjectExtras(
+          ProjectExtrasAnnotate(
+            labelTeamId,
+            validateTeamId,
+            createdLabels,
+            "detection",
+            true,
+            None,
+            labelGroups
+          )
         )
-      })
-      ProjectExtras(
-        ProjectExtrasAnnotate(
-          labelTeamId,
-          validateTeamId,
-          createdLabels,
-          "detection",
-          true,
-          None,
-          labelGroups
+      case _ =>
+        val defaultLabelId = UUID.randomUUID()
+        val defaultLayerGroupId = UUID.randomUUID()
+        val defaultLabels = List(
+          ProjectExtrasAnnotateLabel(
+            "Test",
+            defaultLabelId,
+            "red",
+            defaultLayerGroupId,
+            false
+          )
         )
-      )
-    case _ =>
-      val defaultLabelId = UUID.randomUUID()
-      val defaultLayerGroupId = UUID.randomUUID()
-      val defaultLabels = List(
-        ProjectExtrasAnnotateLabel(
-          "Test",
-          defaultLabelId,
-          "red",
-          defaultLayerGroupId,
-          false
+        ProjectExtras(
+          ProjectExtrasAnnotate(
+            labelTeamId,
+            validateTeamId,
+            defaultLabels,
+            "detection",
+            true,
+            None,
+            Map(defaultLayerGroupId -> "Test Group")
+          )
         )
-      )
-      ProjectExtras(
-        ProjectExtrasAnnotate(
-          labelTeamId,
-          validateTeamId,
-          defaultLabels,
-          "detection",
-          true,
-          None,
-          Map(defaultLayerGroupId -> "Test Group")
-        )
-      )
-  }
+    }
 
   def fixupAnnotationProjectExportCreate(
       annotationProjectExport: StacExport.AnnotationProjectExport,
@@ -455,22 +467,23 @@ trait PropTestHelpers {
       childStatus: TaskStatus,
       taskType: Option[TaskType],
       reviews: Option[Map[UUID, Review]] = None
-  ): Task.TaskFeatureCollectionCreate = Task.TaskFeatureCollectionCreate(
-    _type = "FeatureCollection",
-    features = List(
-      Task.TaskFeatureCreate(
-        properties = Task.TaskPropertiesCreate(
-          status = childStatus,
-          annotationProjectId = parentTask.properties.annotationProjectId,
-          note = parentTask.properties.note,
-          taskType = taskType,
-          parentTaskId = Some(parentTask.id),
-          reviews = reviews
-        ),
-        geometry = parentTask.geometry
+  ): Task.TaskFeatureCollectionCreate =
+    Task.TaskFeatureCollectionCreate(
+      _type = "FeatureCollection",
+      features = List(
+        Task.TaskFeatureCreate(
+          properties = Task.TaskPropertiesCreate(
+            status = childStatus,
+            annotationProjectId = parentTask.properties.annotationProjectId,
+            note = parentTask.properties.note,
+            taskType = taskType,
+            parentTaskId = Some(parentTask.id),
+            reviews = reviews
+          ),
+          geometry = parentTask.geometry
+        )
       )
     )
-  )
 
   def setReviewToTaskCreate(
       feature: Task.TaskFeature,
@@ -494,13 +507,15 @@ trait PropTestHelpers {
 
   def loopStatus(
       status: TaskStatus
-  ): TaskStatus = status match {
-    case TaskStatus.Unlabeled            => TaskStatus.LabelingInProgress
-    case TaskStatus.LabelingInProgress   => TaskStatus.Labeled
-    case TaskStatus.Labeled              => TaskStatus.ValidationInProgress
-    case TaskStatus.ValidationInProgress => TaskStatus.Validated
-    case TaskStatus.Validated            => TaskStatus.Flagged
-    case TaskStatus.Flagged              => TaskStatus.Invalid
-    case TaskStatus.Invalid              => TaskStatus.Unlabeled
-  }
+  ): TaskStatus =
+    status match {
+      case TaskStatus.Unlabeled            => TaskStatus.LabelingInProgress
+      case TaskStatus.LabelingInProgress   => TaskStatus.Labeled
+      case TaskStatus.Labeled              => TaskStatus.ValidationInProgress
+      case TaskStatus.ValidationInProgress => TaskStatus.Validated
+      case TaskStatus.Validated            => TaskStatus.Flagged
+      case TaskStatus.Flagged              => TaskStatus.Invalid
+      case TaskStatus.Invalid              => TaskStatus.Unlabeled
+      case TaskStatus.Split                => TaskStatus.Invalid
+    }
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -1587,18 +1587,10 @@ class TaskDaoSpec
                   tasks.features.head.properties.id,
                   PageRequest(0, 10, Map.empty)
                 )
-                parents <- TaskDao.listTasks(
-                  TaskQueryParameters(),
-                  dbAnnotationProj.id,
-                  PageRequest(0, 10, Map.empty)
-                )
-              } yield { (parents, children) }
+              } yield { children }
 
-            val (parents, children) = connIO.transact(xa).unsafeRunSync
-            assert(
-              parents.count == 1,
-              "Count of parents should be correct"
-            )
+            val children = connIO.transact(xa).unsafeRunSync
+
             assert(
               children.count == taskFeaturesCreate.features.length - 1,
               "Count of children should be correct"

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -14,6 +14,7 @@ import doobie.postgres.implicits._
 import eu.timepit.refined.refineMV
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
+import geotrellis.vector.{io => _, _}
 import monocle.Lens
 import monocle.macros.GenLens
 import org.scalacheck.Prop.forAll
@@ -56,13 +57,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 collection <- TaskDao.insertTasks(
                   fixupTaskFeaturesCollection(
                     taskFeaturesCreate,
@@ -109,13 +111,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 collection <- TaskDao.insertTasks(
                   fixupTaskFeaturesCollection(
                     taskFeaturesCreate,
@@ -126,17 +129,18 @@ class TaskDaoSpec
                 fetched <- collection.features traverse { feat =>
                   TaskDao.unsafeGetTaskById(feat.id)
                 }
-                annoProj <- AnnotationProjectDao
-                  .unsafeGetById(dbAnnotationProj.id)
+                annoProj <-
+                  AnnotationProjectDao
+                    .unsafeGetById(dbAnnotationProj.id)
               } yield { (collection, fetched, annoProj) }
 
             val (featureCollection, fetched, annotationProject) =
               connIO.transact(xa).unsafeRunSync
 
-            val projectTaskSummaryCount = annotationProject.taskStatusSummary flatMap {
-              summary =>
+            val projectTaskSummaryCount =
+              annotationProject.taskStatusSummary flatMap { summary =>
                 Some(summary.valuesIterator.foldLeft(0)(_ + _))
-            }
+              }
 
             assert(
               projectTaskSummaryCount == Some(featureCollection.features.size),
@@ -184,13 +188,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 createdScene <- maybeSceneData traverse {
                   case (datasourceCreate, sceneCreate) =>
                     for {
@@ -265,13 +270,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 collection <- TaskDao.insertTasks(
                   fixupTaskFeaturesCollection(
                     taskFeaturesCreate,
@@ -310,11 +316,14 @@ class TaskDaoSpec
                 platform,
                 projectCreate
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(projectId = Some(dbProject.id)),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(projectId =
+                      Some(dbProject.id)
+                    ),
+                    dbUser
+                  )
               collection <- TaskDao.insertTasks(
                 fixupTaskFeaturesCollection(
                   taskFeaturesCreate,
@@ -332,28 +341,30 @@ class TaskDaoSpec
                 ),
                 dbUser
               )
-              annoProjAfterUpdate <- AnnotationProjectDao
-                .unsafeGetById(dbAnnotationProj.id)
+              annoProjAfterUpdate <-
+                AnnotationProjectDao
+                  .unsafeGetById(dbAnnotationProj.id)
               // have to delete actions on the task to be able to delete it
               _ <- fr"TRUNCATE TABLE task_actions;".update.run
               delete <- TaskDao.deleteTask(collection.features.head.id)
-              annoProjAfterDelete <- AnnotationProjectDao
-                .unsafeGetById(dbAnnotationProj.id)
-              _ <- TaskDao.query
-                .filter(fr"annotation_project_id = ${dbAnnotationProj.id}")
-                .delete
+              annoProjAfterDelete <-
+                AnnotationProjectDao
+                  .unsafeGetById(dbAnnotationProj.id)
+              _ <-
+                TaskDao.query
+                  .filter(fr"annotation_project_id = ${dbAnnotationProj.id}")
+                  .delete
               annoProjAfterDrop <- AnnotationProjectDao.unsafeGetById(
                 dbAnnotationProj.id
               )
-            } yield
-              (
-                update,
-                delete,
-                annoProjAfterUpdate,
-                collection.features.size,
-                annoProjAfterDelete,
-                annoProjAfterDrop
-              )
+            } yield (
+              update,
+              delete,
+              annoProjAfterUpdate,
+              collection.features.size,
+              annoProjAfterDelete,
+              annoProjAfterDrop
+            )
 
             val (
               updateResult,
@@ -374,10 +385,10 @@ class TaskDaoSpec
               .flatMap(_.get(TaskStatus.Unlabeled.toString))
             val labeledCountAfterDelete = annoProjAfterDel.taskStatusSummary
               .flatMap(_.get(TaskStatus.Labeled.toString))
-            val taskCountAfterDropAll = annoProjAfterDropAll.taskStatusSummary flatMap {
-              summary =>
+            val taskCountAfterDropAll =
+              annoProjAfterDropAll.taskStatusSummary flatMap { summary =>
                 Some(summary.valuesIterator.foldLeft(0)(_ + _))
-            }
+              }
 
             assert(
               unlabeledCountAfterUpdate == Some(taskOriginalCount - 1),
@@ -439,13 +450,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 collection <- TaskDao.insertTasks(
                   Task.TaskFeatureCollectionCreate(
                     features = List(
@@ -517,11 +529,14 @@ class TaskDaoSpec
                 platform,
                 projectCreate
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(projectId = Some(dbProject.id)),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(projectId =
+                      Some(dbProject.id)
+                    ),
+                    dbUser
+                  )
               collection <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
@@ -596,13 +611,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 _ <- TaskDao.insertTasks(
                   fixupTaskFeaturesCollection(
                     taskFeaturesCreate,
@@ -663,14 +679,15 @@ class TaskDaoSpec
                 dbUser,
                 dbPlatform
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(
-                    labelersTeamId = Some(labelTeam.id),
-                    validatorsTeamId = Some(validateTeam.id)
-                  ),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(
+                      labelersTeamId = Some(labelTeam.id),
+                      validatorsTeamId = Some(validateTeam.id)
+                    ),
+                    dbUser
+                  )
               collection <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
@@ -786,14 +803,15 @@ class TaskDaoSpec
                 dbUser,
                 dbPlatform
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(
-                    labelersTeamId = Some(labelTeam.id),
-                    validatorsTeamId = Some(validateTeam.id)
-                  ),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(
+                      labelersTeamId = Some(labelTeam.id),
+                      validatorsTeamId = Some(validateTeam.id)
+                    ),
+                    dbUser
+                  )
               collection <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
@@ -889,14 +907,15 @@ class TaskDaoSpec
                 dbUser,
                 dbPlatform
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(
-                    labelersTeamId = Some(labelTeam.id),
-                    validatorsTeamId = Some(validateTeam.id)
-                  ),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(
+                      labelersTeamId = Some(labelTeam.id),
+                      validatorsTeamId = Some(validateTeam.id)
+                    ),
+                    dbUser
+                  )
               collection <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
@@ -994,14 +1013,15 @@ class TaskDaoSpec
                 dbUser,
                 dbPlatform
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(
-                    labelersTeamId = Some(labelTeam.id),
-                    validatorsTeamId = Some(validateTeam.id)
-                  ),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(
+                      labelersTeamId = Some(labelTeam.id),
+                      validatorsTeamId = Some(validateTeam.id)
+                    ),
+                    dbUser
+                  )
               _ <- TaskDao.insertTasks(
                 Task.TaskFeatureCollectionCreate(
                   features = List(
@@ -1067,13 +1087,14 @@ class TaskDaoSpec
                 platform,
                 projectCreate
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(
-                    projectId = Some(dbProject.id)
-                  ),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(
+                      projectId = Some(dbProject.id)
+                    ),
+                    dbUser
+                  )
               collectionOne <- TaskDao.insertTasks(
                 fixupTaskFeaturesCollection(
                   taskFeaturesCreateOne,
@@ -1121,13 +1142,14 @@ class TaskDaoSpec
                 platform,
                 projectCreate
               )
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate.copy(
-                    projectId = Some(dbProject.id)
-                  ),
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate.copy(
+                      projectId = Some(dbProject.id)
+                    ),
+                    dbUser
+                  )
               unionedExtent <- TaskDao.createUnionedGeomExtent(
                 dbAnnotationProj.id,
                 Nil
@@ -1153,11 +1175,12 @@ class TaskDaoSpec
           {
             val expiryIO = for {
               dbUser <- UserDao.create(userCreate)
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate,
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate,
+                    dbUser
+                  )
               insertedTasks <- TaskDao.insertTasks(
                 fixupTaskFeaturesCollection(
                   taskFeatureCollectionCreate,
@@ -1171,11 +1194,16 @@ class TaskDaoSpec
               }
               numberExpiredBogus <- TaskDao.expireStuckTasks(9000 seconds)
               numberExpired <- TaskDao.expireStuckTasks(0 seconds)
-              listedTasks <- TaskDao.query
-                .filter(fr"annotation_project_id = ${dbAnnotationProj.id}")
-                .list
-            } yield
-              (insertedTasks, numberExpiredBogus, numberExpired, listedTasks)
+              listedTasks <-
+                TaskDao.query
+                  .filter(fr"annotation_project_id = ${dbAnnotationProj.id}")
+                  .list
+            } yield (
+              insertedTasks,
+              numberExpiredBogus,
+              numberExpired,
+              listedTasks
+            )
 
             val (
               insertedTasks,
@@ -1246,11 +1274,12 @@ class TaskDaoSpec
           {
             val expiryIO = for {
               dbUser <- UserDao.create(userCreate)
-              dbAnnotationProj <- AnnotationProjectDao
-                .insert(
-                  annotationProjectCreate,
-                  dbUser
-                )
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate,
+                    dbUser
+                  )
               insertedLabelingInProgressTasks <- TaskDao.insertTasks(
                 fixupTaskFeaturesCollection(
                   taskFeatureCollectionCreate,
@@ -1276,17 +1305,17 @@ class TaskDaoSpec
                 dbUser
               )
               numberExpired <- TaskDao.expireStuckTasks(0 seconds)
-              listedTasks <- TaskDao.query
-                .filter(fr"annotation_project_id = ${dbAnnotationProj.id}")
-                .list
+              listedTasks <-
+                TaskDao.query
+                  .filter(fr"annotation_project_id = ${dbAnnotationProj.id}")
+                  .list
               reExpired <- TaskDao.expireStuckTasks(0 seconds)
-            } yield
-              (
-                insertedValidationInProgressTasks.features.length + insertedLabelingInProgressTasks.features.length,
-                numberExpired,
-                listedTasks,
-                reExpired
-              )
+            } yield (
+              insertedValidationInProgressTasks.features.length + insertedLabelingInProgressTasks.features.length,
+              numberExpired,
+              listedTasks,
+              reExpired
+            )
 
             val (inProgressUnlockedTasks, numberExpired, allTasks, reExpired) =
               expiryIO.transact(xa).unsafeRunSync
@@ -1396,7 +1425,9 @@ class TaskDaoSpec
 
               val postExpirationStatus = expiryIO.transact(xa).unsafeRunSync
 
-              if (finalStatus == TaskStatus.ValidationInProgress || finalStatus == TaskStatus.LabelingInProgress) {
+              if (
+                finalStatus == TaskStatus.ValidationInProgress || finalStatus == TaskStatus.LabelingInProgress
+              ) {
                 assert(
                   postExpirationStatus === nextStatus,
                   "In progress tasks should be reverted to their previous status"
@@ -1525,13 +1556,14 @@ class TaskDaoSpec
                   platform,
                   projectCreate
                 )
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate.copy(
-                      projectId = Some(dbProject.id)
-                    ),
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate.copy(
+                        projectId = Some(dbProject.id)
+                      ),
+                      dbUser
+                    )
                 tasks <- TaskDao.insertTasks(
                   fixupTaskFeaturesCollection(
                     taskFeaturesCreate,
@@ -1578,7 +1610,9 @@ class TaskDaoSpec
     }
   }
 
-  test("updating reviews of tasks should update review status of their parent") {
+  test(
+    "updating reviews of tasks should update review status of their parent"
+  ) {
     check {
       forAll {
         (
@@ -1590,11 +1624,12 @@ class TaskDaoSpec
             val connIO =
               for {
                 dbUser <- UserDao.create(userCreate)
-                dbAnnotationProj <- AnnotationProjectDao
-                  .insert(
-                    annotationProjectCreate,
-                    dbUser
-                  )
+                dbAnnotationProj <-
+                  AnnotationProjectDao
+                    .insert(
+                      annotationProjectCreate,
+                      dbUser
+                    )
                 tasks <- TaskDao.insertTasks(
                   fixupTaskFeaturesCollection(
                     taskFeaturesCreate,
@@ -1704,43 +1739,42 @@ class TaskDaoSpec
 
             assert(
               pAfterCInsert
-                .map(
-                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
+                .map(t =>
+                  t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
                 )
                 .toSet === Set(true),
               "Parent task review status is pending after inserting children tasks"
             )
             assert(
               pAfterCOneUpdate
-                .map(
-                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
+                .map(t =>
+                  t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
                 )
                 .toSet === Set(true),
               "Parent task review status is pending after 1 out of 3 children tasks has reviews"
             )
             assert(
               pAfterCTwoUpdate
-                .map(
-                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
+                .map(t =>
+                  t.reviewStatus == Some(TaskReviewStatus.ReviewPending)
                 )
                 .toSet === Set(true),
               "Parent task review status is pending after 2 out of 3 children tasks have reviews"
             )
             assert(
               pAfterCThreeUpdate
-                .map(
-                  t =>
-                    t.reviewStatus == Some(
-                      TaskReviewStatus.ReviewNeedsAttention
-                    )
+                .map(t =>
+                  t.reviewStatus == Some(
+                    TaskReviewStatus.ReviewNeedsAttention
+                  )
                 )
                 .toSet === Set(true),
               "Parent task review status is needs attention after 3 out of 3 children tasks have reviews with Fail vote"
             )
             assert(
               pAfterCTwoUpdatePass
-                .map(
-                  t => t.reviewStatus == Some(TaskReviewStatus.ReviewValidated)
+                .map(t =>
+                  t.reviewStatus == Some(TaskReviewStatus.ReviewValidated)
                 )
                 .toSet === Set(true),
               "Parent task review status is validated after all 3 children tasks have Pass votes"
@@ -1843,6 +1877,72 @@ class TaskDaoSpec
                 .intersect(listed1.features.map(_.id).toSet) == Set.empty,
               "No tasks inserted for campaign 2 were listed for campaign 1"
             )
+            true
+          }
+      }
+    }
+  }
+
+  test("splitting a task creates four new tasks") {
+    check {
+      forAll {
+        (
+            userCreate: User.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+        ) =>
+          {
+            val tfcFirstTaskOnly = taskFeatureCollectionCreate.copy(
+              features = taskFeatureCollectionCreate.features.take(1)
+            )
+            val taskSplitIO = for {
+              dbUser <- UserDao.create(userCreate)
+              dbAnnotationProj <-
+                AnnotationProjectDao
+                  .insert(
+                    annotationProjectCreate,
+                    dbUser
+                  )
+              Task.TaskFeatureCollection(_, features) <- TaskDao.insertTasks(
+                fixupTaskFeaturesCollection(
+                  tfcFirstTaskOnly,
+                  dbAnnotationProj
+                ),
+                dbUser
+              )
+              firstTask = features.headOption
+              splitTasks <- firstTask traverse { task =>
+                TaskDao.splitTask(task.id, dbUser)
+              }
+            } yield (firstTask, splitTasks)
+
+            val (firstTaskO, splitTasksO) =
+              taskSplitIO.transact(xa).unsafeRunSync
+
+            val geomsO = splitTasksO flatMap { _.features.toNel }
+
+            (firstTaskO, geomsO).mapN {
+              case (task, features) =>
+                assert(
+                  features
+                    .map(_.geometry.geom.extent)
+                    .reduceLeft(_.combine(_)) == task.geometry.geom.extent,
+                  "Combined extent of split tasks is the extent of the initial task"
+                )
+
+                features map { feature =>
+                  assert(
+                    task.geometry.geom.contains(feature.geometry.geom),
+                    "Split task geometry is contained in initial task geometry"
+                  )
+                }
+            } getOrElse {
+              assert(
+                taskFeatureCollectionCreate.features.isEmpty,
+                "Without features, there should be no geometries to test with"
+              )
+            }
+
             true
           }
       }


### PR DESCRIPTION
## Overview

This PR allows users to split a task into four tasks while keeping annotations.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Notes

I checked `ReadTasks` scope because it would be a serious drag to need write permissions or someone with more authority in order to split tasks while working on something. I can be talked into `CreateTasks` but I'm not 100% sure what permissions look like for people who've had projects shared with them.

## Testing Instructions

- test as part of raster-foundry/annotate#1057

Helps with raster-foundry/annotate#347
