### PR TITLE
Include more label MVT fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Add TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)
 - Support fetching random task session [#5525](https://github.com/raster-foundry/raster-foundry/pull/5525)
-
-### Added
 - Added TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)
 - Added CRUD endpoints for annotation project label class groups and label classses [#5526](https://github.com/raster-foundry/raster-foundry/pull/5526)
+- Added additional fields to the labels MVT endpoint [#5530](https://github.com/raster-foundry/raster-foundry/pull/5530)
 
 ## [1.56.0] - 2020-12-04
 ### Added

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1101,16 +1101,14 @@ object Generators extends ArbitraryInstances {
           LabelGeomType.PolygonLabel
         )
       ),
-      Gen.option(nonEmptyStringGen),
-      arbitrary[Boolean]
+      Gen.option(nonEmptyStringGen)
     ).mapN(AnnotationLabelClass.Create.apply _)
 
   private def labelClassGroupGen: Gen[AnnotationLabelClassGroup.Create] =
     (
       nonEmptyStringGen,
       Gen.option(Gen.choose(0, 1000)),
-      Gen.listOfN(1, labelClassCreateGen),
-      arbitrary[Boolean]
+      Gen.listOfN(1, labelClassCreateGen)
     ).mapN(AnnotationLabelClassGroup.Create.apply _)
 
   private def annotationProjectCreateGen: Gen[AnnotationProject.Create] =
@@ -1504,8 +1502,11 @@ object Generators extends ArbitraryInstances {
         taskSessionCompleteGen
       }
 
-    implicit def arbLabelClassCreate: Arbitrary[AnnotationLabelClass.Create] = Arbitrary { labelClassCreateGen }
+    implicit def arbLabelClassCreate: Arbitrary[AnnotationLabelClass.Create] =
+      Arbitrary { labelClassCreateGen }
 
