### PR TITLE
Assign ACRs in campaign random task endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Backsplash server does its own access logging [#5531](https://github.com/raster-foundry/raster-foundry/pull/5531)
 - Include annotation project id + TMS triple in traces for MVT requests [#5533](https://github.com/raster-foundry/raster-foundry/pull/5533)
 - Added label class and label class group endpoints for campaigns [#5534](https://github.com/raster-foundry/raster-foundry/pull/5534)
+- Added a QP for granting requester accesses to project and campaign in the campaign random task GET endpoint [#5539](https://github.com/raster-foundry/raster-foundry/pull/5539)
 
 ### Removed
 - Remove Nginx configuration and containers for Backsplash [#5532](https://github.com/raster-foundry/raster-foundry/pull/5532)

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -519,24 +519,21 @@ trait CampaignRoutes
                         )
                       }
                   }
-                  _ <- randomTaskOpt traverse { randomTask =>
-                    acrsOpt traverse { acrs =>
-                      CampaignDao.addPermissionsMany(
-                        randomTask.properties.campaignId,
-                        acrs.toList,
-                        false
-                      )
-                    }
-                  }
-                  _ <- randomTaskOpt traverse { randomTask =>
-                    acrsOpt traverse { acrs =>
-                      AnnotationProjectDao.addPermissionsMany(
-                        randomTask.properties.id,
-                        acrs.toList,
-                        false
-                      )
-                    }
-                  }
+                  _ <- (randomTaskOpt, acrsOpt).tupled traverse {
+                    case (randomTask, acrs) =>
+                      (
+                        CampaignDao.addPermissionsMany(
+                          randomTask.properties.campaignId,
+                          acrs.toList,
+                          false
+                        ),
+                        AnnotationProjectDao.addPermissionsMany(
+                          randomTask.properties.annotationProjectId,
+                          acrs.toList,
+                          false
+                        )
+                      ).tupled
+                  } void
                 } yield randomTaskOpt
               ).transact(xa).unsafeToFuture
             }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -47,6 +47,11 @@ trait QueryParameterDeserializers {
   implicit val deserializerTaskType: Unmarshaller[String, TaskType] =
     Unmarshaller.strict[String, TaskType] { s =>
       TaskType.fromString(s)
+    }
+
+  implicit val deserializerActionType: Unmarshaller[String, ActionType] =
+    Unmarshaller.strict[String, ActionType] { s =>
+      ActionType.fromString(s)
     }
 
 }
@@ -242,4 +247,9 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
           'isActive.as[Boolean].?
         )
     ).as(CampaignQueryParameters.apply _)
