### PR TITLE
Add and test unlimited project / 10 campaign scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Simple shares don't always return 500 responses [#5510](https://github.com/raster-foundry/raster-foundry/pull/5510)
 - Upgraded GeoTrellis to remove seams for some zoom + extent + projection combinations [#5515](https://github.com/raster-foundry/raster-foundry/pull/5515)
 
+### Changed
+- Groundwork users can create unlimited annotation projects, but only 10 campaigns [#5516](https://github.com/raster-foundry/raster-foundry/pull/5516)
+
 ## [1.53.0] - 2020-11-16
 ### Added
 - Adding labels will now delete all prior labels first [#5512](https://github.com/raster-foundry/raster-foundry/pull/5512)

--- a/app-backend/datamodel/src/main/scala/Scope.scala
+++ b/app-backend/datamodel/src/main/scala/Scope.scala
@@ -49,31 +49,32 @@ object Domain {
   case object AnnotationProjects extends Domain("annotationProjects")
   case object Campaigns extends Domain("campaigns")
 
-  def fromStringTry(s: String): Try[Domain] = s match {
-    case "analyses"           => Success(Analyses)
-    case "annotationGroups"   => Success(AnnotationGroups)
-    case "annotationUploads"  => Success(AnnotationUploads)
-    case "datasources"        => Success(Datasources)
-    case "exports"            => Success(Exports)
-    case "featureFlags"       => Success(FeatureFlags)
-    case "licenses"           => Success(Licenses)
-    case "mapTokens"          => Success(MapTokens)
-    case "organizations"      => Success(Organizations)
-    case "platforms"          => Success(Platforms)
-    case "projects"           => Success(Projects)
-    case "scenes"             => Success(Scenes)
-    case "shapes"             => Success(Shapes)
-    case "stacExports"        => Success(StacExports)
-    case "teams"              => Success(Teams)
-    case "templates"          => Success(Templates)
-    case "thumbnails"         => Success(Thumbnails)
-    case "tokens"             => Success(Tokens)
-    case "uploads"            => Success(Uploads)
-    case "users"              => Success(Users)
-    case "annotationProjects" => Success(AnnotationProjects)
-    case "campaigns"          => Success(Campaigns)
-    case _                    => Failure(new Exception(s"Cannot parse Domain from string $s"))
-  }
+  def fromStringTry(s: String): Try[Domain] =
+    s match {
+      case "analyses"           => Success(Analyses)
+      case "annotationGroups"   => Success(AnnotationGroups)
+      case "annotationUploads"  => Success(AnnotationUploads)
+      case "datasources"        => Success(Datasources)
+      case "exports"            => Success(Exports)
+      case "featureFlags"       => Success(FeatureFlags)
+      case "licenses"           => Success(Licenses)
+      case "mapTokens"          => Success(MapTokens)
+      case "organizations"      => Success(Organizations)
+      case "platforms"          => Success(Platforms)
+      case "projects"           => Success(Projects)
+      case "scenes"             => Success(Scenes)
+      case "shapes"             => Success(Shapes)
+      case "stacExports"        => Success(StacExports)
+      case "teams"              => Success(Teams)
+      case "templates"          => Success(Templates)
+      case "thumbnails"         => Success(Thumbnails)
+      case "tokens"             => Success(Tokens)
+      case "uploads"            => Success(Uploads)
+      case "users"              => Success(Users)
+      case "annotationProjects" => Success(AnnotationProjects)
+      case "campaigns"          => Success(Campaigns)
+      case _                    => Failure(new Exception(s"Cannot parse Domain from string $s"))
+    }
 }
 
 sealed abstract class Action(repr: String) {
@@ -123,46 +124,47 @@ object Action {
   case object UpdateTasks extends Action("updateTasks")
   case object UpdateUserRole extends Action("updateUserRole")
 
-  def fromStringTry(s: String): Try[Action] = s match {
-    case "addScenes"            => Success(AddScenes)
-    case "addUser"              => Success(AddUser)
-    case "bulkCreate"           => Success(BulkCreate)
-    case "colorCorrect"         => Success(ColorCorrect)
-    case "clone"                => Success(Clone)
-    case "create"               => Success(Create)
-    case "createAnnotation"     => Success(CreateAnnotation)
-    case "createExport"         => Success(CreateExport)
-    case "createScopes"         => Success(CreateScopes)
-    case "createTaskGrid"       => Success(CreateTaskGrid)
-    case "createTasks"          => Success(CreateTasks)
-    case "delete"               => Success(Delete)
-    case "deleteAnnotation"     => Success(DeleteAnnotation)
-    case "deleteScopes"         => Success(DeleteScopes)
-    case "deleteTasks"          => Success(DeleteTasks)
-    case "download"             => Success(Download)
-    case "editScenes"           => Success(EditScenes)
-    case "listExports"          => Success(ListExports)
-    case "listUsers"            => Success(ListUsers)
-    case "read"                 => Success(Read)
-    case "readUsers"            => Success(ReadUsers)
-    case "readPermissions"      => Success(ReadPermissions)
-    case "readScopes"           => Success(ReadScopes)
-    case "readSelf"             => Success(ReadSelf)
-    case "readSentinelMetadata" => Success(ReadSentinelMetadata)
-    case "readTasks"            => Success(ReadTasks)
-    case "readThumbnail"        => Success(ReadThumbnail)
-    case "removeUser"           => Success(RemoveUser)
-    case "search"               => Success(Search)
-    case "share"                => Success(Share)
-    case "update"               => Success(Update)
-    case "updateAnnotation"     => Success(UpdateAnnotation)
-    case "updateDropbox"        => Success(UpdateDropbox)
-    case "updateScopes"         => Success(UpdateScopes)
-    case "updateSelf"           => Success(UpdateSelf)
-    case "updateTasks"          => Success(UpdateTasks)
-    case "updateUserRole"       => Success(UpdateUserRole)
-    case _                      => Failure(new Exception(s"Cannot parse Action from string $s"))
-  }
+  def fromStringTry(s: String): Try[Action] =
+    s match {
+      case "addScenes"            => Success(AddScenes)
+      case "addUser"              => Success(AddUser)
+      case "bulkCreate"           => Success(BulkCreate)
+      case "colorCorrect"         => Success(ColorCorrect)
+      case "clone"                => Success(Clone)
+      case "create"               => Success(Create)
+      case "createAnnotation"     => Success(CreateAnnotation)
+      case "createExport"         => Success(CreateExport)
+      case "createScopes"         => Success(CreateScopes)
+      case "createTaskGrid"       => Success(CreateTaskGrid)
+      case "createTasks"          => Success(CreateTasks)
+      case "delete"               => Success(Delete)
+      case "deleteAnnotation"     => Success(DeleteAnnotation)
+      case "deleteScopes"         => Success(DeleteScopes)
+      case "deleteTasks"          => Success(DeleteTasks)
+      case "download"             => Success(Download)
+      case "editScenes"           => Success(EditScenes)
+      case "listExports"          => Success(ListExports)
+      case "listUsers"            => Success(ListUsers)
+      case "read"                 => Success(Read)
+      case "readUsers"            => Success(ReadUsers)
+      case "readPermissions"      => Success(ReadPermissions)
+      case "readScopes"           => Success(ReadScopes)
+      case "readSelf"             => Success(ReadSelf)
+      case "readSentinelMetadata" => Success(ReadSentinelMetadata)
+      case "readTasks"            => Success(ReadTasks)
+      case "readThumbnail"        => Success(ReadThumbnail)
+      case "removeUser"           => Success(RemoveUser)
+      case "search"               => Success(Search)
+      case "share"                => Success(Share)
+      case "update"               => Success(Update)
+      case "updateAnnotation"     => Success(UpdateAnnotation)
+      case "updateDropbox"        => Success(UpdateDropbox)
+      case "updateScopes"         => Success(UpdateScopes)
+      case "updateSelf"           => Success(UpdateSelf)
+      case "updateTasks"          => Success(UpdateTasks)
+      case "updateUserRole"       => Success(UpdateUserRole)
+      case _                      => Failure(new Exception(s"Cannot parse Action from string $s"))
+    }
 }
 
 /** A ScopedAction is a combination of a domain, an action, and a limit.
@@ -262,47 +264,49 @@ object Scope {
   }
 
   implicit val encScope: Encoder[Scope] = new Encoder[Scope] {
-    def apply(thing: Scope): Json = thing match {
-      case Scopes.RasterFoundryOrganizationAdmin =>
-        Json.fromString("organizations:admin")
-      case Scopes.RasterFoundryUser =>
-        Json.fromString("platformUser")
-      case Scopes.GroundworkUser => Json.fromString("groundworkUser")
-      case Scopes.RasterFoundryPlatformAdmin =>
-        Json.fromString("platforms:admin")
-      case Scopes.RasterFoundryTeamsAdmin => Json.fromString("teams:admin")
-      case Scopes.AnnotateTasksScope      => Json.fromString("annotateTasks")
-      case SimpleScope(actions) =>
-        Json.fromString((actions map { action =>
-          action.repr
-        }).mkString(";"))
-      case ComplexScope(actions) =>
-        Json.fromString((actions map { action =>
-          action.repr
-        }).mkString(";"))
-    }
+    def apply(thing: Scope): Json =
+      thing match {
+        case Scopes.RasterFoundryOrganizationAdmin =>
+          Json.fromString("organizations:admin")
+        case Scopes.RasterFoundryUser =>
+          Json.fromString("platformUser")
+        case Scopes.GroundworkUser => Json.fromString("groundworkUser")
+        case Scopes.RasterFoundryPlatformAdmin =>
+          Json.fromString("platforms:admin")
+        case Scopes.RasterFoundryTeamsAdmin => Json.fromString("teams:admin")
+        case Scopes.AnnotateTasksScope      => Json.fromString("annotateTasks")
+        case SimpleScope(actions) =>
+          Json.fromString((actions map { action =>
+            action.repr
+          }).mkString(";"))
+        case ComplexScope(actions) =>
+          Json.fromString((actions map { action =>
+            action.repr
+          }).mkString(";"))
+      }
   }
 
   implicit val decScope: Decoder[Scope] = new Decoder[Scope] {
-    def apply(c: HCursor): Decoder.Result[Scope] = c.value.asString match {
-      case Some(s) =>
-        Scopes.cannedPolicyFromString(s).orElse {
-          s.split(";").toList match {
-            case List("") => Right(Monoid[Scope].empty)
-            case actions =>
-              Monoid[Either[Error, Scope]]
-                .combineAll(
-                  actions map { action =>
-                    (decode[ScopedAction](s""""$action"""") map { scopedAct =>
-                      new SimpleScope(Set(scopedAct))
-                    }).orElse(Scopes.cannedPolicyFromString(action))
-                  }
-                )
-                .leftMap(err => DecodingFailure(err.getMessage, Nil))
+    def apply(c: HCursor): Decoder.Result[Scope] =
+      c.value.asString match {
+        case Some(s) =>
+          Scopes.cannedPolicyFromString(s).orElse {
+            s.split(";").toList match {
+              case List("") => Right(Monoid[Scope].empty)
+              case actions =>
+                Monoid[Either[Error, Scope]]
+                  .combineAll(
+                    actions map { action =>
+                      (decode[ScopedAction](s""""$action"""") map { scopedAct =>
+                        new SimpleScope(Set(scopedAct))
+                      }).orElse(Scopes.cannedPolicyFromString(action))
+                    }
+                  )
+                  .leftMap(err => DecodingFailure(err.getMessage, Nil))
+            }
           }
-        }
-      case _ => Left(DecodingFailure("Scope", c.history))
-    }
+        case _ => Left(DecodingFailure("Scope", c.history))
+      }
   }
 }
 
@@ -330,18 +334,19 @@ object Scopes {
       }
     )
 
-  def cannedPolicyFromString(s: String): Either[Error, Scope] = s match {
-    case "organizations:admin" =>
-      Right(Scopes.RasterFoundryOrganizationAdmin)
-    case "platformUser"    => Right(Scopes.RasterFoundryUser)
-    case "groundworkUser"  => Right(Scopes.GroundworkUser)
-    case "platforms:admin" => Right(Scopes.RasterFoundryPlatformAdmin)
-    case "teams:admin"     => Right(Scopes.RasterFoundryTeamsAdmin)
-    case "annotateTasks"   => Right(Scopes.AnnotateTasksScope)
-    case _ =>
-      val message = s"$s is not a canned policy"
-      Left(ParsingFailure(message, new Exception(message)))
-  }
+  def cannedPolicyFromString(s: String): Either[Error, Scope] =
+    s match {
+      case "organizations:admin" =>
+        Right(Scopes.RasterFoundryOrganizationAdmin)
+      case "platformUser"    => Right(Scopes.RasterFoundryUser)
+      case "groundworkUser"  => Right(Scopes.GroundworkUser)
+      case "platforms:admin" => Right(Scopes.RasterFoundryPlatformAdmin)
+      case "teams:admin"     => Right(Scopes.RasterFoundryTeamsAdmin)
+      case "annotateTasks"   => Right(Scopes.AnnotateTasksScope)
+      case _ =>
+        val message = s"$s is not a canned policy"
+        Left(ParsingFailure(message, new Exception(message)))
+    }
 
   private def makeCRUDScopedActions(domain: Domain): Set[ScopedAction] =
     Set(
@@ -477,7 +482,9 @@ object Scopes {
 
   case object TeamsCRUD
       extends SimpleScope(
-        Set(ScopedAction(Domain.Teams, Action.ListUsers, None)) ++ makeCRUDScopedActions(
+        Set(
+          ScopedAction(Domain.Teams, Action.ListUsers, None)
+        ) ++ makeCRUDScopedActions(
           Domain.Teams
         )
       )
@@ -579,7 +586,7 @@ object Scopes {
           ScopedAction(
             Domain.AnnotationProjects,
             Action.Create,
-            Some(10.toLong)
+            None
           ),
           ScopedAction(Domain.AnnotationProjects, Action.Share, Some(5.toLong)),
           ScopedAction(Domain.Projects, Action.Create, None),

--- a/app-backend/datamodel/src/test/scala/ScopeSpec.scala
+++ b/app-backend/datamodel/src/test/scala/ScopeSpec.scala
@@ -5,8 +5,8 @@ import cats.kernel.laws.discipline.MonoidTests
 import io.circe.parser._
 import io.circe.testing.{ArbitraryInstances, CodecTests}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 class ScopeSpec
@@ -80,34 +80,35 @@ class ScopeSpec
       } yield ScopedAction(domain, action, limit)
     }
 
-  def cannedPolicyGen: Gen[Scope] = Gen.oneOf(
-    Scopes.AnalysesCRUD,
-    Scopes.AnnotationGroupsCRUD,
-    Scopes.AnnotationUploadsCRUD,
-    Scopes.DatasourcesCRUD,
-    Scopes.ExportsCRUD,
-    Scopes.FeatureFlagsScope,
-    Scopes.LicensesScope,
-    Scopes.MapTokensCRUD,
-    Scopes.OrganizationAdmin,
-    Scopes.OrganizationsMember,
-    Scopes.PlatformDomainAdminScope,
-    Scopes.PlatformDomainMemberScope,
-    Scopes.ProjectAnnotateScope,
-    Scopes.ProjectsCRUD,
-    Scopes.ShapesCRUD,
-    Scopes.StacExportsCRUD,
-    Scopes.ScenesCRUD,
-    Scopes.TeamsCRUD,
-    Scopes.TemplatesCRUD,
-    Scopes.UploadsCRUD,
-    Scopes.UsersAdminScope,
-    Scopes.UserSelfScope,
-    Scopes.RasterFoundryPlatformAdmin,
-    Scopes.RasterFoundryUser,
-    Scopes.RasterFoundryTeamsAdmin,
-    Scopes.RasterFoundryOrganizationAdmin
-  )
+  def cannedPolicyGen: Gen[Scope] =
+    Gen.oneOf(
+      Scopes.AnalysesCRUD,
+      Scopes.AnnotationGroupsCRUD,
+      Scopes.AnnotationUploadsCRUD,
+      Scopes.DatasourcesCRUD,
+      Scopes.ExportsCRUD,
+      Scopes.FeatureFlagsScope,
+      Scopes.LicensesScope,
+      Scopes.MapTokensCRUD,
+      Scopes.OrganizationAdmin,
+      Scopes.OrganizationsMember,
+      Scopes.PlatformDomainAdminScope,
+      Scopes.PlatformDomainMemberScope,
+      Scopes.ProjectAnnotateScope,
+      Scopes.ProjectsCRUD,
+      Scopes.ShapesCRUD,
+      Scopes.StacExportsCRUD,
+      Scopes.ScenesCRUD,
+      Scopes.TeamsCRUD,
+      Scopes.TemplatesCRUD,
+      Scopes.UploadsCRUD,
+      Scopes.UsersAdminScope,
+      Scopes.UserSelfScope,
+      Scopes.RasterFoundryPlatformAdmin,
+      Scopes.RasterFoundryUser,
+      Scopes.RasterFoundryTeamsAdmin,
+      Scopes.RasterFoundryOrganizationAdmin
+    )
 
   // Not separating out into a separate object until we have more than
   // one of these. I don't think for the most part we depend on laws holding,
@@ -147,7 +148,11 @@ class ScopeSpec
     val action2 = ScopedAction(Domain.Projects, Action.Create, Some(10L))
     assert(
       Scopes
-        .resolveFor(Domain.Projects, Action.Create, Set(action1, action2)) == Some(
+        .resolveFor(
+          Domain.Projects,
+          Action.Create,
+          Set(action1, action2)
+        ) == Some(
         action1
       )
     )
@@ -158,7 +163,11 @@ class ScopeSpec
     val action2 = ScopedAction(Domain.Projects, Action.Create, Some(10L))
     assert(
       Scopes
-        .resolveFor(Domain.Projects, Action.Create, Set(action1, action2)) == Some(
+        .resolveFor(
+          Domain.Projects,
+          Action.Create,
+          Set(action1, action2)
+        ) == Some(
         action2
       )
     )
@@ -167,5 +176,29 @@ class ScopeSpec
   test("action resolution should not resolve missing actions") {
     val action = ScopedAction(Domain.Projects, Action.Create, Some(5L))
     assert(Scopes.resolveFor(Domain.Scenes, Action.Create, Set(action)).isEmpty)
+  }
+
+  test("Groundwork users can create 10 campaigns") {
+    assert(
+      Scopes
+        .resolveFor(
+          Domain.Campaigns,
+          Action.Create,
+          Scopes.GroundworkUser.actions
+        )
+        .flatMap(_.limit) == Some(10L)
+    )
+  }
+
+  test("Groundwork users can create unlimited annotation projects") {
+    assert(
+      Scopes
+        .resolveFor(
+          Domain.AnnotationProjects,
+          Action.Create,
+          Scopes.GroundworkUser.actions
+        )
+        .flatMap(_.limit) == None
+    )
   }
 }


### PR DESCRIPTION
## Overview

This PR updates Groundwork user scopes so that annotation project creation is unlimited and campaign creation has a limit of 10 campaigns. It also adds unit tests expressing this expectation.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- Run tests

Closes raster-foundry/groundwork#1136
