### PR TITLE
Add cache control to label and task MVT routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.66.0] - 2021-07-27
-### Fixed
-- Corrected strategy for acquiring note text when regressing task statuses to "flagged" [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
-
-### Added
-- Failed task lock expirations now send errors to rollbar [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
-- Added a static page [#5607](https://github.com/raster-foundry/raster-foundry/pull/5607)
+### Changed
+- MVT layers for tasks and labels send cache-directives for more freshness [#5608](https://github.com/raster-foundry/raster-foundry/pull/5608)
 
 ## [1.66.0] - 2021-07-23
 ### Fixed
@@ -23,6 +17,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Remove frontend & promote backend [#5602](https://github.com/raster-foundry/raster-foundry/pull/5602)
 - Added additional locking for auto task unlocker [#5604](https://github.com/raster-foundry/raster-foundry/pull/5604/files)
+
+## [1.66.0] - 2021-07-27
+### Fixed
+- Corrected strategy for acquiring note text when regressing task statuses to "flagged" [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
+
+### Added
+- Failed task lock expirations now send errors to rollbar [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
+- Added a static page [#5607](https://github.com/raster-foundry/raster-foundry/pull/5607)
 
 ## 1.65.0 - 2021-06-30
 ### Changed
@@ -986,6 +988,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Included missing `pow` operation for decoding json representations of analyses [#4179](https://github.com/raster-foundry/raster-foundry/pull/4140), [#4155](https://github.com/raster-foundry/raster-foundry/issues/4155)
 
 [Unreleased]: https://github.com/raster-foundry/raster-foundry/compare/v1.66.0...HEAD
+[1.66.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.65.0...v1.66.0
 [1.66.0]: https://github.com/raster-foundry/raster-foundry/compare/v1.65.0...v1.66.0
 [1.64.3]: https://github.com/raster-foundry/raster-foundry/compare/v1.64.2...v1.64.3
 [1.64.2]: https://github.com/raster-foundry/raster-foundry/compare/v1.64.1...v1.64.2


### PR DESCRIPTION
## Overview

This PR adds a `no-cache` directive to the task MVT response and a `max-age=60` directive to the label MVT response. In conjunction with raster-foundry/groundwork#1593, it helps make sure the project overviews are significantly more up-to-date.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Notes

We have to do this kind of testing for now because of internal caching in mapbox-gl -- the GroundWork PR maaaaybe addresses that? it's a bit unclear.

## Testing Instructions

ON STAGING

- find an annotation project project with some unlabeled tasks
- choose one of them (remember where it is)
- label it and confirm
- click the x
- reopen the project overview --  your task will not have a new status 😡

On this branch locally

- assemble backsplash, bring up servers
- bring up local GroundWork
- do the same thing
- note that when you reopen the task map, your task has a _new status_ 😎
- inspect a label MVT response's headers and note that it has a `max-age` (this is because the label MVTs have a higher worst-case cost to calculate so we don't want _always_ to re-fetch because it's scary)

Closes #5595 

Closes #5594 
