### PR TITLE
Add rewrite for `/tiles/` prefixed tile requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added rewrite for tile requests prefixed with `/tiles/` [#5527](https://github.com/raster-foundry/raster-foundry/pull/5527)
 
 ## [1.55.0] - 2020-12-03
 ### Added

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/RequestRewriteMiddleware.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/RequestRewriteMiddleware.scala
@@ -13,15 +13,37 @@ import org.http4s.dsl.io._
 import java.util.UUID
 
 object RequestRewriteMiddleware {
-  private def getDefaultLayerId(projectId: UUID,
-                                xa: Transactor[IO]): OptionT[IO, UUID] =
+  private def getDefaultLayerId(
+      projectId: UUID,
+      xa: Transactor[IO]
+  ): OptionT[IO, UUID] =
     OptionT { ProjectDao.getProjectById(projectId).transact(xa) } map {
       _.defaultLayerId
     }
 
+  private def rewrite(
+      req: Request[IO],
+      projectId: UUID,
+      z: Int,
+      x: Int,
+      y: Int,
+      service: HttpRoutes[IO],
+      xa: Transactor[IO]
+  ) = {
+    for {
+      defaultLayerId <- getDefaultLayerId(projectId, xa)
+      resp <- service(
+        req.withPathInfo(
+          s"/${projectId}/layers/${defaultLayerId}/${z}/${x}/${y}"
+        )
+      )
+    } yield resp
+  }
+
   def apply(
       service: HttpRoutes[IO],
-      xa: Transactor[IO]): Kleisli[OptionT[IO, ?], Request[IO], Response[IO]] =
+      xa: Transactor[IO]
+  ): Kleisli[OptionT[IO, ?], Request[IO], Response[IO]] =
     Kleisli { req: Request[IO] =>
       {
         // match on the request here and route to the service if it matches the deprecated route
@@ -29,19 +51,18 @@ object RequestRewriteMiddleware {
         // Due to middleware application order, we have to strip a trailing slash here
         if (req.pathInfo.charAt(req.pathInfo.length - 1) == '/') {
           apply(service, xa)(
-            req.withPathInfo(
-              req.pathInfo.substring(0, req.pathInfo.length - 1)))
+            req.withPathInfo(req.pathInfo.substring(0, req.pathInfo.length - 1))
+          )
         } else if (scriptName.isEmpty) {
           req match {
-            case GET -> Root / UUIDWrapper(projectId) / IntVar(z) / IntVar(x) / IntVar(
-                  y) =>
-              for {
-                defaultLayerId <- getDefaultLayerId(projectId, xa)
-                resp <- service(
-                  req.withPathInfo(
-                    s"/${projectId}/layers/${defaultLayerId}/${z}/${x}/${y}"))
-              } yield resp
-
+            case GET -> Root / "tiles" / UUIDWrapper(projectId) / IntVar(
+                  z
+                ) / IntVar(x) / IntVar(y) =>
+              rewrite(req, projectId, z, x, y, service, xa)
+            case GET -> Root / UUIDWrapper(projectId) / IntVar(z) / IntVar(
+                  x
+                ) / IntVar(y) =>
+              rewrite(req, projectId, z, x, y, service, xa)
             case GET -> Root / UUIDWrapper(projectId) / "histogram" =>
               for {
                 defaultLayerId <- getDefaultLayerId(projectId, xa)

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/RequestRewriteMiddleware.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/RequestRewriteMiddleware.scala
@@ -40,6 +40,7 @@ object RequestRewriteMiddleware {
     } yield resp
   }
 
+  @SuppressWarnings(Array("RepeatedCaseBody"))
   def apply(
       service: HttpRoutes[IO],
       xa: Transactor[IO]


### PR DESCRIPTION
## Overview

This used to be in nginx, but we stopped deploying the
nginx sidecar container recently and this needs to happen
in application code now.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

See that the same tile loads either with or without the tiles prefix
![tiles-rewrite](https://user-images.githubusercontent.com/898060/101203441-a8068480-3638-11eb-8dc5-829b4bf49df0.gif)

## Testing Instructions

- see demo