### PR TITLE
Add endpoint to get active task session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Switched to group query builder for AnnotationLabels for all non-test code [#5596](https://github.com/raster-foundry/raster-foundry/pull/5596)
 
+### Added
+- Added an endpoint to get active task session [#5599](https://github.com/raster-foundry/raster-foundry/pull/5599)
+
 ## 1.65.0 - 2021-06-30
 ### Changed
 - Added index to annotation label class id in the labels to classes join table [#5587](https://github.com/raster-foundry/raster-foundry/pull/5587)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -255,6 +255,7 @@ Path,Domain:Action,Verb
 /api/campaigns/{campaignId}/performance/validate,campaigns:read,get
 /api/tasks/{taskId}/sessions,annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions,annotationProjects:createAnnotation,post
+/api/tasks/{taskId}/sessions/active,annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions/{sessionId},annotationProjects:readTasks,get
 /api/tasks/{taskId}/sessions/{sessionId}/keep-alive,annotationProjects:createAnnotation,put
 /api/tasks/{taskId}/sessions/{sessionId}/complete,annotationProjects:createAnnotation,put

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -154,8 +154,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <-
-                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
+                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                  taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType
@@ -645,8 +645,7 @@ trait TaskRoutes
             case Success(rowCount) =>
               if (rowCount == -1) complete {
                 StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
-              }
-              else complete { StatusCodes.OK }
+              } else complete { StatusCodes.OK }
             case Failure(e) =>
               logger.error(e.getMessage)
               complete {

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -672,11 +672,19 @@ trait TaskRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          complete {
+          onComplete {
             TaskSessionDao
-              .getActiveSessionByTaskId(taskId, user)
+              .getActiveSessionByTaskId(taskId)
               .transact(xa)
               .unsafeToFuture
+          } {
+            case Success(Some(session)) =>
+              complete((StatusCodes.Created, session))
+            case Success(None) =>
+              complete(StatusCodes.NoContent)
+            case Failure(e) =>
+              logger.error(e.getMessage)
+              complete(StatusCodes.BadRequest, "ERROR IN LABEL DELETE")
           }
         }
       }

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -154,8 +154,8 @@ trait TaskRoutes
           entity(as[TaskSession.Create]) { taskSessionCreate =>
             onComplete {
               (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
+                hasActiveSession <-
+                  TaskSessionDao.hasActiveSessionByTaskId(taskId)
                 hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
                   taskId,
                   taskSessionCreate.sessionType
@@ -645,7 +645,8 @@ trait TaskRoutes
             case Success(rowCount) =>
               if (rowCount == -1) complete {
                 StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
-              } else complete { StatusCodes.OK }
+              }
+              else complete { StatusCodes.OK }
             case Failure(e) =>
               logger.error(e.getMessage)
               complete {
@@ -672,13 +673,11 @@ trait TaskRoutes
             .transact(xa)
             .unsafeToFuture
         } {
-          rejectEmptyResponse {
-            complete {
-              TaskSessionDao
-                .getActiveSessionByTaskId(taskId, user)
-                .transact(xa)
-                .unsafeToFuture
-            }
+          complete {
+            TaskSessionDao
+              .getActiveSessionByTaskId(taskId, user)
+              .transact(xa)
+              .unsafeToFuture
           }
         }
       }

--- a/app-backend/db/src/main/scala/TaskSessionDao.scala
+++ b/app-backend/db/src/main/scala/TaskSessionDao.scala
@@ -447,10 +447,9 @@ object TaskSessionDao extends Dao[TaskSession] {
     } yield replaced
 
   def getActiveSessionByTaskId(
-      taskId: UUID,
-      user: User
+      taskId: UUID
   ): ConnectionIO[Option[TaskSession]] =
-    activeSessionByTaskIdQB(taskId, Some(user.id))
+    activeSessionByTaskIdQB(taskId)
       .list(PageRequest(0, 1, Map("last_tick_at" -> Order.Desc)))
       .map(_.headOption)
 }


### PR DESCRIPTION
## Overview

This PR adds an endpoint `api/tasks/{id}/session/active` to return the active session of a task.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~Swagger specification updated~
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- CI should pass as new property tests were added for the dao method
- Assemble backend, run migration, spin up frontend and backend, grab a token
- From the DB, grab a task's ID that has UNLABELED status
- Get an active session of the task. It should return an empty response
```
curl --location --request GET 'http://localhost:<your port number>/api/tasks/<task_id>/sessions/active' \
--header 'Authorization: Bearer <your_token>'
```
- Create a task session
```
curl --location --request POST 'http://localhost:<your port number>/api/tasks/<task_id>/sessions' \
--header 'Authorization: Bearer <your_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "sessionType": "LABEL_SESSION"
}'
```
- Get an active session of the task. It should return the session you just created
```
curl --location --request GET 'http://localhost:<your port number>/api/tasks/<task_id>/sessions/active' \
--header 'Authorization: Bearer <your_token>'
```
- Complete this session
```
curl --location --request PUT 'http://localhost:9091/api/tasks/<task_id>/sessions/<session_id>/complete' \
--header 'Authorization: Bearer <your_token>' \
--header 'Content-Type: application/json' \
--data-raw '{
    "toStatus": "LABELED",
    "note": null
}'
```
- Get an active session of the task. It should return an empty response
```
curl --location --request GET 'http://localhost:<your port number>/api/tasks/<task_id>/sessions/active' \
--header 'Authorization: Bearer <your_token>'
```

Closes https://github.com/raster-foundry/groundwork/issues/1549
