### PR TITLE
Update annotation_project.py with campaignId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Fixed
 - Tasks can be unlocked by users other than the user who locked them [#5514](https://github.com/raster-foundry/raster-foundry/pull/5514)
+- Made python Upload datamodel aware of campaign ID [#5513](https://github.com/raster-foundry/raster-foundry/pull/5513)
 
 ## [1.54.0] - 2020-11-25
 ### Added

--- a/app-tasks/rf/src/rf/models/annotation_project.py
+++ b/app-tasks/rf/src/rf/models/annotation_project.py
@@ -18,6 +18,7 @@ class AnnotationProject(BaseModel):
         labelersTeamId=None,
         validatorsTeamId=None,
         projectId=None,
+        campaignId=None
     ):
         self.id = id
         self.name = name
@@ -31,6 +32,7 @@ class AnnotationProject(BaseModel):
         self.labelersTeamId = labelersTeamId
         self.validatorsTeamId = validatorsTeamId
         self.projectId = projectId
+        self.campaignId = campaignId
 
     def to_dict(self):
         return dict(
@@ -46,6 +48,7 @@ class AnnotationProject(BaseModel):
             validatorsTeamId=self.validatorsTeamId,
             projectId=self.projectId,
             status=self.status,
+            campaignId=self.campaignId
         )
 
     def update_status(self, status):
@@ -67,4 +70,5 @@ class AnnotationProject(BaseModel):
             labelersTeamId=d.get("labelersTeamId"),
             validatorsTeamId=d.get("validatorsTeamId"),
             projectId=d.get("projectId"),
+            campaignId=d.get("campaignId")
         )


### PR DESCRIPTION
## Overview

This PR makes our python data-model aware of the existence of the `campaignId` field so that it doesn't get blown away during upload processing.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- TKTK

Closes #XXX
