### PR TITLE
Add TaskSession data model and basic endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 - Added rewrite for tile requests prefixed with `/tiles/` [#5527](https://github.com/raster-foundry/raster-foundry/pull/5527)
+- Add TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)
 
 ## [1.55.0] - 2020-12-03
 ### Added

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -225,3 +225,8 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/share,campaigns:share,post
 /api/campaigns/{campaignId}/share,campaigns:share,get
 /api/campaigns/{campaignId}/share/{userId},campaigns:read,delete
+/api/tasks/{taskId}/sessions,annotationProjects:readTasks,get
+/api/tasks/{taskId}/sessions,annotationProjects:createAnnotation,post
+/api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get
+/api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
+/api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -11,6 +11,7 @@ import akka.http.scaladsl.server._
 import cats.implicits._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
+import doobie.postgres.implicits._
 
 import scala.util.{Failure, Success}
 
@@ -28,43 +29,302 @@ trait TaskRoutes
       pathEndOrSingleSlash {
         get { listTasks }
       }
-    }
-  }
-
-  def listTasks: Route = authenticate { user =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
-      user
-    ) {
-      (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
-        'annotationProjectId.as[UUID].?
-      )) { (page, annotationProjectParams, taskParams, annotationProjectId) =>
-        onComplete {
-          (for {
-            annotationProjects <- AnnotationProjectDao
-              .authQuery(user, ObjectType.AnnotationProject, None, None, None)
-              .filter(annotationProjectParams)
-              .filter(annotationProjectId)
-              .list(page.limit) map { projects =>
-              projects map { _.id }
+    } ~ pathPrefix(JavaUUID) { taskId =>
+      {
+        pathPrefix("sessions") {
+          pathEndOrSingleSlash {
+            post {
+              createTaskSession(taskId)
+            } ~ get {
+              listTaskSessions(taskId)
             }
-            taskO <- annotationProjects.toNel traverse { projectIds =>
-              TaskDao
-                .randomTask(taskParams, projectIds)
+          } ~ pathPrefix(JavaUUID) { sessionId =>
+            {
+              pathEndOrSingleSlash {
+                get {
+                  getTaskSession(taskId, sessionId)
+                }
+              } ~ pathPrefix("keep-alive") {
+                put {
+                  keepSessionAlive(taskId, sessionId)
+                }
+              } ~ pathPrefix("complete") {
+                put {
+                  completeSession(taskId, sessionId)
+                }
+              }
             }
-          } yield {
-            taskO.flatten
-          }).transact(xa).unsafeToFuture
-        } {
-          case Success(Some(task)) =>
-            complete { task }
-          case Success(None) =>
-            complete { HttpResponse(StatusCodes.OK) }
-          case Failure(e) =>
-            logger.error(e.getMessage)
-            complete { HttpResponse(StatusCodes.BadRequest) }
+          }
         }
       }
     }
   }
+
+  def listTasks: Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+        user
+      ) {
+        (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
+          'annotationProjectId.as[UUID].?
+        )) { (page, annotationProjectParams, taskParams, annotationProjectId) =>
+          onComplete {
+            (for {
+              annotationProjects <- AnnotationProjectDao
+                .authQuery(
+                  user,
+                  ObjectType.AnnotationProject,
+                  None,
+                  None,
+                  None
+                )
+                .filter(annotationProjectParams)
+                .filter(annotationProjectId)
+                .list(page.limit) map { projects =>
+                projects map { _.id }
+              }
+              taskO <- annotationProjects.toNel traverse { projectIds =>
+                TaskDao
+                  .randomTask(taskParams, projectIds)
+              }
+            } yield {
+              taskO.flatten
+            }).transact(xa).unsafeToFuture
+          } {
+            case Success(Some(task)) =>
+              complete { task }
+            case Success(None) =>
+              complete { HttpResponse(StatusCodes.OK) }
+            case Failure(e) =>
+              logger.error(e.getMessage)
+              complete { HttpResponse(StatusCodes.BadRequest) }
+          }
+        }
+      }
+    }
+
+  // To create a task session:
+  // - the user needs to have access to the annotation project or campaign
+  // - there should be no active sessions on the task
+  // - the session type should match the current task status
+  def createTaskSession(taskId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authorized(
+              taskId,
+              user,
+              ActionType.Annotate
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[TaskSession.Create]) { taskSessionCreate =>
+            onComplete {
+              (for {
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
+                hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
+                  taskId,
+                  taskSessionCreate.sessionType
+                )
+              } yield (!hasActiveSession, hasValidStatus))
+                .transact(xa)
+                .unsafeToFuture
+
+            } {
+              case Success((true, true)) =>
+                complete {
+                  TaskSessionDao
+                    .insert(taskSessionCreate, user, taskId)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+              case Success((false, _)) =>
+                complete { StatusCodes.Conflict -> "ACTIVE_SESSION_EXISTS" }
+              case Success((_, false)) =>
+                complete { StatusCodes.BadRequest -> "STATUS_MISMATCH" }
+              case _ => complete { HttpResponse(StatusCodes.BadRequest) }
+            }
+          }
+        }
+      }
+    }
+
+  def listTaskSessions(taskId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authorized(
+              taskId,
+              user,
+              ActionType.View
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          (withPagination) { page =>
+            complete {
+              TaskSessionDao.query
+                .filter(fr"task_id = ${taskId}")
+                .page(page)
+                .transact(xa)
+                .unsafeToFuture()
+            }
+          }
+        }
+      }
+    }
+
+  def getTaskSession(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authorized(
+              taskId,
+              user,
+              ActionType.View
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          rejectEmptyResponse {
+            complete {
+              TaskSessionDao
+                .getTaskSessionById(sessionId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+      }
+    }
+
+  def keepSessionAlive(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          (
+            TaskSessionDao
+              .authorized(
+                taskId,
+                user,
+                ActionType.Annotate
+              ),
+            TaskSessionDao.isOwner(taskId, sessionId, user)
+          ).tupled
+            .map({ authed =>
+              authed._1 && authed._2
+            })
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onComplete {
+            TaskSessionDao
+              .isSessionActive(sessionId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            case Success(true) =>
+              complete {
+                TaskSessionDao
+                  .keepTaskSessionAlive(sessionId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            case Success(false) =>
+              complete { StatusCodes.Conflict -> "SESSION_EXPIRED" }
+            case _ =>
+              complete { HttpResponse(StatusCodes.BadRequest) }
+
+          }
+        }
+      }
+    }
+
+  def completeSession(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          (
+            TaskSessionDao
+              .authorized(
+                taskId,
+                user,
+                ActionType.Annotate
+              ),
+            TaskSessionDao.isOwner(taskId, sessionId, user)
+          ).tupled
+            .map({ authed =>
+              authed._1 && authed._2
+            })
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[TaskSession.Complete]) { taskSessionComplete =>
+            {
+              onComplete {
+                (for {
+                  isActive <- TaskSessionDao.isSessionActive(sessionId)
+                  hasValidStatus <- TaskSessionDao.isToStatusMatchTaskSession(
+                    sessionId,
+                    taskSessionComplete.toStatus
+                  )
+                } yield (isActive, hasValidStatus)).transact(xa).unsafeToFuture
+              } {
+                case Success((true, true)) =>
+                  complete {
+                    (for {
+                      _ <- TaskSessionDao.completeTaskSession(
+                        sessionId,
+                        taskSessionComplete
+                      )
+                      taskOpt <- TaskDao.getTaskById(taskId)
+                      rowCount <- taskOpt traverse { task =>
+                        val taskToUpdate = Task.TaskFeatureCreate(
+                          properties = Task.TaskPropertiesCreate(
+                            status = taskSessionComplete.toStatus,
+                            annotationProjectId = task.annotationProjectId,
+                            note = taskSessionComplete.note,
+                            taskType = Some(task.taskType),
+                            parentTaskId = task.parentTaskId,
+                            reviews = Some(task.reviews)
+                          ),
+                          geometry = task.geometry
+                        )
+                        TaskDao.updateTask(taskId, taskToUpdate, user)
+                      }
+                    } yield rowCount).transact(xa).unsafeToFuture
+                  }
+                case Success((false, _)) =>
+                  complete { StatusCodes.Conflict -> "SESSION_EXPIRED" }
+                case Success((_, false)) =>
+                  complete { StatusCodes.BadRequest -> "STATUS_MISMATCH" }
+                case _ =>
+                  complete { HttpResponse(StatusCodes.BadRequest) }
+              }
+            }
+          }
+        }
+      }
+    }
 }

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -115,3 +115,8 @@ statusReaping {
   advisoryLockConstant = 1
   advisoryLockConstant = ${?DB_TASK_STATUS_ADVISORY_LOCK_CONSTANT}
 }
