### PR TITLE
Add migration to cascade delete label class group on campaign deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Changed
 - Label class groups can have campaign IDs edited [#5548](https://github.com/raster-foundry/raster-foundry/pull/5548)
+- Update annotation project GET endpoint to read from the right source of label class summary [#5551](https://github.com/raster-foundry/raster-foundry/pull/5551)
+
+### Added
+- Add migration to cascade delete label class group on campaign deletion [#5552](https://github.com/raster-foundry/raster-foundry/pull/5552)
 
 ## [1.60.1] - 2021-02-23
 ### Fixed
 - Remove interior rings from data-footprint before generating task grid [#5550](https://github.com/raster-foundry/raster-foundry/pull/5550)
-
-### Changed
-- Update annotation project GET endpoint to read from the right source of label class summary[#5551](https://github.com/raster-foundry/raster-foundry/pull/5551)
 
 ## [1.60.0] - 2021-02-19
 ### Changed

--- a/app-backend/db/src/main/resources/migrations/V70__cascade_delete_class_group_on_campaign_delete.sql
+++ b/app-backend/db/src/main/resources/migrations/V70__cascade_delete_class_group_on_campaign_delete.sql
@@ -1,0 +1,4 @@
+ALTER TABLE annotation_label_class_groups
+  DROP CONSTRAINT "annotation_label_class_groups_campaign_id_fkey",
+  ADD CONSTRAINT "annotation_label_class_groups_campaign_id_fkey"
+    FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE;


### PR DESCRIPTION
## Overview

This PR adds a migration to update the constraints on `annotation_label_class_groups` table, so that when a campaign is deleted, the corresponding label class groups are also deleted, which will make campaign deletion happy.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~ Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- `./scripts/migrate migrate` should work
- `./scripts/psql` and then `\d annotation_label_class_groups`, it should show the updated constrains on the `campaign_id` field of this table
- connect GW frontend to RF backend, and delete a campaign that has class definition -- it should work

Closes https://github.com/raster-foundry/groundwork/issues/1257
