### PR TITLE
Remove unnecessary authorization check from unlocking tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Tasks can be unlocked by users other than the user who locked them [#5514](https://github.com/raster-foundry/raster-foundry/pull/5514)
 
 ## [1.54.0] - 2020-11-25
 ### Added
@@ -821,7 +823,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/compare/v1.54.0...HEAD
 [1.54.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.53.0...v1.54.0
 [1.53.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.52.2...v1.53.0
-[1.52.2]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
 [1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.0...1.52.1
 [1.52.0]: https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0
 [1.51.0]: https://github.com/raster-foundry/raster-foundry/compare/1.50.0...1.51.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -823,6 +823,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/compare/v1.54.0...HEAD
 [1.54.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.53.0...v1.54.0
 [1.53.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.52.2...v1.53.0
+[1.52.2]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
 [1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.0...1.52.1
 [1.52.0]: https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0
 [1.51.0]: https://github.com/raster-foundry/raster-foundry/compare/1.50.0...1.51.0


### PR DESCRIPTION
## Overview

this PR removes the check to make sure that the user attempting to unlock the task is the person who locked it. That made sense in a world where we trusted that locks would always be deleted, but in a world where sometimes locks linger for extended periods despite our repeated efforts to stymie that behavior, it's important for users working on a labeling project to be able to unlock each others' tasks.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- get rid of the condition attached to disabling the unlock button in Groundwork (just set [this](https://github.com/raster-foundry/groundwork/blob/develop/src/pages/BasicProjectDetails/Overview/TaskMap/Menu.tsx#L188) to false)
- bring up groundwork locally pointing to local RF servers **on the RF `develop` branch**
- pick a user id for someone who isn't the dev user and lock a task in one of the dev user's annotation projects:

```
update tasks set status = 'VALIDATION_IN_PROGRESS', locked_by = '<the user id>', locked_on = now() where id = '4a4f390e-6c7c-4119-b0c9-fe8273b24e59';
```

- log in as the dev user
- try to unlock that task -- it'll stick out on the project detail page: http://localhost:3000/app/projects/13dd152a-db3a-45f7-ba6b-c7274e679351/overview
- it should fail
- stop your rf servers
- assemble api server
- bring your rf servers back up
- set the lock again in the db just to be sure
- try to unlock the task again in the groundwork frontend
- you should succeed

closes raster-foundry/groundwork#1127