### PR TITLE
Update annotation project GET endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Remove interior rings from data-footprint before generating task grid [#5550](https://github.com/raster-foundry/raster-foundry/pull/5550)
 
+### Changed
+- Update annotation project GET endpoint to read from the right source of label class summary[#5551](https://github.com/raster-foundry/raster-foundry/pull/5551)
+
 ## [1.60.0] - 2021-02-19
 ### Changed
 - Use campaign URL in intercom message when applicable [#5547](https://github.com/raster-foundry/raster-foundry/pull/5547)

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -205,16 +205,15 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <-
-        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-          case (classGroup, idx) =>
-            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-              classGroup,
-              Some(annotationProject),
-              None,
-              idx
-            )
-        }
+      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+        case (classGroup, idx) =>
+          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+            classGroup,
+            Some(annotationProject),
+            None,
+            idx
+          )
+      }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -230,9 +229,8 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByProjectId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -378,12 +376,11 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      projectIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -410,14 +407,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(classes =>
-              LabelClass(
-                LabelClassName.VectorName(group.name),
-                LabelClassClasses.NamedLabelClasses(
-                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                )
-              )
-            )
+            .map(
+              classes =>
+                LabelClass(
+                  LabelClassName.VectorName(group.name),
+                  LabelClassClasses.NamedLabelClasses(
+                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                  )
+              ))
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -440,9 +437,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -450,9 +447,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -503,40 +500,37 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[AnnotationProject](
-            fieldNames: _*
-          )
+      annotationProjectCopy <- insertQuery.update
+        .withUniqueGeneratedKeys[AnnotationProject](
+          fieldNames: _*
+        )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <-
-            AnnotationLabelClassDao
-              .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <-
-            AnnotationLabelClassGroupDao
-              .insertAnnotationLabelClassGroup(
-                AnnotationLabelClassGroup.Create(
-                  classGroup.name,
-                  Some(classGroup.index),
-                  labelClasses.map { labelClass =>
-                    AnnotationLabelClass.Create(
-                      labelClass.name,
-                      labelClass.colorHexCode,
-                      labelClass.default,
-                      labelClass.determinant,
-                      labelClass.index,
-                      labelClass.geometryType,
-                      labelClass.description
-                    )
-                  }
-                ),
-                Some(annotationProjectCopy),
-                None,
-                0,
-                labelClasses
-              )
+          labelClasses <- AnnotationLabelClassDao
+            .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <- AnnotationLabelClassGroupDao
+            .insertAnnotationLabelClassGroup(
+              AnnotationLabelClassGroup.Create(
+                classGroup.name,
+                Some(classGroup.index),
+                labelClasses.map { labelClass =>
+                  AnnotationLabelClass.Create(
+                    labelClass.name,
+                    labelClass.colorHexCode,
+                    labelClass.default,
+                    labelClass.determinant,
+                    labelClass.index,
+                    labelClass.geometryType,
+                    labelClass.description
+                  )
+                }
+              ),
+              Some(annotationProjectCopy),
+              None,
+              0,
+              labelClasses
+            )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -567,20 +561,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
-            acc ++ List(
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.View
-              ),
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.Annotate
-              )
-            )
-          )
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
+            ))
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules


### PR DESCRIPTION
## Overview

This PR updates the annotation project `GET` endpoint so that:
- if it has a `campaignId`, it returns label class summary based on the label group(s) attached to the campaign
- otherwise, it returns the label class summary based on label group(s) attached to the project

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- A `test` branch should be live on staging now, so follow the instructions here https://github.com/raster-foundry/groundwork/pull/1265 to test
- Then manually go to `/app/project-list` in GW and select a project not attached to any campaign. The dashboard should show the label counts correctly as well

Closes https://github.com/raster-foundry/groundwork/issues/1264
