### PR TITLE
Pro export polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - STAC exports with COGs get uploaded to a prefix with an expiration policy configured [#5622](https://github.com/raster-foundry/raster-foundry/pull/5622)
 ### Fixed
-- Fixed STAC export image item's asset `href`s [#5621](https://github.com/raster-foundry/raster-foundry/pull/5621)
+- Fixed STAC export image item's asset `href`s [#5621](https://github.com/raster-foundry/raster-foundry/pull/5621), [#5625](https://github.com/raster-foundry/raster-foundry/pull/5625)
 
 ## [1.67.0] - 2021-09-01
 ### Changed

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -264,7 +264,11 @@ case class ExportData private (
                 file,
                 s"images/${sceneItem.value.id}/item.json"
               )
-          case _ => IO.pure(())
+          case _ =>
+            encodableToFile(
+              (withCollection `compose` withParentLinks)(sceneItem.value),
+              file,
+              s"images/${sceneItem.value.id}/item.json")
         }
     }).void
   }
@@ -684,12 +688,11 @@ class CampaignStacExport(
             }
           ).flatten: _*
       )
-      s3Links: Map[newtypes.AnnotationProjectId, newtypes.S3URL] = Map(
-        List(maybeCOGAssetAndS3Link flatMap {
-          case ((_, maybeS3Link)) => Some(maybeS3Link)
-          case _                  => None
-        }).flatten: _*
-      )
+      s3Links: Map[newtypes.AnnotationProjectId, newtypes.S3URL] = maybeCOGAssetAndS3Link
+        .map({ pair =>
+          Map(pair._2)
+        })
+        .getOrElse(Map.empty)
     } yield (assets, s3Links)
   }
 

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -92,6 +92,7 @@ object StacExport {
       taskStatuses: List[String],
       downloadUrl: Option[String],
       annotationProjectId: Option[UUID],
+      exportAssetTypes: Option[NonEmptyList[ExportAssetType]],
       expiration: Option[Timestamp]
   )
 
@@ -109,6 +110,7 @@ object StacExport {
       export.taskStatuses,
       signedDownload,
       export.annotationProjectId,
+      export.exportAssetTypes,
       export.expiration
     )
 

--- a/app-backend/datamodel/src/main/scala/StacExport.scala
+++ b/app-backend/datamodel/src/main/scala/StacExport.scala
@@ -91,7 +91,8 @@ object StacExport {
       exportStatus: ExportStatus,
       taskStatuses: List[String],
       downloadUrl: Option[String],
-      annotationProjectId: Option[UUID]
+      annotationProjectId: Option[UUID],
+      expiration: Option[Timestamp]
   )
 
   def signDownloadUrl(export: StacExport, signedDownload: Option[String]) =
@@ -107,7 +108,8 @@ object StacExport {
       export.exportStatus,
       export.taskStatuses,
       signedDownload,
-      export.annotationProjectId
+      export.annotationProjectId,
+      export.expiration
     )
 
   sealed abstract class Create {


### PR DESCRIPTION
## Overview

This PR fixes a few small bugs related to pro export:

- includes the asset types in the export object after signing
- includes the expiration in the export object after signing
- makes sure that we still write the item when we don't have a COG asset

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

I can demo this since I have a nice export lying around locally that goes fast

- assemble servers and batch
- bring up servers
- bring up GroundWork pointed to local
- create an export and process it
- refresh the STAC list and look at the network tab -- the `/stac` response should include expiration and export asset types
- download your export -- even though it doesn't have a COG you should still have an item

Closes #5624
