### PR TITLE
Keep score in toAnnotationLabelWithClassesCreate

### DIFF
--- a/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
+++ b/app-backend/datamodel/src/main/scala/AnnotationLabel.scala
@@ -189,7 +189,8 @@ object AnnotationLabelWithClasses {
         properties.annotationLabelClasses,
         properties.description,
         properties.isActive,
-        properties.sessionId
+        properties.sessionId,
+        properties.score
       )
     }
   }


### PR DESCRIPTION
## Overview

This PR fixes a bug where a transformation in the process from POST / PUT labels -> put labels in the database -> serialize labels back out was throwing away the score. Specifically, when we converted the features in an `AnnotationLabelWithClassesFeatureCollectionCreate` to `AnnotationLabelWithClasses.Create`, we dropped the score. Well really _I_ dropped the score. Get 'em next time.

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible

## Testing Instructions

- testing as part of foss4g workshop label import notebook -- scores should stick, and resulting cloned projects should have score filters