### PR TITLE
Use original filename for COG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Changed
 - Indexed all foreign key references to users [#5611](https://github.com/raster-foundry/raster-foundry/pull/5611)
+- Use original filename for COG [#5613](https://github.com/raster-foundry/raster-foundry/pull/5613)
 
 ### Fixed
 - Updated some setup steps and Auth0 interaction for more convenient external user use [#5612](https://github.com/raster-foundry/raster-foundry/pull/5612)

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Helper and development scripts are located in the `./scripts` directory at the r
 | `cipublish`             | Publish container images to container image repositories.    |
 | `load_development_data` | Load data for development purposes from S3                   |
 | `rsync-back`            | Perform a one-way `rsync` from the VM to the host.           |
+| `process-upload`        | Process an upload in development                             |
 
 ## Testing
 
@@ -123,4 +124,13 @@ Run all the tests:
 
 ```bash
 $ ./scripts/test
+```
+
+## Processing Imagery
+
+In staging and production, a batch job will automatically be kicked off for processing after a
+successful upload. In development, you need to process the upload manually which you can do like so:
+
+```bash
+$ ./scripts/process-upload <upload_id>
 ```

--- a/app-backend/api/src/main/scala/uploads/Credentials.scala
+++ b/app-backend/api/src/main/scala/uploads/Credentials.scala
@@ -2,7 +2,7 @@ package com.rasterfoundry.api.uploads
 
 import com.rasterfoundry.api.utils.Config
 import com.rasterfoundry.common.S3
-import com.rasterfoundry.datamodel.User
+import com.rasterfoundry.datamodel.Upload
 
 import com.amazonaws.auth.{AWSCredentials, AWSSessionCredentials}
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
@@ -11,14 +11,15 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
 
 import java.sql.Timestamp
-import java.util.{Date, UUID}
+import java.util.Date
 
 @JsonCodec
-final case class Credentials(AccessKeyId: String,
-                             Expiration: String,
-                             SecretAccessKey: String,
-                             SessionToken: String)
-    extends AWSCredentials
+final case class Credentials(
+    AccessKeyId: String,
+    Expiration: String,
+    SecretAccessKey: String,
+    SessionToken: String
+) extends AWSCredentials
     with AWSSessionCredentials {
   override def getAWSAccessKeyId: String = this.AccessKeyId
 
@@ -28,20 +29,20 @@ final case class Credentials(AccessKeyId: String,
 }
 
 @JsonCodec
-final case class CredentialsWithBucketPath(credentials: Credentials,
-                                           bucketPath: String)
+final case class CredentialsWithBucketPath(
+    credentials: Credentials,
+    bucketPath: String
+)
 
 object CredentialsService extends Config with LazyLogging {
 
-  def getCredentials(user: User,
-                     uploadId: UUID,
-                     jwt: String): CredentialsWithBucketPath = {
-    val path = s"user-uploads/${user.id}/${uploadId.toString}"
+  def getCredentials(upload: Upload, jwt: String): CredentialsWithBucketPath = {
+    val path = upload.s3Path
     val stsClient = AWSSecurityTokenServiceClientBuilder.defaultClient
     val stsRequest = new AssumeRoleWithWebIdentityRequest
 
     stsRequest.setRoleArn(scopedUploadRoleArn)
-    stsRequest.setRoleSessionName(s"upload${uploadId}")
+    stsRequest.setRoleSessionName(s"upload${upload.id}")
     stsRequest.setWebIdentityToken(jwt)
     // Sessions for AWS account owners are restricted to a maximum of 3600 seconds. Longer durations seemed to give 501.
     // https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/securitytoken/model/GetSessionTokenRequest.html

--- a/app-backend/datamodel/src/main/scala/Upload.scala
+++ b/app-backend/datamodel/src/main/scala/Upload.scala
@@ -29,7 +29,11 @@ final case class Upload(
     bytesUploaded: Long,
     annotationProjectId: Option[UUID],
     generateTasks: Boolean
-)
+) {
+
+  lazy val s3Path: String =
+    s"user-uploads/$createdBy/$id"
+}
 
 object Upload {
 

--- a/app-tasks/rf/src/rf/uploads/geotiff/factories.py
+++ b/app-tasks/rf/src/rf/uploads/geotiff/factories.py
@@ -68,15 +68,15 @@ class GeoTiffS3SceneFactory(object):
             logger.info("Downloading %s => %s", infile, filename)
             bucket = s3.Bucket(bucket_name)
             with get_tempdir() as tempdir:
-                tmp_fname = os.path.join(tempdir, filename)
-                bucket.download_file(key, tmp_fname)
+                tmp_path = os.path.join(tempdir, filename)
+                bucket.download_file(key, tmp_path)
 
                 if self.fileType == "NON_SPATIAL":
-                    warped_fname = cog.georeference_file(tmp_fname)
+                    warped_path = cog.georeference_file(tmp_path)
                 else:
-                    warped_fname = tmp_fname
+                    warped_path = tmp_path
 
-                cog_path = cog.convert_to_cog(warped_fname, tempdir)
+                cog_path = cog.convert_to_cog(warped_path, tempdir, filename)
                 scene = self.create_geotiff_scene(
                     cog_path, os.path.splitext(filename)[0]
                 )
@@ -90,7 +90,7 @@ class GeoTiffS3SceneFactory(object):
                     )[0]
                 images = [
                     self.create_geotiff_image(
-                        warped_fname, unquote(scene.ingestLocation), scene, cog_path
+                        warped_path, unquote(scene.ingestLocation), scene, cog_path
                     )
                 ]
 

--- a/app-tasks/rf/src/rf/utils/cog.py
+++ b/app-tasks/rf/src/rf/utils/cog.py
@@ -44,7 +44,7 @@ def georeference_file(file_path):
     return translated_tiff
 
 
-def convert_to_cog(tif_path, local_dir, include_tiling_scheme: bool = True):
+def convert_to_cog(tif_path: str, local_dir: str, orig_filename: str, include_tiling_scheme: bool = True):
     is_valid_cog, _, _ = cog_validate(tif_path, strict=True)
     if is_valid_cog is True:
         logger.info("Skipping conversion of %s to a cog", tif_path)
@@ -53,7 +53,10 @@ def convert_to_cog(tif_path, local_dir, include_tiling_scheme: bool = True):
     logger.info("Converting %s to a cog", tif_path)
     with rasterio.open(tif_path) as src:
         has_64_bit = rasterio.dtypes.float64 in src.dtypes
-    out_path = os.path.join(local_dir, "cog.tif")
+    cog_dir = os.path.join(local_dir, "cog")
+    if not os.path.exists(cog_dir):
+        os.makedirs(cog_dir)
+    out_path = os.path.join(cog_dir, orig_filename)
     cog_command = [
         "gdal_translate",
         tif_path,
@@ -81,7 +84,7 @@ def convert_to_cog(tif_path, local_dir, include_tiling_scheme: bool = True):
             logger.warn(
                 "Couldn't process the tif with default command. Retrying without TILING_SCHEME=GoogleMapsCompatible"
             )
-            return convert_to_cog(tif_path, local_dir, False)
+            return convert_to_cog(tif_path, local_dir, orig_filename, False)
         else:
             raise
     return out_path

--- a/scripts/process-upload
+++ b/scripts/process-upload
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${RF_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0" username)
+Convenience script for processing an upload by id in development.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker-compose run --rm \
+                batch \
+                rf process-upload "$@"
+    fi
+fi
+

--- a/scripts/process-upload
+++ b/scripts/process-upload
@@ -13,13 +13,23 @@ Convenience script for processing an upload by id in development.
 "
 }
 
+function is_service_running() {
+  docker ps -q -f "status=running" --no-trunc | grep -q "$(docker-compose ps -q "$1")"
+}
+
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
-        docker-compose run --rm \
-                batch \
-                rf process-upload "$@"
+        service_name='api-server'
+        if is_service_running $service_name ; then
+            docker-compose run --rm \
+                    batch \
+                    rf process-upload "$@"
+        else
+            echo "The $service_name service must be running for upload processing to succeed. Exiting."
+            exit 1
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Overview
Maintain the original filename when generating COGs.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~[ ] Swagger specification updated~
- ~[ ] New tables and queries have appropriate indices added~
- ~[ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~[ ] Any new SQL strings have tests~
- ~[ ] Any new endpoints have scope validation and are included in the integration test csv~

### Demo
COGs now have a S3 URI like: `s3://<bucket>/user-uploads/<user_id>/<scene_id>/<original_filename>`. For example:
```
$ aws s3 ls 's3://rasterfoundry-development-data-us-east-1/user-uploads/auth0|59318a9d2fbbca3e16bcfc92/0d7b3e29-2dae-48f0-b8a0-e2d1659852ad/'
2021-08-11 15:42:15   17976459 382.tif
```

## Testing Instructions
- `sbt "project api" assembly`
- `docker-compose build batch`
- `./scripts/server`
- Grab a test TIF from the Groundwork UAT folder (I tested with 382.tif): https://drive.google.com/drive/u/0/folders/1-WkhZT7rt4NtmGSCj7HNsr18VdpjgrH-
- Upload file to Groundwork (upload should succeed)
- Run new convenience script to process upload (see README)
- Ensure output like `INFO:rf.utils.cog:Converting /tmp/tmp91r0rt7x/382.tif to a cog` is shown so that we know we're generating a new COG
- Run `./scripts/psql`
- Look up the upload id via `select id from uploads order by created_at desc limit 1;
- Look up the scene id via `select id from scenes order by created_at desc limit 1;`
- Ensure COG has maintained the original filename via command like so: `aws s3 ls s3://rasterfoundry-development-data-us-east-1/user-uploads/<user_id>/<scene_id>/<original_filename>`

Closes #5597 
