### PR TITLE
Only create one intercom notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Backsplash background processes for automatic task unlocks no longe rcompete with each other [#5503](https://github.com/raster-foundry/raster-foundry/pull/5503)
 - Simple shares don't always return 500 responses [#5510](https://github.com/raster-foundry/raster-foundry/pull/5510)
 
-## 1.52.2 - 2020-11-05
+## [1.52.2] - 2020-11-05
 ### Fixed
 - Removed incompatible creation option from cogification command when the image has 64-bit data [#5506](https://github.com/raster-foundry/raster-foundry/pull/5506)
 
@@ -809,7 +809,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included missing `pow` operation for decoding json representations of analyses [#4179](https://github.com/raster-foundry/raster-foundry/pull/4140), [#4155](https://github.com/raster-foundry/raster-foundry/issues/4155)
 
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/tree/develop
-[1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
+[1.52.2]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
+[1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.0...1.52.1
 [1.52.0]: https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0
 [1.51.0]: https://github.com/raster-foundry/raster-foundry/compare/1.50.0...1.51.0
 [1.50.0]: https://github.com/raster-foundry/raster-foundry/compare/1.49.0...1.50.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Tasks that have `VALIDATION_IN_PROGRESS` or `LABELING_IN_PROGRESS` but no lock data are also expired automatically [#5496](https://github.com/raster-foundry/raster-foundry/pull/5496)
 - Backsplash background processes for automatic task unlocks no longe rcompete with each other [#5503](https://github.com/raster-foundry/raster-foundry/pull/5503)
+- Simple shares don't always return 500 responses [#5510](https://github.com/raster-foundry/raster-foundry/pull/5510)
 
-## [1.52.2] - 2020-11-05
+## 1.52.2 - 2020-11-05
 ### Fixed
 - Removed incompatible creation option from cogification command when the image has 64-bit data [#5506](https://github.com/raster-foundry/raster-foundry/pull/5506)
 
@@ -809,7 +810,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/tree/develop
 [1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
-[1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.0...1.52.1
 [1.52.0]: https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0
 [1.51.0]: https://github.com/raster-foundry/raster-foundry/compare/1.50.0...1.51.0
 [1.50.0]: https://github.com/raster-foundry/raster-foundry/compare/1.49.0...1.50.0

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -23,9 +23,10 @@ import com.rasterfoundry.api.tool.ToolRoutes
 import com.rasterfoundry.api.toolrun.ToolRunRoutes
 import com.rasterfoundry.api.uploads.UploadRoutes
 import com.rasterfoundry.api.user.UserRoutes
-import com.rasterfoundry.api.utils.Config
+import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
 
 import akka.http.scaladsl.model.HttpMethods._
+import cats.effect.IO
 import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
 import ch.megard.akka.http.cors.scaladsl.settings._
 
@@ -35,7 +36,6 @@ import scala.collection.immutable.Seq
   * Contains all routes for Raster Foundry API/Healthcheck endpoints.
   *
   * Actual routes should be written in the relevant feature as much as is feasible
-  *
   */
 trait Router
     extends HealthCheckRoutes
@@ -66,6 +66,8 @@ trait Router
   val settings = CorsSettings.defaultSettings.copy(
     allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE)
   )
+
+  def notifier: IO[IntercomNotifications]
 
   val routes = cors(settings) {
     pathPrefix("healthcheck") {

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -15,9 +15,6 @@ import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.circe.syntax._
-import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
-
-import scala.concurrent.Future
 
 import java.util.UUID
 
@@ -31,137 +28,83 @@ trait AnnotationProjectPermissionRoutes
 
   implicit def contextShift: ContextShift[IO]
 
-  val notifierIOAnnotationProject = AsyncHttpClientCatsBackend[IO]() map {
-    backend =>
-      new IntercomNotifications(backend)
-  }
+  def notifier: IO[IntercomNotifications]
 
-  def listPermissions(projectId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        AnnotationProjectDao
-          .authorized(
-            user,
-            ObjectType.AnnotationProject,
-            projectId,
-            ActionType.Edit
-          )
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
+  def listPermissions(projectId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
           AnnotationProjectDao
-            .getPermissions(projectId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def replacePermissions(projectId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationProjects, Action.Share, None),
-      user
-    ) {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
-        authorizeAsync {
-          (for {
-            auth1 <- AnnotationProjectDao.authorized(
+            .authorized(
               user,
               ObjectType.AnnotationProject,
               projectId,
               ActionType.Edit
             )
-            auth2 <- acrList traverse { acr =>
-              AnnotationProjectDao.isValidPermission(acr, user)
-            }
-          } yield {
-            auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
-              case true =>
-                AnnotationProjectDao.isReplaceWithinScopedLimit(
-                  Domain.AnnotationProjects,
-                  user,
-                  acrList
-                )
-              case _ => false
-            })
-          }).transact(xa).unsafeToFuture()
+            .transact(xa)
+            .unsafeToFuture
         } {
-          val distinctUserIds = acrList
-            .foldMap(acr => acr.getUserId map { Set(_) })
-            .getOrElse(Set.empty)
-            .toList
           complete {
-            (AnnotationProjectDao
-              .replacePermissions(projectId, acrList)
-              .transact(xa) <* (AnnotationProjectDao
-              .unsafeGetById(
-                projectId
-              )
-              .transact(xa) flatMap { annotationProject =>
-              (distinctUserIds traverse { userId =>
-                // it's safe to do this unsafely because we know the user exists from
-                // the isValidPermission check
-                UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
-                  sharedUser =>
-                    notifierIOAnnotationProject flatMap { notifier =>
-                      notifier.shareNotify(
-                        sharedUser,
-                        user,
-                        annotationProject,
-                        "project"
-                      )
-                    }
-                }
-              })
-            })).unsafeToFuture
+            AnnotationProjectDao
+              .getPermissions(projectId)
+              .transact(xa)
+              .unsafeToFuture
           }
         }
       }
     }
-  }
 
-  def addPermission(projectId: UUID): Route = authenticate { user =>
-    val shareCount =
-      AnnotationProjectDao
-        .getShareCount(projectId, user.id)
-        .transact(xa)
-        .unsafeToFuture
-    authorizeScopeLimit(
-      shareCount,
-      Domain.AnnotationProjects,
-      Action.Share,
-      user
-    ) {
-      entity(as[ObjectAccessControlRule]) { acr =>
-        authorizeAsync {
-          (for {
-            auth1 <- AnnotationProjectDao.authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            auth2 <- AnnotationProjectDao.isValidPermission(acr, user)
-          } yield {
-            auth1.toBoolean && auth2
-          }).transact(xa).unsafeToFuture()
-        } {
-          complete {
-            (AnnotationProjectDao
-              .addPermission(projectId, acr)
-              .transact(xa) <* (
-              AnnotationProjectDao
-                .unsafeGetById(projectId)
+  def replacePermissions(projectId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.Share, None),
+        user
+      ) {
+        entity(as[List[ObjectAccessControlRule]]) { acrList =>
+          authorizeAsync {
+            (for {
+              auth1 <- AnnotationProjectDao.authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Edit
+              )
+              auth2 <- acrList traverse { acr =>
+                AnnotationProjectDao.isValidPermission(acr, user)
+              }
+            } yield {
+              auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
+                case true =>
+                  AnnotationProjectDao.isReplaceWithinScopedLimit(
+                    Domain.AnnotationProjects,
+                    user,
+                    acrList
+                  )
+                case _ => false
+              })
+            }).transact(xa).unsafeToFuture()
+          } {
+            val distinctUserIds = acrList
+              .foldMap(acr => acr.getUserId map { Set(_) })
+              .getOrElse(Set.empty)
+              .toList
+            complete {
+              (AnnotationProjectDao
+                .replacePermissions(projectId, acrList)
+                .transact(xa) <* (AnnotationProjectDao
+                .unsafeGetById(
+                  projectId
+                )
                 .transact(xa) flatMap { annotationProject =>
-                acr.getUserId traverse { userId =>
+                (distinctUserIds traverse { userId =>
+                  // it's safe to do this unsafely because we know the user exists from
+                  // the isValidPermission check
                   UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
                     sharedUser =>
-                      notifierIOAnnotationProject flatMap { notifier =>
+                      notifier flatMap { notifier =>
                         notifier.shareNotify(
                           sharedUser,
                           user,
@@ -170,43 +113,98 @@ trait AnnotationProjectPermissionRoutes
                         )
                       }
                   }
-                }
-              }
-            )).unsafeToFuture
+                })
+              })).unsafeToFuture
+            }
           }
         }
       }
     }
-  }
 
-  def deletePermissions(projectId: UUID): Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationProjects, Action.Share, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
+  def addPermission(projectId: UUID): Route =
+    authenticate { user =>
+      val shareCount =
         AnnotationProjectDao
-          .authorized(
-            user,
-            ObjectType.AnnotationProject,
-            projectId,
-            ActionType.Edit
-          )
+          .getShareCount(projectId, user.id)
           .transact(xa)
           .unsafeToFuture
-      } {
-        complete {
-          AnnotationProjectDao
-            .deletePermissions(projectId)
-            .transact(xa)
-            .unsafeToFuture
+      authorizeScopeLimit(
+        shareCount,
+        Domain.AnnotationProjects,
+        Action.Share,
+        user
+      ) {
+        entity(as[ObjectAccessControlRule]) { acr =>
+          authorizeAsync {
+            (for {
+              auth1 <- AnnotationProjectDao.authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Edit
+              )
+              auth2 <- AnnotationProjectDao.isValidPermission(acr, user)
+            } yield {
+              auth1.toBoolean && auth2
+            }).transact(xa).unsafeToFuture()
+          } {
+            complete {
+              (AnnotationProjectDao
+                .addPermission(projectId, acr)
+                .transact(xa) <* (
+                AnnotationProjectDao
+                  .unsafeGetById(projectId)
+                  .transact(xa) flatMap { annotationProject =>
+                  acr.getUserId traverse { userId =>
+                    UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                      sharedUser =>
+                        notifier flatMap { notifier =>
+                          notifier.shareNotify(
+                            sharedUser,
+                            user,
+                            annotationProject,
+                            "project"
+                          )
+                        }
+                    }
+                  }
+                }
+              )).unsafeToFuture
+            }
+          }
         }
       }
     }
-  }
 
-  def listAnnotationProjectShares(projectId: UUID): Route = authenticate {
-    user =>
+  def deletePermissions(projectId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.Share, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          AnnotationProjectDao
+            .authorized(
+              user,
+              ObjectType.AnnotationProject,
+              projectId,
+              ActionType.Edit
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            AnnotationProjectDao
+              .deletePermissions(projectId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
+    }
+
+  def listAnnotationProjectShares(projectId: UUID): Route =
+    authenticate { user =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Share, None),
         user
@@ -230,7 +228,7 @@ trait AnnotationProjectPermissionRoutes
           }
         }
       }
-  }
+    }
 
   def deleteAnnotationProjectShare(projectId: UUID, deleteId: String): Route =
     authenticate { user =>
@@ -274,120 +272,136 @@ trait AnnotationProjectPermissionRoutes
       }
     }
 
-  def shareAnnotationProject(projectId: UUID): Route = authenticate { user =>
-    val shareCount =
-      AnnotationProjectDao
-        .getShareCount(projectId, user.id)
-        .transact(xa)
-        .unsafeToFuture
-    authorizeScopeLimit(
-      shareCount,
-      Domain.AnnotationProjects,
-      Action.Share,
-      user
-    ) {
-      entity(as[UserShareInfo]) { userByEmail =>
-        authorize {
-          (userByEmail.actionType match {
-            case Some(ActionType.Annotate) | Some(ActionType.Validate) | None =>
-              true
-            case _ => false
-          })
-        } {
-          complete {
-            Auth0Service.getManagementBearerToken flatMap { managementToken =>
-              (for {
-                // Everything has to be Futures here because of methods in akka-http / Auth0Service
-                users <- UserDao
-                  .findUsersByEmail(userByEmail.email)
-                  .transact(xa)
-                  .unsafeToFuture
-                userPlatform <- UserDao
-                  .unsafeGetUserPlatform(user.id)
-                  .transact(xa)
-                  .unsafeToFuture
-                annotationProjectO <- AnnotationProjectDao
-                  .getById(projectId)
-                  .transact(xa)
-                  .unsafeToFuture
-                permissions <- users match {
-                  case Nil =>
-                    for {
-                      auth0User <- OptionT {
-                        Auth0Service.findGroundworkUser(
-                          userByEmail.email,
-                          managementToken
-                        )
-                      } getOrElseF {
-                        Auth0Service
-                          .createGroundworkUser(
-                            userByEmail.email,
-                            managementToken
-                          )
-                      }
-                      newUserOpt <- (auth0User.user_id traverse { userId =>
-                        for {
-                          user <- UserDao.create(
-                            User.Create(
-                              userId,
-                              email = userByEmail.email,
-                              scope = Scopes.GroundworkUser
-                            )
-                          )
-                          _ <- UserGroupRoleDao.createDefaultRoles(user)
-                          _ <- AnnotationProjectDao.copyProject(
-                            UUID.fromString(groundworkSampleProject),
-                            user
-                          )
-                        } yield user
-                      }).transact(xa).unsafeToFuture
-                      notifier <- notifierIOAnnotationProject.unsafeToFuture
-                      acrs = newUserOpt map { newUser =>
-                        notifier
-                          .getDefaultShare(newUser, userByEmail.actionType)
-                      } getOrElse Nil
-                      _ <- (newUserOpt, annotationProjectO).tupled traverse {
-                        case (newUser, annotationProject) =>
-                          // if silent param is not provided, we notify
-                          val isSilent = userByEmail.silent.getOrElse(false)
-                          if (!isSilent) {
-                            notifier.shareNotifyNewUser(
-                              managementToken,
-                              user,
-                              userByEmail.email,
-                              newUser.id,
-                              userPlatform,
-                              annotationProject,
-                              "project",
-                              Notifications.getInvitationMessage
-                            )
-                          } else {
-                            Future.unit
+  def shareAnnotationProject(projectId: UUID): Route =
+    authenticate { user =>
+      val shareCount =
+        AnnotationProjectDao
+          .getShareCount(projectId, user.id)
+          .transact(xa)
+          .unsafeToFuture
+      authorizeScopeLimit(
+        shareCount,
+        Domain.AnnotationProjects,
+        Action.Share,
+        user
+      ) {
+        entity(as[UserShareInfo]) { userByEmail =>
+          authorize {
+            (userByEmail.actionType match {
+              case Some(ActionType.Annotate) | Some(ActionType.Validate) |
+                  None =>
+                true
+              case _ => false
+            })
+          } {
+            complete {
+              Auth0Service.getManagementBearerToken flatMap { managementToken =>
+                (for {
+                  // Everything has to be Futures here because of methods in akka-http / Auth0Service
+                  users <- UserDao
+                    .findUsersByEmail(userByEmail.email)
+                    .transact(xa)
+                  userPlatform <- UserDao
+                    .unsafeGetUserPlatform(user.id)
+                    .transact(xa)
+                  annotationProjectO <- AnnotationProjectDao
+                    .getById(projectId)
+                    .transact(xa)
+                  permissions <- users match {
+                    case Nil =>
+                      for {
+                        auth0User <- OptionT {
+                          IO.fromFuture {
+                            IO {
+                              Auth0Service.findGroundworkUser(
+                                userByEmail.email,
+                                managementToken
+                              )
+                            }
                           }
-                      }
-                      // this is not an existing user,
-                      // there is no project specific ACR yet,
-                      // so no need to remove Validate action if only want Annotate
-                      dbAcrs <- (acrs traverse { acr =>
-                        AnnotationProjectDao
-                          .addPermission(projectId, acr)
-                      }).transact(xa).unsafeToFuture
-                    } yield dbAcrs
-                  case existingUsers =>
-                    existingUsers traverse { existingUser =>
-                      notifierIOAnnotationProject.unsafeToFuture flatMap {
-                        notifier =>
+                        } getOrElseF {
+                          IO.fromFuture {
+                            IO {
+                              Auth0Service
+                                .createGroundworkUser(
+                                  userByEmail.email,
+                                  managementToken
+                                )
+                            }
+                          }
+                        }
+                        newUserOpt <- (auth0User.user_id traverse { userId =>
+                          for {
+                            user <- UserDao.create(
+                              User.Create(
+                                userId,
+                                email = userByEmail.email,
+                                scope = Scopes.GroundworkUser
+                              )
+                            )
+                            _ <- UserGroupRoleDao.createDefaultRoles(user)
+                            _ <- AnnotationProjectDao.copyProject(
+                              UUID.fromString(groundworkSampleProject),
+                              user
+                            )
+                          } yield user
+                        }).transact(xa)
+                        notifier <- notifier
+                        acrs = newUserOpt map { newUser =>
+                          notifier
+                            .getDefaultShare(newUser, userByEmail.actionType)
+                        } getOrElse Nil
+                        _ <- (newUserOpt, annotationProjectO).tupled traverse {
+                          case (newUser, annotationProject) =>
+                            // if silent param is not provided, we notify
+                            val isSilent = userByEmail.silent.getOrElse(false)
+                            if (!isSilent) {
+                              IO.fromFuture {
+                                IO {
+                                  notifier.shareNotifyNewUser(
+                                    managementToken,
+                                    user,
+                                    userByEmail.email,
+                                    newUser.id,
+                                    userPlatform,
+                                    annotationProject,
+                                    "project",
+                                    Notifications.getInvitationMessage
+                                  )
+                                }
+                              }
+                            } else {
+                              IO.unit
+                            }
+                        }
+                        // this is not an existing user,
+                        // there is no project specific ACR yet,
+                        // so no need to remove Validate action if only want Annotate
+                        dbAcrs <- (acrs traverse { acr =>
+                          AnnotationProjectDao
+                            .addPermission(projectId, acr)
+                        }).transact(xa)
+                      } yield dbAcrs
+                    case existingUsers =>
+                      existingUsers traverse { existingUser =>
+                        notifier flatMap { notifier =>
                           val acrs =
                             notifier.getDefaultShare(
                               existingUser,
                               userByEmail.actionType
                             )
-                          Auth0Service
-                            .addUserMetadata(
-                              existingUser.id,
-                              managementToken,
-                              Map("app_metadata" -> Map("annotateApp" -> true)).asJson
-                            ) *>
+                          IO.fromFuture {
+                            IO {
+                              Auth0Service
+                                .addUserMetadata(
+                                  existingUser.id,
+                                  managementToken,
+                                  Map(
+                                    "app_metadata" -> Map("annotateApp" -> true)
+                                  ).asJson
+                                )
+                            }
+                          } *>
                             (AnnotationProjectDao
                               .handleSharedPermissions(
                                 projectId,
@@ -411,16 +425,16 @@ trait AnnotationProjectPermissionRoutes
                                   }
                                 case _ => IO.pure(())
                               }
-                            )).unsafeToFuture
-                      }
+                            ))
+                        }
 
-                    } map { _.flatten }
-                }
-              } yield permissions)
+                      } map { _.flatten }
+                  }
+                } yield permissions).unsafeToFuture
+              }
             }
           }
         }
       }
     }
-  }
 }


### PR DESCRIPTION
## Overview

This PR makes it so that we only ever create a single `IntercomNotifier`, which does enough to resolve implicits that we don't get a null pointer exception when we share with existing users.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

**hide whitespace changes in review** scalafmt got way too excited

There's still some kind of issue with `akka-streams` and an unsubscribed response entity that I'm working out, but this at least solves the immediate problem of "always error".

I believe this will also require some frontend changes to report the information about which email addresses had unsuccessful shares, but I don't think we know what that should look like or if that's information that we will want that we're not worried about exposing to users. Since the errors were the result of NPEs for existing users only, I don't think there are actually real errors that we needed to report.

An issue is that bad email addresses don't show up as errors -- for example, our SMTP logs show that the server was perfectly happy to pass off the message to the azavea mail server for `jsantuc@azavea.com`. I'm not sure whether there's anything we can do about that.

## Testing Instructions

- assemble api server
- bring up servers
- bring up groundwork
- go to the sharing tab of a project you're allowed to share
- put in the email address for a user who exists and share
- you shouldn't see an error

I don't know how to test the returning-all-errors part aside from trusting the `ValidatedNel` data type -- changes in eb5a35a

Closes raster-foundry/groundwork#1108