### PR TITLE
Set is_active when splitting tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Fixed
 - Applied missing index to annotation label classes table [#5585](https://github.com/raster-foundry/raster-foundry/pull/5585)
+- Set is_active when splitting tasks [#5586](https://github.com/raster-foundry/raster-foundry/pull/5586)
 
 ## [1.64.2] - 2021-05-28
 ### Fixed

--- a/app-backend/db/src/main/scala/ProjectDao.scala
+++ b/app-backend/db/src/main/scala/ProjectDao.scala
@@ -390,10 +390,6 @@ object ProjectDao
         )
       }
     } yield {
-      logger
-        .info(
-          s"Kicking off layer overview creation for project-$projectId-layer-$projectLayerId"
-        )
       sceneToLayerInserts
     }
   }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -906,7 +906,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
     -- insert into labels and label classes from the old view
     label_insert as
       (insert into annotation_labels (
-        id, created_at, created_by, annotation_project_id, annotation_task_id, geometry, description
+        id, created_at, created_by, annotation_project_id, annotation_task_id, geometry, description, is_active
       ) (
         SELECT new_label_id,
                now(),
@@ -914,14 +914,21 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
                annotation_project_id,
                new_task_id,
                geom,
-               description from overlapping_labels
-      ))
-    insert into annotation_labels_annotation_label_classes (
-      annotation_label_id,
-      annotation_class_id
-    ) (
-      SELECT new_label_id, annotation_class_id from overlapping_labels
+               description,
+               true
+        FROM overlapping_labels
+      )),
+    -- insert label classes
+    label_class_insert as (
+      insert into annotation_labels_annotation_label_classes (
+        annotation_label_id,
+        annotation_class_id
+      ) (
+        SELECT new_label_id, annotation_class_id from overlapping_labels
+      )
     )
+    -- update the old labels no longer to be active
+    update annotation_labels set is_active = false where annotation_task_id = $oldTaskId
   """
 
   def splitTask(


### PR DESCRIPTION
## Overview

This PR sets `is_active` appropriately when splitting tasks.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

There's an open question about task splits still, which is -- what happens with the task session? Do the new labels still get associated with the current task session? Does the labeling session post-split continue on the next task? Not clear to me! Anyway, this solves the immediate problem and we should talk about the rest later.

I think we'll have to get `is_active` and session stuff from the previous task eventually, but I'm skipping that for now to make things work again.

## Testing Instructions

- with the develop branch:
  - assemble api server
  - start servers, GroundWork
  - create an object detection project or use one you already have (it's easiest to see the manifestation of the error with object detection)
  - draw labels in four corners of one of the tasks
  - split it and look at the task counts on the project overview page -- there will be TOO MANY
- check out this branch and assemble api server
  - repeat the label then split workflow on a different task
  - note that your count only increased by the number of labels you drew 🎉