### PR TITLE
Use JDK11 images when we're running a JAR

### DIFF
--- a/app-backend/api/Dockerfile
+++ b/app-backend/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
+FROM openjdk:11-slim
 
 RUN \
     adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf

--- a/app-backend/backsplash-server/Dockerfile
+++ b/app-backend/backsplash-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
 
 RUN \
     adduser --system --disabled-password --home /var/lib/rf --shell /sbin/nologin --disabled-password --group rf

--- a/app-tasks/Dockerfile
+++ b/app-tasks/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/openjdk-gdal:3.1-jdk8-slim
+FROM quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
 # did you change the image here, possibly to upgrade gdal?
 # if so, make sure that you verify that tifs that have trouble
 # becoming COGs due to the tiling scheme can still be processed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   api-server:
     # If changing container, make sure to update app-backend/api/Dockerfile as well
-    image: quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
+    image: openjdk:11-slim
     links:
       - postgres:database.service.rasterfoundry.internal
       - memcached:memcached.service.rasterfoundry.internal
@@ -123,7 +123,7 @@ services:
 
   backsplash:
     # If changing container, make sure to update app-backend/backsplash-server/Dockerfile as well
-    image: quay.io/azavea/openjdk-gdal:2.4-jdk8-slim
+    image: quay.io/azavea/openjdk-gdal:2.4-jdk11-slim
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Overview

Reverts the changes made in #5401 that were originally introduced by #5035.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Swagger specification updated
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

TBD.

Resolves https://github.com/azavea/raster-foundry-platform/issues/743
