### PR TITLE
Use campaign URL in intercom message when applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use campaign URL in intercom message when applicable [#5547](https://github.com/raster-foundry/raster-foundry/pull/5547)
 
 ## [1.59.0] - 2021-02-17
 ### Added


### PR DESCRIPTION
## Overview

This PR updates the `run()` method in `CreateTaskGrid` class of GroundWork batch job, which handles intercom message sending in the end, so that it sends a link to the campaign's image overview UI if a project/image within it is successfully processed. If the processed project is not associated with any campaign, it will send the project overview URL instead.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Push up a test branch
- When the test branch is deployed to staging, open up GroundWork staging
- Create a campaign using the campaign creation workflow
- When image is processed, it should send you an intercom notification with a link to the campaign's image overview page. Make sure the URL works

Closes https://github.com/raster-foundry/groundwork/issues/1146