-    implicit  def arbLabelClassGroup: Arbitrary[AnnotationLabelClassGroup.Create] = Arbitrary{ labelClassGroupGen }
+    implicit def arbLabelClassGroup
+        : Arbitrary[AnnotationLabelClassGroup.Create] =
+      Arbitrary { labelClassGroupGen }
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationLabelClass.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabelClass.scala
@@ -31,8 +31,7 @@ object AnnotationLabelClass {
       determinant: Option[Boolean],
       index: Int,
       geometryType: Option[LabelGeomType] = None,
-      description: Option[String] = None,
-      isActive: Boolean = true
+      description: Option[String] = None
   )
 
   object Create {

--- a/app-backend/datamodel/src/main/scala/AnnotationLabelClassGroup.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabelClassGroup.scala
@@ -29,20 +29,19 @@ final case class AnnotationLabelClassGroup(
 
 object AnnotationLabelClassGroup {
   implicit val encAnnotationLabelClassGroup
-    : Encoder[AnnotationLabelClassGroup] = deriveEncoder
+      : Encoder[AnnotationLabelClassGroup] = deriveEncoder
   implicit val decAnnotationLabelClassGroup
-    : Decoder[AnnotationLabelClassGroup] = deriveDecoder
+      : Decoder[AnnotationLabelClassGroup] = deriveDecoder
 
   final case class Create(
       name: String,
       index: Option[Int],
-      classes: List[AnnotationLabelClass.Create],
-      isActive: Boolean = true
+      classes: List[AnnotationLabelClass.Create]
   )
 
   object Create {
     implicit val decAnnotationLabelClassGroupCreate
-      : Decoder[AnnotationLabelClassGroup.Create] = deriveDecoder
+        : Decoder[AnnotationLabelClassGroup.Create] = deriveDecoder
   }
 
   final case class WithLabelClasses(

--- a/app-backend/datamodel/src/main/scala/AnnotationLabelClassGroup.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabelClassGroup.scala
@@ -29,9 +29,9 @@ final case class AnnotationLabelClassGroup(
 
 object AnnotationLabelClassGroup {
   implicit val encAnnotationLabelClassGroup
-      : Encoder[AnnotationLabelClassGroup] = deriveEncoder
+    : Encoder[AnnotationLabelClassGroup] = deriveEncoder
   implicit val decAnnotationLabelClassGroup
-      : Decoder[AnnotationLabelClassGroup] = deriveDecoder
+    : Decoder[AnnotationLabelClassGroup] = deriveDecoder
 
   final case class Create(
       name: String,
@@ -41,7 +41,7 @@ object AnnotationLabelClassGroup {
 
   object Create {
     implicit val decAnnotationLabelClassGroupCreate
-        : Decoder[AnnotationLabelClassGroup.Create] = deriveDecoder
+      : Decoder[AnnotationLabelClassGroup.Create] = deriveDecoder
   }
 
   final case class WithLabelClasses(

--- a/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
@@ -34,12 +34,13 @@ object AnnotationLabelClassDao extends Dao[AnnotationLabelClass] {
       parent: Option[AnnotationLabelClass]
   ): ConnectionIO[AnnotationLabelClass] =
     for {
-      newLabelClass <- (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
-        fr"""VALUES (
+      newLabelClass <-
+        (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+          fr"""VALUES (
         uuid_generate_v4(), ${classCreate.name}, ${annotationLabelGroup.id},
         ${classCreate.colorHexCode}, ${classCreate.default}, ${classCreate.determinant},
         ${classCreate.index}, ${classCreate.geometryType}, ${classCreate.description},
-        ${classCreate.isActive}
+        true
       )""").update.withUniqueGeneratedKeys[AnnotationLabelClass](fieldNames: _*)
       _ <- parent traverse { parentClass =>
         fr"INSERT INTO label_class_history VALUES (${parentClass.id}, ${newLabelClass.id})".update.run

--- a/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassDao.scala
@@ -34,9 +34,8 @@ object AnnotationLabelClassDao extends Dao[AnnotationLabelClass] {
       parent: Option[AnnotationLabelClass]
   ): ConnectionIO[AnnotationLabelClass] =
     for {
-      newLabelClass <-
-        (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
-          fr"""VALUES (
+      newLabelClass <- (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+        fr"""VALUES (
         uuid_generate_v4(), ${classCreate.name}, ${annotationLabelGroup.id},
         ${classCreate.colorHexCode}, ${classCreate.default}, ${classCreate.determinant},
         ${classCreate.index}, ${classCreate.geometryType}, ${classCreate.description},

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -62,6 +62,8 @@ object MVTLayerDao {
             join_table_join.geometry,
             ST_TileEnvelope(${z},${x},${y})
           ) AS geom,
+          join_table_join.annotation_task_id,
+          annotation_label_classes.id as label_class_id,
           annotation_label_classes.name,
           annotation_label_classes.color_hex_code
         FROM

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassDaoSpec.scala
@@ -70,8 +70,7 @@ class AnnotationLabelClassDaoSpec
                 alc.determinant,
                 alc.index,
                 alc.geometryType,
-                alc.description,
-                alc.isActive
+                alc.description
               )
             )
             .toSet
@@ -134,8 +133,7 @@ class AnnotationLabelClassDaoSpec
                   alc.determinant,
                   alc.index,
                   alc.geometryType,
-                  alc.description,
-                  alc.isActive
+                  alc.description
                 )
               )
 
@@ -176,8 +174,7 @@ class AnnotationLabelClassDaoSpec
             determinant = annotationLabelClassCreate.determinant,
             index = annotationLabelClassCreate.index,
             geometryType = annotationLabelClassCreate.geometryType,
-            description = annotationLabelClassCreate.description,
-            isActive = annotationLabelClassCreate.isActive
+            description = annotationLabelClassCreate.description
           )
           val updateIO = for {
             user <- UserDao.create(userCreate)

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassGroupDaoSpec.scala
@@ -115,8 +115,7 @@ class AnnotationLabelClassGroupDaoSpec
             name = labelClassGroupCreate.name,
             annotationProjectId = None,
             campaignId = None,
-            index = labelClassGroupCreate.index.getOrElse(0),
-            isActive = labelClassGroupCreate.isActive
+            index = labelClassGroupCreate.index.getOrElse(0)
           )
           val updateIO = for {
             user <- UserDao.create(userCreate)


### PR DESCRIPTION
## Overview

This PR does two things:
- adds `annotation_task_id` and `label_class_id` to the MVT data for labels
- removes `isActive` from the create case classes for label classes and groups

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- This will be best tested by an accompanying PR