### PR TITLE
Setup improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Updated some setup steps and Auth0 interaction for more convenient external user use [#5612](https://github.com/raster-foundry/raster-foundry/pull/5612)
 
 ## [1.66.2] - 2021-07-29
 ### Changed
 - MVT layers for tasks and labels send cache-directives for more freshness [#5608](https://github.com/raster-foundry/raster-foundry/pull/5608)
-
-## [1.66.0] - 2021-07-27
-### Fixed
-- Corrected strategy for acquiring note text when regressing task statuses to "flagged" [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
-
-### Added
-- Failed task lock expirations now send errors to rollbar [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
-- Added a static page [#5607](https://github.com/raster-foundry/raster-foundry/pull/5607)
 
 ## [1.66.0] - 2021-07-23
 ### Fixed
@@ -27,6 +21,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Remove frontend & promote backend [#5602](https://github.com/raster-foundry/raster-foundry/pull/5602)
 - Added additional locking for auto task unlocker [#5604](https://github.com/raster-foundry/raster-foundry/pull/5604/files)
+
+## [1.66.0] - 2021-07-27
+### Fixed
+- Corrected strategy for acquiring note text when regressing task statuses to "flagged" [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
+
+### Added
+- Failed task lock expirations now send errors to rollbar [#5606](https://github.com/raster-foundry/raster-foundry/pull/5606)
+- Added a static page [#5607](https://github.com/raster-foundry/raster-foundry/pull/5607)
 
 ## 1.65.0 - 2021-06-30
 ### Changed

--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -366,9 +366,11 @@ trait Authentication extends Directives with LazyLogging {
       case _       => GroupRole.Member
     }
 
-    val isGroundworkUser = jwtClaims
-      .getBooleanClaim("https://app.rasterfoundry.com;annotateApp")
-      .booleanValue()
+    val isGroundworkUser = Option(
+      jwtClaims
+        .getBooleanClaim("https://app.rasterfoundry.com;annotateApp")) map {
+      _.booleanValue()
+    } getOrElse false
 
     val userScope: Scope =
       Option(

--- a/app-backend/datamodel/src/main/scala/auth/AuthorizedToken.scala
+++ b/app-backend/datamodel/src/main/scala/auth/AuthorizedToken.scala
@@ -1,9 +1,31 @@
 package com.rasterfoundry.datamodel.auth
 
-import io.circe.generic.JsonCodec
+import cats.syntax.all._
+import io.circe.{Decoder, Encoder, HCursor}
+import io.circe.generic.semiauto._
 
-@JsonCodec
 final case class AuthorizedToken(id_token: String,
                                  access_token: String,
                                  expires_in: Int,
                                  token_type: String)
+
+object AuthorizedToken {
+  implicit val encAuthorizedToken: Encoder[AuthorizedToken] = deriveEncoder
+
+  implicit val decAuthorizedToken: Decoder[AuthorizedToken] = { (c: HCursor) =>
+    (
+      c.get[Option[String]]("id_token"),
+      c.get[String]("access_token"),
+      c.get[Int]("expires_in"),
+      c.get[String]("token_type")
+    ).mapN {
+      case (idTokenO, accessToken, expiresIn, tokenType) =>
+        AuthorizedToken(
+          idTokenO getOrElse accessToken,
+          accessToken,
+          expiresIn,
+          tokenType
+        )
+    }
+  }
+}

--- a/app-backend/datamodel/src/main/scala/auth/AuthorizedToken.scala
+++ b/app-backend/datamodel/src/main/scala/auth/AuthorizedToken.scala
@@ -1,8 +1,8 @@
 package com.rasterfoundry.datamodel.auth
 
 import cats.syntax.all._
-import io.circe.{Decoder, Encoder, HCursor}
 import io.circe.generic.semiauto._
+import io.circe.{Decoder, Encoder, HCursor}
 
 final case class AuthorizedToken(id_token: String,
                                  access_token: String,

--- a/scripts/update
+++ b/scripts/update
@@ -18,10 +18,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         echo "Building Scala assembly JARs"
-        pushd "app-backend"
-            ./sbt \
-                ";api/assembly;backsplash-server/assembly;batch/assembly;backsplash-export/assembly"
-        popd
+        ./sbt \
+            ";api/assembly;backsplash-server/assembly;batch/assembly;backsplash-export/assembly"
 
         echo "Running application database migrations"
         ./scripts/migrate migrate


### PR DESCRIPTION
## Overview

This PR makes a few changes to setup instructions and interaction with Auth0.

The setup instructions change was to remove the directory navigation from `scripts/setup`. After #5602, it's no longer correct to switch to `app-backend` to assemble things.

The Auth0 interaction changes make it so that:

- we don't get a `NullPointerException` when we have JWTs that are missing a specific claim
- we can get exchange refresh tokens for bearer tokens using the ROP flow documented in azavea/raster-foundry-platform#1306 (the response is a different shape in that setting)

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- tested extensively as part of azavea/raster-foundry-platform#1295
