### PR TITLE
Add endpoint to update task status and action only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - CRUD for task session labels [#5590](https://github.com/raster-foundry/raster-foundry/pull/5590)
+- Endpoint to update task status and action only [#5593](https://github.com/raster-foundry/raster-foundry/pull/5593)
 
 ### Fixed
 - Improved performance of random review task query [#5588](https://github.com/raster-foundry/raster-foundry/pull/5588)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -48,6 +48,7 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/,annotationProjects:readTasks,get
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/,annotationProjects:updateTasks,put
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/,annotationProjects:deleteTasks,delete
+/api/annotation-projects/{annotationProjectID}/tasks/{taskID}/status,annotationProjects:updateTasks,put
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/lock/,annotationProjects:createAnnotation,post
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/lock/,annotationProjects:createAnnotation,delete
 /api/annotation-projects/{annotationProjectID}/tasks/{taskID}/labels,annotationProjects:createAnnotation,put

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -341,15 +341,14 @@ trait AnnotationProjectTaskRoutes
           }).transact(xa).unsafeToFuture
         } {
           entity(as[TaskNextStatus]) { taskNextStatus =>
-            complete {
+            onSuccess(
               TaskDao
                 .updateTaskStatus(taskId, taskNextStatus, user)
-                .transact(xa) map {
-                case None =>
-                  HttpResponse(StatusCodes.NotFound)
-                case _ =>
-                  HttpResponse(StatusCodes.NoContent)
-              } unsafeToFuture
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              case Some(task) => complete((StatusCodes.Accepted, task))
+              case _          => complete(StatusCodes.NotFound)
             }
           }
         }

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -317,6 +317,45 @@ trait AnnotationProjectTaskRoutes
       }
     }
 
+  def updateTaskStatus(projectId: UUID, taskId: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.AnnotationProjects, Action.UpdateTasks, None),
+        user
+      ) {
+        authorizeAsync {
+          (for {
+            auth1 <- AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Annotate
+              )
+            auth2 <- TaskDao.isLockingUserOrUnlocked(taskId, user)
+            auth3 <- TaskDao.getTaskById(taskId) map { taskO =>
+              taskO map { _.annotationProjectId }
+            }
+          } yield {
+            auth1.toBoolean && auth2 && auth3 == Some(projectId)
+          }).transact(xa).unsafeToFuture
+        } {
+          entity(as[TaskNextStatus]) { taskNextStatus =>
+            complete {
+              TaskDao
+                .updateTaskStatus(taskId, taskNextStatus, user)
+                .transact(xa) map {
+                case None =>
+                  HttpResponse(StatusCodes.NotFound)
+                case _ =>
+                  HttpResponse(StatusCodes.NoContent)
+              } unsafeToFuture
+            }
+          }
+        }
+      }
+    }
+
   def lockTask(projectId: UUID, taskId: UUID): Route =
     toggleLock(projectId, taskId, TaskDao.lockTask(taskId))
 
@@ -474,20 +513,8 @@ trait AnnotationProjectTaskRoutes
                     annotationLabelWithClassesCreate.toList,
                     user
                   )
-                _ <- fc.nextStatus traverse {
-                  status =>
-                    // this is fine to do unsafely, because we know from authorization that the
-                    // task definitely exists
-                    TaskDao.unsafeGetTaskById(taskId) flatMap { task =>
-                      val taskFeature =
-                        task.copy(status = status).toGeoJSONFeature(Nil)
-                      val tfc = taskFeature.toFeatureCreate
-                      TaskDao.updateTask(
-                        task.id,
-                        tfc,
-                        user
-                      )
-                    }
+                _ <- fc.nextStatus traverse { status =>
+                  TaskDao.updateTaskStatus(taskId, TaskNextStatus(status), user)
                 }
               } yield {
                 insert

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -178,6 +178,12 @@ trait AnnotationProjectRoutes
             } ~ delete {
               deleteTask(projectId, taskId)
             }
+          } ~ pathPrefix("status") {
+            pathEndOrSingleSlash {
+              put {
+                updateTaskStatus(projectId, taskId)
+              }
+            }
           } ~ pathPrefix("lock") {
             pathEndOrSingleSlash {
               post {

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1046,6 +1046,19 @@ object Generators extends ArbitraryInstances {
   private def taskStatusListGen: Gen[List[TaskStatus]] =
     Gen.oneOf(0, 5) flatMap { Gen.listOfN(_, taskStatusGen) }
 
+  private def taskNextStatusGen: Gen[TaskNextStatus] =
+    for {
+      nextStatus <- taskStatusGen
+      note <-
+        if (nextStatus == TaskStatus.Flagged) {
+          nonEmptyStringGen map { s =>
+            Some(NonEmptyString.unsafeFrom(s))
+          }
+        } else {
+          Gen.const(None)
+        }
+    } yield TaskNextStatus(nextStatus, note)
+
   private val stacAnnotationExportGenTup =
     (
       nonEmptyStringGen,
@@ -1509,5 +1522,8 @@ object Generators extends ArbitraryInstances {
     implicit def arbLabelClassGroup
         : Arbitrary[AnnotationLabelClassGroup.Create] =
       Arbitrary { labelClassGroupGen }
+
+    implicit def arbTaskNextStatus: Arbitrary[TaskNextStatus] =
+      Arbitrary { taskNextStatusGen }
   }
 }

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -414,3 +414,13 @@ final case class UnionedGeomWithStatus(
     status: TaskStatus,
     geometry: Projected[Geometry]
 )
+
+final case class TaskNextStatus(
+    nextStatus: TaskStatus,
+    note: Option[NonEmptyString] = None
+)
+
+object TaskNextStatus {
+  implicit val decTaskNextStatus: Decoder[TaskNextStatus] =
+    deriveDecoder
+}

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/TaskDaoSpec.scala
@@ -2098,9 +2098,14 @@ class TaskDaoSpec
                 case (afterUpdate, beforeUpdate) =>
                   val isStatusUpdateCorrect =
                     afterUpdate.properties.status == taskNextStatus.nextStatus
+
                   val isNoteUpdateCorrect =
                     afterUpdate.properties.note == taskNextStatus.note
-                  val isActionUpdateCorrect =
+
+                  val isActionUpdateCorrect = if (
+                    beforeUpdate.properties.status == taskNextStatus.nextStatus
+                  ) afterUpdate.properties.actions.size == 0
+                  else
                     afterUpdate.properties.actions.exists(action =>
                       action.fromStatus == beforeUpdate.properties.status && action.toStatus == taskNextStatus.nextStatus
                     )


### PR DESCRIPTION
## Overview

This PR:
- adds a data model and an endpoint for updating task status and action only
- adds dao methods and property tests for this new endpoint
- updates endpoint for adding label, so that when next status is provided in the label request, use the new dao method to update task status and action

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [X] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- CI should pass as new tests are added in this PR
- Use instructions in: https://github.com/raster-foundry/groundwork/pull/1529 to test changes in action

Closes https://github.com/azavea/raster-foundry-platform/issues/1278
