### PR TITLE
Use correct version of sbt in scripts/update

### DIFF
--- a/scripts/update
+++ b/scripts/update
@@ -22,7 +22,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     else
         echo "Building Scala assembly JARs"
         pushd "app-backend"
-            sbt \
+            ./sbt \
                 ";api/assembly;backsplash-server/assembly;batch/assembly;backsplash-export/assembly"
         popd
 


### PR DESCRIPTION
## Overview

The update script was using the system `sbt`, rather than the one local to the repo. This could result in Java version issues.

### Checklist

- ~~[ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible~~
- ~~[ ] Swagger specification updated~~
- ~~[ ] New tables and queries have appropriate indices added~~
- ~~[ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~~
- ~~[ ] Any new SQL strings have tests~~
- ~~[ ] Any new endpoints have scope validation and are included in the integration test csv~~

## Testing Instructions

- Run `./scripts/update` and ensure it succeeds
