### PR TITLE
Endpoint for campaign label class group summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added an endpoint for campaign label class group summary [#5541](https://github.com/raster-foundry/raster-foundry/pull/5541)
 
 ## [1.58.0] - 2021-01-13
 ### Added

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -223,6 +223,7 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId},campaigns:read,get
 /api/campaigns/{campaignId},campaigns:update,put
 /api/campaigns/{campaignId},campaigns:delete,delete
+/api/campaigns/{campaignId}/label-class-summary,campaigns:read,get
 /api/campaigns/{campaignId}/actions,campaigns:readPermissions,get
 /api/campaigns/{campaignId}/projects,annotationProjects:read,get
 /api/campaigns/{campaignId}/permissions,campaigns:readPermissions,get

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -50,6 +50,13 @@ trait CampaignRoutes
               deleteCampaign(campaignId)
             }
         } ~
+          pathPrefix("label-class-summary") {
+            pathEndOrSingleSlash {
+              get {
+                getCampaignLabelClassSummary(campaignId)
+              }
+            }
+          } ~
           pathPrefix("clone") {
             pathEndOrSingleSlash {
               post {
@@ -597,6 +604,35 @@ trait CampaignRoutes
                     page
                   )
                 )
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+      }
+    }
+
+  def getCampaignLabelClassSummary(campaignId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Read, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          CampaignDao
+            .authorized(
+              user,
+              ObjectType.Campaign,
+              campaignId,
+              ActionType.View
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          rejectEmptyResponse {
+            complete {
+              CampaignDao
+                .getLabelClassSummary(campaignId)
                 .transact(xa)
                 .unsafeToFuture
             }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -182,7 +182,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -111,7 +111,7 @@ object AnnotationProject {
       )
 
     def withSummary(
-        labelClassSummary: List[AnnotationProject.LabelClassGroupSummary]
+        labelClassSummary: List[LabelClassGroupSummary]
     ) =
       AnnotationProject.WithRelatedAndLabelClassSummary(
         id,
@@ -138,28 +138,6 @@ object AnnotationProject {
   object WithRelated {
     implicit val encRelated: Encoder[WithRelated] = deriveEncoder
     implicit val decRelated: Decoder[WithRelated] = deriveDecoder
-  }
-
-  final case class LabelClassSummary(
-      labelClassId: UUID,
-      labelClassName: String,
-      count: Int
-  )
-
-  object LabelClassSummary {
-    implicit val encLabelClassGroupSummary: Encoder[LabelClassSummary] =
-      deriveEncoder
-  }
-
-  final case class LabelClassGroupSummary(
-      labelClassGroupId: UUID,
-      labelClassGroupName: String,
-      labelClassSummaries: List[LabelClassSummary]
-  )
-
-  object LabelClassGroupSummary {
-    implicit val encLabelClassGroupSummary: Encoder[LabelClassGroupSummary] =
-      deriveEncoder
   }
 
   final case class WithRelatedAndLabelClassSummary(
@@ -204,7 +182,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-      : Encoder[WithRelatedAndLabelClassSummary] =
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/LabelClassSummary.scala
+++ b/app-backend/datamodel/src/main/scala/LabelClassSummary.scala
@@ -1,0 +1,27 @@
+package com.rasterfoundry.datamodel
+
+import io.circe._
+import io.circe.generic.semiauto._
+import java.util.UUID
+
+final case class LabelClassSummary(
+    labelClassId: UUID,
+    labelClassName: String,
+    count: Int
+)
+
+object LabelClassSummary {
+  implicit val encLabelClassGroupSummary: Encoder[LabelClassSummary] =
+    deriveEncoder
+}
+
+final case class LabelClassGroupSummary(
+    labelClassGroupId: UUID,
+    labelClassGroupName: String,
+    labelClassSummaries: List[LabelClassSummary]
+)
+
+object LabelClassGroupSummary {
+  implicit val encLabelClassGroupSummary: Encoder[LabelClassGroupSummary] =
+    deriveEncoder
+}

--- a/app-backend/datamodel/src/main/scala/LabelClassSummary.scala
+++ b/app-backend/datamodel/src/main/scala/LabelClassSummary.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.datamodel
 
 import io.circe._
 import io.circe.generic.semiauto._
+
 import java.util.UUID
 
 final case class LabelClassSummary(

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -205,15 +205,16 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-        case (classGroup, idx) =>
-          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-            classGroup,
-            Some(annotationProject),
-            None,
-            idx
-          )
-      }
+      labelClassGroups <-
+        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+          case (classGroup, idx) =>
+            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+              classGroup,
+              Some(annotationProject),
+              None,
+              idx
+            )
+        }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -229,8 +230,9 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <- AnnotationLabelClassGroupDao
-        .listByProjectId(id)
+      labelClassGroup <-
+        AnnotationLabelClassGroupDao
+          .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -249,14 +251,15 @@ object AnnotationProjectDao
       withRelatedO <- getWithRelatedById(id)
       labelClassGroups <- AnnotationLabelClassGroupDao.listByProjectId(id)
       labelClassSummaries <- labelClassGroups traverse { labelClassGroup =>
-        AnnotationLabelDao.countByProjectAndGroup(id, labelClassGroup.id).map {
-          summary =>
-            AnnotationProject.LabelClassGroupSummary(
+        AnnotationLabelDao
+          .countByProjectsAndGroup(List(id), labelClassGroup.id)
+          .map { summary =>
+            LabelClassGroupSummary(
               labelClassGroup.id,
               labelClassGroup.name,
               summary
             )
-        }
+          }
       }
     } yield {
       withRelatedO map { withRelated =>
@@ -368,11 +371,12 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <- (fr"select id from " ++ Fragment.const(
-        tableName
-      ) ++ fr" where owner = $userId")
-        .query[UUID]
-        .to[List]
+      projectIds <-
+        (fr"select id from " ++ Fragment.const(
+          tableName
+        ) ++ fr" where owner = $userId")
+          .query[UUID]
+          .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -399,14 +403,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(
-              classes =>
-                LabelClass(
-                  LabelClassName.VectorName(group.name),
-                  LabelClassClasses.NamedLabelClasses(
-                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                  )
-              ))
+            .map(classes =>
+              LabelClass(
+                LabelClassName.VectorName(group.name),
+                LabelClassClasses.NamedLabelClasses(
+                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                )
+              )
+            )
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -429,9 +433,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Annotate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -439,9 +443,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Validate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -492,37 +496,40 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <- insertQuery.update
-        .withUniqueGeneratedKeys[AnnotationProject](
-          fieldNames: _*
-        )
+      annotationProjectCopy <-
+        insertQuery.update
+          .withUniqueGeneratedKeys[AnnotationProject](
+            fieldNames: _*
+          )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <- AnnotationLabelClassDao
-            .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <- AnnotationLabelClassGroupDao
-            .insertAnnotationLabelClassGroup(
-              AnnotationLabelClassGroup.Create(
-                classGroup.name,
-                Some(classGroup.index),
-                labelClasses.map { labelClass =>
-                  AnnotationLabelClass.Create(
-                    labelClass.name,
-                    labelClass.colorHexCode,
-                    labelClass.default,
-                    labelClass.determinant,
-                    labelClass.index,
-                    labelClass.geometryType,
-                    labelClass.description
-                  )
-                }
-              ),
-              Some(annotationProjectCopy),
-              None,
-              0,
-              labelClasses
-            )
+          labelClasses <-
+            AnnotationLabelClassDao
+              .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <-
+            AnnotationLabelClassGroupDao
+              .insertAnnotationLabelClassGroup(
+                AnnotationLabelClassGroup.Create(
+                  classGroup.name,
+                  Some(classGroup.index),
+                  labelClasses.map { labelClass =>
+                    AnnotationLabelClass.Create(
+                      labelClass.name,
+                      labelClass.colorHexCode,
+                      labelClass.default,
+                      labelClass.determinant,
+                      labelClass.index,
+                      labelClass.geometryType,
+                      labelClass.description
+                    )
+                  }
+                ),
+                Some(annotationProjectCopy),
+                None,
+                0,
+                labelClasses
+              )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -553,20 +560,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())(
-            (acc, userId) =>
-              acc ++ List(
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.View
-                ),
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.Annotate
-                )
-            ))
+          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
+            acc ++ List(
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.View
+              ),
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.Annotate
+              )
+            )
+          )
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -205,16 +205,15 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <-
-        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-          case (classGroup, idx) =>
-            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-              classGroup,
-              Some(annotationProject),
-              None,
-              idx
-            )
-        }
+      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+        case (classGroup, idx) =>
+          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+            classGroup,
+            Some(annotationProject),
+            None,
+            idx
+          )
+      }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -230,9 +229,8 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByProjectId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -371,12 +369,11 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      projectIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -403,14 +400,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(classes =>
-              LabelClass(
-                LabelClassName.VectorName(group.name),
-                LabelClassClasses.NamedLabelClasses(
-                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                )
-              )
-            )
+            .map(
+              classes =>
+                LabelClass(
+                  LabelClassName.VectorName(group.name),
+                  LabelClassClasses.NamedLabelClasses(
+                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                  )
+              ))
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -433,9 +430,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -443,9 +440,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -496,40 +493,37 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[AnnotationProject](
-            fieldNames: _*
-          )
+      annotationProjectCopy <- insertQuery.update
+        .withUniqueGeneratedKeys[AnnotationProject](
+          fieldNames: _*
+        )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <-
-            AnnotationLabelClassDao
-              .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <-
-            AnnotationLabelClassGroupDao
-              .insertAnnotationLabelClassGroup(
-                AnnotationLabelClassGroup.Create(
-                  classGroup.name,
-                  Some(classGroup.index),
-                  labelClasses.map { labelClass =>
-                    AnnotationLabelClass.Create(
-                      labelClass.name,
-                      labelClass.colorHexCode,
-                      labelClass.default,
-                      labelClass.determinant,
-                      labelClass.index,
-                      labelClass.geometryType,
-                      labelClass.description
-                    )
-                  }
-                ),
-                Some(annotationProjectCopy),
-                None,
-                0,
-                labelClasses
-              )
+          labelClasses <- AnnotationLabelClassDao
+            .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <- AnnotationLabelClassGroupDao
+            .insertAnnotationLabelClassGroup(
+              AnnotationLabelClassGroup.Create(
+                classGroup.name,
+                Some(classGroup.index),
+                labelClasses.map { labelClass =>
+                  AnnotationLabelClass.Create(
+                    labelClass.name,
+                    labelClass.colorHexCode,
+                    labelClass.default,
+                    labelClass.determinant,
+                    labelClass.index,
+                    labelClass.geometryType,
+                    labelClass.description
+                  )
+                }
+              ),
+              Some(annotationProjectCopy),
+              None,
+              0,
+              labelClasses
+            )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -560,20 +554,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
-            acc ++ List(
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.View
-              ),
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.Annotate
-              )
-            )
-          )
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
+            ))
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -148,7 +148,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       video_link, partner_name, partner_logo, parent_campaign_id,
       continent, tags, resource_link
     )""" ++
-          fr"""VALUES
+        fr"""VALUES
       (uuid_generate_v4(), now(), ${user.id}, ${campaignCreate.name},
        ${campaignCreate.campaignType}, ${campaignCreate.description},
        ${campaignCreate.videoLink}, ${campaignCreate.partnerName},
@@ -171,9 +171,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
   ): ConnectionIO[Option[Campaign.WithRelated]] =
     for {
       campaignO <- getCampaignById(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByCampaignId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByCampaignId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -214,12 +213,11 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      campaignIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      campaignIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       campaignShareCounts <- campaignIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -232,10 +230,10 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       copyResourceLink: Boolean = false
   ): ConnectionIO[Campaign] = {
     val tagCol = tagsO
-      .map(tags =>
-        Fragment
-          .const(s"ARRAY[${tags.map(t => s"'${t}'").mkString(",")}]::text[]")
-      )
+      .map(
+        tags =>
+          Fragment
+            .const(s"ARRAY[${tags.map(t => s"'${t}'").mkString(",")}]::text[]"))
       .getOrElse(Fragment.const("tags"))
     val resourceLinkF = if (copyResourceLink) fr"resource_link" else fr"null"
     val insertQuery = (fr"""
