### PR TITLE
Cover all the bases on random task project listing and actions requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Remove Nginx configuration and containers for Backsplash [#5532](https://github.com/raster-foundry/raster-foundry/pull/5532)
 
 ### Changed
-- Annotation projects can always be authorized from their parent campaign [#5536](ttps://github.com/raster-foundry/raster-foundry/pull/5536)
+- Annotation projects can always be authorized from their parent campaign [#5536](ttps://github.com/raster-foundry/raster-foundry/pull/5536), [#5537](https://github.com/raster-foundry/raster-foundry/pull/5537)
 - Render label MVTs in the tile server instead of in the database [#5538](https://github.com/raster-foundry/raster-foundry/pull/5538)
 
 ## [1.57.0] - 2020-12-16

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -398,8 +398,7 @@ trait AnnotationProjectRoutes
                 } yield {
                   println(s"Campaign actions: ${campaignActions}")
                   (projectActions ++ campaignActions)
-                }).transact(xa)
-                  .unsafeToFuture
+                }).transact(xa).unsafeToFuture
               }
           }
         }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -1034,20 +1034,19 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <-
-        AnnotationProjectDao
-          .authQuery(
-            user,
-            ObjectType.AnnotationProject,
-            None,
-            None,
-            None
-          )
-          .filter(annotationProjectParams)
-          .filter(annotationProjectIdOpt)
-          .list(limit) map { projects =>
-          projects map { _.id }
-        }
+      annotationProjectIds <- AnnotationProjectDao
+        .authQuery(
+          user,
+          ObjectType.AnnotationProject,
+          None,
+          None,
+          None
+        )
+        .filter(annotationProjectParams)
+        .filter(annotationProjectIdOpt)
+        .list(limit) map { projects =>
+        projects map { _.id }
+      }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1088,10 +1087,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case None => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <-
-        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-          projectIds =>
-            randomTask(taskParams, projectIds)
-        }
+      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+        projectIds =>
+          randomTask(taskParams, projectIds)
+      }
     } yield taskOpt
 }


### PR DESCRIPTION
## Overview

This PR fixes one thing I missed in #5536 -- in the random task endpoint, we don't get projects with `.authorize`, we call the `authQuery` directly. Since annotation projects in campaigns aren't shared directly, this was correctly not finding any authorized projects when the annotationProjectId query parameter was included.

This PR changes the project id listing so that it checks all of:

- directly authorized projects for the user
- project ids in the requested campaign if the user is allowed to view that campaign
- the requested project id if it exists and the user is allowed to see its parent campaign

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- test with raster-foundry/groundwork#1195