### PR TITLE
Make upload limit check stricter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Retried cogification for tifs that fail to become cogs with no appropriate zoom level error [#5573](https://github.com/raster-foundry/raster-foundry/pull/5573)
 - Fixed campaign task list endpoint [#5572](https://github.com/raster-foundry/raster-foundry/pull/5572)
 
+### Changed
+- Make upload limit check stricter [#5575](https://github.com/raster-foundry/raster-foundry/pull/5575)
+
 ## [1.62.1] - 2021-04-19
 ### Fixed
 - Corrected normalization behavior for scene thumbnails and annotation projects [#5569](https://github.com/raster-foundry/raster-foundry/pull/5569)

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -7,20 +7,21 @@ import com.rasterfoundry.database.UploadDao
 import com.rasterfoundry.database.filter.Filterables._
 import com.rasterfoundry.datamodel._
 
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers.HttpChallenge
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.{AuthenticationFailedRejection, Route}
-import cats.implicits._
 import cats.effect.IO
+import cats.implicits._
 import com.amazonaws.HttpMethod
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 
-import java.util.UUID
-import scala.util.Success
 import scala.concurrent.Future
+import scala.util.Success
+
+import java.util.UUID
 
 trait UploadRoutes
     extends Authentication
@@ -171,7 +172,9 @@ trait UploadRoutes
           onComplete {
             for {
               isBelow <- isBelowLimitCheck(
-                userBytesUploaded map { bytes => bytes + potentialNewBytes },
+                userBytesUploaded map { bytes =>
+                  bytes + potentialNewBytes
+                },
                 Domain.Uploads,
                 Action.Create,
                 user
@@ -256,10 +259,8 @@ trait UploadRoutes
                 if (rowsUpdated == 0) {
                   return complete { HttpResponse(StatusCodes.NoContent) }
                 }
-                if (
-                  upload.uploadStatus != UploadStatus.Uploaded &&
-                  updateUpload.uploadStatus == UploadStatus.Uploaded
-                ) {
+                if (upload.uploadStatus != UploadStatus.Uploaded &&
+                    updateUpload.uploadStatus == UploadStatus.Uploaded) {
                   kickoffSceneImport(upload.id)
                 }
                 complete { HttpResponse(StatusCodes.NoContent) }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -176,14 +176,14 @@ trait UploadRoutes
           ) {
             onComplete {
               for {
-                uploadOpt <- UploadDao
-                  .insert(uploadToInsert, user, potentialNewBytes)
-                  .map(Some(_))
-                  .transact(xa)
-                  .unsafeToFuture
-              } yield uploadOpt
+                upload <-
+                  UploadDao
+                    .insert(uploadToInsert, user, potentialNewBytes)
+                    .transact(xa)
+                    .unsafeToFuture
+              } yield upload
             } {
-              case Success(Some(upload)) =>
+              case Success(upload) =>
                 if (upload.uploadStatus == UploadStatus.Uploaded) {
                   kickoffSceneImport(upload.id)
                 }
@@ -251,8 +251,10 @@ trait UploadRoutes
                 if (rowsUpdated == 0) {
                   return complete { HttpResponse(StatusCodes.NoContent) }
                 }
-                if (upload.uploadStatus != UploadStatus.Uploaded &&
-                    updateUpload.uploadStatus == UploadStatus.Uploaded) {
+                if (
+                  upload.uploadStatus != UploadStatus.Uploaded &&
+                  updateUpload.uploadStatus == UploadStatus.Uploaded
+                ) {
                   kickoffSceneImport(upload.id)
                 }
                 complete { HttpResponse(StatusCodes.NoContent) }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -176,12 +176,11 @@ trait UploadRoutes
           ) {
             onComplete {
               for {
-                uploadOpt <-
-                  UploadDao
-                    .insert(uploadToInsert, user, potentialNewBytes)
-                    .map(Some(_))
-                    .transact(xa)
-                    .unsafeToFuture
+                uploadOpt <- UploadDao
+                  .insert(uploadToInsert, user, potentialNewBytes)
+                  .map(Some(_))
+                  .transact(xa)
+                  .unsafeToFuture
               } yield uploadOpt
             } {
               case Success(Some(upload)) =>
@@ -252,10 +251,8 @@ trait UploadRoutes
                 if (rowsUpdated == 0) {
                   return complete { HttpResponse(StatusCodes.NoContent) }
                 }
-                if (
-                  upload.uploadStatus != UploadStatus.Uploaded &&
-                  updateUpload.uploadStatus == UploadStatus.Uploaded
-                ) {
+                if (upload.uploadStatus != UploadStatus.Uploaded &&
+                    updateUpload.uploadStatus == UploadStatus.Uploaded) {
                   kickoffSceneImport(upload.id)
                 }
                 complete { HttpResponse(StatusCodes.NoContent) }

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -176,11 +176,10 @@ trait UploadRoutes
           ) {
             onComplete {
               for {
-                upload <-
-                  UploadDao
-                    .insert(uploadToInsert, user, potentialNewBytes)
-                    .transact(xa)
-                    .unsafeToFuture
+                upload <- UploadDao
+                  .insert(uploadToInsert, user, potentialNewBytes)
+                  .transact(xa)
+                  .unsafeToFuture
               } yield upload
             } {
               case Success(upload) =>
@@ -251,10 +250,8 @@ trait UploadRoutes
                 if (rowsUpdated == 0) {
                   return complete { HttpResponse(StatusCodes.NoContent) }
                 }
-                if (
-                  upload.uploadStatus != UploadStatus.Uploaded &&
-                  updateUpload.uploadStatus == UploadStatus.Uploaded
-                ) {
+                if (upload.uploadStatus != UploadStatus.Uploaded &&
+                    updateUpload.uploadStatus == UploadStatus.Uploaded) {
                   kickoffSceneImport(upload.id)
                 }
                 complete { HttpResponse(StatusCodes.NoContent) }

--- a/app-backend/datamodel/src/main/scala/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/Upload.scala
@@ -49,16 +49,15 @@ object Upload {
       files
         .map(new AmazonS3URI(_))
         .filter(dataBucket == _.getBucket)
-        .map(
-          s3Uri =>
-            s3Client
-              .getObjectMetadata(
-                new GetObjectMetadataRequest(
-                  s3Uri.getBucket,
-                  s3Uri.getKey
-                )
+        .map(s3Uri =>
+          s3Client
+            .getObjectMetadata(
+              new GetObjectMetadataRequest(
+                s3Uri.getBucket,
+                s3Uri.getKey
               )
-              .getContentLength()
+            )
+            .getContentLength()
         )
         .sum
         .toLong
@@ -89,7 +88,8 @@ object Upload {
       source: Option[String],
       keepInSourceBucket: Option[Boolean],
       annotationProjectId: Option[UUID],
-      generateTasks: Boolean
+      generateTasks: Boolean,
+      fileSizeBytes: Option[Long] = None
   ) {
     def toUpload(
         user: User,
@@ -113,10 +113,10 @@ object Upload {
         // when intendedOwner and user are different people, we check that both the two users' platforms
         // match and that the acting user is an admin of that platform
         case (
-            Some(intendedOwner),
-            Some(ownerPlatformId),
-            _,
-            (userPlatformId, userIsPlatformAdmin)
+              Some(intendedOwner),
+              Some(ownerPlatformId),
+              _,
+              (userPlatformId, userIsPlatformAdmin)
             ) =>
           if (ownerPlatformId == userPlatformId && userIsPlatformAdmin) {
             intendedOwner

--- a/app-backend/datamodel/src/main/scala/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/Upload.scala
@@ -49,16 +49,16 @@ object Upload {
       files
         .map(new AmazonS3URI(_))
         .filter(dataBucket == _.getBucket)
-        .map(s3Uri =>
-          s3Client
-            .getObjectMetadata(
-              new GetObjectMetadataRequest(
-                s3Uri.getBucket,
-                s3Uri.getKey
+        .map(
+          s3Uri =>
+            s3Client
+              .getObjectMetadata(
+                new GetObjectMetadataRequest(
+                  s3Uri.getBucket,
+                  s3Uri.getKey
+                )
               )
-            )
-            .getContentLength()
-        )
+              .getContentLength())
         .sum
         .toLong
 
@@ -113,10 +113,10 @@ object Upload {
         // when intendedOwner and user are different people, we check that both the two users' platforms
         // match and that the acting user is an admin of that platform
         case (
-              Some(intendedOwner),
-              Some(ownerPlatformId),
-              _,
-              (userPlatformId, userIsPlatformAdmin)
+            Some(intendedOwner),
+            Some(ownerPlatformId),
+            _,
+            (userPlatformId, userIsPlatformAdmin)
             ) =>
           if (ownerPlatformId == userPlatformId && userIsPlatformAdmin) {
             intendedOwner

--- a/app-backend/db/src/main/scala/UploadDao.scala
+++ b/app-backend/db/src/main/scala/UploadDao.scala
@@ -76,7 +76,7 @@ object UploadDao extends Dao[Upload] {
         bytesUploaded
       )
       insertedUpload <- (
-          sql"""
+        sql"""
        INSERT INTO uploads
          (id, created_at, created_by, modified_at,
           owner, upload_status, file_type, upload_type,
@@ -91,26 +91,26 @@ object UploadDao extends Dao[Upload] {
          ${upload.annotationProjectId}, ${upload.generateTasks}
        )
       """.update.withUniqueGeneratedKeys[Upload](
-            "id",
-            "created_at",
-            "created_by",
-            "modified_at",
-            "owner",
-            "upload_status",
-            "file_type",
-            "upload_type",
-            "files",
-            "datasource",
-            "metadata",
-            "visibility",
-            "project_id",
-            "layer_id",
-            "source",
-            "keep_in_source_bucket",
-            "bytes_uploaded",
-            "annotation_project_id",
-            "generate_tasks"
-          )
+          "id",
+          "created_at",
+          "created_by",
+          "modified_at",
+          "owner",
+          "upload_status",
+          "file_type",
+          "upload_type",
+          "files",
+          "datasource",
+          "metadata",
+          "visibility",
+          "project_id",
+          "layer_id",
+          "source",
+          "keep_in_source_bucket",
+          "bytes_uploaded",
+          "annotation_project_id",
+          "generate_tasks"
+        )
       )
     } yield insertedUpload
 
@@ -144,11 +144,11 @@ object UploadDao extends Dao[Upload] {
       owner <- UserDao.unsafeGetUserById(oldUpload.owner)
     } yield (oldUpload, newStatus, nAffected, userPlatform, owner)) flatMap {
       case (
-            oldUpload: Upload,
-            newStatus: UploadStatus,
-            nAffected: Int,
-            platform: Platform,
-            owner: User
+          oldUpload: Upload,
+          newStatus: UploadStatus,
+          nAffected: Int,
+          platform: Platform,
+          owner: User
           ) => {
         (
           oldUpload.uploadStatus,


### PR DESCRIPTION
## Overview

This PR updates the upload create and update endpoints to enforce stricter storage quota checks.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Follow steps in https://github.com/raster-foundry/groundwork/pull/1406 to test

Closes https://github.com/raster-foundry/raster-foundry/issues/5565

