### PR TITLE
Support random task session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,5 @@ app-lambda/opt/*
 # Typescript stubs from panrec
 stubs/
 *.semanticdb
+
+.prettierignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)
+- Support fetching random task session [#5525](https://github.com/raster-foundry/raster-foundry/pull/5525)
 
 ## [1.56.0] - 2020-12-04
 ### Added
 - Added rewrite for tile requests prefixed with `/tiles/` [#5527](https://github.com/raster-foundry/raster-foundry/pull/5527)
-- Add TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)
-- Support fetching random task session [#5525](https://github.com/raster-foundry/raster-foundry/pull/5525)
 
 ## [1.55.0] - 2020-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added rewrite for tile requests prefixed with `/tiles/` [#5527](https://github.com/raster-foundry/raster-foundry/pull/5527)
 - Add TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)
+- Support fetching random task session [#5525](https://github.com/raster-foundry/raster-foundry/pull/5525)
 
 ## [1.55.0] - 2020-12-03
 ### Added

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -230,4 +230,4 @@ Path,Domain:Action,Verb
 /api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
 /api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put
-/api/tasks/random-session,annotationProjects:readTasks,get
+/api/tasks/random-session,annotationProjects:readTasks,post

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -230,4 +230,4 @@ Path,Domain:Action,Verb
 /api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
 /api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put
-/api/tasks/random-session,annotationProjects:readTasks,post
+/api/tasks/session,annotationProjects:readTasks,post

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -230,3 +230,4 @@ Path,Domain:Action,Verb
 /api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
 /api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put
+/api/tasks/sessions/random,annotationProjects:readTasks,get

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -230,4 +230,4 @@ Path,Domain:Action,Verb
 /api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
 /api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put
-/api/tasks/sessions/random,annotationProjects:readTasks,get
+/api/tasks/random-session,annotationProjects:readTasks,get

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -57,7 +57,7 @@ trait TaskRoutes
           }
         }
       }
-    } ~ pathPrefix("random-session") {
+    } ~ pathPrefix("session") {
       pathEndOrSingleSlash {
         post { randomTaskSession }
       }

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -59,7 +59,7 @@ trait TaskRoutes
       }
     } ~ pathPrefix("random-session") {
       pathEndOrSingleSlash {
-        get { randomTaskSession }
+        post { randomTaskSession }
       }
     }
   }
@@ -121,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
+                hasActiveSession <-
+                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -121,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <-
-                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -57,15 +57,10 @@ trait TaskRoutes
           }
         }
       }
-    } ~ pathPrefix("sessions") {
+    } ~ pathPrefix("random-session") {
       pathEndOrSingleSlash {
-        pathPrefix("random") {
-          pathEndOrSingleSlash {
-            get { randomTaskSession }
-          }
-        }
+        get { randomTaskSession }
       }
-
     }
   }
 
@@ -126,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
+                hasActiveSession <-
+                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType
@@ -352,7 +347,9 @@ trait TaskRoutes
               case Success(Some(session)) =>
                 complete { session }
               case Success(None) =>
-                complete { HttpResponse(StatusCodes.OK) }
+                complete {
+                  StatusCodes.BadRequest -> "No matching task to create a session for"
+                }
               case Failure(e) =>
                 logger.error(e.getMessage)
                 complete { HttpResponse(StatusCodes.BadRequest) }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -518,4 +518,15 @@ trait PropTestHelpers {
       case TaskStatus.Invalid              => TaskStatus.Unlabeled
       case TaskStatus.Split                => TaskStatus.Invalid
     }
+
+  def customTaskSessionIO(
+      taskSessionCreate: TaskSession.Create,
+      user: User,
+      fromStatus: TaskStatus,
+      taskId: UUID
+  ) =
+    (fr"""
+      INSERT INTO task_sessions VALUES
+        (uuid_generate_v4(), now(), now() - INTERVAL '10 min', NULL, ${fromStatus}, NULL, ${taskSessionCreate.sessionType},
+        ${user.id}, ${taskId})""").update.withUniqueGeneratedKeys[UUID]("id")
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskSessionDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskSessionDaoSpec.scala
@@ -2,17 +2,13 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.common.Generators.Implicits._
 import com.rasterfoundry.datamodel._
-import com.rasterfoundry.database.Implicits._
 
 import cats.implicits._
 import doobie.implicits._
-import doobie.postgres.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
-
-import java.util.UUID
 
 class TaskSessionDaoSpec
     extends AnyFunSuite
@@ -20,17 +16,6 @@ class TaskSessionDaoSpec
     with Checkers
     with DBTestConfig
     with PropTestHelpers {
-  def customTaskSessionIO(
-      taskSessionCreate: TaskSession.Create,
-      user: User,
-      fromStatus: TaskStatus,
-      taskId: UUID
-  ) =
-    (fr"""
-      INSERT INTO task_sessions VALUES
-        (uuid_generate_v4(), now(), now() - INTERVAL '10 min', NULL, ${fromStatus}, NULL, ${taskSessionCreate.sessionType},
-        ${user.id}, ${taskId})""").update.withUniqueGeneratedKeys[UUID]("id")
-
   test("insert a task session") {
     check {
       forAll(


### PR DESCRIPTION
## Overview

This PR adds an endpoint for getting a random task session with the same QPs on the previous random task endpoint.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- Run migrations, assemble apis, spin up server, grab a token
- Grab an annotation project id

**START OF ATTENTION: `curl` command updated**
- Replace the `<id>` and `<token>` in the following. It should return a random task's session:
```
curl --location --request GET 'http://localhost:9091/api/tasks/random-session?status=UNLABELED&annotationProjectId=<annotation project ID>' \
--header 'Authorization: Bearer <your token>'
```
**END OF ATTENTION: `curl` command updated**

- Look at the new property test. Make sure it makes sense to you. Make sure the property tests pass.
- Bonus point: in an annotation project, make it so that only one task can be requested (e.g. only one task is unlabeled when you request unlabeled tasks; only one task has no active session, etc.). Then make sure that making the above call works as expected

Closes https://github.com/raster-foundry/groundwork/issues/1144