+
+  def campaignRandomTaskQueryParameters =
+    parameters(
+      'requestAction.as(deserializerActionType).*
+    ).as(CampaignRandomTaskQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -91,10 +91,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -146,7 +146,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -178,10 +178,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -206,10 +206,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -261,10 +261,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -337,10 +337,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -354,10 +354,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -381,10 +381,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -421,10 +421,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -447,10 +447,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -460,10 +460,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -497,10 +497,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -537,10 +537,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -553,10 +553,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -572,10 +572,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -653,10 +653,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -671,10 +671,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -685,10 +685,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -706,10 +706,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 
@@ -729,4 +729,17 @@ object CampaignQueryParameters {
     deriveEncoder[CampaignQueryParameters]
   implicit def decCampaignQueryParameters: Decoder[CampaignQueryParameters] =
     deriveDecoder[CampaignQueryParameters]
+}
+
+final case class CampaignRandomTaskQueryParameters(
+    requestAction: Iterable[ActionType] = Seq.empty[ActionType]
+)
+
+object CampaignRandomTaskQueryParameters {
+  implicit def encCampaignRandomTaskQueryParameters
+      : Encoder[CampaignRandomTaskQueryParameters] =
+    deriveEncoder[CampaignRandomTaskQueryParameters]
+  implicit def decCampaignRandomTaskQueryParameters
+      : Decoder[CampaignRandomTaskQueryParameters] =
+    deriveDecoder[CampaignRandomTaskQueryParameters]
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -91,10 +91,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -146,7 +146,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -178,10 +178,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -206,10 +206,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -261,10 +261,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -337,10 +337,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -354,10 +354,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -381,10 +381,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -421,10 +421,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -447,10 +447,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -460,10 +460,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -497,10 +497,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -537,10 +537,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -553,10 +553,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -572,10 +572,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -653,10 +653,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -671,10 +671,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -685,10 +685,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -706,10 +706,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 
@@ -737,9 +737,9 @@ final case class CampaignRandomTaskQueryParameters(
 
 object CampaignRandomTaskQueryParameters {
   implicit def encCampaignRandomTaskQueryParameters
-      : Encoder[CampaignRandomTaskQueryParameters] =
+    : Encoder[CampaignRandomTaskQueryParameters] =
     deriveEncoder[CampaignRandomTaskQueryParameters]
   implicit def decCampaignRandomTaskQueryParameters
-      : Decoder[CampaignRandomTaskQueryParameters] =
+    : Decoder[CampaignRandomTaskQueryParameters] =
     deriveDecoder[CampaignRandomTaskQueryParameters]
 }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -231,9 +231,9 @@ object Task {
 
   object TaskPropertiesWithCampaign {
     implicit val encTaskPropertiesWithCampaign
-      : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
+        : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
     implicit val decTaskPropertiesWithCamapgin
-      : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
+        : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
   }
 
   final case class TaskPropertiesCreate(
@@ -262,8 +262,8 @@ object Task {
 
   object TaskFeature {
     implicit val encTaskFeature: Encoder[TaskFeature] =
-      Encoder.forProduct4("id", "type", "properties", "geometry")(
-        tf => (tf.id, tf._type, tf.properties, tf.geometry)
+      Encoder.forProduct4("id", "type", "properties", "geometry")(tf =>
+        (tf.id, tf._type, tf.properties, tf.geometry)
       )
     implicit val decTaskFeature: Decoder[TaskFeature] =
       Decoder.forProduct4("id", "properties", "geometry", "type")(
@@ -280,8 +280,8 @@ object Task {
 
   object TaskFeatureWithCampaign {
     implicit val encTaskFeature: Encoder[TaskFeatureWithCampaign] =
-      Encoder.forProduct4("id", "type", "properties", "geometry")(
-        tf => (tf.id, tf._type, tf.properties, tf.geometry)
+      Encoder.forProduct4("id", "type", "properties", "geometry")(tf =>
+        (tf.id, tf._type, tf.properties, tf.geometry)
       )
     implicit val decTaskFeature: Decoder[TaskFeatureWithCampaign] =
       Decoder.forProduct4("id", "properties", "geometry", "type")(
@@ -304,8 +304,8 @@ object Task {
         TaskFeatureCreate.apply _
       )
     implicit val encTaskFeatureCreate: Encoder[TaskFeatureCreate] =
-      Encoder.forProduct3("properties", "geometry", "type")(
-        tfc => (tfc.properties, tfc.geometry, tfc._type)
+      Encoder.forProduct3("properties", "geometry", "type")(tfc =>
+        (tfc.properties, tfc.geometry, tfc._type)
       )
   }
 
@@ -319,11 +319,10 @@ object Task {
       Encoder.forProduct2(
         "type",
         "features"
-      )(
-        tfc =>
-          (
-            tfc._type,
-            tfc.features
+      )(tfc =>
+        (
+          tfc._type,
+          tfc.features
         )
       )
 
@@ -341,15 +340,13 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-      : Decoder[TaskFeatureCollectionCreate] =
+        : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-      : Encoder[TaskFeatureCollectionCreate] =
-      Encoder.forProduct2("type", "features")(
-        tfc => (tfc._type, tfc.features)
-      )
+        : Encoder[TaskFeatureCollectionCreate] =
+      Encoder.forProduct2("type", "features")(tfc => (tfc._type, tfc.features))
   }
 
   final case class TaskGridCreateProperties(
@@ -358,10 +355,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-      : Encoder[TaskGridCreateProperties] =
+        : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-      : Decoder[TaskGridCreateProperties] =
+        : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 
@@ -377,8 +374,8 @@ object Task {
         TaskGridFeatureCreate.apply _
       )
     implicit val encTaskGridFeatureCreate: Encoder[TaskGridFeatureCreate] =
-      Encoder.forProduct3("properties", "geometry", "type")(
-        tfc => (tfc.properties, tfc.geometry, tfc._type)
+      Encoder.forProduct3("properties", "geometry", "type")(tfc =>
+        (tfc.properties, tfc.geometry, tfc._type)
       )
   }
 }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -231,9 +231,9 @@ object Task {
 
   object TaskPropertiesWithCampaign {
     implicit val encTaskPropertiesWithCampaign
-        : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
+      : Encoder[TaskPropertiesWithCampaign] = deriveEncoder
     implicit val decTaskPropertiesWithCamapgin
-        : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
+      : Decoder[TaskPropertiesWithCampaign] = deriveDecoder
   }
 
   final case class TaskPropertiesCreate(
@@ -263,8 +263,7 @@ object Task {
   object TaskFeature {
     implicit val encTaskFeature: Encoder[TaskFeature] =
       Encoder.forProduct4("id", "type", "properties", "geometry")(tf =>
-        (tf.id, tf._type, tf.properties, tf.geometry)
-      )
+        (tf.id, tf._type, tf.properties, tf.geometry))
     implicit val decTaskFeature: Decoder[TaskFeature] =
       Decoder.forProduct4("id", "properties", "geometry", "type")(
         TaskFeature.apply _
@@ -281,8 +280,7 @@ object Task {
   object TaskFeatureWithCampaign {
     implicit val encTaskFeature: Encoder[TaskFeatureWithCampaign] =
       Encoder.forProduct4("id", "type", "properties", "geometry")(tf =>
-        (tf.id, tf._type, tf.properties, tf.geometry)
-      )
+        (tf.id, tf._type, tf.properties, tf.geometry))
     implicit val decTaskFeature: Decoder[TaskFeatureWithCampaign] =
       Decoder.forProduct4("id", "properties", "geometry", "type")(
         TaskFeatureWithCampaign.apply _
@@ -305,8 +303,7 @@ object Task {
       )
     implicit val encTaskFeatureCreate: Encoder[TaskFeatureCreate] =
       Encoder.forProduct3("properties", "geometry", "type")(tfc =>
-        (tfc.properties, tfc.geometry, tfc._type)
-      )
+        (tfc.properties, tfc.geometry, tfc._type))
   }
 
   case class TaskFeatureCollection(
@@ -319,12 +316,12 @@ object Task {
       Encoder.forProduct2(
         "type",
         "features"
-      )(tfc =>
-        (
-          tfc._type,
-          tfc.features
-        )
-      )
+      )(
+        tfc =>
+          (
+            tfc._type,
+            tfc.features
+        ))
 
     implicit val decTaskFeatureCollection: Decoder[TaskFeatureCollection] =
       Decoder.forProduct2(
@@ -340,12 +337,12 @@ object Task {
 
   object TaskFeatureCollectionCreate {
     implicit val decTaskFeatureCollectionCreate
-        : Decoder[TaskFeatureCollectionCreate] =
+      : Decoder[TaskFeatureCollectionCreate] =
       Decoder.forProduct2("type", "features")(
         TaskFeatureCollectionCreate.apply _
       )
     implicit val encTaskFeatureCollectionCreate
-        : Encoder[TaskFeatureCollectionCreate] =
+      : Encoder[TaskFeatureCollectionCreate] =
       Encoder.forProduct2("type", "features")(tfc => (tfc._type, tfc.features))
   }
 
@@ -355,10 +352,10 @@ object Task {
 
   object TaskGridCreateProperties {
     implicit val encTaskGridCreateProperties
-        : Encoder[TaskGridCreateProperties] =
+      : Encoder[TaskGridCreateProperties] =
       deriveEncoder
     implicit val decTaskGridCreateProperties
-        : Decoder[TaskGridCreateProperties] =
+      : Decoder[TaskGridCreateProperties] =
       deriveDecoder
   }
 
@@ -375,8 +372,7 @@ object Task {
       )
     implicit val encTaskGridFeatureCreate: Encoder[TaskGridFeatureCreate] =
       Encoder.forProduct3("properties", "geometry", "type")(tfc =>
-        (tfc.properties, tfc.geometry, tfc._type)
-      )
+        (tfc.properties, tfc.geometry, tfc._type))
   }
 }
 


### PR DESCRIPTION
## Overview

This PR adds a QP to the random task fetching endpoint for campaigns to assign ACRs. 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Follow instructions here: https://github.com/azavea/earthrise-ibm/pull/37

Closes https://github.com/azavea/earthrise-ibm/issues/7
