### PR TITLE
Fix bad logic for getting most recent note in task status regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Corrected strategy for acquiring note text when regressing task statuses to "flagged" [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
+
+### Added
+- Failed task lock expirations now send errors to rollbar [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
 
 ## [1.66.0] - 2021-07-23
 ### Fixed

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.backsplash.server
 import com.rasterfoundry.backsplash.MosaicImplicits
 import com.rasterfoundry.backsplash.error._
 import com.rasterfoundry.backsplash.middleware.AccessLoggingMiddleware
+import com.rasterfoundry.common.RollbarNotifier
 import com.rasterfoundry.common.{Config => CommonConfig}
 import com.rasterfoundry.database.Config.statusReapingConfig
 import com.rasterfoundry.database.TaskDao
@@ -20,7 +21,6 @@ import cats.implicits._
 import com.colisweb.tracing.core.TracingContextBuilder
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.olegpy.meow.hierarchy._
-import com.typesafe.scalalogging.LazyLogging
 import cron4s.Cron
 import doobie.implicits._
 import eu.timepit.fs2cron.awakeEveryCron
@@ -35,7 +35,7 @@ import scala.concurrent.duration._
 
 import java.util.concurrent.{Executors, TimeUnit}
 
-object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
+object Main extends IOApp with HistogramStoreImplicits with RollbarNotifier {
 
   val rasterIO: ContextShift[IO] = IO.contextShift(
     ExecutionContext.fromExecutor(
@@ -165,6 +165,7 @@ object Main extends IOApp with HistogramStoreImplicits with LazyLogging {
     .attempt
     .map {
       _.leftMap { err =>
+        sendError(err)
         logger.error(err.getMessage)
       }
     }

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -756,7 +756,6 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
               -instant.toEpochMilli
             })
           sorted.drop(1).headOption map { secondMostRecentStamp =>
-            println(s"Most recent stamp: $secondMostRecentStamp")
             val previousStatus = secondMostRecentStamp.toStatus
             val previousNote = secondMostRecentStamp.note
             (previousStatus, previousNote)

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -730,7 +730,7 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
       """).update.run
   }
 
-  private def regressTaskStatus(
+  private[database] def regressTaskStatus(
       taskId: UUID,
       taskStatus: TaskStatus
   ): ConnectionIO[(TaskStatus, Option[NonEmptyString])] =


### PR DESCRIPTION
## Overview

This PR:

- [x] adds a failing (initially) test reproducing how the unlocker is failing in production
- [x] adds Rollbar to the auto-unlocker call so we'll see when it's not working better
- [x] fixes the logic so we'll get the note correctly and not get into this (exact) situation again

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Demo

First CI failure is the demonstration that the test cooperates

### Notes

Search "Failing row contains" in CloudWatch logs in the backsplash container to see that this replicates the production failure.

The `task unlocking respects most recent status` test ensures that I didn't ruin the other task status logic while fixing the flagged task logic.

## Testing Instructions

- tests are fine

Closes #5605 
