### PR TITLE
Improve scene delete query

### DIFF
--- a/app-backend/batch/src/main/scala/removeScenes/RemoveScenes.scala
+++ b/app-backend/batch/src/main/scala/removeScenes/RemoveScenes.scala
@@ -37,6 +37,7 @@ class RemoveScenes(
       AND scenes.acquisition_date >= ${startTs}
       AND scenes.acquisition_date <= ${endTs}
       AND scenes.datasource = $datasourceId
+    )
     """.update.run.transact(xa)
 }
 

--- a/app-backend/batch/src/main/scala/removeScenes/RemoveScenes.scala
+++ b/app-backend/batch/src/main/scala/removeScenes/RemoveScenes.scala
@@ -29,9 +29,8 @@ class RemoveScenes(
 
   def removeScenes: IO[Int] =
     fr"""
-    DELETE FROM scenes
-    USING scenes AS scn
-    LEFT JOIN scenes_to_layers ON scn.id = scenes_to_layers.scene_id
+    DELETE FROM scenes WHERE id IN (
+    SELECT id FROM scenes LEFT JOIN scenes_to_layers ON scenes.id = scenes_to_layers.scene_id
     WHERE
       -- scene_id NULL means we didn't find a scene_id in the layers table
       scene_id IS NULL
@@ -39,7 +38,6 @@ class RemoveScenes(
       AND scenes.acquisition_date <= ${endTs}
       AND scenes.datasource = $datasourceId
     """.update.run.transact(xa)
-
 }
 
 object RemoveScenes extends Job {

--- a/app-backend/db/src/main/resources/migrations/V67__add_fk_indices_in_scene_delete_tree.sql
+++ b/app-backend/db/src/main/resources/migrations/V67__add_fk_indices_in_scene_delete_tree.sql
@@ -1,5 +1,0 @@
-CREATE INDEX CONCURRENTLY images_scene_idx ON images (scene);
-
-CREATE INDEX CONCURRENTLY bands_image_idx ON bands (image_id);
-
-CREATE INDEX CONCURRENTLY thumbnails_scene_idx ON thumbnails (scene);


### PR DESCRIPTION
## Overview

This PR changes the scene delete query from a self join to a `delete where id in (...)`. the self join worked fine locally but with the size of the staging table (which is smaller than the prod table) took... a number of hours for a single week. Using the list of ids, Sentinel-2 scene deletion for a month took a few minutes, and Landsat 8 took about a minute.

It also includes the changes from #5507 to take down migration 67 since it was 100% redundant 😢 

### Checklist

- ~Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~ not user-facing

## Testing Instructions

- assemble batch jar
- bring up database and memcached
- delete some landsat 8 scenes to make sure the sql syntax is correct: `./scripts/console batch 'java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main remove-scenes 697a0b91-b7a8-446e-842c-97cda155554d 2018-08-01'`
- inspect the staging db session to see similar examples of this query

supersedes #5507 

closes #5507 