+
+taskSessionTtl {
+  taskSessionTtlSeconds = 300
+  taskSessionTtlSeconds = ${?DB_TASK_SESSION_TTL_SECONDS}
+}

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1171,6 +1171,27 @@ object Generators extends ArbitraryInstances {
       arbitrary[Boolean]
     ).mapN(Campaign.Clone.apply _)
 
+  private def taskSessionCreateGen: Gen[TaskSession.Create] =
+    for {
+      taskSessionType <- Gen.oneOf(
+        TaskSessionType.LabelSession,
+        TaskSessionType.ValidateSession
+      )
+    } yield TaskSession.Create(
+      taskSessionType
+    )
+
+  private def taskSessionCompleteGen: Gen[TaskSession.Complete] =
+    for {
+      toStatus <- taskStatusGen
+      note <- nonEmptyStringGen map { s =>
+        Some(NonEmptyString.unsafeFrom(s))
+      }
+    } yield TaskSession.Complete(
+      toStatus,
+      note
+    )
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] =
       Arbitrary {
@@ -1469,6 +1490,16 @@ object Generators extends ArbitraryInstances {
     implicit def arbCampaignClone: Arbitrary[Campaign.Clone] =
       Arbitrary {
         campaignCloneGen
+      }
+
+    implicit def arbTaskSessionCreate: Arbitrary[TaskSession.Create] =
+      Arbitrary {
+        taskSessionCreateGen
+      }
+
+    implicit def arbTaskSessionComplete: Arbitrary[TaskSession.Complete] =
+      Arbitrary {
+        taskSessionCompleteGen
       }
 
   }

--- a/app-backend/datamodel/src/main/scala/TaskSession.scala
+++ b/app-backend/datamodel/src/main/scala/TaskSession.scala
@@ -1,0 +1,47 @@
+package com.rasterfoundry.datamodel
+
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe._
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.refined._
+
+import java.sql.Timestamp
+import java.util.UUID
+
+final case class TaskSession(
+    id: UUID,
+    createdAt: Timestamp,
+    lastTickAt: Timestamp,
+    completedAt: Option[Timestamp],
+    fromStatus: TaskStatus,
+    toStatus: Option[TaskStatus],
+    sessionType: TaskSessionType,
+    userId: String,
+    taskId: UUID,
+    note: Option[String]
+)
+
+object TaskSession {
+  implicit val encTaskSession: Encoder[TaskSession] = deriveEncoder
+  implicit val decTaskSession: Decoder[TaskSession] = deriveDecoder
+
+  final case class Create(
+      sessionType: TaskSessionType
+  )
+
+  object Create {
+    implicit val decCreate: Decoder[Create] = deriveDecoder
+    implicit val encCreate: Encoder[Create] = deriveEncoder
+  }
+
+  final case class Complete(
+      toStatus: TaskStatus,
+      note: Option[NonEmptyString]
+  )
+
+  object Complete {
+    implicit val decComplete: Decoder[Complete] = deriveDecoder
+    implicit val encComplete: Encoder[Complete] = deriveEncoder
+  }
+
+}

--- a/app-backend/datamodel/src/main/scala/TaskSessionType.scala
+++ b/app-backend/datamodel/src/main/scala/TaskSessionType.scala
@@ -1,0 +1,27 @@
+package com.rasterfoundry.datamodel
+
+import cats.implicits._
+import io.circe._
+
+sealed abstract class TaskSessionType(val repr: String) {
+  override def toString = repr
+}
+
+object TaskSessionType {
+  case object LabelSession extends TaskSessionType("LABEL_SESSION")
+  case object ValidateSession extends TaskSessionType("VALIDATE_SESSION")
+
+  def fromString(s: String): TaskSessionType =
+    s.toUpperCase match {
+      case "LABEL_SESSION"    => LabelSession
+      case "VALIDATE_SESSION" => ValidateSession
+    }
+
+  implicit val taskSessionEncoder: Encoder[TaskSessionType] =
+    Encoder.encodeString.contramap[TaskSessionType](_.toString)
+
+  implicit val taskSessionDecoder: Decoder[TaskSessionType] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(fromString(str)).leftMap(_ => "TaskSessionType")
+    }
+}

