### PR TITLE
Repair slow annotation label query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Moved aggregate out of full table query for label list [#5584](https://github.com/raster-foundry/raster-foundry/pull/5584)
 
 ## [1.64.1] - 2021-05-18
 ### Fixed

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -121,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <-
-                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -121,8 +121,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
+                hasActiveSession <-
+                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -81,8 +81,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})"
-        )
+          fr"(${label.id}, ${labelClassId})")
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -195,22 +194,20 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName =
-        groupedLabelClasses
-          .map { classGroups =>
-            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-          }
-          .flatten
-          .toMap
-          .collect {
-            case (k, Some(v)) => k -> v.name
-          }
-      classIdToLabelName =
-        groupedLabelClasses
-          .map(_._2)
-          .flatten
-          .map(c => c.id -> c.name)
-          .toMap
+      classIdToGroupName = groupedLabelClasses
+        .map { classGroups =>
+          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+        }
+        .flatten
+        .toMap
+        .collect {
+          case (k, Some(v)) => k -> v.name
+        }
+      classIdToLabelName = groupedLabelClasses
+        .map(_._2)
+        .flatten
+        .map(c => c.id -> c.name)
+        .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -222,11 +219,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield StacGeoJSONFeatureCollection(
-      annotations.map(anno =>
-        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
-      )
-    ).asJson
+    } yield
+      StacGeoJSONFeatureCollection(
+        annotations.map(anno =>
+          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
+      ).asJson
     fcIo.value
   }
 
@@ -235,12 +232,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <-
-        TaskDao.query
-          .filter(
-            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-          )
-          .select
+      parentTask <- TaskDao.query
+        .filter(
+          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+        )
+        .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM

--- a/app-backend/db/src/main/scala/Dao.scala
+++ b/app-backend/db/src/main/scala/Dao.scala
@@ -17,6 +17,7 @@ import doobie.{LogHandler => _, _}
 import scala.concurrent.duration.FiniteDuration
 
 import java.util.UUID
+import cats.data.NonEmptyList
 
 /**
   * This is abstraction over the listing of arbitrary types from the DB with filters/pagination
@@ -42,16 +43,24 @@ abstract class Dao[Model: Read: Write] extends Filterables {
   /** Begin construction of a complex, filtered query */
   def query: Dao.QueryBuilder[Model] =
     Dao.QueryBuilder[Model](selectF, tableF, List.empty)
