### PR TITLE
Update Session complete endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Moved aggregate out of full table query for label list [#5584](https://github.com/raster-foundry/raster-foundry/pull/5584)
 
+### Changed
+- Session complete now deactivates previous labels [#5583](https://github.com/raster-foundry/raster-foundry/pull/5583)
+
 ## [1.64.1] - 2021-05-18
 ### Fixed
 - Ensured task actions are updated in single request for labels and task status [#5581](https://github.com/raster-foundry/raster-foundry/pull/5581)

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -8,7 +8,6 @@ import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.server._
-import cats.data.NonEmptyList
 import cats.implicits._
 import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
 import doobie.implicits._
@@ -122,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
+                hasActiveSession <-
+                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -121,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <-
-                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -122,8 +122,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <-
-                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/datamodel/src/main/scala/TaskSession.scala
+++ b/app-backend/datamodel/src/main/scala/TaskSession.scala
@@ -18,7 +18,8 @@ final case class TaskSession(
     sessionType: TaskSessionType,
     userId: String,
     taskId: UUID,
-    note: Option[String]
+    note: Option[String],
+    previousSessionId: Option[UUID]
 )
 
 object TaskSession {

--- a/app-backend/db/src/main/resources/migrations/V76__add_previous_session_to_sessions.sql
+++ b/app-backend/db/src/main/resources/migrations/V76__add_previous_session_to_sessions.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    task_sessions
+ADD
+    COLUMN previous_session_id uuid REFERENCES task_sessions (id);

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -73,7 +73,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})")
+          fr"(${label.id}, ${labelClassId})"
+        )
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -186,20 +187,22 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName = groupedLabelClasses
-        .map { classGroups =>
-          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-        }
-        .flatten
-        .toMap
-        .collect {
-          case (k, Some(v)) => k -> v.name
-        }
-      classIdToLabelName = groupedLabelClasses
-        .map(_._2)
-        .flatten
-        .map(c => c.id -> c.name)
-        .toMap
+      classIdToGroupName =
+        groupedLabelClasses
+          .map { classGroups =>
+            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+          }
+          .flatten
+          .toMap
+          .collect {
+            case (k, Some(v)) => k -> v.name
+          }
+      classIdToLabelName =
+        groupedLabelClasses
+          .map(_._2)
+          .flatten
+          .map(c => c.id -> c.name)
+          .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -211,11 +214,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield
-      StacGeoJSONFeatureCollection(
-        annotations.map(anno =>
-          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
-      ).asJson
+    } yield StacGeoJSONFeatureCollection(
+      annotations.map(anno =>
+        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
+      )
+    ).asJson
     fcIo.value
   }
 
