### PR TITLE
Add CRUD for task session labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Added index to annotation label class id in the labels to classes join table [#5587](https://github.com/raster-foundry/raster-foundry/pull/5587)
 
+### Added
+- CRUD for task session labels [#5590](https://github.com/raster-foundry/raster-foundry/pull/5590)
+
 ### Fixed
 - Improved performance of random review task query [#5588](https://github.com/raster-foundry/raster-foundry/pull/5588)
 

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -258,3 +258,10 @@ Path,Domain:Action,Verb
 /api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
 /api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put
 /api/tasks/session,annotationProjects:readTasks,post
+/api/tasks/{taskId}/sessions/{sessionId}/labels,annotationProjects:createAnnotation,get
+/api/tasks/{taskId}/sessions/{sessionId}/labels,annotationProjects:createAnnotation,post
+/api/tasks/{taskId}/sessions/{sessionId}/labels/{labelId},annotationProjects:createAnnotation,get
+/api/tasks/{taskId}/sessions/{sessionId}/labels/{labelId},annotationProjects:createAnnotation,put
+/api/tasks/{taskId}/sessions/{sessionId}/labels/{labelId},annotationProjects:createAnnotation,delete
+/api/tasks/{taskId}/sessions/{sessionId}/labels/bulk,annotationProjects:createAnnotation,post
+/api/tasks/{taskId}/sessions/{sessionId}/labels/bulk,annotationProjects:createAnnotation,put

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -72,12 +72,12 @@ trait TaskRoutes
                       }
                     }
                   }
-                }
-              } ~ pathPrefix("bulk") {
-                post {
-                  bulkCreateSessionLabels(taskId, sessionId)
-                } ~ put {
-                  bulkUpdateSessionLabels(taskId, sessionId)
+                } ~ pathPrefix("bulk") {
+                  post {
+                    bulkCreateSessionLabels(taskId, sessionId)
+                  } ~ put {
+                    bulkUpdateSessionLabels(taskId, sessionId)
+                  }
                 }
               }
             }
@@ -148,8 +148,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
+                hasActiveSession <-
+                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType
@@ -639,7 +639,8 @@ trait TaskRoutes
             case Success(rowCount) =>
               if (rowCount == -1) complete {
                 StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
-              } else complete { StatusCodes.OK }
+              }
+              else complete { StatusCodes.OK }
             case Failure(e) =>
               logger.error(e.getMessage)
               complete {

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -4,6 +4,7 @@ import com.rasterfoundry.akkautil._
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
 import com.rasterfoundry.database.Implicits._
 import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel.GeoJsonCodec._
 import com.rasterfoundry.datamodel._
 
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
@@ -51,6 +52,32 @@ trait TaskRoutes
               } ~ pathPrefix("complete") {
                 put {
                   completeSession(taskId, sessionId)
+                }
+              } ~ pathPrefix("labels") {
+                pathEndOrSingleSlash {
+                  get {
+                    listSessionLabels(taskId, sessionId)
+                  } ~ post {
+                    createLabel(taskId, sessionId)
+                  }
+                } ~ pathPrefix(JavaUUID) { labelId =>
+                  {
+                    pathEndOrSingleSlash {
+                      get {
+                        getLabel(taskId, sessionId, labelId)
+                      } ~ put {
+                        updateLabel(taskId, sessionId, labelId)
+                      } ~ delete {
+                        deleteLabel(taskId, sessionId, labelId)
+                      }
+                    }
+                  }
+                }
+              } ~ pathPrefix("bulk") {
+                post {
+                  bulkCreateSessionLabels(taskId, sessionId)
+                } ~ put {
+                  bulkUpdateSessionLabels(taskId, sessionId)
                 }
               }
             }
@@ -363,6 +390,262 @@ trait TaskRoutes
                 logger.error(e.getMessage)
                 complete { HttpResponse(StatusCodes.BadRequest) }
             }
