### PR TITLE
[wip] Add Groundwork Pro upgrade workflow

### DIFF
--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -137,6 +137,13 @@ trait Authentication extends Directives with LazyLogging {
     ConfigurableJwtValidator(jwkSet).validate(token)
   }
 
+  def getBooleanClaimOrFallback(
+      claims: JWTClaimsSet,
+      key: String,
+      fallback: java.lang.Boolean
+  ): java.lang.Boolean =
+    Try { claims.getBooleanClaim(key) } getOrElse { fallback }
+
   def getStringClaimOrBlank(claims: JWTClaimsSet, key: String): String =
     Option(claims.getStringClaim(key)).getOrElse("")
 
@@ -226,6 +233,12 @@ trait Authentication extends Directives with LazyLogging {
         val email = getStringClaimOrBlank(jwtClaims, "email")
         val name = getNameOrFallback(jwtClaims)
         val picture = getStringClaimOrBlank(jwtClaims, "picture")
+        val groundworkProUser =
+          getBooleanClaimOrFallback(
+            jwtClaims,
+            "https://app.rasterfoundry.com;groundworkProUser",
+            false
+          )
         final case class MembershipAndUser(
             platform: Option[Platform],
             user: User
@@ -238,7 +251,36 @@ trait Authentication extends Directives with LazyLogging {
           (user, roles) <- OptionT {
             u match {
               case UserOptionAndRoles(Some(user), roles) =>
-                IO.pure(Some((user, roles)))
+                val campaignScope = Scopes.resolveFor(
+                  Domain.Campaigns,
+                  Action.Create,
+                  user.scope.actions
+                )
+                campaignScope match {
+                  // a user who is present, who has a campaign creation scope, who has no limit
+                  // doesn't need to have the pro scope appended since they're already superpowered
+                  // for campaign creation
+                  case Some(ScopedAction(_, _, None)) =>
+                    IO.pure(Some((user, roles)))
+                  // similarly, a user who is present, who has a campaign creation scope, who has a limit
+                  // at least as large as the Groundwork Pro scope limit doesn't require any action
+                  case Some(ScopedAction(_, _, Some(x))) if x >= 50L =>
+                    IO.pure(Some((user, roles)))
+                  // For a user who has a scope that is present and less than 50L, if they're a pro user,
+                  // we need to append the Groundwork Pro user scope to their record
+                  case Some(_) if groundworkProUser =>
+                    (UserDao
+                      .appendScope(user.id, Scopes.GroundworkProUser) flatMap {
+                      _ =>
+                        UserDao.unsafeGetUserById(user.id) map { user =>
+                          Some((user, roles))
+                        }
+                    }).transact(xa)
+                  // a user who is present but has no campaigns claim is not a pro user, so do nothing. Also,
+                  // for any other limit if they don't have the groundwork pro claim in their JWT, do
+                  // nothing
+                  case None | Some(_) => IO.pure(Some((user, roles)))
+                }
               case UserOptionAndRoles(None, _) => {
                 createUserWithRoles(userId, email, name, picture, jwtClaims)
                   .transact(xa)
@@ -368,7 +410,8 @@ trait Authentication extends Directives with LazyLogging {
 
     val isGroundworkUser = Option(
       jwtClaims
-        .getBooleanClaim("https://app.rasterfoundry.com;annotateApp")) map {
+        .getBooleanClaim("https://app.rasterfoundry.com;annotateApp")
+    ) map {
       _.booleanValue()
     } getOrElse false
 


### PR DESCRIPTION
## Overview

This (wip) PR updates scopes and the authentication flow to bump users' limits when a special key is present in their JWT.
It's wip because there's some cursed caching going on and I haven't figured out where yet.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] Any new SQL strings have tests

### Demo

forthcoming

### Notes

There's still an Auth0 rule in the mix here, because adidng things to `app_metadata` doesn't automatically add them to the JWT, but fortunately the rule is just "copy what's in `app_metadata`" instead of anything involving inference about organization membership from emails.

## Testing Instructions

- forthcoming

Closes #XXX
