### PR TITLE
Export tileurls for campaigns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [1.61.2] - 2021-03-30
 ### Changed
 - Campaign creates can include an owner [#5558](https://github.com/raster-foundry/raster-foundry/pull/5558)
+- Always link to TMS layer in STAC export [#5564](https://github.com/raster-foundry/raster-foundry/pull/5564/)
 
 ### Fixed
 - Copy and routing for campaign and annotation projects were synchronized with the frontend app [#5558](https://github.com/raster-foundry/raster-foundry/pull/5558)

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -259,7 +259,7 @@ final case class WriteStacCatalog(
     logger.info(s"Exporting STAC export for record $exportId...")
 
     logger.info(s"Getting STAC export data for record $exportId...")
-    
+
     (for {
       exportDefinition <- StacExportDao.unsafeGetById(exportId).transact(xa)
       tempDir = ScalaFile.newTemporaryDirectory()

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -72,7 +72,7 @@ final case class WriteStacCatalog(
     )
 
     val sceneItems: List[ImageryItem] = sceneTaskAnnotation.scenes match {
-      case _ =>
+      case Nil =>
         List(
           TileLayersItemWithAbsolute(
             Utils.getTileLayersItem(
@@ -84,19 +84,19 @@ final case class WriteStacCatalog(
             )
           )
         )
-      // case scenes =>
-      //   scenes flatMap { scene =>
-      //     (
-      //       Utils.getSceneItem(
-      //         catalog,
-      //         layerCollectionPrefix,
-      //         imageCollection,
-      //         scene
-      //       ),
-      //       scene.ingestLocation
-      //     ).mapN(SceneItemWithAbsolute.apply _)
+      case scenes =>
+        scenes flatMap { scene =>
+          (
+            Utils.getSceneItem(
+              catalog,
+              layerCollectionPrefix,
+              imageCollection,
+              scene
+            ),
+            scene.ingestLocation
+          ).mapN(SceneItemWithAbsolute.apply _)
 
-      //   }
+        }
     }
 
     val absoluteLayerCollection =
@@ -276,6 +276,7 @@ final case class WriteStacCatalog(
         runAnnotationProject(exportDefinition, pid, tempDir, exportPath)
       }
       _ <- exportDefinition.campaignId traverse { campaignId =>
+        // this is the spot
         new CampaignStacExport(campaignId, xa, exportDefinition).run() flatMap {
           case Some(exportData) =>
             exportData.toFileSystem(tempDir)

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -500,11 +500,11 @@ class CampaignStacExport(
       scene: Scene,
       annotationProject: AnnotationProject
   ): Option[newtypes.SceneItem] = {
-    val s3ImageLocation = scene.ingestLocation
+    val tileUrl = Option(s"http://localhost:8081/${scene.id}/{z}/{x}/{y}")
     val footprint = scene.dataFootprint
     val sceneCreationTime =
       scene.filterFields.acquisitionDate orElse Some(scene.createdAt)
-    (s3ImageLocation, footprint, sceneCreationTime) mapN {
+    (tileUrl, footprint, sceneCreationTime) mapN {
       case (url, footprint, timestamp) =>
         makeSceneItem(
           url,

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -543,10 +543,10 @@ class CampaignStacExport(
       // make the catalog for this annotation project
       // make the scene item for this annotation project with a tile layer asset
       imageryItemO <- imageryItemFromTileLayers(
-          annotationProject,
-          inputState.exportDefinition.taskStatuses
-        )
-        
+        annotationProject,
+        inputState.exportDefinition.taskStatuses
+      )
+
       imageryItemsAppend = imageryItemO map { (item: newtypes.SceneItem) =>
         Map(newtypes.AnnotationProjectId(annotationProject.id) -> item)
       } getOrElse Map.empty


### PR DESCRIPTION
## Overview

Closes [raster-foundry-platform #1221](https://github.com/azavea/raster-foundry-platform/issues/1221)

This PR changes the campaign STAC export to use tile layers in image assets href whether or not the annotation project is connected to a scene. 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Run an export on preloaded development data and confirm that image hrefs point to tile layers rather than s3 urls

- create export:
```
echo '{                                                                                                                 
    "name": "sample  export",
    "taskStatuses": [],
    "license": {
        "license": "proprietary",
        "url": null
    },
    "campaignId": "8d5f36b7-83a5-4115-975b-278bbc059c09"
}' | http --auth-type=jwt POST :9100/api/stac/
```
- run export with export id from previous step: ./scripts/console batch 'java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog [export id]'`
- pull down STAC catalog from s3: `aws s3 cp s3://rasterfoundry-development-data-us-east-1/stac-exports/[export id]/catalog.zip .`
- unzip and viem image item json: `cat images/4600dd56-d5d5-47f5-9750-29d3532ec00b.json`
```
{
  "id" : "4600dd56-d5d5-47f5-9750-29d3532ec00b",
  "stac_version" : "1.0.0-beta2",
  "stac_extensions" : [
  ],
  "type" : "Feature",
  "geometry" : {
    "type" : "Polygon",
    "coordinates" : [
      [
        [
          -62.888833201706134,
          2.7225909904053625
        ],
        [
          -62.888833201706134,
          2.7876611771213438
        ],
        [
          -62.789451993286306,
          2.7876611771213438
        ],
        [
          -62.789451993286306,
          2.7225909904053625
        ],
        [
          -62.888833201706134,
          2.7225909904053625
        ]
      ]
    ]
  },
  "bbox" : [
    -62.888833201706134,
    2.7225909904053625,
    -62.789451993286306,
    2.7876611771213438
  ],
  "links" : [
    {
      "href" : "./collection.json",
      "rel" : "collection",
      "type" : "application/json",
      "title" : null
    },
    {
      "href" : "../catalog.json",
      "rel" : "root",
      "type" : "application/json",
      "title" : null
    }
  ],
  "assets" : {
    "default" : {
      "href" : "http://localhost:8081/149161fe-9ba9-46bf-84d0-fda1b74341bb/{z}/{x}/{y}",
      "title" : "default",
      "description" : "TMS tiles",
      "roles" : [
        "data"
      ],
      "type" : "image/png"
    }
  },
  "collection" : "scenes-ae1d0f4a-4703-4eca-a034-5ff68bf66c3b",
  "properties" : {
    "datetime" : "2021-04-12T15:46:11.978Z"
  }
```
- confirm asset href points to tile layer rather than s3

Closes [#1221](https://github.com/azavea/raster-foundry-platform/issues/1221)