### PR TITLE
Restore disableAutoCorrect param and remove superfluous task filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Restored ability to disable color correction, since simplified color correction darkened some client imagery [#5556](https://github.com/raster-foundry/raster-foundry/pull/5556)
+- Allowed tasks with parents not to be automatically filtered out of task queries [#5556](https://github.com/raster-foundry/raster-foundry/pull/5556)
 
 ## [1.61.0] - 2021-03-04
 ### Changed

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/BacksplashImage.scala
@@ -52,6 +52,7 @@ final case class BacksplashGeotiff(
     mask: Option[MultiPolygon],
     footprint: MultiPolygon,
     metadata: SceneMetadataFields,
+    disableColorCorrect: Boolean,
     xa: Transactor[IO]
 ) extends LazyLogging
     with BacksplashImage[IO] {
@@ -227,6 +228,8 @@ sealed trait BacksplashImage[F[_]] extends LazyLogging {
       y: Int,
       context: TracingContext[F]
   ): F[Option[MultibandTile]]
+
+  val disableColorCorrect: Boolean
 
   /** Read tile with tracing * */
   def read(

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/MosaicImplicits.scala
@@ -197,18 +197,23 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                   .span("renderMosaicMultiband.colorCorrect") use {
                   _ =>
                     IO {
-                      im map { mbTile =>
-                        val noDataValue = getNoDataValue(mbTile.cellType)
-                        logger.debug(
-                          s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
-                        )
-                        relevant.corrections.colorCorrect(
-                          mbTile,
-                          hists,
-                          relevant.metadata.noDataValue orElse noDataValue orElse Some(
-                            0
+                      im map {
+                        mbTile =>
+                          val noDataValue = getNoDataValue(mbTile.cellType)
+                          logger.debug(
+                            s"NODATA Value: $noDataValue with CellType: ${mbTile.cellType}"
                           )
-                        )
+                          if (relevant.disableColorCorrect) {
+                            mbTile
+                          } else {
+                            relevant.corrections.colorCorrect(
+                              mbTile,
+                              hists,
+                              relevant.metadata.noDataValue orElse noDataValue orElse Some(
+                                0
+                              )
+                            )
+                          }
                       }
                     }
                 }
@@ -410,11 +415,15 @@ class MosaicImplicits[HistStore: HistogramStore](histStore: HistStore)
                               logger.debug(
                                 s"N bands in resulting tile: ${mbTile.bands.length}"
                               )
-                              relevant.corrections.colorCorrect(
-                                mbTile,
-                                hists,
-                                None
-                              )
+                              if (relevant.disableColorCorrect) {
+                                mbTile
+                              } else {
+                                relevant.corrections.colorCorrect(
+                                  mbTile,
+                                  hists,
+                                  None
+                                )
+                              }
                             }
                           }
                         }

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/Parameters.scala
@@ -80,6 +80,8 @@ object Parameters {
       extends OptionalQueryParamDecoderMatcher[String]("tag")
   object VoidCacheQueryParamMatcher
       extends QueryParamDecoderMatcher[Boolean]("voidCache")
+  object DisableAutoCorrectionQueryParamDecoder
+      extends OptionalQueryParamDecoderMatcher[Boolean]("disableAutoCorrect")
   object ZoomQueryParamMatcher extends QueryParamDecoderMatcher[Int]("zoom")
   object BrightnessFloorQueryParamMatcher
       extends OptionalQueryParamDecoderMatcher[Int]("floor")

--- a/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
+++ b/app-backend/backsplash-core/src/main/scala/com/rasterfoundry/backsplash/RenderableStore.scala
@@ -22,6 +22,7 @@ import java.util.UUID
       window: Option[Projected[Polygon]],
       bandOverride: Option[BandOverride],
       imageSubset: Option[NEL[UUID]],
+      disableColorCorrect: Boolean,
       tracingContext: TracingContext[IO] = NoOpTracingContext[IO]("no-op-read")
   ): BacksplashMosaic
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/implicits/RenderableStoreImplicits.scala
@@ -36,6 +36,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
   private def mosaicDefinitionToImage(
       mosaicDefinition: MosaicDefinition,
       bandOverride: Option[BandOverride],
+      disableColorCorrect: Boolean,
       projId: UUID
   ): BacksplashImage[IO] = {
     val singleBandOptions =
@@ -90,6 +91,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
       mosaicDefinition.mask,
       footprint,
       mosaicDefinition.sceneMetadataFields,
+      disableColorCorrect,
       xa
     )
   }
@@ -102,6 +104,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
           window: Option[Projected[Polygon]],
           bandOverride: Option[BandOverride],
           imageSubset: Option[NEL[UUID]],
+          disableColorCorrectt: Boolean,
           tracingContext: TracingContext[IO]
       ): BacksplashMosaic = {
         val tags = Map("sceneId" -> projId.toString)
@@ -138,6 +141,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
                     None, // not adding the mask here, since out of functional scope for md to image
                     footprint,
                     scene.metadataFields,
+                    disableColorCorrectt,
                     xa
                   )
                 )