--- a/app-backend/db/src/main/resources/migrations/V67__Add_task_session.sql
+++ b/app-backend/db/src/main/resources/migrations/V67__Add_task_session.sql
@@ -1,0 +1,20 @@
+CREATE TYPE task_session_type AS ENUM (
+    'LABEL_SESSION', 'VALIDATE_SESSION'
+);
+
+CREATE TABLE public.task_sessions (
+    id uuid primary key,
+    created_at timestamp without time zone NOT NULL,
+    last_tick_at timestamp without time zone NOT NULL,
+    completed_at timestamp without time zone,
+    from_status task_status NOT NULL,
+    to_status task_status,
+    session_type task_session_type NOT NULL,
+    user_id text references users (id) ON DELETE CASCADE NOT NULL,
+    task_id uuid references tasks (id) ON DELETE CASCADE NOT NULL,
+    note text
+);
+
+CREATE INDEX IF NOT EXISTS task_sessions_last_tick_at_completed_at_idx ON public.task_sessions USING btree (last_tick_at, completed_at);
+CREATE INDEX IF NOT EXISTS task_sessions_task_id_idx ON public.task_sessions USING btree (task_id);
+CREATE INDEX IF NOT EXISTS task_sessions_user_id_idx ON public.task_sessions USING btree (user_id);

