### PR TITLE
Call scripts/build-lambda before infra plan

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -72,6 +72,7 @@ node {
 
       dir('raster-foundry-deployment') {
         wrap([$class: 'AnsiColorBuildWrapper']) {
+          sh './scripts/build-lambda'
           sh 'docker-compose -f docker-compose.yml -f docker-compose.ci.yml run --rm terraform ./scripts/infra plan'
           withCredentials([[$class: 'StringBinding',
                             credentialsId: 'ROLLBAR_ACCESS_TOKEN',


### PR DESCRIPTION
## Overview

This PR calls `scripts/build-lambda` before any infra steps. It supports azavea/raster-foundry-platform#1090 and azavea/raster-foundry-deployment#265

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- none

Helps with azavea/raster-foundry-platform#1090