+
+  def groupQuery(groups: NonEmptyList[Fragment]): Dao.GroupQueryBuilder[Model] =
+    Dao.GroupQueryBuilder[Model](
+      selectF,
+      tableF,
+      groups,
+      Nil
+    )
 }
 
 object Dao extends LazyLogging {
 
   implicit val logHandler: LogHandler = LogHandler {
     case Success(
-        s: String,
-        a: List[Any],
-        e1: FiniteDuration,
-        e2: FiniteDuration
+          s: String,
+          a: List[Any],
+          e1: FiniteDuration,
+          e2: FiniteDuration
         ) =>
       val queryString =
         s.lines.dropWhile(_.trim.isEmpty).toArray.mkString("\n  ")
@@ -104,6 +113,49 @@ object Dao extends LazyLogging {
       """.stripMargin)
   }
 
+  // This case class represents
+  final case class GroupQueryBuilder[Model: Read: Write](
+      selectF: Fragment,
+      tableF: Fragment,
+      groups: NonEmptyList[Fragment],
+      filters: List[Option[Fragment]]
+  ) {
+
+    /** Add another filter to the query being constructed */
+    def filter[M >: Model, T](
+        thing: T
+    )(implicit filterable: Filterable[M, T]): GroupQueryBuilder[Model] =
+      this.copy(filters = filters ++ filterable.toFilters(thing))
+
+    def filter[M >: Model](
+        thing: Fragment
+    )(implicit filterable: Filterable[M, Fragment]): GroupQueryBuilder[Model] =
+      thing match {
+        case Fragment.empty => this
+        case _              => this.copy(filters = filters ++ filterable.toFilters(thing))
+      }
+
+    def filter[M >: Model](id: UUID)(implicit
+        filterable: Filterable[M, Option[Fragment]]
+    ): GroupQueryBuilder[Model] = {
+      this.copy(filters = filters ++ filterable.toFilters(Some(fr"id = ${id}")))
+    }
+
+    def filter[M >: Model](
+        fragments: List[Option[Fragment]]
+    ): GroupQueryBuilder[Model] = {
+      this.copy(filters = filters ::: fragments)
+    }
+
+    private def noLimitListQ: Query0[Model] =
+      (selectF ++ fr"FROM" ++ tableF ++ Fragments.whereAndOpt(
+        filters: _*
+      ) ++ fr"GROUP BY" ++ groups.intercalate(fr","))
+        .query[Model]
+
+    def list: ConnectionIO[List[Model]] = noLimitListQ.to[List]
+  }
+
   final case class QueryBuilder[Model: Read: Write](
       selectF: Fragment,
       tableF: Fragment,
@@ -130,8 +182,8 @@ object Dao extends LazyLogging {
         case _              => this.copy(filters = filters ++ filterable.toFilters(thing))
       }
 
-    def filter[M >: Model](id: UUID)(
-        implicit filterable: Filterable[M, Option[Fragment]]
+    def filter[M >: Model](id: UUID)(implicit
+        filterable: Filterable[M, Option[Fragment]]
     ): QueryBuilder[Model] = {
       this.copy(filters = filters ++ filterable.toFilters(Some(fr"id = ${id}")))
     }
@@ -180,10 +232,11 @@ object Dao extends LazyLogging {
         groupClause: Fragment = Fragment.empty
     ): ConnectionIO[PaginatedResponse[T]] = {
       for {
-        page <- (selectF ++ Fragments.whereAndOpt(filters: _*) ++ groupClause ++ Page(
-          pageRequest.copy(sort = orderClause ++ pageRequest.sort)
-        )).query[T]
-          .to[List]
+        page <-
+          (selectF ++ Fragments.whereAndOpt(filters: _*) ++ groupClause ++ Page(
+            pageRequest.copy(sort = orderClause ++ pageRequest.sort)
+          )).query[T]
+            .to[List]
         (count: Int, hasNext: Boolean) <- doCount match {
           case true => {
             (countF ++ Fragments.whereAndOpt(filters: _*))
@@ -251,11 +304,13 @@ object Dao extends LazyLogging {
       listQ(pageRequest).to[List]
     }
 
-    /** Short circuit for quickly getting an approximate count for large queries (e.g. scenes) **/
+    /** Short circuit for quickly getting an approximate count for large queries (e.g. scenes) * */
     def sceneCountIO(exactCountOption: Option[Boolean]): ConnectionIO[Int] = {
       val countQuery = countF ++ Fragments.whereAndOpt(filters: _*)
       val over100IO: ConnectionIO[Boolean] =
-        (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"offset 100") ++ fr")")
+        (fr"SELECT EXISTS(" ++ (selectF ++ Fragments.whereAndOpt(
+          filters: _*
+        ) ++ fr"offset 100") ++ fr")")
           .query[Boolean]
           .unique
       over100IO.flatMap(over100 => {
@@ -282,7 +337,7 @@ object Dao extends LazyLogging {
       (selectF ++ Fragments.whereAndOpt(filters: _*))
         .query[Model]
 
-    /**Provide a stream of responses */
+    /** Provide a stream of responses */
     def stream: fs2.Stream[ConnectionIO, Model] =
       noLimitListQ.stream
 
@@ -292,11 +347,15 @@ object Dao extends LazyLogging {
     }
 
     def listQ(offset: Int, limit: Int): Query0[Model] =
-      (selectF ++ Fragments.whereAndOpt(filters: _*) ++ fr"OFFSET $offset" ++ fr"LIMIT $limit")
+      (selectF ++ Fragments.whereAndOpt(
+        filters: _*
+      ) ++ fr"OFFSET $offset" ++ fr"LIMIT $limit")
         .query[Model]
 
     def listQ(offset: Int, limit: Int, orderClause: Fragment): Query0[Model] =
-      (selectF ++ Fragments.whereAndOpt(filters: _*) ++ orderClause ++ fr"OFFSET $offset" ++ fr"LIMIT $limit")
+      (selectF ++ Fragments.whereAndOpt(
+        filters: _*
+      ) ++ orderClause ++ fr"OFFSET $offset" ++ fr"LIMIT $limit")
         .query[Model]
 
     /** Provide a list of responses */


### PR DESCRIPTION
## Overview

This PR introduces a new query builder for all Daos called the `GroupQueryBuilder`. It lets us add filters to grouped queries in an abstract way. Currently, the only type of query it supports is an unlimited list. The reason for this is that it's only currently used to fix an [especially painful label query](https://azavea.slack.com/archives/C011W71JPM0/p1622151830009700?thread_ts=1622151615.008600&cid=C011W71JPM0), where we had a `GROUP BY` in a subquery to avoid collisions with the querybuilder logic, or at least that's my theory for why we had that.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

### Notes

Applying this change manually to a query from slow query logs took total time from ~1.5 seconds to < 1 ms.

## Testing Instructions

- tests are fine