--- a/app-backend/db/src/main/scala/Config.scala
+++ b/app-backend/db/src/main/scala/Config.scala
@@ -42,4 +42,10 @@ object Config {
       UUID.fromString(auth0Config.getString("defaultOrganizationId"))
     val systemUser = auth0Config.getString("systemUser")
   }
+
+  object taskSessionTtlConfig {
+    private val taskSessionTtlConfig = config.getConfig("taskSessionTtl")
+    val taskSessionTtlSeconds =
+      taskSessionTtlConfig.getInt("taskSessionTtlSeconds")
+  }
 }

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -1,0 +1,234 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.database.Config.taskSessionTtlConfig
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.datamodel.TaskSessionType.LabelSession
+import com.rasterfoundry.datamodel.TaskSessionType.ValidateSession
+import com.rasterfoundry.datamodel._
+
+import cats.Applicative
+import cats.implicits._
+import doobie._
+import doobie.implicits._
+import doobie.implicits.javasql._
+import doobie.postgres.implicits._
+
+import java.util.UUID
+
+object TaskSessionDao extends Dao[TaskSession] {
+
+  val tableName = "task_sessions"
+
+  override val fieldNames = List(
+    "id",
+    "created_at",
+    "last_tick_at",
+    "completed_at",
+    "from_status",
+    "to_status",
+    "session_type",
+    "user_id",
+    "task_id",
+    "note"
+  )
+
+  def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
+
+  def getTaskSessionById(
+      id: UUID
+  ): ConnectionIO[Option[TaskSession]] =
+    query.filter(id).selectOption
+
+  def unsafeGetTaskSessionById(
+      id: UUID
+  ): ConnectionIO[TaskSession] =
+    query.filter(id).select
+
+  def insertTaskSession(
+      taskSessionCreate: TaskSession.Create,
+      user: User,
+      fromStatus: TaskStatus,
+      taskId: UUID
+  ): ConnectionIO[TaskSession] =
+    (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+      fr"""VALUES
+      (uuid_generate_v4(), now(), now(), NULL, ${fromStatus}, NULL, ${taskSessionCreate.sessionType},
+       ${user.id}, ${taskId}, NULL)
+    """).update.withUniqueGeneratedKeys[TaskSession](
+      fieldNames: _*
+    )
+
+  def insert(
+      taskSessionCreate: TaskSession.Create,
+      user: User,
+      taskId: UUID
+  ): ConnectionIO[Option[TaskSession]] =
+    TaskDao
+      .getTaskById(taskId)
+      .flatMap(taskOpt =>
+        taskOpt traverse { task =>
+          TaskSessionDao.insertTaskSession(
+            taskSessionCreate,
+            user,
+            task.status,
+            taskId
+          )
+      })
+
+  def keepTaskSessionAlive(id: UUID): ConnectionIO[Int] =
+    (fr"UPDATE " ++ tableF ++ fr"""SET
+      last_tick_at = now()
+    WHERE
+      id = $id
+    """).update.run;
+
+  def completeTaskSession(
+      id: UUID,
+      taskSessionComplete: TaskSession.Complete
+  ): ConnectionIO[Int] = {
+    val noteUpdateF = taskSessionComplete.note match {
+      case Some(note) => fr"note = ${note.toString},"
+      case _          => fr""
+    }
+    (fr"UPDATE " ++ tableF ++ fr"SET" ++ noteUpdateF ++ fr"""
+      to_status = ${taskSessionComplete.toStatus},
+      completed_at = now()
+      WHERE
+        id = ${id}
+    """).update.run;
+  }
+
+  def hasActiveSessionByTaskId(taskId: UUID): ConnectionIO[Boolean] =
+    query
+      .filter(fr"task_id = ${taskId}")
+      .filter(fr"completed_at is NULL")
+      .filter(
+        Fragment.const(
+          s"last_tick_at + INTERVAL '${taskSessionTtlConfig.taskSessionTtlSeconds} seconds' > now()"
+        )
+      )
+      .exists
+
+  def isSessionTypeMatchTaskStatus(
+      taskId: UUID,
+      sessionType: TaskSessionType
+  ): ConnectionIO[Boolean] =
+    for {
+      taskOpt <- TaskDao.getTaskById(taskId)
+      isMatch <- taskOpt traverse { task =>
+        if (task.status == TaskStatus.Invalid || task.status == TaskStatus.Split) {
+          Applicative[ConnectionIO].pure(false)
+        } else {
+          sessionType match {
+            case TaskSessionType.LabelSession =>
+              Applicative[ConnectionIO].pure(
+                task.status == TaskStatus.Unlabeled ||
+                  task.status == TaskStatus.LabelingInProgress ||
+                  task.status == TaskStatus.Labeled ||
+                  task.status == TaskStatus.Flagged
+              )
+            case TaskSessionType.ValidateSession =>
+              Applicative[ConnectionIO].pure(
+                task.status == TaskStatus.Labeled ||
+                  task.status == TaskStatus.ValidationInProgress ||
+                  task.status == TaskStatus.Validated ||
+                  task.status == TaskStatus.Flagged
+              )
+          }
+        }
+      }
+    } yield {
+      isMatch match {
+        case Some(result) => result
+        case _            => false
+      }
+    }
+
+  def isToStatusMatchTaskSession(
+      id: UUID,
+      toStatus: TaskStatus
+  ): ConnectionIO[Boolean] =
+    for {
+      sessionOpt <- getTaskSessionById(id)
+      isMatch <- sessionOpt traverse { session =>
+        session.sessionType match {
+          case LabelSession =>
+            Applicative[ConnectionIO].pure(
+              toStatus == TaskStatus.Unlabeled ||
+                toStatus == TaskStatus.Split ||
+                toStatus == TaskStatus.Flagged ||
+                toStatus == TaskStatus.Labeled
+            )
+
+          case ValidateSession =>
+            Applicative[ConnectionIO].pure(
+              toStatus == TaskStatus.Labeled ||
+                toStatus == TaskStatus.Validated ||
+                toStatus == TaskStatus.Flagged ||
+                toStatus == TaskStatus.Invalid
+            )
+        }
+      }
+    } yield {
+      isMatch match {
+        case Some(result) => result
+        case _            => false
+      }
+    }
+
+  def authorized(
+      taskId: UUID,
+      user: User,
+      actionType: ActionType
+  ): ConnectionIO[Boolean] =
+    for {
+      taskOpt <- TaskDao.getTaskById(taskId)
+      projectOpt <- taskOpt flatTraverse { task =>
+        AnnotationProjectDao.getById(task.annotationProjectId)
+      }
+      authProject <- taskOpt traverse { task =>
+        AnnotationProjectDao.authorized(
+          user,
+          ObjectType.AnnotationProject,
+          task.annotationProjectId,
+          actionType
+        )
+      }
+      authCampaign <- (projectOpt flatTraverse { project =>
+        project.campaignId traverse { campaignId =>
+          CampaignDao
+            .authorized(user, ObjectType.Campaign, campaignId, actionType)
+        }
+      })
+    } yield {
+      (authProject, authCampaign) match {
+        case (Some(authedProject), None)  => authedProject.toBoolean
+        case (None, Some(authedCampaign)) => authedCampaign.toBoolean
+        case (Some(authedProject), Some(authedCampaign)) =>
+          authedProject.toBoolean && authedCampaign.toBoolean
+        case _ => false
+      }
+    }
+
+  def isOwner(
+      taskId: UUID,
+      sessionID: UUID,
+      user: User
+  ): ConnectionIO[Boolean] =
+    query
+      .filter(fr"user_id = ${user.id}")
+      .filter(fr"task_id = ${taskId}")
+      .filter(fr"id = ${sessionID}")
+      .exists
+
+  def isSessionActive(sessionId: UUID): ConnectionIO[Boolean] =
+    query
+      .filter(fr"id = ${sessionId}")
+      .filter(fr"completed_at is NULL")
+      .filter(
+        Fragment.const(
+          s"last_tick_at + INTERVAL '${taskSessionTtlConfig.taskSessionTtlSeconds} seconds' > now()"
+        )
+      )
+      .exists
+}

