### PR TITLE
Make RF project-less annotation projects exportable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Added an endpoint for campaign label class group summary [#5541](https://github.com/raster-foundry/raster-foundry/pull/5541)
 
+### Fixed
+- STAC exports for annotation projects without RF projects are no longer catalogs without children [#5540](https://github.com/raster-foundry/raster-foundry/pull/5540)
+
 ## [1.58.0] - 2021-01-13
 ### Added
 - Backsplash server does its own access logging [#5531](https://github.com/raster-foundry/raster-foundry/pull/5531)

--- a/app-backend/batch/src/main/scala/stacExport/ExportData.scala
+++ b/app-backend/batch/src/main/scala/stacExport/ExportData.scala
@@ -5,12 +5,16 @@ import com.rasterfoundry.datamodel._
 import com.azavea.stac4s.extensions.label.LabelItemExtension
 import io.circe.Json
 
+import java.util.UUID
+
 case class ExportData(
     scenes: List[Scene],
-    scenesGeomExtent: UnionedGeomExtent,
+    scenesGeomExtent: Option[UnionedGeomExtent],
     tasks: List[Task],
     taskGeomExtent: UnionedGeomExtent,
     annotations: Json,
     labelItemExtension: LabelItemExtension,
-    taskStatuses: List[TaskStatus]
+    taskStatuses: List[TaskStatus],
+    projectLayerId: Option[UUID],
+    tileLayers: List[TileLayer]
 )


### PR DESCRIPTION
## Overview

This PR makes it so that in v1 STAC exports, if we don't have a `project` that backs the annotation project (as is the case with SpaceNet projects), we fall back to creating a source item from the tile layers linked to the annotation project.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

It doesn't do the same in campaign exports yet. Similar changes are necessary, but I'll get to them in the morning. With the v1 changes as a model, campaign export changes should be a breeze.

I didn't create a tile json for the item. I think it might be valuable to change the role to something other than data though, since that will maybe help differentiate the types of source assets for people who have project-less and project-ful exports.

## Testing Instructions

- assemble batch, api-server, backsplash, bring up rf and groundwork -- from `sbt` shell in `app-backend`, `;api/assembly;backsplash-server/assembly;batch/assembly`
- create a new annotation project locally and process it's upload -- follow steps in GroundWork to get set up, but use the recent `.env.local` from the #groundwork channel
- open a postgres shell (`./scripts/psql`) and set `project_id` to null for the annotation project you just created
- in GroundWork, create a STAC export for your annotation project
- get its id, then `./scripts/console batch 'java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <ID for your STAC export>'`
- download the result (search `s3` in logs to figure out where it lives -- it'll be there + `/catalog.zip`) and unzip it
- `cd` to `catalog`, then `tree`
- find the label item
- `cd` to where the label item lives, then `cat <path to the label item>.json | jq .links` -- confirm it has a link to the source item
- `cat <the source link> | jq .assets` -- confirm that the link from the label item exists and that it has TMS layers in assets

Closes raster-foundry/groundwork#1027
