### PR TITLE
Update Unlocking Behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Tasks can be unlocked by users other than the user who locked them [#5514](https://github.com/raster-foundry/raster-foundry/pull/5514)
 - Made python Upload datamodel aware of campaign ID [#5513](https://github.com/raster-foundry/raster-foundry/pull/5513)
+- Fixed advisory lock behavior and also fixed unlocking to skip from statuses that are the same [#5523](https://github.com/raster-foundry/raster-foundry/pull/5523)
 
 ### Changed
 - Groundwork users can create unlimited annotation projects, but only 10 campaigns [#5516](https://github.com/raster-foundry/raster-foundry/pull/5516)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -154,7 +154,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
 
   private val statusExpirationDuration =
     statusReapingConfig.taskStatusExpirationSeconds.seconds
-  private val everyMinute = Cron.unsafeParse("0 * * ? * *")
+  private val everyMinute = Cron.unsafeParse("0 */5 * ? * *")
   val scheduled: fs2.Stream[IO, Either[Unit, Int]] = awakeEveryCron[IO](
     everyMinute
   ) *> (fs2.Stream

--- a/app-backend/common/src/main/resources/reference.conf
+++ b/app-backend/common/src/main/resources/reference.conf
@@ -111,4 +111,7 @@ sceneSearch {
 statusReaping {
   taskStatusExpirationSeconds = 3600
   taskStatusExpirationSeconds = ${?DB_TASK_STATUS_EXPIRATION_SECONDS}
+
+  advisoryLockConstant = 1
+  advisoryLockConstant = ${?DB_TASK_STATUS_ADVISORY_LOCK_CONSTANT}
 }

--- a/app-backend/db/src/main/scala/Config.scala
+++ b/app-backend/db/src/main/scala/Config.scala
@@ -30,6 +30,8 @@ object Config {
     private val statusReapingConfig = config.getConfig("statusReaping")
     val taskStatusExpirationSeconds =
       statusReapingConfig.getInt("taskStatusExpirationSeconds")
+    val advisoryLockConstant =
+      statusReapingConfig.getInt("advisoryLockConstant")
   }
 
   object auth0Config {

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -1,5 +1,6 @@
 package com.rasterfoundry.database
 
+import com.rasterfoundry.database.Config.statusReapingConfig
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.datamodel.GeoJsonCodec.PaginatedGeoJsonResponse
 import com.rasterfoundry.datamodel.Task.TaskPropertiesCreate
@@ -743,54 +744,66 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       case status => (status, Option.empty[NonEmptyString]).pure[ConnectionIO]
     }
 
-  def expireStuckTasks(taskExpiration: FiniteDuration): ConnectionIO[Int] =
-    for {
-      _ <- info("Expiring stuck tasks")
-      _ <- fr"""select pg_advisory_lock(max(floor(EXTRACT(EPOCH FROM unlocked_time))) :: integer) from last_unlocked""".query.unique.void
-      defaultUser <- UserDao.unsafeGetUserById("default")
-      stuckLockedTasks <- query
-        .filter(
-          fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-        )
-        .list
-      stuckUnlockedTasks <- query
-        .filter(
-          fr"""
+  def expireStuckTasks(taskExpiration: FiniteDuration): ConnectionIO[Int] = {
+    val lockAcquiredBoolean =
+      fr"select pg_try_advisory_xact_lock(${statusReapingConfig.advisoryLockConstant})"
+        .query[Boolean]
+        .unique
+
+    lockAcquiredBoolean.flatMap {
+      case false =>
+        for {
+          _ <- info("Skipping unlocking stuck tasks - could not acquire lock")
+        } yield 0
+      case true =>
+        for {
+          _ <- info("Expiring stuck tasks")
+          defaultUser <- UserDao.unsafeGetUserById("default")
+          stuckLockedTasks <- query
+            .filter(
+              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+            )
+            .list
+          stuckUnlockedTasks <- query
+            .filter(
+              fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
-        )
-        .list
-      _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-        projectIdsList =>
-          val projectIdsSet = projectIdsList.toNes
-          warn(
-            s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
-          )
-      }
-      _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
-        regressTaskStatus(task.id, task.status) flatMap {
-          case (newStatus, newNote) =>
-            val update =
-              Task.TaskFeatureCreate(
-                TaskPropertiesCreate(
-                  newStatus,
-                  task.annotationProjectId,
-                  newNote,
-                  Some(task.taskType),
-                  task.parentTaskId,
-                  Some(task.reviews),
-                  task.reviewStatus
-                ),
-                task.geometry
+            )
+            .list
+          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+            projectIdsList =>
+              val projectIdsSet = projectIdsList.toNes
+              warn(
+                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-            updateTask(task.id, update, defaultUser) <* unlockTask(task.id)
-        }
-      }
-      _ <- fr"""update last_unlocked set unlocked_time = ${Timestamp.from(
-        Instant.now
-      )}""".update.run
-    } yield (stuckLockedTasks.length + stuckUnlockedTasks.length)
+          }
+          _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
+            regressTaskStatus(task.id, task.status) flatMap {
+              case (newStatus, newNote) =>
+                val update =
+                  Task.TaskFeatureCreate(
+                    TaskPropertiesCreate(
+                      newStatus,
+                      task.annotationProjectId,
+                      newNote,
+                      Some(task.taskType),
+                      task.parentTaskId,
+                      Some(task.reviews),
+                      task.reviewStatus
+                    ),
+                    task.geometry
+                  )
+                updateTask(task.id, update, defaultUser) <* unlockTask(task.id)
+            }
+          }
+          _ <- fr"""update last_unlocked set unlocked_time = ${Timestamp.from(
+            Instant.now
+          )}""".update.run
+        } yield (stuckLockedTasks.length + stuckUnlockedTasks.length)
+    }
+  }
 
   def randomTask(
       queryParams: TaskQueryParameters,


### PR DESCRIPTION
## Overview

Two things were causing the task unlocking to behave abnormally:
 - the way we were getting the advisory lock meant that sometimes a transaction could be waiting on a lock almost indefinitely
 - the task unlocker failed when the "from status" of the most recent task action was the same as the current status when labeling/validating in progress

To fix the lock acquiring we switched to a `pg_try_advisory_xact_lock` which attempts to get a lock, if it can't then it returns false and the rest of the unlocking is skipped. If it can acquire a lock then it holds the lock until the transaction is complete.

To fix the "from status" issue we filter out previous actions where the from status was equal.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

Tested in staging
