### PR TITLE
Authorize based on task <-> project combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Retried cogification for tifs that fail to become cogs with no appropriate zoom level error [#5573](https://github.com/raster-foundry/raster-foundry/pull/5573)
 - Fixed campaign task list endpoint [#5572](https://github.com/raster-foundry/raster-foundry/pull/5572)
 - Included CORS headers with error responses when appropriate [#5574](https://github.com/raster-foundry/raster-foundry/pull/5574)
+- Task authorization now verifies project relationship [#5576](https://github.com/raster-foundry/raster-foundry/pull/5576)
 
 ## [1.62.1] - 2021-04-19
 ### Fixed

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -233,11 +233,12 @@ trait AnnotationProjectTaskRoutes
               ),
             TaskDao.getTaskById(taskId)
           ).mapN({
-            case (success @ AuthSuccess(_), Some(task)) =>
-              if (task.annotationProjectId == projectId) success
-              else AuthFailure[AnnotationProject]()
-            case _ => AuthFailure[AnnotationProject]()
-          }).transact(xa)
+              case (success @ AuthSuccess(_), Some(task)) =>
+                if (task.annotationProjectId == projectId) success
+                else AuthFailure[AnnotationProject]()
+              case _ => AuthFailure[AnnotationProject]()
+            })
+            .transact(xa)
             .unsafeToFuture
         } {
           complete {
@@ -255,14 +256,13 @@ trait AnnotationProjectTaskRoutes
       ) {
         authorizeAsync {
           (for {
-            auth1 <-
-              AnnotationProjectDao
-                .authorized(
-                  user,
-                  ObjectType.AnnotationProject,
-                  projectId,
-                  ActionType.Annotate
-                )
+            auth1 <- AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Annotate
+              )
             auth2 <- TaskDao.isLockingUserOrUnlocked(taskId, user)
             auth3 <- TaskDao.getTaskById(taskId) map { taskO =>
               taskO map { _.annotationProjectId }
@@ -302,11 +302,12 @@ trait AnnotationProjectTaskRoutes
               ),
             TaskDao.getTaskById(taskId)
           ).mapN({
-            case (success @ AuthSuccess(_), Some(task)) =>
-              if (task.annotationProjectId == projectId) success
-              else AuthFailure[AnnotationProject]()
-            case _ => AuthFailure[AnnotationProject]()
-          }).transact(xa)
+              case (success @ AuthSuccess(_), Some(task)) =>
+                if (task.annotationProjectId == projectId) success
+                else AuthFailure[AnnotationProject]()
+              case _ => AuthFailure[AnnotationProject]()
+            })
+            .transact(xa)
             .unsafeToFuture
         } {
           complete {
@@ -342,8 +343,7 @@ trait AnnotationProjectTaskRoutes
                 ActionType.Annotate
               ),
             TaskDao.getTaskById(taskId)
-          )
-            .mapN({
+          ).mapN({
               case (success @ AuthSuccess(_), Some(task)) =>
                 if (task.annotationProjectId == projectId) success
                 else AuthFailure[AnnotationProject]()
@@ -439,14 +439,13 @@ trait AnnotationProjectTaskRoutes
       ) {
         authorizeAsync {
           (for {
-            auth1 <-
-              AnnotationProjectDao
-                .authorized(
-                  user,
-                  ObjectType.AnnotationProject,
-                  projectId,
-                  actionType
-                )
+            auth1 <- AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                actionType
+              )
             auth2 <- TaskDao.hasStatus(
               taskId,
               requiredStatuses
@@ -464,19 +463,17 @@ trait AnnotationProjectTaskRoutes
             }
             onSuccess(
               (for {
-                _ <-
-                  if (deleteBeforeAdding) {
-                    AnnotationLabelDao
-                      .deleteByProjectIdAndTaskId(projectId, taskId)
-                  } else { 0.pure[ConnectionIO] }
-                insert <-
+                _ <- if (deleteBeforeAdding) {
                   AnnotationLabelDao
-                    .insertAnnotations(
-                      projectId,
-                      taskId,
-                      annotationLabelWithClassesCreate.toList,
-                      user
-                    )
+                    .deleteByProjectIdAndTaskId(projectId, taskId)
+                } else { 0.pure[ConnectionIO] }
+                insert <- AnnotationLabelDao
+                  .insertAnnotations(
+                    projectId,
+                    taskId,
+                    annotationLabelWithClassesCreate.toList,
+                    user
+                  )
               } yield {
                 insert
               }).transact(xa)
@@ -541,8 +538,7 @@ trait AnnotationProjectTaskRoutes
                   ActionType.Annotate
                 ),
               TaskDao.getTaskById(taskId)
-            )
-              .mapN({
+            ).mapN({
                 case (success @ AuthSuccess(_), Some(task)) =>
                   if (task.annotationProjectId == projectId) success
                   else AuthFailure[AnnotationProject]()
@@ -578,11 +574,12 @@ trait AnnotationProjectTaskRoutes
               ),
             TaskDao.getTaskById(taskId)
           ).mapN({
-            case (success @ AuthSuccess(_), Some(task)) =>
-              if (task.annotationProjectId == projectId) success
-              else AuthFailure[AnnotationProject]()
-            case _ => AuthFailure[AnnotationProject]()
-          }).transact(xa)
+              case (success @ AuthSuccess(_), Some(task)) =>
+                if (task.annotationProjectId == projectId) success
+                else AuthFailure[AnnotationProject]()
+              case _ => AuthFailure[AnnotationProject]()
+            })
+            .transact(xa)
             .unsafeToFuture
         } {
           complete {


### PR DESCRIPTION
## Overview

This PR checks that tasks users are interested in interacting with are in the project that the route says.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- assemble API server
- get a token with your dev user -- `echo '{"refresh_token": "the-dev-user-refresh-token"}' | http :9000/api/tokens | jq .id_token`
- `export JWT_AUTH_TOKEN=that-token`
- try this request -- `http --auth-type=jwt :9000/api/annotation-projects/6e35b51e-4d67-4cb0-bf23-ca265ef49b24/tasks/3279f4ba-455f-421d-b822-3acb5c502e5b`
- you should get a 403
- check that that task isn't in that project
- verify that all the routes in `AnnotationProjectTaskRoutes` that invoke methods just from `TaskDao` with the `taskId` have the similar authorization

Closes raster-foundry/groundwork#1360