### PR TITLE
Always authorize annotation projects via campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Removed
 - Remove Nginx configuration and containers for Backsplash [#5532](https://github.com/raster-foundry/raster-foundry/pull/5532)
 
+### Changed
+- Annotation projects can always be authorized from their parent campaign [#5536](ttps://github.com/raster-foundry/raster-foundry/pull/5536)
+
 ## [1.57.0] - 2020-12-16
 ### Added
 - Add TaskSession data model and basic endpoints [#5522](https://github.com/raster-foundry/raster-foundry/pull/5522)

--- a/app-backend/datamodel/src/main/scala/AuthResult.scala
+++ b/app-backend/datamodel/src/main/scala/AuthResult.scala
@@ -1,5 +1,9 @@
 package com.rasterfoundry.datamodel
 
+import cats.{Applicative, Functor}
+import cats.syntax.applicative._
+import cats.syntax.functor._
+
 sealed trait AuthResult[T] {
   def toBoolean: Boolean
 }
@@ -15,8 +19,31 @@ case class AuthFailure[T]() extends AuthResult[T] {
 }
 
 object AuthResult {
-  def fromOption[T](src: Option[T]): AuthResult[T] = src match {
-    case Some(v) => AuthSuccess(v)
-    case _       => AuthFailure()
-  }
+  def fromOption[T](src: Option[T]): AuthResult[T] =
+    src match {
+      case Some(v) => AuthSuccess(v)
+      case _       => AuthFailure()
+    }
+
+  def combine[T](x: AuthResult[T], y: AuthResult[T]): AuthResult[T] =
+    (x, y) match {
+      case (succ @ AuthSuccess(_), _) => succ
+      case (_, succ @ AuthSuccess(_)) => succ
+      case _                          => AuthFailure()
+    }
+
+  def success[F[_]: Applicative, T](v: T): F[AuthResult[T]] =
+    AuthSuccess(v).pure[F].widen
+
+  def failed[F[_]: Applicative, T]: F[AuthResult[T]] =
+    AuthFailure[T]().pure[F].widen
+
+  implicit val functorAuthResult: Functor[AuthResult] =
+    new Functor[AuthResult] {
+      def map[A, B](fa: AuthResult[A])(f: A => B): AuthResult[B] =
+        fa match {
+          case AuthSuccess(v) => AuthSuccess(f(v))
+          case AuthFailure()  => AuthFailure()
+        }
+    }
 }

--- a/app-backend/datamodel/src/main/scala/AuthResult.scala
+++ b/app-backend/datamodel/src/main/scala/AuthResult.scala
@@ -1,8 +1,8 @@
 package com.rasterfoundry.datamodel
 
-import cats.{Applicative, Functor}
 import cats.syntax.applicative._
 import cats.syntax.functor._
+import cats.{Applicative, Functor}
 
 sealed trait AuthResult[T] {
   def toBoolean: Boolean

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -73,17 +73,51 @@ object AnnotationProjectDao
         )
     }
 
+  private def projectAuthorized(
+      user: User,
+      objectType: ObjectType,
+      projectId: UUID,
+      actionType: ActionType
+  ) =
+    this.query
+      .filter(authorizedF(user, objectType, actionType))
+      .filter(projectId)
+      .selectOption
+      .map(AuthResult.fromOption _)
+
+  private def campaignAuthorized(
+      user: User,
+      projectId: UUID,
+      actionType: ActionType
+  ): ConnectionIO[AuthResult[AnnotationProject]] =
+    getById(projectId) flatMap {
+      case Some(project) =>
+        project.campaignId traverse { campaignId =>
+          CampaignDao.authorized(
+            user,
+            ObjectType.Campaign,
+            campaignId,
+            actionType
+          )
+        } map {
+          case Some(result) => result map { _ => project }
+          case None         => AuthFailure()
+        }
+      case _ => AuthResult.failed[ConnectionIO, AnnotationProject]
+    }
+
   def authorized(
       user: User,
       objectType: ObjectType,
       objectId: UUID,
       actionType: ActionType
   ): ConnectionIO[AuthResult[AnnotationProject]] =
-    this.query
-      .filter(authorizedF(user, objectType, actionType))
-      .filter(objectId)
-      .selectOption
-      .map(AuthResult.fromOption _)
+    (
+      projectAuthorized(user, objectType, objectId, actionType),
+      campaignAuthorized(user, objectId, actionType)
+    ).mapN(
+      AuthResult.combine
+    )
 
   def getProjectById(
       annotationProjectId: UUID
@@ -168,15 +202,16 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-        case (classGroup, idx) =>
-          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-            classGroup,
-            Some(annotationProject),
-            None,
-            idx
-          )
-      }
+      labelClassGroups <-
+        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+          case (classGroup, idx) =>
+            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+              classGroup,
+              Some(annotationProject),
+              None,
+              idx
+            )
+        }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -192,8 +227,9 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <- AnnotationLabelClassGroupDao
-        .listByProjectId(id)
+      labelClassGroup <-
+        AnnotationLabelClassGroupDao
+          .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -331,11 +367,12 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <- (fr"select id from " ++ Fragment.const(
-        tableName
-      ) ++ fr" where owner = $userId")
-        .query[UUID]
-        .to[List]
+      projectIds <-
+        (fr"select id from " ++ Fragment.const(
+          tableName
+        ) ++ fr" where owner = $userId")
+          .query[UUID]
+          .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -362,14 +399,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(
-              classes =>
-                LabelClass(
-                  LabelClassName.VectorName(group.name),
-                  LabelClassClasses.NamedLabelClasses(
-                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                  )
-              ))
+            .map(classes =>
+              LabelClass(
+                LabelClassName.VectorName(group.name),
+                LabelClassClasses.NamedLabelClasses(
+                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                )
+              )
+            )
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -392,9 +429,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Annotate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -402,9 +439,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Validate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -455,37 +492,40 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <- insertQuery.update
-        .withUniqueGeneratedKeys[AnnotationProject](
-          fieldNames: _*
-        )
+      annotationProjectCopy <-
+        insertQuery.update
+          .withUniqueGeneratedKeys[AnnotationProject](
+            fieldNames: _*
+          )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <- AnnotationLabelClassDao
-            .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <- AnnotationLabelClassGroupDao
-            .insertAnnotationLabelClassGroup(
-              AnnotationLabelClassGroup.Create(
-                classGroup.name,
-                Some(classGroup.index),
-                labelClasses.map { labelClass =>
-                  AnnotationLabelClass.Create(
-                    labelClass.name,
-                    labelClass.colorHexCode,
-                    labelClass.default,
-                    labelClass.determinant,
-                    labelClass.index,
-                    labelClass.geometryType,
-                    labelClass.description
-                  )
-                }
-              ),
-              Some(annotationProjectCopy),
-              None,
-              0,
-              labelClasses
-            )
+          labelClasses <-
+            AnnotationLabelClassDao
+              .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <-
+            AnnotationLabelClassGroupDao
+              .insertAnnotationLabelClassGroup(
+                AnnotationLabelClassGroup.Create(
+                  classGroup.name,
+                  Some(classGroup.index),
+                  labelClasses.map { labelClass =>
+                    AnnotationLabelClass.Create(
+                      labelClass.name,
+                      labelClass.colorHexCode,
+                      labelClass.default,
+                      labelClass.determinant,
+                      labelClass.index,
+                      labelClass.geometryType,
+                      labelClass.description
+                    )
+                  }
+                ),
+                Some(annotationProjectCopy),
+                None,
+                0,
+                labelClasses
+              )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -516,20 +556,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())(
-            (acc, userId) =>
-              acc ++ List(
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.View
-                ),
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.Annotate
-                )
-            ))
+          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
+            acc ++ List(
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.View
+              ),
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.Annotate
+              )
+            )
+          )
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules


### PR DESCRIPTION
## Overview

This PR makes it so that the default `.authorize` function on annotation projects uses campaign authorization if the project is in a campaign.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

It's pushed as a `test/` branch -- you can see that it's working if you load up the deploy preview for https://github.com/raster-foundry/groundwork/pull/1195 and look at one of the multi-image campaigns. All the `/actions` requests are successful, while on `develop`, they all fail

## Testing Instructions

(as long as 
- load up the deploy preview for the linked Groundwork PR above
- open your network tab
- navigate to a multi-image campaign
- all the `/actions` requests should be successful
- load up the single image campaign
- you should be able to see the MVT layers

Closes raster-foundry/groundwork#1155