@@ -247,9 +245,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            WHERE id = ${id}
         """)
     for {
-      campaignCopyId <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[UUID]("id")
+      campaignCopyId <- insertQuery.update
+        .withUniqueGeneratedKeys[UUID]("id")
       campaignCopy <- unsafeGetCampaignById(campaignCopyId)
       annotationProjects <- AnnotationProjectDao.listByCampaign(id)
       _ <- annotationProjects traverse { project =>
@@ -438,9 +435,9 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       permissions <- getPermissions(campaignId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -448,9 +445,9 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -524,12 +521,11 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       campaignId: UUID
   ): ConnectionIO[List[LabelClassGroupSummary]] =
     for {
-      labelClassGroups <-
-        AnnotationLabelClassGroupDao.listByCampaignId(campaignId)
-      projects <-
-        AnnotationProjectDao.query
-          .filter(fr"campaign_id = $campaignId")
-          .list
+      labelClassGroups <- AnnotationLabelClassGroupDao.listByCampaignId(
+        campaignId)
+      projects <- AnnotationProjectDao.query
+        .filter(fr"campaign_id = $campaignId")
+        .list
       projectIds = projects.map(_.id)
       labelClassSummaries <- labelClassGroups traverse { labelClassGroup =>
         AnnotationLabelDao

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -18,12 +18,6 @@ class AnnotationLabelDaoSpec
     with DBTestConfig
     with PropTestHelpers {
 
-  def addClasses(
-      label: AnnotationLabelWithClasses.Create,
-      classes: List[UUID]
-  ): AnnotationLabelWithClasses.Create =
-    label.copy(annotationLabelClasses = classes.take(1))
-
   test("insert annotations") {
     check {
       forAll(
@@ -40,8 +34,9 @@ class AnnotationLabelDaoSpec
 
           val insertIO = for {
             user <- UserDao.create(userCreate)
-            annotationProject <- AnnotationProjectDao
-              .insert(toInsert, user)
+            annotationProject <-
+              AnnotationProjectDao
+                .insert(toInsert, user)
             classIds = annotationProject.labelClassGroups flatMap {
               _.labelClasses
             } map { _.id }
@@ -91,8 +86,9 @@ class AnnotationLabelDaoSpec
 
           val listIO = for {
             user <- UserDao.create(userCreate)
-            annotationProject <- AnnotationProjectDao
-              .insert(toInsert, user)
+            annotationProject <-
+              AnnotationProjectDao
+                .insert(toInsert, user)
             fixedUpTasks = fixupTaskFeaturesCollection(
               taskFeatureCollectionCreate,
               annotationProject,
@@ -145,8 +141,9 @@ class AnnotationLabelDaoSpec
 
           val listIO = for {
             user <- UserDao.create(userCreate)
-            annotationProject <- AnnotationProjectDao
-              .insert(toInsert, user)
+            annotationProject <-
+              AnnotationProjectDao
+                .insert(toInsert, user)
             fixedUpTasks = fixupTaskFeaturesCollection(
               taskFeatureCollectionCreate,
               annotationProject,
@@ -168,11 +165,12 @@ class AnnotationLabelDaoSpec
               withClasses,
               user
             )
-            listedByTask <- AnnotationLabelDao
-              .listWithClassesByProjectIdAndTaskId(
-                annotationProject.id,
-                task.id
-              )
+            listedByTask <-
+              AnnotationLabelDao
+                .listWithClassesByProjectIdAndTaskId(
+                  annotationProject.id,
+                  task.id
+                )
           } yield listedByTask
 
           val listedByTask = listIO.transact(xa).unsafeRunSync
@@ -199,8 +197,9 @@ class AnnotationLabelDaoSpec
         ) => {
           val summaryIO = for {
             user <- UserDao.create(userCreate)
-            annotationProject <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            annotationProject <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
             fixedUpTasks = fixupTaskFeaturesCollection(
               taskFeatureCollectionCreate,
               annotationProject,
@@ -210,9 +209,10 @@ class AnnotationLabelDaoSpec
               fixedUpTasks.copy(features = fixedUpTasks.features.take(1)),
               user
             ) map { _.features.head }
-            classIds = annotationProject.labelClassGroups.head.labelClasses map {
-              _.id
-            }
+            classIds =
+              annotationProject.labelClassGroups.head.labelClasses map {
+                _.id
+              }
             withClasses = annotationCreates map { create =>
               addClasses(create, classIds)
             }
@@ -222,12 +222,12 @@ class AnnotationLabelDaoSpec
               withClasses,
               user
             )
-            summaryReal <- AnnotationLabelDao.countByProjectAndGroup(
-              annotationProject.id,
+            summaryReal <- AnnotationLabelDao.countByProjectsAndGroup(
+              List(annotationProject.id),
               annotationProject.labelClassGroups.head.id
             )
-            summaryBogus <- AnnotationLabelDao.countByProjectAndGroup(
-              annotationProject.id,
+            summaryBogus <- AnnotationLabelDao.countByProjectsAndGroup(
+              List(annotationProject.id),
               UUID.randomUUID
             )
           } yield { (classIds, summaryReal, summaryBogus) }
@@ -235,21 +235,20 @@ class AnnotationLabelDaoSpec
           val (classIds, summaryReal, summaryBogus) =
             summaryIO.transact(xa).unsafeRunSync
 
-          classIds map {
-            classId =>
-              val labelSummaryO = summaryReal.find(_.labelClassId == classId)
-              val expectation = if (annotationCreates.isEmpty) {
-                None
-              } else {
-                Some(annotationCreates.size)
-              }
-              assert(
-                (labelSummaryO map {
-                  (summ: AnnotationProject.LabelClassSummary) =>
-                    summ.count
-                }) == expectation,
-                "All the annotations with the real class were counted"
-              )
+          classIds map { classId =>
+            val labelSummaryO = summaryReal.find(_.labelClassId == classId)
+            val expectation = if (annotationCreates.isEmpty) {
+              None
+            } else {
+              Some(annotationCreates.size)
+            }
+            assert(
+              (labelSummaryO map {
+                (summ: LabelClassSummary) =>
+                  summ.count
+              }) == expectation,
+              "All the annotations with the real class were counted"
+            )
           }
 
           assert(
@@ -274,8 +273,9 @@ class AnnotationLabelDaoSpec
         ) => {
           val listIO = for {
             user <- UserDao.create(userCreate)
-            annotationProject <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            annotationProject <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
             fixedUpTasks = fixupTaskFeaturesCollection(
               taskFeatureCollectionCreate,
               annotationProject,
@@ -297,13 +297,15 @@ class AnnotationLabelDaoSpec
               withClasses,
               user
             )
-            _ <- AnnotationLabelDao
-              .deleteByProjectIdAndTaskId(annotationProject.id, task.id)
-            listedByTask <- AnnotationLabelDao
-              .listWithClassesByProjectIdAndTaskId(
-                annotationProject.id,
-                task.id
-              )
+            _ <-
+              AnnotationLabelDao
+                .deleteByProjectIdAndTaskId(annotationProject.id, task.id)
+            listedByTask <-
+              AnnotationLabelDao
+                .listWithClassesByProjectIdAndTaskId(
+                  annotationProject.id,
+                  task.id
+                )
           } yield listedByTask
 
           val listed = listIO.transact(xa).unsafeRunSync
@@ -330,8 +332,9 @@ class AnnotationLabelDaoSpec
         ) => {
           val listIO = for {
             user <- UserDao.create(userCreate)
-            annotationProject <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            annotationProject <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
             fixedUpTasks = fixupTaskFeaturesCollection(
               taskFeatureCollectionCreate,
               annotationProject,
@@ -341,9 +344,10 @@ class AnnotationLabelDaoSpec
               fixedUpTasks.copy(features = fixedUpTasks.features.take(1)),
               user
             ) map { _.features.head }
-            classIds = annotationProject.labelClassGroups.head.labelClasses map {
-              _.id
-            }
+            classIds =
+              annotationProject.labelClassGroups.head.labelClasses map {
+                _.id
+              }
             withClasses = annotationCreates map { create =>
               addClasses(create, classIds)
             }
@@ -361,26 +365,24 @@ class AnnotationLabelDaoSpec
 
           val annotationsO = listIO.transact(xa).unsafeRunSync
           annotationsO
-            .flatMap(
-              annotations => {
-                val annotationsJson = annotations.asObject.get
-                assert(
-                  annotationsJson.keys.toSet.contains("features"),
-                  "stac annotation has features property"
-                )
-                val feats =
-                  annotationsJson.toMap
-                    .get("features")
-                    .map(_.asArray)
-                    .flatten
-                    .get
-                assert(
-                  feats.size == annotationCreates.size,
-                  "all inserted features are in export"
-                )
-                feats.headOption.map(_.asObject)
-              }
-            )
+            .flatMap(annotations => {
+              val annotationsJson = annotations.asObject.get
+              assert(
+                annotationsJson.keys.toSet.contains("features"),
+                "stac annotation has features property"
+              )
+              val feats =
+                annotationsJson.toMap
+                  .get("features")
+                  .map(_.asArray)
+                  .flatten
+                  .get
+              assert(
+                feats.size == annotationCreates.size,
+                "all inserted features are in export"
+              )
+              feats.headOption.map(_.asObject)
+            })
             .flatten
             .map(feature => {
               val requiredLabelFields =
@@ -422,7 +424,8 @@ class AnnotationLabelDaoSpec
                       .get(groupName)
                       .map(_.asString)
                       .flatten
-                      .get),
+                      .get
+                  ),
                 "stac label value for group name exists"
               )
             })

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/PropTestHelpers.scala
@@ -529,4 +529,10 @@ trait PropTestHelpers {
       INSERT INTO task_sessions VALUES
         (uuid_generate_v4(), now(), now() - INTERVAL '10 min', NULL, ${fromStatus}, NULL, ${taskSessionCreate.sessionType},
         ${user.id}, ${taskId})""").update.withUniqueGeneratedKeys[UUID]("id")
+
+  def addClasses(
+      label: AnnotationLabelWithClasses.Create,
+      classes: List[UUID]
+  ): AnnotationLabelWithClasses.Create =
+    label.copy(annotationLabelClasses = classes.take(1))
 }


### PR DESCRIPTION
## Overview

This PR adds an endpoint for getting label class group summary on campaign level.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- property tests should pass
- GET to `/api/campaigns/{campaignId}/label-class-summary` should return summary if you have labels created using campaign level classes

Closes https://github.com/raster-foundry/groundwork/issues/1164
