### PR TITLE
Make authentication in testing a bit more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - STAC exports for annotation projects without RF projects are no longer catalogs without children [#5540](https://github.com/raster-foundry/raster-foundry/pull/5540)
+- Added retry and caching to a flaky integration test [#5545](https://github.com/raster-foundry/raster-foundry/pull/5545)
 
 ## [1.58.0] - 2021-01-13
 ### Added

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -141,13 +141,13 @@ trait Authentication extends Directives with LazyLogging {
       (Option(claims.getStringClaim(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-      }
+    }
 
     val compareDelegatedToEmail = (field: String) =>
       (delegatedProfile.map(_.getAsString(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-      }
+    }
 
     compareToEmail("name")
       .orElse(compareToEmail("nickname"))
@@ -179,7 +179,7 @@ trait Authentication extends Directives with LazyLogging {
       str match {
         case s if !s.trim.isEmpty => Some(s)
         case _                    => None
-      }
+    }
 
     val defaultFromClaims = (field: String, str: String) =>
       optionEmpty(field)
@@ -252,8 +252,8 @@ trait Authentication extends Directives with LazyLogging {
               }
             }
           }
-          platformRole =
-            roles.find(role => role.groupType == GroupType.Platform)
+          platformRole = roles.find(role =>
+            role.groupType == GroupType.Platform)
           plat <- OptionT {
             platformRole match {
               case Some(role) =>

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -91,10 +91,8 @@ trait Authentication extends Directives with LazyLogging {
   def authenticate: Directive1[User] = {
     extractTokenHeader.flatMap {
       case Some(token) =>
-        println(s"Authenticating token: $token")
         authenticateWithToken(token.split(" ").last)
       case None =>
-        println("Didn't get a token to authenticate with")
         reject(AuthenticationFailedRejection(CredentialsRejected, challenge))
     }
   }

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -72,8 +72,10 @@ trait Authentication extends Directives with LazyLogging {
   def authenticate: Directive1[User] = {
     extractTokenHeader.flatMap {
       case Some(token) =>
+        println(s"Authenticating token: $token")
         authenticateWithToken(token.split(" ").last)
       case None =>
+        println("Didn't get a token to authenticate with")
         reject(AuthenticationFailedRejection(CredentialsRejected, challenge))
     }
   }

--- a/app-backend/akkautil/src/main/scala/CommonHandlers.scala
+++ b/app-backend/akkautil/src/main/scala/CommonHandlers.scala
@@ -81,7 +81,7 @@ trait CommonHandlers extends RouteDirectives {
         complete {
           Map("simResult" -> userActions.contains(scopedAction)).asJson
         }
-      case nope =>
+      case _ =>
         fallback
     })
 

--- a/app-backend/akkautil/src/main/scala/CommonHandlers.scala
+++ b/app-backend/akkautil/src/main/scala/CommonHandlers.scala
@@ -82,7 +82,6 @@ trait CommonHandlers extends RouteDirectives {
           Map("simResult" -> userActions.contains(scopedAction)).asJson
         }
       case nope =>
-        println(s"Result of header parse: $nope")
         fallback
     })
 

--- a/app-backend/api-it/src/test/scala/ScopeSpec.scala
+++ b/app-backend/api-it/src/test/scala/ScopeSpec.scala
@@ -100,7 +100,7 @@ class ScopeSpec extends AnyFunSpec {
     out
   }
 
-  lazy val authTokenE: Either[String, TokenResponse] = {
+  val authTokenE: Either[String, TokenResponse] = {
     val tokenRoute = makeRoute("/api/tokens/")
     val response =
       basicRequest
@@ -110,7 +110,6 @@ class ScopeSpec extends AnyFunSpec {
         .send()
     response.body match {
       case Right(tokenResp) =>
-        println("getting a token")
         Right(tokenResp)
       case _ => {
         Left("could not get token")
@@ -123,7 +122,6 @@ class ScopeSpec extends AnyFunSpec {
       scope: Scope,
       expectSuccess: Boolean
   ): RequestT[Empty, Either[String, String], Nothing] = {
-    println(s"Token for requests: ${tokenResp.id_token}")
     val root =
       basicRequest.header("X-PolicySim", "true").auth.bearer(tokenResp.id_token)
     val scopeStringNoQuotes = scope.asJson.noSpaces.replace("\"", "")
@@ -147,12 +145,13 @@ class ScopeSpec extends AnyFunSpec {
       case Delete => request.delete(path)
     }).response(asJson[SimResponse])
 
-  def routes(rows: List[Either[String, UnparsedRow]]) = Table(
-    ("Path", "Domain:Action", "Verb"),
-    (rows collect {
-      case Right(row) => row.tupled
-    }): _*
-  )
+  def routes(rows: List[Either[String, UnparsedRow]]) =
+    Table(
+      ("Path", "Domain:Action", "Verb"),
+      (rows collect {
+        case Right(row) => row.tupled
+      }): _*
+    )
 
   def getSimResult(
       baseRequest: RequestT[Empty, Either[String, String], Nothing],
@@ -170,6 +169,7 @@ class ScopeSpec extends AnyFunSpec {
     assert(
       resultBody == Right(SimResponse(expectation)),
       s"""
+        |
         | Authorization expectation failed.
         | Received $resultBody
         | Expected $expectation

--- a/app-backend/api-it/src/test/scala/ScopeSpec.scala
+++ b/app-backend/api-it/src/test/scala/ScopeSpec.scala
@@ -109,7 +109,9 @@ class ScopeSpec extends AnyFunSpec {
         .response(asJson[TokenResponse])
         .send()
     response.body match {
-      case Right(tokenResp) => Right(tokenResp)
+      case Right(tokenResp) =>
+        println("getting a token")
+        Right(tokenResp)
       case _ => {
         Left("could not get token")
       }

--- a/app-backend/api-it/src/test/scala/ScopeSpec.scala
+++ b/app-backend/api-it/src/test/scala/ScopeSpec.scala
@@ -161,13 +161,17 @@ class ScopeSpec extends AnyFunSpec {
       addMethod(baseRequest, requestUri, row.verb).send()
     // for some reason I'm not allowed to bail on the Id wrapper in the previous step, though I'd really
     // prefer to. this is a bit janky but I'm not sure what to do about it.
-    val resultBody: Either[String, SimResponse] = response.body.leftMap(
-      err =>
-        s"body deserialization failed: $err, code: ${response.code} body: ${response.body}"
+    val resultBody: Either[String, SimResponse] = response.body.leftMap(err =>
+      s"body deserialization failed: $err, code: ${response.code} body: ${response.body}"
     )
     assert(
       resultBody == Right(SimResponse(expectation)),
-      s"Authorization expectation failed: received $resultBody, expected $expectation"
+      s"""
+        | Authorization expectation failed.
+        | Received $resultBody
+        | Expected $expectation
+        | From url: $requestUri
+        | """.trim.stripMargin
     )
   }
 

--- a/app-backend/api-it/src/test/scala/ScopeSpec.scala
+++ b/app-backend/api-it/src/test/scala/ScopeSpec.scala
@@ -121,6 +121,7 @@ class ScopeSpec extends AnyFunSpec {
       scope: Scope,
       expectSuccess: Boolean
   ): RequestT[Empty, Either[String, String], Nothing] = {
+    println(s"Token for requests: ${tokenResp.id_token}")
     val root =
       basicRequest.header("X-PolicySim", "true").auth.bearer(tokenResp.id_token)
     val scopeStringNoQuotes = scope.asJson.noSpaces.replace("\"", "")

--- a/app-backend/api-it/src/test/scala/ScopeSpec.scala
+++ b/app-backend/api-it/src/test/scala/ScopeSpec.scala
@@ -100,7 +100,7 @@ class ScopeSpec extends AnyFunSpec {
     out
   }
 
-  val authTokenE: Either[String, TokenResponse] = {
+  lazy val authTokenE: Either[String, TokenResponse] = {
     val tokenRoute = makeRoute("/api/tokens/")
     val response =
       basicRequest

--- a/app-backend/api/src/main/resources/application.conf
+++ b/app-backend/api/src/main/resources/application.conf
@@ -19,6 +19,9 @@ auth0 {
   domain = ""
   domain = ${?AUTH0_DOMAIN}
 
+  enableCache = "false"
+  enableCache = ${?AUTH0_ENABLE_CACHE}
+
   # Auth0 Bearer with proper permissions for Management API
   bearer = ""
   bearer = ${?AUTH0_MANAGEMENT_BEARER}

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -370,8 +370,9 @@ trait AnnotationProjectRoutes
             case false =>
               complete {
                 (for {
-                  projectO <- AnnotationProjectDao
-                    .getById(projectId)
+                  projectO <-
+                    AnnotationProjectDao
+                      .getById(projectId)
                   projectActions <- projectO traverse { project =>
                     if (project.createdBy == user.id) {
                       Set("*").pure[ConnectionIO]
@@ -396,7 +397,6 @@ trait AnnotationProjectRoutes
                     }
                   } map { _ getOrElse Set.empty }
                 } yield {
-                  println(s"Campaign actions: ${campaignActions}")
                   (projectActions ++ campaignActions)
                 }).transact(xa).unsafeToFuture
               }

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -370,9 +370,8 @@ trait AnnotationProjectRoutes
             case false =>
               complete {
                 (for {
-                  projectO <-
-                    AnnotationProjectDao
-                      .getById(projectId)
+                  projectO <- AnnotationProjectDao
+                    .getById(projectId)
                   projectActions <- projectO traverse { project =>
                     if (project.createdBy == user.id) {
                       Set("*").pure[ConnectionIO]

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -560,6 +560,10 @@ lazy val akkautil = project
       Dependencies.nimbusJose,
       Dependencies.nimbusJoseJwt,
       Dependencies.postgres,
+      Dependencies.refined,
+      Dependencies.scalacacheCore,
+      Dependencies.scalacacheCaffeine,
+      Dependencies.shapeless,
       Dependencies.typesafeConfig
     )
   })

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -139,6 +139,7 @@ services:
       - RF_LOG_LEVEL=INFO
       - COURSIER_CACHE=/root/.coursier
       - SCOPE_IT_API_HOST=http://api.service.rasterfoundry.internal:9000
+      - AUTH0_ENABLE_CACHE=true
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./data/:/opt/data/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -138,7 +138,7 @@ services:
     environment:
       - RF_LOG_LEVEL=INFO
       - COURSIER_CACHE=/root/.coursier
-      - SCOPE_IT_API_HOST=http://api.service.rasterfoundry.internal/api
+      - SCOPE_IT_API_HOST=http://api.service.rasterfoundry.internal:9000/api
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./data/:/opt/data/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -138,6 +138,7 @@ services:
     environment:
       - RF_LOG_LEVEL=INFO
       - COURSIER_CACHE=/root/.coursier
+      - SCOPE_IT_API_HOST=http://api.service.rasterfoundry.internal/api
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./data/:/opt/data/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -138,7 +138,7 @@ services:
     environment:
       - RF_LOG_LEVEL=INFO
       - COURSIER_CACHE=/root/.coursier
-      - SCOPE_IT_API_HOST=http://api.service.rasterfoundry.internal:9000/api
+      - SCOPE_IT_API_HOST=http://api.service.rasterfoundry.internal:9000
     volumes:
       - ./app-backend/:/opt/raster-foundry/app-backend/
       - ./data/:/opt/data/


### PR DESCRIPTION
## Overview

This PR does four important things:

1. exposes the SCOPE_IT_API_HOST in the docker-compose file, in case you think that might be what's going horribly wrong with the scopes tests
2. memoizes the result of JWT verification for 1 minute at a time
3. adds retrying to JWT verification, so that when we randomly fail due to a read timeout in seemingly 0 seconds (something something java sockets) we can try again (up to10 times)

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Notes

computers were a mistake

why do this now? `develop` builds are failing and I don't want to be debugging this problem during / right before the planned maintenance window next week. It's stressful enough debugging flaky CI without that kind of time pressure.

## Testing Instructions

- CI

Closes #5529 
