### PR TITLE
Upgrade gt to 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Added
 - Added campaign to limits endpoint [#5511](https://github.com/raster-foundry/raster-foundry/pull/5511)
 
 ### Fixed
 - Simple shares don't always return 500 responses [#5510](https://github.com/raster-foundry/raster-foundry/pull/5510)
+- Upgraded GeoTrellis to remove seams for some zoom + extent + projection combinations [#5515](https://github.com/raster-foundry/raster-foundry/pull/5515)
 
 ## [1.53.0] - 2020-11-16
 ### Added
@@ -818,7 +818,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/compare/v1.53.0...HEAD
 [1.53.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.52.2...v1.53.0
-[1.52.2]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
 [1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.0...1.52.1
 [1.52.0]: https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0
 [1.51.0]: https://github.com/raster-foundry/raster-foundry/compare/1.50.0...1.51.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Tasks that have `VALIDATION_IN_PROGRESS` or `LABELING_IN_PROGRESS` but no lock data are also expired automatically [#5496](https://github.com/raster-foundry/raster-foundry/pull/5496)
 - Backsplash background processes for automatic task unlocks no longe rcompete with each other [#5503](https://github.com/raster-foundry/raster-foundry/pull/5503)
 
-## 1.52.2 - 2020-11-05
+## [1.52.2] - 2020-11-05
 ### Fixed
 - Removed incompatible creation option from cogification command when the image has 64-bit data [#5506](https://github.com/raster-foundry/raster-foundry/pull/5506)
 
@@ -818,6 +818,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/compare/v1.53.0...HEAD
 [1.53.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.52.2...v1.53.0
+[1.52.2]: https://github.com/raster-foundry/raster-foundry/compare/1.52.1...1.52.2
 [1.52.1]: https://github.com/raster-foundry/raster-foundry/compare/1.52.0...1.52.1
 [1.52.0]: https://github.com/raster-foundry/raster-foundry/compare/1.51.0...1.52.0
 [1.51.0]: https://github.com/raster-foundry/raster-foundry/compare/1.50.0...1.51.0

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -91,46 +91,48 @@ object AnnotationProject {
       campaignId: Option[UUID] = None,
       capturedAt: Option[Timestamp] = None
   ) {
-    def toProject = AnnotationProject(
-      id,
-      createdAt,
-      createdBy,
-      name,
-      projectType,
-      taskSizeMeters,
-      taskSizePixels,
-      aoi,
-      labelersTeamId,
-      validatorsTeamId,
-      projectId,
-      status,
-      taskStatusSummary,
-      campaignId,
-      capturedAt
-    )
+    def toProject =
+      AnnotationProject(
+        id,
+        createdAt,
+        createdBy,
+        name,
+        projectType,
+        taskSizeMeters,
+        taskSizePixels,
+        aoi,
+        labelersTeamId,
+        validatorsTeamId,
+        projectId,
+        status,
+        taskStatusSummary,
+        campaignId,
+        capturedAt
+      )
 
     def withSummary(
         labelClassSummary: List[AnnotationProject.LabelClassGroupSummary]
-    ) = AnnotationProject.WithRelatedAndLabelClassSummary(
-      id,
-      createdAt,
-      createdBy,
-      name,
-      projectType,
-      taskSizeMeters,
-      taskSizePixels,
-      aoi,
-      labelersTeamId,
-      validatorsTeamId,
-      projectId,
-      status,
-      tileLayers,
-      labelClassGroups,
-      taskStatusSummary,
-      labelClassSummary,
-      campaignId,
-      capturedAt
-    )
+    ) =
+      AnnotationProject.WithRelatedAndLabelClassSummary(
+        id,
+        createdAt,
+        createdBy,
+        name,
+        projectType,
+        taskSizeMeters,
+        taskSizePixels,
+        aoi,
+        labelersTeamId,
+        validatorsTeamId,
+        projectId,
+        status,
+        tileLayers,
+        labelClassGroups,
+        taskStatusSummary,
+        labelClassSummary,
+        campaignId,
+        capturedAt
+      )
   }
 
   object WithRelated {
@@ -179,7 +181,26 @@ object AnnotationProject {
       labelClassSummary: List[LabelClassGroupSummary],
       campaignId: Option[UUID] = None,
       capturedAt: Option[Timestamp] = None
-  )
+  ) {
+    def toProject =
+      AnnotationProject(
+        id,
+        createdAt,
+        createdBy,
+        name,
+        projectType,
+        taskSizeMeters,
+        taskSizePixels,
+        aoi,
+        labelersTeamId,
+        validatorsTeamId,
+        projectId,
+        status,
+        taskStatusSummary,
+        campaignId,
+        capturedAt
+      )
+  }
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary

--- a/app-backend/datamodel/src/main/scala/Campaign.scala
+++ b/app-backend/datamodel/src/main/scala/Campaign.scala
@@ -72,6 +72,7 @@ object Campaign {
 
   object Create {
     implicit val decCreate: Decoder[Create] = deriveDecoder
+    implicit val encCreate: Encoder[Create] = deriveEncoder
   }
 
   final case class Clone(

--- a/app-backend/project/Dependencies.scala
+++ b/app-backend/project/Dependencies.scala
@@ -41,7 +41,7 @@ object Version {
   val flyway = "6.0.8"
   val fs2 = "2.4.2"
   val fs2Cron = "0.2.2"
-  val geotrellis = "3.5.0"
+  val geotrellis = "3.5.1"
   val geotrellisServer = "4.1.0"
   val guava = "20.0"
   val hadoop = "2.8.4"


### PR DESCRIPTION
## Overview

This PR upgrades GeoTrellis to 3.5.1. This release has already been tested via a snapshot.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I'd push a test branch but staging is messy right now (or maybe not anymore?), so I think we should rely on the previous test with the snapshot

This PR also includes two small convenience fixes based on work in gkeeper -- namely, that `Campaign.Create`s don't have an encoder, and that there's no easy conversion from `AnnotationProjectWithRelatedAndLabelClassSummary` to `AnnotationProject`

## Testing Instructions

- trust the last test

Closes #5508 