--- a/app-backend/db/src/main/scala/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/meta/EnumMeta.scala
@@ -127,4 +127,7 @@ trait EnumMeta {
       TaskReviewStatus.fromString,
       _.repr
     )
+
+  implicit val taskSessionTypeMeta: Meta[TaskSessionType] =
+    pgEnumString("task_session_type", TaskSessionType.fromString, _.repr)
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskSessionDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskSessionDaoSpec.scala
@@ -1,0 +1,386 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.common.Generators.Implicits._
+import com.rasterfoundry.datamodel._
+import com.rasterfoundry.database.Implicits._
+
+import cats.implicits._
+import doobie.implicits._
+import doobie.postgres.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
+
+import java.util.UUID
+
+class TaskSessionDaoSpec
+    extends AnyFunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+  def customTaskSessionIO(
+      taskSessionCreate: TaskSession.Create,
+      user: User,
+      fromStatus: TaskStatus,
+      taskId: UUID
+  ) =
+    (fr"""
+      INSERT INTO task_sessions VALUES
+        (uuid_generate_v4(), now(), now() - INTERVAL '10 min', NULL, ${fromStatus}, NULL, ${taskSessionCreate.sessionType},
+        ${user.id}, ${taskId})""").update.withUniqueGeneratedKeys[UUID]("id")
+
+  test("insert a task session") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
+        ) => {
+          val tfcFirstTaskOnly = taskFeaturesCreate.copy(
+            features = taskFeaturesCreate.features.take(1)
+          )
+          val insertIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbAnnotationProj <-
+              AnnotationProjectDao
+                .insert(
+                  annotationProjectCreate.copy(projectId = None),
+                  dbUser
+                )
+            Task.TaskFeatureCollection(_, features) <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                tfcFirstTaskOnly,
+                dbAnnotationProj
+              ),
+              dbUser
+            )
+            firstTask = features.headOption
+            dbTaskSession <- firstTask traverse { task =>
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  dbUser,
+                  task.properties.status,
+                  task.id
+                )
+            }
+          } yield (dbTaskSession, firstTask, dbUser)
+
+          val (taskSessionOpt, firstTaskOpt, user) =
+            insertIO.transact(xa).unsafeRunSync
+
+          val sessionAndTaskOpt = (taskSessionOpt, firstTaskOpt).tupled
+
+          assert(
+            sessionAndTaskOpt match {
+              case Some((session, task)) =>
+                session.taskId == task.id &&
+                  session.userId == user.id &&
+                  session.completedAt == None &&
+                  session.fromStatus == task.properties.status &&
+                  session.toStatus == None &&
+                  session.sessionType == taskSessionCreate.sessionType
+              case _ => true
+            },
+            "Task session insert works"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("get a task session by id") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
+        ) => {
+          val tfcFirstTaskOnly = taskFeaturesCreate.copy(
+            features = taskFeaturesCreate.features.take(1)
+          )
+          val fetchIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbAnnotationProj <-
+              AnnotationProjectDao
+                .insert(
+                  annotationProjectCreate.copy(projectId = None),
+                  dbUser
+                )
+            Task.TaskFeatureCollection(_, features) <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                tfcFirstTaskOnly,
+                dbAnnotationProj
+              ),
+              dbUser
+            )
+            firstTask = features.headOption
+            dbTaskSession <- firstTask traverse { task =>
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  dbUser,
+                  task.properties.status,
+                  task.id
+                )
+            }
+            fetched <- dbTaskSession flatTraverse { session =>
+              TaskSessionDao.getTaskSessionById(session.id)
+            }
+          } yield (dbTaskSession, fetched)
+
+          val (taskSessionInsertedOpt, taskSessionFetchedOpt) =
+            fetchIO.transact(xa).unsafeRunSync
+
+          val insertedAndFetchedOpt =
+            (taskSessionInsertedOpt, taskSessionFetchedOpt).tupled
+
+          assert(
+            insertedAndFetchedOpt match {
+              case Some((inserted, fetched)) =>
+                inserted == fetched
+              case _ => true
+            },
+            "Task session fetch works"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("keep a session alive") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
+        ) => {
+          val tfcFirstTaskOnly = taskFeaturesCreate.copy(
+            features = taskFeaturesCreate.features.take(1)
+          )
+          val aliveIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbAnnotationProj <-
+              AnnotationProjectDao
+                .insert(
+                  annotationProjectCreate.copy(projectId = None),
+                  dbUser
+                )
+            Task.TaskFeatureCollection(_, features) <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                tfcFirstTaskOnly,
+                dbAnnotationProj
+              ),
+              dbUser
+            )
+            firstTask = features.headOption
+            dbTaskSessionId <- firstTask traverse { task =>
+              customTaskSessionIO(
+                taskSessionCreate,
+                dbUser,
+                task.properties.status,
+                task.id
+              )
+            }
+            almostDead <- dbTaskSessionId flatTraverse { sessionId =>
+              TaskSessionDao.getTaskSessionById(sessionId)
+            }
+            _ <- dbTaskSessionId traverse { sessionId =>
+              TaskSessionDao.keepTaskSessionAlive(sessionId)
+            }
+            reborn <- dbTaskSessionId flatTraverse { sessionId =>
+              TaskSessionDao.getTaskSessionById(sessionId)
+            }
+          } yield (almostDead, reborn)
+
+          val (almostDeadSession, rebornSession) =
+            aliveIO.transact(xa).unsafeRunSync
+
+          val eternalityOpt =
+            (almostDeadSession, rebornSession).tupled
+
+          assert(
+            eternalityOpt match {
+              case Some((dead, alive)) =>
+                dead.lastTickAt != alive.lastTickAt
+              case _ => true
+            },
+            "Task session can be kept alive"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("complete a task session") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create,
+            taskSessionComplete: TaskSession.Complete
+        ) => {
+          val tfcFirstTaskOnly = taskFeaturesCreate.copy(
+            features = taskFeaturesCreate.features.take(1)
+          )
+          val completeIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbAnnotationProj <-
+              AnnotationProjectDao
+                .insert(
+                  annotationProjectCreate.copy(projectId = None),
+                  dbUser
+                )
+            Task.TaskFeatureCollection(_, features) <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                tfcFirstTaskOnly,
+                dbAnnotationProj
+              ),
+              dbUser
+            )
+            firstTask = features.headOption
+            dbTaskSession <- firstTask traverse { task =>
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  dbUser,
+                  task.properties.status,
+                  task.id
+                )
+            }
+            _ <- dbTaskSession traverse { session =>
+              TaskSessionDao.completeTaskSession(
+                session.id,
+                taskSessionComplete
+              )
+            }
+            completed <- dbTaskSession flatTraverse { session =>
+              TaskSessionDao.getTaskSessionById(session.id)
+            }
+          } yield completed
+
+          val completedSessionOpt = completeIO.transact(xa).unsafeRunSync
+
+          assert(
+            completedSessionOpt match {
+              case Some(completedSession) =>
+                completedSession.completedAt != None &&
+                  completedSession.toStatus == Some(
+                    taskSessionComplete.toStatus
+                  ) &&
+                  completedSession.note == taskSessionComplete.note.map(
+                    _.toString
+                  )
+              case _ => true
+            },
+            "Task session can be kept alive"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("check active session") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            annotationProjectCreate: AnnotationProject.Create,
+            taskFeaturesCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create,
+            taskSessionComplete: TaskSession.Complete
+        ) => {
+          val tfcFirstTaskOnly = taskFeaturesCreate.copy(
+            features = taskFeaturesCreate.features.take(1)
+          )
+          val activeIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbAnnotationProj <-
+              AnnotationProjectDao
+                .insert(
+                  annotationProjectCreate.copy(projectId = None),
+                  dbUser
+                )
+            Task.TaskFeatureCollection(_, features) <- TaskDao.insertTasks(
+              fixupTaskFeaturesCollection(
+                tfcFirstTaskOnly,
+                dbAnnotationProj
+              ),
+              dbUser
+            )
+            firstTask = features.headOption
+            dbTaskSessionId <- firstTask traverse { task =>
+              customTaskSessionIO(
+                taskSessionCreate,
+                dbUser,
+                task.properties.status,
+                task.id
+              )
+            }
+            // the custom session's last tick was 10 minutes ago, it is not an active one anymore
+            isActiveSessionOne <- firstTask traverse { task =>
+              TaskSessionDao.hasActiveSessionByTaskId(task.id)
+            }
+            // now we update the session's last tick at by keeping it alive
+            _ <- dbTaskSessionId traverse { sessionId =>
+              TaskSessionDao.keepTaskSessionAlive(sessionId)
+            }
+            // the session now should have a more recent last tick at, and it is not complete yet
+            isActiveSessionTwo <- firstTask traverse { task =>
+              TaskSessionDao.hasActiveSessionByTaskId(task.id)
+            }
+            // now we complete the session
+            _ <- dbTaskSessionId traverse { sessionId =>
+              TaskSessionDao.completeTaskSession(
+                sessionId,
+                taskSessionComplete
+              )
+            }
+            // the session now should be complete
+            isActiveSessionThree <- firstTask traverse { task =>
+              TaskSessionDao.hasActiveSessionByTaskId(task.id)
+            }
+          } yield (isActiveSessionOne, isActiveSessionTwo, isActiveSessionThree)
+
+          val (
+            isActiveSessionOneOpt,
+            isActiveSessionTwoOpt,
+            isActiveSessionThreeOpt
+          ) =
+            activeIO.transact(xa).unsafeRunSync
+
+          val tuped = (
+            isActiveSessionOneOpt,
+            isActiveSessionTwoOpt,
+            isActiveSessionThreeOpt
+          ).tupled
+
+          assert(
+            tuped match {
+              case Some((one, two, three)) =>
+                one == false && two == true && three == false
+              case _ => true
+            },
+            "Task session can be kept alive"
+          )
+          true
+        }
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR adds the following for task sessions
- [X] migration
- [X] data model
- [X] dao methods for insert, get, keep alive, complete
- [X] dao method tests
- [x] api

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions
- Assemble backend, run migration, spin up frontend and backend, grab a token
- From the DB, grab a task's ID that has `UNLABELED` status
- Create a task session:
```
curl --location --request POST 'http://localhost:9091/api/tasks/<task_id>/sessions' \
--header 'Authorization: Bearer <your_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "sessionType": "LABEL_SESSION"
}'
```
- List task sessions for this task
```
curl --location --request GET 'http://localhost:9091/api/tasks/<task_id>/sessions' \
--header 'Authorization: Bearer <your_token>' \
```
- Get details of a session:
```
curl --location --request GET 'http://localhost:9091/api/tasks/<task_id>/sessions/<session_id>' \
--header 'Authorization: Bearer <your_token>' \
```
- Keep the session alive -- get the session again, and make sure that the `last_tick_at` field is updated:
```
curl --location --request PUT 'http://localhost:9091/api/tasks/<task_id>/sessions/<session_id>/keep-alive' \
--header 'Authorization: Bearer <your_token>' \
```
- Complete a session -- get the session again, and make sure that the `completed_at` field and the `to_status` field are updated:
```
curl --location --request PUT 'http://localhost:9091/api/tasks/<task_id>/sessions/<session_id>/complete' \
--header 'Authorization: Bearer <your_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "toStatus": "LABELED"
}'
```
- New property tests should pass. Make sure the test cases make sense to you

Closes https://github.com/raster-foundry/groundwork/issues/1142
