### PR TITLE
Expose human-in-the-loop info on annotation project routes and MVT labels layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - Included a README in STAC exports for campaigns [#5610](https://github.com/raster-foundry/raster-foundry/pull/5610/)
 - Added a `score` field to labels [#5614](https://github.com/raster-foundry/raster-foundry/pull/5614)
+- Added human-in-the-loop info to annotation project routes and label MVT [#5617](https://github.com/raster-foundry/raster-foundry/pull/5617)
 
 ### Removed
 - Tore down backsplash-export module and job [#5610](https://github.com/raster-foundry/raster-foundry/pull/5610/)
@@ -662,7 +663,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [1.20.0] - 2019-05-01
 ### Added
 - Included tests for project layer split behavior [#4901](https://github.com/raster-foundry/raster-foundry/pull/4901)
-- New publish page now lists analyses for selected layers [\\4902](https://github.com/raster-foundry/raster-foundry/pull/4902)
+- New publish page now lists analyses for selected layers [\4902](https://github.com/raster-foundry/raster-foundry/pull/4902)
 - Created metrics table and MetricDao for incrementing request counts [#4916](https://github.com/raster-foundry/raster-foundry/pull/4916)
 
 ### Changed
@@ -720,7 +721,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Preserve state of visible layers [#4802](https://github.com/raster-foundry/raster-foundry/pull/4802)
 - Display processing imports on layer scenes UI [#4809](https://github.com/raster-foundry/raster-foundry/pull/4809)
 - Added quick edit functionality for project analyses [#4804](https://github.com/raster-foundry/raster-foundry/pull/4804)
-- Add zooming, showing, hiding options to multi-select menu on analyses, layers [\\4816](https://github.com/raster-foundry/raster-foundry/pull/4816)
+- Add zooming, showing, hiding options to multi-select menu on analyses, layers [\4816](https://github.com/raster-foundry/raster-foundry/pull/4816)
 - Added API specifications back to core repository [#4819](https://github.com/raster-foundry/raster-foundry/pull/4819)
 - Added tile server support for visualizing masked mosaic layers [#4822](https://github.com/raster-foundry/raster-foundry/pull/4822/)
 - Added `overviewsLocation` and `minZoomLevel` to `projectLayers` [#4857](https://github.com/raster-foundry/raster-foundry/pull/4857)
@@ -805,7 +806,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added project, project layer, and template ID fields to tool runs for later filtering [#4546](https://github.com/raster-foundry/raster-foundry/pull/4546) and to API routes as filter fields [#4551](https://github.com/raster-foundry/raster-foundry/pull/4551)
 - Added project layer mosaic and scene order endpoint [#4547](https://github.com/raster-foundry/raster-foundry/pull/4547)
 - Add Layer ID to Annotations and Annotation Groups [#4558](https://github.com/raster-foundry/raster-foundry/pull/4558)
-- Support uploads to project layers on the API [#\\4524](https://github.com/raster-foundry/raster-foundry/pull/4524)
+- Support uploads to project layers on the API [#\4524](https://github.com/raster-foundry/raster-foundry/pull/4524)
 
 ### Changed
 - Reorganized project structure to simplify dependency graph (`tool` was mostly removed;   `tool`s still-relevant pieces,   `bridge`, and `datamodel` moved into the project `common`) [#4564](https://github.com/raster-foundry/raster-foundry/pull/4564)
@@ -825,7 +826,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Shapes drawn within the scene search filter context can now be saved [#4474](https://github.com/raster-foundry/raster-foundry/pull/4474)
-- Mosaics are again constructed with rasters instead of with IO[rasters][\#4498](<https://github.com/raster-foundry/raster-foundry/pull/4498>)
+- Mosaics are again constructed with rasters instead of with IO\[rasters][#4498](https://github.com/raster-foundry/raster-foundry/pull/4498)
 - Improved healthcheck logic in backsplash healthcheck endpoint [#4548](https://github.com/raster-foundry/raster-foundry/pull/4548)
 - Fixed bug for publishing project page [#4578](https://github.com/raster-foundry/raster-foundry/pull/4578)
 
@@ -912,7 +913,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added S3 path suggestions in scene import modal when users upload imageries from S3 buckets [#4290](https://github.com/raster-foundry/raster-foundry/pull/4290)
 - Enabled deleting lab templates on the frontend [#4287](https://github.com/raster-foundry/raster-foundry/pull/4287)
 - Added support for viewing public projects using backsplash [#4299](https://github.com/raster-foundry/raster-foundry/pull/4299)
-- Added script for reprocessing sentinel 2 scenes which were imported with the wrong number of bands [\4349]\(<https://github.com/raster-foundry/raster-foundry/pull/4349>
+- Added script for reprocessing sentinel 2 scenes which were imported with the wrong number of bands \[\4349]\(<https://github.com/raster-foundry/raster-foundry/pull/4349>
 
 ### Changed
 - Populate user profiles from their identity tokens more intelligently [#4298](https://github.com/raster-foundry/raster-foundry/pull/4298)
@@ -946,7 +947,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [1.14.0] - 2018-11-08
 ### Added
 - Administration
-  - Allow platforms to set a "From" email field in order to change notification "From" name [#\\4214](https://github.com/raster-foundry/raster-foundry/pull/4214)
+  - Allow platforms to set a "From" email field in order to change notification "From" name [#\4214](https://github.com/raster-foundry/raster-foundry/pull/4214)
   - Allow platform administrators to create uploads for other users within their platforms [#4237](https://github.com/raster-foundry/raster-foundry/pull/4237)
 - Added summary endpoint for annotation groups to list the number of labels with different qualities (YES, NO, MISS, UNSURE) to support annotation applications [#4221](https://github.com/raster-foundry/raster-foundry/pull/4221)
 - Added project histogram support for COG and Avro scenes in backsplash [#4190](https://github.com/raster-foundry/raster-foundry/pull/4190)

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -21,6 +21,7 @@ Path,Domain:Action,Verb
 /api/annotation-projects/{annotationProjectID}/,annotationProjects:read,get
 /api/annotation-projects/{annotationProjectID}/,annotationProjects:update,put
 /api/annotation-projects/{annotationProjectID}/,annotationProjects:delete,delete
+/api/annotation-projects/{annotationProjectID}/hitl,annotationProjects:read,get
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:readPermissions,get
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,put
 /api/annotation-projects/{annotationProjectID}/permissions/,annotationProjects:share,post

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -414,9 +414,8 @@ trait AnnotationProjectRoutes
             case false =>
               complete {
                 (for {
-                  projectO <-
-                    AnnotationProjectDao
-                      .getById(projectId)
+                  projectO <- AnnotationProjectDao
+                    .getById(projectId)
                   projectActions <- projectO traverse { project =>
                     if (project.createdBy == user.id) {
                       Set("*").pure[ConnectionIO]

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1150,7 +1150,7 @@ object Generators extends ArbitraryInstances {
       Gen.option(nonEmptyStringGen),
       Gen.const(true),
       Gen.option(uuidGen),
-      Gen.option(arbitrary[Int].map(_.toDouble))
+      Gen.option(arbitrary[Int].map(_.toFloat))
     ).mapN(AnnotationLabelWithClasses.Create.apply _)
 
   private def continentGen: Gen[Continent] =

--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -55,7 +55,7 @@ final case class AnnotationLabelWithClasses(
     description: Option[String] = None,
     isActive: Boolean,
     sessionId: Option[UUID] = None,
-    score: Option[Double] = None,
+    score: Option[Float] = None,
     annotationLabelClasses: List[UUID] = Nil
 ) extends GeoJSONSerializable[AnnotationLabelWithClasses.GeoJSON] {
   def toGeoJSONFeature =
@@ -128,7 +128,7 @@ object AnnotationLabelWithClasses {
       description: Option[String] = None,
       isActive: Boolean,
       sessionId: Option[UUID],
-      score: Option[Double] = None
+      score: Option[Float] = None
   ) {
     def toAnnotationLabelWithClasses(
         annotationProjectId: UUID,
@@ -253,7 +253,7 @@ final case class AnnotationLabelWithClassesPropertiesCreate(
     description: Option[String] = None,
     isActive: Boolean = true,
     sessionId: Option[UUID] = None,
-    score: Option[Double] = None
+    score: Option[Float] = None
 )
 
 object AnnotationLabelWithClassesPropertiesCreate {
@@ -272,7 +272,7 @@ object AnnotationLabelWithClassesPropertiesCreate {
           description: Option[String],
           isActive: Option[Boolean],
           sessionId: Option[UUID],
-          score: Option[Double]
+          score: Option[Float]
       ) =>
         AnnotationLabelWithClassesPropertiesCreate(
           annotationLabelClasses,
@@ -294,7 +294,7 @@ final case class AnnotationLabelWithClassesProperties(
     description: Option[String] = None,
     isActive: Boolean,
     sessionId: Option[UUID],
-    score: Option[Double]
+    score: Option[Float]
 )
 
 final case class StacGeoJSONFeatureCollection(

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -83,8 +83,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
     val labelClassFragments: List[Fragment] =
       annotationLabelsWithClasses flatMap { label =>
         label.annotationLabelClasses.map(labelClassId =>
-          fr"(${label.id}, ${labelClassId})"
-        )
+          fr"(${label.id}, ${labelClassId})")
       }
     for {
       insertedAnnotationIds <- annotationFragments.toNel traverse { fragments =>
@@ -197,22 +196,20 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .map((group.id, _))
       })
       labelGroupMap = labelGroups.map(g => (g.id -> g)).toMap
-      classIdToGroupName =
-        groupedLabelClasses
-          .map { classGroups =>
-            classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
-          }
-          .flatten
-          .toMap
-          .collect {
-            case (k, Some(v)) => k -> v.name
-          }
-      classIdToLabelName =
-        groupedLabelClasses
-          .map(_._2)
-          .flatten
-          .map(c => c.id -> c.name)
-          .toMap
+      classIdToGroupName = groupedLabelClasses
+        .map { classGroups =>
+          classGroups._2.map(_.id -> labelGroupMap.get(classGroups._1))
+        }
+        .flatten
+        .toMap
+        .collect {
+          case (k, Some(v)) => k -> v.name
+        }
+      classIdToLabelName = groupedLabelClasses
+        .map(_._2)
+        .flatten
+        .map(c => c.id -> c.name)
+        .toMap
       annotations <- OptionT.liftF(
         (selectF ++ taskJoinF ++ Fragments
           .whereAndOpt(
@@ -224,11 +221,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
           .query[AnnotationLabelWithClasses]
           .to[List]
       )
-    } yield StacGeoJSONFeatureCollection(
-      annotations.map(anno =>
-        anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName)
-      )
-    ).asJson
+    } yield
+      StacGeoJSONFeatureCollection(
+        annotations.map(anno =>
+          anno.toStacGeoJSONFeature(classIdToGroupName, classIdToLabelName))
+      ).asJson
     fcIo.value
   }
 
@@ -237,12 +234,11 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
       parentAnnotationProjectId: ParentAnnotationProjectId
   ): ConnectionIO[Unit] =
     for {
-      parentTask <-
-        TaskDao.query
-          .filter(
-            fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
-          )
-          .select
+      parentTask <- TaskDao.query
+        .filter(
+          fr"annotation_project_id = ${parentAnnotationProjectId.parentAnnotationProjectId}"
+        )
+        .select
       _ <- fr"""
       WITH source_labels_with_classes AS (
         SELECT * FROM
@@ -319,8 +315,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
 
     val labelClassF: List[Fragment] =
       label.annotationLabelClasses.map(labelClassId =>
-        fr"(${id}, ${labelClassId})"
-      )
+        fr"(${id}, ${labelClassId})")
 
     val updateLabelF = (fr"UPDATE " ++ tableF ++ fr"""SET
       geometry = ${label.geometry},

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -25,7 +25,7 @@ object MVTLayerDao {
       geom: Projected[Geometry],
       envelope: ProjectedExtent,
       taskId: UUID,
-      score: Option[Double],
+      score: Option[Float],
       labelClassId: UUID,
       className: String,
       colorHexCode: String

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -25,6 +25,7 @@ object MVTLayerDao {
       geom: Projected[Geometry],
       envelope: ProjectedExtent,
       taskId: UUID,
+      score: Option[Double],
       labelClassId: UUID,
       className: String,
       colorHexCode: String
@@ -83,6 +84,7 @@ object MVTLayerDao {
           annotation_labels.geometry,
           ST_TileEnvelope(${z}, ${x}, ${y}) as envelope,
           annotation_labels.annotation_task_id,
+          annotation_labels.score,
           annotation_label_classes.id as label_class_id,
           annotation_label_classes.name,
           annotation_label_classes.color_hex_code

--- a/app-backend/db/src/main/scala/MVTLayerDao.scala
+++ b/app-backend/db/src/main/scala/MVTLayerDao.scala
@@ -35,8 +35,8 @@ object MVTLayerDao {
         "annotation_task_id" -> VString(taskId.toString),
         "label_class_id" -> VString(labelClassId.toString),
         "name" -> VString(className),
-        "color_hex_code" -> VString(colorHexCode)
-      )
+        "color_hex_code" -> VString(colorHexCode),
+      ) ++ score.fold(Map.empty[String, Value])(v => Map("score" -> VDouble(v)))
   }
 
   private[database] def getAnnotationProjectTasksQ(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -634,7 +634,7 @@ class AnnotationLabelDaoSpec
 
           val hasScores = insertIO.transact(xa).unsafeRunSync
           assert(
-            hasScores === annotationCreates.exists(create => create.score.isSome),
+            hasScores === annotationCreates.exists(create => create.score.isDefined),
             "Project should have scores when input labels have scores"
           )
 

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -634,7 +634,7 @@ class AnnotationLabelDaoSpec
 
           val hasScores = insertIO.transact(xa).unsafeRunSync
           assert(
-            hasScores === annotationCreates.exists(create => create.scores.isSome),
+            hasScores === annotationCreates.exists(create => create.score.isSome),
             "Project should have scores when input labels have scores"
           )
 


### PR DESCRIPTION
## Overview

This PR:

- adds a new route to annotation projects called `hitl`, which exposes whether any labels in that project have _scores_ attached to them as a boolean
- adds label scores to the label MVT layer when present

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

### Demo

Here's what it enables:

https://user-images.githubusercontent.com/5702984/131262186-6aea69ca-6ba8-47da-8ffd-b1932433f72c.mp4

### Notes

The `hitl` boolean information _could_ live on the projects themselves, but I opted against that for now to avoid having to worry about how messing that query would affect other parts of applications that consume annotation projects. This way if I get the query wrong or it turns out to be more costly than I expect (it shouldn't! it's an "exists" query on an indexed column) most things won't have to care, and if we want to Do This For Real™️ we can update it later.

## Testing Instructions

- tests as part of a forthcoming linked GroundWork PR