@@ -157,6 +161,7 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
           window: Option[Projected[Polygon]],
           bandOverride: Option[BandOverride],
           imageSubset: Option[NEL[UUID]],
+          disableColorCorrect: Boolean,
           tracingContext: TracingContext[IO]
       ): BacksplashMosaic = {
         val tags = Map("projectId" -> projId.toString)
@@ -187,7 +192,12 @@ class RenderableStoreImplicits(xa: Transactor[IO])(
             (
               tracingContext,
               mosaicDefinitions map { md =>
-                mosaicDefinitionToImage(md, bandOverride, projId)
+                mosaicDefinitionToImage(
+                  md,
+                  bandOverride,
+                  disableColorCorrect,
+                  projId
+                )
               }
             )
           }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -294,6 +294,9 @@ object Task {
   ) {
     def withStatus(status: TaskStatus): TaskFeatureCreate =
       this.copy(properties = this.properties.copy(status = status))
+
+    def withTaskType(taskType: TaskType): TaskFeatureCreate =
+      this.copy(properties = this.properties.copy(taskType = Some(taskType)))
   }
 
   object TaskFeatureCreate {

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -349,9 +349,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-        _.taskSizeMeters
-      })
+      taskSizeO =
+        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+          _.taskSizeMeters
+        })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -765,26 +766,29 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <- query
-            .filter(
-              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-            )
-            .list
-          stuckUnlockedTasks <- query
-            .filter(
-              fr"""
+          stuckLockedTasks <-
+            query
+              .filter(
+                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+              )
+              .list
+          stuckUnlockedTasks <-
+            query
+              .filter(
+                fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
-            )
-            .list
-          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-            projectIdsList =>
-              val projectIdsSet = projectIdsList.toNes
-              warn(
-                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-          }
+              .list
+          _ <-
+            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+              projectIdsList =>
+                val projectIdsSet = projectIdsList.toNes
+                warn(
+                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
+                )
+            }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -829,7 +833,6 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
             Nil
           )
           .filter(queryParams)
-          .filter(fr"parent_task_id IS NULL")
           .filter(Fragments.in(fr"annotation_project_id", annotationProjectIds))
           .filter(Fragment.const(s"""(
             (
@@ -868,9 +871,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <- query
-        .filter(fr"parent_task_id = $taskId")
-        .page(pageRequest)
+      paginatedResponse <-
+        query
+          .filter(fr"parent_task_id = $taskId")
+          .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -1001,8 +1005,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-            reassociateLabelF(taskId, taskFeature.id).update.run
-          }).void
+              reassociateLabelF(taskId, taskFeature.id).update.run
+            }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1030,19 +1034,20 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <- AnnotationProjectDao
-        .authQuery(
-          user,
-          ObjectType.AnnotationProject,
-          None,
-          None,
-          None
-        )
-        .filter(annotationProjectParams)
-        .filter(annotationProjectIdOpt)
-        .list(limit) map { projects =>
-        projects map { _.id }
-      }
+      annotationProjectIds <-
+        AnnotationProjectDao
+          .authQuery(
+            user,
+            ObjectType.AnnotationProject,
+            None,
+            None,
+            None
+          )
+          .filter(annotationProjectParams)
+          .filter(annotationProjectIdOpt)
+          .list(limit) map { projects =>
+          projects map { _.id }
+        }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1083,9 +1088,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case None => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-        projectIds =>
-          randomTask(taskParams, projectIds)
-      }
+      taskOpt <-
+        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+          projectIds =>
+            randomTask(taskParams, projectIds)
+        }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -348,10 +348,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO =
-        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-          _.taskSizeMeters
-        })
+      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+        _.taskSizeMeters
+      })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -765,29 +764,26 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <-
-            query
-              .filter(
-                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-              )
-              .list
-          stuckUnlockedTasks <-
-            query
-              .filter(
-                fr"""
+          stuckLockedTasks <- query
+            .filter(
+              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+            )
+            .list
+          stuckUnlockedTasks <- query
+            .filter(
+              fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
+            )
+            .list
+          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+            projectIdsList =>
+              val projectIdsSet = projectIdsList.toNes
+              warn(
+                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-              .list
-          _ <-
-            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-              projectIdsList =>
-                val projectIdsSet = projectIdsList.toNes
-                warn(
-                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
-                )
-            }
+          }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -869,10 +865,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <-
-        query
-          .filter(fr"parent_task_id = $taskId")
-          .page(pageRequest)
+      paginatedResponse <- query
+        .filter(fr"parent_task_id = $taskId")
+        .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -1003,8 +998,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-              reassociateLabelF(taskId, taskFeature.id).update.run
-            }).void
+            reassociateLabelF(taskId, taskFeature.id).update.run
+          }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1032,20 +1027,19 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <-
-        AnnotationProjectDao
-          .authQuery(
-            user,
-            ObjectType.AnnotationProject,
-            None,
-            None,
-            None
-          )
-          .filter(annotationProjectParams)
-          .filter(annotationProjectIdOpt)
-          .list(limit) map { projects =>
-          projects map { _.id }
-        }
+      annotationProjectIds <- AnnotationProjectDao
+        .authQuery(
+          user,
+          ObjectType.AnnotationProject,
+          None,
+          None,
+          None
+        )
+        .filter(annotationProjectParams)
+        .filter(annotationProjectIdOpt)
+        .list(limit) map { projects =>
+        projects map { _.id }
+      }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1086,10 +1080,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case None => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <-
-        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-          projectIds =>
-            randomTask(taskParams, projectIds)
-        }
+      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+        projectIds =>
+          randomTask(taskParams, projectIds)
+      }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -704,7 +704,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
            'UNLABELED', null, null, geometry, ${toProject}, task_type,
            null, '{}'::jsonb, null
            FROM """ ++ tableF ++ fr"""
-           WHERE annotation_project_id = ${fromProject} AND parent_task_id IS NULL
+           WHERE annotation_project_id = ${fromProject}
       """).update.run
   }
 
