### PR TITLE
Put all rejection handling in one place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Retried cogification for tifs that fail to become cogs with no appropriate zoom level error [#5573](https://github.com/raster-foundry/raster-foundry/pull/5573)
 - Fixed campaign task list endpoint [#5572](https://github.com/raster-foundry/raster-foundry/pull/5572)
+- Included CORS headers with error responses when appropriate [#5574](https://github.com/raster-foundry/raster-foundry/pull/5574)
 
 ## [1.62.1] - 2021-04-19
 ### Fixed

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -25,12 +25,7 @@ import com.rasterfoundry.api.uploads.UploadRoutes
 import com.rasterfoundry.api.user.UserRoutes
 import com.rasterfoundry.api.utils.{Config, IntercomNotifications}
 
-import akka.http.scaladsl.model.HttpMethods._
 import cats.effect.IO
-import ch.megard.akka.http.cors.scaladsl.CorsDirectives._
-import ch.megard.akka.http.cors.scaladsl.settings._
-
-import scala.collection.immutable.Seq
 
 /**
   * Contains all routes for Raster Foundry API/Healthcheck endpoints.
@@ -63,13 +58,9 @@ trait Router
     with TaskRoutes
     with CampaignRoutes {
 
-  val settings = CorsSettings.defaultSettings.copy(
-    allowedMethods = Seq(GET, POST, PUT, HEAD, OPTIONS, DELETE)
-  )
-
   def notifier: IO[IntercomNotifications]
 
-  val routes = cors(settings) {
+  def routes =
     pathPrefix("healthcheck") {
       healthCheckRoutes
     } ~
@@ -141,5 +132,4 @@ trait Router
       pathPrefix("feature-flags") {
         featureFlagRoutes
       }
-  }
 }


### PR DESCRIPTION
## Overview

This PR puts all of our rejection handling in one place and also uses the default rejection handler in addition to the custom RF one.
The upshot of that is that common sense handling like "include the CORS headers if needed" is free. I opted to move all of that into `Main` instead of into the `Router` because it's consistent with how `Backsplash` organizes things -- now the `Router` is only responsible for assembling routes, and `Main` is responsible for things like CORS and middlewares.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- use raster-foundry/groundwork#1394 to test

Closes azavea/raster-foundry-platform#402
