### PR TITLE
Fix color correction for byte rasters and scene thumbnails, and MVT coordinate space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Corrected normalization behavior for scene thumbnails and annotation projects [#5569](https://github.com/raster-foundry/raster-foundry/pull/5569)
+- Restored coordinate space to 4096x4096 in label MVT [#5569](https://github.com/raster-foundry/raster-foundry/pull/5569)
 
 ## [1.62.0] - 2021-04-14
 ### Changed

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/SceneService.scala
@@ -174,7 +174,7 @@ class SceneService[HistStore](
             sceneToBacksplashGeotiff(
               scene,
               bands,
-              true,
+              false,
               lowerQuantile,
               upperQuantile
             ).map(a => (tracingContext, List(a)))

--- a/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
+++ b/app-backend/common/src/main/scala/com/rasterfoundry/common/color/ColorCorrect.scala
@@ -30,7 +30,7 @@ object ColorCorrect extends LazyLogging {
       val bands = tile.bands.zip(rgbHist).map {
         case (rgbTile, histogram) =>
           val breaks = histogram.quantileBreaks(100)
-          val (oldTrueMin, oldTrueMax) = (breaks(0), breaks(255))
+          val (oldTrueMin, oldTrueMax) = (breaks(0), breaks(99))
           if (oldTrueMin < 0 || oldTrueMax > 255) {
             val oldMin =
               breaks(lowerQuantile.getOrElse(defaultLowerBound)).toInt

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -175,7 +175,7 @@ object MVTLayerDao {
       def empty: StrictLayer =
         StrictLayer(
           "default",
-          256,
+          4096,
           2,
           tiling.tmsLevels(z).mapTransform.keyToExtent(x, y),
           Nil,


### PR DESCRIPTION
## Overview

This PR fixes three things:

- it expands the coordinate space for MVTs from 256 to 4096 coords -- this is the default, and the 256 was leftover from performance testing. I believe that the reduced coordinate space is responsible for some visual artifacts I've encountered while testing with complex labels, and also the size of the coordinate space had no impact on performance when I tested.
- it skips normalization when the min/max for the histogram breaks are in the 0 - 255 range
- it turns color correction back on for scene thumbnails, since without color correction we got the fuzzy chaos imagery

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

Thumbnail of non-byte raster:

![thumbnail](https://user-images.githubusercontent.com/5702984/115054406-69fa5680-9e9d-11eb-87bd-e444987dc0cf.png)

Byte raster vis:

![image](https://user-images.githubusercontent.com/5702984/115054480-7b436300-9e9d-11eb-8551-51395943ac24.png)

compare byte raster vis to prod:

![image](https://user-images.githubusercontent.com/5702984/115054539-8d250600-9e9d-11eb-967d-0e295d22d422.png)

I don't have a good demo for the MVT coordinate space, but you can verify the claim about the default here: https://postgis.net/docs/ST_AsMVT.html (in the `extent` argument)

You can also see the difference with some user data in [this Slack thread](https://azavea.slack.com/archives/C089LBS6S/p1618846116084700?thread_ts=1618839680.077400&cid=C089LBS6S)

## Testing Instructions

- assemble servers
- bring up servers and groundwork
- upload and process a byte raster -- you can use any of the NAIP imagery in the sample data
- upload and process a non-byte raster -- you can use the PlanetScope scene in the sample data
- they should both look nice with default correction
- get the id of the scene created when you processed the PlanetScope data
- grab a groundwork token
- make a thumbnail request for the planet scope scene: `http :8081/scenes/<scene-id>/thumbnail?floor=25&height=128&token=your-token > thumbnail.png`
- view the thumbnail -- it should not look chaotic

Closes #5568 

Closes azavea/raster-foundry-platform#1219
