### PR TITLE
Add sessionId and isActive to AnnotationLabel 

### DIFF
--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1134,7 +1134,9 @@ object Generators extends ArbitraryInstances {
     (
       projectedMultiPolygonGen3857,
       Gen.const(Nil),
-      Gen.option(nonEmptyStringGen)
+      Gen.option(nonEmptyStringGen),
+      Gen.const(true),
+      Gen.option(uuidGen)
     ).mapN(AnnotationLabelWithClasses.Create.apply _)
 
   private def continentGen: Gen[Continent] =

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -49,9 +49,9 @@ final case class AnnotationLabelWithClasses(
     annotationProjectId: UUID,
     annotationTaskId: UUID,
     description: Option[String] = None,
-    annotationLabelClasses: List[UUID],
     isActive: Boolean,
-    sessionId: Option[UUID] = None
+    sessionId: Option[UUID] = None,
+    annotationLabelClasses: List[UUID]
 ) extends GeoJSONSerializable[AnnotationLabelWithClasses.GeoJSON] {
   def toGeoJSONFeature =
     AnnotationLabelWithClasses.GeoJSON(
@@ -128,9 +128,9 @@ object AnnotationLabelWithClasses {
         annotationProjectId,
         annotationTaskId,
         description,
-        annotationLabelClasses,
         isActive,
-        sessionId
+        sessionId,
+        annotationLabelClasses
       )
     }
   }
@@ -149,7 +149,7 @@ object AnnotationLabelWithClasses {
       properties: AnnotationLabelWithClassesPropertiesCreate
   ) {
     def toAnnotationLabelWithClassesCreate
-      : AnnotationLabelWithClasses.Create = {
+        : AnnotationLabelWithClasses.Create = {
       AnnotationLabelWithClasses.Create(
         geometry,
         properties.annotationLabelClasses,
@@ -196,21 +196,21 @@ object AnnotationLabelWithClasses {
 
   object StacGeoJSON {
     implicit val stacGeoJsonEncoder: Encoder[StacGeoJSON] =
-      Encoder.forProduct3("geometry", "type", "properties")(
-        geojson =>
+      Encoder.forProduct3("geometry", "type", "properties")(geojson =>
+        (
+          geojson.geometry,
+          geojson._type,
           (
-            geojson.geometry,
-            geojson._type,
-            (
-              Map(
-                "id" -> geojson.id.asJson,
-                "createdAt" -> geojson.properties.createdAt.asJson,
-                "createdBy" -> geojson.properties.createdBy.asJson,
-                "annotationProjectId" -> geojson.properties.annotationProjectId.asJson,
-                "annotationTaskId" -> geojson.properties.annotationTaskId.asJson
-              ) ++ geojson.classMap.map(e => (e._1 -> e._2.asJson))
-            )
-        ))
+            Map(
+              "id" -> geojson.id.asJson,
+              "createdAt" -> geojson.properties.createdAt.asJson,
+              "createdBy" -> geojson.properties.createdBy.asJson,
+              "annotationProjectId" -> geojson.properties.annotationProjectId.asJson,
+              "annotationTaskId" -> geojson.properties.annotationTaskId.asJson
+            ) ++ geojson.classMap.map(e => (e._1 -> e._2.asJson))
+          )
+        )
+      )
   }
 }
 
@@ -242,7 +242,7 @@ object AnnotationLabelWithClassesPropertiesCreate {
           description,
           isActive getOrElse true,
           sessionId
-      )
+        )
     )
 }
 

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -149,7 +149,7 @@ object AnnotationLabelWithClasses {
       properties: AnnotationLabelWithClassesPropertiesCreate
   ) {
     def toAnnotationLabelWithClassesCreate
-        : AnnotationLabelWithClasses.Create = {
+      : AnnotationLabelWithClasses.Create = {
       AnnotationLabelWithClasses.Create(
         geometry,
         properties.annotationLabelClasses,
@@ -196,21 +196,21 @@ object AnnotationLabelWithClasses {
 
   object StacGeoJSON {
     implicit val stacGeoJsonEncoder: Encoder[StacGeoJSON] =
-      Encoder.forProduct3("geometry", "type", "properties")(geojson =>
-        (
-          geojson.geometry,
-          geojson._type,
+      Encoder.forProduct3("geometry", "type", "properties")(
+        geojson =>
           (
-            Map(
-              "id" -> geojson.id.asJson,
-              "createdAt" -> geojson.properties.createdAt.asJson,
-              "createdBy" -> geojson.properties.createdBy.asJson,
-              "annotationProjectId" -> geojson.properties.annotationProjectId.asJson,
-              "annotationTaskId" -> geojson.properties.annotationTaskId.asJson
-            ) ++ geojson.classMap.map(e => (e._1 -> e._2.asJson))
-          )
-        )
-      )
+            geojson.geometry,
+            geojson._type,
+            (
+              Map(
+                "id" -> geojson.id.asJson,
+                "createdAt" -> geojson.properties.createdAt.asJson,
+                "createdBy" -> geojson.properties.createdBy.asJson,
+                "annotationProjectId" -> geojson.properties.annotationProjectId.asJson,
+                "annotationTaskId" -> geojson.properties.annotationTaskId.asJson
+              ) ++ geojson.classMap.map(e => (e._1 -> e._2.asJson))
+            )
+        ))
   }
 }
 
@@ -242,7 +242,7 @@ object AnnotationLabelWithClassesPropertiesCreate {
           description,
           isActive getOrElse true,
           sessionId
-        )
+      )
     )
 }
 

--- a/app-backend/db/src/main/resources/migrations/V74__add_session_to_label.sql
+++ b/app-backend/db/src/main/resources/migrations/V74__add_session_to_label.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.annotation_labels
+ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT TRUE,
+ADD COLUMN session_id uuid REFERENCES task_sessions(id) ON DELETE CASCADE;

--- a/app-backend/db/src/main/resources/migrations/V75__add_index_to_annotation_labels.sql
+++ b/app-backend/db/src/main/resources/migrations/V75__add_index_to_annotation_labels.sql
@@ -1,0 +1,7 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS annotation_labels_is_active_idx
+ON public.annotation_labels
+USING btree (is_active);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS annotation_labels_session_id_idx
+ON public.annotation_labels
+USING btree (session_id);

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -73,8 +73,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})"
-        )
+          fr"(${label.id}, ${labelClassId})")
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -187,22 +186,20 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName =
-        groupedLabelClasses
-          .map { classGroups =>
-            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-          }
-          .flatten
-          .toMap
-          .collect {
-            case (k, Some(v)) => k -> v.name
-          }
-      classIdToLabelName =
-        groupedLabelClasses
-          .map(_._2)
-          .flatten
-          .map(c => c.id -> c.name)
-          .toMap
+      classIdToGroupName = groupedLabelClasses
+        .map { classGroups =>
+          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+        }
+        .flatten
+        .toMap
+        .collect {
+          case (k, Some(v)) => k -> v.name
+        }
+      classIdToLabelName = groupedLabelClasses
+        .map(_._2)
+        .flatten
+        .map(c => c.id -> c.name)
+        .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -214,11 +211,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield StacGeoJSONFeatureCollection(
-      annotations.map(anno =>
-        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
-      )
-    ).asJson
+    } yield
+      StacGeoJSONFeatureCollection(
+        annotations.map(anno =>
+          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
+      ).asJson
     fcIo.value
   }
 
