### PR TITLE
Support Intercom conversations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for Intercom conversations [#5571](https://github.com/raster-foundry/raster-foundry/pull/5571)
 
 ## [1.62.1] - 2021-04-19
 ### Fixed

--- a/app-backend/api/src/main/scala/Main.scala
+++ b/app-backend/api/src/main/scala/Main.scala
@@ -32,15 +32,16 @@ object Main extends App with Config with Router {
       )
     )
 
+  val xa = RFTransactor.buildTransactor()
+
   val notifier = for {
     notifierIO <- Async.memoize(AsyncHttpClientCatsBackend[IO]() map {
       backend =>
-        new IntercomNotifications(backend)
+        new IntercomNotifications(backend, xa)
     })
     notifier <- notifierIO
   } yield notifier
 
-  val xa = RFTransactor.buildTransactor()
   implicit val ec = ExecutionContext.Implicits.global
 
   val commonLabelClassGroupRoutes = new CommonLabelClassGroupRoutes(xa, ec)

--- a/app-backend/api/src/main/scala/utils/Config.scala
+++ b/app-backend/api/src/main/scala/utils/Config.scala
@@ -36,7 +36,7 @@ trait Config {
 
   val intercomAppId = intercomConfig.getString("appId")
   val intercomToken = IntercomToken(intercomConfig.getString("token"))
-  val intercomAdminId = UserId(intercomConfig.getString("adminId"))
+  val intercomAdminId = AdminId(intercomConfig.getString("adminId"))
   val groundworkUrlBase = intercomConfig.getString("groundworkUrlBase")
 
   val rollbarClientToken = rollbarConfig.getString("clientToken")

--- a/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
+++ b/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
@@ -2,7 +2,6 @@ package com.rasterfoundry.api.utils
 
 import com.rasterfoundry.api.user.{Auth0Service, PasswordResetTicket}
 import com.rasterfoundry.database.notification.Notify
-import com.rasterfoundry.database.util.RFTransactor
 import com.rasterfoundry.database.UserIntercomConversationDao
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.notification.email.Model.{HtmlBody, PlainBody}
@@ -11,9 +10,11 @@ import com.rasterfoundry.notification.intercom.{
   IntercomConversation,
   LiveIntercomNotifier
 }
-import com.rasterfoundry.notification.intercom.Model.{ExternalId, Message}
+import com.rasterfoundry.notification.intercom.Model.Message
 
 import cats.effect.{ContextShift, IO}
+import doobie.Transactor
+import doobie.implicits._
 import sttp.client.SttpBackend
 import sttp.client.asynchttpclient.WebSocketHandler
 
@@ -26,14 +27,12 @@ class IntercomNotifications(
       IO,
       Nothing,
       WebSocketHandler
-    ]
+    ],
+    xa: Transactor[IO]
 )(implicit contextShift: ContextShift[IO])
     extends Config {
 
   private val intercomNotifier = new LiveIntercomNotifier[IO](backend)
-
-  private val xa =
-    RFTransactor.nonHikariTransactor(RFTransactor.TransactorConfig())
 
   private val groundworkConfig =
     GroundworkConfig(intercomToken, intercomAdminId)

--- a/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
+++ b/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
@@ -1,16 +1,16 @@
 package com.rasterfoundry.api.utils
 
 import com.rasterfoundry.api.user.{Auth0Service, PasswordResetTicket}
-import com.rasterfoundry.database.notification.Notify
 import com.rasterfoundry.database.UserIntercomConversationDao
+import com.rasterfoundry.database.notification.Notify
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.notification.email.Model.{HtmlBody, PlainBody}
+import com.rasterfoundry.notification.intercom.Model.Message
 import com.rasterfoundry.notification.intercom.{
   GroundworkConfig,
   IntercomConversation,
   LiveIntercomNotifier
 }
-import com.rasterfoundry.notification.intercom.Model.Message
 
 import cats.effect.{ContextShift, IO}
 import doobie.Transactor
@@ -149,16 +149,15 @@ class IntercomNotifications(
         value,
         ticket
       )
-      _ <-
-        Notify
-          .sendEmail(
-            sharingUserPlatform.publicSettings,
-            sharingUserPlatform.privateSettings,
-            newUserEmail,
-            subject,
-            messageRich.underlying,
-            messagePlain.underlying
-          )
+      _ <- Notify
+        .sendEmail(
+          sharingUserPlatform.publicSettings,
+          sharingUserPlatform.privateSettings,
+          newUserEmail,
+          subject,
+          messageRich.underlying,
+          messagePlain.underlying
+        )
     } yield ()).attempt.void.unsafeToFuture
   }
 

--- a/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
+++ b/app-backend/api/src/main/scala/utils/IntercomNotifications.scala
@@ -2,9 +2,15 @@ package com.rasterfoundry.api.utils
 
 import com.rasterfoundry.api.user.{Auth0Service, PasswordResetTicket}
 import com.rasterfoundry.database.notification.Notify
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.database.UserIntercomConversationDao
 import com.rasterfoundry.datamodel._
 import com.rasterfoundry.notification.email.Model.{HtmlBody, PlainBody}
-import com.rasterfoundry.notification.intercom.LiveIntercomNotifier
+import com.rasterfoundry.notification.intercom.{
+  GroundworkConfig,
+  IntercomConversation,
+  LiveIntercomNotifier
+}
 import com.rasterfoundry.notification.intercom.Model.{ExternalId, Message}
 
 import cats.effect.{ContextShift, IO}
