### PR TITLE
Make campaign and annotation project deletion async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Made campaign and annotation project delete async [#5559](https://github.com/raster-foundry/raster-foundry/pull/5559)
 
 ## [1.61.1] - 2021-03-10
 ### Fixed

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -7,14 +7,18 @@ import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
-import cats.effect.IO
+import cats.effect._
 import cats.implicits._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+
+import scala.concurrent.ExecutionContext
 
 import java.util.UUID
+import java.util.concurrent.Executors
 
 trait AnnotationProjectRoutes
     extends CommonHandlers
@@ -26,6 +30,18 @@ trait AnnotationProjectRoutes
     with AnnotationProjectPermissionRoutes
     with AnnotationProjectLabelClassGroupRoutes
     with AnnotationProjectLabelClassRoutes {
+
+  val annotationProjectDeleteContext = ExecutionContext.fromExecutor(
+    Executors.newCachedThreadPool(
+      new ThreadFactoryBuilder()
+        .setNameFormat("annotation-project-delete-%d")
+        .build()
+    )
+  )
+  val annotationProjectDeleteContextShift =
+    IO.contextShift(annotationProjectDeleteContext)
+  val annotationProjectDeleteBlocker =
+    Blocker.liftExecutionContext(annotationProjectDeleteContext)
 
   val xa: Transactor[IO]
 
@@ -336,14 +352,30 @@ trait AnnotationProjectRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          onSuccess(
-            AnnotationProjectDao
-              .deleteById(projectId, user)
-              .transact(xa)
-              .unsafeToFuture
-          ) {
-            completeSingleOrNotFound
-          }
+          val updateFieldIO = for {
+            projectOpt <- AnnotationProjectDao.getProjectById(projectId)
+            updated <- projectOpt traverse { project =>
+              AnnotationProjectDao.update(
+                project.copy(isActive = false),
+                project.id
+              )
+            }
+          } yield updated
+
+          val deleteIO = for {
+            _ <- updateFieldIO.transact(xa)
+            deleted <- annotationProjectDeleteBlocker.blockOn(
+              AnnotationProjectDao
+                .deleteById(projectId, user)
+                .transact(xa)
+                .start(annotationProjectDeleteContextShift)
+            )(annotationProjectDeleteContextShift)
+          } yield deleted
+
+          complete(
+            StatusCodes.Accepted,
+            deleteIO.void.unsafeToFuture
+          )
         }
       }
     }