+        }
+      }
+    }
+
+  def listSessionLabels(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authorized(
+              taskId,
+              user,
+              ActionType.View
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            TaskSessionDao
+              .listActiveLabels(sessionId)
+              .transact(xa)
+              .unsafeToFuture
+              .map { labels: List[AnnotationLabelWithClasses] =>
+                labels.map(_.toGeoJSONFeature)
+              }
+          }
+        }
+      }
+    }
+
+  def createLabel(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authWriteLabelToSession(taskId, sessionId, user)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[AnnotationLabelWithClasses.GeoJSONFeatureCreate]) {
+            featureCreate =>
+              onSuccess(
+                TaskSessionDao
+                  .insertLabels(
+                    taskId,
+                    sessionId,
+                    List(featureCreate.toAnnotationLabelWithClassesCreate),
+                    user
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+                  .map { labels: List[AnnotationLabelWithClasses] =>
+                    // the inserted annotation is just one feature
+                    // so we return the first feature from the returned list
+                    labels.headOption.map(_.toGeoJSONFeature)
+                  }
+              ) { createdLabel =>
+                complete((StatusCodes.Created, createdLabel))
+              }
+          }
+        }
+      }
+    }
+
+  def bulkCreateSessionLabels(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authWriteLabelToSession(taskId, sessionId, user)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) { fc =>
+            val labelWithClassesCreateList = fc.features map {
+              _.toAnnotationLabelWithClassesCreate
+            }
+            onSuccess(
+              TaskSessionDao
+                .insertLabels(
+                  taskId,
+                  sessionId,
+                  labelWithClassesCreateList.toList,
+                  user
+                )
+                .transact(xa)
+                .unsafeToFuture
+                .map { labels: List[AnnotationLabelWithClasses] =>
+                  fromSeqToFeatureCollection[
+                    AnnotationLabelWithClasses,
+                    AnnotationLabelWithClasses.GeoJSON
+                  ](
+                    labels
+                  )
+                }
+            ) { createdLabels =>
+              complete((StatusCodes.Created, createdLabels))
+            }
+          }
+        }
+      }
+    }
+
+  def bulkUpdateSessionLabels(taskId: UUID, sessionId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authWriteLabelToSession(taskId, sessionId, user)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[AnnotationLabelWithClassesFeatureCollection]) { fc =>
+            val labelWithClassesCreateList = fc.features map {
+              _.toAnnotationLabelWithClassesOpt
+            }
+            onSuccess(
+              TaskSessionDao
+                .bulkReplaceLabelsInSession(
+                  taskId,
+                  sessionId,
+                  labelWithClassesCreateList.toList.flatten,
+                  user
+                )
+                .transact(xa)
+                .unsafeToFuture
+                .map { labels: List[AnnotationLabelWithClasses] =>
+                  fromSeqToFeatureCollection[
+                    AnnotationLabelWithClasses,
+                    AnnotationLabelWithClasses.GeoJSON
+                  ](
+                    labels
+                  )
+                }
+            ) { createdLabels =>
+              complete((StatusCodes.Created, createdLabels))
+            }
+          }
+        }
+      }
+    }
+
+  def getLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authorized(
+              taskId,
+              user,
+              ActionType.View
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          rejectEmptyResponse {
+            complete {
+              TaskSessionDao
+                .getLabel(sessionId, labelId)
+                .transact(xa)
+                .unsafeToFuture
+                .map { labelOpt: Option[AnnotationLabelWithClasses] =>
+                  labelOpt.map(_.toGeoJSONFeature)
+                }
+            }
+          }
+        }
+      }
+    }
+
+  def updateLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authWriteLabelToSession(taskId, sessionId, user)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[AnnotationLabelWithClasses.GeoJSON]) { feature =>
+            onSuccess(
+              (feature.toAnnotationLabelWithClassesOpt traverse { label =>
+                TaskSessionDao
+                  .updateLabel(
+                    taskId,
+                    sessionId,
+                    labelId,
+                    label,
+                    user
+                  )
+              }).transact(xa).unsafeToFuture
+            ) {
+              case Some(updatedLabel) =>
+                complete(
+                  (StatusCodes.Created, updatedLabel.map(_.toGeoJSONFeature))
+                )
+              case _ =>
+                complete(
+                  (StatusCodes.BadRequest -> "NO MATCHING LABEL TO UPDATE")
+                )
+            }
+          }
+        }
+      }
+    }
+
+  def deleteLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
+        user
+      ) {
+        authorizeAsync {
+          TaskSessionDao
+            .authWriteLabelToSession(
+              taskId,
+              sessionId,
+              user
+            )
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onComplete {
+            TaskSessionDao
+              .deleteLabel(taskId, sessionId, labelId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            case Success(rowCount) =>
+              if (rowCount == -1) complete {
+                StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
+              } else complete { StatusCodes.OK }
+            case Failure(e) =>
+              logger.error(e.getMessage)
+              complete {
+                StatusCodes.BadRequest -> "ERROR IN LABEL DELETE"
+              }
+          }
         }
       }
     }

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -148,8 +148,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <-
-                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType
@@ -639,8 +639,7 @@ trait TaskRoutes
             case Success(rowCount) =>
               if (rowCount == -1) complete {
                 StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
-              }
-              else complete { StatusCodes.OK }
+              } else complete { StatusCodes.OK }
             case Failure(e) =>
               logger.error(e.getMessage)
               complete {

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -39,6 +39,10 @@ final case class AnnotationLabelWithClassesFeatureCollectionCreate(
     features: Seq[AnnotationLabelWithClasses.GeoJSONFeatureCreate],
     nextStatus: Option[TaskStatus] = None
 )
+@JsonCodec
+final case class AnnotationLabelWithClassesFeatureCollection(
+    features: Seq[AnnotationLabelWithClasses.GeoJSON]
+)
 
 @JsonCodec
 final case class AnnotationLabelWithClasses(
@@ -98,6 +102,15 @@ final case class AnnotationLabelWithClasses(
       classMap
     )
   }
+
+  def toCreate =
+    AnnotationLabelWithClasses.Create(
+      geometry,
+      annotationLabelClasses,
+      description,
+      isActive,
+      sessionId
+    )
 }
 
 object AnnotationLabelWithClasses {
@@ -141,7 +154,23 @@ object AnnotationLabelWithClasses {
       geometry: Option[Projected[Geometry]],
       properties: AnnotationLabelWithClassesProperties,
       @JsonKey("type") _type: String = "Feature"
-  ) extends GeoJSONFeature
+  ) extends GeoJSONFeature {
+    def toAnnotationLabelWithClassesOpt =
+      geometry map { geom =>
+        AnnotationLabelWithClasses(
+          id,
+          properties.createdAt,
+          properties.createdBy,
+          geom,
+          properties.annotationProjectId,
+          properties.annotationTaskId,
+          properties.description,
+          properties.isActive,
+          properties.sessionId,
+          properties.annotationLabelClasses
+        )
+      }
+  }
 
   @JsonCodec
   final case class GeoJSONFeatureCreate(

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -287,7 +287,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     )).update.run
   }
 
