### PR TITLE
Simplify backsplash color correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Label class groups can have campaign IDs edited [#5548](https://github.com/raster-foundry/raster-foundry/pull/5548)
 - Update boto3 file upload method to support uploading large COG after processing [#5553](https://github.com/raster-foundry/raster-foundry/pull/5553)
 - Update annotation project GET endpoint to read from the right source of label class summary [#5551](https://github.com/raster-foundry/raster-foundry/pull/5551)
+- Simplify backsplash color correct [#5554](https://github.com/raster-foundry/raster-foundry/pull/5554)
 
 ### Added
 - Add migration to cascade delete label class group on campaign deletion [#5552](https://github.com/raster-foundry/raster-foundry/pull/5552)

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -52,7 +52,6 @@ final case class BacksplashGeotiff(
     mask: Option[MultiPolygon],
     footprint: MultiPolygon,
     metadata: SceneMetadataFields,
-    disableAutoCorrect: Option[Boolean],
     xa: Transactor[IO]
 ) extends LazyLogging
     with BacksplashImage[IO] {
@@ -218,7 +217,6 @@ sealed trait BacksplashImage[F[_]] extends LazyLogging {
   val projectLayerId: UUID
   val mask: Option[MultiPolygon]
   val metadata: SceneMetadataFields
-  val disableAutoCorrect: Option[Boolean]
 
   val enableGDAL = Config.RasterSource.enableGDAL
 

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -197,20 +197,18 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                   .span("renderMosaicMultiband.colorCorrect") use {
                   _ =>
                     IO {
-                      im map {
-                        mbTile =>
-                          val noDataValue = getNoDataValue(mbTile.cellType)
-                          logger.debug(
-                            s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
+                      im map { mbTile =>
+                        val noDataValue = getNoDataValue(mbTile.cellType)
+                        logger.debug(
+                          s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
+                        )
+                        relevant.corrections.colorCorrect(
+                          mbTile,
+                          hists,
+                          relevant.metadata.noDataValue orElse noDataValue orElse Some(
+                            0
                           )
-                          relevant.corrections.colorCorrect(
-                            mbTile,
-                            hists,
-                            relevant.metadata.noDataValue orElse noDataValue orElse Some(
-                              0
-                            ),
-                            relevant.disableAutoCorrect
-                          )
+                        )
                       }
                     }
                 }
@@ -415,8 +413,7 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                               relevant.corrections.colorCorrect(
                                 mbTile,
                                 hists,
-                                None,
-                                relevant.disableAutoCorrect
+                                None
                               )
                             }
                           }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
@@ -29,7 +29,8 @@ object Parameters {
       * See Path.scala in http4s
       */
     def unapply(
-        params: Map[String, Seq[String]]): Some[Option[BandOverride]] = {
+        params: Map[String, Seq[String]]
+    ): Some[Option[BandOverride]] = {
       Some {
         (
           params.get("redBand") flatMap { _.headOption } map {
@@ -79,8 +80,6 @@ object Parameters {
       extends OptionalQueryParamDecoderMatcher[String]("tag")
   object VoidCacheQueryParamMatcher
       extends QueryParamDecoderMatcher[Boolean]("voidCache")
-  object DisableAutoCorrectionQueryParamDecoder
-      extends OptionalQueryParamDecoderMatcher[Boolean]("disableAutoCorrect")
   object ZoomQueryParamMatcher extends QueryParamDecoderMatcher[Int]("zoom")
   object BrightnessFloorQueryParamMatcher
       extends OptionalQueryParamDecoderMatcher[Int]("floor")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
@@ -22,7 +22,6 @@ import java.util.UUID
       window: Option[Projected[Polygon]],
       bandOverride: Option[BandOverride],
       imageSubset: Option[NEL[UUID]],
-      disableAutoCorrect: Option[Boolean],
       tracingContext: TracingContext[IO] = NoOpTracingContext[IO]("no-op-read")
   ): BacksplashMosaic
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/MamlAdapter.scala
@@ -39,7 +39,6 @@ class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
                                 None,
                                 None,
                                 None,
-                                None,
                                 NoOpTracingContext[IO]("no-op-read"))
             } map {
               case (tracingContext, bsiList) =>
@@ -61,7 +60,6 @@ class BacksplashMamlAdapter[HistStore, LayerStore: RenderableStore](
             s"${layerId.toString}_${bandActual}" -> (
               layerStore
                 .read(layerId,
-                      None,
                       None,
                       None,
                       None,

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -1,31 +1,10 @@
 package com.rasterfoundry.common.color
 import com.typesafe.scalalogging.LazyLogging
-import geotrellis.raster.UByteConstantNoDataCellType
 import geotrellis.raster.histogram.Histogram
-import geotrellis.raster.{isData, ArrayTile, MultibandTile}
+import geotrellis.raster.{MultibandTile}
 import io.circe.generic.JsonCodec
-import spire.syntax.cfor.cfor
 
-/**
-  * Usage of Approximations.{pow | exp} functions can allow to speed up this function on 10 - 15ms.
-  * We can consider these functions usages in case of real performance issues caused by a long color correction.
-  */
 object ColorCorrect extends LazyLogging {
-
-  final case class LayerClipping(
-      redMin: Int,
-      redMax: Int,
-      greenMin: Int,
-      greenMax: Int,
-      blueMin: Int,
-      blueMax: Int
-  )
-  sealed trait ClipValue
-  final case class ClipBounds(min: Int, max: Int) extends ClipValue
-  final case class MaybeClipBounds(maybeMin: Option[Int], maybeMax: Option[Int])
-      extends ClipValue
-  final case class ClippingParams(band: Int, bounds: ClipValue)
-
   @JsonCodec
   final case class Params(
       redBand: Int,
@@ -35,202 +14,27 @@ object ColorCorrect extends LazyLogging {
     def colorCorrect(
         tile: MultibandTile,
         hist: Seq[Histogram[Double]],
-        nodataValue: Option[Double],
+        noDataValue: Option[Double],
         disableAutoCorrect: Option[Boolean]
     ): MultibandTile = {
+      if (disableAutoCorrect getOrElse false) return tile
       val indexedHist = hist.toIndexedSeq
       val rgbHist = Seq(redBand, greenBand, blueBand) map { indexedHist(_) }
-      ColorCorrect(tile, rgbHist, nodataValue, disableAutoCorrect)
-    }
-  }
-
-  @inline def normalizePerPixel(
-      pixelValue: Double,
-      oldMin: Int,
-      oldMax: Int,
-      newMin: Int,
-      newMax: Int,
-      noDataValue: Option[Double]
-  ): Int = {
-    if (isData(pixelValue)) {
-      val dNew = newMax - newMin
-      val dOld = oldMax - oldMin
-
-      if (noDataValue.exists(nd => (nd - pixelValue).abs < 0.00000001)) {
-        0
-      } else if (dOld == 0) {
-        // When dOld is nothing we still need to clamp
-        val v = {
-          if (pixelValue > newMax) newMax
-          else if (pixelValue < newMin) newMin
-          else pixelValue.toInt
-        }
-
-        v
-      } else {
-        val v = {
-          val scaled = (((pixelValue - oldMin) * dNew) / dOld) + newMin
-
-          if (scaled > newMax) newMax
-          else if (scaled < newMin) newMin
-          else scaled.toInt
-        }
-
-        v
+      val bands = tile.bands.zip(rgbHist).map {
+        case (rgbTile, histogram) =>
+          val breaks = histogram.quantileBreaks(100)
+          val oldMin = breaks(0).toInt
+          val oldMax = breaks(99).toInt
+          rgbTile
+            .withNoData(noDataValue)
+            .mapIfSet { cell =>
+              if (cell < oldMin) oldMin
+              else if (cell > oldMax) oldMax
+              else cell
+            }
+            .normalize(oldMin, oldMax, 1, 255)
       }
-    } else pixelValue.toInt
-  }
-
-  val rgbBand: (Option[Int], Option[Int], Int) => Some[Int] =
-    (specificBand: Option[Int], allBands: Option[Int], tileDefault: Int) =>
-      specificBand.fold(allBands)(Some(_)).fold(Some(tileDefault))(x => Some(x))
-
-  def normalize(rgbTile: MultibandTile,
-                layerNormalizeArgs: Map[String, ClipBounds],
-                noDataValue: Option[Double]): MultibandTile = {
-    val (red, green, blue) = (rgbTile.band(0), rgbTile.band(1), rgbTile.band(2))
-    val tileCellType = UByteConstantNoDataCellType
-    val (dstRed, dstGreen, dstBlue) = (
-      ArrayTile.alloc(tileCellType, rgbTile.cols, rgbTile.rows),
-      ArrayTile.alloc(tileCellType, rgbTile.cols, rgbTile.rows),
-      ArrayTile.alloc(tileCellType, rgbTile.cols, rgbTile.rows)
-    )
-
-    /** These are all super unsafe destructurings
-      * I tried to make the assumptions more explicit by naming the keys instead
-      * of numbering them, but if you see this and feel nervous about it, that's
-      * reasonable.
-      * It's safe, because the layerNormalizeArgs are constructed and consumed in
-      * this and only this file, so there's no way for this map to get all wonky,
-      * but, future reader, your concern is not unreasonable.
-      */
-    val ClipBounds(rmin, rmax) = layerNormalizeArgs("red")
-    val ClipBounds(gmin, gmax) = layerNormalizeArgs("green")
-    val ClipBounds(bmin, bmax) = layerNormalizeArgs("blue")
-
-    val tileMin = 1
-    val (rclipMin, rclipMax, rnewMin, rnewMax) = (rmin, rmax, tileMin, 255)
-    val (gclipMin, gclipMax, gnewMin, gnewMax) = (gmin, gmax, tileMin, 255)
-    val (bclipMin, bclipMax, bnewMin, bnewMax) = (bmin, bmax, tileMin, 255)
-
-    /** In this case for some reason with this func wrap it works faster ¯\_(ツ)_/¯ (it was micro benchmarked) */
-    lazyWrapper {
-      cfor(0)(_ < rgbTile.cols, _ + 1) { col =>
-        cfor(0)(_ < rgbTile.rows, _ + 1) { row =>
-          val (r, g, b) =
-            (
-              ColorCorrect.normalizePerPixel(
-                red.getDouble(col, row),
-                rclipMin,
-                rclipMax,
-                rnewMin,
-                rnewMax,
-                noDataValue
-              ),
-              ColorCorrect.normalizePerPixel(
-                green.getDouble(col, row),
-                gclipMin,
-                gclipMax,
-                gnewMin,
-                gnewMax,
-                noDataValue
-              ),
-              ColorCorrect.normalizePerPixel(
-                blue.getDouble(col, row),
-                bclipMin,
-                bclipMax,
-                bnewMin,
-                bnewMax,
-                noDataValue
-              )
-            )
-
-          dstRed.set(col, row, r.toInt)
-          dstGreen.set(col, row, g.toInt)
-          dstBlue.set(col, row, b.toInt)
-        }
-      }
+      MultibandTile(bands)
     }
-
-    MultibandTile(dstRed, dstGreen, dstBlue)
   }
-
-  def apply(rgbTile: MultibandTile,
-            rgbHist: Seq[Histogram[Double]],
-            noDataValue: Option[Double],
-            disableAutoCorrectOption: Option[Boolean]): MultibandTile = {
-    val _rgbTile = rgbTile
-    val _rgbHist = rgbHist
-
-    val disableCorrection = disableAutoCorrectOption match {
-      case Some(true) => true
-      case _          => false
-    }
-
-    var isCorrected = false
-    val layerRgbClipping = {
-      val range = 1 until 255
-      val iMaxMin: Array[(Int, Int)] = Array.ofDim(3)
-      cfor(0)(_ < _rgbHist.length, _ + 1) { index =>
-        val hst = _rgbHist(index)
-        val statsOption = hst.statistics()
-        val imin = hst.minValue().map(_.toInt).getOrElse(0)
-        val imax = hst.maxValue().map(_.toInt).getOrElse(255)
-
-        // if data is a byte raster (0, 255) don't do anything
-        // else if stats are available, clip assuming a normal distribution
-        // else use the histogram's min/max
-        if (imin >= 0 && imax <= 255) {
-          iMaxMin(index) = (0, 255)
-        } else {
-          (imin, imax, statsOption) match {
-            case (_, _, Some(stats)) =>
-              // assuming a normal distribution, clips 2nd and 98th percentiles of values
-              val newMin =
-                if (disableCorrection) imin
-                else stats.mean + (stats.stddev * -2.05)
-              val newMax =
-                if (disableCorrection) imax
-                else stats.mean + (stats.stddev * 2.05)
-              // assume non-negative values, otherwise visualization is weird
-              // I think this happens because the distribution is non-normal
-              iMaxMin(index) =
-                (if (newMin < 0) 0 else newMin.toInt, newMax.toInt)
-            case (min, max, _) => iMaxMin(index) = (min, max)
-          }
-        }
-        logger.trace(s"Histogram Min/Max: ${iMaxMin(index)}")
-
-        isCorrected = {
-          if (range.contains(imin) && range.contains(imax)) true
-          else false
-        }
-      }
-
-      if (!isCorrected) {
-        val (rmin, rmax) = iMaxMin(0)
-        val (gmin, gmax) = iMaxMin(1)
-        val (bmin, bmax) = iMaxMin(2)
-        LayerClipping(rmin, rmax, gmin, gmax, bmin, bmax)
-      } else LayerClipping(0, 255, 0, 255, 0, 255)
-    }
-
-    val layerNormalizeArgs: Map[String, ClipBounds] = Map(
-      "red" -> ClipBounds(layerRgbClipping.redMin, layerRgbClipping.redMax),
-      "green" -> ClipBounds(layerRgbClipping.greenMin,
-                            layerRgbClipping.greenMax),
-      "blue" -> ClipBounds(layerRgbClipping.blueMin, layerRgbClipping.blueMax)
-    )
-
-    logger.trace(s"Layer Normalize Args: ${layerNormalizeArgs}")
-    normalize(_rgbTile, layerNormalizeArgs, noDataValue)
-  }
-
-  @inline def clampColor(z: Int): Int = {
-    if (z < 0) 0
-    else if (z > 255) 255
-    else z
-  }
-
-  private def lazyWrapper[T](f: => T): T = f
 }

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -14,10 +14,8 @@ object ColorCorrect extends LazyLogging {
     def colorCorrect(
         tile: MultibandTile,
         hist: Seq[Histogram[Double]],
-        noDataValue: Option[Double],
-        disableAutoCorrect: Option[Boolean]
+        noDataValue: Option[Double]
     ): MultibandTile = {
-      if (disableAutoCorrect getOrElse false) return tile
       val indexedHist = hist.toIndexedSeq
       val rgbHist = Seq(redBand, greenBand, blueBand) map { indexedHist(_) }
       val bands = tile.bands.zip(rgbHist).map {


### PR DESCRIPTION
## Overview

This PR:
- removes the `disableAutoCorrect` QP
- simplifies the color correction logic in backsplash

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- I pushed a `/test` branch up so staging should reflect the changes in this PR; feel free to push `test/asu/simplify-color-correct` again in case staging is overwritten
- Go to GroundWork staging -- make sure the recent images show up just fine
- Upload the image in question in [here](https://azavea.slack.com/archives/C089LBS6S/p1613585378118400?thread_ts=1613573510.106100&cid=C089LBS6S) in GW and make sure it displays just fine without disabling the auto color correction

Closes https://github.com/azavea/raster-foundry-platform/issues/1202
