### PR TITLE
Add performance endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Improved performance of random review task query [#5588](https://github.com/raster-foundry/raster-foundry/pull/5588)
 
+### Added
+- Added performance endpoints for labeling and validation [#5589](https://github.com/raster-foundry/raster-foundry/pull/5589)
+
 ## [1.64.3] - 2021-06-02
 ### Fixed
 - Applied missing index to annotation label classes table [#5585](https://github.com/raster-foundry/raster-foundry/pull/5585)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -250,6 +250,8 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/share,campaigns:share,post
 /api/campaigns/{campaignId}/share,campaigns:share,get
 /api/campaigns/{campaignId}/share/{userId},campaigns:read,delete
+/api/campaigns/{campaignId}/performance/label,campaigns:read,get
+/api/campaigns/{campaignId}/performance/validate,campaigns:read,get
 /api/tasks/{taskId}/sessions,annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions,annotationProjects:createAnnotation,post
 /api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -702,16 +702,28 @@ trait CampaignRoutes
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
       ) {
-        withPagination { page =>
-          complete {
-            CampaignDao
-              .performance(
-                campaignId,
-                taskSessionType,
-                page
-              )
-              .transact(xa)
-              .unsafeToFuture
+        authorizeAuthResultAsync(
+          CampaignDao
+            .authorized(
+              user,
+              ObjectType.Campaign,
+              campaignId,
+              ActionType.Validate
+            )
+            .transact(xa)
+            .unsafeToFuture
+        ) {
+          withPagination { page =>
+            complete {
+              CampaignDao
+                .performance(
+                  campaignId,
+                  taskSessionType,
+                  page
+                )
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
       }

--- a/app-backend/datamodel/src/main/scala/CampaignPerformance.scala
+++ b/app-backend/datamodel/src/main/scala/CampaignPerformance.scala
@@ -1,0 +1,39 @@
+package com.rasterfoundry.datamodel
+
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveDecoder
+
+import scala.util.Try
+
+final case class CampaignPerformance(
+    avatarUri: String,
+    name: String,
+    tasksComplete: Long,
+    hoursSpent: Double
+)
+
+object CampaignPerformance {
+  implicit val decCampaignPerformance: Decoder[CampaignPerformance] =
+    deriveDecoder
+
+  // make encoding responsible for the average calculation to save the
+  // database one aggregation and to make it impossible to mess up the
+  // calculation in a way that creates an inconsistent result
+  implicit val encCampaignPerformance: Encoder[CampaignPerformance] =
+    Encoder.forProduct5(
+      "imageUri",
+      "name",
+      "tasksComplete",
+      "hoursSpent",
+      "averageTasksPerHour"
+    )(
+      perf =>
+        (
+          perf.avatarUri,
+          perf.name,
+          perf.tasksComplete,
+          perf.hoursSpent,
+          Try(perf.tasksComplete / perf.hoursSpent).toOption
+      ))
+}

--- a/app-backend/datamodel/src/main/scala/CampaignPerformance.scala
+++ b/app-backend/datamodel/src/main/scala/CampaignPerformance.scala
@@ -9,8 +9,9 @@ import scala.util.Try
 final case class CampaignPerformance(
     avatarUri: String,
     name: String,
-    tasksComplete: Long,
-    hoursSpent: Double
+    userId: String,
+    hoursSpent: Double,
+    tasksComplete: Long
 )
 
 object CampaignPerformance {
@@ -21,9 +22,10 @@ object CampaignPerformance {
   // database one aggregation and to make it impossible to mess up the
   // calculation in a way that creates an inconsistent result
   implicit val encCampaignPerformance: Encoder[CampaignPerformance] =
-    Encoder.forProduct5(
+    Encoder.forProduct6(
       "imageUri",
       "name",
+      "userId",
       "tasksComplete",
       "hoursSpent",
       "averageTasksPerHour"
@@ -32,6 +34,7 @@ object CampaignPerformance {
         (
           perf.avatarUri,
           perf.name,
+          perf.userId,
           perf.tasksComplete,
           perf.hoursSpent,
           Try(perf.tasksComplete / perf.hoursSpent).toOption

--- a/app-backend/datamodel/src/main/scala/PaginatedGeoJsonResponse.scala
+++ b/app-backend/datamodel/src/main/scala/PaginatedGeoJsonResponse.scala
@@ -28,11 +28,11 @@ object GeoJsonCodec {
 
   @ConfiguredJsonCodec
   final case class PaginatedGeoJsonResponse[T](
-      count: Int,
+      count: Long,
       hasPrevious: Boolean,
       hasNext: Boolean,
-      page: Int,
-      pageSize: Int,
+      page: Long,
+      pageSize: Long,
       features: Iterable[T],
       _type: String = "FeatureCollection"
   )
@@ -49,7 +49,9 @@ object GeoJsonCodec {
       )
   }
 
-  def fromSeqToFeatureCollection[T1 <: GeoJSONSerializable[T2],
+  def fromSeqToFeatureCollection[T1 <: GeoJSONSerializable[
+                                   T2
+                                 ],
                                  T2 <: GeoJSONFeature](
       features: Iterable[T1]
   ): GeoJsonFeatureCollection[T2] = {
@@ -59,7 +61,9 @@ object GeoJsonCodec {
     )
   }
 
-  def fromPaginatedResponseToGeoJson[T1 <: GeoJSONSerializable[T2],
+  def fromPaginatedResponseToGeoJson[T1 <: GeoJSONSerializable[
+                                       T2
+                                     ],
                                      T2 <: GeoJSONFeature](
       resp: PaginatedResponse[T1]
   ): PaginatedGeoJsonResponse[T2] = {

--- a/app-backend/datamodel/src/main/scala/PaginatedResponse.scala
+++ b/app-backend/datamodel/src/main/scala/PaginatedResponse.scala
@@ -13,9 +13,11 @@ import io.circe.generic.JsonCodec
   * @param results sequence of results for a page
   */
 @JsonCodec
-final case class PaginatedResponse[A](count: Int,
-                                      hasPrevious: Boolean,
-                                      hasNext: Boolean,
-                                      page: Int,
-                                      pageSize: Int,
-                                      results: Seq[A])
+final case class PaginatedResponse[A](
+    count: Long,
+    hasPrevious: Boolean,
+    hasNext: Boolean,
+    page: Long,
+    pageSize: Long,
+    results: Seq[A]
+)

--- a/app-backend/datamodel/src/main/scala/com/rasterfoundry/datamodel/PageRequest.scala
+++ b/app-backend/datamodel/src/main/scala/com/rasterfoundry/datamodel/PageRequest.scala
@@ -1,3 +1,7 @@
 package com.rasterfoundry.datamodel
 
-final case class PageRequest(offset: Int, limit: Int, sort: Map[String, Order])
+final case class PageRequest(
+    offset: Long,
+    limit: Long,
+    sort: Map[String, Order]
+)

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -139,8 +139,7 @@ object AnnotationDao extends Dao[Annotation] {
                     project.copy(defaultAnnotationGroup = Some(defaultId)),
                     project.id
                   )
-                  .map(_ => defaultId)
-            )
+                  .map(_ => defaultId))
       }
       annotationFragments: List[Fragment] = annotations.map(
         (annotationCreate: Annotation.Create) => {
@@ -157,8 +156,7 @@ object AnnotationDao extends Dao[Annotation] {
           ${annotation.geometry}, ${annotation.annotationGroup}, ${annotation.labeledBy}, ${annotation.verifiedBy},
           ${annotation.projectLayerId}, ${annotation.taskId}
         )"""
-        }
-      )
+        })
       insertedAnnotations <- annotationFragments.toNel
         .map(
           fragments =>
@@ -183,8 +181,7 @@ object AnnotationDao extends Dao[Annotation] {
                 "task_id"
               )
               .compile
-              .toList
-        )
+              .toList)
         .getOrElse(List[Annotation]().pure[ConnectionIO])
     } yield insertedAnnotations
   }
@@ -273,10 +270,8 @@ object AnnotationDao extends Dao[Annotation] {
         }),
         queryParams.bboxPolygon match {
           case Some(bboxPolygons) =>
-            val fragments = bboxPolygons.map(
-              bbox =>
-                fr"(_ST_Intersects(a.geometry, ${bbox}) AND a.geometry && ${bbox})"
-            )
+            val fragments = bboxPolygons.map(bbox =>
+              fr"(_ST_Intersects(a.geometry, ${bbox}) AND a.geometry && ${bbox})")
             Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
           case _ => None
         }
@@ -321,7 +316,7 @@ object AnnotationDao extends Dao[Annotation] {
       )).query[AnnotationWithOwnerInfo]
         .to[List]
       count <- (countF ++ Fragments.whereAndOpt(filters: _*))
-        .query[Int]
+        .query[Long]
         .unique
     } yield {
       val hasPrevious = pageRequest.offset > 0

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -561,4 +561,10 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
           }
       }
     } yield labelClassSummaries
+
+  def performance(
+      campaignId: UUID,
+      sessionEndState: TaskSessionType,
+      sort: Map[String, Order]
+  ): ConnectionIO[PaginatedResponse[CampaignPerformance]] = ???
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -565,6 +565,6 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
   def performance(
       campaignId: UUID,
       sessionEndState: TaskSessionType,
-      sort: Map[String, Order]
+      page: PageRequest
   ): ConnectionIO[PaginatedResponse[CampaignPerformance]] = ???
 }

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -2,6 +2,7 @@ package com.rasterfoundry.database
 
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database.types._
+import com.rasterfoundry.database.util.Page
 import com.rasterfoundry.datamodel._
 
 import cats.data.OptionT
@@ -562,9 +563,88 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       }
     } yield labelClassSummaries
 
+  private[database] def performanceQ(
+      campaignId: UUID,
+      sessionType: TaskSessionType,
+      page: PageRequest
+  ): Query0[CampaignPerformance] = {
+    val (fromStatus, toStatus): (TaskStatus, TaskStatus) = sessionType match {
+      case TaskSessionType.LabelSession =>
+        (TaskStatus.Unlabeled, TaskStatus.Labeled)
+      case TaskSessionType.ValidateSession =>
+        (TaskStatus.Labeled, TaskStatus.Validated)
+    }
+
+    (fr"""
+    with total_time_spent as (
+      select user_id, sum(date_part('epoch', last_tick_at - completed_at)) / (60 * 60) as duration
+      from
+        task_sessions join tasks on tasks.id = task_sessions.task_id
+        join annotation_projects on tasks.annotation_project_id = annotation_projects.id
+      where annotation_projects.campaign_id = $campaignId
+      group by user_id
+    ),
+    total_tasks_completed as (
+      select user_id, count(distinct(task_sessions.id)) as tasks_completed
+      from
+        task_sessions join tasks on task_sessions.task_id = tasks.id
+        join annotation_projects on tasks.annotation_project_id = annotation_projects.id
+      where from_status = $fromStatus and to_status = $toStatus
+      and campaign_id = $campaignId
+      group by user_id
+    )
+    select users.profile_image_uri, users.name, users.id,
+    total_time_spent.duration, total_tasks_completed.tasks_completed
+    from
+      total_tasks_completed join users on total_tasks_completed.user_id = users.id
+      join total_time_spent on total_time_spent.user_id = users.id
+    """ ++ Page(page)).query[CampaignPerformance]
+  }
+
+  private[database] def uniqueUsersQ(campaignId: UUID): Query0[Long] = fr"""
+    select count(distinct(user_id))
+    from
+      task_sessions join tasks on task_sessions.task_id = tasks.id
+      join annotation_projects on tasks.annotation_project_id = annotation_projects.id
+      where campaign_id = $campaignId
+  """.query[Long]
+
   def performance(
       campaignId: UUID,
-      sessionEndState: TaskSessionType,
+      sessionType: TaskSessionType,
       page: PageRequest
-  ): ConnectionIO[PaginatedResponse[CampaignPerformance]] = ???
+  ): ConnectionIO[PaginatedResponse[CampaignPerformance]] = {
+
+    // it's hard to use the GroupQueryBuilder here, since the task complete counts
+    // and total time spent have different support in task_sessions.
+    // the latter uses _all_ task sessions in this campaign, while the former uses
+    // only task sessions that result in a complete session.
+    // so instead, it's back to the common table expression adventure that has
+    // bitten us recently with performance problems where we had unfiltered joins.
+    // since it's on my mind, I just won't _do_ that, but uh you, dear reader,
+    // should be suspicious that I'm going to get this exactly right from a
+    // scalable query perspective.
+    // also note: this "time spent" doesn't do any de-duplication, which will give
+    // us weird results if, for example, someone opens multiple tabs to do labeling.
+    // this calculation gets a lot harder when worrying about overlapping intervals.
+    // that said, this effectively results in a performance penalty for keeping a lot
+    // of tasks pretty much locked against others interacting with them, which I think
+    // is a reasonable thing to do.
+    val perfQuery = performanceQ(campaignId, sessionType, page)
+      .to[List]
+
+    val uniqueUsersQuery: ConnectionIO[Long] = uniqueUsersQ(campaignId).unique
+
+    (perfQuery, uniqueUsersQuery) mapN {
+      case (results, count) =>
+        PaginatedResponse(
+          count.toInt,
+          page.offset > 0,
+          count > (page.offset + 1 * page.limit),
+          page.offset,
+          page.limit,
+          results
+        )
+    }
+  }
 }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -1023,7 +1023,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       user: User,
       annotationProjectParams: AnnotationProjectQueryParameters,
       annotationProjectIdOpt: Option[UUID],
-      limit: Int,
+      limit: Long,
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[Task.TaskFeature]] =
     for {
@@ -1038,7 +1038,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
         .filter(annotationProjectParams)
         .filter(annotationProjectIdOpt)
         .filter(fr"is_active = true")
-        .list(limit) map { projects =>
+        .list(limit.toInt) map { projects =>
         projects map { _.id }
       }
       campaignAuthedProjects <- annotationProjectParams.campaignId traverse {
@@ -1057,7 +1057,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
                   .filter(annotationProjectParams)
                   .filter(annotationProjectIdOpt)
                   .filter(fr"is_active = true")
-                  .list(limit) map { projects =>
+                  .list(limit.toInt) map { projects =>
                   projects map { _.id }
                 }
               case AuthFailure() => List.empty[UUID].pure[ConnectionIO]

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -240,7 +240,7 @@ object TaskSessionDao extends Dao[TaskSession] {
       user: User,
       annotationProjectParams: AnnotationProjectQueryParameters,
       annotationProjectIdOpt: Option[UUID],
-      limit: Int,
+      limit: Long,
       taskParams: TaskQueryParameters
   ): ConnectionIO[Option[TaskSession]] = {
     val sessionCreate =
@@ -259,7 +259,7 @@ object TaskSessionDao extends Dao[TaskSession] {
         )
         .filter(annotationProjectParams)
         .filter(annotationProjectIdOpt)
-        .list(limit) map { projects =>
+        .list(limit.toInt) map { projects =>
         projects map { _.id }
       }
       taskOpt <- annotationProjectIds.toNel flatTraverse { projectIds =>

--- a/app-backend/db/src/main/scala/util/Page.scala
+++ b/app-backend/db/src/main/scala/util/Page.scala
@@ -33,9 +33,9 @@ object Page {
       case "childrenCount"  => Some("children_count")
       case "capturedAt"     => Some("captured_at")
       case "tasksCompleted" => Some("tasks_completed")
-      case "hoursSpent"     => Some("hours_spent")
-      case "labellingRate"  => Some("tasks_completed / hours_spent")
-      case "validationRate" => Some("tasks_completed / hours_spent")
+      case "hoursSpent"     => Some("duration")
+      case "labellingRate"  => Some("tasks_completed / duration")
+      case "validationRate" => Some("tasks_completed / duration")
       case _                => None
     }
   }
@@ -45,8 +45,8 @@ object Page {
       pageRequest: PageRequest,
       defaultOrderBy: Fragment = fr"id ASC"
   ): Fragment = {
-    val offset: Int = pageRequest.offset * pageRequest.limit
-    val limit: Int = pageRequest.limit
+    val offset = pageRequest.offset * pageRequest.limit
+    val limit = pageRequest.limit
 
     val orderBy: Fragment = createOrderClause(pageRequest, defaultOrderBy)
     orderBy ++ fr"LIMIT $limit OFFSET $offset"

--- a/app-backend/db/src/main/scala/util/Page.scala
+++ b/app-backend/db/src/main/scala/util/Page.scala
@@ -21,18 +21,22 @@ object Page {
       // the COALESCE of these two columns is indexed already
       case "acquisitionDatetime" =>
         Some("COALESCE(acquisition_date, created_at)")
-      case "sunAzimuth"    => Some("sun_azimuth")
-      case "sunElevation"  => Some("sun_elevation")
-      case "cloudCover"    => Some("cloud_cover")
-      case "createdAt"     => Some("created_at")
-      case "modifiedAt"    => Some("modified_at")
-      case "title"         => Some("title")
-      case "id"            => Some("id")
-      case "role"          => Some("role")
-      case "visibility"    => Some("visibility")
-      case "childrenCount" => Some("children_count")
-      case "capturedAt"    => Some("captured_at")
-      case _               => None
+      case "sunAzimuth"     => Some("sun_azimuth")
+      case "sunElevation"   => Some("sun_elevation")
+      case "cloudCover"     => Some("cloud_cover")
+      case "createdAt"      => Some("created_at")
+      case "modifiedAt"     => Some("modified_at")
+      case "title"          => Some("title")
+      case "id"             => Some("id")
+      case "role"           => Some("role")
+      case "visibility"     => Some("visibility")
+      case "childrenCount"  => Some("children_count")
+      case "capturedAt"     => Some("captured_at")
+      case "tasksCompleted" => Some("tasks_completed")
+      case "hoursSpent"     => Some("hours_spent")
+      case "labellingRate"  => Some("tasks_completed / hours_spent")
+      case "validationRate" => Some("tasks_completed / hours_spent")
+      case _                => None
     }
   }
 
@@ -48,10 +52,11 @@ object Page {
     orderBy ++ fr"LIMIT $limit OFFSET $offset"
   }
 
-  def apply(pageRequest: Option[PageRequest]): Fragment = pageRequest match {
-    case Some(pr) => apply(pr)
-    case None     => fr""
-  }
+  def apply(pageRequest: Option[PageRequest]): Fragment =
+    pageRequest match {
+      case Some(pr) => apply(pr)
+      case None     => fr""
+    }
 
   @SuppressWarnings((Array("TraversableHead")))
   def createOrderClause(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignPerformanceSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/CampaignPerformanceSpec.scala
@@ -1,0 +1,60 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.datamodel.{Order, PageRequest, TaskSessionType}
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.util.UUID
+
+class CampaignPerformanceSpec
+    extends AnyFunSuite
+    with doobie.scalatest.IOChecker
+    with DBTestConfig {
+
+  val transactor = xa
+
+  val campaignId: UUID = UUID.randomUUID
+
+  test("performance query is valid for label sessions") {
+    check {
+      CampaignDao.performanceQ(
+        campaignId,
+        TaskSessionType.LabelSession,
+        PageRequest(
+          0,
+          10,
+          Map(
+            "hoursSpent" -> Order.Asc,
+            "tasksCompleted" -> Order.Desc,
+            "labellingRate" -> Order.Asc
+          )
+        )
+      )
+    }
+  }
+
+  test("performance query is valid for validation sessions") {
+    check {
+      CampaignDao.performanceQ(
+        campaignId,
+        TaskSessionType.ValidateSession,
+        PageRequest(
+          0,
+          10,
+          Map(
+            "hoursSpent" -> Order.Asc,
+            "tasksCompleted" -> Order.Desc,
+            "validationRate" -> Order.Asc
+          )
+        )
+      )
+    }
+  }
+
+  test("unique users query is valid") {
+    check {
+      CampaignDao.uniqueUsersQ(campaignId)
+    }
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR adds performance endpoints for campaign labeling and validating.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Notes

One surprising change here was changing types in `Page` and `PaginatedResponse`. According to `doobie`, the `limit` and `offset` parameters expected `bigints`, while we were passing `Int`s. I think maybe this doesn't make a difference in real life when running queries, but because so many of our queries are _run_ instead of just _typechecked_, we didn't notice until now (or something changed with doobie and postgres between when we started with doobie and now). Anyway, I don't think this will make a practical difference?

These queries are typechecked instead of property tested because the amount of setup necessary to get a realistic test with pagination and multiple users and expectations over aggregations and sorts is pretty huge. Instead I made sure that the pagination request included sorts over all of the fields we're interested in and verified that it's still a valid query.

Also, I included a lengthy comment about the performance issues we've had with unfiltered subqueries in CTEs recently, but I'll mention it here as well -- I think I did the right thing, but I could be wrong, so please check while reviewing that you think I've filtered the intermediate CTEs appropriately.

## Testing Instructions

- point GW to local RF to make sure that the pagination changes don't mess with the campaigns list
- inspect query and make sure you agree it includes everything needed for the linked issue

Closes raster-foundry/groundwork#1463
