### PR TITLE
filter tasks by campaign in random review task query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Added index to annotation label class id in the labels to classes join table [#5587](https://github.com/raster-foundry/raster-foundry/pull/5587)
 
+### Fixed
+- Improved performance of random review task query [#5588](https://github.com/raster-foundry/raster-foundry/pull/5588)
+
 ## [1.64.3] - 2021-06-02
 ### Fixed
 - Applied missing index to annotation label classes table [#5585](https://github.com/raster-foundry/raster-foundry/pull/5585)

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -317,6 +317,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
           ON ta.task_id = t2.id
           AND ta.user_id = ${user.id}
           AND ta.to_status = ${TaskStatus.Validated.toString}::task_status
+        JOIN annotation_projects ON annotation_projects.id = t2.annotation_project_id
+        JOIN campaigns ON campaigns.parent_campaign_id = ${campaignId}
         WHERE t2.task_type = ${TaskType.Review.toString}::task_type
         GROUP BY t1.id, t2.id
       ),


### PR DESCRIPTION
## Overview

This PR filters tasks to those in the campaign requested in the random task endpoint. Without this filter, this section of the query was running its aggregation on the whole tasks table https://github.com/raster-foundry/raster-foundry/blob/develop/app-backend/db/src/main/scala/CampaignDao.scala#L298-L307

This change improved my test query from 2.5s to 232ms, which still isn't ideal but is enough of an improvement that it should keep the database happier.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

### Notes

I'm a little confused about the relationships here -- for some reason it doesn't matter to the tests if I join via `t1` or `t2` in the changed section. That said, I think the cases exercised by the tests are sufficient to show that it actually doesn't matter, instead of this being a weird artifact of something we did.

## Testing Instructions

- tests

Helps with azavea/raster-foundry-platform#1263