@@ -21,11 +27,29 @@ class IntercomNotifications(
       Nothing,
       WebSocketHandler
     ]
-)(implicit
-  contextShift: ContextShift[IO])
+)(implicit contextShift: ContextShift[IO])
     extends Config {
 
   private val intercomNotifier = new LiveIntercomNotifier[IO](backend)
+
+  private val xa =
+    RFTransactor.nonHikariTransactor(RFTransactor.TransactorConfig())
+
+  private val groundworkConfig =
+    GroundworkConfig(intercomToken, intercomAdminId)
+
+  private def getConversation(
+      id: String
+  ): IO[Option[UserIntercomConversation]] =
+    UserIntercomConversationDao.getByUserId(id).transact(xa)
+
+  private def insertConversation(
+      userId: String,
+      conversationId: String
+  ): IO[UserIntercomConversation] =
+    UserIntercomConversationDao
+      .insertUserConversation(userId, conversationId)
+      .transact(xa)
 
   def getDefaultShare(
       user: User,
@@ -83,15 +107,18 @@ class IntercomNotifications(
     } else {
       valueType
     }
-    intercomNotifier
-      .notifyUser(
-        intercomToken,
-        intercomAdminId,
-        ExternalId(sharedUser.id),
-        Message(s"""
+    val message = Message(s"""
         | ${getSharer(sharingUser)} has shared a ${singularized} with you!
         | ${groundworkUrlBase}/app/${valueType}/${value.id}/overview
         | """.trim.stripMargin)
+    IntercomConversation
+      .notifyIO(
+        sharedUser.id,
+        message,
+        groundworkConfig,
+        intercomNotifier,
+        getConversation,
+        insertConversation
       )
       .attempt
   }
@@ -123,15 +150,16 @@ class IntercomNotifications(
         value,
         ticket
       )
-      _ <- Notify
-        .sendEmail(
-          sharingUserPlatform.publicSettings,
-          sharingUserPlatform.privateSettings,
-          newUserEmail,
-          subject,
-          messageRich.underlying,
-          messagePlain.underlying
-        )
+      _ <-
+        Notify
+          .sendEmail(
+            sharingUserPlatform.publicSettings,
+            sharingUserPlatform.privateSettings,
+            newUserEmail,
+            subject,
+            messageRich.underlying,
+            messagePlain.underlying
+          )
     } yield ()).attempt.void.unsafeToFuture
   }
 

--- a/app-backend/batch/src/main/scala/groundwork/Config.scala
+++ b/app-backend/batch/src/main/scala/groundwork/Config.scala
@@ -9,6 +9,6 @@ object Config {
   val config = ConfigFactory.load()
   private val intercomConfig = config.getConfig("intercom")
   val intercomToken = IntercomToken(intercomConfig.getString("token"))
-  val intercomAdminId = UserId(intercomConfig.getString("adminId"))
+  val intercomAdminId = AdminId(intercomConfig.getString("adminId"))
   val groundworkUrlBase = intercomConfig.getString("groundworkUrlBase")
 }

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -23,7 +23,7 @@ import com.rasterfoundry.notification.intercom.{
 }
 
 import cats.data.OptionT
-import cats.effect.{Async, IO, LiftIO}
+import cats.effect.{Async, ContextShift, IO, LiftIO}
 import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
 import doobie.implicits._
@@ -37,7 +37,8 @@ class CreateTaskGrid(
     taskSizeMeters: Double,
     notifier: IntercomNotifier[IO],
     xa: Transactor[IO]
-) extends LazyLogging {
+)(implicit cs: ContextShift[IO])
+    extends LazyLogging {
 
   private def info(s: String): ConnectionIO[Unit] =
     LiftIO[ConnectionIO].liftIO(

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -17,6 +17,7 @@ import com.rasterfoundry.datamodel.{
 }
 import com.rasterfoundry.notification.intercom.Model._
 import com.rasterfoundry.notification.intercom.{
+  IntercomConversation,
   IntercomNotifier,
   LiveIntercomNotifier
 }
@@ -42,6 +43,8 @@ class CreateTaskGrid(
     LiftIO[ConnectionIO].liftIO(
       IO { logger.info(s) }
     )
+
+  val dbIO = new DbIO(xa);
 
   def run(): IO[Unit] =
     (for {
@@ -95,22 +98,28 @@ class CreateTaskGrid(
       _ <- OptionT.liftF { info("Updated annotation project") }
     } yield annotationProject).value.transact(xa) flatMap {
       case Some(annotationProject) =>
-        notifier.notifyUser(
-          Config.intercomToken,
-          Config.intercomAdminId,
-          ExternalId(annotationProject.createdBy),
-          Message(annotationProject.campaignId match {
-            case Some(campaignId) =>
-              s"""Your image "${annotationProject.name}" is ready! ${Config.groundworkUrlBase}/app/campaign/${campaignId}/overview?s=${annotationProject.id}"""
-            case _ =>
-              s"""Your project "${annotationProject.name}" is ready! ${Config.groundworkUrlBase}/app/projects/${annotationProject.id}/overview"""
-          })
+        val message = Message(annotationProject.campaignId match {
+          case Some(campaignId) =>
+            s"""Your image "${annotationProject.name}" is ready! ${Config.groundworkUrlBase}/app/campaign/${campaignId}/overview?s=${annotationProject.id}"""
+          case _ =>
+            s"""Your project "${annotationProject.name}" is ready! ${Config.groundworkUrlBase}/app/projects/${annotationProject.id}/overview"""
+        })
+
+        IntercomConversation.notifyIO(
+          annotationProject.createdBy,
+          message,
+          dbIO.groundworkConfig,
+          notifier,
+          dbIO.getConversation,
+          dbIO.insertConversation
         )
+
       case None =>
         (for {
-          projectO <- AnnotationProjectDao.query
-            .filter(annotationProjectId)
-            .selectOption
+          projectO <-
+            AnnotationProjectDao.query
+              .filter(annotationProjectId)
+              .selectOption
           _ <- projectO traverse { project =>
             AnnotationProjectDao.update(
               project.copy(status = AnnotationProjectStatus.TaskGridFailure),
@@ -124,18 +133,21 @@ class CreateTaskGrid(
             case (user, project) =>
               val entity =
                 if (project.campaignId.isEmpty) "project" else "image"
-              LiftIO[ConnectionIO].liftIO {
-                notifier.notifyUser(
-                  Config.intercomToken,
-                  Config.intercomAdminId,
-                  ExternalId(user.id),
-                  Message(
-                    s"""
+              val message = Message(
+                s"""
                   | Your ${entity} "${project.name}" failed to process. If you'd like help
                   | troubleshooting, please reach out to us here or at
                   | groundwork@azavea.com."
                   """.trim.stripMargin
-                  )
+              )
+              LiftIO[ConnectionIO].liftIO {
+                IntercomConversation.notifyIO(
+                  user.id,
+                  message,
+                  dbIO.groundworkConfig,
+                  notifier,
+                  dbIO.getConversation,
+                  dbIO.insertConversation
                 )
               }
           }

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -117,10 +117,9 @@ class CreateTaskGrid(
 
       case None =>
         (for {
-          projectO <-
-            AnnotationProjectDao.query
-              .filter(annotationProjectId)
-              .selectOption
+          projectO <- AnnotationProjectDao.query
+            .filter(annotationProjectId)
+            .selectOption
           _ <- projectO traverse { project =>
             AnnotationProjectDao.update(
               project.copy(status = AnnotationProjectStatus.TaskGridFailure),

--- a/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
+++ b/app-backend/batch/src/main/scala/groundwork/NotifyIntercom.scala
@@ -1,10 +1,13 @@
 package com.rasterfoundry.batch.groundwork
 
 import com.rasterfoundry.batch.Job
+import com.rasterfoundry.database.util.RFTransactor
+import com.rasterfoundry.notification.intercom.IntercomConversation
 import com.rasterfoundry.notification.intercom.Model._
 import com.rasterfoundry.notification.intercom._
 
 import cats.effect.{Async, IO}
+import doobie.hikari.HikariTransactor
 import sttp.client.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 object NotifyIntercomProgram extends Job {
@@ -17,25 +20,35 @@ object NotifyIntercomProgram extends Job {
     backend <- backendRef
   } yield backend
 
-  def runJob(args: List[String]): IO[Unit] = args match {
-    case externalId +: msg +: Nil =>
-      for {
-        backend <- getBackend
-        _ <- {
-          val notifier = new LiveIntercomNotifier[IO](backend)
-          notifier.notifyUser(
-            Config.intercomToken,
-            Config.intercomAdminId,
-            ExternalId(externalId),
-            Message(msg)
+  def runJob(args: List[String]): IO[Unit] = {
+    RFTransactor.xaResource.use(transactor => {
+      implicit val xa: HikariTransactor[IO] = transactor
+
+      val dbIO = new DbIO(xa);
+
+      args match {
+        case externalId +: msg +: Nil =>
+          for {
+            backend <- getBackend
+            _ <- {
+              IntercomConversation.notifyIO(
+                externalId,
+                Message(msg),
+                dbIO.groundworkConfig,
+                new LiveIntercomNotifier[IO](backend),
+                dbIO.getConversation,
+                dbIO.insertConversation
+              )
+            }
+          } yield ()
+        case _ =>
+          IO.raiseError(
+            new Exception(
+              s"Arguments should match pattern `USER_ID MESSAGE`. Got $args"
+            )
           )
-        }
-      } yield ()
-    case _ =>
-      IO.raiseError(
-        new Exception(
-          s"Arguments should match pattern `USER_ID MESSAGE`. Got $args"
-        )
-      )
+      }
+
+    })
   }
 }

--- a/app-backend/batch/src/main/scala/groundwork/dbIO.scala
+++ b/app-backend/batch/src/main/scala/groundwork/dbIO.scala
@@ -5,14 +5,12 @@ import com.rasterfoundry.datamodel.UserIntercomConversation
 import com.rasterfoundry.notification.intercom.GroundworkConfig
 
 import cats.effect.{ContextShift, IO}
+import doobie.implicits._
 import doobie.Transactor
 
 class DbIO(
     xa: Transactor[IO]
-)(implicit
-    val
-    cs: ContextShift[IO]
-) {
+)(implicit cs: ContextShift[IO]) {
   val groundworkConfig =
     GroundworkConfig(Config.intercomToken, Config.intercomAdminId)
 

--- a/app-backend/batch/src/main/scala/groundwork/dbIO.scala
+++ b/app-backend/batch/src/main/scala/groundwork/dbIO.scala
@@ -5,8 +5,8 @@ import com.rasterfoundry.datamodel.UserIntercomConversation
 import com.rasterfoundry.notification.intercom.GroundworkConfig
 
 import cats.effect.{ContextShift, IO}
-import doobie.implicits._
 import doobie.Transactor
+import doobie.implicits._
 
 class DbIO(
     xa: Transactor[IO]

--- a/app-backend/batch/src/main/scala/groundwork/dbIO.scala
+++ b/app-backend/batch/src/main/scala/groundwork/dbIO.scala
@@ -1,0 +1,31 @@
+package com.rasterfoundry.batch.groundwork
+
+import com.rasterfoundry.database.UserIntercomConversationDao
+import com.rasterfoundry.datamodel.UserIntercomConversation
+import com.rasterfoundry.notification.intercom.GroundworkConfig
+
+import cats.effect.{ContextShift, IO}
+import doobie.Transactor
+
+class DbIO(
+    xa: Transactor[IO]
+)(implicit
+    val
+    cs: ContextShift[IO]
+) {
+  val groundworkConfig =
+    GroundworkConfig(Config.intercomToken, Config.intercomAdminId)
+
+  def getConversation(
+      id: String
+  ): IO[Option[UserIntercomConversation]] =
+    UserIntercomConversationDao.getByUserId(id).transact(xa)
+
+  def insertConversation(
+      userId: String,
+      conversationId: String
+  ): IO[UserIntercomConversation] =
+    UserIntercomConversationDao
+      .insertUserConversation(userId, conversationId)
+      .transact(xa)
+}

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -220,13 +220,12 @@ final case class WriteStacCatalog(
       exportPath: String
   ): IO[Unit] =
     (for {
-      layerInfoMap <-
-        DatabaseIO
-          .sceneTaskAnnotationforLayers(
-            annotationProjectId,
-            exportDefinition.taskStatuses
-          )
-          .transact(xa)
+      layerInfoMap <- DatabaseIO
+        .sceneTaskAnnotationforLayers(
+          annotationProjectId,
+          exportDefinition.taskStatuses
+        )
+        .transact(xa)
       _ = logger.info(s"Writing export under prefix: $exportPath")
       catalog = Utils.getAnnotationProjectStacCatalog(
         exportDefinition,
@@ -248,17 +247,16 @@ final case class WriteStacCatalog(
           exportData
         )
       }
-      _ <-
-        AnnotationProjectDao
-          .unsafeGetById(annotationProjectId)
-          .transact(xa) flatMap { project =>
-          val message = Message(s"""
+      _ <- AnnotationProjectDao
+        .unsafeGetById(annotationProjectId)
+        .transact(xa) flatMap { project =>
+        val message = Message(s"""
               | Your STAC export for project ${project.name} has completed!
               | You can see exports for your project at
               | ${GroundworkConfig.groundworkUrlBase}/app/projects/${annotationProjectId}/exports 
               """.trim.stripMargin)
-          notify(ExternalId(exportDefinition.owner), message)
-        }
+        notify(ExternalId(exportDefinition.owner), message)
+      }
     } yield ())
 
   def run(): IO[Unit] = {
@@ -273,13 +271,12 @@ final case class WriteStacCatalog(
       _ = tempDir.deleteOnExit()
       currentPath = s"s3://$dataBucket/stac-exports"
       exportPath = s"$currentPath/${exportDefinition.id}"
-      _ <-
-        StacExportDao
-          .update(
-            exportDefinition.copy(exportStatus = ExportStatus.Exporting),
-            exportDefinition.id
-          )
-          .transact(xa)
+      _ <- StacExportDao
+        .update(
+          exportDefinition.copy(exportStatus = ExportStatus.Exporting),
+          exportDefinition.id
+        )
+        .transact(xa)
 
       _ <- exportDefinition.annotationProjectId traverse { pid =>
         runAnnotationProject(exportDefinition, pid, tempDir, exportPath)

--- a/app-backend/build.sbt
+++ b/app-backend/build.sbt
@@ -771,6 +771,7 @@ lazy val notification = Project("notification", file("notification"))
       Dependencies.sttpCore,
       Dependencies.sttpAsyncBackend,
       Dependencies.sttpCirce,
+      Dependencies.sttpJson,
       Dependencies.sttpModel
     )
   })

--- a/app-backend/datamodel/src/main/scala/UserIntercomConversation.scala
+++ b/app-backend/datamodel/src/main/scala/UserIntercomConversation.scala
@@ -1,0 +1,6 @@
+package com.rasterfoundry.datamodel
+
+final case class UserIntercomConversation(
+    userId: String,
+    conversationId: String
+)

--- a/app-backend/db/src/main/resources/migrations/V73__Add_users_intercom_conversations.sql
+++ b/app-backend/db/src/main/resources/migrations/V73__Add_users_intercom_conversations.sql
@@ -1,7 +1,6 @@
 CREATE TABLE public.user_intercom_conversations (
-    user_id text NOT NULL references users (id) ON DELETE CASCADE,
+    user_id text NOT NULL references users (id) ON DELETE CASCADE UNIQUE,
     conversation_id text NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS user_intercom_conversations_user_id_idx ON public.user_intercom_conversations USING btree (user_id);
-CREATE INDEX IF NOT EXISTS user_intercom_conversations_conversation_id_idx ON public.user_intercom_conversations USING btree (conversation_id);

--- a/app-backend/db/src/main/resources/migrations/V73__Add_users_intercom_conversations.sql
+++ b/app-backend/db/src/main/resources/migrations/V73__Add_users_intercom_conversations.sql
@@ -1,0 +1,7 @@
+CREATE TABLE public.user_intercom_conversations (
+    user_id text NOT NULL references users (id) ON DELETE CASCADE,
+    conversation_id text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS user_intercom_conversations_user_id_idx ON public.user_intercom_conversations USING btree (user_id);
+CREATE INDEX IF NOT EXISTS user_intercom_conversations_conversation_id_idx ON public.user_intercom_conversations USING btree (conversation_id);

--- a/app-backend/db/src/main/scala/UserIntercomConversationDao.scala
+++ b/app-backend/db/src/main/scala/UserIntercomConversationDao.scala
@@ -1,0 +1,32 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.datamodel.UserIntercomConversation
+
+import doobie._
+import doobie.implicits._
+
+object UserIntercomConversationDao extends Dao[UserIntercomConversation] {
+  val tableName = "user_intercom_conversations"
+  override val fieldNames = List(
+    "user_id",
+    "conversation_id"
+  )
+
+  def selectF: Fragment = fr"SELECT " ++ selectFieldsF ++ fr" FROM " ++ tableF
+
+  def getByUserId(
+      userId: String
+  ): ConnectionIO[Option[UserIntercomConversation]] =
+    query.filter(fr"user_id = $userId").selectOption
+
+  def insertUserConversation(
+      userId: String,
+      conversationId: String
+  ): ConnectionIO[UserIntercomConversation] =
+    (fr"INSERT INTO" ++ tableF ++ fr"(" ++ insertFieldsF ++ fr")" ++
+      fr"VALUES (${userId}, ${conversationId})").update
+      .withUniqueGeneratedKeys[UserIntercomConversation](
+        fieldNames: _*
+      )
+
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserIntercomConversationDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserIntercomConversationDaoSpec.scala
@@ -1,0 +1,57 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.common.Generators.Implicits._
+import com.rasterfoundry.datamodel._
+
+import doobie.implicits._
+import org.scalacheck.Prop.forAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
+
+class UserIntercomConversationDaoSpec
+    extends AnyFunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers
+    with ConnectionIOLogger {
+  test("insert a user intercom conversation and then get it") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            conversationId: String
+        ) => {
+          val insertAndGetIO = for {
+            user <- UserDao.create(userCreate)
+            inserted <- UserIntercomConversationDao.insertUserConversation(
+              user.id,
+              conversationId
+            )
+            dbConvo <- UserIntercomConversationDao.getByUserId(user.id)
+          } yield (inserted, user, dbConvo)
+
+          val (insertedConversation, insertedUser, dbConversation) =
+            insertAndGetIO.transact(xa).unsafeRunSync
+
+          assert(
+            insertedConversation.userId == insertedUser.id,
+            "Inserted user conversation's user ID is correct"
+          )
+          assert(
+            insertedConversation.conversationId == conversationId,
+            "Inserted user conversation's conversation ID is correct"
+          )
+          assert(
+            dbConversation == Some(
+              UserIntercomConversation(insertedUser.id, conversationId)
+            ),
+            "Fetched user conversation object matches what was inserted"
+          )
+          true
+        }
+      )
+    }
+  }
+}

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/IntercomConversation.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/IntercomConversation.scala
@@ -8,7 +8,7 @@ import cats.syntax.all._
 
 case class GroundworkConfig(
     intercomToken: IntercomToken,
-    intercomAdminId: UserId
+    intercomAdminId: AdminId
 )
 
 object IntercomConversation {

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/IntercomConversation.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/IntercomConversation.scala
@@ -35,7 +35,9 @@ object IntercomConversation {
             groundworkConfig.intercomToken,
             ExternalId(userId),
             message
-          ) map { convo => Some(convo.conversationId.underlying) }
+          ) map { convo =>
+            Some(convo.conversationId.underlying)
+          }
       }
       _ <- conversationIdOpt traverse { conversationId =>
         insertConversation(userId, conversationId)

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/IntercomConversation.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/IntercomConversation.scala
@@ -1,0 +1,44 @@
+package com.rasterfoundry.notification.intercom
+
+import com.rasterfoundry.datamodel.{UserIntercomConversation}
+import com.rasterfoundry.notification.intercom.Model._
+
+import cats.effect.IO
+import cats.syntax.all._
+
+case class GroundworkConfig(
+    intercomToken: IntercomToken,
+    intercomAdminId: UserId
+)
+
+object IntercomConversation {
+  def notifyIO(
+      userId: String,
+      message: Message,
+      groundworkConfig: GroundworkConfig,
+      notifier: IntercomNotifier[IO],
+      getConversation: String => IO[Option[UserIntercomConversation]],
+      insertConversation: (String, String) => IO[UserIntercomConversation]
+  ): IO[Unit] =
+    for {
+      conversationOpt <- getConversation(userId)
+      conversationIdOpt <- conversationOpt match {
+        case Some(conversation) =>
+          notifier.replyConversation(
+            groundworkConfig.intercomToken,
+            groundworkConfig.intercomAdminId,
+            conversation.conversationId,
+            message
+          ) *> Option.empty.pure[IO]
+        case _ =>
+          notifier.createConversation(
+            groundworkConfig.intercomToken,
+            ExternalId(userId),
+            message
+          ) map { convo => Some(convo.conversationId.underlying) }
+      }
+      _ <- conversationIdOpt traverse { conversationId =>
+        insertConversation(userId, conversationId)
+      }
+    } yield ()
+}

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
@@ -23,21 +23,23 @@ object Model {
   }
 
   @newtype case class Notification(underlying: String)
-  @newtype case class UserId(underlying: String)
-  object UserId {
-    implicit val encUserId: Encoder[UserId] =
-      Encoder.encodeString.contramap(_.underlying)
-    implicit val decUserId: Decoder[UserId] =
-      Decoder.decodeString.map(UserId.apply _)
-  }
   @newtype case class Message(underlying: String)
   @newtype case class IntercomToken(underlying: String)
 
-  case class AdminObject(adminId: UserId)
+  @newtype case class AdminId(underlying: String)
+  object AdminId {
+    implicit val encAdminId: Encoder[AdminId] =
+      Encoder.encodeString.contramap(_.underlying)
+    implicit val decAdminId: Decoder[AdminId] =
+      Decoder.decodeString.map(AdminId.apply _)
+  }
+
+  case class AdminObject(adminId: AdminId)
   object AdminObject {
     implicit val encAdminObject: Encoder[AdminObject] =
       Encoder.forProduct2("type", "id")(adminObject =>
-        ("admin", adminObject.adminId))
+        ("admin", adminObject.adminId)
+      )
   }
 
   case class UserObject(externalId: ExternalId)
@@ -48,45 +50,29 @@ object Model {
     )(userObject => ("user", userObject.externalId))
   }
 
-  case class MessagePost(adminId: UserId, userId: ExternalId, msg: Message)
-  object MessagePost {
-    implicit val encMessagePost: Encoder[MessagePost] = Encoder.forProduct4(
-      "from",
-      "to",
-      "body",
-      "message_type"
-    )(
-      messagePost =>
-        (
-          AdminObject(messagePost.adminId),
-          UserObject(messagePost.userId),
-          messagePost.msg.underlying,
-          "inapp"
-      ))
-  }
-
   case class ConversationCreate(userId: ExternalId, message: Message)
   object ConversationCreate {
     implicit val encConversationCreate: Encoder[ConversationCreate] =
       Encoder.forProduct2(
         "from",
         "body"
-      )(
-        conversationCreate =>
-          (
-            UserObject(conversationCreate.userId),
-            conversationCreate.message.underlying
-        ))
+      )(conversationCreate =>
+        (
+          UserObject(conversationCreate.userId),
+          conversationCreate.message.underlying
+        )
+      )
   }
 
   case class Conversation(conversationId: ConversationId)
   object Conversation {
     implicit val decConversation: Decoder[Conversation] =
       Decoder.forProduct1("conversation_id")((conversationId: String) =>
-        Conversation(ConversationId(conversationId)))
+        Conversation(ConversationId(conversationId))
+      )
   }
 
-  case class ConversationReply(adminId: UserId, message: Message)
+  case class ConversationReply(adminId: AdminId, message: Message)
   object ConversationReply {
     implicit val encConversationReply: Encoder[ConversationReply] =
       Encoder.forProduct4(
@@ -94,13 +80,13 @@ object Model {
         "type",
         "admin_id",
         "body"
-      )(
-        conversationReply =>
-          (
-            "comment",
-            "admin",
-            conversationReply.adminId.underlying,
-            conversationReply.message.underlying
-        ))
+      )(conversationReply =>
+        (
+          "comment",
+          "admin",
+          conversationReply.adminId.underlying,
+          conversationReply.message.underlying
+        )
+      )
   }
 }

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
@@ -38,8 +38,7 @@ object Model {
   object AdminObject {
     implicit val encAdminObject: Encoder[AdminObject] =
       Encoder.forProduct2("type", "id")(adminObject =>
-        ("admin", adminObject.adminId)
-      )
+        ("admin", adminObject.adminId))
   }
 
   case class UserObject(externalId: ExternalId)
@@ -56,20 +55,19 @@ object Model {
       Encoder.forProduct2(
         "from",
         "body"
-      )(conversationCreate =>
-        (
-          UserObject(conversationCreate.userId),
-          conversationCreate.message.underlying
-        )
-      )
+      )(
+        conversationCreate =>
+          (
+            UserObject(conversationCreate.userId),
+            conversationCreate.message.underlying
+        ))
   }
 
   case class Conversation(conversationId: ConversationId)
   object Conversation {
     implicit val decConversation: Decoder[Conversation] =
       Decoder.forProduct1("conversation_id")((conversationId: String) =>
-        Conversation(ConversationId(conversationId))
-      )
+        Conversation(ConversationId(conversationId)))
   }
 
   case class ConversationReply(adminId: AdminId, message: Message)
@@ -80,13 +78,13 @@ object Model {
         "type",
         "admin_id",
         "body"
-      )(conversationReply =>
-        (
-          "comment",
-          "admin",
-          conversationReply.adminId.underlying,
-          conversationReply.message.underlying
-        )
-      )
+      )(
+        conversationReply =>
+          (
+            "comment",
+            "admin",
+            conversationReply.adminId.underlying,
+            conversationReply.message.underlying
+        ))
   }
 }

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
@@ -14,6 +14,14 @@ object Model {
       Decoder.decodeString.map(ExternalId.apply _)
   }
 
+  @newtype case class ConversationId(underlying: String)
+  object ConversationId {
+    implicit val encConversationId: Encoder[ConversationId] =
+      Encoder.encodeString.contramap(_.underlying)
+    implicit val decConversationId: Decoder[ConversationId] =
+      Decoder.decodeString.map(ConversationId.apply _)
+  }
+
   @newtype case class Notification(underlying: String)
   @newtype case class UserId(underlying: String)
   object UserId {
@@ -25,20 +33,20 @@ object Model {
   @newtype case class Message(underlying: String)
   @newtype case class IntercomToken(underlying: String)
 
-  case class FromObject(adminId: UserId)
-  object FromObject {
-    implicit val encFromObject: Encoder[FromObject] =
-      Encoder.forProduct2("type", "id")(
-        fromObject => ("admin", fromObject.adminId)
+  case class AdminObject(adminId: UserId)
+  object AdminObject {
+    implicit val encAdminObject: Encoder[AdminObject] =
+      Encoder.forProduct2("type", "id")(adminObject =>
+        ("admin", adminObject.adminId)
       )
   }
 
-  case class ToObject(externalId: ExternalId)
-  object ToObject {
-    implicit val encToObject: Encoder[ToObject] = Encoder.forProduct2(
+  case class UserObject(externalId: ExternalId)
+  object UserObject {
+    implicit val encUserObject: Encoder[UserObject] = Encoder.forProduct2(
       "type",
       "user_id"
-    )(toObject => ("user", toObject.externalId))
+    )(userObject => ("user", userObject.externalId))
   }
 
   case class MessagePost(adminId: UserId, userId: ExternalId, msg: Message)
@@ -48,15 +56,53 @@ object Model {
       "to",
       "body",
       "message_type"
-    )(
-      messagePost =>
-        (
-          FromObject(messagePost.adminId),
-          ToObject(messagePost.userId),
-          messagePost.msg.underlying,
-          "inapp"
+    )(messagePost =>
+      (
+        AdminObject(messagePost.adminId),
+        UserObject(messagePost.userId),
+        messagePost.msg.underlying,
+        "inapp"
       )
     )
   }
 
+  case class ConversationCreate(userId: ExternalId, message: Message)
+  object ConversationCreate {
+    implicit val encConversationCreate: Encoder[ConversationCreate] =
+      Encoder.forProduct2(
+        "from",
+        "body"
+      )(conversationCreate =>
+        (
+          UserObject(conversationCreate.userId),
+          conversationCreate.message.underlying
+        )
+      )
+  }
+
+  case class Conversation(conversationId: ConversationId)
+  object Conversation {
+    implicit val decConversation: Decoder[Conversation] =
+      Decoder.forProduct1("conversation_id")((conversationId: String) =>
+        Conversation(ConversationId(conversationId))
+      )
+  }
+
+  case class ConversationReply(adminId: UserId, message: Message)
+  object ConversationReply {
+    implicit val encConversationReply: Encoder[ConversationReply] =
+      Encoder.forProduct4(
+        "message_type",
+        "type",
+        "admin_id",
+        "body"
+      )(conversationReply =>
+        (
+          "comment",
+          "admin",
+          conversationReply.adminId.underlying,
+          conversationReply.message.underlying
+        )
+      )
+  }
 }

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/Model.scala
@@ -37,8 +37,7 @@ object Model {
   object AdminObject {
     implicit val encAdminObject: Encoder[AdminObject] =
       Encoder.forProduct2("type", "id")(adminObject =>
-        ("admin", adminObject.adminId)
-      )
+        ("admin", adminObject.adminId))
   }
 
   case class UserObject(externalId: ExternalId)
@@ -56,14 +55,14 @@ object Model {
       "to",
       "body",
       "message_type"
-    )(messagePost =>
-      (
-        AdminObject(messagePost.adminId),
-        UserObject(messagePost.userId),
-        messagePost.msg.underlying,
-        "inapp"
-      )
-    )
+    )(
+      messagePost =>
+        (
+          AdminObject(messagePost.adminId),
+          UserObject(messagePost.userId),
+          messagePost.msg.underlying,
+          "inapp"
+      ))
   }
 
   case class ConversationCreate(userId: ExternalId, message: Message)
@@ -72,20 +71,19 @@ object Model {
       Encoder.forProduct2(
         "from",
         "body"
-      )(conversationCreate =>
-        (
-          UserObject(conversationCreate.userId),
-          conversationCreate.message.underlying
-        )
-      )
+      )(
+        conversationCreate =>
+          (
+            UserObject(conversationCreate.userId),
+            conversationCreate.message.underlying
+        ))
   }
 
   case class Conversation(conversationId: ConversationId)
   object Conversation {
     implicit val decConversation: Decoder[Conversation] =
       Decoder.forProduct1("conversation_id")((conversationId: String) =>
-        Conversation(ConversationId(conversationId))
-      )
+        Conversation(ConversationId(conversationId)))
   }
 
   case class ConversationReply(adminId: UserId, message: Message)
@@ -96,13 +94,13 @@ object Model {
         "type",
         "admin_id",
         "body"
-      )(conversationReply =>
-        (
-          "comment",
-          "admin",
-          conversationReply.adminId.underlying,
-          conversationReply.message.underlying
-        )
-      )
+      )(
+        conversationReply =>
+          (
+            "comment",
+            "admin",
+            conversationReply.adminId.underlying,
+            conversationReply.message.underlying
+        ))
   }
 }

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/NotifyIntercom.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/NotifyIntercom.scala
@@ -11,11 +11,17 @@ import sttp.client.circe._
 import sttp.model.Uri
 
 trait IntercomNotifier[F[_]] {
-  def notifyUser(
+  def createConversation(
+      intercomToken: IntercomToken,
+      userId: ExternalId,
+      message: Message
+  ): F[Conversation]
+
+  def replyConversation(
       intercomToken: IntercomToken,
       adminId: UserId,
-      userId: ExternalId,
-      msg: Message
+      conversationId: String,
+      message: Message
   ): F[Unit]
 }
 
@@ -31,27 +37,50 @@ class LiveIntercomNotifier[F[_]: Sync](
   implicit val unsafeLoggerF = Slf4jLogger.getLogger[F]
   implicit val sttpBackend = backend
 
-  def notifyUser(
+  def createConversation(
+      intercomToken: IntercomToken,
+      userId: ExternalId,
+      message: Message
+  ): F[Conversation] = {
+    val uri = Uri(java.net.URI.create(s"$sttpApiBase/conversations"))
+    Logger[F].debug(s"Creating a conversation with $userId at $uri") *>
+      basicRequest.auth
+        .bearer(intercomToken.underlying)
+        .header("Accept", "application/json")
+        .post(uri)
+        .body(ConversationCreate(userId, message))
+        .response(asJson[Conversation])
+        .send() flatMap { res =>
+      res.body match {
+        case Left(err) =>
+          throw new RuntimeException(
+            s"Failed to create a conversation with ${userId}, error message: ${err.toString()}"
+          )
+        case Right(conversation) => conversation.pure[F]
+      }
+    }
+  }
+
+  def replyConversation(
       intercomToken: IntercomToken,
       adminId: UserId,
-      userId: ExternalId,
-      msg: Message
+      conversationId: String,
+      message: Message
   ): F[Unit] = {
-    val uri = Uri(java.net.URI.create(s"$sttpApiBase/messages"))
-    val resp =
-      Logger[F].debug(s"Notifying $userId at $uri") *>
-        basicRequest.auth
-          .bearer(intercomToken.underlying)
-          .header("Accept", "application/json")
-          .post(uri)
-          .body(MessagePost(adminId, userId, msg))
-          .send() flatMap { resp =>
-        resp.body match {
-          case Left(err) => Logger[F].error(err)
-          case _         => ().pure[F]
-        }
+    val uri = Uri(
+      java.net.URI.create(s"$sttpApiBase/conversations/$conversationId/reply")
+    )
+    (Logger[F].debug(s"Replying a conversation ID: $conversationId at $uri") *>
+      basicRequest.auth
+        .bearer(intercomToken.underlying)
+        .header("Accept", "application/json")
+        .post(uri)
+        .body(ConversationReply(adminId, message))
+        .send() flatMap { resp =>
+      resp.body match {
+        case Left(err) => Logger[F].error(err)
+        case _         => ().pure[F]
       }
-
-    resp.void
+    }).void
   }
 }

--- a/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/NotifyIntercom.scala
+++ b/app-backend/notification/src/main/scala/com/rasterfoundry/notification/intercom/NotifyIntercom.scala
@@ -19,7 +19,7 @@ trait IntercomNotifier[F[_]] {
 
   def replyConversation(
       intercomToken: IntercomToken,
-      adminId: UserId,
+      adminId: AdminId,
       conversationId: String,
       message: Message
   ): F[Unit]
@@ -63,7 +63,7 @@ class LiveIntercomNotifier[F[_]: Sync](
 
   def replyConversation(
       intercomToken: IntercomToken,
-      adminId: UserId,
+      adminId: AdminId,
       conversationId: String,
       message: Message
   ): F[Unit] = {


### PR DESCRIPTION
## Overview

This PR supports intercom communications by having conversations with customers:
- add migration, data model, dao methods, and tests for previous conversation IDs and for new conversation IDs
- add intercom endpoint calls for creating a conversation and for replying to conversations
- in places where we dispatch intercom notifications, hook up the above two to work together:
    - create task grid
    - upload processing
    - stac exports

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

### Demo

All system messages appear in one conversation
![Screen Shot 2021-04-20 at 12 30 19 PM](https://user-images.githubusercontent.com/16109558/115432340-42282d00-a1d4-11eb-8888-2e7dfcfb71ba.png)

## Testing Instructions

- Run migration
- Assemble api jar and batch jar, rebuild batch service if need be
- In a batch shell, make sure running the following creates a conversation in intercom message with this dev user. Sending subsequent messages should all show in this conversation
```
java -cp /opt/raster-foundry/jars/batch-assembly.jar com.rasterfoundry.batch.Main notify-intercom <dev user ID> <message>
```
- Connect local GW to your local RF servers, create a campaign and upload an image, process the upload. After upload processing, the message should be sent to the same conversation as above
- Do a STAC export of a campaign. When export is ready, a message should be sent to the same conversation to the dev user as the above

Closes https://github.com/raster-foundry/groundwork/issues/1035