@@ -370,8 +402,9 @@ trait AnnotationProjectRoutes
             case false =>
               complete {
                 (for {
-                  projectO <- AnnotationProjectDao
-                    .getById(projectId)
+                  projectO <-
+                    AnnotationProjectDao
+                      .getById(projectId)
                   projectActions <- projectO traverse { project =>
                     if (project.createdBy == user.id) {
                       Set("*").pure[ConnectionIO]

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -9,11 +9,11 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
 import cats.effect._
 import cats.implicits._
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.ExecutionContext
 
@@ -402,9 +402,8 @@ trait AnnotationProjectRoutes
             case false =>
               complete {
                 (for {
-                  projectO <-
-                    AnnotationProjectDao
-                      .getById(projectId)
+                  projectO <- AnnotationProjectDao
+                    .getById(projectId)
                   projectActions <- projectO traverse { project =>
                     if (project.createdBy == user.id) {
                       Set("*").pure[ConnectionIO]

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -48,12 +48,12 @@ trait CampaignProjectRoutes
           (withPagination & annotationProjectQueryParameters) {
             (page, annotationProjectQP) =>
               complete {
-                AnnotationProjectDao.query
-                  .filter(
-                    annotationProjectQP.copy(campaignId = Some(campaignId))
+                AnnotationProjectDao
+                  .paginatedProjectsByCampaignId(
+                    campaignId,
+                    page,
+                    annotationProjectQP
                   )
-                  .page(page)
-                  .flatMap(AnnotationProjectDao.toWithRelated)
                   .transact(xa)
                   .unsafeToFuture
               }

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -2,20 +2,20 @@ package com.rasterfoundry.api.campaign
 
 import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
-import com.rasterfoundry.database._
 import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.database._
 import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server._
 import cats.effect._
 import cats.implicits._
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.postgres.implicits._
 import doobie.util.transactor.Transactor
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 
 import scala.concurrent.ExecutionContext
 

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -231,7 +231,8 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
         annotationProjectFilterParameters &
         parameters(
           'campaignId.as[UUID].?,
-          'capturedAt.as(deserializerTimestamp).?
+          'capturedAt.as(deserializerTimestamp).?,
+          'isActive.as[Boolean].?
         )
     ).as(AnnotationProjectQueryParameters.apply _)
 

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -22,7 +22,8 @@ final case class AnnotationProject(
     status: AnnotationProjectStatus,
     taskStatusSummary: Option[Map[String, Int]] = None,
     campaignId: Option[UUID] = None,
-    capturedAt: Option[Timestamp] = None
+    capturedAt: Option[Timestamp] = None,
+    isActive: Boolean
 ) {
   def withRelated(
       tileLayers: List[TileLayer],
@@ -45,7 +46,8 @@ final case class AnnotationProject(
       labelClassGroups,
       taskStatusSummary,
       campaignId,
-      capturedAt
+      capturedAt,
+      isActive
     )
 }
 
@@ -89,7 +91,8 @@ object AnnotationProject {
       labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
       taskStatusSummary: Option[Map[String, Int]] = None,
       campaignId: Option[UUID] = None,
-      capturedAt: Option[Timestamp] = None
+      capturedAt: Option[Timestamp] = None,
+      isActive: Boolean
   ) {
     def toProject =
       AnnotationProject(
@@ -107,7 +110,8 @@ object AnnotationProject {
         status,
         taskStatusSummary,
         campaignId,
-        capturedAt
+        capturedAt,
+        isActive
       )
 
     def withSummary(
@@ -131,7 +135,8 @@ object AnnotationProject {
         taskStatusSummary,
         labelClassSummary,
         campaignId,
-        capturedAt
+        capturedAt,
+        isActive
       )
   }
 
@@ -158,7 +163,8 @@ object AnnotationProject {
       taskStatusSummary: Option[Map[String, Int]] = None,
       labelClassSummary: List[LabelClassGroupSummary],
       campaignId: Option[UUID] = None,
-      capturedAt: Option[Timestamp] = None
+      capturedAt: Option[Timestamp] = None,
+      isActive: Boolean
   ) {
     def toProject =
       AnnotationProject(
@@ -176,13 +182,14 @@ object AnnotationProject {
         status,
         taskStatusSummary,
         campaignId,
-        capturedAt
+        capturedAt,
+        isActive
       )
   }
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-      : Encoder[WithRelatedAndLabelClassSummary] =
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -189,7 +189,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -53,7 +53,62 @@ final case class AnnotationProject(
 
 object AnnotationProject {
   implicit val encAnnotationProject: Encoder[AnnotationProject] = deriveEncoder
-  implicit val decAnnotationProject: Decoder[AnnotationProject] = deriveDecoder
+  implicit val decAnnotationProject: Decoder[AnnotationProject] =
+    Decoder.forProduct16(
+      "id",
+      "createdAt",
+      "createdBy",
+      "name",
+      "projectType",
+      "taskSizeMeters",
+      "taskSizePixels",
+      "aoi",
+      "labelersTeamId",
+      "validatorsTeamId",
+      "projectId",
+      "status",
+      "taskStatusSummary",
+      "campaignId",
+      "capturedAt",
+      "isActive"
+    )(
+      (
+          id: UUID,
+          createdAt: Timestamp,
+          createdBy: String,
+          name: String,
+          projectType: AnnotationProjectType,
+          taskSizeMeters: Option[Double],
+          taskSizePixels: Int,
+          aoi: Option[Projected[Geometry]],
+          labelersTeamId: Option[UUID],
+          validatorsTeamId: Option[UUID],
+          projectId: Option[UUID],
+          status: AnnotationProjectStatus,
+          taskStatusSummary: Option[Map[String, Int]],
+          campaignId: Option[UUID],
+          capturedAt: Option[Timestamp],
+          isActive: Option[Boolean]
+      ) =>
+        AnnotationProject(
+          id,
+          createdAt,
+          createdBy,
+          name,
+          projectType,
+          taskSizeMeters,
+          taskSizePixels,
+          aoi,
+          labelersTeamId,
+          validatorsTeamId,
+          projectId,
+          status,
+          taskStatusSummary,
+          campaignId,
+          capturedAt,
+          isActive getOrElse true
+        )
+    )
 
   final case class Create(
       name: String,
@@ -142,7 +197,68 @@ object AnnotationProject {
 
   object WithRelated {
     implicit val encRelated: Encoder[WithRelated] = deriveEncoder
-    implicit val decRelated: Decoder[WithRelated] = deriveDecoder
+    implicit val decRelated: Decoder[WithRelated] =
+      Decoder.forProduct18(
+        "id",
+        "createdAt",
+        "createdBy",
+        "name",
+        "projectType",
+        "taskSizeMeters",
+        "taskSizePixels",
+        "aoi",
+        "labelersTeamId",
+        "validatorsTeamId",
+        "projectId",
+        "status",
+        "tileLayers",
+        "labelClassGroups",
+        "taskStatusSummary",
+        "campaignId",
+        "capturedAt",
+        "isActive"
+      )(
+        (
+            id: UUID,
+            createdAt: Timestamp,
+            createdBy: String,
+            name: String,
+            projectType: AnnotationProjectType,
+            taskSizeMeters: Option[Double],
+            taskSizePixels: Int,
+            aoi: Option[Projected[Geometry]],
+            labelersTeamId: Option[UUID],
+            validatorsTeamId: Option[UUID],
+            projectId: Option[UUID],
+            status: AnnotationProjectStatus,
+            tileLayers: List[TileLayer],
+            labelClassGroups: List[AnnotationLabelClassGroup.WithLabelClasses],
+            taskStatusSummary: Option[Map[String, Int]],
+            campaignId: Option[UUID],
+            capturedAt: Option[Timestamp],
+            isActive: Option[Boolean]
+        ) =>
+          WithRelated(
+            id,
+            createdAt,
+            createdBy,
+            name,
+            projectType,
+            taskSizeMeters,
+            taskSizePixels,
+            aoi,
+            labelersTeamId,
+            validatorsTeamId,
+            projectId,
+            status,
+            tileLayers,
+            labelClassGroups,
+            taskStatusSummary,
+            campaignId,
+            capturedAt,
+            isActive getOrElse true
+          )
+      )
   }
 
   final case class WithRelatedAndLabelClassSummary(
@@ -189,7 +305,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-      : Encoder[WithRelatedAndLabelClassSummary] =
+        : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/AnnotationProject.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationProject.scala
@@ -107,7 +107,7 @@ object AnnotationProject {
           campaignId,
           capturedAt,
           isActive getOrElse true
-        )
+      )
     )
 
   final case class Create(
@@ -257,7 +257,7 @@ object AnnotationProject {
             campaignId,
             capturedAt,
             isActive getOrElse true
-          )
+        )
       )
   }
 
@@ -305,7 +305,7 @@ object AnnotationProject {
 
   object WithRelatedAndLabelClassSummary {
     implicit val encRelatedAndSummary
-        : Encoder[WithRelatedAndLabelClassSummary] =
+      : Encoder[WithRelatedAndLabelClassSummary] =
       deriveEncoder
   }
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -91,10 +91,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-      : Encoder[SceneSearchModeQueryParams] =
+    : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-      : Decoder[SceneSearchModeQueryParams] =
+    : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -146,7 +146,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-      : Encoder[ProjectSceneQueryParameters] =
+    : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -178,10 +178,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-      : Encoder[CombinedToolQueryParameters] =
+    : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-      : Decoder[CombinedToolQueryParameters] =
+    : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -206,10 +206,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-      : Encoder[CombinedFootprintQueryParams] =
+    : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-      : Decoder[CombinedFootprintQueryParams] =
+    : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -261,10 +261,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-      : Encoder[OwnershipTypeQueryParameters] =
+    : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-      : Decoder[OwnershipTypeQueryParameters] =
+    : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -337,10 +337,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-      : Encoder[CombinedToolRunQueryParameters] =
+    : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-      : Decoder[CombinedToolRunQueryParameters] =
+    : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -354,10 +354,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-      : Encoder[DatasourceQueryParameters] =
+    : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-      : Decoder[DatasourceQueryParameters] =
+    : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -381,10 +381,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-      : Encoder[CombinedMapTokenQueryParameters] =
+    : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-      : Decoder[CombinedMapTokenQueryParameters] =
+    : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -421,10 +421,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-      : Encoder[DropboxAuthQueryParameters] =
+    : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-      : Decoder[DropboxAuthQueryParameters] =
+    : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -447,10 +447,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-      : Encoder[AnnotationQueryParameters] =
+    : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-      : Decoder[AnnotationQueryParameters] =
+    : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -460,10 +460,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-      : Encoder[AnnotationExportQueryParameters] =
+    : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -497,10 +497,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-      : Encoder[ActivationQueryParameters] =
+    : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-      : Decoder[ActivationQueryParameters] =
+    : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -537,10 +537,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-      : Encoder[PlatformIdQueryParameters] =
+    : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-      : Decoder[PlatformIdQueryParameters] =
+    : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -553,10 +553,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-      : Encoder[OrganizationQueryParameters] =
+    : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-      : Decoder[OrganizationQueryParameters] =
+    : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -572,10 +572,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-      : Encoder[SceneThumbnailQueryParameters] =
+    : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-      : Decoder[SceneThumbnailQueryParameters] =
+    : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -653,10 +653,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-      : Encoder[UserTaskActivityParameters] =
+    : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-      : Decoder[UserTaskActivityParameters] =
+    : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -671,10 +671,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-      : Encoder[StacExportQueryParameters] =
+    : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-      : Decoder[StacExportQueryParameters] =
+    : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -685,10 +685,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-      : Encoder[AnnotationProjectFilterQueryParameters] =
+    : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-      : Decoder[AnnotationProjectFilterQueryParameters] =
+    : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -707,10 +707,10 @@ final case class AnnotationProjectQueryParameters(
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-      : Encoder[AnnotationProjectQueryParameters] =
+    : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-      : Decoder[AnnotationProjectQueryParameters] =
+    : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 
@@ -738,9 +738,9 @@ final case class CampaignRandomTaskQueryParameters(
 
 object CampaignRandomTaskQueryParameters {
   implicit def encCampaignRandomTaskQueryParameters
-      : Encoder[CampaignRandomTaskQueryParameters] =
+    : Encoder[CampaignRandomTaskQueryParameters] =
     deriveEncoder[CampaignRandomTaskQueryParameters]
   implicit def decCampaignRandomTaskQueryParameters
-      : Decoder[CampaignRandomTaskQueryParameters] =
+    : Decoder[CampaignRandomTaskQueryParameters] =
     deriveDecoder[CampaignRandomTaskQueryParameters]
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -91,10 +91,10 @@ final case class SceneSearchModeQueryParams(
 
 object SceneSearchModeQueryParams {
   implicit def encSceneSearchModeQueryParams
-    : Encoder[SceneSearchModeQueryParams] =
+      : Encoder[SceneSearchModeQueryParams] =
     deriveEncoder[SceneSearchModeQueryParams]
   implicit def decSceneSearchModeQueryParams
-    : Decoder[SceneSearchModeQueryParams] =
+      : Decoder[SceneSearchModeQueryParams] =
     deriveDecoder[SceneSearchModeQueryParams]
 }
 
@@ -146,7 +146,7 @@ final case class ProjectSceneQueryParameters(
 
 object ProjectSceneQueryParameters {
   implicit def encProjectSceneQueryParameters
-    : Encoder[ProjectSceneQueryParameters] =
+      : Encoder[ProjectSceneQueryParameters] =
     deriveEncoder[ProjectSceneQueryParameters]
   implicit def decProjectQueryParameters: Decoder[ProjectSceneQueryParameters] =
     deriveDecoder[ProjectSceneQueryParameters]
@@ -178,10 +178,10 @@ final case class CombinedToolQueryParameters(
 
 object CombinedToolQueryParameters {
   implicit def encCombinedToolQueryParameters
-    : Encoder[CombinedToolQueryParameters] =
+      : Encoder[CombinedToolQueryParameters] =
     deriveEncoder[CombinedToolQueryParameters]
   implicit def decCombinedToolQueryParameters
-    : Decoder[CombinedToolQueryParameters] =
+      : Decoder[CombinedToolQueryParameters] =
     deriveDecoder[CombinedToolQueryParameters]
 }
 
@@ -206,10 +206,10 @@ final case class CombinedFootprintQueryParams(
 
 object CombinedFootprintQueryParams {
   implicit def encCombinedFootprintQueryParams
-    : Encoder[CombinedFootprintQueryParams] =
+      : Encoder[CombinedFootprintQueryParams] =
     deriveEncoder[CombinedFootprintQueryParams]
   implicit def decCombinedFootprintQueryParams
-    : Decoder[CombinedFootprintQueryParams] =
+      : Decoder[CombinedFootprintQueryParams] =
     deriveDecoder[CombinedFootprintQueryParams]
 }
 
@@ -261,10 +261,10 @@ final case class OwnershipTypeQueryParameters(
 
 object OwnershipTypeQueryParameters {
   implicit def encOwnershipTypeQueryParameters
-    : Encoder[OwnershipTypeQueryParameters] =
+      : Encoder[OwnershipTypeQueryParameters] =
     deriveEncoder[OwnershipTypeQueryParameters]
   implicit def decOwnershipTypeQueryParameters
-    : Decoder[OwnershipTypeQueryParameters] =
+      : Decoder[OwnershipTypeQueryParameters] =
     deriveDecoder[OwnershipTypeQueryParameters]
 }
 
@@ -337,10 +337,10 @@ final case class CombinedToolRunQueryParameters(
 
 object CombinedToolRunQueryParameters {
   implicit def encCombinedToolRunQueryParameters
-    : Encoder[CombinedToolRunQueryParameters] =
+      : Encoder[CombinedToolRunQueryParameters] =
     deriveEncoder[CombinedToolRunQueryParameters]
   implicit def decCombinedToolRunQueryParameters
-    : Decoder[CombinedToolRunQueryParameters] =
+      : Decoder[CombinedToolRunQueryParameters] =
     deriveDecoder[CombinedToolRunQueryParameters]
 }
 
@@ -354,10 +354,10 @@ final case class DatasourceQueryParameters(
 
 object DatasourceQueryParameters {
   implicit def encDatasourceQueryParameters
-    : Encoder[DatasourceQueryParameters] =
+      : Encoder[DatasourceQueryParameters] =
     deriveEncoder[DatasourceQueryParameters]
   implicit def decDatasourceQueryParameters
-    : Decoder[DatasourceQueryParameters] =
+      : Decoder[DatasourceQueryParameters] =
     deriveDecoder[DatasourceQueryParameters]
 }
 
@@ -381,10 +381,10 @@ final case class CombinedMapTokenQueryParameters(
 
 object CombinedMapTokenQueryParameters {
   implicit def encCombinedMapTokenQueryParameters
-    : Encoder[CombinedMapTokenQueryParameters] =
+      : Encoder[CombinedMapTokenQueryParameters] =
     deriveEncoder[CombinedMapTokenQueryParameters]
   implicit def decCombinedMapTokenQueryParameters
-    : Decoder[CombinedMapTokenQueryParameters] =
+      : Decoder[CombinedMapTokenQueryParameters] =
     deriveDecoder[CombinedMapTokenQueryParameters]
 }
 
@@ -421,10 +421,10 @@ final case class DropboxAuthQueryParameters(code: Option[String] = None)
 
 object DropboxAuthQueryParameters {
   implicit def encDropboxAuthQueryParameters
-    : Encoder[DropboxAuthQueryParameters] =
+      : Encoder[DropboxAuthQueryParameters] =
     deriveEncoder[DropboxAuthQueryParameters]
   implicit def decDropboxAuthQueryParameters
-    : Decoder[DropboxAuthQueryParameters] =
+      : Decoder[DropboxAuthQueryParameters] =
     deriveDecoder[DropboxAuthQueryParameters]
 }
 
@@ -447,10 +447,10 @@ final case class AnnotationQueryParameters(
 
 object AnnotationQueryParameters {
   implicit def encAnnotationQueryParameters
-    : Encoder[AnnotationQueryParameters] =
+      : Encoder[AnnotationQueryParameters] =
     deriveEncoder[AnnotationQueryParameters]
   implicit def decAnnotationQueryParameters
-    : Decoder[AnnotationQueryParameters] =
+      : Decoder[AnnotationQueryParameters] =
     deriveDecoder[AnnotationQueryParameters]
 }
 
@@ -460,10 +460,10 @@ final case class AnnotationExportQueryParameters(
 
 object AnnotationExportQueryParameters {
   implicit def encAnnotationExportQueryParameters
-    : Encoder[AnnotationExportQueryParameters] =
+      : Encoder[AnnotationExportQueryParameters] =
     deriveEncoder[AnnotationExportQueryParameters]
   implicit def decAnnotationExportQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -497,10 +497,10 @@ final case class ActivationQueryParameters(isActive: Option[Boolean] = None)
 
 object ActivationQueryParameters {
   implicit def encActivationQueryParameters
-    : Encoder[ActivationQueryParameters] =
+      : Encoder[ActivationQueryParameters] =
     deriveEncoder[ActivationQueryParameters]
   implicit def decActivationQueryParameters
-    : Decoder[ActivationQueryParameters] =
+      : Decoder[ActivationQueryParameters] =
     deriveDecoder[ActivationQueryParameters]
 }
 
@@ -537,10 +537,10 @@ final case class PlatformIdQueryParameters(platformId: Option[UUID] = None)
 
 object PlatformIdQueryParameters {
   implicit def encPlatformIdQueryParameters
-    : Encoder[PlatformIdQueryParameters] =
+      : Encoder[PlatformIdQueryParameters] =
     deriveEncoder[PlatformIdQueryParameters]
   implicit def decPlatformIdQueryParameters
-    : Decoder[PlatformIdQueryParameters] =
+      : Decoder[PlatformIdQueryParameters] =
     deriveDecoder[PlatformIdQueryParameters]
 }
 
@@ -553,10 +553,10 @@ final case class OrganizationQueryParameters(
 
 object OrganizationQueryParameters {
   implicit def encOrganizationQueryParameters
-    : Encoder[OrganizationQueryParameters] =
+      : Encoder[OrganizationQueryParameters] =
     deriveEncoder[OrganizationQueryParameters]
   implicit def decOrganizationQueryParameters
-    : Decoder[OrganizationQueryParameters] =
+      : Decoder[OrganizationQueryParameters] =
     deriveDecoder[OrganizationQueryParameters]
 }
 
@@ -572,10 +572,10 @@ final case class SceneThumbnailQueryParameters(
 
 object SceneThumbnailQueryParameters {
   implicit def encSceneThumbnailQueryParameters
-    : Encoder[SceneThumbnailQueryParameters] =
+      : Encoder[SceneThumbnailQueryParameters] =
     deriveEncoder[SceneThumbnailQueryParameters]
   implicit def decSceneThumbnailQueryParameters
-    : Decoder[SceneThumbnailQueryParameters] =
+      : Decoder[SceneThumbnailQueryParameters] =
     deriveDecoder[SceneThumbnailQueryParameters]
 }
 
@@ -653,10 +653,10 @@ final case class UserTaskActivityParameters(
 
 object UserTaskActivityParameters {
   implicit def encUserTaskActivityParameters
-    : Encoder[UserTaskActivityParameters] =
+      : Encoder[UserTaskActivityParameters] =
     deriveEncoder[UserTaskActivityParameters]
   implicit def decUserTaskActivityParameters
-    : Decoder[UserTaskActivityParameters] =
+      : Decoder[UserTaskActivityParameters] =
     deriveDecoder[UserTaskActivityParameters]
 }
 
@@ -671,10 +671,10 @@ final case class StacExportQueryParameters(
 
 object StacExportQueryParameters {
   implicit def encStacExportQueryParameters
-    : Encoder[StacExportQueryParameters] =
+      : Encoder[StacExportQueryParameters] =
     deriveEncoder[StacExportQueryParameters]
   implicit def decStacExportQueryParameters
-    : Decoder[StacExportQueryParameters] =
+      : Decoder[StacExportQueryParameters] =
     deriveDecoder[StacExportQueryParameters]
 }
 
@@ -685,10 +685,10 @@ final case class AnnotationProjectFilterQueryParameters(
 
 object AnnotationProjectFilterQueryParameters {
   implicit def encGroupQueryParameters
-    : Encoder[AnnotationProjectFilterQueryParameters] =
+      : Encoder[AnnotationProjectFilterQueryParameters] =
     deriveEncoder[AnnotationProjectFilterQueryParameters]
   implicit def decGroupQueryParameters
-    : Decoder[AnnotationProjectFilterQueryParameters] =
+      : Decoder[AnnotationProjectFilterQueryParameters] =
     deriveDecoder[AnnotationProjectFilterQueryParameters]
 }
 
@@ -701,15 +701,16 @@ final case class AnnotationProjectQueryParameters(
     projectFilterParams: AnnotationProjectFilterQueryParameters =
       AnnotationProjectFilterQueryParameters(),
     campaignId: Option[UUID] = None,
-    capturedAt: Option[Timestamp] = None
+    capturedAt: Option[Timestamp] = None,
+    isActive: Option[Boolean] = None
 )
 
 object AnnotationProjectQueryParameters {
   implicit def encAnnotationProjectQueryParameters
-    : Encoder[AnnotationProjectQueryParameters] =
+      : Encoder[AnnotationProjectQueryParameters] =
     deriveEncoder[AnnotationProjectQueryParameters]
   implicit def decAnnotationProjectQueryParameters
-    : Decoder[AnnotationProjectQueryParameters] =
+      : Decoder[AnnotationProjectQueryParameters] =
     deriveDecoder[AnnotationProjectQueryParameters]
 }
 
@@ -737,9 +738,9 @@ final case class CampaignRandomTaskQueryParameters(
 
 object CampaignRandomTaskQueryParameters {
   implicit def encCampaignRandomTaskQueryParameters
-    : Encoder[CampaignRandomTaskQueryParameters] =
+      : Encoder[CampaignRandomTaskQueryParameters] =
     deriveEncoder[CampaignRandomTaskQueryParameters]
   implicit def decCampaignRandomTaskQueryParameters
-    : Decoder[CampaignRandomTaskQueryParameters] =
+      : Decoder[CampaignRandomTaskQueryParameters] =
     deriveDecoder[CampaignRandomTaskQueryParameters]
 }

--- a/app-backend/db/src/main/resources/migrations/V71__add_is_active_to_annotation_projects.sql
+++ b/app-backend/db/src/main/resources/migrations/V71__add_is_active_to_annotation_projects.sql
@@ -1,0 +1,3 @@
+-- update annotation_projects table to include is_active column
+ALTER TABLE public.annotation_projects
+ADD COLUMN is_active boolean NOT NULL default true;

--- a/app-backend/db/src/main/resources/migrations/V72__add_index_to_is_active_on_annotation_project.sql
+++ b/app-backend/db/src/main/resources/migrations/V72__add_index_to_is_active_on_annotation_project.sql
@@ -1,0 +1,4 @@
+-- add btree index on is_active field of annotation_projects table
+CREATE INDEX IF NOT EXISTS annotation_projects_is_active_idx
+ON public.annotation_projects
+USING btree (is_active);

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,15 +206,16 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-        case (classGroup, idx) =>
-          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-            classGroup,
-            Some(annotationProject),
-            None,
-            idx
-          )
-      }
+      labelClassGroups <-
+        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+          case (classGroup, idx) =>
+            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+              classGroup,
+              Some(annotationProject),
+              None,
+              idx
+            )
+        }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -230,8 +231,9 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <- AnnotationLabelClassGroupDao
-        .listByProjectId(id)
+      labelClassGroup <-
+        AnnotationLabelClassGroupDao
+          .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -378,11 +380,12 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <- (fr"select id from " ++ Fragment.const(
-        tableName
-      ) ++ fr" where owner = $userId")
-        .query[UUID]
-        .to[List]
+      projectIds <-
+        (fr"select id from " ++ Fragment.const(
+          tableName
+        ) ++ fr" where owner = $userId")
+          .query[UUID]
+          .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -409,14 +412,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(
-              classes =>
-                LabelClass(
-                  LabelClassName.VectorName(group.name),
-                  LabelClassClasses.NamedLabelClasses(
-                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                  )
-              ))
+            .map(classes =>
+              LabelClass(
+                LabelClassName.VectorName(group.name),
+                LabelClassClasses.NamedLabelClasses(
+                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                )
+              )
+            )
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -439,9 +442,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Annotate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -449,9 +452,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Validate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -502,37 +505,40 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <- insertQuery.update
-        .withUniqueGeneratedKeys[AnnotationProject](
-          fieldNames: _*
-        )
+      annotationProjectCopy <-
+        insertQuery.update
+          .withUniqueGeneratedKeys[AnnotationProject](
+            fieldNames: _*
+          )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <- AnnotationLabelClassDao
-            .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <- AnnotationLabelClassGroupDao
-            .insertAnnotationLabelClassGroup(
-              AnnotationLabelClassGroup.Create(
-                classGroup.name,
-                Some(classGroup.index),
-                labelClasses.map { labelClass =>
-                  AnnotationLabelClass.Create(
-                    labelClass.name,
-                    labelClass.colorHexCode,
-                    labelClass.default,
-                    labelClass.determinant,
-                    labelClass.index,
-                    labelClass.geometryType,
-                    labelClass.description
-                  )
-                }
-              ),
-              Some(annotationProjectCopy),
-              None,
-              0,
-              labelClasses
-            )
+          labelClasses <-
+            AnnotationLabelClassDao
+              .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <-
+            AnnotationLabelClassGroupDao
+              .insertAnnotationLabelClassGroup(
+                AnnotationLabelClassGroup.Create(
+                  classGroup.name,
+                  Some(classGroup.index),
+                  labelClasses.map { labelClass =>
+                    AnnotationLabelClass.Create(
+                      labelClass.name,
+                      labelClass.colorHexCode,
+                      labelClass.default,
+                      labelClass.determinant,
+                      labelClass.index,
+                      labelClass.geometryType,
+                      labelClass.description
+                    )
+                  }
+                ),
+                Some(annotationProjectCopy),
+                None,
+                0,
+                labelClasses
+              )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -563,20 +569,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())(
-            (acc, userId) =>
-              acc ++ List(
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.View
-                ),
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.Annotate
-                )
-            ))
+          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
+            acc ++ List(
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.View
+              ),
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.Annotate
+              )
+            )
+          )
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules
@@ -636,4 +642,14 @@ object AnnotationProjectDao
         ProjectLayerScenesDao.listLayerScenesRaw(project.defaultLayerId)
       }
     } yield { scenes flatMap { _.headOption } }
+
+  def paginatedProjectsByCampaignId(
+      campaignId: UUID,
+      page: PageRequest,
+      params: AnnotationProjectQueryParameters
+  ): ConnectionIO[PaginatedResponse[AnnotationProject.WithRelated]] =
+    listByCampaignQB(campaignId)
+      .filter(params)
+      .page(page)
+      .flatMap(AnnotationProjectDao.toWithRelated)
 }

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,16 +206,15 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <-
-        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-          case (classGroup, idx) =>
-            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-              classGroup,
-              Some(annotationProject),
-              None,
-              idx
-            )
-        }
+      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+        case (classGroup, idx) =>
+          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+            classGroup,
+            Some(annotationProject),
+            None,
+            idx
+          )
+      }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -231,9 +230,8 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByProjectId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -380,12 +378,11 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      projectIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -412,14 +409,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(classes =>
-              LabelClass(
-                LabelClassName.VectorName(group.name),
-                LabelClassClasses.NamedLabelClasses(
-                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                )
-              )
-            )
+            .map(
+              classes =>
+                LabelClass(
+                  LabelClassName.VectorName(group.name),
+                  LabelClassClasses.NamedLabelClasses(
+                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                  )
+              ))
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -442,9 +439,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -452,9 +449,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -505,40 +502,37 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[AnnotationProject](
-            fieldNames: _*
-          )
+      annotationProjectCopy <- insertQuery.update
+        .withUniqueGeneratedKeys[AnnotationProject](
+          fieldNames: _*
+        )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <-
-            AnnotationLabelClassDao
-              .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <-
-            AnnotationLabelClassGroupDao
-              .insertAnnotationLabelClassGroup(
-                AnnotationLabelClassGroup.Create(
-                  classGroup.name,
-                  Some(classGroup.index),
-                  labelClasses.map { labelClass =>
-                    AnnotationLabelClass.Create(
-                      labelClass.name,
-                      labelClass.colorHexCode,
-                      labelClass.default,
-                      labelClass.determinant,
-                      labelClass.index,
-                      labelClass.geometryType,
-                      labelClass.description
-                    )
-                  }
-                ),
-                Some(annotationProjectCopy),
-                None,
-                0,
-                labelClasses
-              )
+          labelClasses <- AnnotationLabelClassDao
+            .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <- AnnotationLabelClassGroupDao
+            .insertAnnotationLabelClassGroup(
+              AnnotationLabelClassGroup.Create(
+                classGroup.name,
+                Some(classGroup.index),
+                labelClasses.map { labelClass =>
+                  AnnotationLabelClass.Create(
+                    labelClass.name,
+                    labelClass.colorHexCode,
+                    labelClass.default,
+                    labelClass.determinant,
+                    labelClass.index,
+                    labelClass.geometryType,
+                    labelClass.description
+                  )
+                }
+              ),
+              Some(annotationProjectCopy),
+              None,
+              0,
+              labelClasses
+            )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -569,20 +563,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
-            acc ++ List(
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.View
-              ),
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.Annotate
-              )
-            )
-          )
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
+            ))
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -349,10 +349,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO =
-        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-          _.taskSizeMeters
-        })
+      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+        _.taskSizeMeters
+      })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -766,29 +765,26 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <-
-            query
-              .filter(
-                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-              )
-              .list
-          stuckUnlockedTasks <-
-            query
-              .filter(
-                fr"""
+          stuckLockedTasks <- query
+            .filter(
+              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+            )
+            .list
+          stuckUnlockedTasks <- query
+            .filter(
+              fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
+            )
+            .list
+          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+            projectIdsList =>
+              val projectIdsSet = projectIdsList.toNes
+              warn(
+                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-              .list
-          _ <-
-            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-              projectIdsList =>
-                val projectIdsSet = projectIdsList.toNes
-                warn(
-                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
-                )
-            }
+          }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -870,10 +866,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <-
-        query
-          .filter(fr"parent_task_id = $taskId")
-          .page(pageRequest)
+      paginatedResponse <- query
+        .filter(fr"parent_task_id = $taskId")
+        .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -1004,8 +999,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-              reassociateLabelF(taskId, taskFeature.id).update.run
-            }).void
+            reassociateLabelF(taskId, taskFeature.id).update.run
+          }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1033,21 +1028,20 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <-
-        AnnotationProjectDao
-          .authQuery(
-            user,
-            ObjectType.AnnotationProject,
-            None,
-            None,
-            None
-          )
-          .filter(annotationProjectParams)
-          .filter(annotationProjectIdOpt)
-          .filter(fr"is_active = true")
-          .list(limit) map { projects =>
-          projects map { _.id }
-        }
+      annotationProjectIds <- AnnotationProjectDao
+        .authQuery(
+          user,
+          ObjectType.AnnotationProject,
+          None,
+          None,
+          None
+        )
+        .filter(annotationProjectParams)
+        .filter(annotationProjectIdOpt)
+        .filter(fr"is_active = true")
+        .list(limit) map { projects =>
+        projects map { _.id }
+      }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1089,10 +1083,9 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           case _ => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <-
-        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-          projectIds =>
-            randomTask(taskParams, projectIds)
-        }
+      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+        projectIds =>
+          randomTask(taskParams, projectIds)
+      }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -349,9 +349,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           AnnotationProjectDao.getFootprint(annotationProject.id)
         case _ => None.pure[ConnectionIO]
       }
-      taskSizeO = taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
-        _.taskSizeMeters
-      })
+      taskSizeO =
+        taskGridFeatureCreate.properties.sizeMeters orElse (annotationProjectO flatMap {
+          _.taskSizeMeters
+        })
       gridInsert <- (geomO, taskSizeO).tupled.map { geomAndSize =>
         val (geom, size) = geomAndSize
         (insertF ++ fr"""
@@ -765,26 +766,29 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         for {
           _ <- info("Expiring stuck tasks")
           defaultUser <- UserDao.unsafeGetUserById("default")
-          stuckLockedTasks <- query
-            .filter(
-              fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
-            )
-            .list
-          stuckUnlockedTasks <- query
-            .filter(
-              fr"""
+          stuckLockedTasks <-
+            query
+              .filter(
+                fr"locked_on <= ${Timestamp.from(Instant.now.minusMillis(taskExpiration.toMillis))}"
+              )
+              .list
+          stuckUnlockedTasks <-
+            query
+              .filter(
+                fr"""
             locked_on IS NULL AND
             (status = ${TaskStatus.LabelingInProgress: TaskStatus} OR
              status = ${TaskStatus.ValidationInProgress: TaskStatus})"""
-            )
-            .list
-          _ <- (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
-            projectIdsList =>
-              val projectIdsSet = projectIdsList.toNes
-              warn(
-                s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
               )
-          }
+              .list
+          _ <-
+            (stuckUnlockedTasks map { _.annotationProjectId }).toNel traverse {
+              projectIdsList =>
+                val projectIdsSet = projectIdsList.toNes
+                warn(
+                  s"Annotation project IDs for stuck in progress but unlocked tasks: $projectIdsSet"
+                )
+            }
           _ <- (stuckLockedTasks ++ stuckUnlockedTasks) traverse { task =>
             regressTaskStatus(task.id, task.status) flatMap {
               case (newStatus, newNote) =>
@@ -866,9 +870,10 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
   ): ConnectionIO[PaginatedGeoJsonResponse[Task.TaskFeature]] = {
 
     for {
-      paginatedResponse <- query
-        .filter(fr"parent_task_id = $taskId")
-        .page(pageRequest)
+      paginatedResponse <-
+        query
+          .filter(fr"parent_task_id = $taskId")
+          .page(pageRequest)
 
       withActions <- paginatedResponse.results.toList traverse { task =>
         unsafeGetActionsForTask(task)
@@ -999,8 +1004,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
           )
           // - reassociate *the overlapping portions* of all labels on the parent task with the new task
           () <- (newTaskFeatureCollection.features traverse { taskFeature =>
-            reassociateLabelF(taskId, taskFeature.id).update.run
-          }).void
+              reassociateLabelF(taskId, taskFeature.id).update.run
+            }).void
           taskFeature = task.toGeoJSONFeature(Nil)
           createProperties = taskFeature.properties.toCreate.copy(
             status = TaskStatus.Split
@@ -1028,19 +1033,21 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
-      annotationProjectIds <- AnnotationProjectDao
-        .authQuery(
-          user,
-          ObjectType.AnnotationProject,
-          None,
-          None,
-          None
-        )
-        .filter(annotationProjectParams)
-        .filter(annotationProjectIdOpt)
-        .list(limit) map { projects =>
-        projects map { _.id }
-      }
+      annotationProjectIds <-
+        AnnotationProjectDao
+          .authQuery(
+            user,
+            ObjectType.AnnotationProject,
+            None,
+            None,
+            None
+          )
+          .filter(annotationProjectParams)
+          .filter(annotationProjectIdOpt)
+          .filter(fr"is_active = true")
+          .list(limit) map { projects =>
+          projects map { _.id }
+        }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
         campaignId =>
           for {
@@ -1056,6 +1063,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
                   .listByCampaignQB(campaignId)
                   .filter(annotationProjectParams)
                   .filter(annotationProjectIdOpt)
+                  .filter(fr"is_active = true")
                   .list(limit) map { projects =>
                   projects map { _.id }
                 }
@@ -1066,7 +1074,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       } map { _ getOrElse Nil }
       idAuthedProjects <- annotationProjectIdOpt flatTraverse { projectId =>
         AnnotationProjectDao.getProjectById(projectId) flatMap {
-          case Some(ap) =>
+          case Some(ap) if ap.isActive == true =>
             ap.campaignId traverse { campaignId =>
               CampaignDao.authorized(
                 user,
@@ -1078,12 +1086,13 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
                 case AuthFailure()  => Nil
               }
             }
-          case None => Option(List.empty[UUID]).pure[ConnectionIO]
+          case _ => Option(List.empty[UUID]).pure[ConnectionIO]
         }
       } map { _ getOrElse Nil }
-      taskOpt <- (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
-        projectIds =>
-          randomTask(taskParams, projectIds)
-      }
+      taskOpt <-
+        (annotationProjectIds ++ campaignAuthedProjects ++ idAuthedProjects).distinct.toNel flatTraverse {
+          projectIds =>
+            randomTask(taskParams, projectIds)
+        }
     } yield taskOpt
 }

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -47,7 +47,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-    : Filterable[Any, TimestampQueryParameters] =
+      : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -59,7 +59,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-    : Filterable[Any, ProjectQueryParameters] =
+      : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -88,7 +88,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-    : Filterable[Any, CombinedToolQueryParameters] =
+      : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -101,7 +101,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-    : Filterable[Any, AnnotationQueryParameters] =
+      : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -129,9 +129,8 @@ trait Filterables extends RFMeta with LazyLogging {
             }),
             annotParams.bboxPolygon match {
               case Some(bboxPolygons) =>
-                val fragments = bboxPolygons.map(
-                  bbox =>
-                    fr"(_ST_Intersects(geometry, ${bbox}) AND geometry && ${bbox})"
+                val fragments = bboxPolygons.map(bbox =>
+                  fr"(_ST_Intersects(geometry, ${bbox}) AND geometry && ${bbox})"
                 )
                 Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
               case _ => None
@@ -140,7 +139,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-    : Filterable[Any, CombinedSceneQueryParams] =
+      : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -193,9 +192,8 @@ trait Filterables extends RFMeta with LazyLogging {
             }),
             (sceneParams.bboxPolygon, sceneParams.shape) match {
               case (Some(bboxPolygons), _) =>
-                val fragments = bboxPolygons.map(
-                  bbox =>
-                    fr"(_ST_Intersects(data_footprint, ${bbox}) AND tile_footprint && ${bbox})"
+                val fragments = bboxPolygons.map(bbox =>
+                  fr"(_ST_Intersects(data_footprint, ${bbox}) AND tile_footprint && ${bbox})"
                 )
                 Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
               case _ => None
@@ -204,7 +202,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-    : Filterable[Any, ProjectSceneQueryParameters] =
+      : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -219,7 +217,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-    : Filterable[Any, CombinedMapTokenQueryParameters] =
+      : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -227,7 +225,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-    : Filterable[Any, CombinedToolRunQueryParameters] =
+      : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -255,26 +253,27 @@ trait Filterables extends RFMeta with LazyLogging {
       List(Some(fragment))
     }
 
-  implicit def maybeTFilter[T](
-      implicit filterable: Filterable[Any, T]
-  ): Filterable[Any, Option[T]] = Filterable[Any, Option[T]] {
-    case None        => List.empty[Option[Fragment]]
-    case Some(thing) => filterable.toFilters(thing)
-  }
+  implicit def maybeTFilter[T](implicit
+      filterable: Filterable[Any, T]
+  ): Filterable[Any, Option[T]] =
+    Filterable[Any, Option[T]] {
+      case None        => List.empty[Option[Fragment]]
+      case Some(thing) => filterable.toFilters(thing)
+    }
 
-  implicit def listTFilter[T](
-      implicit filterable: Filterable[Any, T]
-  ): Filterable[Any, List[T]] = Filterable[Any, List[T]] {
-    someFilterables: List[T] =>
+  implicit def listTFilter[T](implicit
+      filterable: Filterable[Any, T]
+  ): Filterable[Any, List[T]] =
+    Filterable[Any, List[T]] { someFilterables: List[T] =>
       {
         someFilterables
           .map(filterable.toFilters)
           .foldLeft(List.empty[Option[Fragment]])(_ ++ _)
       }
-  }
+    }
 
   implicit val datasourceQueryparamsFilter
-    : Filterable[Any, DatasourceQueryParameters] =
+      : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -345,7 +344,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-    : Filterable[Any, ThumbnailQueryParameters] =
+      : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -360,7 +359,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-    : Filterable[Any, PlatformQueryParameters] =
+      : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -370,7 +369,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-    : Filterable[Any, OrganizationQueryParameters] =
+      : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -385,14 +384,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-    : Filterable[Organization, SearchQueryParameters] =
+      : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-    : Filterable[User, SearchQueryParameters] =
+      : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -403,7 +402,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-    : Filterable[Any, Projected[MultiPolygon]] =
+      : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -414,7 +413,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-    : Filterable[Any, StacExportQueryParameters] =
+      : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -434,19 +433,20 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationProjectQueryParametersFilter
-    : Filterable[Any, AnnotationProjectQueryParameters] =
+      : Filterable[Any, AnnotationProjectQueryParameters] =
     Filterable[Any, AnnotationProjectQueryParameters] {
       params: AnnotationProjectQueryParameters =>
-        val taskStatusF = params.projectFilterParams.taskStatusesInclude.toList.toNel map {
-          statusList =>
-            val statusFilterF = statusList map { status =>
-              Some(
-                fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'"
-              )
-            }
-            Fragment.const("(") ++ Fragments
-              .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
-        }
+        val taskStatusF =
+          params.projectFilterParams.taskStatusesInclude.toList.toNel map {
+            statusList =>
+              val statusFilterF = statusList map { status =>
+                Some(
+                  fr"(annotation_projects.task_status_summary ->> ${status.toString}) > '0'"
+                )
+              }
+              Fragment.const("(") ++ Fragments
+                .orOpt(statusFilterF.toList: _*) ++ Fragment.const(")")
+          }
         Filters.ownerQP(params.ownerParams, fr"annotation_projects.owner") ++
           Filters.searchQP(
             params.searchParams,
@@ -462,12 +462,15 @@ trait Filterables extends RFMeta with LazyLogging {
             params.campaignId.map({ campaignId =>
               fr"annotation_projects.campaign_id = $campaignId"
             }),
+            params.isActive.map({ isActive =>
+              fr"is_active = $isActive"
+            }),
             taskStatusF
           )
     }
 
   implicit val campaignQueryParametersFilter
-    : Filterable[Any, CampaignQueryParameters] =
+      : Filterable[Any, CampaignQueryParameters] =
     Filterable[Any, CampaignQueryParameters] {
       params: CampaignQueryParameters =>
         Filters.ownerQP(params.ownerParams, fr"owner") ++

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -47,7 +47,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val timestampQueryParamsFilter
-      : Filterable[Any, TimestampQueryParameters] =
+    : Filterable[Any, TimestampQueryParameters] =
     Filterable[Any, TimestampQueryParameters] {
       tsParams: TimestampQueryParameters =>
         Filters.timestampQP(tsParams)
@@ -59,7 +59,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectQueryParametersFilter
-      : Filterable[Any, ProjectQueryParameters] =
+    : Filterable[Any, ProjectQueryParameters] =
     Filterable[Any, ProjectQueryParameters] {
       projectParams: ProjectQueryParameters =>
         Filters.timestampQP(projectParams.timestampParams) ++
@@ -88,7 +88,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val CombinedToolQueryParametersFilter
-      : Filterable[Any, CombinedToolQueryParameters] =
+    : Filterable[Any, CombinedToolQueryParameters] =
     Filterable[Any, CombinedToolQueryParameters] {
       toolParams: CombinedToolQueryParameters =>
         Filters.timestampQP(toolParams.timestampParams) ++
@@ -101,7 +101,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationQueryparamsFilter
-      : Filterable[Any, AnnotationQueryParameters] =
+    : Filterable[Any, AnnotationQueryParameters] =
     Filterable[Any, AnnotationQueryParameters] {
       annotParams: AnnotationQueryParameters =>
         Filters.userQP(annotParams.userParams) ++
@@ -130,8 +130,7 @@ trait Filterables extends RFMeta with LazyLogging {
             annotParams.bboxPolygon match {
               case Some(bboxPolygons) =>
                 val fragments = bboxPolygons.map(bbox =>
-                  fr"(_ST_Intersects(geometry, ${bbox}) AND geometry && ${bbox})"
-                )
+                  fr"(_ST_Intersects(geometry, ${bbox}) AND geometry && ${bbox})")
                 Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
               case _ => None
             }
@@ -139,7 +138,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedSceneQueryParams
-      : Filterable[Any, CombinedSceneQueryParams] =
+    : Filterable[Any, CombinedSceneQueryParams] =
     Filterable[Any, CombinedSceneQueryParams] {
       combineSceneParams: CombinedSceneQueryParams =>
         val sceneParams = combineSceneParams.sceneParams
@@ -193,8 +192,7 @@ trait Filterables extends RFMeta with LazyLogging {
             (sceneParams.bboxPolygon, sceneParams.shape) match {
               case (Some(bboxPolygons), _) =>
                 val fragments = bboxPolygons.map(bbox =>
-                  fr"(_ST_Intersects(data_footprint, ${bbox}) AND tile_footprint && ${bbox})"
-                )
+                  fr"(_ST_Intersects(data_footprint, ${bbox}) AND tile_footprint && ${bbox})")
                 Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
               case _ => None
             }
@@ -202,7 +200,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val projectSceneQueryParameters
-      : Filterable[Any, ProjectSceneQueryParameters] =
+    : Filterable[Any, ProjectSceneQueryParameters] =
     Filterable[Any, ProjectSceneQueryParameters] { params =>
       List(
         params.ingested.map({
@@ -217,7 +215,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val mapTokenQueryParametersFilter
-      : Filterable[Any, CombinedMapTokenQueryParameters] =
+    : Filterable[Any, CombinedMapTokenQueryParameters] =
     Filterable[Any, CombinedMapTokenQueryParameters] {
       mapTokenParams: CombinedMapTokenQueryParameters =>
         Filters.userQP(mapTokenParams.userParams) ++
@@ -225,7 +223,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val combinedToolRunQueryParameters
-      : Filterable[Any, CombinedToolRunQueryParameters] =
+    : Filterable[Any, CombinedToolRunQueryParameters] =
     Filterable[Any, CombinedToolRunQueryParameters] {
       combinedToolRunParams: CombinedToolRunQueryParameters =>
         Filters.userQP(combinedToolRunParams.userParams) ++
@@ -253,17 +251,17 @@ trait Filterables extends RFMeta with LazyLogging {
       List(Some(fragment))
     }
 
-  implicit def maybeTFilter[T](implicit
-      filterable: Filterable[Any, T]
-  ): Filterable[Any, Option[T]] =
+  implicit def maybeTFilter[T](
+      implicit
+      filterable: Filterable[Any, T]): Filterable[Any, Option[T]] =
     Filterable[Any, Option[T]] {
       case None        => List.empty[Option[Fragment]]
       case Some(thing) => filterable.toFilters(thing)
     }
 
-  implicit def listTFilter[T](implicit
-      filterable: Filterable[Any, T]
-  ): Filterable[Any, List[T]] =
+  implicit def listTFilter[T](
+      implicit
+      filterable: Filterable[Any, T]): Filterable[Any, List[T]] =
     Filterable[Any, List[T]] { someFilterables: List[T] =>
       {
         someFilterables
@@ -273,7 +271,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val datasourceQueryparamsFilter
-      : Filterable[Any, DatasourceQueryParameters] =
+    : Filterable[Any, DatasourceQueryParameters] =
     Filterable[Any, DatasourceQueryParameters] {
       dsParams: DatasourceQueryParameters =>
         Filters.searchQP(dsParams.searchParams, List("name")) ++
@@ -344,7 +342,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val thumbnailParamsFilter
-      : Filterable[Any, ThumbnailQueryParameters] =
+    : Filterable[Any, ThumbnailQueryParameters] =
     Filterable[Any, ThumbnailQueryParameters] {
       params: ThumbnailQueryParameters =>
         Filters.thumbnailQP(params)
@@ -359,7 +357,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val platformQueryparamsFilter
-      : Filterable[Any, PlatformQueryParameters] =
+    : Filterable[Any, PlatformQueryParameters] =
     Filterable[Any, PlatformQueryParameters] {
       params: PlatformQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -369,7 +367,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val organizationQueryparamsFilter
-      : Filterable[Any, OrganizationQueryParameters] =
+    : Filterable[Any, OrganizationQueryParameters] =
     Filterable[Any, OrganizationQueryParameters] {
       params: OrganizationQueryParameters =>
         Filters.timestampQP(params.timestampParams) ++
@@ -384,14 +382,14 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val orgSearchQueryParamsFilter
-      : Filterable[Organization, SearchQueryParameters] =
+    : Filterable[Organization, SearchQueryParameters] =
     Filterable[Organization, SearchQueryParameters] {
       params: SearchQueryParameters =>
         Filters.searchQP(params, List("name"))
     }
 
   implicit val userSearchQueryParamsFilter
-      : Filterable[User, SearchQueryParameters] =
+    : Filterable[User, SearchQueryParameters] =
     Filterable[User, SearchQueryParameters] { params: SearchQueryParameters =>
       Filters.searchQP(params, List("name", "email", "id"))
     }
@@ -402,7 +400,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit def projectedMultiPolygonFilter
-      : Filterable[Any, Projected[MultiPolygon]] =
+    : Filterable[Any, Projected[MultiPolygon]] =
     Filterable[Any, Projected[MultiPolygon]] { geom =>
       List(Some(fr"ST_Intersects(data_footprint, ${geom})"))
     }
@@ -413,7 +411,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val labelStacExportQPFilter
-      : Filterable[Any, StacExportQueryParameters] =
+    : Filterable[Any, StacExportQueryParameters] =
     Filterable[Any, StacExportQueryParameters] {
       params: StacExportQueryParameters =>
         Filters.onlyUserQP(params.userParams) ++
@@ -433,7 +431,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val annotationProjectQueryParametersFilter
-      : Filterable[Any, AnnotationProjectQueryParameters] =
+    : Filterable[Any, AnnotationProjectQueryParameters] =
     Filterable[Any, AnnotationProjectQueryParameters] {
       params: AnnotationProjectQueryParameters =>
         val taskStatusF =
@@ -470,7 +468,7 @@ trait Filterables extends RFMeta with LazyLogging {
     }
 
   implicit val campaignQueryParametersFilter
-      : Filterable[Any, CampaignQueryParameters] =
+    : Filterable[Any, CampaignQueryParameters] =
     Filterable[Any, CampaignQueryParameters] {
       params: CampaignQueryParameters =>
         Filters.ownerQP(params.ownerParams, fr"owner") ++

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationProjectDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationProjectDaoSpec.scala
@@ -28,8 +28,9 @@ class AnnotationProjectDaoSpec
         ) => {
           val insertIO = for {
             user <- UserDao.create(userCreate)
-            inserted <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            inserted <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
           } yield inserted
 
           val result = insertIO.transact(xa).unsafeRunSync
@@ -73,10 +74,11 @@ class AnnotationProjectDaoSpec
 
           val listIO = for {
             user <- UserDao.create(userCreate)
-            insertedProjects <- annotationProjectCreates
-              .take(pageSize) traverse { toInsert =>
-              AnnotationProjectDao.insert(toInsert, user)
-            }
+            insertedProjects <-
+              annotationProjectCreates
+                .take(pageSize) traverse { toInsert =>
+                AnnotationProjectDao.insert(toInsert, user)
+              }
             _ <- insertedProjects traverse { project =>
               TaskDao.insertTasks(
                 fixupTaskFeaturesCollection(
@@ -87,12 +89,13 @@ class AnnotationProjectDaoSpec
                 user
               )
             }
-            listed <- AnnotationProjectDao
-              .listProjects(
-                pageRequest,
-                AnnotationProjectQueryParameters(),
-                user
-              )
+            listed <-
+              AnnotationProjectDao
+                .listProjects(
+                  pageRequest,
+                  AnnotationProjectQueryParameters(),
+                  user
+                )
           } yield (listed, insertedProjects)
 
           val (listedProjects, dbProjects) = listIO.transact(xa).unsafeRunSync
@@ -124,10 +127,11 @@ class AnnotationProjectDaoSpec
 
           val listIO = for {
             user <- UserDao.create(userCreate)
-            insertedProjects <- annotationProjectCreates
-              .take(pageSize) traverse { toInsert =>
-              AnnotationProjectDao.insert(toInsert, user)
-            }
+            insertedProjects <-
+              annotationProjectCreates
+                .take(pageSize) traverse { toInsert =>
+                AnnotationProjectDao.insert(toInsert, user)
+              }
             _ <- insertedProjects traverse { project =>
               TaskDao.insertTasks(
                 fixupTaskFeaturesCollection(
@@ -138,8 +142,9 @@ class AnnotationProjectDaoSpec
                 user
               )
             }
-            insertedProject <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            insertedProject <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
             _ <- TaskDao.insertTasks(
               fixupTaskFeaturesCollection(
                 taskFeaturesCreate,
@@ -148,16 +153,18 @@ class AnnotationProjectDaoSpec
               ),
               user
             )
-            listed <- AnnotationProjectDao
-              .listProjects(
-                pageRequest,
-                AnnotationProjectQueryParameters(
-                  projectFilterParams = AnnotationProjectFilterQueryParameters(
-                    taskStatusesInclude = Seq(TaskStatus.Unlabeled)
-                  )
-                ),
-                user
-              )
+            listed <-
+              AnnotationProjectDao
+                .listProjects(
+                  pageRequest,
+                  AnnotationProjectQueryParameters(
+                    projectFilterParams =
+                      AnnotationProjectFilterQueryParameters(
+                        taskStatusesInclude = Seq(TaskStatus.Unlabeled)
+                      )
+                  ),
+                  user
+                )
           } yield { (listed, insertedProjects) }
 
           val (projects, unlabeledProjects) =
@@ -246,8 +253,9 @@ class AnnotationProjectDaoSpec
         ) => {
           val insertIO = for {
             user <- UserDao.create(userCreate)
-            inserted <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            inserted <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
             fetched <- AnnotationProjectDao.getById(inserted.id)
           } yield { (inserted, fetched) }
 
@@ -275,15 +283,23 @@ class AnnotationProjectDaoSpec
         ) => {
           val updateIO = for {
             user <- UserDao.create(userCreate)
-            insertedCampaign <- CampaignDao
-              .insertCampaign(
-                campaignCreate.copy(parentCampaignId = None),
-                user
-              )
-            inserted1 <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
-            inserted2 <- AnnotationProjectDao
-              .insert(annotationProjectUpdate.copy(campaignId = Some(insertedCampaign.id)), user)
+            insertedCampaign <-
+              CampaignDao
+                .insertCampaign(
+                  campaignCreate.copy(parentCampaignId = None),
+                  user
+                )
+            inserted1 <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
+            inserted2 <-
+              AnnotationProjectDao
+                .insert(
+                  annotationProjectUpdate.copy(campaignId =
+                    Some(insertedCampaign.id)
+                  ),
+                  user
+                )
             _ <- AnnotationProjectDao.update(inserted2.toProject, inserted1.id)
             fetched <- AnnotationProjectDao.unsafeGetById(inserted1.id)
           } yield (fetched, inserted2)
@@ -333,8 +349,9 @@ class AnnotationProjectDaoSpec
         ) => {
           val deleteIO = for {
             user <- UserDao.create(userCreate)
-            inserted <- AnnotationProjectDao
-              .insert(annotationProjectCreate, user)
+            inserted <-
+              AnnotationProjectDao
+                .insert(annotationProjectCreate, user)
             deleted <- AnnotationProjectDao.deleteById(inserted.id, user)
             fetched <- AnnotationProjectDao.getById(inserted.id)
           } yield { (deleted, fetched) }
@@ -367,31 +384,35 @@ class AnnotationProjectDaoSpec
 
           val listIO = for {
             user <- UserDao.create(userCreate)
-            insertedCampaign <- CampaignDao
-              .insertCampaign(
-                campaignCreate.copy(parentCampaignId = None),
-                user
-              )
-            insertedProjects <- annotationProjectCreates1
-              .take(pageSize) traverse { toInsert =>
-              AnnotationProjectDao
-                .insert(
-                  toInsert.copy(campaignId = Some(insertedCampaign.id)),
+            insertedCampaign <-
+              CampaignDao
+                .insertCampaign(
+                  campaignCreate.copy(parentCampaignId = None),
                   user
                 )
-            }
-            _ <- annotationProjectCreates2
-              .take(pageSize) traverse { toInsert =>
-              AnnotationProjectDao.insert(toInsert, user)
-            }
-            listed <- AnnotationProjectDao
-              .listProjects(
-                pageRequest,
-                AnnotationProjectQueryParameters(
-                  campaignId = Some(insertedCampaign.id)
-                ),
-                user
-              )
+            insertedProjects <-
+              annotationProjectCreates1
+                .take(pageSize) traverse { toInsert =>
+                AnnotationProjectDao
+                  .insert(
+                    toInsert.copy(campaignId = Some(insertedCampaign.id)),
+                    user
+                  )
+              }
+            _ <-
+              annotationProjectCreates2
+                .take(pageSize) traverse { toInsert =>
+                AnnotationProjectDao.insert(toInsert, user)
+              }
+            listed <-
+              AnnotationProjectDao
+                .listProjects(
+                  pageRequest,
+                  AnnotationProjectQueryParameters(
+                    campaignId = Some(insertedCampaign.id)
+                  ),
+                  user
+                )
           } yield (listed, insertedProjects)
 
           val (listedProjects, dbProjects) = listIO.transact(xa).unsafeRunSync
@@ -423,24 +444,27 @@ class AnnotationProjectDaoSpec
 
           val listIO = for {
             user <- UserDao.create(userCreate)
-            insertedProjects <- annotationProjectCreates1
-              .take(pageSize) traverse { toInsert =>
+            insertedProjects <-
+              annotationProjectCreates1
+                .take(pageSize) traverse { toInsert =>
+                AnnotationProjectDao
+                  .insert(toInsert.copy(capturedAt = Some(capturedAt)), user)
+              }
+            _ <-
+              annotationProjectCreates2
+                .take(pageSize) traverse { toInsert =>
+                AnnotationProjectDao
+                  .insert(toInsert, user)
+              }
+            listed <-
               AnnotationProjectDao
-                .insert(toInsert.copy(capturedAt = Some(capturedAt)), user)
-            }
-            _ <- annotationProjectCreates2
-              .take(pageSize) traverse { toInsert =>
-              AnnotationProjectDao
-                .insert(toInsert, user)
-            }
-            listed <- AnnotationProjectDao
-              .listProjects(
-                pageRequest,
-                AnnotationProjectQueryParameters(
-                  capturedAt = Some(capturedAt)
-                ),
-                user
-              )
+                .listProjects(
+                  pageRequest,
+                  AnnotationProjectQueryParameters(
+                    capturedAt = Some(capturedAt)
+                  ),
+                  user
+                )
           } yield (listed, insertedProjects)
 
           val (listedProjects, dbProjects) =
@@ -449,6 +473,65 @@ class AnnotationProjectDaoSpec
           assert(
             listedProjects.count == dbProjects.size,
             "Listed projects are those with updated capture timestamp"
+          )
+
+          true
+        }
+      )
+    }
+  }
+
+  test("list annotation projects by campaign") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            annotationProjectCreateOne: AnnotationProject.Create,
+            annotationProjectCreateTwo: AnnotationProject.Create,
+            campaignCreate: Campaign.Create
+        ) => {
+          val pageSize = 20
+          val pageRequest = PageRequest(0, pageSize, Map.empty)
+
+          val listIO = for {
+            user <- UserDao.create(userCreate)
+            dbCampaign <- CampaignDao.insertCampaign(
+              campaignCreate.copy(parentCampaignId = None),
+              user
+            )
+            _ <- AnnotationProjectDao.insert(
+              annotationProjectCreateOne.copy(campaignId = Some(dbCampaign.id)),
+              user
+            )
+            dbProjTwo <- AnnotationProjectDao.insert(
+              annotationProjectCreateTwo.copy(campaignId = Some(dbCampaign.id)),
+              user
+            )
+            _ <- AnnotationProjectDao.update(
+              dbProjTwo.toProject.copy(isActive = false),
+              dbProjTwo.id
+            )
+            notFiltered <- AnnotationProjectDao.paginatedProjectsByCampaignId(
+              dbCampaign.id,
+              pageRequest,
+              AnnotationProjectQueryParameters()
+            )
+            filtered <- AnnotationProjectDao.paginatedProjectsByCampaignId(
+              dbCampaign.id,
+              pageRequest,
+              AnnotationProjectQueryParameters().copy(isActive = Some(true))
+            )
+          } yield (notFiltered, filtered)
+
+          val (listed, filteredList) = listIO.transact(xa).unsafeRunSync
+
+          assert(
+            listed.results.length == 2,
+            "annotation projects are listed by default ignoring the is_active field"
+          )
+          assert(
+            filteredList.results.length == 1,
+            "annotation projects are listed by is_active field"
           )
 
           true

--- a/app-tasks/rf/src/rf/models/annotation_project.py
+++ b/app-tasks/rf/src/rf/models/annotation_project.py
@@ -11,6 +11,7 @@ class AnnotationProject(BaseModel):
         projectType,
         taskSizePixels,
         status,
+        isActive,
         createdAt=None,
         createdBy=None,
         taskSizeMeters=None,
@@ -25,6 +26,7 @@ class AnnotationProject(BaseModel):
         self.projectType = projectType
         self.taskSizePixels = taskSizePixels
         self.status = status
+        self.isActive = isActive
         self.createdAt = createdAt
         self.createdBy = createdBy
         self.taskSizeMeters = taskSizeMeters
@@ -48,7 +50,8 @@ class AnnotationProject(BaseModel):
             validatorsTeamId=self.validatorsTeamId,
             projectId=self.projectId,
             status=self.status,
-            campaignId=self.campaignId
+            campaignId=self.campaignId,
+            isActive=self.isActive
         )
 
     def update_status(self, status):
@@ -63,6 +66,7 @@ class AnnotationProject(BaseModel):
             d.get("projectType"),
             d.get("taskSizePixels"),
             d.get("status"),
+            d.get("isActive"),
             createdAt=d.get("createdAt"),
             createdBy=d.get("createdBy"),
             taskSizeMeters=d.get("taskSizeMeters"),


### PR DESCRIPTION
## Overview

This PR:
- adds a migration to add `is_active` field to `annotation_projects`
- updates data model, dao methods, and added QP as a result of adding this field
- makes campaign delete async
- makes annotation project delete async
- adds property tests for the QPs on annotation project and on campaign
- updates data model of annotation project in our cogification workflow

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [x] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions
- Push up a `test` branch
- Follow instructions in https://github.com/raster-foundry/groundwork/pull/1341 should cover it