@@ -847,7 +847,6 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       case false =>
         val builder = query
           .filter(queryParams)
-          .filter(fr"parent_task_id IS NULL")
           .filter(Fragments.in(fr"annotation_project_id", annotationProjectIds))
         (selectF ++ Fragments.whereAndOpt(
           builder.filters: _*

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -349,10 +349,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO =
-        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-          _.taskSizeMeters
-        })
+      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+        _.taskSizeMeters
+      })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -766,29 +765,26 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <-
-            query
-              .filter(
-                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-              )
-              .list
-          stuckUnlockedTasks <-
-            query
-              .filter(
-                fr"""
+          stuckLockedTasks <- query
+            .filter(
+              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+            )
+            .list
+          stuckUnlockedTasks <- query
+            .filter(
+              fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
+            )
+            .list
+          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+            projectIdsList =>
+              val projectIdsSet = projectIdsList.toNes
+              warn(
+                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-              .list
-          _ <-
-            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-              projectIdsList =>
-                val projectIdsSet = projectIdsList.toNes
-                warn(
-                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
-                )
-            }
+          }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -872,10 +868,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <-
-        query
-          .filter(fr"parent_task_id = $taskId")
-          .page(pageRequest)
+      paginatedResponse <- query
+        .filter(fr"parent_task_id = $taskId")
+        .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -1006,8 +1001,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-              reassociateLabelF(taskId, taskFeature.id).update.run
-            }).void
+            reassociateLabelF(taskId, taskFeature.id).update.run
+          }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1035,20 +1030,19 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <-
-        AnnotationProjectDao
-          .authQuery(
-            user,
-            ObjectType.AnnotationProject,
-            None,
-            None,
-            None
-          )
-          .filter(annotationProjectParams)
-          .filter(annotationProjectIdOpt)
-          .list(limit) map { projects =>
-          projects map { _.id }
-        }
+      annotationProjectIds <- AnnotationProjectDao
+        .authQuery(
+          user,
+          ObjectType.AnnotationProject,
+          None,
+          None,
+          None
+        )
+        .filter(annotationProjectParams)
+        .filter(annotationProjectIdOpt)
+        .list(limit) map { projects =>
+        projects map { _.id }
+      }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1089,10 +1083,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case None => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <-
-        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-          projectIds =>
-            randomTask(taskParams, projectIds)
-        }
+      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+        projectIds =>
+          randomTask(taskParams, projectIds)
+      }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -195,7 +195,6 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       )
       .filter(queryParams)
       .filter(fr"annotation_project_id = $annotationProjectId")
-      .filter(fr"parent_task_id IS NULL")
 
   def taskForCampaignQB(
       queryParams: TaskQueryParameters,
@@ -225,10 +224,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
     for {
       paginatedResponse <- actionFiltered match {
         case true =>
-          tasksForAnnotationProjectQB(
-            queryParams,
-            campaignId
-          ).filter(fr"parent_task_id IS NULL")
+          tasksForAnnotationProjectQB(queryParams, campaignId)
             .page(pageRequest)
         case _ =>
           tasksForAnnotationProjectQB(queryParams, campaignId)
@@ -353,9 +349,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-        _.taskSizeMeters
-      })
+      taskSizeO =
+        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+          _.taskSizeMeters
+        })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -769,26 +766,29 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <- query
-            .filter(
-              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-            )
-            .list
-          stuckUnlockedTasks <- query
-            .filter(
-              fr"""
+          stuckLockedTasks <-
+            query
+              .filter(
+                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+              )
+              .list
+          stuckUnlockedTasks <-
+            query
+              .filter(
+                fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
-            )
-            .list
-          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-            projectIdsList =>
-              val projectIdsSet = projectIdsList.toNes
-              warn(
-                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-          }
+              .list
+          _ <-
+            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+              projectIdsList =>
+                val projectIdsSet = projectIdsList.toNes
+                warn(
+                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
+                )
+            }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -872,9 +872,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <- query
-        .filter(fr"parent_task_id = $taskId")
-        .page(pageRequest)
+      paginatedResponse <-
+        query
+          .filter(fr"parent_task_id = $taskId")
+          .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -1005,8 +1006,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-            reassociateLabelF(taskId, taskFeature.id).update.run
-          }).void
+              reassociateLabelF(taskId, taskFeature.id).update.run
+            }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1034,19 +1035,20 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <- AnnotationProjectDao
-        .authQuery(
-          user,
-          ObjectType.AnnotationProject,
-          None,
-          None,
-          None
-        )
-        .filter(annotationProjectParams)
-        .filter(annotationProjectIdOpt)
-        .list(limit) map { projects =>
-        projects map { _.id }
-      }
+      annotationProjectIds <-
+        AnnotationProjectDao
+          .authQuery(
+            user,
+            ObjectType.AnnotationProject,
+            None,
+            None,
+            None
+          )
+          .filter(annotationProjectParams)
+          .filter(annotationProjectIdOpt)
+          .list(limit) map { projects =>
+          projects map { _.id }
+        }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1087,9 +1089,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case None => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-        projectIds =>
-          randomTask(taskParams, projectIds)
-      }
+      taskOpt <-
+        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+          projectIds =>
+            randomTask(taskParams, projectIds)
+        }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -195,7 +195,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       )
       .filter(queryParams)
       .filter(fr"annotation_project_id = $annotationProjectId")
