### PR TITLE
Index label classes in labels <-> classes join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added index to annotation label class id in the labels to classes join table [#5587](https://github.com/raster-foundry/raster-foundry/pull/5587)
 
 ## [1.64.3] - 2021-06-02
 ### Fixed

--- a/app-backend/db/src/main/resources/migrations/V78__index_label_class_in_labels_to_classes_join.sql
+++ b/app-backend/db/src/main/resources/migrations/V78__index_label_class_in_labels_to_classes_join.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS annotation_labels_annotation_label_classes_class_id_idx ON annotation_labels_annotation_label_classes (annotation_class_id);


### PR DESCRIPTION
## Overview

This PR adds a migration for an index on the label class id in the `annotation_labels_annotation_label_classes` table.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests (CI will fail if the migration is bad)

### Notes

Dropped a query from > 700ms to 78ms

## Testing Instructions

- run the query from the linked issue in metabase
- see that it's fast now (if you choose "table" view from the dropdown, you can copy the json out really easily for tatiyants.com/pev)

Helps with azavea/raster-foundry-platform#1263
