### PR TITLE
Remove bad migration

### DIFF
--- a/app-backend/db/src/main/resources/migrations/V67__add_fk_indices_in_scene_delete_tree.sql
+++ b/app-backend/db/src/main/resources/migrations/V67__add_fk_indices_in_scene_delete_tree.sql
@@ -1,5 +1,0 @@
-CREATE INDEX CONCURRENTLY images_scene_idx ON images (scene);
-
-CREATE INDEX CONCURRENTLY bands_image_idx ON bands (image_id);
-
-CREATE INDEX CONCURRENTLY thumbnails_scene_idx ON thumbnails (scene);


### PR DESCRIPTION
## Overview

This PR removes a superfluous migration that added indices... to things that were already indexed. I'm not really sure how I missed this the first time, but:

- images already have an index on their scene foreign key
- bands already have an index on their image foreign key
- thumbnails already have an index on their scene foreign key

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~

## Notes

This was never deployed so we won't have any weird prod migration adventures

## Testing Instructions

- load development data
