### PR TITLE
Ship COG exports to special prefix for expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- STAC exports with COGs get uploaded to a prefix with an expiration policy configured [#5622](https://github.com/raster-foundry/raster-foundry/pull/5622)
 
 ## [1.67.0] - 2021-09-01
 ### Changed

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -16,6 +16,7 @@ import com.rasterfoundry.notification.intercom.{
 }
 
 import better.files.{File => ScalaFile}
+import cats.data.Nested
 import cats.effect._
 import cats.implicits._
 import com.amazonaws.services.s3.AmazonS3URI
@@ -24,6 +25,8 @@ import doobie._
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
 
+import java.sql.Timestamp
+import java.time.{Duration, Instant}
 import java.util.UUID
 
 final case class WriteStacCatalog(
@@ -67,7 +70,12 @@ final case class WriteStacCatalog(
       exportDefinition <- StacExportDao.unsafeGetById(exportId).transact(xa)
       tempDir = ScalaFile.newTemporaryDirectory()
       _ = tempDir.deleteOnExit()
-      currentPath = s"s3://$dataBucket/stac-exports"
+      isCogExport = Nested(exportDefinition.exportAssetTypes)
+        .find(_ == ExportAssetType.COG)
+        .isDefined
+      currentPath = if (isCogExport) {
+        s"s3://$dataBucket/stac-exports/cog-exports"
+      } else { s"s3://$dataBucket/stac-exports" }
       exportPath = s"$currentPath/${exportDefinition.id}"
       _ <- StacExportDao
         .update(
@@ -103,7 +111,9 @@ final case class WriteStacCatalog(
         val updatedExport =
           exportDefinition.copy(
             exportStatus = ExportStatus.Exported,
-            exportLocation = Some(exportPath)
+            exportLocation = Some(exportPath),
+            expiration =
+              Some(Timestamp.from(Instant.now.plus(Duration.ofDays(30L))))
           )
         StacExportDao.update(updatedExport, exportDefinition.id).transact(xa)
       }

--- a/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
+++ b/app-backend/batch/src/main/scala/stacExport/WriteStacCatalog.scala
@@ -112,8 +112,9 @@ final case class WriteStacCatalog(
           exportDefinition.copy(
             exportStatus = ExportStatus.Exported,
             exportLocation = Some(exportPath),
-            expiration =
+            expiration = if (isCogExport) {
               Some(Timestamp.from(Instant.now.plus(Duration.ofDays(30L))))
+            } else { None }
           )
         StacExportDao.update(updatedExport, exportDefinition.id).transact(xa)
       }

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -704,12 +704,12 @@ class CampaignStacExport(
       taskStatuses: List[String]
   ): IO[Option[newtypes.SceneItem]] = {
     for {
-      _ <- IO(logger.info(s"Building layer item from tile layers"))
+      _ <- IO(logger.info(s"Building imagery item from tile layers"))
       maybeScene <- AnnotationProjectDao
         .getFirstScene(annotationProject.id)
         .transact(xa)
       _ <- IO {
-        logger.info(maybeScene match {
+        logger.debug(maybeScene match {
           case Some(scene) => s"Found scene with id ${scene.id}"
           case _           => "No scene found"
         })
@@ -718,7 +718,7 @@ class CampaignStacExport(
         .listByProjectId(annotationProject.id)
         .transact(xa)
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Found ${tileLayers.size} tile layers"
         )
       }
@@ -737,17 +737,17 @@ class CampaignStacExport(
         )
       }
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Found assets $assets"
         )
       }
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Found links $links"
         )
       }
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Returning STAC item $item"
         )
       }

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -597,7 +597,7 @@ class CampaignStacExport(
     val maybeIngestLocation = maybeScene flatMap { _.ingestLocation }
     val signedUrlDurationInDays = 7
     for {
-      maybeSignedURLAsset: Option[Tuple2[String, StacAsset]] <- maybeIngestLocation match {
+      maybeSignedURLAsset: Option[(String, StacAsset)] <- maybeIngestLocation match {
         case Some(ingestLocation)
             if includeAssetTypeInExport(
               exportAssetTypes,
@@ -627,9 +627,9 @@ class CampaignStacExport(
         case _ =>
           IO.pure(None)
       }
-      maybeCOGAssetAndS3Link: Option[(Tuple2[String, StacAsset], Tuple2[
-        newtypes.AnnotationProjectId,
-        newtypes.S3URL])] <- maybeIngestLocation match {
+      maybeCOGAssetAndS3Link: Option[((String, StacAsset),
+      (newtypes.AnnotationProjectId,
+      newtypes.S3URL))] <- maybeIngestLocation match {
         case Some(ingestLocation)
             if includeAssetTypeInExport(
               exportAssetTypes,
@@ -658,22 +658,21 @@ class CampaignStacExport(
         case _ =>
           IO.pure(None)
       }
-      tileLayersAssets: List[Tuple2[String, StacAsset]] = tileLayers map {
-        layer =>
-          (
-            layer.name,
-            StacAsset(
-              layer.url,
-              Some("Image layer"), // The displayed title for clients and users
-              Some(s"${layer.layerType} tiles"),
-              Set(StacAssetRole.Data),
-              layer.layerType match {
-                case MVT =>
-                  Some(VendorMediaType("application/vnd.mapbox-vector-tile"))
-                case TMS => Some(`image/png`)
-              }
-            )
+      tileLayersAssets: List[(String, StacAsset)] = tileLayers map { layer =>
+        (
+          layer.name,
+          StacAsset(
+            layer.url,
+            Some("Image layer"), // The displayed title for clients and users
+            Some(s"${layer.layerType} tiles"),
+            Set(StacAssetRole.Data),
+            layer.layerType match {
+              case MVT =>
+                Some(VendorMediaType("application/vnd.mapbox-vector-tile"))
+              case TMS => Some(`image/png`)
+            }
           )
+        )
       }
       assets: Map[String, StacAsset] = Map(
         tileLayersAssets ++

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -594,32 +594,7 @@ class CampaignStacExport(
       annotationProjectId: UUID
   ): IO[(Map[String, StacAsset],
          Map[newtypes.AnnotationProjectId, newtypes.S3URL])] = {
-    val maybeIngestLocation = maybeScene match {
-      case Some(
-          Scene(
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            _,
-            Some(ingestLocation),
-            _,
-            _,
-            _,
-            _
-          )
-          ) =>
-        Some(ingestLocation)
-      case _ => None
-    }
+    val maybeIngestLocation = maybeScene flatMap { _.ingestLocation }
     val signedUrlDurationInDays = 7
     for {
       maybeSignedURLAsset: Option[Tuple2[String, StacAsset]] <- maybeIngestLocation match {

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -523,7 +523,8 @@ class CampaignStacExport(
           README.render(
             projList,
             state.annotationProjectLabelItems,
-            state.annotationProjectImageryItems
+            state.annotationProjectImageryItems,
+            state.exportDefinition.exportAssetTypes
           )
       }
     } yield {

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -741,11 +741,6 @@ class CampaignStacExport(
       }
       _ <- IO {
         logger.debug(
-          s"Found links $links"
-        )
-      }
-      _ <- IO {
-        logger.debug(
           s"Returning STAC item $item"
         )
       }

--- a/app-backend/batch/src/main/scala/stacExport/v2/README.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/README.scala
@@ -18,6 +18,9 @@ object README {
     "| :--------- | ----------- | ------------ |"
   )
 
+  private def tableEscape(s: String): String =
+    s.replace("|", """\\|""")
+
   private def renderRow(
       annotationProject: AnnotationProject,
       labelItemMap: LabelItemMap,
@@ -32,7 +35,7 @@ object README {
           s"labels/${labelItem.value.id}.json"
         val imageryItemPath =
           s"images/${imageryItem.value.id}/item.json"
-        s"| ${annotationProject.name} | $labelItemPath | $imageryItemPath |"
+        s"| ${tableEscape(annotationProject.name)} | $labelItemPath | $imageryItemPath |"
     }
 
   }
@@ -42,12 +45,12 @@ object README {
   ): String = {
     val assetDescriptionList = assetTypes map {
       case ExportAssetType.SignedURL =>
-        """| - *Signed URLs*: These URLs are links to files in AWS S3.
-           |   You can download those files by visiting the link in any browser.
-           |   After seven days, the URL will no longer work.""".trim.stripMargin
+        """|- *Signed URLs*: These URLs are links to files in AWS S3.
+           |  You can download those files by visiting the link in any browser.
+           |  After seven days, the URL will no longer work.""".trim.stripMargin
       case ExportAssetType.COG =>
-        """| - *Cloud-optimized GeoTIFFs*: These links refer to files present in the export. You can find them at the address listed relative to the item location.
-           |   You can open these files in QGIS.""".stripMargin
+        """|- *Cloud-optimized GeoTIFFs*: These links refer to files present in the export. You can find them at the address listed relative to the item location.
+           |  You can open these files in QGIS.""".trim.stripMargin
     }
     assetDescriptionList.toList.mkString("\n")
   }
@@ -57,15 +60,15 @@ object README {
   ): String = {
     val tmsDescription =
       """Imagery items in this export contain [TMS](https://en.wikipedia.org/wiki/Tile_Map_Service) URLs. You can put those
-  TMS URLs into tools like [geojson.io](http://geojson.io/#map=2/20.0/0.0) (via "Meta" -> "Add map layer") or QGIS (via
-  "XYZ Tiles") to view them."""
+TMS URLs into tools like [geojson.io](http://geojson.io/#map=2/20.0/0.0) (via "Meta" -> "Add map layer") or QGIS (via
+"XYZ Tiles") to view them."""
 
     exportAssetTypes.fold(tmsDescription)(nelAssetTypes => {
       tmsDescription ++ s"""
         | Imagery items also contain the following extra assets:
         |
-        | ${renderExtraAssetDescriptions(nelAssetTypes)}
-      """
+        |${renderExtraAssetDescriptions(nelAssetTypes)}
+      """.trim.stripMargin
     })
   }
 

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -26,7 +26,8 @@ final case class StacExport(
     taskStatuses: List[String],
     annotationProjectId: Option[UUID],
     campaignId: Option[UUID],
-    exportAssetTypes: Option[NonEmptyList[ExportAssetType]]
+    exportAssetTypes: Option[NonEmptyList[ExportAssetType]],
+    expiration: Option[Timestamp]
 ) {
   def createStacCollection(
       stacVersion: String,
@@ -148,6 +149,7 @@ object StacExport {
         this.taskStatuses.map(_.toString),
         Some(annotationProjectId),
         None,
+        None,
         None
       )
     }
@@ -178,7 +180,8 @@ object StacExport {
         this.taskStatuses.map(_.toString),
         None,
         Some(campaignId),
-        exportAssetTypes
+        exportAssetTypes,
+        None
       )
     }
   }

--- a/app-backend/db/src/main/resources/migrations/V82__add_expiration_to_stac_exports.sql
+++ b/app-backend/db/src/main/resources/migrations/V82__add_expiration_to_stac_exports.sql
@@ -1,0 +1,4 @@
+ALTER TABLE
+    stac_exports
+ADD
+    COLUMN expiration timestamp with time zone;

--- a/app-backend/db/src/main/scala/StacExportDao.scala
+++ b/app-backend/db/src/main/scala/StacExportDao.scala
@@ -20,7 +20,7 @@ object StacExportDao extends Dao[StacExport] {
         id, created_at, created_by, modified_at, owner,
         name, license, export_location, export_status,
         task_statuses, annotation_project_id, campaign_id,
-        export_asset_types
+        export_asset_types, expiration
       FROM
     """ ++ tableF
 
@@ -71,7 +71,8 @@ object StacExportDao extends Dao[StacExport] {
       "task_statuses",
       "annotation_project_id",
       "campaign_id",
-      "export_asset_types"
+      "export_asset_types",
+      "expiration"
     )
   }
 
@@ -81,7 +82,8 @@ object StacExportDao extends Dao[StacExport] {
       modified_at = ${now},
       name = ${stacExport.name},
       export_location = ${stacExport.exportLocation},
-      export_status = ${stacExport.exportStatus}
+      export_status = ${stacExport.exportStatus},
+      expiration = ${stacExport.expiration}
       where id = ${id}
       """).update.run
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/StacExportDaoSpec.scala
@@ -9,6 +9,8 @@ import org.scalacheck.Prop.forAll
 import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import java.sql.Timestamp
+import java.time.{Duration, Instant}
 
 class StacExportDaoSpec
     extends AnyFunSuite
@@ -208,6 +210,7 @@ class StacExportDaoSpec
             projectCreate: AnnotationProject.Create,
             stacExportCreate: StacExport.AnnotationProjectExport
         ) => {
+          val newExpiration = Timestamp.from(Instant.now.plus(Duration.ofDays(30L)))
           val updatetStacExportIO = for {
             dbUser <- UserDao.create(userCreate)
             dbProject <- AnnotationProjectDao.insert(projectCreate, dbUser)
@@ -223,7 +226,8 @@ class StacExportDaoSpec
               dbStacExport.copy(
                 exportStatus = ExportStatus.Exported,
                 exportLocation = Some(""),
-                taskStatuses = List()
+                taskStatuses = List(),
+                expiration=Some(newExpiration)
               ),
               dbStacExport.id
             )
@@ -267,6 +271,10 @@ class StacExportDaoSpec
           assert(
             se.annotationProjectId == selectedSe.annotationProjectId,
             "Selected and inserted StacExport annotation project ids should be the same"
+          )
+          assert(
+            selectedSe.expiration.isDefined && selectedSe.expiration == Some(newExpiration),
+            "Expiration was correctly updated"
           )
           true
         }


### PR DESCRIPTION
## Overview

This PR updates the STAC export code to ship exports with COGs to a special prefix. That prefix matches what's configured in azavea/raster-foundry-deployment#290.

It also:

- updates the generated README to describe what assets are present
- makes logs a little less noisy
- escapes `|` characters in project names, since they were breaking the markdown table

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [x] Any new SQL strings have tests

## Testing Instructions

- Download the catalog at `s3://rasterfoundry-development-data-us-east-1/stac-exports/cog-exports/41336b2c-2467-44e4-a04b-061ee0adb85c/catalog.zip` and unzip it
- check out its README -- it should look nice
- put its README in something that renders markdown (either preview in VSCode or throw it into a gist or something) and confirm that the project names' pipes appear in the right column
- note that its path is at `$DATA_BUCKET/stac-exports/cog-exports` and that that matches the linked deployment PR

Closes #5598 

Closes azavea/raster-foundry-platform#1319