-      .filter(fr"parent_task_id IS NULL")
+      .filter(fr"task_type = 'LABEL' :: task_type")
 
   def taskForCampaignQB(
       queryParams: TaskQueryParameters,

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -349,10 +349,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO =
-        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-          _.taskSizeMeters
-        })
+      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+        _.taskSizeMeters
+      })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -766,29 +765,26 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <-
-            query
-              .filter(
-                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-              )
-              .list
-          stuckUnlockedTasks <-
-            query
-              .filter(
-                fr"""
+          stuckLockedTasks <- query
+            .filter(
+              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+            )
+            .list
+          stuckUnlockedTasks <- query
+            .filter(
+              fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
+            )
+            .list
+          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+            projectIdsList =>
+              val projectIdsSet = projectIdsList.toNes
+              warn(
+                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-              .list
-          _ <-
-            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-              projectIdsList =>
-                val projectIdsSet = projectIdsList.toNes
-                warn(
-                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
-                )
-            }
+          }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -870,10 +866,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <-
-        query
-          .filter(fr"parent_task_id = $taskId")
-          .page(pageRequest)
+      paginatedResponse <- query
+        .filter(fr"parent_task_id = $taskId")
+        .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -1004,8 +999,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-              reassociateLabelF(taskId, taskFeature.id).update.run
-            }).void
+            reassociateLabelF(taskId, taskFeature.id).update.run
+          }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1033,20 +1028,19 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <-
-        AnnotationProjectDao
-          .authQuery(
-            user,
-            ObjectType.AnnotationProject,
-            None,
-            None,
-            None
-          )
-          .filter(annotationProjectParams)
-          .filter(annotationProjectIdOpt)
-          .list(limit) map { projects =>
-          projects map { _.id }
-        }
+      annotationProjectIds <- AnnotationProjectDao
+        .authQuery(
+          user,
+          ObjectType.AnnotationProject,
+          None,
+          None,
+          None
+        )
+        .filter(annotationProjectParams)
+        .filter(annotationProjectIdOpt)
+        .list(limit) map { projects =>
+        projects map { _.id }
+      }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1087,10 +1081,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case None => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <-
-        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-          projectIds =>
-            randomTask(taskParams, projectIds)
-        }
+      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+        projectIds =>
+          randomTask(taskParams, projectIds)
+      }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -228,7 +228,6 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
             .page(pageRequest)
         case _ =>
           tasksForAnnotationProjectQB(queryParams, campaignId)
-            .filter(fr"parent_task_id IS NULL")
             .page(pageRequest)
       }
       withActions <- paginatedResponse.results.toList traverse { task =>

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -465,6 +465,7 @@ class TaskDaoSpec
                         taskFeatureCreate,
                         dbAnnotationProj
                       ).withStatus(TaskStatus.Unlabeled)
+                        .withTaskType(TaskType.Label)
                     )
                   ),
                   dbUser

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -60,7 +60,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   build batch
 
         echo "Running tests"
-        # GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
+        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
         echo "All tests pass!"
     fi
 fi

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -60,7 +60,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
                   build batch
 
         echo "Running tests"
-        GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
+        # GIT_COMMIT="${GIT_COMMIT}" ./scripts/test
         echo "All tests pass!"
     fi
 fi


### PR DESCRIPTION
## Overview

This PR:

- restores the `disableAutoCorrect` param, since our color correction darkened some client imagery
- lets tasks with parents through in two methods in TaskDao, since split tasks have parents

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

`test/` branch incoming

## Testing Instructions

### Random task fix
- Create a spacenet campaign
- open a task
- split it
- label a split-result task
- Confirm the campaign level validation button is enabled and takes you to a split-result task to validate

### Disable auto color correct
- download an image or two (not single band since that's unaffected) from the [Slack thread](https://azavea.slack.com/archives/C089LBS6S/p1615305867067800?thread_ts=1615298602.064900&cid=C089LBS6S)
- create lessons with the images you've downloaded
- view the tiles in the lesson
- view the imagery in QGIS
- compare, they should be very similar and the tiles in the lesson shouldn't be artificially darkened

Closes #5555 
