### PR TITLE
Index the label class group fk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Applied missing index to annotation label classes table [#5585](https://github.com/raster-foundry/raster-foundry/pull/5585)
 
 ## [1.64.2] - 2021-05-28
 ### Fixed

--- a/app-backend/db/src/main/resources/migrations/V77__index_label_class_group_fk.sql
+++ b/app-backend/db/src/main/resources/migrations/V77__index_label_class_group_fk.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS annotation_label_classes_annotation_label_group_id_idx ON annotation_label_classes (annotation_label_group_id);


### PR DESCRIPTION
## Overview

One query that slows down under load is the query for label classes within a group. It turns out we didn't index that foreign key. With as many classes as there are in prod, this can slow down under load.

The query plan for the query currently deployed uses a `SEQ SCAN` on the table to filter for the group. After I applied this index, it uses an index scan instead.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] New tables and queries have appropriate indices added

## Testing Instructions

- I can show the query plans