@@ -224,11 +227,12 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <- TaskDao.query
-        .filter(
-          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-        )
-        .select
+      parentTask <-
+        TaskDao.query
+          .filter(
+            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+          )
+          .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM
@@ -269,4 +273,14 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       )
       """.update.run
     } yield ()
+
+  def toggleBySessionIds(
+      sessionIds: NonEmptyList[UUID],
+      setActive: Boolean
+  ): ConnectionIO[Int] = {
+    (fr"UPDATE " ++ tableF ++ fr"""SET
+      is_active = ${setActive}""" ++ Fragments.whereAndOpt(
+      Some(Fragments.in(fr"session_id", sessionIds))
+    )).update.run;
+  }
 }

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -73,8 +73,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})"
-        )
+          fr"(${label.id}, ${labelClassId})")
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -187,22 +186,20 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName =
-        groupedLabelClasses
-          .map { classGroups =>
-            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-          }
-          .flatten
-          .toMap
-          .collect {
-            case (k, Some(v)) => k -> v.name
-          }
-      classIdToLabelName =
-        groupedLabelClasses
-          .map(_._2)
-          .flatten
-          .map(c => c.id -> c.name)
-          .toMap
+      classIdToGroupName = groupedLabelClasses
+        .map { classGroups =>
+          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+        }
+        .flatten
+        .toMap
+        .collect {
+          case (k, Some(v)) => k -> v.name
+        }
+      classIdToLabelName = groupedLabelClasses
+        .map(_._2)
+        .flatten
+        .map(c => c.id -> c.name)
+        .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -214,11 +211,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield StacGeoJSONFeatureCollection(
-      annotations.map(anno =>
-        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
-      )
-    ).asJson
+    } yield
+      StacGeoJSONFeatureCollection(
+        annotations.map(anno =>
+          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
+      ).asJson
     fcIo.value
   }
 
@@ -227,12 +224,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <-
-        TaskDao.query
-          .filter(
-            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-          )
-          .select
+      parentTask <- TaskDao.query
+        .filter(
+          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+        )
+        .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -73,7 +73,8 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})")
+          fr"(${label.id}, ${labelClassId})"
+        )
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -186,20 +187,22 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName = groupedLabelClasses
-        .map { classGroups =>
-          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-        }
-        .flatten
-        .toMap
-        .collect {
-          case (k, Some(v)) => k -> v.name
-        }
-      classIdToLabelName = groupedLabelClasses
-        .map(_._2)
-        .flatten
-        .map(c => c.id -> c.name)
-        .toMap
+      classIdToGroupName =
+        groupedLabelClasses
+          .map { classGroups =>
+            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+          }
+          .flatten
+          .toMap
+          .collect {
+            case (k, Some(v)) => k -> v.name
+          }
+      classIdToLabelName =
+        groupedLabelClasses
+          .map(_._2)
+          .flatten
+          .map(c => c.id -> c.name)
+          .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -211,11 +214,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield
-      StacGeoJSONFeatureCollection(
-        annotations.map(anno =>
-          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
-      ).asJson
+    } yield StacGeoJSONFeatureCollection(
+      annotations.map(anno =>
+        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
+      )
+    ).asJson
     fcIo.value
   }
 
@@ -224,11 +227,12 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <- TaskDao.query
-        .filter(
-          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-        )
-        .select
+      parentTask <-
+        TaskDao.query
+          .filter(
+            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+          )
+          .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM
@@ -270,13 +274,12 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       """.update.run
     } yield ()
 
