### PR TITLE
Update boto3 file upload method to support uploading large COG after processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Changed
 - Label class groups can have campaign IDs edited [#5548](https://github.com/raster-foundry/raster-foundry/pull/5548)
+- Update boto3 file upload method to support uploading large COG after processing [#5553](https://github.com/raster-foundry/raster-foundry/pull/5553)
 
 ## [1.60.1] - 2021-02-23
 ### Fixed

--- a/app-tasks/rf/src/rf/utils/io.py
+++ b/app-tasks/rf/src/rf/utils/io.py
@@ -208,7 +208,7 @@ def upload_tifs(tifs, user_id, scene_id, bucket_name=None):
 
         s3_uris.append("s3://{}/{}".format(bucket, quote(key)))
         with open(tif, "rb") as inf:
-            s3_client.put_object(Bucket=bucket, Body=inf, Key=key)
+            s3_client.upload_fileobj(Fileobj=inf, Bucket=bucket, Key=key)
     return s3_uris
 
 


### PR DESCRIPTION
## Overview

This PR updates the upload method from boto3 that we use to upload a processed scene to S3 after cogification.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- I pushed a `test` branch of this change to staging, which we may use directly to test this PR. If by the time of review, staging is overwritten, feel free to push a test branch again.
- Grab a large geotif on S3 (>5GB?). If you don't have one handy, I'd suggest using the ingest location attached to this scene: `38c78971-2bd9-4160-ae3e-9bee3d1cded8` in prod DB.
- Go to RF staging, select "Data" tab, and click on "Import scenes" button. Why not using GW -- it currently only supports geotif upload, so you will need to upload a huge tif
- Choose a datasource, under "Geotiff" tab, select S3 icon and paste in the url from the second step
- If the image you use is huge, processing time is very likely to exceed our 30 min timeout limit. So to save some time, after submitting the job, go to AWS batch dashboard, terminate the job manually and then clone the job. Update the timeout limit to, say, 1.5 hours, then submit the job
- Make sure the job succeeds.

Closes https://github.com/raster-foundry/raster-foundry/issues/5463
