### PR TITLE
Skip cogification if upload is already a cog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Updated setup instructions and scripts [#5544](https://github.com/raster-foundry/raster-foundry/pull/5544)
+- Skip cogification on uploads if the tiff is already a cog [#557](https://github.com/raster-foundry/raster-foundry/pull/5557)
 
 ## [1.61.0] - 2021-03-04
 ### Changed

--- a/app-tasks/rf/requirements.txt
+++ b/app-tasks/rf/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.7.71
 pytest==2.9.2
 pytest-runner==2.9
-rasterio==1.1.6
+rasterio==1.1.7
 pyproj==2.4.2
 ipython==5.1.0
 pyjwt==1.4.2
@@ -12,3 +12,4 @@ click==6.7
 dropbox==9.0.0
 requests==2.21.0
 shapely==1.7.1
+rio-cogeo==2.1.3

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -45,7 +45,7 @@ def georeference_file(file_path):
 
 
 def convert_to_cog(tif_path, local_dir):
-    is_valid_cog, _, _ = cog_validate(tif_path)
+    is_valid_cog, _, _ = cog_validate(tif_path, strict=True)
     if is_valid_cog is True:
         logger.info("Skipping conversion of %s to a cog", tif_path)
         return tif_path

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -4,6 +4,7 @@ from rf.utils.io import s3_bucket_and_key_from_url
 
 import boto3
 import rasterio
+from rio_cogeo.cogeo import cog_validate
 
 import logging
 from multiprocessing import cpu_count, Pool
@@ -44,6 +45,11 @@ def georeference_file(file_path):
 
 
 def convert_to_cog(tif_path, local_dir):
+    is_valid_cog, _, _ = cog_validate(tif_path)
+    if is_valid_cog is True:
+        logger.info("Skipping conversion of %s to a cog", tif_path)
+        return tif_path
+
     logger.info("Converting %s to a cog", tif_path)
     with rasterio.open(tif_path) as src:
         has_64_bit = rasterio.dtypes.float64 in src.dtypes

--- a/app-tasks/rf/src/rf/utils/footprint.py
+++ b/app-tasks/rf/src/rf/utils/footprint.py
@@ -53,7 +53,7 @@ def complex_footprint(tif_path: str) -> MultiPolygon:
     nodata = ds.nodata
     downsampled_transform = ds.transform * ds.transform.scale(DOWNSAMPLE_FACTOR)
     src_proj = Proj(ds.crs)
-    dst_proj = Proj({"init": "EPSG:4326"})
+    dst_proj = Proj("EPSG:4326")
     if nodata is not None:
         data_mask = (band != nodata).astype(rasterio.uint8)
     else:


### PR DESCRIPTION
## Overview

This PR updates the upload processing task to skip the cogification if the uploaded image is already a cog. 

update: added the `strict=True` falg to cog validation, which will return false for cogs that don't have overviews 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

- To make this work, I needed to install `rio-cogeo` which required updating rasterio from 1.1.6 to 1.1.7
- If the upload image is already a cog (and therefore cogification is skipped), I added a statement to the log indicating so
- I changed the format that we specify the web mercator crs in `footprint.py` to avoid some deprecation warnings from pyproj

## Testing Instructions

1. start the server: `./scripts/server`
2. export a JWT auth token `export JWT_AUTH_TOKEN=[the token]`
3. Test non-cog input:
   - create upload json file:
`upload-non-cog.json`
```
{
    "uploadStatus": "uploaded",
    "fileType": "geotiff",
    "uploadType": "s3",
    "files": ["s3://rasterfoundry-development-data-us-east-1/small-non-cog.tif"],
    "datasource": "c14c8e97-ba85-4677-ac9c-069cfef1f0b1",
    "metadata": {},
    "owner": null,
    "visibility": "public",
    "projectId": null,
    "layerId": null,
    "source": null,
    "keepInSourceBucket": null,
    "annotationProjectId": null,
    "generateTasks": false
}
```
   - create the upload: `cat upload.json | http --auth-type=jwt post :9100/api/uploads/`
   - copy the id field from the json output
   - process the upload: `./scripts/console batch "rf process-upload [id from previous step]"`
   - look for the following output:
```
The following warnings were found:
- The file is greater than 512xH or 512xW, it is recommended to include internal overviews

The following errors were found:
- The file is greater than 512xH or 512xW, but is not tiled
INFO:rf.utils.cog:Converting /tmp/tmpakn2wswy/small-non-cog.tif to a cog
Input file size is 3689, 2437
0...10...20...30...40...50...60...70...80...90...100 - done.
```
   - confirm that the uploaded output is a valid cog: `rio cogeo validate "s3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/ba3917ed-7b02-4c15-92d2-730d2d9f5266/cog.tif"`

4. Repeat step 3 replacing the json file with one that points to a cog:
`upload-cog.json`
```
{
    "uploadStatus": "uploaded",
    "fileType": "geotiff",
    "uploadType": "s3",
    "files": ["s3://rasterfoundry-development-data-us-east-1/small-cog.tif"],
    "datasource": "c14c8e97-ba85-4677-ac9c-069cfef1f0b1",
    "metadata": {},
    "owner": null,
    "visibility": "public",
    "projectId": null,
    "layerId": null,
    "source": null,
    "keepInSourceBucket": null,
    "annotationProjectId": null,
    "generateTasks": false
}
```
   - You should not see the cogification output in the logs, instead you will see
```
INFO:rf.utils.cog:Skipping conversion of /tmp/tmp81txcw6w/small-cog.tif to a cog
```
   - validate that the uploaded tiff is also a cog, the output will look like this:
```
s3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/107e2d94-35fd-48c8-9c42-727965cd5f32/small-cog.tif is a valid cloud optimized GeoTIFF
```

Closes [#1208](https://github.com/azavea/raster-foundry-platform/issues/1208) and #5421 