-  def toggleByLabelId(
+  def toggleByActiveLabelId(
       id: UUID,
       toggle: Boolean
   ): ConnectionIO[Int] = {

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -392,7 +392,7 @@ object TaskSessionDao extends Dao[TaskSession] {
       } yield updatedLabel
     } else {
       for {
-        _ <- AnnotationLabelDao.toggleByLabelId(labelId, false)
+        _ <- AnnotationLabelDao.toggleByActiveLabelId(labelId, false)
         inserted <- insertLabels(
           taskId,
           sessionId,
@@ -421,7 +421,7 @@ object TaskSessionDao extends Dao[TaskSession] {
         case Some(label) if label.annotationTaskId == taskId =>
           if (label.sessionId == Some(sessionId))
             filterLabel(sessionId, labelId).delete
-          else AnnotationLabelDao.toggleByLabelId(labelId, false)
+          else AnnotationLabelDao.toggleByActiveLabelId(labelId, false)
         case _ => (-1).pure[ConnectionIO]
       }
     } yield row

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskSessionDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskSessionDaoSpec.scala
@@ -494,11 +494,11 @@ class TaskSessionDaoSpec
               }
               labelToUpdateOpt = insertedLabelsOpt flatMap (_.headOption)
               _ <- labelToUpdateOpt traverse { labelToUpdate =>
-                AnnotationLabelDao.toggleByLabelId(labelToUpdate.id, false)
+                AnnotationLabelDao.toggleByActiveLabelId(labelToUpdate.id, false)
               }
               listedLabels <- TaskSessionDao.listActiveLabels(dbTaskSession.id)
               _ <- labelToUpdateOpt traverse { labelToUpdate =>
-                AnnotationLabelDao.toggleByLabelId(labelToUpdate.id, true)
+                AnnotationLabelDao.toggleByActiveLabelId(labelToUpdate.id, true)
               }
               listedLabelsAfterToggle <-
                 TaskSessionDao.listActiveLabels(dbTaskSession.id)


### PR DESCRIPTION
## Overview

This PR adds label CRUD endpoint related to task sessions.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- Assemble backend, run migration, spin up frontend and backend, grab a token
- From the DB, grab a task's ID that has UNLABELED status
- Grab some label classes from one of your campaign that has the task from step 2
- Create a task session with the task ID you grabbed from the last step
```
curl --location --request POST 'http://localhost:<your port number>/api/tasks/<task id>/sessions' \
--header 'Authorization: Bearer <your_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "sessionType": "LABEL_SESSION"
}'
```
- List active labels of this session. It should return an empty list
```
curl --location --request GET 'http://localhost:<your port>/api/tasks/<task id>/sessions/<session id from previous response>/labels' \
--header 'Authorization: Bearer <your token>'
```
- Post a label to this session, it should return a Feature of what you posted:
```
curl --location --request POST 'http://localhost:<port>/api/tasks/<task ID>/sessions/<session ID>/labels' \
--header 'Authorization: Bearer <token>' \
--header 'Content-Type: application/json' \
--data-raw '{
      "type": "Feature",
      "properties": {
        "annotationLabelClasses": [
          "<a class ID from step 3>"
        ],
        "sessionId": "<session ID>"
      },
      "geometry": {
        "type": "MultiPolygon",
        "coordinates": [
          [
            [
              [
                28.4849851,
                41.1065474
              ],
              [
                28.4855833,
                41.1065253
              ],
              [
                28.4855812,
                41.1068195
              ],
              [
                28.4849895,
                41.1068381
              ],
              [
                28.4849851,
                41.1065474
              ]
            ]
          ]
        ]
      }
    }'
```
- Now run the list request again to make sure there is one active label listed
- Now send `GET` to this one label, it should return a Feature of the polygon you posted to this session:
```
curl --location --request GET 'http://localhost:<port>/api/tasks/<task id>/sessions/<session id>/labels/<label id>' \
--header 'Authorization: Bearer <token>'
```
- Copy the return from the `GET`, which is a label object as a Feature. Update its label class to some other available classes from the step 3, and send `PUT` to update the label class. Inspect the return, the label class should be updated:
```
curl --location --request PUT 'http://localhost:<port>/api/tasks/<task id>/sessions/<session id>/labels/<label id>' \
--header 'Authorization: Bearer token' \
--header 'Content-Type: application/json' \
--data-raw '{
    "id": "<ID>",
    "geometry": <geom>,
    "properties": {
        ...
        "annotationLabelClasses": [
            "<another class ID>"
        ],
        ...
    },
    "type": "Feature"
}'
```
- Delete a single label should also work:
```
curl --location --request DELETE 'http://localhost:<port>/api/tasks/<task ID>/sessions/<session id>/labels/<label id>' \
--header 'Authorization: Bearer token'
```

Closes https://github.com/raster-foundry/groundwork/issues/1434
