### PR TITLE
Add multi-polygon safe inner ring removal to grid process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove interior rings from data-footprint before generating task grid [#5550](https://github.com/raster-foundry/raster-foundry/pull/5550)
 
 ## [1.60.0] - 2021-02-19
 ### Changed

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -83,16 +83,16 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       }
     } yield page
     paginatedScenes.flatMap { (pr: PaginatedResponse[Scene]) =>
-      scenesToProjectScenes(pr.results.toList, layerId).map(projectScenes =>
-        PaginatedResponse[Scene.ProjectScene](
-          pr.count,
-          pr.hasPrevious,
-          pr.hasNext,
-          pr.page,
-          pr.pageSize,
-          projectScenes
-        )
-      )
+      scenesToProjectScenes(pr.results.toList, layerId).map(
+        projectScenes =>
+          PaginatedResponse[Scene.ProjectScene](
+            pr.count,
+            pr.hasPrevious,
+            pr.hasNext,
+            pr.page,
+            pr.pageSize,
+            projectScenes
+        ))
     }
   }
 

--- a/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
+++ b/app-backend/db/src/main/scala/ProjectLayerScenesDao.scala
@@ -39,7 +39,9 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       | (scenes_to_layers JOIN project_layers ON scenes_to_layers.project_layer_id = project_layers.id) s2lpl
       | JOIN projects ON s2lpl.project_id = projects.id
       """.trim.stripMargin
-    ) ++ Fragments.whereAnd(fr"project_id = ${projectId}") ++ fr"GROUP BY project_layer_id")
+    ) ++ Fragments.whereAnd(
+      fr"project_id = ${projectId}"
+    ) ++ fr"GROUP BY project_layer_id")
       .query[(UUID, Int)]
       .to[List]
   }
@@ -81,15 +83,14 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       }
     } yield page
     paginatedScenes.flatMap { (pr: PaginatedResponse[Scene]) =>
-      scenesToProjectScenes(pr.results.toList, layerId).map(
-        projectScenes =>
-          PaginatedResponse[Scene.ProjectScene](
-            pr.count,
-            pr.hasPrevious,
-            pr.hasNext,
-            pr.page,
-            pr.pageSize,
-            projectScenes
+      scenesToProjectScenes(pr.results.toList, layerId).map(projectScenes =>
+        PaginatedResponse[Scene.ProjectScene](
+          pr.count,
+          pr.hasPrevious,
+          pr.hasNext,
+          pr.page,
+          pr.pageSize,
+          projectScenes
         )
       )
     }
@@ -110,9 +111,12 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       val datasources = SceneWithRelatedDao.getScenesDatasources(scenes map {
         _.datasource
       })
-      val sceneToLayers = SceneWithRelatedDao.getScenesToLayers(scenes map {
-        _.id
-      }, layerId)
+      val sceneToLayers = SceneWithRelatedDao.getScenesToLayers(
+        scenes map {
+          _.id
+        },
+        layerId
+      )
       (thumbnails, datasources, sceneToLayers).tupled
     }
 
@@ -150,11 +154,13 @@ object ProjectLayerScenesDao extends Dao[Scene] {
       layerId: UUID
   ): ConnectionIO[Option[Projected[Geometry]]] =
     (fr"""
-    SELECT
-      ST_MakePolygon(ST_ExteriorRing(ST_Transform(ST_Union(s.data_footprint), 4326))) AS geometry
-    FROM scenes s
-    JOIN scenes_to_layers stl
-    ON s.id = stl.scene_id
-    WHERE stl.project_layer_id = ${layerId}
+    SELECT ST_Union(ST_MakePolygon(ST_ExteriorRing(A.geom)))
+    FROM (
+      SELECT (st_dump(st_transform(data_footprint, 4326))).geom
+      FROM scenes s
+      JOIN scenes_to_layers stl
+      ON s.id = stl.scene_id
+      WHERE stl.project_layer_id = ${layerId}
+    ) A
   """).query[Option[Projected[Geometry]]].unique
 }


### PR DESCRIPTION
## Overview

This PR updates the query used to generate the data footprint that is passed to the ST_MakeGrid UDF.

Previously, a data_footprint with inner-rings due to NODATA (regardless of correctness) would cause tasks to also have those holes.

This PR ensures all interior rings are removed from the (multi)polygon data footprint before it is passed to ST_MakeGrid.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

I can share with you the project generated with a proper grid using the test branch associated with this PR