@@ -227,12 +224,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <-
-        TaskDao.query
-          .filter(
-            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-          )
-          .select
+      parentTask <- TaskDao.query
+        .filter(
+          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+        )
+        .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -25,7 +25,9 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     "geometry",
     "annotation_project_id",
     "annotation_task_id",
-    "description"
+    "description",
+    "is_active",
+    "session_id"
   )
   val selectF: Fragment = fr"SELECT" ++
     selectFieldsF ++ fr", classes.class_ids as annotation_label_classes FROM " ++
@@ -36,6 +38,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       GROUP BY annotation_label_id
     ) as classes ON """ ++ Fragment.const(tableName) ++ fr".id = " ++
     fr"classes.annotation_label_id"
+
+  val whereActiveF = fr"is_active = true"
 
   def insertAnnotations(
       annotationProjectId: UUID,
@@ -63,13 +67,14 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
         ${annotationLabel.id}, ${annotationLabel.createdAt},
         ${annotationLabel.createdBy}, ${annotationLabel.geometry},
         ${annotationLabel.annotationProjectId}, ${annotationLabel.annotationTaskId},
-        ${annotationLabel.description}
+        ${annotationLabel.description}, ${annotationLabel.isActive}, ${annotationLabel.sessionId}
        )"""
     )
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})")
+          fr"(${label.id}, ${labelClassId})"
+        )
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -93,7 +98,10 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
   def listProjectLabels(
       projectId: UUID
   ): ConnectionIO[List[AnnotationLabelWithClasses]] = {
-    query.filter(fr"annotation_project_id = ${projectId}").list
+    query
+      .filter(fr"annotation_project_id = ${projectId}")
+      .filter(whereActiveF)
+      .list
   }
 
   def countByProjectsAndGroup(
@@ -103,6 +111,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val projectIdsF = projectIds map { projectId =>
       fr"$projectId"
     }
+    val activeLabelF = fr"al.is_active = true"
     val fragment = (fr"""
   SELECT
     alalc.annotation_class_id AS label_class_id,
@@ -119,7 +128,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
   WHERE
     al.annotation_project_id in (""" ++ projectIdsF.intercalate(fr",") ++ fr""")
   AND
-    alcls.annotation_label_group_id = ${annotationLabelClassGroupId}
+    alcls.annotation_label_group_id = ${annotationLabelClassGroupId}""" ++ activeLabelF ++ fr"""
   GROUP BY
     alalc.annotation_class_id,
     alcls.name
@@ -134,6 +143,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     query
       .filter(fr"annotation_project_id=$projectId")
       .filter(fr"annotation_task_id=$taskId")
+      .filter(whereActiveF)
       .list
       .map { listed =>
         listed.map(_.toGeoJSONFeature)
@@ -159,6 +169,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val taskFilterF = fr"tasks.annotation_project_id = ${annotationProjectId}"
     val labelFilterF =
       fr"annotation_labels.annotation_project_id = ${annotationProjectId}"
+    val activeLabelF = fr"annotation_labels.is_active = true"
     val statusFilterFO = taskStatuses.toNel map { statuses =>
       Fragments.in(fr"tasks.status", statuses.map(TaskStatus.fromString(_)))
     }
@@ -176,31 +187,38 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName = groupedLabelClasses
-        .map { classGroups =>
-          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-        }
-        .flatten
-        .toMap
-        .collect {
-          case (k, Some(v)) => k -> v.name
-        }
-      classIdToLabelName = groupedLabelClasses
-        .map(_._2)
-        .flatten
-        .map(c => c.id -> c.name)
-        .toMap
+      classIdToGroupName =
+        groupedLabelClasses
+          .map { classGroups =>
+            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+          }
+          .flatten
+          .toMap
+          .collect {
+            case (k, Some(v)) => k -> v.name
+          }
+      classIdToLabelName =
+        groupedLabelClasses
+          .map(_._2)
+          .flatten
+          .map(c => c.id -> c.name)
+          .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
-          .whereAndOpt(Some(taskFilterF), Some(labelFilterF), statusFilterFO))
+          .whereAndOpt(
+            Some(taskFilterF),
+            Some(labelFilterF),
+            statusFilterFO,
+            Some(activeLabelF)
+          ))
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield
-      StacGeoJSONFeatureCollection(
-        annotations.map(anno =>
-          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
-      ).asJson
+    } yield StacGeoJSONFeatureCollection(
+      annotations.map(anno =>
+        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
+      )
+    ).asJson
     fcIo.value
   }
 
@@ -209,11 +227,12 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <- TaskDao.query
-        .filter(
-          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-        )
-        .select
+      parentTask <-
+        TaskDao.query
+          .filter(
+            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+          )
+          .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM
@@ -221,6 +240,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
              annotation_labels.id = annotation_labels_annotation_label_classes.annotation_label_id)
         WHERE
           annotation_project_id = ${childAnnotationProjectId.childAnnotationProjectId}
+          AND is_active = true
       ),
       -- is this identical to selecting from annotation labels? probably! but running everything
       -- through the join table makes me feel more optimistic about likelihood of writing

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -73,7 +73,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})")
+          fr"(${label.id}, ${labelClassId})"
+        )
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -110,7 +111,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val projectIdsF = projectIds map { projectId =>
       fr"$projectId"
     }
-    val activeLabelF = fr"al.is_active = true"
+    val activeLabelF = fr"AND al.is_active = true"
     val fragment = (fr"""
   SELECT
     alalc.annotation_class_id AS label_class_id,
@@ -186,20 +187,22 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName = groupedLabelClasses
-        .map { classGroups =>
-          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-        }
-        .flatten
-        .toMap
-        .collect {
-          case (k, Some(v)) => k -> v.name
-        }
-      classIdToLabelName = groupedLabelClasses
-        .map(_._2)
-        .flatten
-        .map(c => c.id -> c.name)
-        .toMap
+      classIdToGroupName =
+        groupedLabelClasses
+          .map { classGroups =>
+            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+          }
+          .flatten
+          .toMap
+          .collect {
+            case (k, Some(v)) => k -> v.name
+          }
+      classIdToLabelName =
+        groupedLabelClasses
+          .map(_._2)
+          .flatten
+          .map(c => c.id -> c.name)
+          .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -211,11 +214,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield
-      StacGeoJSONFeatureCollection(
-        annotations.map(anno =>
-          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
-      ).asJson
+    } yield StacGeoJSONFeatureCollection(
+      annotations.map(anno =>
+        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
+      )
+    ).asJson
     fcIo.value
   }
 
@@ -224,11 +227,12 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <- TaskDao.query
-        .filter(
-          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-        )
-        .select
+      parentTask <-
+        TaskDao.query
+          .filter(
+            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+          )
+          .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -97,6 +97,7 @@ object MVTLayerDao {
             ST_TileEnvelope(${z}, ${x}, ${y})
           )
           AND annotation_labels.annotation_project_id = ${annotationProjectId}
+          AND annotation_labels.is_active = true
           AND tasks.status <> 'SPLIT'
       """.query[LabelTileGeometry]
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -25,7 +25,8 @@ class AnnotationLabelDaoSpec
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
             annotationCreates: List[AnnotationLabelWithClasses.Create],
-            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
         ) => {
 
           val toInsert = annotationProjectCreate.copy(
@@ -49,11 +50,20 @@ class AnnotationLabelDaoSpec
               fixedUpTasks.copy(features = fixedUpTasks.features.take(1)),
               user
             ) map { _.features.head }
+            dbTaskSession <-
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  user,
+                  task.properties.status,
+                  task.id
+                )
             created <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,
               task.id,
               annotationCreates map { create =>
                 addClasses(create, classIds)
+                  .copy(sessionId = Some(dbTaskSession.id))
               },
               user
             )
@@ -78,7 +88,8 @@ class AnnotationLabelDaoSpec
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
             annotationCreates: List[AnnotationLabelWithClasses.Create],
-            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
         ) => {
           val toInsert = annotationProjectCreate.copy(
             labelClassGroups = annotationProjectCreate.labelClassGroups.take(1)
@@ -101,8 +112,18 @@ class AnnotationLabelDaoSpec
             classIds = annotationProject.labelClassGroups flatMap {
               _.labelClasses
             } map { _.id }
+            dbTaskSession <-
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  user,
+                  task.properties.status,
+                  task.id
+                )
             withClasses = annotationCreates map { create =>
-              addClasses(create, classIds)
+              addClasses(create, classIds).copy(sessionId =
+                Some(dbTaskSession.id)
+              )
             }
             _ <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,
@@ -133,7 +154,8 @@ class AnnotationLabelDaoSpec
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
             annotationCreates: List[AnnotationLabelWithClasses.Create],
-            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
         ) => {
           val toInsert = annotationProjectCreate.copy(
             labelClassGroups = annotationProjectCreate.labelClassGroups.take(1)
@@ -156,8 +178,18 @@ class AnnotationLabelDaoSpec
             classIds = annotationProject.labelClassGroups flatMap {
               _.labelClasses
             } map { _.id }
+            dbTaskSession <-
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  user,
+                  task.properties.status,
+                  task.id
+                )
             withClasses = annotationCreates map { create =>
-              addClasses(create, classIds)
+              addClasses(create, classIds).copy(sessionId =
+                Some(dbTaskSession.id)
+              )
             }
             _ <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,
@@ -193,7 +225,8 @@ class AnnotationLabelDaoSpec
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
             annotationCreates: List[AnnotationLabelWithClasses.Create],
-            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
         ) => {
           val summaryIO = for {
             user <- UserDao.create(userCreate)
@@ -213,8 +246,18 @@ class AnnotationLabelDaoSpec
               annotationProject.labelClassGroups.head.labelClasses map {
                 _.id
               }
+            dbTaskSession <-
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  user,
+                  task.properties.status,
+                  task.id
+                )
             withClasses = annotationCreates map { create =>
-              addClasses(create, classIds)
+              addClasses(create, classIds).copy(sessionId =
+                Some(dbTaskSession.id)
+              )
             }
             _ <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,
@@ -243,9 +286,8 @@ class AnnotationLabelDaoSpec
               Some(annotationCreates.size)
             }
             assert(
-              (labelSummaryO map {
-                (summ: LabelClassSummary) =>
-                  summ.count
+              (labelSummaryO map { (summ: LabelClassSummary) =>
+                summ.count
               }) == expectation,
               "All the annotations with the real class were counted"
             )
@@ -269,7 +311,8 @@ class AnnotationLabelDaoSpec
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
             annotationCreates: List[AnnotationLabelWithClasses.Create],
-            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
         ) => {
           val listIO = for {
             user <- UserDao.create(userCreate)
@@ -288,8 +331,18 @@ class AnnotationLabelDaoSpec
             classIds = annotationProject.labelClassGroups flatMap {
               _.labelClasses
             } map { _.id }
+            dbTaskSession <-
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  user,
+                  task.properties.status,
+                  task.id
+                )
             withClasses = annotationCreates map { create =>
-              addClasses(create, classIds)
+              addClasses(create, classIds).copy(sessionId =
+                Some(dbTaskSession.id)
+              )
             }
             _ <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,
@@ -328,7 +381,8 @@ class AnnotationLabelDaoSpec
             userCreate: User.Create,
             annotationProjectCreate: AnnotationProject.Create,
             annotationCreates: List[AnnotationLabelWithClasses.Create],
-            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate
+            taskFeatureCollectionCreate: Task.TaskFeatureCollectionCreate,
+            taskSessionCreate: TaskSession.Create
         ) => {
           val listIO = for {
             user <- UserDao.create(userCreate)
@@ -348,8 +402,18 @@ class AnnotationLabelDaoSpec
               annotationProject.labelClassGroups.head.labelClasses map {
                 _.id
               }
+            dbTaskSession <-
+              TaskSessionDao
+                .insertTaskSession(
+                  taskSessionCreate,
+                  user,
+                  task.properties.status,
+                  task.id
+                )
             withClasses = annotationCreates map { create =>
-              addClasses(create, classIds)
+              addClasses(create, classIds).copy(sessionId =
+                Some(dbTaskSession.id)
+              )
             }
             _ <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -1483,7 +1483,7 @@ class CampaignDaoSpec
               )
             classIds = createdGroup.labelClasses.map { _.id }
             withClasses = annotationCreates map { create =>
-              addClasses(create, classIds)
+              addClasses(create, classIds).copy(sessionId = None)
             }
             _ <- AnnotationLabelDao.insertAnnotations(
               annotationProject.id,

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -942,7 +942,8 @@ class CampaignDaoSpec
                 childLabels map { labelCreate =>
                   labelCreate.copy(
                     annotationLabelClasses =
-                      Random.shuffle(childClasses).take(1)
+                      Random.shuffle(childClasses).take(1),
+                    sessionId = None
                   )
                 },
                 dbChildUser

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignDaoSpec.scala
@@ -955,6 +955,7 @@ class CampaignDaoSpec
                   .filter(
                     fr"annotation_project_id = ${dbParentAnnotationProject.id}"
                   )
+                  .filter(fr"is_active = true")
                   .count
             } yield (childInserted, labelCountOnParentProject)
 


### PR DESCRIPTION
## Overview

This PR:
- updates the `annotation_labels` table with two new columns `is_active` and `session_id`
- updates the data model of `AnnotationLabel` and its related so that the current frontend data model won't need to change
- updates the dao methods so that they list `is_active = true` labels when appropriate
- updates property tests so that they take these fields into consideration

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should pass
- Run migrations
- Assemble servers, connect GW frontend to your local RF servers
- In a campaign, make sure the label and validate UIs still let you label, confirm, reopen, validate tasks and submit labels with no issues -- this is to make sure that no frontend changes needed as a result of backend data model changes
- Manually update the `is_active` field of one of the labels you created/validated in the previous step in the DB
- Go to the task that contains the above label and make sure it is not listed
- If your campaign is NOT of segmentation type, the label counts on the dashboard should change as well
- Go to the dashboard of the project that contains the label and check the task map. Make sure the label you set to inactive is not listed by the MVT layer

Closes https://github.com/raster-foundry/groundwork/issues/1432
