### PR TITLE
Use parTraverseN to control mosaic parallelism

### DIFF
--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -474,7 +474,9 @@ trait AnnotationProjectTaskRoutes
                     annotationLabelWithClassesCreate.toList,
                     user
                   )
-                _ <- TaskDao.updateStatus(taskId, fc.nextStatus)
+                _ <- fc.nextStatus traverse { status =>
+                  TaskDao.updateStatus(taskId, status)
+                }
               } yield {
                 insert
               }).transact(xa)

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -39,7 +39,7 @@ final case class AnnotationLabelPropertiesCreate(
 @JsonCodec
 final case class AnnotationLabelWithClassesFeatureCollectionCreate(
     features: Seq[AnnotationLabelWithClasses.GeoJSONFeatureCreate],
-    nextStatus: TaskStatus
+    nextStatus: Option[TaskStatus] = None
 )
 
 @JsonCodec
@@ -136,7 +136,7 @@ object AnnotationLabelWithClasses {
   @JsonCodec
   final case class GeoJSONFeatureCreate(
       geometry: Projected[Geometry],
-      properties: AnnotationLabelWithClassesPropertiesCreate,
+      properties: AnnotationLabelWithClassesPropertiesCreate
   ) {
     def toAnnotationLabelWithClassesCreate
       : AnnotationLabelWithClasses.Create = {


### PR DESCRIPTION
## Overview

This PR uses `parTraverseN` from cats-effect to prevent huge mosaics from trying to parallelize over every contained scene. Here's a quick snapshot of why that's bad:

![image](https://user-images.githubusercontent.com/5702984/117336498-7e58c000-ae59-11eb-9ce0-656c4aa52e70.png)

That single request also created nearly 600 `raster-io` threads. Woops!

Those spikes up to almost 4gb of heap usage on a nearly 7gb heap are from a single request. Here's the same request with the capped parallelism:

![image](https://user-images.githubusercontent.com/5702984/117337134-39815900-ae5a-11eb-8641-780f4e223a62.png)

And even requesting the whole layer at the same zoom (so there are several requests trying to use the cached threadpool at the same time) my max thread number is still < 300.

Anyway, this should prevent the kind of resource-based crash we recently saw.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- assemble backsplash
- bring up API server and backsplash
- get a bearer token for dev using either the refresh token in lastpass or by copying it from dev tools in GW and put it in the JWT_AUTH_TOKEN env variable
- get a nice list of COGs in the same zone (I can send you one the list of COGs from the linked issue)
- use [this little script](https://gist.github.com/jisantuc/a0a039461d0cd464a48a2eb0bc362845) to make yourself a project with all the scenes in it
- wait a bit -- the API server has to go fetch geometry data for all those scenes. This took like six minutes for me because there are only four workers in the background task pool for that I think.
- point visualvm to your tile server at localhost:9030
- Once all the scenes are INGESTED, point QGIS or geojson.io or something to the tile layer it printed out -- prefix it with http://localhost:8081
- make some requests by zooming and panning around in the zone where your scenes are-- it should take some time before your thread numbers go crazy. different requests are _each_ allowed the concurrency value for traversing their mosaics, so you'll still add some, but you won't get to 600 of them at least

Closes azavea/raster-foundry-platform#1237
