### PR TITLE
Add classes to campaign export label STAC item and label data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed campaign STAC exports so that classes are added to label STAC item and label data [#5570](https://github.com/raster-foundry/raster-foundry/pull/5570)
 
 ## [1.62.0] - 2021-04-14
 ### Changed

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -173,23 +173,22 @@ case class ExportData private (
   )(implicit cs: ContextShift[IO]): IO[Unit] = {
     val withCollection =
       optics.itemCollectionLens.modify(_ => Some(imageryCollectionId))
-    val withParentLinks = optics.itemLinksLens.modify(links =>
-      StacLink(
-        "./collection.json",
-        StacLinkType.Collection,
-        Some(`application/json`),
-        None
-      ) +: StacLink(
-        "../catalog.json",
-        StacLinkType.StacRoot,
-        Some(`application/json`),
-        None
-      ) +:
-        links.filter(link =>
+    val withParentLinks = optics.itemLinksLens.modify(
+      links =>
+        StacLink(
+          "./collection.json",
+          StacLinkType.Collection,
+          Some(`application/json`),
+          None
+        ) +: StacLink(
+          "../catalog.json",
+          StacLinkType.StacRoot,
+          Some(`application/json`),
+          None
+        ) +:
+          links.filter(link =>
           !Set[StacLinkType](StacLinkType.Collection, StacLinkType.StacRoot)
-            .contains(link.rel)
-        )
-    )
+            .contains(link.rel)))
 
     def withAsset(stacItem: StacItem): IO[StacItem] = {
       stacItem.assets.get("data") match {
@@ -197,13 +196,12 @@ case class ExportData private (
           IO {
             s3Client.maybeSignUri(asset.href, duration = Duration.ofDays(7))
           } map { signedUrl =>
-            (optics.itemAssetLens.modify(assets =>
-              assets ++ Map(
-                "data" -> optics.assetHrefLens
-                  .modify(_ => signedUrl)(asset)
-              )
-            )
-            )(stacItem)
+            (optics.itemAssetLens.modify(
+              assets =>
+                assets ++ Map(
+                  "data" -> optics.assetHrefLens
+                    .modify(_ => signedUrl)(asset)
+              )))(stacItem)
           }
         case None =>
           IO.pure(stacItem)
@@ -353,35 +351,34 @@ case class ExportData private (
   )(implicit cs: ContextShift[IO]): IO[Unit] = {
     val withCollection =
       optics.itemCollectionLens.modify(_ => Some(labelCollectionId))
-    val withParentLinks = optics.itemLinksLens.modify(links =>
-      StacLink(
-        "./collection.json",
-        StacLinkType.Collection,
-        Some(`application/json`),
-        None
-      ) +: StacLink(
-        "../catalog.json",
-        StacLinkType.StacRoot,
-        Some(`application/json`),
-        None
-      ) +:
-        links.filter(link =>
+    val withParentLinks = optics.itemLinksLens.modify(
+      links =>
+        StacLink(
+          "./collection.json",
+          StacLinkType.Collection,
+          Some(`application/json`),
+          None
+        ) +: StacLink(
+          "../catalog.json",
+          StacLinkType.StacRoot,
+          Some(`application/json`),
+          None
+        ) +:
+          links.filter(link =>
           !Set[StacLinkType](StacLinkType.Collection, StacLinkType.StacRoot)
-            .contains(link.rel)
-        )
-    )
+            .contains(link.rel)))
     def withAsset(labelItem: StacItem) =
-      optics.itemAssetLens.modify(assets =>
-        assets ++ Map(
-          "data" -> StacItemAsset(
-            s"./data/${labelItem.id}.geojson",
-            None,
-            None,
-            Set(StacAssetRole.Data),
-            Some(`application/geo+json`)
-          )
-        )
-      )(labelItem)
+      optics.itemAssetLens.modify(
+        assets =>
+          assets ++ Map(
+            "data" -> StacItemAsset(
+              s"./data/${labelItem.id}.geojson",
+              None,
+              None,
+              Set(StacAssetRole.Data),
+              Some(`application/geo+json`)
+            )
+        ))(labelItem)
     (annotationProjectLabelItems.toList traverse {
       case (_, v) =>
         encodableToFile(
@@ -435,9 +432,8 @@ class CampaignStacExport(
     xa: Transactor[IO],
     exportDefinition: StacExport
 )(implicit
-    val
-    cs: ContextShift[IO]
-) {
+  val
+  cs: ContextShift[IO]) {
 
   val runExport = StateT { step }
 
@@ -511,14 +507,12 @@ class CampaignStacExport(
       taskStatuses: List[String]
   ): IO[Option[newtypes.SceneItem]] =
     for {
-      tileLayers <-
-        TileLayerDao
-          .listByProjectId(annotationProject.id)
-          .transact(xa)
-      extentO <-
-        TaskDao
-          .createUnionedGeomExtent(annotationProject.id, taskStatuses)
-          .transact(xa)
+      tileLayers <- TileLayerDao
+        .listByProjectId(annotationProject.id)
+        .transact(xa)
+      extentO <- TaskDao
+        .createUnionedGeomExtent(annotationProject.id, taskStatuses)
+        .transact(xa)
       item = extentO map { unionedGeom =>
         makeTileLayersItem(
           tileLayers,
@@ -543,14 +537,13 @@ class CampaignStacExport(
         Map(newtypes.AnnotationProjectId(annotationProject.id) -> item)
       } getOrElse Map.empty
       // make label asset
-      featureGeoJSON <-
-        AnnotationLabelDao
-          .getAnnotationJsonByTaskStatus(
-            annotationProject.id,
-            inputState.exportDefinition.taskStatuses,
-            inputState.labelGroupOpt
-          )
-          .transact(xa)
+      featureGeoJSON <- AnnotationLabelDao
+        .getAnnotationJsonByTaskStatus(
+          annotationProject.id,
+          inputState.exportDefinition.taskStatuses,
+          inputState.labelGroupOpt
+        )
+        .transact(xa)
       labelAssetAppend = featureGeoJSON map { geojson =>
         Map(
           newtypes.AnnotationProjectId(annotationProject.id) -> newtypes
@@ -558,20 +551,18 @@ class CampaignStacExport(
         )
       } getOrElse Map.empty
       // make the label item
-      taskExtent <-
-        TaskDao
-          .createUnionedGeomExtent(
-            annotationProject.id,
-            inputState.exportDefinition.taskStatuses
-          )
-          .transact(xa)
-      labelItemExtensionO <-
-        AnnotationProjectDao
-          .getAnnotationProjectStacInfo(
-            annotationProject.id,
-            inputState.labelGroupOpt
-          )
-          .transact(xa)
+      taskExtent <- TaskDao
+        .createUnionedGeomExtent(
+          annotationProject.id,
+          inputState.exportDefinition.taskStatuses
+        )
+        .transact(xa)
+      labelItemExtensionO <- AnnotationProjectDao
+        .getAnnotationProjectStacInfo(
+          annotationProject.id,
+          inputState.labelGroupOpt
+        )
+        .transact(xa)
       labelItemsAppend = (taskExtent, labelItemExtensionO, imageryItemO) mapN {
         case (extent, labelItemExtension, imageryItem) =>
           Map(

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -69,8 +69,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})"
-        )
+          fr"(${label.id}, ${labelClassId})")
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -167,7 +166,9 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       labelGroups <- OptionT.liftF(
         labelGroupsOpt.fold(
           AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
-        )({ groups => groups.pure[ConnectionIO] })
+        )({ groups =>
+          groups.pure[ConnectionIO]
+        })
       )
       groupedLabelClasses <- OptionT.liftF(labelGroups traverse { group =>
         AnnotationLabelClassDao
@@ -175,33 +176,31 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName =
-        groupedLabelClasses
-          .map { classGroups =>
-            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-          }
-          .flatten
-          .toMap
-          .collect {
-            case (k, Some(v)) => k -> v.name
-          }
-      classIdToLabelName =
-        groupedLabelClasses
-          .map(_._2)
-          .flatten
-          .map(c => c.id -> c.name)
-          .toMap
+      classIdToGroupName = groupedLabelClasses
+        .map { classGroups =>
+          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+        }
+        .flatten
+        .toMap
+        .collect {
+          case (k, Some(v)) => k -> v.name
+        }
+      classIdToLabelName = groupedLabelClasses
+        .map(_._2)
+        .flatten
+        .map(c => c.id -> c.name)
+        .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(Some(taskFilterF), Some(labelFilterF), statusFilterFO))
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield StacGeoJSONFeatureCollection(
-      annotations.map(anno =>
-        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
-      )
-    ).asJson
+    } yield
+      StacGeoJSONFeatureCollection(
+        annotations.map(anno =>
+          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
+      ).asJson
     fcIo.value
   }
 
@@ -210,12 +209,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <-
-        TaskDao.query
-          .filter(
-            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-          )
-          .select
+      parentTask <- TaskDao.query
+        .filter(
+          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+        )
+        .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -69,7 +69,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})")
+          fr"(${label.id}, ${labelClassId})"
+        )
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -164,11 +165,9 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     }
     val fcIo = for {
       labelGroups <- OptionT.liftF(
-        labelGroupsOpt match {
-          case Some(groups) => groups.pure[ConnectionIO]
-          case _ =>
-            AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
-        }
+        labelGroupsOpt.fold(
+          AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
+        )({ groups => groups.pure[ConnectionIO] })
       )
       groupedLabelClasses <- OptionT.liftF(labelGroups traverse { group =>
         AnnotationLabelClassDao
@@ -176,31 +175,33 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName = groupedLabelClasses
-        .map { classGroups =>
-          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-        }
-        .flatten
-        .toMap
-        .collect {
-          case (k, Some(v)) => k -> v.name
-        }
-      classIdToLabelName = groupedLabelClasses
-        .map(_._2)
-        .flatten
-        .map(c => c.id -> c.name)
-        .toMap
+      classIdToGroupName =
+        groupedLabelClasses
+          .map { classGroups =>
+            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+          }
+          .flatten
+          .toMap
+          .collect {
+            case (k, Some(v)) => k -> v.name
+          }
+      classIdToLabelName =
+        groupedLabelClasses
+          .map(_._2)
+          .flatten
+          .map(c => c.id -> c.name)
+          .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(Some(taskFilterF), Some(labelFilterF), statusFilterFO))
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield
-      StacGeoJSONFeatureCollection(
-        annotations.map(anno =>
-          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
-      ).asJson
+    } yield StacGeoJSONFeatureCollection(
+      annotations.map(anno =>
+        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
+      )
+    ).asJson
     fcIo.value
   }
 
@@ -209,11 +210,12 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <- TaskDao.query
-        .filter(
-          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-        )
-        .select
+      parentTask <-
+        TaskDao.query
+          .filter(
+            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+          )
+          .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -150,7 +150,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
 
   def getAnnotationJsonByTaskStatus(
       annotationProjectId: UUID,
-      taskStatuses: List[String]
+      taskStatuses: List[String],
+      labelGroupsOpt: Option[List[AnnotationLabelClassGroup]] = None
   ): ConnectionIO[Option[Json]] = {
     val taskJoinF = fr"JOIN tasks on " ++ Fragment.const(
       tableName
@@ -163,7 +164,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     }
     val fcIo = for {
       labelGroups <- OptionT.liftF(
-        AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
+        labelGroupsOpt match {
+          case Some(groups) => groups.pure[ConnectionIO]
+          case _ =>
+            AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
+        }
       )
       groupedLabelClasses <- OptionT.liftF(labelGroups traverse { group =>
         AnnotationLabelClassDao

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,15 +206,16 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-        case (classGroup, idx) =>
-          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-            classGroup,
-            Some(annotationProject),
-            None,
-            idx
-          )
-      }
+      labelClassGroups <-
+        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+          case (classGroup, idx) =>
+            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+              classGroup,
+              Some(annotationProject),
+              None,
+              idx
+            )
+        }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -230,8 +231,9 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <- AnnotationLabelClassGroupDao
-        .listByProjectId(id)
+      labelClassGroup <-
+        AnnotationLabelClassGroupDao
+          .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -378,11 +380,12 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <- (fr"select id from " ++ Fragment.const(
-        tableName
-      ) ++ fr" where owner = $userId")
-        .query[UUID]
-        .to[List]
+      projectIds <-
+        (fr"select id from " ++ Fragment.const(
+          tableName
+        ) ++ fr" where owner = $userId")
+          .query[UUID]
+          .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -397,11 +400,9 @@ object AnnotationProjectDao
         getProjectById(annotationProjectId)
       }
       labelGroups <- OptionT.liftF(
-        labelGroupsOpt match {
-          case Some(groups) => groups.pure[ConnectionIO]
-          case _ =>
-            AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
-        }
+        labelGroupsOpt.fold(
+          AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
+        )({ groups => groups.pure[ConnectionIO] })
       )
       groupedLabelClasses <- OptionT.liftF(labelGroups traverse { group =>
         AnnotationLabelClassDao
@@ -414,14 +415,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(
-              classes =>
-                LabelClass(
-                  LabelClassName.VectorName(group.name),
-                  LabelClassClasses.NamedLabelClasses(
-                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                  )
-              ))
+            .map(classes =>
+              LabelClass(
+                LabelClassName.VectorName(group.name),
+                LabelClassClasses.NamedLabelClasses(
+                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                )
+              )
+            )
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -444,9 +445,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Annotate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -454,9 +455,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Validate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -507,37 +508,40 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <- insertQuery.update
-        .withUniqueGeneratedKeys[AnnotationProject](
-          fieldNames: _*
-        )
+      annotationProjectCopy <-
+        insertQuery.update
+          .withUniqueGeneratedKeys[AnnotationProject](
+            fieldNames: _*
+          )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <- AnnotationLabelClassDao
-            .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <- AnnotationLabelClassGroupDao
-            .insertAnnotationLabelClassGroup(
-              AnnotationLabelClassGroup.Create(
-                classGroup.name,
-                Some(classGroup.index),
-                labelClasses.map { labelClass =>
-                  AnnotationLabelClass.Create(
-                    labelClass.name,
-                    labelClass.colorHexCode,
-                    labelClass.default,
-                    labelClass.determinant,
-                    labelClass.index,
-                    labelClass.geometryType,
-                    labelClass.description
-                  )
-                }
-              ),
-              Some(annotationProjectCopy),
-              None,
-              0,
-              labelClasses
-            )
+          labelClasses <-
+            AnnotationLabelClassDao
+              .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <-
+            AnnotationLabelClassGroupDao
+              .insertAnnotationLabelClassGroup(
+                AnnotationLabelClassGroup.Create(
+                  classGroup.name,
+                  Some(classGroup.index),
+                  labelClasses.map { labelClass =>
+                    AnnotationLabelClass.Create(
+                      labelClass.name,
+                      labelClass.colorHexCode,
+                      labelClass.default,
+                      labelClass.determinant,
+                      labelClass.index,
+                      labelClass.geometryType,
+                      labelClass.description
+                    )
+                  }
+                ),
+                Some(annotationProjectCopy),
+                None,
+                0,
+                labelClasses
+              )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -568,20 +572,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())(
-            (acc, userId) =>
-              acc ++ List(
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.View
-                ),
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.Annotate
-                )
-            ))
+          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
+            acc ++ List(
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.View
+              ),
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.Annotate
+              )
+            )
+          )
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,16 +206,15 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <-
-        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-          case (classGroup, idx) =>
-            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-              classGroup,
-              Some(annotationProject),
-              None,
-              idx
-            )
-        }
+      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+        case (classGroup, idx) =>
+          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+            classGroup,
+            Some(annotationProject),
+            None,
+            idx
+          )
+      }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -231,9 +230,8 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByProjectId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -380,12 +378,11 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      projectIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -417,14 +414,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(classes =>
-              LabelClass(
-                LabelClassName.VectorName(group.name),
-                LabelClassClasses.NamedLabelClasses(
-                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                )
-              )
-            )
+            .map(
+              classes =>
+                LabelClass(
+                  LabelClassName.VectorName(group.name),
+                  LabelClassClasses.NamedLabelClasses(
+                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                  )
+              ))
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -447,9 +444,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -457,9 +454,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -510,40 +507,37 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[AnnotationProject](
-            fieldNames: _*
-          )
+      annotationProjectCopy <- insertQuery.update
+        .withUniqueGeneratedKeys[AnnotationProject](
+          fieldNames: _*
+        )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <-
-            AnnotationLabelClassDao
-              .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <-
-            AnnotationLabelClassGroupDao
-              .insertAnnotationLabelClassGroup(
-                AnnotationLabelClassGroup.Create(
-                  classGroup.name,
-                  Some(classGroup.index),
-                  labelClasses.map { labelClass =>
-                    AnnotationLabelClass.Create(
-                      labelClass.name,
-                      labelClass.colorHexCode,
-                      labelClass.default,
-                      labelClass.determinant,
-                      labelClass.index,
-                      labelClass.geometryType,
-                      labelClass.description
-                    )
-                  }
-                ),
-                Some(annotationProjectCopy),
-                None,
-                0,
-                labelClasses
-              )
+          labelClasses <- AnnotationLabelClassDao
+            .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <- AnnotationLabelClassGroupDao
+            .insertAnnotationLabelClassGroup(
+              AnnotationLabelClassGroup.Create(
+                classGroup.name,
+                Some(classGroup.index),
+                labelClasses.map { labelClass =>
+                  AnnotationLabelClass.Create(
+                    labelClass.name,
+                    labelClass.colorHexCode,
+                    labelClass.default,
+                    labelClass.determinant,
+                    labelClass.index,
+                    labelClass.geometryType,
+                    labelClass.description
+                  )
+                }
+              ),
+              Some(annotationProjectCopy),
+              None,
+              0,
+              labelClasses
+            )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -574,20 +568,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
-            acc ++ List(
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.View
-              ),
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.Annotate
-              )
-            )
-          )
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
+            ))
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,16 +206,15 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <-
-        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-          case (classGroup, idx) =>
-            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-              classGroup,
-              Some(annotationProject),
-              None,
-              idx
-            )
-        }
+      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+        case (classGroup, idx) =>
+          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+            classGroup,
+            Some(annotationProject),
+            None,
+            idx
+          )
+      }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -231,9 +230,8 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByProjectId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -380,12 +378,11 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      projectIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -402,7 +399,9 @@ object AnnotationProjectDao
       labelGroups <- OptionT.liftF(
         labelGroupsOpt.fold(
           AnnotationLabelClassGroupDao.listByProjectId(annotationProjectId)
-        )({ groups => groups.pure[ConnectionIO] })
+        )({ groups =>
+          groups.pure[ConnectionIO]
+        })
       )
       groupedLabelClasses <- OptionT.liftF(labelGroups traverse { group =>
         AnnotationLabelClassDao
@@ -415,14 +414,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(classes =>
-              LabelClass(
-                LabelClassName.VectorName(group.name),
-                LabelClassClasses.NamedLabelClasses(
-                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                )
-              )
-            )
+            .map(
+              classes =>
+                LabelClass(
+                  LabelClassName.VectorName(group.name),
+                  LabelClassClasses.NamedLabelClasses(
+                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                  )
+              ))
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -445,9 +444,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -455,9 +454,9 @@ object AnnotationProjectDao
               _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -508,40 +507,37 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[AnnotationProject](
-            fieldNames: _*
-          )
+      annotationProjectCopy <- insertQuery.update
+        .withUniqueGeneratedKeys[AnnotationProject](
+          fieldNames: _*
+        )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <-
-            AnnotationLabelClassDao
-              .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <-
-            AnnotationLabelClassGroupDao
-              .insertAnnotationLabelClassGroup(
-                AnnotationLabelClassGroup.Create(
-                  classGroup.name,
-                  Some(classGroup.index),
-                  labelClasses.map { labelClass =>
-                    AnnotationLabelClass.Create(
-                      labelClass.name,
-                      labelClass.colorHexCode,
-                      labelClass.default,
-                      labelClass.determinant,
-                      labelClass.index,
-                      labelClass.geometryType,
-                      labelClass.description
-                    )
-                  }
-                ),
-                Some(annotationProjectCopy),
-                None,
-                0,
-                labelClasses
-              )
+          labelClasses <- AnnotationLabelClassDao
+            .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <- AnnotationLabelClassGroupDao
+            .insertAnnotationLabelClassGroup(
+              AnnotationLabelClassGroup.Create(
+                classGroup.name,
+                Some(classGroup.index),
+                labelClasses.map { labelClass =>
+                  AnnotationLabelClass.Create(
+                    labelClass.name,
+                    labelClass.colorHexCode,
+                    labelClass.default,
+                    labelClass.determinant,
+                    labelClass.index,
+                    labelClass.geometryType,
+                    labelClass.description
+                  )
+                }
+              ),
+              Some(annotationProjectCopy),
+              None,
+              0,
+              labelClasses
+            )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -572,20 +568,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
-            acc ++ List(
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.View
-              ),
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.Annotate
-              )
-            )
-          )
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
+            ))
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules


### PR DESCRIPTION
## Overview

This PR fixes a bug in campaign STAC exports so that:
- the label data has class name information
- the label stac time has class names

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Assemble batch jar, rebuild batch service, spin up servers
- Connect local Groundwork to your local RF servers
- In a campaign with class definition and labels, start an export, and grab the export ID
- Open a batch bash shell while servers are running, run `java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main write_stac_catalog <export id>`
- On the Groundwork frontend, download the export,
- Make sure the label data has label name info. Make sure the label stac item has label class info.

Closes https://github.com/raster-foundry/raster-foundry/issues/5567
