### PR TITLE
Make label addition idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.53.0] - 2020-11-16
 ### Added
+- Adding labels will now delete all prior labels first []
 - STAC label items now include the task statuses in a `groundwork:taskStatuses` property [#5490](https://github.com/raster-foundry/raster-foundry/pull/5490)
 - Tasks can be listed by campaign [#5494](https://github.com/raster-foundry/raster-foundry/pull/5494)
 - Campaigns can be shared with only an email [#5495](https://github.com/raster-foundry/raster-foundry/pull/5495)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [1.53.0] - 2020-11-16
 ### Added
-- Adding labels will now delete all prior labels first []
+- Adding labels will now delete all prior labels first [#5512](https://github.com/raster-foundry/raster-foundry/pull/5512)
 - STAC label items now include the task statuses in a `groundwork:taskStatuses` property [#5490](https://github.com/raster-foundry/raster-foundry/pull/5490)
 - Tasks can be listed by campaign [#5494](https://github.com/raster-foundry/raster-foundry/pull/5494)
 - Campaigns can be shared with only an email [#5495](https://github.com/raster-foundry/raster-foundry/pull/5495)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -38,11 +38,11 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/,annotationProjects:deleteTasks,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/lock/,annotationProjects:createAnnotation,post
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/lock/,annotationProjects:createAnnotation,delete
-/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:createAnnotation,post
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:createAnnotation,put
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:read,get
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:deleteAnnotation,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/children,annotationProjects:readTasks,get
-/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/validate/,annotationProjects:createAnnotation,post
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/validate/,annotationProjects:createAnnotation,put
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/split/,annotationProjects:readTasks,post
 /api/licenses/,licenses:read,get
 /api/licenses/{licenseID},licenses:read,get

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -426,7 +426,7 @@ trait AnnotationProjectTaskRoutes
             onSuccess(
               (for {
                 _ <- AnnotationLabelDao
-                  .deleteByProjectIdAndTaskId(projectId, task)
+                  .deleteByProjectIdAndTaskId(projectId, taskId)
                 insert <- AnnotationLabelDao
                   .insertAnnotations(
                     projectId,

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -424,14 +424,19 @@ trait AnnotationProjectTaskRoutes
               _.toAnnotationLabelWithClassesCreate
             }
             onSuccess(
-              AnnotationLabelDao
-                .insertAnnotations(
-                  projectId,
-                  taskId,
-                  annotationLabelWithClassesCreate.toList,
-                  user
-                )
-                .transact(xa)
+              (for {
+                _ <- AnnotationLabelDao
+                  .deleteByProjectIdAndTaskId(projectId, task)
+                insert <- AnnotationLabelDao
+                  .insertAnnotations(
+                    projectId,
+                    taskId,
+                    annotationLabelWithClassesCreate.toList,
+                    user
+                  )
+              } yield {
+                insert
+              }).transact(xa)
                 .unsafeToFuture
                 .map { annotations: List[AnnotationLabelWithClasses] =>
                   fromSeqToFeatureCollection[

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -121,17 +121,15 @@ trait AnnotationProjectRoutes
                   pathEndOrSingleSlash {
                     get {
                       listTaskLabels(projectId, taskId)
-                    } ~
-                      post {
-                        addTaskLabels(projectId, taskId)
-                      } ~
-                      delete {
-                        deleteTaskLabels(projectId, taskId)
-                      }
+                    } ~ put {
+                      addTaskLabels(projectId, taskId)
+                    } ~ delete {
+                      deleteTaskLabels(projectId, taskId)
+                    }
                   }
                 } ~ pathPrefix("validate") {
                   pathEndOrSingleSlash {
-                    post {
+                    put {
                       validateTaskLabels(projectId, taskId)
                     }
                   }

--- a/docs/swagger/spec.yml
+++ b/docs/swagger/spec.yml
@@ -3418,6 +3418,56 @@ paths:
           description: "Unexpected error"
           schema:
             $ref: "#/definitions/Error"
+  /projects/{projectID}/layers/{layerID}/tasks/{taskID}/labels:
+    put:
+      summary: "Update labels of a task from this project layer"
+      tags:
+        - Imagery
+      parameters:
+        - $ref: "#/parameters/projectID"
+        - $ref: "#/parameters/layerID"
+        - $ref: "#/parameters/taskID"
+        - name: taskUpdate
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/TaskFeatureUpdate"
+      responses:
+        204:
+          description: "No content, update successful"
+        403:
+          description: "Insufficient permissions for resource or resource does not exist"
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: "Unexpected error"
+          schema:
+            $ref: "#/definitions/Error"
+  /projects/{projectID}/layers/{layerID}/tasks/{taskID}/validate:
+    put:
+      summary: "Update labels of a task from this project layer"
+      tags:
+        - Imagery
+      parameters:
+        - $ref: "#/parameters/projectID"
+        - $ref: "#/parameters/layerID"
+        - $ref: "#/parameters/taskID"
+        - name: taskUpdate
+          in: body
+          required: true
+          schema:
+            $ref: "#/definitions/TaskFeatureUpdate"
+      responses:
+        204:
+          description: "No content, update successful"
+        403:
+          description: "Insufficient permissions for resource or resource does not exist"
+          schema:
+            $ref: "#/definitions/Error"
+        default:
+          description: "Unexpected error"
+          schema:
+            $ref: "#/definitions/Error"
   /projects/{projectID}/layers/{layerID}/tasks/{taskID}/lock:
     post:
       summary: "Lock a task so that it cannot be updated or locked by another user"


### PR DESCRIPTION
## Overview

Rewriting labels currently requires `DELETE` + `POST`. This changes the `POST` to a `PUT` and transactionally handles deletion/overwrite

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Swagger specification updated
- [x] New tables and queries have appropriate indices added
- [x] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv


### Notes

`POST`s will need to be changed to `PUT`s in groundwork

## Testing Instructions

- Run integration tests
- Throw a `PUT` at the new endpoints

Closes #1105
