### PR TITLE
Make campaign id editable for label class groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Label class groups can have campaign IDs edited [#5548](https://github.com/raster-foundry/raster-foundry/pull/5548)
 
 ## [1.60.1] - 2021-02-23
 ### Fixed

--- a/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
@@ -117,9 +117,10 @@ object AnnotationLabelClassGroupDao
     for {
       groupOpt <- groupIO
       classes <- AnnotationLabelClassDao.listAnnotationLabelClassByGroupId(id)
-    } yield groupOpt map { group =>
-      group.withLabelClasses(classes)
-    }
+    } yield
+      groupOpt map { group =>
+        group.withLabelClasses(classes)
+      }
   }
 
   def update(id: UUID, group: AnnotationLabelClassGroup): ConnectionIO[Int] =

--- a/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelClassGroupDao.scala
@@ -117,16 +117,16 @@ object AnnotationLabelClassGroupDao
     for {
       groupOpt <- groupIO
       classes <- AnnotationLabelClassDao.listAnnotationLabelClassByGroupId(id)
-    } yield
-      groupOpt map { group =>
-        group.withLabelClasses(classes)
-      }
+    } yield groupOpt map { group =>
+      group.withLabelClasses(classes)
+    }
   }
 
   def update(id: UUID, group: AnnotationLabelClassGroup): ConnectionIO[Int] =
     (fr"UPDATE " ++ tableF ++ fr"""SET
       name = ${group.name},
-      idx = ${group.index}
+      idx = ${group.index},
+      campaign_id = ${group.campaignId}
     WHERE
       id = $id
     """).update.run;

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassGroupDaoSpec.scala
@@ -125,7 +125,10 @@ class AnnotationLabelClassGroupDaoSpec
               AnnotationProjectDao
                 .insert(annotationProjectCreate, user)
             classGroupOpt = insertedProject.labelClassGroups.headOption
-            insertedCampaign <- CampaignDao.insertCampaign(campaignCreate, user)
+            insertedCampaign <- CampaignDao.insertCampaign(
+              campaignCreate.copy(parentCampaignId = None),
+              user
+            )
             updateGroup = groupToUpdate(insertedCampaign)
             _ <- classGroupOpt traverse { group =>
               AnnotationLabelClassGroupDao.update(
@@ -146,7 +149,7 @@ class AnnotationLabelClassGroupDaoSpec
               case Some((group, groupUpdated)) =>
                 group.annotationProjectId == groupUpdated.annotationProjectId &&
                   group.isActive == groupUpdated.isActive &&
-                  group.campaignId == updateGroup.campaignId &&
+                  groupUpdated.campaignId == updateGroup.campaignId &&
                   groupUpdated.index == updateGroup.index &&
                   groupUpdated.name == updateGroup.name
               case None if annotationProjectCreate.labelClassGroups.size == 0 =>

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassGroupDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelClassGroupDaoSpec.scala
@@ -108,44 +108,52 @@ class AnnotationLabelClassGroupDaoSpec
         (
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
+            campaignCreate: Campaign.Create,
             labelClassGroupCreate: AnnotationLabelClassGroup.Create
         ) => {
-          val groupToUpdate = AnnotationLabelClassGroup(
-            id = UUID.randomUUID,
-            name = labelClassGroupCreate.name,
-            annotationProjectId = None,
-            campaignId = None,
-            index = labelClassGroupCreate.index.getOrElse(0)
-          )
+          val groupToUpdate = (campaign: Campaign) =>
+            AnnotationLabelClassGroup(
+              id = UUID.randomUUID,
+              name = labelClassGroupCreate.name,
+              annotationProjectId = None,
+              campaignId = Some(campaign.id),
+              index = labelClassGroupCreate.index.getOrElse(0)
+            )
           val updateIO = for {
             user <- UserDao.create(userCreate)
-            inserted <-
+            insertedProject <-
               AnnotationProjectDao
                 .insert(annotationProjectCreate, user)
-            classGroupOpt = inserted.labelClassGroups.headOption
+            classGroupOpt = insertedProject.labelClassGroups.headOption
+            insertedCampaign <- CampaignDao.insertCampaign(campaignCreate, user)
+            updateGroup = groupToUpdate(insertedCampaign)
             _ <- classGroupOpt traverse { group =>
-              AnnotationLabelClassGroupDao.update(group.id, groupToUpdate)
+              AnnotationLabelClassGroupDao.update(
+                group.id,
+                updateGroup
+              )
             }
             classGroupUpdatedOpt <- classGroupOpt flatTraverse { group =>
               AnnotationLabelClassGroupDao.getGroupWithClassesById(group.id)
             }
-          } yield { (classGroupOpt, classGroupUpdatedOpt) }
+          } yield { (classGroupOpt, updateGroup, classGroupUpdatedOpt) }
 
-          val (groupOpt, groupUpdatedOpt) = updateIO.transact(xa).unsafeRunSync
+          val (groupOpt, updateGroup, groupUpdatedOpt) =
+            updateIO.transact(xa).unsafeRunSync
 
           assert(
             (groupOpt, groupUpdatedOpt).tupled match {
               case Some((group, groupUpdated)) =>
                 group.annotationProjectId == groupUpdated.annotationProjectId &&
                   group.isActive == groupUpdated.isActive &&
-                  group.campaignId == groupUpdated.campaignId &&
-                  groupUpdated.index == groupToUpdate.index &&
-                  groupUpdated.name == groupToUpdate.name
+                  group.campaignId == updateGroup.campaignId &&
+                  groupUpdated.index == updateGroup.index &&
+                  groupUpdated.name == updateGroup.name
               case None if annotationProjectCreate.labelClassGroups.size == 0 =>
                 true
               case _ => false
             },
-            "Only name and index fields can be updated for label class group"
+            "Only name, index, and campaign id fields can be updated for label class group"
           )
 
           true


### PR DESCRIPTION
## Overview

To promote annotation projects to campaigns, we need to copy the label class groups to the campaigns we create. However, we can't edit the campaign id on label class groups currently, so that's impossible. This PR fixes that.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

- use raster-foundry/gkeeper#13 to bundle an annotation project to a campaign while the test/ branch for this PR is deployed
