### PR TITLE
Extend healthcheck to 10 seconds in service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Indexed all foreign key references to users [#5611](https://github.com/raster-foundry/raster-foundry/pull/5611)
 - Use original filename for COG [#5613](https://github.com/raster-foundry/raster-foundry/pull/5613)
+- Extended backsplash healthcheck timeout to 10 seconds, which is longer than the ALB healthcheck timeout [#5616](https://github.com/raster-foundry/raster-foundry/pull/5616)
 
 ### Fixed
 - Updated some setup steps and Auth0 interaction for more convenient external user use [#5612](https://github.com/raster-foundry/raster-foundry/pull/5612)

--- a/app-backend/backsplash-server/src/main/resources/application.conf
+++ b/app-backend/backsplash-server/src/main/resources/application.conf
@@ -12,6 +12,9 @@ server {
   timeoutSeconds = 15
   timeoutSeconds = ${?BACKSPLASH_SERVER_TIMEOUT}
 
+  healthcheckTimeoutSeconds = 10
+  healthcheckTimeoutSeconds = ${?BACKSPLASH_SERVER_HEALTHCHECK_TIMEOUT}
+
   doAccessLogging = false
   doAccessLogging = ${?BACKSPLASH_SERVER_ACCESS_LOGGING}
 }

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Config.scala
@@ -14,6 +14,8 @@ object Config {
   object server {
     private val serverConfig = config.getConfig("server")
     val timeoutSeconds = serverConfig.getInt("timeoutSeconds")
+    val healthcheckTimeoutSeconds =
+      serverConfig.getInt("healthcheckTimeoutSeconds")
     val doAccessLogging = serverConfig.getBoolean("doAccessLogging")
   }
 

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/Main.scala
@@ -56,6 +56,12 @@ object Main extends IOApp with HistogramStoreImplicits with RollbarNotifier {
   val timeout: FiniteDuration =
     new FiniteDuration(Config.server.timeoutSeconds, TimeUnit.SECONDS)
 
+  val healthcheckTimeout: FiniteDuration =
+    new FiniteDuration(
+      Config.server.healthcheckTimeoutSeconds,
+      TimeUnit.SECONDS
+    )
+
   val backsplashErrorHandler: HttpErrorHandler[IO, BacksplashException] =
     new BacksplashHttpErrorHandler[IO]
 
@@ -154,7 +160,8 @@ object Main extends IOApp with HistogramStoreImplicits with RollbarNotifier {
   )
 
   val healthcheckService: HttpRoutes[IO] = new HealthcheckService(
-    xa
+    xa,
+    healthcheckTimeout
   ).routes
 
   private val statusExpirationDuration =

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
@@ -41,7 +41,7 @@ class HealthcheckService(xa: Transactor[IO])(
           case _ => HealthResult[Id](Health.Healthy)
         }
       }
-      .through(mods.timeoutToSick(3 seconds))
+      .through(mods.timeoutToSick(10 seconds))
       .through(mods.tagWith("db"))
 
   private def cacheHealth =
@@ -54,7 +54,7 @@ class HealthcheckService(xa: Transactor[IO])(
           case _ => HealthResult[Id](Health.Healthy)
         }
       }
-      .through(mods.timeoutToSick(3 seconds))
+      .through(mods.timeoutToSick(10 seconds))
       .through(mods.tagWith("cache"))
 
   val routes: HttpRoutes[IO] = HttpRoutes.of {

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/services/HealthcheckService.scala
@@ -18,10 +18,11 @@ import sup.{mods, Health, HealthCheck, HealthResult}
 
 import scala.concurrent.duration._
 
-class HealthcheckService(xa: Transactor[IO])(
-    implicit timer: Timer[IO],
-    contextShift: ContextShift[IO]
-) extends Http4sDsl[IO]
+class HealthcheckService(xa: Transactor[IO], timeout: FiniteDuration)(
+    implicit
+    timer: Timer[IO],
+    contextShift: ContextShift[IO])
+    extends Http4sDsl[IO]
     with LazyLogging {
 
   val cache = ProjectLayerCache.projectLayerCache
@@ -41,7 +42,7 @@ class HealthcheckService(xa: Transactor[IO])(
           case _ => HealthResult[Id](Health.Healthy)
         }
       }
-      .through(mods.timeoutToSick(10 seconds))
+      .through(mods.timeoutToSick(timeout))
       .through(mods.tagWith("db"))
 
   private def cacheHealth =
@@ -54,7 +55,7 @@ class HealthcheckService(xa: Transactor[IO])(
           case _ => HealthResult[Id](Health.Healthy)
         }
       }
-      .through(mods.timeoutToSick(10 seconds))
+      .through(mods.timeoutToSick(timeout))
       .through(mods.tagWith("cache"))
 
   val routes: HttpRoutes[IO] = HttpRoutes.of {
@@ -66,11 +67,13 @@ class HealthcheckService(xa: Transactor[IO])(
         val report = result.value
         if (report.health == Health.sick) {
           ServiceUnavailable(
-            Map("result" -> "sick".asJson,
-                "errors" -> report.checks
-                  .filter(_.health == Health.sick)
-                  .map(_.tag)
-                  .asJson)
+            Map(
+              "result" -> "sick".asJson,
+              "errors" -> report.checks
+                .filter(_.health == Health.sick)
+                .map(_.tag)
+                .asJson
+            )
           )
         } else {
           Ok(Map("result" -> "A-ok"))


### PR DESCRIPTION
## Overview

This PR extends the healthcheck timeout in backsplash from 3 to 10 seconds. 10 seconds isn't a magic / perfect number, but it's at least longer than the ALB healthcheck, which we want to be the case so that whether the load balancer can receive a timely response from the tile server determines service health.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

### Notes

I verified that the healthcheck parallelism was cooperating by adding prints at the start and end of each healthcheck and got these logs:

```
backsplash_1              | Checking db health
backsplash_1              | Checking cache health
backsplash_1              | Done checking db health
backsplash_1              | Done checking cache health
```

So that part is at least cooperating 🤔

This doesn't affect healthcheck speed, but it should get us fewer false positives

## Testing Instructions

- compare the value here to [the configured value in the deployment repo](https://github.com/azavea/raster-foundry-deployment/blob/develop/core/terraform/backsplash.tf#L56-L67) and make sure it's longer

Closes azavea/raster-foundry-platform#1318
