### PR TITLE
get exterior ring of scene footprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Removed holes from union of scene footprints before task grid construction [#5549](https://github.com/raster-foundry/raster-foundry/pull/5549)
 
 ## [1.59.0] - 2021-02-17
 ### Added

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -151,7 +151,7 @@ object ProjectLayerScenesDao extends Dao[Scene] {
   ): ConnectionIO[Option[Projected[Geometry]]] =
     (fr"""
     SELECT
-      ST_Transform(ST_Union(s.data_footprint), 4326) AS geometry
+      ST_MakePolygon(ST_ExteriorRing(ST_Transform(ST_Union(s.data_footprint), 4326))) AS geometry
     FROM scenes s
     JOIN scenes_to_layers stl
     ON s.id = stl.scene_id


### PR DESCRIPTION
## Overview

This PR gets the exterior ring of the scene footprint union before passing anything off to the `ST_MakeGrid` function. Locally, it worked _fine_, so probably it won't cause the db to explode again? But I'm including upload testing in the next release issue, which will eventually reference this PR.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

### Demo

We tested with a Sentinel-2 COG that previously wound up with holes, and it doesn't anymore.

## Testing Instructions

- paired / demoed

Closes #1203