-  def toggleBySessionIds(
-      sessionIds: NonEmptyList[UUID],
-      setActive: Boolean
+  def toggleBySessionId(
+      sessionId: UUID
   ): ConnectionIO[Int] = {
     (fr"UPDATE " ++ tableF ++ fr"""SET
-      is_active = ${setActive}""" ++ Fragments.whereAndOpt(
-      Some(Fragments.in(fr"session_id", sessionIds))
-    )).update.run;
+      is_active = not is_active""" ++ Fragments.whereAndOpt(
+      Some(fr"session_id = ${sessionId}")
+    )).update.run
   }
 }

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -289,8 +289,10 @@ object TaskSessionDao extends Dao[TaskSession] {
       .filter(fr"task_sessions.task_id = ${taskId}")
       .filter(excludeSessionIdsOpt match {
         case Some(excludeSessionIds) if excludeSessionIds.size > 0 =>
-          fr"task_sessions.id NOT in (${excludeSessionIds.map(id => fr"${id}").intercalate(fr",")})"
-        case _ => fr""
+          Some(
+            fr"task_sessions.id NOT in (${excludeSessionIds.map(id => fr"${id}").intercalate(fr",")})"
+          )
+        case _ => None
       })
       .list
 

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -73,7 +73,8 @@ object TaskSessionDao extends Dao[TaskSession] {
             task.status,
             taskId
           )
-      })
+        }
+      )
 
   def keepTaskSessionAlive(id: UUID): ConnectionIO[Int] =
     (fr"UPDATE " ++ tableF ++ fr"""SET
@@ -116,7 +117,9 @@ object TaskSessionDao extends Dao[TaskSession] {
     for {
       taskOpt <- TaskDao.getTaskById(taskId)
       isMatch <- taskOpt traverse { task =>
-        if (task.status == TaskStatus.Invalid || task.status == TaskStatus.Split) {
+        if (
+          task.status == TaskStatus.Invalid || task.status == TaskStatus.Split
+        ) {
           Applicative[ConnectionIO].pure(false)
         } else {
           sessionType match {
@@ -195,11 +198,11 @@ object TaskSessionDao extends Dao[TaskSession] {
         )
       }
       authCampaign <- (projectOpt flatTraverse { project =>
-        project.campaignId traverse { campaignId =>
-          CampaignDao
-            .authorized(user, ObjectType.Campaign, campaignId, actionType)
-        }
-      })
+          project.campaignId traverse { campaignId =>
+            CampaignDao
+              .authorized(user, ObjectType.Campaign, campaignId, actionType)
+          }
+        })
     } yield {
       (authProject, authCampaign) match {
         case (Some(authedProject), None)  => authedProject.toBoolean
@@ -245,19 +248,20 @@ object TaskSessionDao extends Dao[TaskSession] {
         case _    => TaskSession.Create(TaskSessionType.ValidateSession)
       }
     for {
-      annotationProjectIds <- AnnotationProjectDao
-        .authQuery(
-          user,
-          ObjectType.AnnotationProject,
-          None,
-          None,
-          None
-        )
-        .filter(annotationProjectParams)
-        .filter(annotationProjectIdOpt)
-        .list(limit) map { projects =>
-        projects map { _.id }
-      }
+      annotationProjectIds <-
+        AnnotationProjectDao
+          .authQuery(
+            user,
+            ObjectType.AnnotationProject,
+            None,
+            None,
+            None
+          )
+          .filter(annotationProjectParams)
+          .filter(annotationProjectIdOpt)
+          .list(limit) map { projects =>
+          projects map { _.id }
+        }
       taskOpt <- annotationProjectIds.toNel flatTraverse { projectIds =>
         TaskDao.randomTask(taskParams, projectIds, true)
       }
@@ -277,10 +281,10 @@ object TaskSessionDao extends Dao[TaskSession] {
       excludeSessionIdsOpt: Option[List[UUID]]
   ): ConnectionIO[List[TaskSession]] =
     query
-      .filter(fr"task_id = ${taskId}")
+      .filter(fr"task_sessions.task_id = ${taskId}")
       .filter(excludeSessionIdsOpt match {
         case Some(excludeSessionIds) if excludeSessionIds.size > 0 =>
-          fr"id NOT in ${excludeSessionIds.map(id => fr"${id}").intercalate(fr",")}"
+          fr"task_sessions.id NOT in (${excludeSessionIds.map(id => fr"${id}").intercalate(fr",")})"
         case _ => fr""
       })
       .list

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -73,7 +73,8 @@ object TaskSessionDao extends Dao[TaskSession] {
             task.status,
             taskId
           )
-      })
+        }
+      )
 
   def keepTaskSessionAlive(id: UUID): ConnectionIO[Int] =
     (fr"UPDATE " ++ tableF ++ fr"""SET
@@ -116,7 +117,9 @@ object TaskSessionDao extends Dao[TaskSession] {
     for {
       taskOpt <- TaskDao.getTaskById(taskId)
       isMatch <- taskOpt traverse { task =>
-        if (task.status == TaskStatus.Invalid || task.status == TaskStatus.Split) {
+        if (
+          task.status == TaskStatus.Invalid || task.status == TaskStatus.Split
+        ) {
           Applicative[ConnectionIO].pure(false)
         } else {
           sessionType match {
@@ -195,11 +198,11 @@ object TaskSessionDao extends Dao[TaskSession] {
         )
       }
       authCampaign <- (projectOpt flatTraverse { project =>
-        project.campaignId traverse { campaignId =>
-          CampaignDao
-            .authorized(user, ObjectType.Campaign, campaignId, actionType)
-        }
-      })
+          project.campaignId traverse { campaignId =>
+            CampaignDao
+              .authorized(user, ObjectType.Campaign, campaignId, actionType)
+          }
+        })
     } yield {
       (authProject, authCampaign) match {
         case (Some(authedProject), None)  => authedProject.toBoolean
@@ -245,19 +248,20 @@ object TaskSessionDao extends Dao[TaskSession] {
         case _    => TaskSession.Create(TaskSessionType.ValidateSession)
       }
     for {
-      annotationProjectIds <- AnnotationProjectDao
-        .authQuery(
-          user,
-          ObjectType.AnnotationProject,
-          None,
-          None,
-          None
-        )
-        .filter(annotationProjectParams)
-        .filter(annotationProjectIdOpt)
-        .list(limit) map { projects =>
-        projects map { _.id }
-      }
+      annotationProjectIds <-
+        AnnotationProjectDao
+          .authQuery(
+            user,
+            ObjectType.AnnotationProject,
+            None,
+            None,
+            None
+          )
+          .filter(annotationProjectParams)
+          .filter(annotationProjectIdOpt)
+          .list(limit) map { projects =>
+          projects map { _.id }
+        }
       taskOpt <- annotationProjectIds.toNel flatTraverse { projectIds =>
         TaskDao.randomTask(taskParams, projectIds, true)
       }
@@ -271,4 +275,17 @@ object TaskSessionDao extends Dao[TaskSession] {
       }
     } yield sessionOpt
   }
+
+  def listSessionsByTask(
+      taskId: UUID,
+      excludeSessionIdsOpt: Option[List[UUID]]
+  ): ConnectionIO[List[TaskSession]] =
+    query
+      .filter(fr"task_id = ${taskId}")
+      .filter(excludeSessionIdsOpt match {
+        case Some(excludeSessionIds) if excludeSessionIds.size > 0 =>
+          fr"id NOT in ${excludeSessionIds.map(id => fr"${id}").intercalate(fr",")}"
+        case _ => fr""
+      })
+      .list
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -3,7 +3,6 @@ package com.rasterfoundry.database
 import com.rasterfoundry.common.Generators.Implicits._
 import com.rasterfoundry.datamodel._
 
-import cats.data.NonEmptyList
 import doobie.implicits._
 import org.scalacheck.Prop.forAll
 import org.scalatest.funsuite.AnyFunSuite
@@ -550,19 +549,13 @@ class AnnotationLabelDaoSpec
               },
               user
             )
-            _ <- AnnotationLabelDao.toggleBySessionIds(
-              NonEmptyList(dbTaskSession.id, Nil),
-              false
-            )
+            _ <- AnnotationLabelDao.toggleBySessionId(dbTaskSession.id)
             activeLabels <-
               AnnotationLabelDao.listWithClassesByProjectIdAndTaskId(
                 annotationProject.id,
                 task.id
               )
-            _ <- AnnotationLabelDao.toggleBySessionIds(
-              NonEmptyList.of(dbTaskSession.id),
-              true
-            )
+            _ <- AnnotationLabelDao.toggleBySessionId(dbTaskSession.id)
             reactiveLabels <-
               AnnotationLabelDao.listWithClassesByProjectIdAndTaskId(
                 annotationProject.id,


### PR DESCRIPTION
## Overview

This PR updates the task session complete endpoint so that it disables the labels from the previous sessions of the same task and promotes the current task session.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- CI should pass as new property tests were added for the dao methods
- Follow steps here: https://github.com/raster-foundry/raster-foundry/pull/5522 to create a task session of task `A`, post some labels to the task and `complete` the task session. Make sure the labels are posted to the task and the session and the labels are set to `is_active = true`
- Create a new session of the same task `A`. Post some labels to the session. `complete` the session. Make sure that labels from the session in step two are set to `is_active = false`, and that the labels from the session in this step are posted correctly with the `is_active = true` field

Closes https://github.com/raster-foundry/groundwork/issues/1433
