### PR TITLE
Include platform id in access logs

### DIFF
--- a/app-backend/akkautil/src/main/scala/Authentication.scala
+++ b/app-backend/akkautil/src/main/scala/Authentication.scala
@@ -155,13 +155,13 @@ trait Authentication extends Directives with LazyLogging {
       (Option(claims.getStringClaim(field)), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-      }
+    }
 
     val compareDelegatedToEmail = (field: String) =>
       (delegatedProfile.map(_.get(field).asInstanceOf[String]), email) match {
         case (fld @ Some(f), Some(e)) if f != e => fld
         case (f, _)                             => f
-      }
+    }
 
     compareToEmail("name")
       .orElse(compareToEmail("nickname"))
@@ -193,7 +193,7 @@ trait Authentication extends Directives with LazyLogging {
       str match {
         case s if !s.trim.isEmpty => Some(s)
         case _                    => None
-      }
+    }
 
     val defaultFromClaims = (field: String, str: String) =>
       optionEmpty(field)
@@ -297,8 +297,8 @@ trait Authentication extends Directives with LazyLogging {
               }
             }
           }
-          platformRole =
-            roles.find(role => role.groupType == GroupType.Platform)
+          platformRole = roles.find(role =>
+            role.groupType == GroupType.Platform)
           plat <- OptionT {
             platformRole match {
               case Some(role) =>

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassGroupRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassGroupRoutes.scala
@@ -31,7 +31,7 @@ trait AnnotationProjectLabelClassGroupRoutes
   def commonLabelClassGroupRoutes: CommonLabelClassGroupRoutes
 
   def listAnnotationProjectLabelClassGroups(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -60,7 +60,7 @@ trait AnnotationProjectLabelClassGroupRoutes
     }
 
   def createAnnotationProjectLabelClassGroup(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -113,7 +113,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -140,7 +140,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -172,7 +172,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -198,7 +198,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassGroupRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassGroupRoutes.scala
@@ -31,7 +31,7 @@ trait AnnotationProjectLabelClassGroupRoutes
   def commonLabelClassGroupRoutes: CommonLabelClassGroupRoutes
 
   def listAnnotationProjectLabelClassGroups(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -60,7 +60,7 @@ trait AnnotationProjectLabelClassGroupRoutes
     }
 
   def createAnnotationProjectLabelClassGroup(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -113,7 +113,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -140,7 +140,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -172,7 +172,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -198,7 +198,7 @@ trait AnnotationProjectLabelClassGroupRoutes
       projectId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassRoutes.scala
@@ -26,64 +26,12 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassGroupId: UUID
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          commonLabelClassRoutes.listLabelClasses(labelClassGroupId)
-        }
-      }
-    }
-
-  def addAnnotationProjectLabelClassToGroup(
-      projectId: UUID,
-      groupId: UUID
-  ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationLabelClass.Create]) { labelClassCreate =>
-            commonLabelClassRoutes.addLabelClass(labelClassCreate, groupId)
-          }
-        }
-      }
-    }
-
-  def getAnnotationProjectLabelClass(
-      projectId: UUID,
-      labelClassId: UUID
-  ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Read, None),
-        user
-      ) {
-        {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+          user
+        ) {
           authorizeAuthResultAsync {
             AnnotationProjectDao
               .authorized(
@@ -95,24 +43,21 @@ trait AnnotationProjectLabelClassRoutes
               .transact(xa)
               .unsafeToFuture
           } {
-            commonLabelClassRoutes.getLabelClass(
-              labelClassId
-            )
+            commonLabelClassRoutes.listLabelClasses(labelClassGroupId)
           }
         }
-      }
     }
 
-  def updateAnnotationProjectLabelClass(
+  def addAnnotationProjectLabelClassToGroup(
       projectId: UUID,
-      labelClassId: UUID
+      groupId: UUID
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Update, None),
-        user
-      ) {
-        {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Update, None),
+          user
+        ) {
           authorizeAuthResultAsync {
             AnnotationProjectDao
               .authorized(
@@ -124,65 +69,126 @@ trait AnnotationProjectLabelClassRoutes
               .transact(xa)
               .unsafeToFuture
           } {
-            entity(as[AnnotationLabelClass]) { updatedClass =>
-              commonLabelClassRoutes.updateLabelClass(
-                updatedClass,
+            entity(as[AnnotationLabelClass.Create]) { labelClassCreate =>
+              commonLabelClassRoutes.addLabelClass(labelClassCreate, groupId)
+            }
+          }
+        }
+    }
+
+  def getAnnotationProjectLabelClass(
+      projectId: UUID,
+      labelClassId: UUID
+  ): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+          user
+        ) {
+          {
+            authorizeAuthResultAsync {
+              AnnotationProjectDao
+                .authorized(
+                  user,
+                  ObjectType.AnnotationProject,
+                  projectId,
+                  ActionType.Annotate
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              commonLabelClassRoutes.getLabelClass(
                 labelClassId
               )
             }
           }
         }
-      }
+    }
+
+  def updateAnnotationProjectLabelClass(
+      projectId: UUID,
+      labelClassId: UUID
+  ): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Update, None),
+          user
+        ) {
+          {
+            authorizeAuthResultAsync {
+              AnnotationProjectDao
+                .authorized(
+                  user,
+                  ObjectType.AnnotationProject,
+                  projectId,
+                  ActionType.Edit
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              entity(as[AnnotationLabelClass]) { updatedClass =>
+                commonLabelClassRoutes.updateLabelClass(
+                  updatedClass,
+                  labelClassId
+                )
+              }
+            }
+          }
+        }
     }
 
   def activateAnnotationProjectLabelClass(
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          commonLabelClassRoutes.activeLabelClass(labelClassId)
-        }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            commonLabelClassRoutes.activeLabelClass(labelClassId)
+          }
 
-      }
+        }
     }
 
   def deactivateAnnotationProjectLabelClass(
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          commonLabelClassRoutes.deactivateLabelClass(labelClassId)
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            commonLabelClassRoutes.deactivateLabelClass(labelClassId)
+          }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassRoutes.scala
@@ -26,7 +26,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -51,7 +51,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       groupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -78,7 +78,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -107,7 +107,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -139,7 +139,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -165,7 +165,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectLabelClassRoutes.scala
@@ -26,7 +26,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -51,7 +51,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       groupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -78,7 +78,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -107,7 +107,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -139,7 +139,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -165,7 +165,7 @@ trait AnnotationProjectLabelClassRoutes
       projectId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -62,14 +62,15 @@ trait AnnotationProjectPermissionRoutes
             existingUser,
             userByEmail.actionType
           )
-          dbAcrs <- AnnotationProjectDao
-            .handleSharedPermissions(
-              projectId,
-              existingUser.id,
-              acrs,
-              userByEmail.actionType
-            )
-            .transact(xa)
+          dbAcrs <-
+            AnnotationProjectDao
+              .handleSharedPermissions(
+                projectId,
+                existingUser.id,
+                acrs,
+                userByEmail.actionType
+              )
+              .transact(xa)
           // if silent param is not provided, we notify
           _ <- userByEmail.silent match {
             case Some(false) | None =>
@@ -93,129 +94,79 @@ trait AnnotationProjectPermissionRoutes
     } map { _.combineAll }
 
   def listPermissions(projectId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             AnnotationProjectDao
-              .getPermissions(projectId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def replacePermissions(projectId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Share, None),
-        user
-      ) {
-        entity(as[List[ObjectAccessControlRule]]) { acrList =>
-          authorizeAsync {
-            (for {
-              auth1 <- AnnotationProjectDao.authorized(
+              .authorized(
                 user,
                 ObjectType.AnnotationProject,
                 projectId,
                 ActionType.Edit
               )
-              auth2 <- acrList traverse { acr =>
-                AnnotationProjectDao.isValidPermission(acr, user)
-              }
-            } yield {
-              auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
-                case true =>
-                  AnnotationProjectDao.isReplaceWithinScopedLimit(
-                    Domain.AnnotationProjects,
-                    user,
-                    acrList
-                  )
-                case _ => false
-              })
-            }).transact(xa).unsafeToFuture()
+              .transact(xa)
+              .unsafeToFuture
           } {
-            val distinctUserIds = acrList
-              .foldMap(acr => acr.getUserId map { Set(_) })
-              .getOrElse(Set.empty)
-              .toList
             complete {
-              (AnnotationProjectDao
-                .replacePermissions(projectId, acrList)
-                .transact(xa) <* (AnnotationProjectDao
-                .unsafeGetById(
-                  projectId
-                )
-                .transact(xa) flatMap { annotationProject =>
-                (distinctUserIds traverse { userId =>
-                  // it's safe to do this unsafely because we know the user exists from
-                  // the isValidPermission check
-                  UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
-                    sharedUser =>
-                      notifier.shareNotify(
-                        sharedUser,
-                        user,
-                        annotationProject,
-                        "projects"
-                      )
-                  }
-                })
-              })).unsafeToFuture
+              AnnotationProjectDao
+                .getPermissions(projectId)
+                .transact(xa)
+                .unsafeToFuture
             }
           }
         }
-      }
     }
 
-  def addPermission(projectId: UUID): Route =
-    authenticate { user =>
-      val shareCount =
-        AnnotationProjectDao
-          .getShareCount(projectId, user.id)
-          .transact(xa)
-          .unsafeToFuture
-      authorizeScopeLimit(
-        shareCount,
-        Domain.AnnotationProjects,
-        Action.Share,
-        user
-      ) {
-        entity(as[ObjectAccessControlRule]) { acr =>
-          authorizeAsync {
-            (for {
-              auth1 <- AnnotationProjectDao.authorized(
-                user,
-                ObjectType.AnnotationProject,
-                projectId,
-                ActionType.Edit
-              )
-              auth2 <- AnnotationProjectDao.isValidPermission(acr, user)
-            } yield {
-              auth1.toBoolean && auth2
-            }).transact(xa).unsafeToFuture()
-          } {
-            complete {
-              (AnnotationProjectDao
-                .addPermission(projectId, acr)
-                .transact(xa) <* (
-                AnnotationProjectDao
-                  .unsafeGetById(projectId)
+  def replacePermissions(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Share, None),
+          user
+        ) {
+          entity(as[List[ObjectAccessControlRule]]) { acrList =>
+            authorizeAsync {
+              (for {
+                auth1 <- AnnotationProjectDao.authorized(
+                  user,
+                  ObjectType.AnnotationProject,
+                  projectId,
+                  ActionType.Edit
+                )
+                auth2 <- acrList traverse { acr =>
+                  AnnotationProjectDao.isValidPermission(acr, user)
+                }
+              } yield {
+                auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
+                  case true =>
+                    AnnotationProjectDao.isReplaceWithinScopedLimit(
+                      Domain.AnnotationProjects,
+                      user,
+                      acrList
+                    )
+                  case _ => false
+                })
+              }).transact(xa).unsafeToFuture()
+            } {
+              val distinctUserIds = acrList
+                .foldMap(acr => acr.getUserId map { Set(_) })
+                .getOrElse(Set.empty)
+                .toList
+              complete {
+                (AnnotationProjectDao
+                  .replacePermissions(projectId, acrList)
+                  .transact(xa) <* (AnnotationProjectDao
+                  .unsafeGetById(
+                    projectId
+                  )
                   .transact(xa) flatMap { annotationProject =>
-                  acr.getUserId traverse { userId =>
+                  (distinctUserIds traverse { userId =>
+                    // it's safe to do this unsafely because we know the user exists from
+                    // the isValidPermission check
                     UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
                       sharedUser =>
                         notifier.shareNotify(
@@ -225,244 +176,311 @@ trait AnnotationProjectPermissionRoutes
                           "projects"
                         )
                     }
-                  }
-                }
-              )).unsafeToFuture
+                  })
+                })).unsafeToFuture
+              }
             }
           }
         }
-      }
+    }
+
+  def addPermission(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        val shareCount =
+          AnnotationProjectDao
+            .getShareCount(projectId, user.id)
+            .transact(xa)
+            .unsafeToFuture
+        authorizeScopeLimit(
+          shareCount,
+          Domain.AnnotationProjects,
+          Action.Share,
+          user
+        ) {
+          entity(as[ObjectAccessControlRule]) { acr =>
+            authorizeAsync {
+              (for {
+                auth1 <- AnnotationProjectDao.authorized(
+                  user,
+                  ObjectType.AnnotationProject,
+                  projectId,
+                  ActionType.Edit
+                )
+                auth2 <- AnnotationProjectDao.isValidPermission(acr, user)
+              } yield {
+                auth1.toBoolean && auth2
+              }).transact(xa).unsafeToFuture()
+            } {
+              complete {
+                (AnnotationProjectDao
+                  .addPermission(projectId, acr)
+                  .transact(xa) <* (
+                  AnnotationProjectDao
+                    .unsafeGetById(projectId)
+                    .transact(xa) flatMap { annotationProject =>
+                    acr.getUserId traverse { userId =>
+                      UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                        sharedUser =>
+                          notifier.shareNotify(
+                            sharedUser,
+                            user,
+                            annotationProject,
+                            "projects"
+                          )
+                      }
+                    }
+                  }
+                )).unsafeToFuture
+              }
+            }
+          }
+        }
     }
 
   def deletePermissions(projectId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Share, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Share, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             AnnotationProjectDao
-              .deletePermissions(projectId)
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Edit
+              )
               .transact(xa)
               .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def listAnnotationProjectShares(projectId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Share, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          AnnotationProjectDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              projectId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            AnnotationProjectDao
-              .getSharedUsers(projectId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def deleteAnnotationProjectShare(projectId: UUID, deleteId: String): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Read, None),
-        user
-      ) {
-        (if (user.id == deleteId) {
-           authorizeAuthResultAsync {
-             AnnotationProjectDao
-               .authorized(
-                 user,
-                 ObjectType.AnnotationProject,
-                 projectId,
-                 ActionType.View
-               )
-               .transact(xa)
-               .unsafeToFuture
-           }
-         } else {
-           authorizeAuthResultAsync {
-             AnnotationProjectDao
-               .authorized(
-                 user,
-                 ObjectType.AnnotationProject,
-                 projectId,
-                 ActionType.Edit
-               )
-               .transact(xa)
-               .unsafeToFuture
-           }
-         }) {
-          complete {
-            AnnotationProjectDao
-              .deleteSharedUser(projectId, deleteId)
-              .map(c => if (c > 0) 1 else 0)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def shareAnnotationProject(projectId: UUID): Route =
-    authenticate { user =>
-      val shareCount =
-        AnnotationProjectDao
-          .getShareCount(projectId, user.id)
-          .transact(xa)
-          .unsafeToFuture
-      authorizeScopeLimit(
-        shareCount,
-        Domain.AnnotationProjects,
-        Action.Share,
-        user
-      ) {
-        entity(as[UserShareInfo]) { userByEmail =>
-          authorize {
-            (userByEmail.actionType match {
-              case Some(ActionType.Annotate) | Some(ActionType.Validate) |
-                  None =>
-                true
-              case _ => false
-            })
           } {
-            onSuccess {
-              Auth0Service.getManagementBearerToken flatMap { managementToken =>
-                (for {
-                  // Everything has to be Futures here because of methods in akka-http / Auth0Service
-                  users <- UserDao
-                    .findUsersByEmail(userByEmail.email)
-                    .transact(xa)
-                  userPlatform <- UserDao
-                    .unsafeGetUserPlatform(user.id)
-                    .transact(xa)
-                  annotationProjectO <- AnnotationProjectDao
-                    .getById(projectId)
-                    .transact(xa)
-                  permissions <- users match {
-                    case Nil =>
-                      for {
-                        auth0User <- OptionT {
-                          IO.fromFuture {
-                            IO {
-                              Auth0Service.findGroundworkUser(
-                                userByEmail.email,
-                                managementToken
-                              )
-                            }
-                          }
-                        } getOrElseF {
-                          IO.fromFuture {
-                            IO {
-                              Auth0Service
-                                .createGroundworkUser(
-                                  userByEmail.email,
-                                  managementToken
-                                )
-                            }
-                          }
-                        }
-                        newUserOpt <- (auth0User.user_id traverse { userId =>
-                          for {
-                            user <- UserDao.create(
-                              User.Create(
-                                userId,
-                                email = userByEmail.email,
-                                scope = Scopes.GroundworkUser
-                              )
-                            )
-                            _ <- UserGroupRoleDao.createDefaultRoles(user)
-                            _ <- AnnotationProjectDao.copyProject(
-                              UUID.fromString(groundworkSampleProject),
-                              user
-                            )
-                          } yield user
-                        }).transact(xa)
-                        acrs = newUserOpt map { newUser =>
-                          notifier
-                            .getDefaultShare(newUser, userByEmail.actionType)
-                        } getOrElse Nil
-                        _ <- (newUserOpt, annotationProjectO).tupled traverse {
-                          case (newUser, annotationProject) =>
-                            // if silent param is not provided, we notify
-                            val isSilent = userByEmail.silent.getOrElse(false)
-                            if (!isSilent) {
-                              IO.fromFuture {
-                                IO {
-                                  notifier.shareNotifyNewUser(
-                                    managementToken,
-                                    user,
-                                    userByEmail.email,
-                                    newUser.id,
-                                    userPlatform,
-                                    annotationProject,
-                                    "projects",
-                                    Notifications.getInvitationMessage
-                                  )
-                                }
-                              }
-                            } else {
-                              IO.unit
-                            }
-                        }
-                        // this is not an existing user,
-                        // there is no project specific ACR yet,
-                        // so no need to remove Validate action if only want Annotate
-                        dbAcrs <- (acrs flatTraverse { acr =>
-                          AnnotationProjectDao
-                            .addPermission(projectId, acr)
-                        }).transact(xa)
-                      } yield dbAcrs.validNel
-                    case existingUsers =>
-                      shareWithExistingUsers(
-                        existingUsers,
-                        userByEmail,
-                        managementToken,
-                        projectId,
-                        user
-                      )
-                  }
-                } yield permissions).unsafeToFuture
-              }
-            } {
-              case Validated.Invalid(errs) =>
-                complete {
-                  (
-                    StatusCodes.BadRequest,
-                    Map("failedUsers" -> errs).asJson
-                  )
-                }
-              case Validated.Valid(acrs) =>
-                complete { acrs.asJson }
+            complete {
+              AnnotationProjectDao
+                .deletePermissions(projectId)
+                .transact(xa)
+                .unsafeToFuture
             }
           }
         }
-      }
+    }
+
+  def listAnnotationProjectShares(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Share, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            AnnotationProjectDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                projectId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              AnnotationProjectDao
+                .getSharedUsers(projectId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def deleteAnnotationProjectShare(projectId: UUID, deleteId: String): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+          user
+        ) {
+          (if (user.id == deleteId) {
+             authorizeAuthResultAsync {
+               AnnotationProjectDao
+                 .authorized(
+                   user,
+                   ObjectType.AnnotationProject,
+                   projectId,
+                   ActionType.View
+                 )
+                 .transact(xa)
+                 .unsafeToFuture
+             }
+           } else {
+             authorizeAuthResultAsync {
+               AnnotationProjectDao
+                 .authorized(
+                   user,
+                   ObjectType.AnnotationProject,
+                   projectId,
+                   ActionType.Edit
+                 )
+                 .transact(xa)
+                 .unsafeToFuture
+             }
+           }) {
+            complete {
+              AnnotationProjectDao
+                .deleteSharedUser(projectId, deleteId)
+                .map(c => if (c > 0) 1 else 0)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def shareAnnotationProject(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        val shareCount =
+          AnnotationProjectDao
+            .getShareCount(projectId, user.id)
+            .transact(xa)
+            .unsafeToFuture
+        authorizeScopeLimit(
+          shareCount,
+          Domain.AnnotationProjects,
+          Action.Share,
+          user
+        ) {
+          entity(as[UserShareInfo]) { userByEmail =>
+            authorize {
+              (userByEmail.actionType match {
+                case Some(ActionType.Annotate) | Some(ActionType.Validate) |
+                    None =>
+                  true
+                case _ => false
+              })
+            } {
+              onSuccess {
+                Auth0Service.getManagementBearerToken flatMap {
+                  managementToken =>
+                    (for {
+                      // Everything has to be Futures here because of methods in akka-http / Auth0Service
+                      users <-
+                        UserDao
+                          .findUsersByEmail(userByEmail.email)
+                          .transact(xa)
+                      userPlatform <-
+                        UserDao
+                          .unsafeGetUserPlatform(user.id)
+                          .transact(xa)
+                      annotationProjectO <-
+                        AnnotationProjectDao
+                          .getById(projectId)
+                          .transact(xa)
+                      permissions <- users match {
+                        case Nil =>
+                          for {
+                            auth0User <- OptionT {
+                              IO.fromFuture {
+                                IO {
+                                  Auth0Service.findGroundworkUser(
+                                    userByEmail.email,
+                                    managementToken
+                                  )
+                                }
+                              }
+                            } getOrElseF {
+                              IO.fromFuture {
+                                IO {
+                                  Auth0Service
+                                    .createGroundworkUser(
+                                      userByEmail.email,
+                                      managementToken
+                                    )
+                                }
+                              }
+                            }
+                            newUserOpt <-
+                              (auth0User.user_id traverse { userId =>
+                                for {
+                                  user <- UserDao.create(
+                                    User.Create(
+                                      userId,
+                                      email = userByEmail.email,
+                                      scope = Scopes.GroundworkUser
+                                    )
+                                  )
+                                  _ <- UserGroupRoleDao.createDefaultRoles(user)
+                                  _ <- AnnotationProjectDao.copyProject(
+                                    UUID.fromString(groundworkSampleProject),
+                                    user
+                                  )
+                                } yield user
+                              }).transact(xa)
+                            acrs = newUserOpt map { newUser =>
+                              notifier
+                                .getDefaultShare(
+                                  newUser,
+                                  userByEmail.actionType
+                                )
+                            } getOrElse Nil
+                            _ <-
+                              (newUserOpt, annotationProjectO).tupled traverse {
+                                case (newUser, annotationProject) =>
+                                  // if silent param is not provided, we notify
+                                  val isSilent =
+                                    userByEmail.silent.getOrElse(false)
+                                  if (!isSilent) {
+                                    IO.fromFuture {
+                                      IO {
+                                        notifier.shareNotifyNewUser(
+                                          managementToken,
+                                          user,
+                                          userByEmail.email,
+                                          newUser.id,
+                                          userPlatform,
+                                          annotationProject,
+                                          "projects",
+                                          Notifications.getInvitationMessage
+                                        )
+                                      }
+                                    }
+                                  } else {
+                                    IO.unit
+                                  }
+                              }
+                            // this is not an existing user,
+                            // there is no project specific ACR yet,
+                            // so no need to remove Validate action if only want Annotate
+                            dbAcrs <- (acrs flatTraverse { acr =>
+                                AnnotationProjectDao
+                                  .addPermission(projectId, acr)
+                              }).transact(xa)
+                          } yield dbAcrs.validNel
+                        case existingUsers =>
+                          shareWithExistingUsers(
+                            existingUsers,
+                            userByEmail,
+                            managementToken,
+                            projectId,
+                            user
+                          )
+                      }
+                    } yield permissions).unsafeToFuture
+                }
+              } {
+                case Validated.Invalid(errs) =>
+                  complete {
+                    (
+                      StatusCodes.BadRequest,
+                      Map("failedUsers" -> errs).asJson
+                    )
+                  }
+                case Validated.Valid(acrs) =>
+                  complete { acrs.asJson }
+              }
+            }
+          }
+        }
     }
 }

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectPermissionRoutes.scala
@@ -95,7 +95,7 @@ trait AnnotationProjectPermissionRoutes
 
   def listPermissions(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
           user
@@ -123,7 +123,7 @@ trait AnnotationProjectPermissionRoutes
 
   def replacePermissions(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationProjects, Action.Share, None),
           user
@@ -186,7 +186,7 @@ trait AnnotationProjectPermissionRoutes
 
   def addPermission(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         val shareCount =
           AnnotationProjectDao
             .getShareCount(projectId, user.id)
@@ -240,7 +240,7 @@ trait AnnotationProjectPermissionRoutes
 
   def deletePermissions(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationProjects, Action.Share, None),
           user
@@ -268,7 +268,7 @@ trait AnnotationProjectPermissionRoutes
 
   def listAnnotationProjectShares(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationProjects, Action.Share, None),
           user
@@ -296,7 +296,7 @@ trait AnnotationProjectPermissionRoutes
 
   def deleteAnnotationProjectShare(projectId: UUID, deleteId: String): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationProjects, Action.Read, None),
           user
@@ -339,7 +339,7 @@ trait AnnotationProjectPermissionRoutes
 
   def shareAnnotationProject(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         val shareCount =
           AnnotationProjectDao
             .getShareCount(projectId, user.id)

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -42,7 +42,7 @@ trait AnnotationProjectTaskRoutes
   val xa: Transactor[IO]
 
   def listAnnotationProjectTasks(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -77,7 +77,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def createTasks(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateTasks, None),
         user
@@ -107,7 +107,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def deleteTasks(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.DeleteTasks, None),
         user
@@ -136,7 +136,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def createTaskGrid(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateTaskGrid, None),
         user
@@ -183,7 +183,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def getTaskUserSummary(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -217,7 +217,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def getTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -249,7 +249,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def updateTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.UpdateTasks, None),
         user
@@ -286,7 +286,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def deleteTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.DeleteTasks, None),
         user
@@ -318,7 +318,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def updateTaskStatus(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.UpdateTasks, None),
         user
@@ -366,7 +366,7 @@ trait AnnotationProjectTaskRoutes
       taskId: UUID,
       f: (User => ConnectionIO[Option[Task.TaskFeature]])
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -400,7 +400,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def listTaskLabels(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -470,7 +470,7 @@ trait AnnotationProjectTaskRoutes
       requiredStatuses: List[TaskStatus],
       deleteBeforeAdding: Boolean
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -536,7 +536,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def deleteTaskLabels(projectId: UUID, task: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.DeleteAnnotation, None),
         user
@@ -563,7 +563,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def children(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -599,7 +599,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def splitTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -42,7 +42,7 @@ trait AnnotationProjectTaskRoutes
   val xa: Transactor[IO]
 
   def listAnnotationProjectTasks(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -77,7 +77,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def createTasks(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateTasks, None),
         user
@@ -107,7 +107,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def deleteTasks(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.DeleteTasks, None),
         user
@@ -136,7 +136,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def createTaskGrid(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateTaskGrid, None),
         user
@@ -183,7 +183,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def getTaskUserSummary(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -217,7 +217,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def getTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -249,7 +249,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def updateTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.UpdateTasks, None),
         user
@@ -286,7 +286,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def deleteTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.DeleteTasks, None),
         user
@@ -318,7 +318,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def updateTaskStatus(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.UpdateTasks, None),
         user
@@ -366,7 +366,7 @@ trait AnnotationProjectTaskRoutes
       taskId: UUID,
       f: (User => ConnectionIO[Option[Task.TaskFeature]])
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -400,7 +400,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def listTaskLabels(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -470,7 +470,7 @@ trait AnnotationProjectTaskRoutes
       requiredStatuses: List[TaskStatus],
       deleteBeforeAdding: Boolean
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -536,7 +536,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def deleteTaskLabels(projectId: UUID, task: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.DeleteAnnotation, None),
         user
@@ -563,7 +563,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def children(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -599,7 +599,7 @@ trait AnnotationProjectTaskRoutes
     }
 
   def splitTask(projectId: UUID, taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -243,7 +243,7 @@ trait AnnotationProjectRoutes
   }
 
   def listAnnotationProjects: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -261,7 +261,7 @@ trait AnnotationProjectRoutes
     }
 
   def createAnnotationProject: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScopeLimit(
         AnnotationProjectDao
           .countUserProjects(user)
@@ -285,7 +285,7 @@ trait AnnotationProjectRoutes
     }
 
   def getAnnotationProject(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -314,7 +314,7 @@ trait AnnotationProjectRoutes
     }
 
   def updateAnnotationProject(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -348,7 +348,7 @@ trait AnnotationProjectRoutes
     }
 
   def deleteAnnotationProject(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Delete, None),
         user
@@ -393,7 +393,7 @@ trait AnnotationProjectRoutes
     }
 
   def listUserActions(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
         user
@@ -449,7 +449,7 @@ trait AnnotationProjectRoutes
     }
 
   def checkIsHITLAnnotationProject(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user

--- a/app-backend/api/src/main/scala/annotation-project/Routes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/Routes.scala
@@ -243,7 +243,7 @@ trait AnnotationProjectRoutes
   }
 
   def listAnnotationProjects: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -261,7 +261,7 @@ trait AnnotationProjectRoutes
     }
 
   def createAnnotationProject: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScopeLimit(
         AnnotationProjectDao
           .countUserProjects(user)
@@ -285,7 +285,7 @@ trait AnnotationProjectRoutes
     }
 
   def getAnnotationProject(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -314,7 +314,7 @@ trait AnnotationProjectRoutes
     }
 
   def updateAnnotationProject(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Update, None),
         user
@@ -348,7 +348,7 @@ trait AnnotationProjectRoutes
     }
 
   def deleteAnnotationProject(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Delete, None),
         user
@@ -393,7 +393,7 @@ trait AnnotationProjectRoutes
     }
 
   def listUserActions(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadPermissions, None),
         user
@@ -449,7 +449,7 @@ trait AnnotationProjectRoutes
     }
 
   def checkIsHITLAnnotationProject(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user

--- a/app-backend/api/src/main/scala/campaign/CampaignLabelClassGroupRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignLabelClassGroupRoutes.scala
@@ -31,7 +31,7 @@ trait CampaignLabelClassGroupRoutes
   def commonLabelClassGroupRoutes: CommonLabelClassGroupRoutes
 
   def listCampaignLabelClassGroups(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -60,7 +60,7 @@ trait CampaignLabelClassGroupRoutes
     }
 
   def createCampaignLabelClassGroup(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -110,7 +110,7 @@ trait CampaignLabelClassGroupRoutes
     }
 
   def getCampaignLabelClassGroup(campaignId: UUID, classGroupId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -137,7 +137,7 @@ trait CampaignLabelClassGroupRoutes
       campaignId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -169,7 +169,7 @@ trait CampaignLabelClassGroupRoutes
       campaignId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -195,7 +195,7 @@ trait CampaignLabelClassGroupRoutes
       campaignId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/campaign/CampaignLabelClassGroupRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignLabelClassGroupRoutes.scala
@@ -31,7 +31,7 @@ trait CampaignLabelClassGroupRoutes
   def commonLabelClassGroupRoutes: CommonLabelClassGroupRoutes
 
   def listCampaignLabelClassGroups(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -60,7 +60,7 @@ trait CampaignLabelClassGroupRoutes
     }
 
   def createCampaignLabelClassGroup(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -110,7 +110,7 @@ trait CampaignLabelClassGroupRoutes
     }
 
   def getCampaignLabelClassGroup(campaignId: UUID, classGroupId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -137,7 +137,7 @@ trait CampaignLabelClassGroupRoutes
       campaignId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -169,7 +169,7 @@ trait CampaignLabelClassGroupRoutes
       campaignId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -195,7 +195,7 @@ trait CampaignLabelClassGroupRoutes
       campaignId: UUID,
       classGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/campaign/CampaignLabelClassRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignLabelClassRoutes.scala
@@ -26,58 +26,12 @@ trait CampaignLabelClassRoutes
       campaignId: UUID,
       labelClassGroupId: UUID
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              campaignId,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          commonLabelClassRoutes.listLabelClasses(labelClassGroupId)
-        }
-      }
-    }
-
-  def addCampaignLabelClassToGroup(campaignId: UUID, groupId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationLabelClass.Create]) { labelClassCreate =>
-            commonLabelClassRoutes.addLabelClass(labelClassCreate, groupId)
-          }
-        }
-      }
-    }
-
-  def getCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
+        ) {
           authorizeAuthResultAsync {
             CampaignDao
               .authorized(
@@ -89,21 +43,18 @@ trait CampaignLabelClassRoutes
               .transact(xa)
               .unsafeToFuture
           } {
-            commonLabelClassRoutes.getLabelClass(
-              labelClassId
-            )
+            commonLabelClassRoutes.listLabelClasses(labelClassGroupId)
           }
         }
-      }
     }
 
-  def updateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Update, None),
-        user
-      ) {
-        {
+  def addCampaignLabelClassToGroup(campaignId: UUID, groupId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Update, None),
+          user
+        ) {
           authorizeAuthResultAsync {
             CampaignDao
               .authorized(
@@ -115,62 +66,117 @@ trait CampaignLabelClassRoutes
               .transact(xa)
               .unsafeToFuture
           } {
-            entity(as[AnnotationLabelClass]) { updatedClass =>
-              commonLabelClassRoutes.updateLabelClass(
-                updatedClass,
+            entity(as[AnnotationLabelClass.Create]) { labelClassCreate =>
+              commonLabelClassRoutes.addLabelClass(labelClassCreate, groupId)
+            }
+          }
+        }
+    }
+
+  def getCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
+        ) {
+          {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.AnnotationProject,
+                  campaignId,
+                  ActionType.Annotate
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              commonLabelClassRoutes.getLabelClass(
                 labelClassId
               )
             }
           }
         }
-      }
+    }
+
+  def updateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Update, None),
+          user
+        ) {
+          {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.AnnotationProject,
+                  campaignId,
+                  ActionType.Edit
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              entity(as[AnnotationLabelClass]) { updatedClass =>
+                commonLabelClassRoutes.updateLabelClass(
+                  updatedClass,
+                  labelClassId
+                )
+              }
+            }
+          }
+        }
     }
 
   def activateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          commonLabelClassRoutes.activeLabelClass(labelClassId)
-        }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                campaignId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            commonLabelClassRoutes.activeLabelClass(labelClassId)
+          }
 
-      }
+        }
     }
 
   def deactivateCampaignLabelClass(
       campaignId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.AnnotationProject,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          commonLabelClassRoutes.deactivateLabelClass(labelClassId)
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.AnnotationProject,
+                campaignId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            commonLabelClassRoutes.deactivateLabelClass(labelClassId)
+          }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/campaign/CampaignLabelClassRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignLabelClassRoutes.scala
@@ -26,7 +26,7 @@ trait CampaignLabelClassRoutes
       campaignId: UUID,
       labelClassGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -48,7 +48,7 @@ trait CampaignLabelClassRoutes
     }
 
   def addCampaignLabelClassToGroup(campaignId: UUID, groupId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -72,7 +72,7 @@ trait CampaignLabelClassRoutes
     }
 
   def getCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -98,7 +98,7 @@ trait CampaignLabelClassRoutes
     }
 
   def updateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -127,7 +127,7 @@ trait CampaignLabelClassRoutes
     }
 
   def activateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -153,7 +153,7 @@ trait CampaignLabelClassRoutes
       campaignId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/campaign/CampaignLabelClassRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignLabelClassRoutes.scala
@@ -26,7 +26,7 @@ trait CampaignLabelClassRoutes
       campaignId: UUID,
       labelClassGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -48,7 +48,7 @@ trait CampaignLabelClassRoutes
     }
 
   def addCampaignLabelClassToGroup(campaignId: UUID, groupId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -72,7 +72,7 @@ trait CampaignLabelClassRoutes
     }
 
   def getCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -98,7 +98,7 @@ trait CampaignLabelClassRoutes
     }
 
   def updateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -127,7 +127,7 @@ trait CampaignLabelClassRoutes
     }
 
   def activateCampaignLabelClass(campaignId: UUID, labelClassId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -153,7 +153,7 @@ trait CampaignLabelClassRoutes
       campaignId: UUID,
       labelClassId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -33,7 +33,7 @@ trait CampaignPermissionRoutes
   val xa: Transactor[IO]
 
   def listCampaignPermissions(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
         user
@@ -60,7 +60,7 @@ trait CampaignPermissionRoutes
     }
 
   def replaceCampaignPermissions(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Share, None),
         user
@@ -122,7 +122,7 @@ trait CampaignPermissionRoutes
     }
 
   def addCampaignPermission(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       val shareCount =
         CampaignDao
           .getShareCount(campaignId, user.id)
@@ -175,7 +175,7 @@ trait CampaignPermissionRoutes
     }
 
   def deleteCampaignPermissions(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Share, None),
         user
@@ -202,7 +202,7 @@ trait CampaignPermissionRoutes
     }
 
   def listCampaignShares(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Share, None),
         user
@@ -229,7 +229,7 @@ trait CampaignPermissionRoutes
     }
 
   def deleteCampaignShare(campaignId: UUID, deleteId: String): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
         if (user.id == deleteId) {
           authorizeAuthResultAsync {
@@ -269,7 +269,7 @@ trait CampaignPermissionRoutes
     }
 
   def shareCampaign(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       val shareCount =
         CampaignDao
           .getShareCount(campaignId, user.id)

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -33,7 +33,7 @@ trait CampaignPermissionRoutes
   val xa: Transactor[IO]
 
   def listCampaignPermissions(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
         user
@@ -60,7 +60,7 @@ trait CampaignPermissionRoutes
     }
 
   def replaceCampaignPermissions(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Share, None),
         user
@@ -122,7 +122,7 @@ trait CampaignPermissionRoutes
     }
 
   def addCampaignPermission(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       val shareCount =
         CampaignDao
           .getShareCount(campaignId, user.id)
@@ -175,7 +175,7 @@ trait CampaignPermissionRoutes
     }
 
   def deleteCampaignPermissions(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Share, None),
         user
@@ -202,7 +202,7 @@ trait CampaignPermissionRoutes
     }
 
   def listCampaignShares(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Share, None),
         user
@@ -229,7 +229,7 @@ trait CampaignPermissionRoutes
     }
 
   def deleteCampaignShare(campaignId: UUID, deleteId: String): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
         if (user.id == deleteId) {
           authorizeAuthResultAsync {
@@ -269,7 +269,7 @@ trait CampaignPermissionRoutes
     }
 
   def shareCampaign(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       val shareCount =
         CampaignDao
           .getShareCount(campaignId, user.id)

--- a/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignPermissionRoutes.scala
@@ -33,391 +33,401 @@ trait CampaignPermissionRoutes
   val xa: Transactor[IO]
 
   def listCampaignPermissions(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             CampaignDao
-              .getPermissions(campaignId)
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
               .transact(xa)
               .unsafeToFuture
+          } {
+            complete {
+              CampaignDao
+                .getPermissions(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def replaceCampaignPermissions(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Share, None),
-        user
-      ) {
-        entity(as[List[ObjectAccessControlRule]]) { acrList =>
-          authorizeAsync {
-            (for {
-              auth1 <- CampaignDao.authorized(
-                user,
-                ObjectType.Campaign,
-                campaignId,
-                ActionType.Edit
-              )
-              auth2 <- acrList traverse { acr =>
-                CampaignDao.isValidPermission(acr, user)
-              }
-            } yield {
-              auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
-                case true =>
-                  CampaignDao.isReplaceWithinScopedLimit(
-                    Domain.Campaigns,
-                    user,
-                    acrList
-                  )
-                case _ => false
-              })
-            }).transact(xa).unsafeToFuture()
-          } {
-            val distinctUserIds =
-              acrList
-                .foldMap(acr => acr.getUserId map { Set(_) })
-                .combineAll
-                .toList
-            complete {
-              (CampaignDao
-                .replacePermissions(campaignId, acrList)
-                .transact(xa) <* (
-                CampaignDao
-                  .unsafeGetCampaignById(campaignId)
-                  .transact(xa) flatMap { campaign =>
-                  distinctUserIds traverse { userId =>
-                    UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
-                      sharedUser =>
-                        notifier.shareNotify(
-                          sharedUser,
-                          user,
-                          campaign,
-                          "campaign"
-                        )
-                    }
-
-                  }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Share, None),
+          user
+        ) {
+          entity(as[List[ObjectAccessControlRule]]) { acrList =>
+            authorizeAsync {
+              (for {
+                auth1 <- CampaignDao.authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.Edit
+                )
+                auth2 <- acrList traverse { acr =>
+                  CampaignDao.isValidPermission(acr, user)
                 }
-              )).unsafeToFuture
+              } yield {
+                auth1.toBoolean && (auth2.foldLeft(true)(_ && _) match {
+                  case true =>
+                    CampaignDao.isReplaceWithinScopedLimit(
+                      Domain.Campaigns,
+                      user,
+                      acrList
+                    )
+                  case _ => false
+                })
+              }).transact(xa).unsafeToFuture()
+            } {
+              val distinctUserIds =
+                acrList
+                  .foldMap(acr => acr.getUserId map { Set(_) })
+                  .combineAll
+                  .toList
+              complete {
+                (CampaignDao
+                  .replacePermissions(campaignId, acrList)
+                  .transact(xa) <* (
+                  CampaignDao
+                    .unsafeGetCampaignById(campaignId)
+                    .transact(xa) flatMap { campaign =>
+                    distinctUserIds traverse { userId =>
+                      UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                        sharedUser =>
+                          notifier.shareNotify(
+                            sharedUser,
+                            user,
+                            campaign,
+                            "campaign"
+                          )
+                      }
+
+                    }
+                  }
+                )).unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def addCampaignPermission(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      val shareCount =
-        CampaignDao
-          .getShareCount(campaignId, user.id)
-          .transact(xa)
-          .unsafeToFuture
-      authorizeScopeLimit(
-        shareCount,
-        Domain.Campaigns,
-        Action.Share,
-        user
-      ) {
-        entity(as[ObjectAccessControlRule]) { acr =>
-          authorizeAsync {
-            (for {
-              auth1 <- CampaignDao.authorized(
-                user,
-                ObjectType.Campaign,
-                campaignId,
-                ActionType.Edit
-              )
-              auth2 <- CampaignDao.isValidPermission(acr, user)
-            } yield {
-              auth1.toBoolean && auth2
-            }).transact(xa).unsafeToFuture()
-          } {
-            complete {
-              (CampaignDao
-                .addPermission(campaignId, acr)
-                .transact(xa) <* (
-                CampaignDao
-                  .unsafeGetCampaignById(campaignId)
-                  .transact(xa) flatMap { campaign =>
-                  acr.getUserId traverse { userId =>
-                    UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
-                      sharedUser =>
-                        notifier.shareNotify(
-                          sharedUser,
-                          user,
-                          campaign,
-                          "campaign"
-                        )
+    authenticate {
+      case (user, _) =>
+        val shareCount =
+          CampaignDao
+            .getShareCount(campaignId, user.id)
+            .transact(xa)
+            .unsafeToFuture
+        authorizeScopeLimit(
+          shareCount,
+          Domain.Campaigns,
+          Action.Share,
+          user
+        ) {
+          entity(as[ObjectAccessControlRule]) { acr =>
+            authorizeAsync {
+              (for {
+                auth1 <- CampaignDao.authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.Edit
+                )
+                auth2 <- CampaignDao.isValidPermission(acr, user)
+              } yield {
+                auth1.toBoolean && auth2
+              }).transact(xa).unsafeToFuture()
+            } {
+              complete {
+                (CampaignDao
+                  .addPermission(campaignId, acr)
+                  .transact(xa) <* (
+                  CampaignDao
+                    .unsafeGetCampaignById(campaignId)
+                    .transact(xa) flatMap { campaign =>
+                    acr.getUserId traverse { userId =>
+                      UserDao.unsafeGetUserById(userId).transact(xa) flatMap {
+                        sharedUser =>
+                          notifier.shareNotify(
+                            sharedUser,
+                            user,
+                            campaign,
+                            "campaign"
+                          )
+                      }
                     }
                   }
-                }
-              )).unsafeToFuture
-            }
-          }
-        }
-      }
-    }
-
-  def deleteCampaignPermissions(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Share, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            CampaignDao
-              .deletePermissions(campaignId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def listCampaignShares(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Share, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            CampaignDao
-              .getSharedUsers(campaignId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def deleteCampaignShare(campaignId: UUID, deleteId: String): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
-        if (user.id == deleteId) {
-          authorizeAuthResultAsync {
-            CampaignDao
-              .authorized(
-                user,
-                ObjectType.Campaign,
-                campaignId,
-                ActionType.View
-              )
-              .transact(xa)
-              .unsafeToFuture
-          }
-        } else {
-          authorizeAuthResultAsync {
-            CampaignDao
-              .authorized(
-                user,
-                ObjectType.Campaign,
-                campaignId,
-                ActionType.Edit
-              )
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-        {
-          complete {
-            CampaignDao
-              .deleteSharedUser(campaignId, deleteId)
-              .map(c => if (c > 0) 1 else 0)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def shareCampaign(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      val shareCount =
-        CampaignDao
-          .getShareCount(campaignId, user.id)
-          .transact(xa)
-          .unsafeToFuture
-
-      authorizeScopeLimit(
-        shareCount,
-        Domain.Campaigns,
-        Action.Share,
-        user
-      ) {
-        entity(as[UserShareInfo]) { userByEmail =>
-          authorize {
-            (userByEmail.actionType match {
-              case Some(ActionType.Annotate) | Some(ActionType.Validate) |
-                  None =>
-                true
-              case _ => false
-            })
-          } {
-            complete {
-              Auth0Service.getManagementBearerToken flatMap { managementToken =>
-                for {
-                  // Everything has to be Futures here because of methods in akka-http / Auth0Service
-                  users <- UserDao
-                    .findUsersByEmail(userByEmail.email)
-                    .transact(xa)
-                    .unsafeToFuture
-                  userPlatform <- UserDao
-                    .unsafeGetUserPlatform(user.id)
-                    .transact(xa)
-                    .unsafeToFuture
-                  campaignO <- CampaignDao
-                    .getCampaignById(campaignId)
-                    .transact(xa)
-                    .unsafeToFuture
-                  permissions <- users match {
-                    case Nil =>
-                      for {
-                        auth0User <- OptionT {
-                          Auth0Service.findGroundworkUser(
-                            userByEmail.email,
-                            managementToken
-                          )
-                        } getOrElseF {
-                          Auth0Service
-                            .createGroundworkUser(
-                              userByEmail.email,
-                              managementToken
-                            )
-                        }
-                        newUserOpt <- (auth0User.user_id traverse { userId =>
-                          for {
-                            user <- UserDao.create(
-                              User.Create(
-                                userId,
-                                email = userByEmail.email,
-                                scope = Scopes.GroundworkUser
-                              )
-                            )
-                            _ <- UserGroupRoleDao.createDefaultRoles(user)
-                            _ <- AnnotationProjectDao.copyProject(
-                              UUID.fromString(groundworkSampleProject),
-                              user
-                            )
-                          } yield user
-                        }).transact(xa).unsafeToFuture
-                        acrs = newUserOpt map { newUser =>
-                          notifier.getDefaultShare(
-                            newUser,
-                            userByEmail.actionType
-                          )
-                        } getOrElse Nil
-                        _ <- (newUserOpt, campaignO).tupled traverse {
-                          case (newUser, campaign) =>
-                            // if silent param is not provided, we notify
-                            val isSilent = userByEmail.silent.getOrElse(false)
-                            if (!isSilent) {
-                              notifier.shareNotifyNewUser(
-                                managementToken,
-                                user,
-                                userByEmail.email,
-                                newUser.id,
-                                userPlatform,
-                                campaign,
-                                "campaign",
-                                Notifications.getInvitationMessage
-                              )
-                            } else {
-                              Future.unit
-                            }
-                        }
-                        // this is not an existing user,
-                        // there is no project specific ACR yet,
-                        // so no need to remove Validate action if only want Annotate
-                        dbAcrs <- (acrs traverse { acr =>
-                          CampaignDao
-                            .addPermission(campaignId, acr)
-                        }).transact(xa).unsafeToFuture
-                      } yield dbAcrs
-                    case existingUsers =>
-                      existingUsers traverse { existingUser =>
-                        val acrs =
-                          notifier.getDefaultShare(
-                            existingUser,
-                            userByEmail.actionType
-                          )
-                        Auth0Service
-                          .addUserMetadata(
-                            existingUser.id,
-                            managementToken,
-                            Map(
-                              "app_metadata" -> Map("annotateApp" -> true)
-                            ).asJson
-                          ) *>
-                          (CampaignDao
-                            .handleSharedPermissions(
-                              campaignId,
-                              existingUser.id,
-                              acrs,
-                              userByEmail.actionType
-                            )
-                            .transact(xa) <* (
-                            // if silent param is not provided, we notify
-                            userByEmail.silent match {
-                              case Some(false) | None =>
-                                CampaignDao
-                                  .unsafeGetCampaignById(campaignId)
-                                  .transact(xa) flatMap { campaign =>
-                                  notifier.shareNotify(
-                                    existingUser,
-                                    user,
-                                    campaign,
-                                    "campaign"
-                                  )
-                                }
-                              case _ => IO.pure(())
-                            }
-                          )).unsafeToFuture
-
-                      } map { _.flatten }
-                  }
-                } yield permissions
+                )).unsafeToFuture
               }
             }
           }
         }
-      }
+    }
+
+  def deleteCampaignPermissions(campaignId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Share, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              CampaignDao
+                .deletePermissions(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def listCampaignShares(campaignId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Share, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              CampaignDao
+                .getSharedUsers(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def deleteCampaignShare(campaignId: UUID, deleteId: String): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Campaigns, Action.Read, None), user) {
+          if (user.id == deleteId) {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.View
+                )
+                .transact(xa)
+                .unsafeToFuture
+            }
+          } else {
+            authorizeAuthResultAsync {
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.Edit
+                )
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+          {
+            complete {
+              CampaignDao
+                .deleteSharedUser(campaignId, deleteId)
+                .map(c => if (c > 0) 1 else 0)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def shareCampaign(campaignId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        val shareCount =
+          CampaignDao
+            .getShareCount(campaignId, user.id)
+            .transact(xa)
+            .unsafeToFuture
+
+        authorizeScopeLimit(
+          shareCount,
+          Domain.Campaigns,
+          Action.Share,
+          user
+        ) {
+          entity(as[UserShareInfo]) { userByEmail =>
+            authorize {
+              (userByEmail.actionType match {
+                case Some(ActionType.Annotate) | Some(ActionType.Validate) |
+                    None =>
+                  true
+                case _ => false
+              })
+            } {
+              complete {
+                Auth0Service.getManagementBearerToken flatMap {
+                  managementToken =>
+                    for {
+                      // Everything has to be Futures here because of methods in akka-http / Auth0Service
+                      users <- UserDao
+                        .findUsersByEmail(userByEmail.email)
+                        .transact(xa)
+                        .unsafeToFuture
+                      userPlatform <- UserDao
+                        .unsafeGetUserPlatform(user.id)
+                        .transact(xa)
+                        .unsafeToFuture
+                      campaignO <- CampaignDao
+                        .getCampaignById(campaignId)
+                        .transact(xa)
+                        .unsafeToFuture
+                      permissions <- users match {
+                        case Nil =>
+                          for {
+                            auth0User <- OptionT {
+                              Auth0Service.findGroundworkUser(
+                                userByEmail.email,
+                                managementToken
+                              )
+                            } getOrElseF {
+                              Auth0Service
+                                .createGroundworkUser(
+                                  userByEmail.email,
+                                  managementToken
+                                )
+                            }
+                            newUserOpt <- (auth0User.user_id traverse {
+                              userId =>
+                                for {
+                                  user <- UserDao.create(
+                                    User.Create(
+                                      userId,
+                                      email = userByEmail.email,
+                                      scope = Scopes.GroundworkUser
+                                    )
+                                  )
+                                  _ <- UserGroupRoleDao.createDefaultRoles(user)
+                                  _ <- AnnotationProjectDao.copyProject(
+                                    UUID.fromString(groundworkSampleProject),
+                                    user
+                                  )
+                                } yield user
+                            }).transact(xa).unsafeToFuture
+                            acrs = newUserOpt map { newUser =>
+                              notifier.getDefaultShare(
+                                newUser,
+                                userByEmail.actionType
+                              )
+                            } getOrElse Nil
+                            _ <- (newUserOpt, campaignO).tupled traverse {
+                              case (newUser, campaign) =>
+                                // if silent param is not provided, we notify
+                                val isSilent =
+                                  userByEmail.silent.getOrElse(false)
+                                if (!isSilent) {
+                                  notifier.shareNotifyNewUser(
+                                    managementToken,
+                                    user,
+                                    userByEmail.email,
+                                    newUser.id,
+                                    userPlatform,
+                                    campaign,
+                                    "campaign",
+                                    Notifications.getInvitationMessage
+                                  )
+                                } else {
+                                  Future.unit
+                                }
+                            }
+                            // this is not an existing user,
+                            // there is no project specific ACR yet,
+                            // so no need to remove Validate action if only want Annotate
+                            dbAcrs <- (acrs traverse { acr =>
+                              CampaignDao
+                                .addPermission(campaignId, acr)
+                            }).transact(xa).unsafeToFuture
+                          } yield dbAcrs
+                        case existingUsers =>
+                          existingUsers traverse { existingUser =>
+                            val acrs =
+                              notifier.getDefaultShare(
+                                existingUser,
+                                userByEmail.actionType
+                              )
+                            Auth0Service
+                              .addUserMetadata(
+                                existingUser.id,
+                                managementToken,
+                                Map(
+                                  "app_metadata" -> Map("annotateApp" -> true)
+                                ).asJson
+                              ) *>
+                              (CampaignDao
+                                .handleSharedPermissions(
+                                  campaignId,
+                                  existingUser.id,
+                                  acrs,
+                                  userByEmail.actionType
+                                )
+                                .transact(xa) <* (
+                                // if silent param is not provided, we notify
+                                userByEmail.silent match {
+                                  case Some(false) | None =>
+                                    CampaignDao
+                                      .unsafeGetCampaignById(campaignId)
+                                      .transact(xa) flatMap { campaign =>
+                                      notifier.shareNotify(
+                                        existingUser,
+                                        user,
+                                        campaign,
+                                        "campaign"
+                                      )
+                                    }
+                                  case _ => IO.pure(())
+                                }
+                              )).unsafeToFuture
+
+                          } map { _.flatten }
+                      }
+                    } yield permissions
+                }
+              }
+            }
+          }
+        }
     }
 }

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -25,7 +25,7 @@ trait CampaignProjectRoutes
   val xa: Transactor[IO]
 
   def listCampaignProjects(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -64,7 +64,7 @@ trait CampaignProjectRoutes
     }
 
   def getCampaignProject(campaignId: UUID, annotationProjectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -25,86 +25,88 @@ trait CampaignProjectRoutes
   val xa: Transactor[IO]
 
   def listCampaignProjects(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          (
-            CampaignDao
-              .isActiveCampaign(campaignId),
-            CampaignDao.authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            )
-          ).tupled.transact(xa).unsafeToFuture map {
-            case (true, AuthSuccess(_)) => true
-            case _                      => false
-          }
-        } {
-          (withPagination & annotationProjectQueryParameters) {
-            (page, annotationProjectQP) =>
-              complete {
-                AnnotationProjectDao
-                  .paginatedProjectsByCampaignId(
-                    campaignId,
-                    page,
-                    annotationProjectQP
-                  )
-                  .transact(xa)
-                  .unsafeToFuture
-              }
-          }
-        }
-
-      }
-    }
-
-  def getCampaignProject(campaignId: UUID, annotationProjectId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          (
-            CampaignDao.isActiveCampaign(campaignId),
-            CampaignDao
-              .authorized(
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            (
+              CampaignDao
+                .isActiveCampaign(campaignId),
+              CampaignDao.authorized(
                 user,
                 ObjectType.Campaign,
                 campaignId,
                 ActionType.View
-              ),
-            AnnotationProjectDao.authorized(
-              user,
-              ObjectType.AnnotationProject,
-              annotationProjectId,
-              ActionType.View
-            )
-          ).tupled.transact(xa).unsafeToFuture map {
-            case (true, campaignResult, annotationProjectResult) =>
-              campaignResult.toBoolean || annotationProjectResult.toBoolean
-            case _ => false
-          }
-        } {
-          complete {
-            AnnotationProjectDao
-              .listByCampaignQB(campaignId)
-              .filter(annotationProjectId)
-              .selectOption
-              .flatMap({ projOption =>
-                projOption traverse { proj =>
-                  AnnotationProjectDao.getWithRelatedAndSummaryById(proj.id)
+              )
+            ).tupled.transact(xa).unsafeToFuture map {
+              case (true, AuthSuccess(_)) => true
+              case _                      => false
+            }
+          } {
+            (withPagination & annotationProjectQueryParameters) {
+              (page, annotationProjectQP) =>
+                complete {
+                  AnnotationProjectDao
+                    .paginatedProjectsByCampaignId(
+                      campaignId,
+                      page,
+                      annotationProjectQP
+                    )
+                    .transact(xa)
+                    .unsafeToFuture
                 }
-              })
-              .transact(xa)
-              .unsafeToFuture
+            }
+          }
+
+        }
+    }
+
+  def getCampaignProject(campaignId: UUID, annotationProjectId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            (
+              CampaignDao.isActiveCampaign(campaignId),
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.View
+                ),
+              AnnotationProjectDao.authorized(
+                user,
+                ObjectType.AnnotationProject,
+                annotationProjectId,
+                ActionType.View
+              )
+            ).tupled.transact(xa).unsafeToFuture map {
+              case (true, campaignResult, annotationProjectResult) =>
+                campaignResult.toBoolean || annotationProjectResult.toBoolean
+              case _ => false
+            }
+          } {
+            complete {
+              AnnotationProjectDao
+                .listByCampaignQB(campaignId)
+                .filter(annotationProjectId)
+                .selectOption
+                .flatMap({ projOption =>
+                  projOption traverse { proj =>
+                    AnnotationProjectDao.getWithRelatedAndSummaryById(proj.id)
+                  }
+                })
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
+++ b/app-backend/api/src/main/scala/campaign/CampaignProjectRoutes.scala
@@ -25,7 +25,7 @@ trait CampaignProjectRoutes
   val xa: Transactor[IO]
 
   def listCampaignProjects(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user
@@ -64,7 +64,7 @@ trait CampaignProjectRoutes
     }
 
   def getCampaignProject(campaignId: UUID, annotationProjectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.Read, None),
         user

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -234,499 +234,512 @@ trait CampaignRoutes
   }
 
   def listCampaigns: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        (withPagination & campaignQueryParameters) { (page, campaignQP) =>
-          complete {
-            CampaignDao
-              .listCampaigns(page, campaignQP, user)
-              .transact(xa)
-              .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
+        ) {
+          (withPagination & campaignQueryParameters) { (page, campaignQP) =>
+            complete {
+              CampaignDao
+                .listCampaigns(page, campaignQP, user)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def createCampaign: Route =
-    authenticate { case (user, _) =>
-      authorizeScopeLimit(
-        CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
-        Domain.Campaigns,
-        Action.Create,
-        user
-      ) {
-        entity(as[Campaign.Create]) { newCampaign =>
-          onSuccess(
-            CampaignDao
-              .insertCampaign(newCampaign, user)
-              .transact(xa)
-              .unsafeToFuture
-          ) { campaign =>
-            complete((StatusCodes.Created, campaign))
+    authenticate {
+      case (user, _) =>
+        authorizeScopeLimit(
+          CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
+          Domain.Campaigns,
+          Action.Create,
+          user
+        ) {
+          entity(as[Campaign.Create]) { newCampaign =>
+            onSuccess(
+              CampaignDao
+                .insertCampaign(newCampaign, user)
+                .transact(xa)
+                .unsafeToFuture
+            ) { campaign =>
+              complete((StatusCodes.Created, campaign))
+            }
           }
         }
-      }
     }
 
   def getCampaign(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              CampaignDao
-                .getCampaignWithRelatedById(campaignId)
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-    }
-
-  def updateCampaign(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[Campaign]) { updatedCampaign =>
-            onSuccess(
-              CampaignDao
-                .updateCampaign(
-                  updatedCampaign,
-                  campaignId
-                )
-                .transact(xa)
-                .unsafeToFuture
-            ) {
-              completeSingleOrNotFound
-            }
-          }
-        }
-      }
-    }
-
-  def deleteCampaign(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Delete, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Delete
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          val updateFieldIO = for {
-            campaignOpt <- CampaignDao.getCampaignById(campaignId)
-            _ <- campaignOpt traverse { campaign =>
-              CampaignDao.updateCampaign(
-                campaign.copy(isActive = false),
-                campaign.id
-              )
-            }
-            projectsOpt <- campaignOpt traverse { campaign =>
-              AnnotationProjectDao.query
-                .filter(fr"campaign_id = ${campaign.id}")
-                .list
-            }
-            updated <- projectsOpt traverse { projects =>
-              projects traverse { project =>
-                AnnotationProjectDao
-                  .update(project.copy(isActive = false), project.id)
-              }
-            }
-          } yield updated
-
-          val deleteIO = for {
-            _ <- updateFieldIO.transact(xa)
-            deleted <- campaignDeleteBlocker.blockOn(
-              CampaignDao
-                .deleteCampaign(campaignId, user)
-                .transact(xa)
-                .start(campaignDeleteContextShift)
-            )(campaignDeleteContextShift)
-          } yield deleted
-
-          complete(
-            StatusCodes.Accepted,
-            deleteIO.void.unsafeToFuture
-          )
-        }
-      }
-    }
-
-  def cloneCampaign(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Clone, None),
-        user
-      ) {
-        authorizeAsync {
-          (
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             CampaignDao
               .authorized(
                 user,
                 ObjectType.Campaign,
                 campaignId,
                 ActionType.View
-              ) map {
-              _.toBoolean
-            },
-            CampaignDao.isActiveCampaign(campaignId)
-          ).tupled
-            .map({ authTup =>
-              authTup._1 && authTup._2
-            })
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[Campaign.Clone]) { campaignClone =>
-            onSuccess(
-              (campaignClone.grantAccessToParentCampaignOwner match {
-                case false =>
-                  CampaignDao.copyCampaign(
-                    campaignId,
-                    user,
-                    Some(campaignClone.tags),
-                    campaignClone.copyResourceLink
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                CampaignDao
+                  .getCampaignWithRelatedById(campaignId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def updateCampaign(campaignId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[Campaign]) { updatedCampaign =>
+              onSuccess(
+                CampaignDao
+                  .updateCampaign(
+                    updatedCampaign,
+                    campaignId
                   )
-                case true =>
-                  for {
-                    copiedCampaign <- CampaignDao.copyCampaign(
+                  .transact(xa)
+                  .unsafeToFuture
+              ) {
+                completeSingleOrNotFound
+              }
+            }
+          }
+        }
+    }
+
+  def deleteCampaign(campaignId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Delete, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Delete
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            val updateFieldIO = for {
+              campaignOpt <- CampaignDao.getCampaignById(campaignId)
+              _ <- campaignOpt traverse { campaign =>
+                CampaignDao.updateCampaign(
+                  campaign.copy(isActive = false),
+                  campaign.id
+                )
+              }
+              projectsOpt <- campaignOpt traverse { campaign =>
+                AnnotationProjectDao.query
+                  .filter(fr"campaign_id = ${campaign.id}")
+                  .list
+              }
+              updated <- projectsOpt traverse { projects =>
+                projects traverse { project =>
+                  AnnotationProjectDao
+                    .update(project.copy(isActive = false), project.id)
+                }
+              }
+            } yield updated
+
+            val deleteIO = for {
+              _ <- updateFieldIO.transact(xa)
+              deleted <- campaignDeleteBlocker.blockOn(
+                CampaignDao
+                  .deleteCampaign(campaignId, user)
+                  .transact(xa)
+                  .start(campaignDeleteContextShift)
+              )(campaignDeleteContextShift)
+            } yield deleted
+
+            complete(
+              StatusCodes.Accepted,
+              deleteIO.void.unsafeToFuture
+            )
+          }
+        }
+    }
+
+  def cloneCampaign(campaignId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Clone, None),
+          user
+        ) {
+          authorizeAsync {
+            (
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  campaignId,
+                  ActionType.View
+                ) map {
+                _.toBoolean
+              },
+              CampaignDao.isActiveCampaign(campaignId)
+            ).tupled
+              .map({ authTup =>
+                authTup._1 && authTup._2
+              })
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[Campaign.Clone]) { campaignClone =>
+              onSuccess(
+                (campaignClone.grantAccessToParentCampaignOwner match {
+                  case false =>
+                    CampaignDao.copyCampaign(
                       campaignId,
                       user,
                       Some(campaignClone.tags),
                       campaignClone.copyResourceLink
                     )
-                    copiedProjects <- AnnotationProjectDao.listByCampaign(
-                      copiedCampaign.id
-                    )
-                    originalCampaignO <- CampaignDao.getCampaignById(
-                      campaignId
-                    )
-                    originalCampaignOwnerO = originalCampaignO map {
-                      _.owner
-                    }
-                    _ <- CampaignDao.addPermission(
-                      copiedCampaign.id,
-                      ObjectAccessControlRule(
-                        SubjectType.User,
-                        originalCampaignOwnerO,
-                        ActionType.View
+                  case true =>
+                    for {
+                      copiedCampaign <- CampaignDao.copyCampaign(
+                        campaignId,
+                        user,
+                        Some(campaignClone.tags),
+                        campaignClone.copyResourceLink
                       )
-                    )
-                    _ <- copiedProjects traverse { project =>
-                      AnnotationProjectDao.addPermissionsMany(
-                        project.id,
-                        List(
-                          ObjectAccessControlRule(
-                            SubjectType.User,
-                            originalCampaignOwnerO,
-                            ActionType.View
-                          ),
-                          ObjectAccessControlRule(
-                            SubjectType.User,
-                            originalCampaignOwnerO,
-                            ActionType.Annotate
-                          )
+                      copiedProjects <- AnnotationProjectDao.listByCampaign(
+                        copiedCampaign.id
+                      )
+                      originalCampaignO <- CampaignDao.getCampaignById(
+                        campaignId
+                      )
+                      originalCampaignOwnerO = originalCampaignO map {
+                        _.owner
+                      }
+                      _ <- CampaignDao.addPermission(
+                        copiedCampaign.id,
+                        ObjectAccessControlRule(
+                          SubjectType.User,
+                          originalCampaignOwnerO,
+                          ActionType.View
                         )
                       )
-                    }
-                  } yield copiedCampaign
-              }).transact(xa).unsafeToFuture
-            ) { campaign =>
-              complete((StatusCodes.Created, campaign))
+                      _ <- copiedProjects traverse { project =>
+                        AnnotationProjectDao.addPermissionsMany(
+                          project.id,
+                          List(
+                            ObjectAccessControlRule(
+                              SubjectType.User,
+                              originalCampaignOwnerO,
+                              ActionType.View
+                            ),
+                            ObjectAccessControlRule(
+                              SubjectType.User,
+                              originalCampaignOwnerO,
+                              ActionType.Annotate
+                            )
+                          )
+                        )
+                      }
+                    } yield copiedCampaign
+                }).transact(xa).unsafeToFuture
+              ) { campaign =>
+                complete((StatusCodes.Created, campaign))
+              }
             }
           }
         }
-      }
     }
 
   def listCampaignUserActions(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          user.isSuperuser match {
-            case true => complete(List("*"))
-            case false =>
-              onSuccess(
-                CampaignDao
-                  .getCampaignById(campaignId)
-                  .transact(xa)
-                  .unsafeToFuture
-              ) { campaignO =>
-                complete {
-                  (campaignO traverse { campaign =>
-                    campaign.owner == user.id match {
-                      case true => List("*").pure[ConnectionIO]
-                      case false =>
-                        CampaignDao
-                          .listUserActions(user, campaignId)
-                    }
-                  } map { _.getOrElse(List[String]()) })
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            user.isSuperuser match {
+              case true => complete(List("*"))
+              case false =>
+                onSuccess(
+                  CampaignDao
+                    .getCampaignById(campaignId)
                     .transact(xa)
-                    .unsafeToFuture()
+                    .unsafeToFuture
+                ) { campaignO =>
+                  complete {
+                    (campaignO traverse { campaign =>
+                      campaign.owner == user.id match {
+                        case true => List("*").pure[ConnectionIO]
+                        case false =>
+                          CampaignDao
+                            .listUserActions(user, campaignId)
+                      }
+                    } map { _.getOrElse(List[String]()) })
+                      .transact(xa)
+                      .unsafeToFuture()
+                  }
                 }
-              }
+            }
           }
         }
-      }
     }
 
   def listCampaignCloneOwners(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Clone, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Clone, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             CampaignDao
-              .getCloneOwners(campaignId)
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
               .transact(xa)
               .unsafeToFuture
+          } {
+            complete {
+              CampaignDao
+                .getCloneOwners(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def getReviewTask(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          CampaignDao
-            .isActiveCampaign(campaignId)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          (campaignRandomTaskQueryParameters) { randomTaskQp =>
-            complete {
-              (
-                for {
-                  randomTaskOpt <- CampaignDao.randomReviewTask(
-                    campaignId,
-                    user
-                  )
-                  acrsOpt = randomTaskQp.requestAction.toList.toNel map {
-                    actions =>
-                      actions map { action =>
-                        ObjectAccessControlRule(
-                          SubjectType.User,
-                          Some(user.id),
-                          action
-                        )
-                      }
-                  }
-                  _ <- (randomTaskOpt, acrsOpt).tupled traverse {
-                    case (randomTask, acrs) =>
-                      (
-                        CampaignDao.addPermissionsMany(
-                          randomTask.properties.campaignId,
-                          acrs.toList,
-                          false
-                        ),
-                        AnnotationProjectDao.addPermissionsMany(
-                          randomTask.properties.annotationProjectId,
-                          acrs.toList,
-                          false
-                        )
-                      ).tupled
-                  } void
-                } yield randomTaskOpt
-              ).transact(xa).unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            CampaignDao
+              .isActiveCampaign(campaignId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            (campaignRandomTaskQueryParameters) { randomTaskQp =>
+              complete {
+                (
+                  for {
+                    randomTaskOpt <- CampaignDao.randomReviewTask(
+                      campaignId,
+                      user
+                    )
+                    acrsOpt = randomTaskQp.requestAction.toList.toNel map {
+                      actions =>
+                        actions map { action =>
+                          ObjectAccessControlRule(
+                            SubjectType.User,
+                            Some(user.id),
+                            action
+                          )
+                        }
+                    }
+                    _ <- (randomTaskOpt, acrsOpt).tupled traverse {
+                      case (randomTask, acrs) =>
+                        (
+                          CampaignDao.addPermissionsMany(
+                            randomTask.properties.campaignId,
+                            acrs.toList,
+                            false
+                          ),
+                          AnnotationProjectDao.addPermissionsMany(
+                            randomTask.properties.annotationProjectId,
+                            acrs.toList,
+                            false
+                          )
+                        ).tupled
+                    } void
+                  } yield randomTaskOpt
+                ).transact(xa).unsafeToFuture
+              }
             }
           }
-        }
 
-      }
+        }
     }
 
   def retrieveChildCampaignLabels(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Clone, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Clone, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             CampaignDao
-              .retrieveChildCampaignAnnotations(campaignId)
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Edit
+              )
               .transact(xa)
               .unsafeToFuture
-          } { complete(StatusCodes.NoContent) }
+          } {
+            onSuccess {
+              CampaignDao
+                .retrieveChildCampaignAnnotations(campaignId)
+                .transact(xa)
+                .unsafeToFuture
+            } { complete(StatusCodes.NoContent) }
+          }
         }
-      }
     }
 
   def listCampaignTasks(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync(
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
         ) {
-          (withPagination & taskQueryParameters) { (page, taskParams) =>
-            complete {
-              (
-                TaskDao
-                  .listCampaignTasks(
-                    taskParams,
-                    campaignId,
-                    page
+          authorizeAuthResultAsync(
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          ) {
+            (withPagination & taskQueryParameters) { (page, taskParams) =>
+              complete {
+                (
+                  TaskDao
+                    .listCampaignTasks(
+                      taskParams,
+                      campaignId,
+                      page
+                    )
                   )
-                )
-                .transact(xa)
-                .unsafeToFuture
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def getCampaignLabelClassSummary(campaignId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              CampaignDao
-                .getLabelClassSummary(campaignId)
-                .transact(xa)
-                .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                CampaignDao
+                  .getLabelClassSummary(campaignId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   private def getPerformance(
       campaignId: UUID,
       taskSessionType: TaskSessionType
   ): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Campaigns, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync(
-          CampaignDao
-            .authorized(
-              user,
-              ObjectType.Campaign,
-              campaignId,
-              ActionType.Validate
-            )
-            .transact(xa)
-            .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Campaigns, Action.Read, None),
+          user
         ) {
-          withPagination { page =>
-            complete {
-              CampaignDao
-                .performance(
-                  campaignId,
-                  taskSessionType,
-                  page
-                )
-                .transact(xa)
-                .unsafeToFuture
+          authorizeAuthResultAsync(
+            CampaignDao
+              .authorized(
+                user,
+                ObjectType.Campaign,
+                campaignId,
+                ActionType.Validate
+              )
+              .transact(xa)
+              .unsafeToFuture
+          ) {
+            withPagination { page =>
+              complete {
+                CampaignDao
+                  .performance(
+                    campaignId,
+                    taskSessionType,
+                    page
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def getValidatingPerformance(campaignId: UUID): Route =

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -234,7 +234,7 @@ trait CampaignRoutes
   }
 
   def listCampaigns: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -251,7 +251,7 @@ trait CampaignRoutes
     }
 
   def createCampaign: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScopeLimit(
         CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
         Domain.Campaigns,
@@ -272,7 +272,7 @@ trait CampaignRoutes
     }
 
   def getCampaign(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -301,7 +301,7 @@ trait CampaignRoutes
     }
 
   def updateCampaign(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -335,7 +335,7 @@ trait CampaignRoutes
     }
 
   def deleteCampaign(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Delete, None),
         user
@@ -391,7 +391,7 @@ trait CampaignRoutes
     }
 
   def cloneCampaign(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Clone, None),
         user
@@ -478,7 +478,7 @@ trait CampaignRoutes
     }
 
   def listCampaignUserActions(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
         user
@@ -522,7 +522,7 @@ trait CampaignRoutes
     }
 
   def listCampaignCloneOwners(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Clone, None),
         user
@@ -549,7 +549,7 @@ trait CampaignRoutes
     }
 
   def getReviewTask(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -603,7 +603,7 @@ trait CampaignRoutes
     }
 
   def retrieveChildCampaignLabels(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Clone, None),
         user
@@ -630,7 +630,7 @@ trait CampaignRoutes
     }
 
   def listCampaignTasks(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -665,7 +665,7 @@ trait CampaignRoutes
     }
 
   def getCampaignLabelClassSummary(campaignId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -697,7 +697,7 @@ trait CampaignRoutes
       campaignId: UUID,
       taskSessionType: TaskSessionType
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user

--- a/app-backend/api/src/main/scala/campaign/Routes.scala
+++ b/app-backend/api/src/main/scala/campaign/Routes.scala
@@ -234,7 +234,7 @@ trait CampaignRoutes
   }
 
   def listCampaigns: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -251,7 +251,7 @@ trait CampaignRoutes
     }
 
   def createCampaign: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScopeLimit(
         CampaignDao.countUserCampaigns(user).transact(xa).unsafeToFuture,
         Domain.Campaigns,
@@ -272,7 +272,7 @@ trait CampaignRoutes
     }
 
   def getCampaign(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -301,7 +301,7 @@ trait CampaignRoutes
     }
 
   def updateCampaign(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Update, None),
         user
@@ -335,7 +335,7 @@ trait CampaignRoutes
     }
 
   def deleteCampaign(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Delete, None),
         user
@@ -391,7 +391,7 @@ trait CampaignRoutes
     }
 
   def cloneCampaign(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Clone, None),
         user
@@ -478,7 +478,7 @@ trait CampaignRoutes
     }
 
   def listCampaignUserActions(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.ReadPermissions, None),
         user
@@ -522,7 +522,7 @@ trait CampaignRoutes
     }
 
   def listCampaignCloneOwners(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Clone, None),
         user
@@ -549,7 +549,7 @@ trait CampaignRoutes
     }
 
   def getReviewTask(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -603,7 +603,7 @@ trait CampaignRoutes
     }
 
   def retrieveChildCampaignLabels(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Clone, None),
         user
@@ -630,7 +630,7 @@ trait CampaignRoutes
     }
 
   def listCampaignTasks(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -665,7 +665,7 @@ trait CampaignRoutes
     }
 
   def getCampaignLabelClassSummary(campaignId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user
@@ -697,7 +697,7 @@ trait CampaignRoutes
       campaignId: UUID,
       taskSessionType: TaskSessionType
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Campaigns, Action.Read, None),
         user

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -65,7 +65,7 @@ trait DatasourceRoutes
   }
 
   def listDatasources: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Read, None),
         user
@@ -91,7 +91,7 @@ trait DatasourceRoutes
     }
 
   def getDatasource(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Read, None),
         user
@@ -120,7 +120,7 @@ trait DatasourceRoutes
     }
 
   def createDatasource: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Create, None),
         user
@@ -139,7 +139,7 @@ trait DatasourceRoutes
     }
 
   def updateDatasource(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Update, None),
         user
@@ -170,7 +170,7 @@ trait DatasourceRoutes
     }
 
   def deleteDatasource(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Delete, None),
         user
@@ -196,7 +196,7 @@ trait DatasourceRoutes
     }
 
   def listDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
         user
@@ -223,7 +223,7 @@ trait DatasourceRoutes
     }
 
   def replaceDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Share, None),
         user
@@ -271,7 +271,7 @@ trait DatasourceRoutes
     }
 
   def addDatasourcePermission(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Share, None),
         user
@@ -307,7 +307,7 @@ trait DatasourceRoutes
     }
 
   def listUserDatasourceActions(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
         user
@@ -345,7 +345,7 @@ trait DatasourceRoutes
     }
 
   def deleteDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Share, None),
         user

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -65,7 +65,7 @@ trait DatasourceRoutes
   }
 
   def listDatasources: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Read, None),
         user
@@ -91,7 +91,7 @@ trait DatasourceRoutes
     }
 
   def getDatasource(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Read, None),
         user
@@ -120,7 +120,7 @@ trait DatasourceRoutes
     }
 
   def createDatasource: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Create, None),
         user
@@ -139,7 +139,7 @@ trait DatasourceRoutes
     }
 
   def updateDatasource(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Update, None),
         user
@@ -170,7 +170,7 @@ trait DatasourceRoutes
     }
 
   def deleteDatasource(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Delete, None),
         user
@@ -196,7 +196,7 @@ trait DatasourceRoutes
     }
 
   def listDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
         user
@@ -223,7 +223,7 @@ trait DatasourceRoutes
     }
 
   def replaceDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Share, None),
         user
@@ -271,7 +271,7 @@ trait DatasourceRoutes
     }
 
   def addDatasourcePermission(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Share, None),
         user
@@ -307,7 +307,7 @@ trait DatasourceRoutes
     }
 
   def listUserDatasourceActions(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
         user
@@ -345,7 +345,7 @@ trait DatasourceRoutes
     }
 
   def deleteDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Share, None),
         user

--- a/app-backend/api/src/main/scala/datasource/Routes.scala
+++ b/app-backend/api/src/main/scala/datasource/Routes.scala
@@ -65,309 +65,319 @@ trait DatasourceRoutes
   }
 
   def listDatasources: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Read, None),
-        user
-      ) {
-        (withPagination & datasourceQueryParams) {
-          (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
-            complete {
-              DatasourceDao
-                .authQuery(
-                  user,
-                  ObjectType.Datasource,
-                  datasourceParams.ownershipTypeParams.ownershipType,
-                  datasourceParams.groupQueryParameters.groupType,
-                  datasourceParams.groupQueryParameters.groupId
-                )
-                .filter(datasourceParams)
-                .page(page)
-                .transact(xa)
-                .unsafeToFuture
-            }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Read, None),
+          user
+        ) {
+          (withPagination & datasourceQueryParams) {
+            (page: PageRequest, datasourceParams: DatasourceQueryParameters) =>
+              complete {
+                DatasourceDao
+                  .authQuery(
+                    user,
+                    ObjectType.Datasource,
+                    datasourceParams.ownershipTypeParams.ownershipType,
+                    datasourceParams.groupQueryParameters.groupType,
+                    datasourceParams.groupQueryParameters.groupId
+                  )
+                  .filter(datasourceParams)
+                  .page(page)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+          }
         }
-      }
     }
 
   def getDatasource(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          DatasourceDao
-            .authorized(
-              user,
-              ObjectType.Datasource,
-              datasourceId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              DatasourceDao
-                .getDatasourceById(datasourceId)
-                .transact(xa)
-                .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Read, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            DatasourceDao
+              .authorized(
+                user,
+                ObjectType.Datasource,
+                datasourceId,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                DatasourceDao
+                  .getDatasourceById(datasourceId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def createDatasource: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Create, None),
-        user
-      ) {
-        entity(as[Datasource.Create]) { newDatasource =>
-          onSuccess(
-            DatasourceDao
-              .createDatasource(newDatasource, user)
-              .transact(xa)
-              .unsafeToFuture
-          ) { datasource =>
-            complete((StatusCodes.Created, datasource))
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Create, None),
+          user
+        ) {
+          entity(as[Datasource.Create]) { newDatasource =>
+            onSuccess(
+              DatasourceDao
+                .createDatasource(newDatasource, user)
+                .transact(xa)
+                .unsafeToFuture
+            ) { datasource =>
+              complete((StatusCodes.Created, datasource))
+            }
           }
         }
-      }
     }
 
   def updateDatasource(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync(
-          DatasourceDao
-            .authorized(
-              user,
-              ObjectType.Datasource,
-              datasourceId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Update, None),
+          user
         ) {
-          entity(as[Datasource]) { updateDatasource =>
-            onSuccess(
-              DatasourceDao
-                .updateDatasource(updateDatasource, datasourceId)
-                .transact(xa)
-                .unsafeToFuture
-            ) {
-              completeSingleOrNotFound
+          authorizeAuthResultAsync(
+            DatasourceDao
+              .authorized(
+                user,
+                ObjectType.Datasource,
+                datasourceId,
+                ActionType.Edit
+              )
+              .transact(xa)
+              .unsafeToFuture
+          ) {
+            entity(as[Datasource]) { updateDatasource =>
+              onSuccess(
+                DatasourceDao
+                  .updateDatasource(updateDatasource, datasourceId)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) {
+                completeSingleOrNotFound
+              }
             }
           }
         }
-      }
     }
 
   def deleteDatasource(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Delete, None),
-        user
-      ) {
-        authorizeAsync {
-          DatasourceDao
-            .isDeletable(datasourceId, user)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Delete, None),
+          user
+        ) {
+          authorizeAsync {
             DatasourceDao
-              .deleteDatasourceWithRelated(datasourceId)
+              .isDeletable(datasourceId, user)
               .transact(xa)
               .unsafeToFuture
-          ) { counts: List[Int] =>
-            complete(
-              StatusCodes.OK -> s"${counts(1)} uploads deleted, ${counts(2)} scenes deleted. ${counts(0)} datasources deleted."
-            )
+          } {
+            onSuccess(
+              DatasourceDao
+                .deleteDatasourceWithRelated(datasourceId)
+                .transact(xa)
+                .unsafeToFuture
+            ) { counts: List[Int] =>
+              complete(
+                StatusCodes.OK -> s"${counts(1)} uploads deleted, ${counts(2)} scenes deleted. ${counts(0)} datasources deleted."
+              )
+            }
           }
         }
-      }
     }
 
   def listDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          DatasourceDao
-            .authorized(
-              user,
-              ObjectType.Datasource,
-              datasourceId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
             DatasourceDao
-              .getPermissions(datasourceId)
+              .authorized(
+                user,
+                ObjectType.Datasource,
+                datasourceId,
+                ActionType.View
+              )
               .transact(xa)
               .unsafeToFuture
+          } {
+            complete {
+              DatasourceDao
+                .getPermissions(datasourceId)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def replaceDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Share, None),
-        user
-      ) {
-        entity(as[List[ObjectAccessControlRule]]) { acrList =>
-          authorizeAsync {
-            (
-              DatasourceDao.authorized(
-                user,
-                ObjectType.Datasource,
-                datasourceId,
-                ActionType.Edit
-              ) map {
-                _.toBoolean
-              },
-              acrList traverse { acr =>
-                DatasourceDao.isValidPermission(acr, user)
-              } map {
-                _.foldLeft(true)(_ && _)
-              } map {
-                case true =>
-                  DatasourceDao.isReplaceWithinScopedLimit(
-                    Domain.Datasources,
-                    user,
-                    acrList
-                  )
-                case _ => false
-              }
-            ).tupled
-              .map({ authTup =>
-                authTup._1 && authTup._2
-              })
-              .transact(xa)
-              .unsafeToFuture
-          } {
-            complete {
-              DatasourceDao
-                .replacePermissions(datasourceId, acrList)
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Share, None),
+          user
+        ) {
+          entity(as[List[ObjectAccessControlRule]]) { acrList =>
+            authorizeAsync {
+              (
+                DatasourceDao.authorized(
+                  user,
+                  ObjectType.Datasource,
+                  datasourceId,
+                  ActionType.Edit
+                ) map {
+                  _.toBoolean
+                },
+                acrList traverse { acr =>
+                  DatasourceDao.isValidPermission(acr, user)
+                } map {
+                  _.foldLeft(true)(_ && _)
+                } map {
+                  case true =>
+                    DatasourceDao.isReplaceWithinScopedLimit(
+                      Domain.Datasources,
+                      user,
+                      acrList
+                    )
+                  case _ => false
+                }
+              ).tupled
+                .map({ authTup =>
+                  authTup._1 && authTup._2
+                })
                 .transact(xa)
                 .unsafeToFuture
+            } {
+              complete {
+                DatasourceDao
+                  .replacePermissions(datasourceId, acrList)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def addDatasourcePermission(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Share, None),
-        user
-      ) {
-        entity(as[ObjectAccessControlRule]) { acr =>
-          authorizeAsync {
-            (
-              DatasourceDao.authorized(
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Share, None),
+          user
+        ) {
+          entity(as[ObjectAccessControlRule]) { acr =>
+            authorizeAsync {
+              (
+                DatasourceDao.authorized(
+                  user,
+                  ObjectType.Datasource,
+                  datasourceId,
+                  ActionType.Edit
+                ) map {
+                  _.toBoolean
+                },
+                DatasourceDao.isValidPermission(acr, user)
+              ).tupled
+                .map({ authTup =>
+                  authTup._1 && authTup._2
+                })
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              complete {
+                DatasourceDao
+                  .addPermission(datasourceId, acr)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def listUserDatasourceActions(datasourceId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            DatasourceDao
+              .authorized(
+                user,
+                ObjectType.Datasource,
+                datasourceId,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            onSuccess(
+              DatasourceDao
+                .unsafeGetDatasourceById(datasourceId)
+                .transact(xa)
+                .unsafeToFuture
+            ) { datasource =>
+              datasource.owner == user.id match {
+                case true => complete(List("*"))
+                case false =>
+                  complete {
+                    DatasourceDao
+                      .listUserActions(user, datasourceId)
+                      .transact(xa)
+                      .unsafeToFuture
+                  }
+              }
+            }
+          }
+        }
+    }
+
+  def deleteDatasourcePermissions(datasourceId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Share, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            DatasourceDao
+              .authorized(
                 user,
                 ObjectType.Datasource,
                 datasourceId,
                 ActionType.Edit
-              ) map {
-                _.toBoolean
-              },
-              DatasourceDao.isValidPermission(acr, user)
-            ).tupled
-              .map({ authTup =>
-                authTup._1 && authTup._2
-              })
+              )
               .transact(xa)
               .unsafeToFuture
           } {
             complete {
               DatasourceDao
-                .addPermission(datasourceId, acr)
+                .deletePermissions(datasourceId)
                 .transact(xa)
                 .unsafeToFuture
             }
           }
         }
-      }
-    }
-
-  def listUserDatasourceActions(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          DatasourceDao
-            .authorized(
-              user,
-              ObjectType.Datasource,
-              datasourceId,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            DatasourceDao
-              .unsafeGetDatasourceById(datasourceId)
-              .transact(xa)
-              .unsafeToFuture
-          ) { datasource =>
-            datasource.owner == user.id match {
-              case true => complete(List("*"))
-              case false =>
-                complete {
-                  DatasourceDao
-                    .listUserActions(user, datasourceId)
-                    .transact(xa)
-                    .unsafeToFuture
-                }
-            }
-          }
-        }
-      }
-    }
-
-  def deleteDatasourcePermissions(datasourceId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Share, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          DatasourceDao
-            .authorized(
-              user,
-              ObjectType.Datasource,
-              datasourceId,
-              ActionType.Edit
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            DatasourceDao
-              .deletePermissions(datasourceId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -66,7 +66,7 @@ trait ExportRoutes
       }
   }
 
-  def listExports: Route = authenticate { case MembershipAndUser(_, user) =>
+  def listExports: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       (withPagination & exportQueryParams) {
         (page: PageRequest, queryParams: ExportQueryParameters) =>
@@ -82,7 +82,7 @@ trait ExportRoutes
     }
   }
 
-  def getExport(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def getExport(exportId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -104,7 +104,7 @@ trait ExportRoutes
     }
   }
 
-  def getExportDefinition(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def getExportDefinition(exportId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -128,7 +128,7 @@ trait ExportRoutes
     }
   }
 
-  def createExport: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createExport: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Create, None), user) {
       entity(as[Export.Create]) { newExport =>
         newExport.exportOptions.as[ExportOptions] match {
@@ -151,7 +151,7 @@ trait ExportRoutes
     }
   }
 
-  def updateExport(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def updateExport(exportId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Update, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -174,7 +174,7 @@ trait ExportRoutes
     }
   }
 
-  def deleteExport(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteExport(exportId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Delete, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -192,7 +192,7 @@ trait ExportRoutes
     }
   }
 
-  def exportFiles(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def exportFiles(exportId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -221,7 +221,7 @@ trait ExportRoutes
     }
   }
 
-  def proxiedFiles(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def proxiedFiles(exportId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -251,7 +251,7 @@ trait ExportRoutes
   }
 
   def redirectRoute(exportId: UUID, objectKey: String): Route =
-    authenticateWithParameter { case MembershipAndUser(_, user) =>
+    authenticateWithParameter { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
         authorizeAsync {
           ExportDao.query

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -251,7 +251,7 @@ trait ExportRoutes
   }
 
   def redirectRoute(exportId: UUID, objectKey: String): Route =
-    authenticateWithParameter { user =>
+    authenticateWithParameter { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
         authorizeAsync {
           ExportDao.query

--- a/app-backend/api/src/main/scala/exports/Routes.scala
+++ b/app-backend/api/src/main/scala/exports/Routes.scala
@@ -66,7 +66,7 @@ trait ExportRoutes
       }
   }
 
-  def listExports: Route = authenticate { user =>
+  def listExports: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       (withPagination & exportQueryParams) {
         (page: PageRequest, queryParams: ExportQueryParameters) =>
@@ -82,7 +82,7 @@ trait ExportRoutes
     }
   }
 
-  def getExport(exportId: UUID): Route = authenticate { user =>
+  def getExport(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -104,7 +104,7 @@ trait ExportRoutes
     }
   }
 
-  def getExportDefinition(exportId: UUID): Route = authenticate { user =>
+  def getExportDefinition(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -128,7 +128,7 @@ trait ExportRoutes
     }
   }
 
-  def createExport: Route = authenticate { user =>
+  def createExport: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Create, None), user) {
       entity(as[Export.Create]) { newExport =>
         newExport.exportOptions.as[ExportOptions] match {
@@ -151,7 +151,7 @@ trait ExportRoutes
     }
   }
 
-  def updateExport(exportId: UUID): Route = authenticate { user =>
+  def updateExport(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Update, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -174,7 +174,7 @@ trait ExportRoutes
     }
   }
 
-  def deleteExport(exportId: UUID): Route = authenticate { user =>
+  def deleteExport(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Delete, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -192,7 +192,7 @@ trait ExportRoutes
     }
   }
 
-  def exportFiles(exportId: UUID): Route = authenticate { user =>
+  def exportFiles(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query
@@ -221,7 +221,7 @@ trait ExportRoutes
     }
   }
 
-  def proxiedFiles(exportId: UUID): Route = authenticate { user =>
+  def proxiedFiles(exportId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Exports, Action.Read, None), user) {
       authorizeAsync {
         ExportDao.query

--- a/app-backend/api/src/main/scala/featureflags/Routes.scala
+++ b/app-backend/api/src/main/scala/featureflags/Routes.scala
@@ -36,7 +36,7 @@ trait FeatureFlagRoutes
 
   def getFeatureFlags: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.FeatureFlags, Action.Read, None),
           user

--- a/app-backend/api/src/main/scala/featureflags/Routes.scala
+++ b/app-backend/api/src/main/scala/featureflags/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.database.FeatureFlagDao

--- a/app-backend/api/src/main/scala/license/LicenseRoutes.scala
+++ b/app-backend/api/src/main/scala/license/LicenseRoutes.scala
@@ -36,7 +36,7 @@ trait LicenseRoutes
 
   def listLicenses: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Licenses, Action.Read, None), user) {
           withPagination { pageRequest =>
             complete(
@@ -48,7 +48,7 @@ trait LicenseRoutes
 
   def getLicense(shortName: String): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Licenses, Action.Read, None), user) {
           rejectEmptyResponse {
             complete(

--- a/app-backend/api/src/main/scala/license/LicenseRoutes.scala
+++ b/app-backend/api/src/main/scala/license/LicenseRoutes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.database.LicenseDao

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -42,7 +42,7 @@ trait MapTokenRoutes
       }
   }
 
-  def listMapTokens: Route = authenticate { user =>
+  def listMapTokens: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.MapTokens, Action.Read, None), user) {
       (withPagination & mapTokenQueryParams) { (page, mapTokenParams) =>
         complete {
@@ -55,7 +55,7 @@ trait MapTokenRoutes
     }
   }
 
-  def createMapToken: Route = authenticate { user =>
+  def createMapToken: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.MapTokens, Action.Create, None), user) {
       entity(as[MapToken.Create]) { newMapToken =>
         authorizeAsync {
@@ -94,7 +94,7 @@ trait MapTokenRoutes
     }
   }
 
-  def getMapToken(mapTokenId: UUID): Route = authenticate { user =>
+  def getMapToken(mapTokenId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.MapTokens, Action.Read, None), user) {
       authorizeAsync {
         MapTokenDao
@@ -117,7 +117,7 @@ trait MapTokenRoutes
     }
   }
 
-  def updateMapToken(mapTokenId: UUID): Route = authenticate { user =>
+  def updateMapToken(mapTokenId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.MapTokens, Action.Update, None), user) {
       authorizeAsync {
         MapTokenDao
@@ -139,7 +139,7 @@ trait MapTokenRoutes
     }
   }
 
-  def deleteMapToken(mapTokenId: UUID): Route = authenticate { user =>
+  def deleteMapToken(mapTokenId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.MapTokens, Action.Delete, None), user) {
       authorizeAsync {
         MapTokenDao

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.database._

--- a/app-backend/api/src/main/scala/maptoken/Routes.scala
+++ b/app-backend/api/src/main/scala/maptoken/Routes.scala
@@ -45,7 +45,7 @@ trait MapTokenRoutes
 
   def listMapTokens: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.MapTokens, Action.Read, None),
           user
@@ -63,7 +63,7 @@ trait MapTokenRoutes
 
   def createMapToken: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.MapTokens, Action.Create, None),
           user
@@ -110,7 +110,7 @@ trait MapTokenRoutes
 
   def getMapToken(mapTokenId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.MapTokens, Action.Read, None),
           user
@@ -138,7 +138,7 @@ trait MapTokenRoutes
 
   def updateMapToken(mapTokenId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.MapTokens, Action.Update, None),
           user
@@ -165,7 +165,7 @@ trait MapTokenRoutes
 
   def deleteMapToken(mapTokenId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.MapTokens, Action.Delete, None),
           user

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Config

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -51,7 +51,7 @@ trait OrganizationRoutes
 
   def getOrganization(orgId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Read, None),
           user
@@ -71,7 +71,7 @@ trait OrganizationRoutes
 
   def searchOrganizations(): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Search, None),
           user
@@ -89,7 +89,7 @@ trait OrganizationRoutes
 
   def addOrganizationLogo(orgID: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Update, None),
           user

--- a/app-backend/api/src/main/scala/organization/Routes.scala
+++ b/app-backend/api/src/main/scala/organization/Routes.scala
@@ -48,7 +48,7 @@ trait OrganizationRoutes
     }
   }
 
-  def getOrganization(orgId: UUID): Route = authenticate { user =>
+  def getOrganization(orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Organizations, Action.Read, None), user) {
       rejectEmptyResponse {
         complete {
@@ -63,7 +63,7 @@ trait OrganizationRoutes
     }
   }
 
-  def searchOrganizations(): Route = authenticate { user =>
+  def searchOrganizations(): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Organizations, Action.Search, None),
       user
@@ -79,7 +79,7 @@ trait OrganizationRoutes
     }
   }
 
-  def addOrganizationLogo(orgID: UUID): Route = authenticate { user =>
+  def addOrganizationLogo(orgID: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Organizations, Action.Update, None),
       user

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -183,7 +183,7 @@ trait PlatformRoutes
   // be able to do list, create, update, delete. Non-super users can only get a platform if they belong to it.
   def listPlatforms: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Platforms, Action.Read, None),
           user
@@ -202,7 +202,7 @@ trait PlatformRoutes
 
   def createPlatform: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Platforms, Action.Create, None),
           user
@@ -221,7 +221,7 @@ trait PlatformRoutes
 
   def getPlatform(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Platforms, Action.Read, None),
           user
@@ -246,7 +246,7 @@ trait PlatformRoutes
 
   def updatePlatform(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Platforms, Action.Update, None),
           user
@@ -271,7 +271,7 @@ trait PlatformRoutes
 
   def listPlatformMembers(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Platforms, Action.ListUsers, None),
           user
@@ -301,7 +301,7 @@ trait PlatformRoutes
   // - filtered by `search=<team name>` if specified
   def listPlatformUserTeams(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Search, None), user) {
           authorizeAsync {
             PlatformDao
@@ -323,7 +323,7 @@ trait PlatformRoutes
 
   def listPlatformOrganizations(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Read, None),
           user
@@ -348,7 +348,7 @@ trait PlatformRoutes
 
   def createOrganization(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Create, None),
           user
@@ -368,7 +368,7 @@ trait PlatformRoutes
 
   def getOrganization(platformId: UUID, orgId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Read, None),
           user
@@ -397,7 +397,7 @@ trait PlatformRoutes
 
   def updateOrganization(platformId: UUID, orgId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Update, None),
           user
@@ -421,7 +421,7 @@ trait PlatformRoutes
 
   def listOrganizationMembers(orgId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.ListUsers, None),
           user
@@ -447,7 +447,7 @@ trait PlatformRoutes
 
   def addUserToOrganization(platformId: UUID, orgId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.AddUser, None),
           user
@@ -479,7 +479,7 @@ trait PlatformRoutes
 
   def removeUserFromOrganization(orgId: UUID, userId: String): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.RemoveUser, None),
           user
@@ -508,7 +508,7 @@ trait PlatformRoutes
 
   def listTeams(platformId: UUID, organizationId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
           authorizeAsync {
             OrganizationDao
@@ -533,7 +533,7 @@ trait PlatformRoutes
 
   def createTeam(platformId: UUID, orgId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Create, None), user) {
           authorizeAsync {
             OrganizationDao
@@ -567,7 +567,7 @@ trait PlatformRoutes
 
   def getTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
           authorizeAsync {
             OrganizationDao
@@ -592,7 +592,7 @@ trait PlatformRoutes
 
   def updateTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Update, None), user) {
           authorizeAsync {
             TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
@@ -615,7 +615,7 @@ trait PlatformRoutes
 
   def deleteTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Delete, None), user) {
           authorizeAsync {
             TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
@@ -631,7 +631,7 @@ trait PlatformRoutes
 
   def listTeamMembers(platformId: UUID, orgId: UUID, teamId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Teams, Action.ListUsers, None),
           user
@@ -664,7 +664,7 @@ trait PlatformRoutes
 
   def addUserToTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.AddUser, None), user) {
           entity(as[UserGroupRole.UserRole]) { ur =>
             authorizeAsync {
@@ -706,7 +706,7 @@ trait PlatformRoutes
       userId: String
   ): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Teams, Action.RemoveUser, None),
           user
@@ -737,7 +737,7 @@ trait PlatformRoutes
 
   def setPlatformStatus(platformId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Platforms, Action.Update, None),
           user
@@ -776,7 +776,7 @@ trait PlatformRoutes
 
   def setOrganizationStatus(platformId: UUID, organizationId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Organizations, Action.Update, None),
           user

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -4,6 +4,7 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
+  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
@@ -180,443 +181,522 @@ trait PlatformRoutes
 
   // @TODO: most platform API interactions should be highly restricted -- only 'super-users' should
   // be able to do list, create, update, delete. Non-super users can only get a platform if they belong to it.
-  def listPlatforms: Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Platforms, Action.Read, None), user) {
-      authorizeAsync {
-        UserDao.isSuperUser(user).transact(xa).unsafeToFuture
-      } {
-        withPagination { page =>
-          complete {
-            PlatformDao.listPlatforms(page).transact(xa).unsafeToFuture
+  def listPlatforms: Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Platforms, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            UserDao.isSuperUser(user).transact(xa).unsafeToFuture
+          } {
+            withPagination { page =>
+              complete {
+                PlatformDao.listPlatforms(page).transact(xa).unsafeToFuture
+              }
+            }
           }
         }
-      }
     }
-  }
 
-  def createPlatform: Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Platforms, Action.Create, None), user) {
-      authorizeAsync {
-        UserDao.isSuperUser(user).transact(xa).unsafeToFuture
-      } {
-        entity(as[Platform]) { platform =>
-          completeOrFail {
-            PlatformDao.create(platform).transact(xa).unsafeToFuture
+  def createPlatform: Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Platforms, Action.Create, None),
+          user
+        ) {
+          authorizeAsync {
+            UserDao.isSuperUser(user).transact(xa).unsafeToFuture
+          } {
+            entity(as[Platform]) { platform =>
+              completeOrFail {
+                PlatformDao.create(platform).transact(xa).unsafeToFuture
+              }
+            }
           }
         }
-      }
     }
-  }
 
-  def getPlatform(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Platforms, Action.Read, None), user) {
-      authorizeAsync {
-        PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
-      } {
-        rejectEmptyResponse {
-          complete {
-            PlatformDao.getPlatformById(platformId).transact(xa).unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def updatePlatform(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Platforms, Action.Update, None), user) {
-      authorizeAsync {
-        PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
-      } {
-        entity(as[Platform]) { platformToUpdate =>
-          completeWithOneOrFail {
+  def getPlatform(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Platforms, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
             PlatformDao
-              .update(platformToUpdate, platformId)
+              .userIsMember(user, platformId)
               .transact(xa)
               .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                PlatformDao
+                  .getPlatformById(platformId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
           }
         }
-      }
     }
-  }
 
-  def listPlatformMembers(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.Platforms, Action.ListUsers, None),
-      user
-    ) {
-      authorizeAsync {
-        PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
-      } {
-        (withPagination & searchParams) { (page, searchParams) =>
-          complete {
+  def updatePlatform(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Platforms, Action.Update, None),
+          user
+        ) {
+          authorizeAsync {
             PlatformDao
-              .listMembers(platformId, page, searchParams, user)
+              .userIsAdmin(user, platformId)
               .transact(xa)
               .unsafeToFuture
+          } {
+            entity(as[Platform]) { platformToUpdate =>
+              completeWithOneOrFail {
+                PlatformDao
+                  .update(platformToUpdate, platformId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
           }
         }
-      }
     }
-  }
+
+  def listPlatformMembers(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Platforms, Action.ListUsers, None),
+          user
+        ) {
+          authorizeAsync {
+            PlatformDao
+              .userIsAdmin(user, platformId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            (withPagination & searchParams) { (page, searchParams) =>
+              complete {
+                PlatformDao
+                  .listMembers(platformId, page, searchParams, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
 
   // List teams:
   // - the operating user belongs to
   // - the operating user can see due to organization membership
   // - limited to first 5 ordered by team name
   // - filtered by `search=<team name>` if specified
-  def listPlatformUserTeams(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Teams, Action.Search, None), user) {
-      authorizeAsync {
-        PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
-      } {
-        (searchParams) { (searchParams) =>
-          complete {
+  def listPlatformUserTeams(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.Search, None), user) {
+          authorizeAsync {
             PlatformDao
-              .listPlatformUserTeams(user, searchParams)
+              .userIsMember(user, platformId)
               .transact(xa)
               .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def listPlatformOrganizations(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
-        } {
-          (withPagination & searchParams) { (page, search) =>
-            complete {
-              OrganizationDao
-                .listPlatformOrganizations(page, search, platformId, user)
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-  }
-
-  def createOrganization(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.Organizations, Action.Create, None),
-      user
-    ) {
-      entity(as[Organization.Create]) { orgToCreate =>
-        completeOrFail {
-          val createdOrg = for {
-            isAdmin <- PlatformDao.userIsAdmin(user, platformId)
-            org <- OrganizationDao.create(orgToCreate.toOrganization(isAdmin))
-          } yield org
-          createdOrg.transact(xa).unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def getOrganization(platformId: UUID, orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
-        } {
-          validateOrganization(platformId, orgId) {
-            rejectEmptyResponse {
+          } {
+            (searchParams) { (searchParams) =>
               complete {
-                OrganizationDao.query
-                  .filter(orgId)
-                  .filter(fr"platform_id = ${platformId}")
-                  .selectOption
+                PlatformDao
+                  .listPlatformUserTeams(user, searchParams)
                   .transact(xa)
                   .unsafeToFuture
               }
             }
           }
         }
-      }
-  }
+    }
 
-  def updateOrganization(platformId: UUID, orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.Update, None),
-        user
-      ) {
-        authorizeAsync {
-          OrganizationDao.userIsAdmin(user, orgId).transact(xa).unsafeToFuture
-        } {
-          validateOrganization(platformId, orgId) {
-            entity(as[Organization]) { orgToUpdate =>
-              completeWithOneOrFail {
+  def listPlatformOrganizations(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            PlatformDao
+              .userIsAdmin(user, platformId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            (withPagination & searchParams) { (page, search) =>
+              complete {
                 OrganizationDao
-                  .update(orgToUpdate, orgId)
+                  .listPlatformOrganizations(page, search, platformId, user)
                   .transact(xa)
                   .unsafeToFuture
               }
             }
           }
         }
-      }
-  }
+    }
+
+  def createOrganization(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.Create, None),
+          user
+        ) {
+          entity(as[Organization.Create]) { orgToCreate =>
+            completeOrFail {
+              val createdOrg = for {
+                isAdmin <- PlatformDao.userIsAdmin(user, platformId)
+                org <-
+                  OrganizationDao.create(orgToCreate.toOrganization(isAdmin))
+              } yield org
+              createdOrg.transact(xa).unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def getOrganization(platformId: UUID, orgId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            PlatformDao
+              .userIsMember(user, platformId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            validateOrganization(platformId, orgId) {
+              rejectEmptyResponse {
+                complete {
+                  OrganizationDao.query
+                    .filter(orgId)
+                    .filter(fr"platform_id = ${platformId}")
+                    .selectOption
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+              }
+            }
+          }
+        }
+    }
+
+  def updateOrganization(platformId: UUID, orgId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.Update, None),
+          user
+        ) {
+          authorizeAsync {
+            OrganizationDao.userIsAdmin(user, orgId).transact(xa).unsafeToFuture
+          } {
+            validateOrganization(platformId, orgId) {
+              entity(as[Organization]) { orgToUpdate =>
+                completeWithOneOrFail {
+                  OrganizationDao
+                    .update(orgToUpdate, orgId)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+              }
+            }
+          }
+        }
+    }
 
   def listOrganizationMembers(orgId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.ListUsers, None),
-        user
-      ) {
-        authorizeAsync {
-          // QUESTION: should this be open to members of the same platform?
-          OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
-        } {
-          (withPagination & searchParams) { (page, searchParams) =>
-            complete {
-              OrganizationDao
-                .listMembers(orgId, page, searchParams, user)
-                .transact(xa)
-                .unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.ListUsers, None),
+          user
+        ) {
+          authorizeAsync {
+            // QUESTION: should this be open to members of the same platform?
+            OrganizationDao
+              .userIsMember(user, orgId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            (withPagination & searchParams) { (page, searchParams) =>
+              complete {
+                OrganizationDao
+                  .listMembers(orgId, page, searchParams, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def addUserToOrganization(platformId: UUID, orgId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.AddUser, None),
-        user
-      ) {
-        entity(as[UserGroupRole.UserRole]) { ur =>
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.AddUser, None),
+          user
+        ) {
+          entity(as[UserGroupRole.UserRole]) { ur =>
+            authorizeAsync {
+              val authCheck = (
+                OrganizationDao.userIsAdmin(user, orgId),
+                PlatformDao.userIsMember(user, platformId),
+                (user.id == ur.userId).pure[ConnectionIO]
+              ).tupled.map(
+                {
+                  case (true, _, _) | (_, true, true) => true
+                  case _                              => false
+                }
+              )
+              authCheck.transact(xa).unsafeToFuture
+            } {
+              complete {
+                OrganizationDao
+                  .addUserRole(platformId, user, ur.userId, orgId, ur.groupRole)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def removeUserFromOrganization(orgId: UUID, userId: String): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.RemoveUser, None),
+          user
+        ) {
           authorizeAsync {
             val authCheck = (
               OrganizationDao.userIsAdmin(user, orgId),
-              PlatformDao.userIsMember(user, platformId),
-              (user.id == ur.userId).pure[ConnectionIO]
+              (userId == user.id).pure[ConnectionIO]
             ).tupled.map(
               {
-                case (true, _, _) | (_, true, true) => true
-                case _                              => false
+                case (true, _) | (_, true) => true
+                case _                     => false
               }
             )
             authCheck.transact(xa).unsafeToFuture
           } {
             complete {
               OrganizationDao
-                .addUserRole(platformId, user, ur.userId, orgId, ur.groupRole)
+                .deactivateUserRoles(userId, orgId)
                 .transact(xa)
                 .unsafeToFuture
             }
           }
         }
-      }
     }
 
-  def removeUserFromOrganization(orgId: UUID, userId: String): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.RemoveUser, None),
-        user
-      ) {
-        authorizeAsync {
-          val authCheck = (
-            OrganizationDao.userIsAdmin(user, orgId),
-            (userId == user.id).pure[ConnectionIO]
-          ).tupled.map(
-            {
-              case (true, _) | (_, true) => true
-              case _                     => false
-            }
-          )
-          authCheck.transact(xa).unsafeToFuture
-        } {
-          complete {
+  def listTeams(platformId: UUID, organizationId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
+          authorizeAsync {
             OrganizationDao
-              .deactivateUserRoles(userId, orgId)
+              .userIsMember(user, organizationId)
               .transact(xa)
               .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def listTeams(platformId: UUID, organizationId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
-        authorizeAsync {
-          OrganizationDao
-            .userIsMember(user, organizationId)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          validateOrganization(platformId, organizationId) {
-            (withPagination & teamQueryParameters) { (page, teamQueryParams) =>
-              complete {
-                TeamDao
-                  .listOrgTeams(organizationId, page, teamQueryParams)
-                  .transact(xa)
-                  .unsafeToFuture
+          } {
+            validateOrganization(platformId, organizationId) {
+              (withPagination & teamQueryParameters) {
+                (page, teamQueryParams) =>
+                  complete {
+                    TeamDao
+                      .listOrgTeams(organizationId, page, teamQueryParams)
+                      .transact(xa)
+                      .unsafeToFuture
+                  }
               }
             }
           }
         }
-      }
-  }
+    }
 
-  def createTeam(platformId: UUID, orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Teams, Action.Create, None), user) {
-      authorizeAsync {
-        OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
-      } {
-        validateOrganization(platformId, orgId) {
-          entity(as[Team.Create]) { newTeamCreate =>
-            onSuccess(
-              OrganizationDao
-                .userIsAdmin(user, orgId)
-                .flatMap {
-                  case true => TeamDao.create(newTeamCreate.toTeam(user))
-                  case _ =>
-                    TeamDao.createWithRole(
-                      newTeamCreate.toTeam(user),
-                      user
-                    )
+  def createTeam(platformId: UUID, orgId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.Create, None), user) {
+          authorizeAsync {
+            OrganizationDao
+              .userIsMember(user, orgId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            validateOrganization(platformId, orgId) {
+              entity(as[Team.Create]) { newTeamCreate =>
+                onSuccess(
+                  OrganizationDao
+                    .userIsAdmin(user, orgId)
+                    .flatMap {
+                      case true => TeamDao.create(newTeamCreate.toTeam(user))
+                      case _ =>
+                        TeamDao.createWithRole(
+                          newTeamCreate.toTeam(user),
+                          user
+                        )
+                    }
+                    .transact(xa)
+                    .unsafeToFuture()
+                ) { team =>
+                  complete(StatusCodes.Created, team)
                 }
-                .transact(xa)
-                .unsafeToFuture()
-            ) { team =>
-              complete(StatusCodes.Created, team)
+              }
             }
           }
         }
-      }
     }
-  }
 
   def getTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
-        authorizeAsync {
-          OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
-        } {
-          validateOrganizationAndTeam(platformId, orgId, teamId) {
-            rejectEmptyResponse {
-              complete {
-                TeamDao.query
-                  .filter(teamId)
-                  .selectOption
-                  .transact(xa)
-                  .unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
+          authorizeAsync {
+            OrganizationDao
+              .userIsMember(user, orgId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            validateOrganizationAndTeam(platformId, orgId, teamId) {
+              rejectEmptyResponse {
+                complete {
+                  TeamDao.query
+                    .filter(teamId)
+                    .selectOption
+                    .transact(xa)
+                    .unsafeToFuture
+                }
               }
             }
           }
         }
-      }
     }
 
   def updateTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Teams, Action.Update, None), user) {
-        authorizeAsync {
-          TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
-        } {
-          validateOrganizationAndTeam(platformId, orgId, teamId) {
-            entity(as[Team]) { updatedTeam =>
-              onSuccess {
-                TeamDao
-                  .update(updatedTeam, teamId)
-                  .transact(xa)
-                  .unsafeToFuture
-              } { team =>
-                complete(StatusCodes.OK, team)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.Update, None), user) {
+          authorizeAsync {
+            TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
+          } {
+            validateOrganizationAndTeam(platformId, orgId, teamId) {
+              entity(as[Team]) { updatedTeam =>
+                onSuccess {
+                  TeamDao
+                    .update(updatedTeam, teamId)
+                    .transact(xa)
+                    .unsafeToFuture
+                } { team =>
+                  complete(StatusCodes.OK, team)
+                }
               }
             }
           }
         }
-      }
     }
 
   def deleteTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Teams, Action.Delete, None), user) {
-        authorizeAsync {
-          TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
-        } {
-          validateOrganizationAndTeam(platformId, orgId, teamId) {
-            completeWithOneOrFail {
-              TeamDao.deactivate(teamId).transact(xa).unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.Delete, None), user) {
+          authorizeAsync {
+            TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
+          } {
+            validateOrganizationAndTeam(platformId, orgId, teamId) {
+              completeWithOneOrFail {
+                TeamDao.deactivate(teamId).transact(xa).unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def listTeamMembers(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Teams, Action.ListUsers, None), user) {
-        authorizeAsync {
-          // The authorization here is necessary to allow users within cross-organizational teams to view
-          // the members within those teams
-          val decisionIO = for {
-            isTeamMember <- TeamDao.userIsMember(user, teamId)
-            isOrganizationMember <- OrganizationDao.userIsMember(user, orgId)
-          } yield {
-            isTeamMember || isOrganizationMember
-          }
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Teams, Action.ListUsers, None),
+          user
+        ) {
+          authorizeAsync {
+            // The authorization here is necessary to allow users within cross-organizational teams to view
+            // the members within those teams
+            val decisionIO = for {
+              isTeamMember <- TeamDao.userIsMember(user, teamId)
+              isOrganizationMember <- OrganizationDao.userIsMember(user, orgId)
+            } yield {
+              isTeamMember || isOrganizationMember
+            }
 
-          decisionIO.transact(xa).unsafeToFuture
-        } {
-          validateOrganizationAndTeam(platformId, orgId, teamId) {
-            (withPagination & searchParams) { (page, searchParams) =>
-              complete {
-                TeamDao
-                  .listMembers(teamId, page, searchParams, user)
-                  .transact(xa)
-                  .unsafeToFuture
+            decisionIO.transact(xa).unsafeToFuture
+          } {
+            validateOrganizationAndTeam(platformId, orgId, teamId) {
+              (withPagination & searchParams) { (page, searchParams) =>
+                complete {
+                  TeamDao
+                    .listMembers(teamId, page, searchParams, user)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
               }
             }
           }
         }
-      }
     }
 
   def addUserToTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Teams, Action.AddUser, None), user) {
-        entity(as[UserGroupRole.UserRole]) { ur =>
-          authorizeAsync {
-            val authCheck = (
-              TeamDao.userIsAdmin(user, teamId),
-              PlatformDao.userIsMember(user, platformId),
-              (user.id == ur.userId).pure[ConnectionIO]
-            ).tupled.map(
-              {
-                case (true, _, _) | (_, true, true) => true
-                case _                              => false
-              }
-            )
-            authCheck.transact(xa).unsafeToFuture
-          } {
-            validateOrganizationAndTeam(platformId, orgId, teamId) {
-              complete {
-                TeamDao
-                  .addUserRole(
-                    platformId,
-                    user,
-                    ur.userId,
-                    teamId,
-                    ur.groupRole
-                  )
-                  .transact(xa)
-                  .unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Teams, Action.AddUser, None), user) {
+          entity(as[UserGroupRole.UserRole]) { ur =>
+            authorizeAsync {
+              val authCheck = (
+                TeamDao.userIsAdmin(user, teamId),
+                PlatformDao.userIsMember(user, platformId),
+                (user.id == ur.userId).pure[ConnectionIO]
+              ).tupled.map(
+                {
+                  case (true, _, _) | (_, true, true) => true
+                  case _                              => false
+                }
+              )
+              authCheck.transact(xa).unsafeToFuture
+            } {
+              validateOrganizationAndTeam(platformId, orgId, teamId) {
+                complete {
+                  TeamDao
+                    .addUserRole(
+                      platformId,
+                      user,
+                      ur.userId,
+                      teamId,
+                      ur.groupRole
+                    )
+                    .transact(xa)
+                    .unsafeToFuture
+                }
               }
             }
           }
         }
-      }
     }
 
   def removeUserFromTeam(
@@ -624,46 +704,59 @@ trait PlatformRoutes
       orgId: UUID,
       teamId: UUID,
       userId: String
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Teams, Action.RemoveUser, None), user) {
-      authorizeAsync {
-        val authCheck = (
-          TeamDao.userIsAdmin(user, teamId),
-          (userId == user.id).pure[ConnectionIO]
-        ).tupled.map(
-          {
-            case (true, _) | (_, true) => true
-            case _                     => false
+  ): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Teams, Action.RemoveUser, None),
+          user
+        ) {
+          authorizeAsync {
+            val authCheck = (
+              TeamDao.userIsAdmin(user, teamId),
+              (userId == user.id).pure[ConnectionIO]
+            ).tupled.map(
+              {
+                case (true, _) | (_, true) => true
+                case _                     => false
+              }
+            )
+            authCheck.transact(xa).unsafeToFuture
+          } {
+            validateOrganizationAndTeam(platformId, orgId, teamId) {
+              complete {
+                TeamDao
+                  .deactivateUserRoles(userId, teamId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
           }
-        )
-        authCheck.transact(xa).unsafeToFuture
-      } {
-        validateOrganizationAndTeam(platformId, orgId, teamId) {
-          complete {
-            TeamDao
-              .deactivateUserRoles(userId, teamId)
+        }
+    }
+
+  def setPlatformStatus(platformId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Platforms, Action.Update, None),
+          user
+        ) {
+          authorizeAsync {
+            PlatformDao
+              .userIsAdmin(user, platformId)
               .transact(xa)
               .unsafeToFuture
+          } {
+            entity(as[ActiveStatus]) {
+              case ActiveStatus(true) =>
+                activatePlatform(platformId, user)
+              case ActiveStatus(false) =>
+                deactivatePlatform(platformId)
+            }
           }
         }
-      }
     }
-  }
-
-  def setPlatformStatus(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Platforms, Action.Update, None), user) {
-      authorizeAsync {
-        PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
-      } {
-        entity(as[ActiveStatus]) {
-          case ActiveStatus(true) =>
-            activatePlatform(platformId, user)
-          case ActiveStatus(false) =>
-            deactivatePlatform(platformId)
-        }
-      }
-    }
-  }
 
   def activatePlatform(platformId: UUID, user: User): Route =
     authorizeScope(ScopedAction(Domain.Platforms, Action.Update, None), user) {
@@ -676,32 +769,34 @@ trait PlatformRoutes
       }
     }
 
-  def deactivatePlatform(platformId: UUID): Route = complete {
-    PlatformDao.deactivatePlatform(platformId).transact(xa).unsafeToFuture
-  }
+  def deactivatePlatform(platformId: UUID): Route =
+    complete {
+      PlatformDao.deactivatePlatform(platformId).transact(xa).unsafeToFuture
+    }
 
   def setOrganizationStatus(platformId: UUID, organizationId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Organizations, Action.Update, None),
-        user
-      ) {
-        authorizeAsync {
-          OrganizationDao
-            .userIsAdmin(user, organizationId)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          validateOrganization(platformId, organizationId) {
-            entity(as[String]) {
-              case status: String if status == OrgStatus.Active.toString =>
-                activateOrganization(platformId, organizationId, user)
-              case status: String if status == OrgStatus.Inactive.toString =>
-                deactivateOrganization(organizationId, user)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Organizations, Action.Update, None),
+          user
+        ) {
+          authorizeAsync {
+            OrganizationDao
+              .userIsAdmin(user, organizationId)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            validateOrganization(platformId, organizationId) {
+              entity(as[String]) {
+                case status: String if status == OrgStatus.Active.toString =>
+                  activateOrganization(platformId, organizationId, user)
+                case status: String if status == OrgStatus.Inactive.toString =>
+                  deactivateOrganization(organizationId, user)
+              }
             }
           }
         }
-      }
     }
 
   def activateOrganization(

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
@@ -357,8 +356,8 @@ trait PlatformRoutes
             completeOrFail {
               val createdOrg = for {
                 isAdmin <- PlatformDao.userIsAdmin(user, platformId)
-                org <-
-                  OrganizationDao.create(orgToCreate.toOrganization(isAdmin))
+                org <- OrganizationDao.create(
+                  orgToCreate.toOrganization(isAdmin))
               } yield org
               createdOrg.transact(xa).unsafeToFuture
             }

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -281,8 +281,7 @@ trait PlatformRoutes
     }
   }
 
-  def listPlatformOrganizations(platformId: UUID): Route = authenticate {
-    user =>
+  def listPlatformOrganizations(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.Read, None),
         user
@@ -319,8 +318,7 @@ trait PlatformRoutes
     }
   }
 
-  def getOrganization(platformId: UUID, orgId: UUID): Route = authenticate {
-    user =>
+  def getOrganization(platformId: UUID, orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.Read, None),
         user
@@ -344,8 +342,7 @@ trait PlatformRoutes
       }
   }
 
-  def updateOrganization(platformId: UUID, orgId: UUID): Route = authenticate {
-    user =>
+  def updateOrganization(platformId: UUID, orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.Update, None),
         user
@@ -448,8 +445,7 @@ trait PlatformRoutes
       }
     }
 
-  def listTeams(platformId: UUID, organizationId: UUID): Route = authenticate {
-    user =>
+  def listTeams(platformId: UUID, organizationId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
         authorizeAsync {
           OrganizationDao

--- a/app-backend/api/src/main/scala/platform/Routes.scala
+++ b/app-backend/api/src/main/scala/platform/Routes.scala
@@ -180,7 +180,7 @@ trait PlatformRoutes
 
   // @TODO: most platform API interactions should be highly restricted -- only 'super-users' should
   // be able to do list, create, update, delete. Non-super users can only get a platform if they belong to it.
-  def listPlatforms: Route = authenticate { user =>
+  def listPlatforms: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Platforms, Action.Read, None), user) {
       authorizeAsync {
         UserDao.isSuperUser(user).transact(xa).unsafeToFuture
@@ -194,7 +194,7 @@ trait PlatformRoutes
     }
   }
 
-  def createPlatform: Route = authenticate { user =>
+  def createPlatform: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Platforms, Action.Create, None), user) {
       authorizeAsync {
         UserDao.isSuperUser(user).transact(xa).unsafeToFuture
@@ -208,7 +208,7 @@ trait PlatformRoutes
     }
   }
 
-  def getPlatform(platformId: UUID): Route = authenticate { user =>
+  def getPlatform(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Platforms, Action.Read, None), user) {
       authorizeAsync {
         PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
@@ -222,7 +222,7 @@ trait PlatformRoutes
     }
   }
 
-  def updatePlatform(platformId: UUID): Route = authenticate { user =>
+  def updatePlatform(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Platforms, Action.Update, None), user) {
       authorizeAsync {
         PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
@@ -239,7 +239,7 @@ trait PlatformRoutes
     }
   }
 
-  def listPlatformMembers(platformId: UUID): Route = authenticate { user =>
+  def listPlatformMembers(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Platforms, Action.ListUsers, None),
       user
@@ -264,7 +264,7 @@ trait PlatformRoutes
   // - the operating user can see due to organization membership
   // - limited to first 5 ordered by team name
   // - filtered by `search=<team name>` if specified
-  def listPlatformUserTeams(platformId: UUID): Route = authenticate { user =>
+  def listPlatformUserTeams(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Teams, Action.Search, None), user) {
       authorizeAsync {
         PlatformDao.userIsMember(user, platformId).transact(xa).unsafeToFuture
@@ -302,7 +302,7 @@ trait PlatformRoutes
       }
   }
 
-  def createOrganization(platformId: UUID): Route = authenticate { user =>
+  def createOrganization(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Organizations, Action.Create, None),
       user
@@ -368,7 +368,7 @@ trait PlatformRoutes
   }
 
   def listOrganizationMembers(orgId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.ListUsers, None),
         user
@@ -390,7 +390,7 @@ trait PlatformRoutes
     }
 
   def addUserToOrganization(platformId: UUID, orgId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.AddUser, None),
         user
@@ -421,7 +421,7 @@ trait PlatformRoutes
     }
 
   def removeUserFromOrganization(orgId: UUID, userId: String): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.RemoveUser, None),
         user
@@ -471,7 +471,7 @@ trait PlatformRoutes
       }
   }
 
-  def createTeam(platformId: UUID, orgId: UUID): Route = authenticate { user =>
+  def createTeam(platformId: UUID, orgId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Teams, Action.Create, None), user) {
       authorizeAsync {
         OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
@@ -501,7 +501,7 @@ trait PlatformRoutes
   }
 
   def getTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
         authorizeAsync {
           OrganizationDao.userIsMember(user, orgId).transact(xa).unsafeToFuture
@@ -522,7 +522,7 @@ trait PlatformRoutes
     }
 
   def updateTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Teams, Action.Update, None), user) {
         authorizeAsync {
           TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
@@ -544,7 +544,7 @@ trait PlatformRoutes
     }
 
   def deleteTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Teams, Action.Delete, None), user) {
         authorizeAsync {
           TeamDao.userIsAdmin(user, teamId).transact(xa).unsafeToFuture
@@ -559,7 +559,7 @@ trait PlatformRoutes
     }
 
   def listTeamMembers(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Teams, Action.ListUsers, None), user) {
         authorizeAsync {
           // The authorization here is necessary to allow users within cross-organizational teams to view
@@ -588,7 +588,7 @@ trait PlatformRoutes
     }
 
   def addUserToTeam(platformId: UUID, orgId: UUID, teamId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Teams, Action.AddUser, None), user) {
         entity(as[UserGroupRole.UserRole]) { ur =>
           authorizeAsync {
@@ -628,7 +628,7 @@ trait PlatformRoutes
       orgId: UUID,
       teamId: UUID,
       userId: String
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Teams, Action.RemoveUser, None), user) {
       authorizeAsync {
         val authCheck = (
@@ -654,7 +654,7 @@ trait PlatformRoutes
     }
   }
 
-  def setPlatformStatus(platformId: UUID): Route = authenticate { user =>
+  def setPlatformStatus(platformId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Platforms, Action.Update, None), user) {
       authorizeAsync {
         PlatformDao.userIsAdmin(user, platformId).transact(xa).unsafeToFuture
@@ -685,7 +685,7 @@ trait PlatformRoutes
   }
 
   def setOrganizationStatus(platformId: UUID, organizationId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Organizations, Action.Update, None),
         user

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -32,7 +32,7 @@ trait ProjectAnnotationRoutes
 
   def listAnnotations(projectId: UUID): Route =
     authenticateAllowAnonymous {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           (authorizeAsync(
             ProjectDao
@@ -80,7 +80,7 @@ trait ProjectAnnotationRoutes
 
   def createAnnotation(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.CreateAnnotation, None),
           user
@@ -120,7 +120,7 @@ trait ProjectAnnotationRoutes
 
   def getAnnotation(projectId: UUID, annotationId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           authorizeAuthResultAsync {
             ProjectDao
@@ -147,7 +147,7 @@ trait ProjectAnnotationRoutes
 
   def updateAnnotation(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.UpdateAnnotation, None),
           user
@@ -180,7 +180,7 @@ trait ProjectAnnotationRoutes
 
   def deleteAnnotation(projectId: UUID, annotationId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
           user
@@ -210,7 +210,7 @@ trait ProjectAnnotationRoutes
 
   def deleteProjectAnnotations(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
           user
@@ -238,7 +238,7 @@ trait ProjectAnnotationRoutes
 
   def listAnnotationGroups(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationGroups, Action.Read, None),
           user
@@ -262,7 +262,7 @@ trait ProjectAnnotationRoutes
 
   def createAnnotationGroup(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationGroups, Action.Create, None),
           user
@@ -292,7 +292,7 @@ trait ProjectAnnotationRoutes
 
   def getAnnotationGroup(projectId: UUID, agId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationGroups, Action.Read, None),
           user
@@ -318,7 +318,7 @@ trait ProjectAnnotationRoutes
       annotationGroupId: UUID
   ): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationGroups, Action.Read, None),
           user
@@ -341,7 +341,7 @@ trait ProjectAnnotationRoutes
 
   def updateAnnotationGroup(projectId: UUID, agId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationGroups, Action.Update, None),
           user
@@ -371,7 +371,7 @@ trait ProjectAnnotationRoutes
 
   def deleteAnnotationGroup(projectId: UUID, agId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.AnnotationGroups, Action.Delete, None),
           user

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -77,7 +77,7 @@ trait ProjectAnnotationRoutes
       }
   }
 
-  def createAnnotation(projectId: UUID): Route = authenticate { user =>
+  def createAnnotation(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.CreateAnnotation, None),
       user
@@ -137,7 +137,7 @@ trait ProjectAnnotationRoutes
   }
 
   def updateAnnotation(projectId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.UpdateAnnotation, None),
         user
@@ -169,7 +169,7 @@ trait ProjectAnnotationRoutes
     }
 
   def deleteAnnotation(projectId: UUID, annotationId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
         user
@@ -197,7 +197,7 @@ trait ProjectAnnotationRoutes
       }
     }
 
-  def deleteProjectAnnotations(projectId: UUID): Route = authenticate { user =>
+  def deleteProjectAnnotations(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
       user
@@ -218,7 +218,7 @@ trait ProjectAnnotationRoutes
     }
   }
 
-  def listAnnotationGroups(projectId: UUID): Route = authenticate { user =>
+  def listAnnotationGroups(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationGroups, Action.Read, None),
       user
@@ -240,7 +240,7 @@ trait ProjectAnnotationRoutes
     }
   }
 
-  def createAnnotationGroup(projectId: UUID): Route = authenticate { user =>
+  def createAnnotationGroup(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationGroups, Action.Create, None),
       user
@@ -288,7 +288,7 @@ trait ProjectAnnotationRoutes
   def getAnnotationGroupSummary(
       projectId: UUID,
       annotationGroupId: UUID
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationGroups, Action.Read, None),
       user

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -110,8 +110,7 @@ trait ProjectAnnotationRoutes
     }
   }
 
-  def getAnnotation(projectId: UUID, annotationId: UUID): Route = authenticate {
-    user =>
+  def getAnnotation(projectId: UUID, annotationId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         authorizeAuthResultAsync {
           ProjectDao
@@ -263,8 +262,7 @@ trait ProjectAnnotationRoutes
     }
   }
 
-  def getAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate {
-    user =>
+  def getAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Read, None),
         user
@@ -309,8 +307,7 @@ trait ProjectAnnotationRoutes
     }
   }
 
-  def updateAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate {
-    user =>
+  def updateAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Update, None),
         user
@@ -338,8 +335,7 @@ trait ProjectAnnotationRoutes
       }
   }
 
-  def deleteAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate {
-    user =>
+  def deleteAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Delete, None),
         user

--- a/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectAnnotationRoutes.scala
@@ -30,334 +30,370 @@ trait ProjectAnnotationRoutes
   implicit val xa: Transactor[IO]
   implicit val ec: ExecutionContext
 
-  def listAnnotations(projectId: UUID): Route = authenticateAllowAnonymous {
-    user =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
-        (authorizeAsync(
-          ProjectDao
-            .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-            .map(_.toBoolean)
-        ) | projectIsPublic(projectId)) {
-          (withPagination & annotationQueryParams) {
-            (page: PageRequest, queryParams: AnnotationQueryParameters) =>
-              complete {
-                (queryParams.withOwnerInfo match {
-                  case Some(true) =>
-                    AnnotationDao
-                      .listByLayerWithOwnerInfo(projectId, page, queryParams)
-                      .transact(xa)
-                      .unsafeToFuture
-                      .map { p =>
-                        {
-                          fromPaginatedResponseToGeoJson[
-                            AnnotationWithOwnerInfo,
-                            AnnotationWithOwnerInfo.GeoJSON
-                          ](p)
-                        }
-                      }
-                  case _ =>
-                    AnnotationDao
-                      .listByLayer(projectId, page, queryParams)
-                      .transact(xa)
-                      .unsafeToFuture
-                      .map { p =>
-                        {
-                          fromPaginatedResponseToGeoJson[
-                            Annotation,
-                            Annotation.GeoJSON
-                          ](p)
-                        }
-                      }
-                })
-              }
-          }
-        }
-      }
-  }
-
-  def createAnnotation(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.Projects, Action.CreateAnnotation, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ProjectDao
-          .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[AnnotationFeatureCollectionCreate]) { fc =>
-          val annotationsCreate = fc.features map {
-            _.toAnnotationCreate
-          }
-          onSuccess(
-            AnnotationDao
-              .insertAnnotations(annotationsCreate.toList, projectId, user)
+  def listAnnotations(projectId: UUID): Route =
+    authenticateAllowAnonymous {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
+          (authorizeAsync(
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
               .transact(xa)
               .unsafeToFuture
-              .map { annotations: List[Annotation] =>
-                fromSeqToFeatureCollection[Annotation, Annotation.GeoJSON](
-                  annotations
-                )
-              }
-          ) { createdAnnotation =>
-            complete((StatusCodes.Created, createdAnnotation))
-          }
-        }
-      }
-    }
-  }
-
-  def getAnnotation(projectId: UUID, annotationId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(user, ObjectType.Project, projectId, ActionType.View)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              AnnotationDao
-                .getAnnotationById(projectId, annotationId)
-                .transact(xa)
-                .unsafeToFuture
-                .map {
-                  _ map {
-                    _.toGeoJSONFeature
-                  }
+              .map(_.toBoolean)
+          ) | projectIsPublic(projectId)) {
+            (withPagination & annotationQueryParams) {
+              (page: PageRequest, queryParams: AnnotationQueryParameters) =>
+                complete {
+                  (queryParams.withOwnerInfo match {
+                    case Some(true) =>
+                      AnnotationDao
+                        .listByLayerWithOwnerInfo(projectId, page, queryParams)
+                        .transact(xa)
+                        .unsafeToFuture
+                        .map { p =>
+                          {
+                            fromPaginatedResponseToGeoJson[
+                              AnnotationWithOwnerInfo,
+                              AnnotationWithOwnerInfo.GeoJSON
+                            ](p)
+                          }
+                        }
+                    case _ =>
+                      AnnotationDao
+                        .listByLayer(projectId, page, queryParams)
+                        .transact(xa)
+                        .unsafeToFuture
+                        .map { p =>
+                          {
+                            fromPaginatedResponseToGeoJson[
+                              Annotation,
+                              Annotation.GeoJSON
+                            ](p)
+                          }
+                        }
+                  })
                 }
             }
           }
         }
-      }
-  }
+    }
 
-  def updateAnnotation(projectId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Projects, Action.UpdateAnnotation, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(
-              user,
-              ObjectType.Project,
-              projectId,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[Annotation.GeoJSON]) {
-            updatedAnnotation: Annotation.GeoJSON =>
+  def createAnnotation(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.CreateAnnotation, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationFeatureCollectionCreate]) { fc =>
+              val annotationsCreate = fc.features map {
+                _.toAnnotationCreate
+              }
               onSuccess(
                 AnnotationDao
-                  .updateAnnotation(projectId, updatedAnnotation.toAnnotation)
+                  .insertAnnotations(annotationsCreate.toList, projectId, user)
                   .transact(xa)
                   .unsafeToFuture
-              ) { count =>
-                completeSingleOrNotFound(count)
+                  .map { annotations: List[Annotation] =>
+                    fromSeqToFeatureCollection[Annotation, Annotation.GeoJSON](
+                      annotations
+                    )
+                  }
+              ) { createdAnnotation =>
+                complete((StatusCodes.Created, createdAnnotation))
               }
+            }
           }
         }
-      }
+    }
+
+  def getAnnotation(projectId: UUID, annotationId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.View)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                AnnotationDao
+                  .getAnnotationById(projectId, annotationId)
+                  .transact(xa)
+                  .unsafeToFuture
+                  .map {
+                    _ map {
+                      _.toGeoJSONFeature
+                    }
+                  }
+              }
+            }
+          }
+        }
+    }
+
+  def updateAnnotation(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.UpdateAnnotation, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[Annotation.GeoJSON]) {
+              updatedAnnotation: Annotation.GeoJSON =>
+                onSuccess(
+                  AnnotationDao
+                    .updateAnnotation(projectId, updatedAnnotation.toAnnotation)
+                    .transact(xa)
+                    .unsafeToFuture
+                ) { count =>
+                  completeSingleOrNotFound(count)
+                }
+            }
+          }
+        }
     }
 
   def deleteAnnotation(projectId: UUID, annotationId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(
-              user,
-              ObjectType.Project,
-              projectId,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            AnnotationDao
-              .deleteById(projectId, annotationId)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
               .transact(xa)
               .unsafeToFuture
-          ) {
-            completeSingleOrNotFound
+          } {
+            onSuccess(
+              AnnotationDao
+                .deleteById(projectId, annotationId)
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              completeSingleOrNotFound
+            }
           }
         }
-      }
     }
 
-  def deleteProjectAnnotations(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ProjectDao
-          .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          AnnotationDao
-            .deleteByProjectLayer(projectId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def listAnnotationGroups(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationGroups, Action.Read, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ProjectDao
-          .authorized(user, ObjectType.Project, projectId, ActionType.View)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          AnnotationGroupDao
-            .listForProject(projectId)
-            .transact(xa)
-            .unsafeToFuture
-
-        }
-      }
-    }
-  }
-
-  def createAnnotationGroup(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationGroups, Action.Create, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ProjectDao
-          .authorized(user, ObjectType.Project, projectId, ActionType.Annotate)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[AnnotationGroup.Create]) { agCreate =>
-          complete {
-            AnnotationGroupDao
-              .createAnnotationGroup(projectId, agCreate, user)
+  def deleteProjectAnnotations(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
               .transact(xa)
               .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def getAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationGroups, Action.Read, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(user, ObjectType.Project, projectId, ActionType.View)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            AnnotationGroupDao
-              .getAnnotationGroup(projectId, agId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-  }
-
-  def getAnnotationGroupSummary(
-      projectId: UUID,
-      annotationGroupId: UUID
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(
-      ScopedAction(Domain.AnnotationGroups, Action.Read, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ProjectDao
-          .authorized(user, ObjectType.Project, projectId, ActionType.View)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          AnnotationGroupDao
-            .getAnnotationGroupSummary(annotationGroupId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def updateAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationGroups, Action.Update, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(
-              user,
-              ObjectType.Project,
-              projectId,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationGroup]) { annotationGroup =>
+          } {
             complete {
-              AnnotationGroupDao
-                .updateAnnotationGroup(projectId, annotationGroup, agId)
+              AnnotationDao
+                .deleteByProjectLayer(projectId)
                 .transact(xa)
                 .unsafeToFuture
             }
           }
         }
-      }
-  }
+    }
 
-  def deleteAnnotationGroup(projectId: UUID, agId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationGroups, Action.Delete, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(
-              user,
-              ObjectType.Project,
-              projectId,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            AnnotationGroupDao
-              .deleteAnnotationGroup(projectId, agId)
+  def listAnnotationGroups(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationGroups, Action.Read, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.View)
               .transact(xa)
               .unsafeToFuture
+          } {
+            complete {
+              AnnotationGroupDao
+                .listForProject(projectId)
+                .transact(xa)
+                .unsafeToFuture
+
+            }
           }
         }
-      }
-  }
+    }
+
+  def createAnnotationGroup(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationGroups, Action.Create, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationGroup.Create]) { agCreate =>
+              complete {
+                AnnotationGroupDao
+                  .createAnnotationGroup(projectId, agCreate, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def getAnnotationGroup(projectId: UUID, agId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationGroups, Action.Read, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.View)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              AnnotationGroupDao
+                .getAnnotationGroup(projectId, agId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def getAnnotationGroupSummary(
+      projectId: UUID,
+      annotationGroupId: UUID
+  ): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationGroups, Action.Read, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.View)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              AnnotationGroupDao
+                .getAnnotationGroupSummary(annotationGroupId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def updateAnnotationGroup(projectId: UUID, agId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationGroups, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationGroup]) { annotationGroup =>
+              complete {
+                AnnotationGroupDao
+                  .updateAnnotationGroup(projectId, annotationGroup, agId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def deleteAnnotationGroup(projectId: UUID, agId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationGroups, Action.Delete, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(
+                user,
+                ObjectType.Project,
+                projectId,
+                ActionType.Annotate
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              AnnotationGroupDao
+                .deleteAnnotationGroup(projectId, agId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
 }

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -50,7 +50,7 @@ trait ProjectLayerAnnotationRoutes
   }
 
   def listLayerAnnotations(projectId: UUID, layerId: UUID): Route =
-    authenticateAllowAnonymous { user =>
+    authenticateAllowAnonymous { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         (authorizeAsync(
           ProjectDao

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -31,8 +31,7 @@ trait ProjectLayerAnnotationRoutes
 
   implicit val ec: ExecutionContext
 
-  def listLayerLabels(projectId: UUID, layerId: UUID): Route = authenticate {
-    user =>
+  def listLayerLabels(projectId: UUID, layerId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         authorizeAsync {
           ProjectDao

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -31,7 +31,7 @@ trait ProjectLayerAnnotationRoutes
 
   implicit val ec: ExecutionContext
 
-  def listLayerLabels(projectId: UUID, layerId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listLayerLabels(projectId: UUID, layerId: UUID): Route = authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         authorizeAsync {
           ProjectDao
@@ -50,7 +50,7 @@ trait ProjectLayerAnnotationRoutes
   }
 
   def listLayerAnnotations(projectId: UUID, layerId: UUID): Route =
-    authenticateAllowAnonymous { case MembershipAndUser(_, user) =>
+    authenticateAllowAnonymous { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         (authorizeAsync(
           ProjectDao
@@ -101,7 +101,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def createLayerAnnotation(projectId: UUID, layerId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.CreateAnnotation, None),
         user
@@ -145,7 +145,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def deleteLayerAnnotations(projectId: UUID, layerId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
         user
@@ -175,7 +175,7 @@ trait ProjectLayerAnnotationRoutes
       projectId: UUID,
       annotationId: UUID,
       layerId: UUID
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
+  ): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAsync {
         ProjectDao
@@ -200,7 +200,7 @@ trait ProjectLayerAnnotationRoutes
     }
   }
   def updateLayerAnnotation(projectId: UUID, layerId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.UpdateAnnotation, None),
         user
@@ -236,7 +236,7 @@ trait ProjectLayerAnnotationRoutes
       annotationId: UUID,
       layerId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
         user
@@ -265,7 +265,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def listLayerAnnotationGroups(projectId: UUID, layerId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Read, None),
         user
@@ -287,7 +287,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def createLayerAnnotationGroup(projectId: UUID, layerId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Create, None),
         user
@@ -319,7 +319,7 @@ trait ProjectLayerAnnotationRoutes
       projectId: UUID,
       layerId: UUID,
       agId: UUID
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
+  ): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationGroups, Action.Read, None),
       user
@@ -351,7 +351,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       agId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Update, None),
         user
@@ -385,7 +385,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       agId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Delete, None),
         user
@@ -417,7 +417,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Read, None),
         user
@@ -451,7 +451,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationUploads, Action.Read, None),
         user
@@ -489,7 +489,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationUploads, Action.Create, None),
         user
@@ -572,7 +572,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID,
       uploadId: UUID
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
+  ): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationUploads, Action.Read, None),
       user
@@ -598,7 +598,7 @@ trait ProjectLayerAnnotationRoutes
       projectLayerId: UUID,
       annotationGroupId: UUID,
       uploadId: UUID
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
+  ): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationUploads, Action.Update, None),
       user
@@ -633,7 +633,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID,
       uploadId: UUID
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
+  ): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationUploads, Action.Delete, None),
       user

--- a/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerAnnotationRoutes.scala
@@ -102,7 +102,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def createLayerAnnotation(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.CreateAnnotation, None),
         user
@@ -146,7 +146,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def deleteLayerAnnotations(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
         user
@@ -176,7 +176,7 @@ trait ProjectLayerAnnotationRoutes
       projectId: UUID,
       annotationId: UUID,
       layerId: UUID
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAsync {
         ProjectDao
@@ -201,7 +201,7 @@ trait ProjectLayerAnnotationRoutes
     }
   }
   def updateLayerAnnotation(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.UpdateAnnotation, None),
         user
@@ -237,7 +237,7 @@ trait ProjectLayerAnnotationRoutes
       annotationId: UUID,
       layerId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.DeleteAnnotation, None),
         user
@@ -266,7 +266,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def listLayerAnnotationGroups(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Read, None),
         user
@@ -288,7 +288,7 @@ trait ProjectLayerAnnotationRoutes
     }
 
   def createLayerAnnotationGroup(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Create, None),
         user
@@ -320,7 +320,7 @@ trait ProjectLayerAnnotationRoutes
       projectId: UUID,
       layerId: UUID,
       agId: UUID
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationGroups, Action.Read, None),
       user
@@ -352,7 +352,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       agId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Update, None),
         user
@@ -386,7 +386,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       agId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Delete, None),
         user
@@ -418,7 +418,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationGroups, Action.Read, None),
         user
@@ -452,7 +452,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationUploads, Action.Read, None),
         user
@@ -490,7 +490,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationUploads, Action.Create, None),
         user
@@ -573,7 +573,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID,
       uploadId: UUID
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationUploads, Action.Read, None),
       user
@@ -599,7 +599,7 @@ trait ProjectLayerAnnotationRoutes
       projectLayerId: UUID,
       annotationGroupId: UUID,
       uploadId: UUID
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationUploads, Action.Update, None),
       user
@@ -634,7 +634,7 @@ trait ProjectLayerAnnotationRoutes
       layerId: UUID,
       annotationGroupId: UUID,
       uploadId: UUID
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.AnnotationUploads, Action.Delete, None),
       user

--- a/app-backend/api/src/main/scala/project/ProjectLayerRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerRoutes.scala
@@ -30,30 +30,40 @@ trait ProjectLayerRoutes
 
   val BULK_OPERATION_MAX_LIMIT = 100
 
-  def createProjectLayer(projectId: UUID): Route = authenticate { user =>
-    authorizeScope(ScopedAction(Domain.Projects, Action.Create, None), user) {
-      entity(as[ProjectLayer.Create]) { newProjectLayer =>
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            ProjectLayerDao
-              .insertProjectLayer(newProjectLayer.toProjectLayer)
-              .transact(xa)
-              .unsafeToFuture
-          ) { projectLayer =>
-            complete(StatusCodes.Created, projectLayer)
+  def createProjectLayer(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.Create, None),
+          user
+        ) {
+          entity(as[ProjectLayer.Create]) { newProjectLayer =>
+            authorizeAuthResultAsync {
+              ProjectDao
+                .authorized(
+                  user,
+                  ObjectType.Project,
+                  projectId,
+                  ActionType.Edit
+                )
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              onSuccess(
+                ProjectLayerDao
+                  .insertProjectLayer(newProjectLayer.toProjectLayer)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) { projectLayer =>
+                complete(StatusCodes.Created, projectLayer)
+              }
+            }
           }
         }
-      }
     }
-  }
 
-  def listProjectLayers(projectId: UUID): Route = authenticateAllowAnonymous {
-    user =>
+  def listProjectLayers(projectId: UUID): Route =
+    authenticateAllowAnonymous { user =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         (authorizeAsync(
           ProjectDao
@@ -73,10 +83,10 @@ trait ProjectLayerRoutes
         }
 
       }
-  }
+    }
 
-  def getProjectLayer(projectId: UUID, layerId: UUID): Route = authenticate {
-    user =>
+  def getProjectLayer(projectId: UUID, layerId: UUID): Route =
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         authorizeAuthResultAsync {
           ProjectDao
@@ -94,10 +104,10 @@ trait ProjectLayerRoutes
           }
         }
       }
-  }
+    }
 
-  def updateProjectLayer(projectId: UUID, layerId: UUID): Route = authenticate {
-    user =>
+  def updateProjectLayer(projectId: UUID, layerId: UUID): Route =
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Update, None), user) {
         authorizeAsync {
           ProjectDao
@@ -117,10 +127,10 @@ trait ProjectLayerRoutes
           }
         }
       }
-  }
+    }
 
-  def deleteProjectLayer(projectId: UUID, layerId: UUID): Route = authenticate {
-    user =>
+  def deleteProjectLayer(projectId: UUID, layerId: UUID): Route =
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Delete, None), user) {
         authorizeAsync {
           ProjectDao
@@ -138,27 +148,28 @@ trait ProjectLayerRoutes
           }
         }
       }
-  }
+    }
 
   def getProjectLayerMosaicDefinition(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
-        authorizeAsync {
-          ProjectDao
-            .authProjectLayerExist(projectId, layerId, user, ActionType.View)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              SceneToLayerDao
-                .getMosaicDefinition(layerId)
-                .transact(xa)
-                .unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
+          authorizeAsync {
+            ProjectDao
+              .authProjectLayerExist(projectId, layerId, user, ActionType.View)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                SceneToLayerDao
+                  .getMosaicDefinition(layerId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def getProjectLayerSceneColorCorrectParams(
@@ -166,22 +177,23 @@ trait ProjectLayerRoutes
       layerId: UUID,
       sceneId: UUID
   ): Route =
-    authenticate { user =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
-        authorizeAsync {
-          ProjectDao
-            .authProjectLayerExist(projectId, layerId, user, ActionType.View)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            SceneToLayerDao
-              .getColorCorrectParams(layerId, sceneId)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
+          authorizeAsync {
+            ProjectDao
+              .authProjectLayerExist(projectId, layerId, user, ActionType.View)
               .transact(xa)
               .unsafeToFuture
+          } {
+            complete {
+              SceneToLayerDao
+                .getColorCorrectParams(layerId, sceneId)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def setProjectLayerSceneColorCorrectParams(
@@ -189,92 +201,95 @@ trait ProjectLayerRoutes
       layerId: UUID,
       sceneId: UUID
   ): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.Projects, Action.ColorCorrect, None),
-        user
-      ) {
-        authorizeAsync {
-          ProjectDao
-            .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[ColorCorrect.Params]) { ccParams =>
-            onSuccess(
-              SceneToLayerDao
-                .setColorCorrectParams(layerId, sceneId, ccParams)
-                .transact(xa)
-                .unsafeToFuture
-            ) { _ =>
-              complete(StatusCodes.NoContent)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.ColorCorrect, None),
+          user
+        ) {
+          authorizeAsync {
+            ProjectDao
+              .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[ColorCorrect.Params]) { ccParams =>
+              onSuccess(
+                SceneToLayerDao
+                  .setColorCorrectParams(layerId, sceneId, ccParams)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) { _ =>
+                complete(StatusCodes.NoContent)
+              }
             }
           }
         }
-      }
     }
 
   def setProjectLayerScenesColorCorrectParams(
       projectId: UUID,
       layerId: UUID
   ): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.Projects, Action.ColorCorrect, None),
-        user
-      ) {
-        authorizeAsync {
-          ProjectDao
-            .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[BatchParams]) { params =>
-            onSuccess(
-              SceneToLayerDao
-                .setColorCorrectParamsBatch(layerId, params)
-                .transact(xa)
-                .unsafeToFuture
-            ) { _ =>
-              complete(StatusCodes.NoContent)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.ColorCorrect, None),
+          user
+        ) {
+          authorizeAsync {
+            ProjectDao
+              .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[BatchParams]) { params =>
+              onSuccess(
+                SceneToLayerDao
+                  .setColorCorrectParamsBatch(layerId, params)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) { _ =>
+                complete(StatusCodes.NoContent)
+              }
             }
           }
         }
-      }
     }
 
   def setProjectLayerSceneOrder(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(
-        ScopedAction(Domain.Projects, Action.ColorCorrect, None),
-        user
-      ) {
-        authorizeAsync {
-          ProjectDao
-            .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[List[UUID]]) { sceneIds =>
-            if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
-              complete(StatusCodes.PayloadTooLarge)
-            }
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.ColorCorrect, None),
+          user
+        ) {
+          authorizeAsync {
+            ProjectDao
+              .authProjectLayerExist(projectId, layerId, user, ActionType.Edit)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[List[UUID]]) { sceneIds =>
+              if (sceneIds.length > BULK_OPERATION_MAX_LIMIT) {
+                complete(StatusCodes.PayloadTooLarge)
+              }
 
-            onSuccess(
-              SceneToLayerDao
-                .setManualOrder(layerId, sceneIds)
-                .transact(xa)
-                .unsafeToFuture
-            ) { _ =>
-              complete(StatusCodes.NoContent)
+              onSuccess(
+                SceneToLayerDao
+                  .setManualOrder(layerId, sceneIds)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) { _ =>
+                complete(StatusCodes.NoContent)
+              }
             }
           }
         }
-      }
     }
 
-  def listLayerScenes(projectId: UUID, layerId: UUID): Route = authenticate {
-    user =>
+  def listLayerScenes(projectId: UUID, layerId: UUID): Route =
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         authorizeAuthResultAsync {
           ProjectDao
@@ -293,84 +308,93 @@ trait ProjectLayerRoutes
           }
         }
       }
-  }
+    }
 
   def listLayerDatasources(projectId: UUID, layerId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
-        (projectQueryParameters) { projectQueryParams =>
-          authorizeAsync {
-            val authorized = for {
-              authProject <- ProjectDao.authorized(
-                user,
-                ObjectType.Project,
-                projectId,
-                ActionType.View
-              )
-              authResult <- (authProject, projectQueryParams.analysisId) match {
-                case (AuthFailure(), Some(analysisId: UUID)) =>
-                  ToolRunDao
-                    .authorizeReferencedProject(user, analysisId, projectId)
-                case (_, _) =>
-                  Applicative[ConnectionIO].pure(authProject.toBoolean)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
+          (projectQueryParameters) { projectQueryParams =>
+            authorizeAsync {
+              val authorized = for {
+                authProject <- ProjectDao.authorized(
+                  user,
+                  ObjectType.Project,
+                  projectId,
+                  ActionType.View
+                )
+                authResult <-
+                  (authProject, projectQueryParams.analysisId) match {
+                    case (AuthFailure(), Some(analysisId: UUID)) =>
+                      ToolRunDao
+                        .authorizeReferencedProject(user, analysisId, projectId)
+                    case (_, _) =>
+                      Applicative[ConnectionIO].pure(authProject.toBoolean)
+                  }
+              } yield authResult
+              authorized.transact(xa).unsafeToFuture
+            } {
+              complete {
+                ProjectLayerDatasourcesDao
+                  .listProjectLayerDatasources(layerId)
+                  .transact(xa)
+                  .unsafeToFuture
               }
-            } yield authResult
-            authorized.transact(xa).unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def getProjectLayerSceneCounts(projectId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.View)
+              .transact(xa)
+              .unsafeToFuture
           } {
             complete {
-              ProjectLayerDatasourcesDao
-                .listProjectLayerDatasources(layerId)
+              ProjectLayerScenesDao
+                .countLayerScenes(projectId)
                 .transact(xa)
+                .map(Map(_: _*))
                 .unsafeToFuture
             }
           }
         }
-      }
-    }
-
-  def getProjectLayerSceneCounts(projectId: UUID): Route =
-    authenticate { user =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(user, ObjectType.Project, projectId, ActionType.View)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            ProjectLayerScenesDao
-              .countLayerScenes(projectId)
-              .transact(xa)
-              .map(Map(_: _*))
-              .unsafeToFuture
-          }
-        }
-      }
     }
 
   def setProjectLayerColorMode(projectId: UUID, layerId: UUID) =
-    authenticate { user =>
-      authorizeScope(ScopedAction(Domain.Projects, Action.Update, None), user) {
-        authorizeAuthResultAsync {
-          ProjectDao
-            .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[ProjectColorModeParams]) { colorBands =>
-            val setProjectLayerColorBandsIO = for {
-              rowsAffected <- SceneToLayerDao
-                .setProjectLayerColorBands(layerId, colorBands)
-            } yield {
-              rowsAffected
-            }
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Projects, Action.Update, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            ProjectDao
+              .authorized(user, ObjectType.Project, projectId, ActionType.Edit)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[ProjectColorModeParams]) { colorBands =>
+              val setProjectLayerColorBandsIO = for {
+                rowsAffected <-
+                  SceneToLayerDao
+                    .setProjectLayerColorBands(layerId, colorBands)
+              } yield {
+                rowsAffected
+              }
 
-            onSuccess(setProjectLayerColorBandsIO.transact(xa).unsafeToFuture) {
-              _ =>
+              onSuccess(
+                setProjectLayerColorBandsIO.transact(xa).unsafeToFuture
+              ) { _ =>
                 complete(StatusCodes.NoContent)
+              }
             }
           }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/project/ProjectLayerRoutes.scala
+++ b/app-backend/api/src/main/scala/project/ProjectLayerRoutes.scala
@@ -36,7 +36,7 @@ trait ProjectLayerRoutes
 
   def createProjectLayer(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.Create, None),
           user
@@ -67,7 +67,7 @@ trait ProjectLayerRoutes
     }
 
   def listProjectLayers(projectId: UUID): Route =
-    authenticateAllowAnonymous { case MembershipAndUser(_, user) =>
+    authenticateAllowAnonymous { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
         (authorizeAsync(
           ProjectDao
@@ -91,7 +91,7 @@ trait ProjectLayerRoutes
 
   def getProjectLayer(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           authorizeAuthResultAsync {
             ProjectDao
@@ -113,7 +113,7 @@ trait ProjectLayerRoutes
 
   def updateProjectLayer(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.Update, None),
           user
@@ -140,7 +140,7 @@ trait ProjectLayerRoutes
 
   def deleteProjectLayer(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.Delete, None),
           user
@@ -165,7 +165,7 @@ trait ProjectLayerRoutes
 
   def getProjectLayerMosaicDefinition(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           authorizeAsync {
             ProjectDao
@@ -191,7 +191,7 @@ trait ProjectLayerRoutes
       sceneId: UUID
   ): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           authorizeAsync {
             ProjectDao
@@ -215,7 +215,7 @@ trait ProjectLayerRoutes
       sceneId: UUID
   ): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.ColorCorrect, None),
           user
@@ -245,7 +245,7 @@ trait ProjectLayerRoutes
       layerId: UUID
   ): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.ColorCorrect, None),
           user
@@ -272,7 +272,7 @@ trait ProjectLayerRoutes
 
   def setProjectLayerSceneOrder(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.ColorCorrect, None),
           user
@@ -303,7 +303,7 @@ trait ProjectLayerRoutes
 
   def listLayerScenes(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           authorizeAuthResultAsync {
             ProjectDao
@@ -326,7 +326,7 @@ trait ProjectLayerRoutes
 
   def listLayerDatasources(projectId: UUID, layerId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           (projectQueryParameters) { projectQueryParams =>
             authorizeAsync {
@@ -361,7 +361,7 @@ trait ProjectLayerRoutes
 
   def getProjectLayerSceneCounts(projectId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
           authorizeAuthResultAsync {
             ProjectDao
@@ -382,7 +382,7 @@ trait ProjectLayerRoutes
 
   def setProjectLayerColorMode(projectId: UUID, layerId: UUID) =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Projects, Action.Update, None),
           user

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -556,8 +556,7 @@ trait ProjectRoutes
     }
   }
 
-  def acceptScene(projectId: UUID, sceneId: UUID): Route = authenticate {
-    user =>
+  def acceptScene(projectId: UUID, sceneId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.AddScenes, None),
         user
@@ -795,8 +794,7 @@ trait ProjectRoutes
   }
 
   /** Set color correction parameters for a list of scenes */
-  def setProjectScenesColorCorrectParams(projectId: UUID) = authenticate {
-    user =>
+  def setProjectScenesColorCorrectParams(projectId: UUID) = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.ColorCorrect, None),
         user

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -453,7 +453,7 @@ trait ProjectRoutes
       }
   }
 
-  def listProjects: Route = authenticate { case MembershipAndUser(_, user) =>
+  def listProjects: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       (withPagination & projectQueryParameters) {
         (page, projectQueryParameters) =>
@@ -467,7 +467,7 @@ trait ProjectRoutes
     }
   }
 
-  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createProject: Route = authenticate { case (user, _) =>
     val userProjectCount = ProjectDao.query
       .filter(fr"owner = ${user.id}")
       .count
@@ -487,7 +487,7 @@ trait ProjectRoutes
     }
   }
 
-  def getProject(projectId: UUID): Route = authenticateAllowAnonymous { case MembershipAndUser(_, user) =>
+  def getProject(projectId: UUID): Route = authenticateAllowAnonymous { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       (authorizeAsync(
         ProjectDao
@@ -503,7 +503,7 @@ trait ProjectRoutes
     }
   }
 
-  def updateProject(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def updateProject(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -525,7 +525,7 @@ trait ProjectRoutes
     }
   }
 
-  def deleteProject(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteProject(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -542,7 +542,7 @@ trait ProjectRoutes
     }
   }
 
-  def listLabels(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listLabels(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -557,7 +557,7 @@ trait ProjectRoutes
     }
   }
 
-  def acceptScene(projectId: UUID, sceneId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def acceptScene(projectId: UUID, sceneId: UUID): Route = authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.AddScenes, None),
         user
@@ -583,7 +583,7 @@ trait ProjectRoutes
       }
   }
 
-  def acceptScenes(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def acceptScenes(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.AddScenes, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -612,7 +612,7 @@ trait ProjectRoutes
     }
   }
 
-  def listProjectScenes(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listProjectScenes(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -637,7 +637,7 @@ trait ProjectRoutes
     }
   }
 
-  def listProjectDatasources(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listProjectDatasources(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Datasources, Action.Read, None), user) {
       (projectQueryParameters) { projectQueryParams =>
         authorizeAsync {
@@ -670,7 +670,7 @@ trait ProjectRoutes
   }
 
   /** Set the manually defined z-ordering for scenes within a given project */
-  def setProjectSceneOrder(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def setProjectSceneOrder(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ColorCorrect, None),
       user
@@ -704,7 +704,7 @@ trait ProjectRoutes
 
   /** Get the color correction paramters for a project/scene pairing */
   def getProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.ColorCorrect, None),
         user
@@ -734,7 +734,7 @@ trait ProjectRoutes
 
   /** Set color correction parameters for a project/scene pairing */
   def setProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.ColorCorrect, None),
         user
@@ -766,7 +766,7 @@ trait ProjectRoutes
       }
     }
 
-  def setProjectColorMode(projectId: UUID) = authenticate { case MembershipAndUser(_, user) =>
+  def setProjectColorMode(projectId: UUID) = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ColorCorrect, None),
       user
@@ -795,7 +795,7 @@ trait ProjectRoutes
   }
 
   /** Set color correction parameters for a list of scenes */
-  def setProjectScenesColorCorrectParams(projectId: UUID) = authenticate { case MembershipAndUser(_, user) =>
+  def setProjectScenesColorCorrectParams(projectId: UUID) = authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.ColorCorrect, None),
         user
@@ -825,7 +825,7 @@ trait ProjectRoutes
   }
 
   /** Get the information which defines mosaicing behavior for each scene in a given project */
-  def getProjectMosaicDefinition(projectId: UUID) = authenticate { case MembershipAndUser(_, user) =>
+  def getProjectMosaicDefinition(projectId: UUID) = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -853,7 +853,7 @@ trait ProjectRoutes
   }
 
   def addProjectScenes(projectId: UUID, layerIdO: Option[UUID] = None): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.AddScenes, None),
         user
@@ -892,7 +892,7 @@ trait ProjectRoutes
       projectId: UUID,
       layerIdO: Option[UUID] = None
   ): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.EditScenes, None),
         user
@@ -933,7 +933,7 @@ trait ProjectRoutes
   def deleteProjectScenes(
       projectId: UUID,
       layerIdO: Option[UUID] = None
-  ): Route = authenticate { case MembershipAndUser(_, user) =>
+  ): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.EditScenes, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -960,7 +960,7 @@ trait ProjectRoutes
     }
   }
 
-  def listProjectPermissions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listProjectPermissions(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ReadPermissions, None),
       user
@@ -981,7 +981,7 @@ trait ProjectRoutes
     }
   }
 
-  def replaceProjectPermissions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def replaceProjectPermissions(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -1025,7 +1025,7 @@ trait ProjectRoutes
     }
   }
 
-  def addProjectPermission(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def addProjectPermission(projectId: UUID): Route = authenticate { case (user, _) =>
     val shareCount =
       ProjectDao.getShareCount(projectId, user.id).transact(xa).unsafeToFuture
     authorizeScopeLimit(
@@ -1064,7 +1064,7 @@ trait ProjectRoutes
     }
   }
 
-  def listUserProjectActions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listUserProjectActions(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ReadPermissions, None),
       user
@@ -1100,7 +1100,7 @@ trait ProjectRoutes
     }
   }
 
-  def deleteProjectPermissions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteProjectPermissions(projectId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ProjectDao

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -452,7 +452,7 @@ trait ProjectRoutes
       }
   }
 
-  def listProjects: Route = authenticate { user =>
+  def listProjects: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       (withPagination & projectQueryParameters) {
         (page, projectQueryParameters) =>
@@ -466,7 +466,7 @@ trait ProjectRoutes
     }
   }
 
-  def createProject: Route = authenticate { user =>
+  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
     val userProjectCount = ProjectDao.query
       .filter(fr"owner = ${user.id}")
       .count
@@ -502,7 +502,7 @@ trait ProjectRoutes
     }
   }
 
-  def updateProject(projectId: UUID): Route = authenticate { user =>
+  def updateProject(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -524,7 +524,7 @@ trait ProjectRoutes
     }
   }
 
-  def deleteProject(projectId: UUID): Route = authenticate { user =>
+  def deleteProject(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -541,7 +541,7 @@ trait ProjectRoutes
     }
   }
 
-  def listLabels(projectId: UUID): Route = authenticate { user =>
+  def listLabels(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -583,7 +583,7 @@ trait ProjectRoutes
       }
   }
 
-  def acceptScenes(projectId: UUID): Route = authenticate { user =>
+  def acceptScenes(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.AddScenes, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -612,7 +612,7 @@ trait ProjectRoutes
     }
   }
 
-  def listProjectScenes(projectId: UUID): Route = authenticate { user =>
+  def listProjectScenes(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -637,7 +637,7 @@ trait ProjectRoutes
     }
   }
 
-  def listProjectDatasources(projectId: UUID): Route = authenticate { user =>
+  def listProjectDatasources(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Datasources, Action.Read, None), user) {
       (projectQueryParameters) { projectQueryParams =>
         authorizeAsync {
@@ -670,7 +670,7 @@ trait ProjectRoutes
   }
 
   /** Set the manually defined z-ordering for scenes within a given project */
-  def setProjectSceneOrder(projectId: UUID): Route = authenticate { user =>
+  def setProjectSceneOrder(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ColorCorrect, None),
       user
@@ -704,7 +704,7 @@ trait ProjectRoutes
 
   /** Get the color correction paramters for a project/scene pairing */
   def getProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.ColorCorrect, None),
         user
@@ -734,7 +734,7 @@ trait ProjectRoutes
 
   /** Set color correction parameters for a project/scene pairing */
   def setProjectSceneColorCorrectParams(projectId: UUID, sceneId: UUID) =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.ColorCorrect, None),
         user
@@ -766,7 +766,7 @@ trait ProjectRoutes
       }
     }
 
-  def setProjectColorMode(projectId: UUID) = authenticate { user =>
+  def setProjectColorMode(projectId: UUID) = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ColorCorrect, None),
       user
@@ -826,7 +826,7 @@ trait ProjectRoutes
   }
 
   /** Get the information which defines mosaicing behavior for each scene in a given project */
-  def getProjectMosaicDefinition(projectId: UUID) = authenticate { user =>
+  def getProjectMosaicDefinition(projectId: UUID) = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -854,7 +854,7 @@ trait ProjectRoutes
   }
 
   def addProjectScenes(projectId: UUID, layerIdO: Option[UUID] = None): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.AddScenes, None),
         user
@@ -893,7 +893,7 @@ trait ProjectRoutes
       projectId: UUID,
       layerIdO: Option[UUID] = None
   ): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Projects, Action.EditScenes, None),
         user
@@ -934,7 +934,7 @@ trait ProjectRoutes
   def deleteProjectScenes(
       projectId: UUID,
       layerIdO: Option[UUID] = None
-  ): Route = authenticate { user =>
+  ): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.EditScenes, None), user) {
       authorizeAuthResultAsync {
         ProjectDao
@@ -961,7 +961,7 @@ trait ProjectRoutes
     }
   }
 
-  def listProjectPermissions(projectId: UUID): Route = authenticate { user =>
+  def listProjectPermissions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ReadPermissions, None),
       user
@@ -982,7 +982,7 @@ trait ProjectRoutes
     }
   }
 
-  def replaceProjectPermissions(projectId: UUID): Route = authenticate { user =>
+  def replaceProjectPermissions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -1026,7 +1026,7 @@ trait ProjectRoutes
     }
   }
 
-  def addProjectPermission(projectId: UUID): Route = authenticate { user =>
+  def addProjectPermission(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     val shareCount =
       ProjectDao.getShareCount(projectId, user.id).transact(xa).unsafeToFuture
     authorizeScopeLimit(
@@ -1065,7 +1065,7 @@ trait ProjectRoutes
     }
   }
 
-  def listUserProjectActions(projectId: UUID): Route = authenticate { user =>
+  def listUserProjectActions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Projects, Action.ReadPermissions, None),
       user
@@ -1101,7 +1101,7 @@ trait ProjectRoutes
     }
   }
 
-  def deleteProjectPermissions(projectId: UUID): Route = authenticate { user =>
+  def deleteProjectPermissions(projectId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ProjectDao

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -4,6 +4,7 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
+  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.scene._

--- a/app-backend/api/src/main/scala/project/Routes.scala
+++ b/app-backend/api/src/main/scala/project/Routes.scala
@@ -486,7 +486,7 @@ trait ProjectRoutes
     }
   }
 
-  def getProject(projectId: UUID): Route = authenticateAllowAnonymous { user =>
+  def getProject(projectId: UUID): Route = authenticateAllowAnonymous { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Projects, Action.Read, None), user) {
       (authorizeAsync(
         ProjectDao

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Config
@@ -189,10 +188,9 @@ trait SceneRoutes
             ) match {
               case (Some(SceneType.COG), true) =>
                 for {
-                  insertedScene <-
-                    SceneDao
-                      .insert(uningestedScene, user)
-                      .transact(xa)
+                  insertedScene <- SceneDao
+                    .insert(uningestedScene, user)
+                    .transact(xa)
                   _ <- metadataIO(insertedScene.id).start
                 } yield insertedScene
 

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -4,6 +4,7 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
+  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Config
@@ -124,433 +125,456 @@ trait SceneRoutes
   }
 
   def listScenes: Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
-        (withPagination & sceneQueryParameters) { (page, sceneParams) =>
-          complete {
-            SceneWithRelatedDao
-              .listAuthorizedScenes(page, sceneParams, user)
-              .transact(xa)
-              .unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
+          (withPagination & sceneQueryParameters) { (page, sceneParams) =>
+            complete {
+              SceneWithRelatedDao
+                .listAuthorizedScenes(page, sceneParams, user)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def createScene: Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
-        entity(as[Scene.Create]) { newScene =>
-          val metadataIO = (sceneId: UUID) => {
-            newScene.ingestLocation traverse { location =>
-              (
-                cogUtils.getGeoTiffInfo(location),
-                cogUtils.histogramFromUri(location),
-                cogUtils.getTiffExtent(location)
-              ).tupled flatMap {
-                case (geotiffInfo, histogram, footprint) =>
-                  ((LayerAttributeDao
-                    .insertLayerAttribute(
-                      LayerAttribute(
-                        sceneId.toString,
-                        0,
-                        "histogram",
-                        histogram.asJson
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
+          entity(as[Scene.Create]) { newScene =>
+            val metadataIO = (sceneId: UUID) => {
+              newScene.ingestLocation traverse { location =>
+                (
+                  cogUtils.getGeoTiffInfo(location),
+                  cogUtils.histogramFromUri(location),
+                  cogUtils.getTiffExtent(location)
+                ).tupled flatMap {
+                  case (geotiffInfo, histogram, footprint) =>
+                    ((LayerAttributeDao
+                      .insertLayerAttribute(
+                        LayerAttribute(
+                          sceneId.toString,
+                          0,
+                          "histogram",
+                          histogram.asJson
+                        )
                       )
-                    )
-                    .attempt map {
-                    _.toOption
-                  }) *> SceneDao
-                    .updateSceneGeoTiffInfo(
-                      geotiffInfo,
-                      sceneId
-                    ) *> SceneDao.updateFootprints(
-                    sceneId,
-                    footprint,
-                    footprint,
-                    user
-                  ) *> SceneDao.markIngested(sceneId)).transact(xa)
+                      .attempt map {
+                      _.toOption
+                    }) *> SceneDao
+                      .updateSceneGeoTiffInfo(
+                        geotiffInfo,
+                        sceneId
+                      ) *> SceneDao.updateFootprints(
+                      sceneId,
+                      footprint,
+                      footprint,
+                      user
+                    ) *> SceneDao.markIngested(sceneId)).transact(xa)
+                }
               }
             }
-          }
 
-          val uningestedScene = newScene
-            .copy(
-              statusFields = newScene.statusFields.copy(
-                ingestStatus = IngestStatus.NotIngested
+            val uningestedScene = newScene
+              .copy(
+                statusFields = newScene.statusFields.copy(
+                  ingestStatus = IngestStatus.NotIngested
+                )
               )
-            )
-          val sceneInsert = (
-            newScene.sceneType,
-            !newScene.ingestLocation.isEmpty
-          ) match {
-            case (Some(SceneType.COG), true) =>
-              for {
-                insertedScene <- SceneDao
-                  .insert(uningestedScene, user)
-                  .transact(xa)
-                _ <- metadataIO(insertedScene.id).start
-              } yield insertedScene
+            val sceneInsert = (
+              newScene.sceneType,
+              !newScene.ingestLocation.isEmpty
+            ) match {
+              case (Some(SceneType.COG), true) =>
+                for {
+                  insertedScene <-
+                    SceneDao
+                      .insert(uningestedScene, user)
+                      .transact(xa)
+                  _ <- metadataIO(insertedScene.id).start
+                } yield insertedScene
 
-            case (_, false) =>
-              SceneDao.insert(uningestedScene, user).transact(xa)
-            case _ =>
-              throw new IllegalArgumentException(
-                "Unable to generate histograms for scene. Please verify that appropriate " ++
-                  "overviews exist. Histogram generation requires an overview smaller than 600x600."
-              )
-          }
+              case (_, false) =>
+                SceneDao.insert(uningestedScene, user).transact(xa)
+              case _ =>
+                throw new IllegalArgumentException(
+                  "Unable to generate histograms for scene. Please verify that appropriate " ++
+                    "overviews exist. Histogram generation requires an overview smaller than 600x600."
+                )
+            }
 
-          onSuccess(sceneInsert.unsafeToFuture) { scene =>
-            if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested)
-              kickoffSceneIngest(scene.id)
-            complete((StatusCodes.Created, scene))
+            onSuccess(sceneInsert.unsafeToFuture) { scene =>
+              if (scene.statusFields.ingestStatus == IngestStatus.ToBeIngested)
+                kickoffSceneIngest(scene.id)
+              complete((StatusCodes.Created, scene))
+            }
           }
         }
-      }
     }
 
   def getScene(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
-        authorizeAsync {
-          SceneDao
-            .authQuery(user, ObjectType.Scene)
-            .filter(sceneId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
+          authorizeAsync {
+            SceneDao
+              .authQuery(user, ObjectType.Scene)
+              .filter(sceneId)
+              .exists
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                SceneWithRelatedDao
+                  .getScene(sceneId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def updateScene(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Update, None), user) {
-        authorizeAuthResultAsync {
-          SceneDao
-            .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[Scene]) { updatedScene =>
-            onSuccess(
-              SceneDao
-                .update(updatedScene, sceneId, user)
-                .transact(xa)
-                .unsafeToFuture
-            ) {
-              completeSingleOrNotFound(_)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Update, None), user) {
+          authorizeAuthResultAsync {
+            SceneDao
+              .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[Scene]) { updatedScene =>
+              onSuccess(
+                SceneDao
+                  .update(updatedScene, sceneId, user)
+                  .transact(xa)
+                  .unsafeToFuture
+              ) {
+                completeSingleOrNotFound(_)
+              }
             }
           }
         }
-      }
     }
 
   def deleteScene(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Delete, None), user) {
-        authorizeAuthResultAsync {
-          SceneDao
-            .authorized(user, ObjectType.Scene, sceneId, ActionType.Delete)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          val response = for {
-            result <- SceneDao.query.filter(sceneId).delete.transact(xa)
-            _ <- SceneDao.deleteCache(sceneId).transact(xa)
-          } yield result
-          onSuccess(response.unsafeToFuture) {
-            completeSingleOrNotFound
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Delete, None), user) {
+          authorizeAuthResultAsync {
+            SceneDao
+              .authorized(user, ObjectType.Scene, sceneId, ActionType.Delete)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            val response = for {
+              result <- SceneDao.query.filter(sceneId).delete.transact(xa)
+              _ <- SceneDao.deleteCache(sceneId).transact(xa)
+            } yield result
+            onSuccess(response.unsafeToFuture) {
+              completeSingleOrNotFound
+            }
           }
         }
-      }
     }
 
   def getDownloadUrl(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Download, None), user) {
-        authorizeAuthResultAsync {
-          SceneWithRelatedDao
-            .authorized(user, ObjectType.Scene, sceneId, ActionType.Download)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
-          ) { scene =>
-            complete {
-              val retrievedScene = scene.getOrElse {
-                throw new Exception(
-                  "Scene does not exist or is not accessible by this user"
-                )
-              }
-              val s3Client = S3()
-              val whitelist = List(s"s3://$dataBucket")
-              (retrievedScene.sceneType, retrievedScene.ingestLocation) match {
-                case (Some(SceneType.COG), Some(ingestLocation)) =>
-                  val signedUrl =
-                    s3Client.maybeSignUri(ingestLocation, whitelist)
-                  List(
-                    Image.Downloadable(
-                      s"${sceneId}_COG.tif",
-                      s"$ingestLocation",
-                      signedUrl
-                    )
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Scenes, Action.Download, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            SceneWithRelatedDao
+              .authorized(user, ObjectType.Scene, sceneId, ActionType.Download)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            onSuccess(
+              SceneWithRelatedDao.getScene(sceneId).transact(xa).unsafeToFuture
+            ) { scene =>
+              complete {
+                val retrievedScene = scene.getOrElse {
+                  throw new Exception(
+                    "Scene does not exist or is not accessible by this user"
                   )
-                case _ =>
-                  retrievedScene.images map { image =>
-                    val downloadUri: String =
-                      s3Client.maybeSignUri(image.sourceUri, whitelist)
-                    image.toDownloadable(downloadUri)
+                }
+                val s3Client = S3()
+                val whitelist = List(s"s3://$dataBucket")
+                (
+                  retrievedScene.sceneType,
+                  retrievedScene.ingestLocation
+                ) match {
+                  case (Some(SceneType.COG), Some(ingestLocation)) =>
+                    val signedUrl =
+                      s3Client.maybeSignUri(ingestLocation, whitelist)
+                    List(
+                      Image.Downloadable(
+                        s"${sceneId}_COG.tif",
+                        s"$ingestLocation",
+                        signedUrl
+                      )
+                    )
+                  case _ =>
+                    retrievedScene.images map { image =>
+                      val downloadUri: String =
+                        s3Client.maybeSignUri(image.sourceUri, whitelist)
+                      image.toDownloadable(downloadUri)
+                    }
+                }
+              }
+            }
+          }
+        }
+    }
+
+  def listScenePermissions(sceneId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAuthResultAsync {
+            SceneDao
+              .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              SceneDao
+                .getPermissions(sceneId)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+    }
+
+  def replaceScenePermissions(sceneId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
+          entity(as[List[ObjectAccessControlRule]]) { acrList =>
+            authorizeAsync {
+              (
+                SceneDao
+                  .authorized(
+                    user,
+                    ObjectType.Scene,
+                    sceneId,
+                    ActionType.Edit
+                  ) map {
+                  _.toBoolean
+                },
+                acrList traverse { acr =>
+                  SceneDao.isValidPermission(acr, user)
+                } map {
+                  _.foldLeft(true)(_ && _)
+                } map {
+                  case true =>
+                    SceneDao.isReplaceWithinScopedLimit(
+                      Domain.Scenes,
+                      user,
+                      acrList
+                    )
+                  case _ => false
+                }
+              ).tupled
+                .map({ authTup =>
+                  authTup._1 && authTup._2
+                })
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              complete {
+                SceneDao
+                  .replacePermissions(sceneId, acrList)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def addScenePermission(sceneId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
+          entity(as[ObjectAccessControlRule]) { acr =>
+            authorizeAsync {
+              (
+                SceneDao
+                  .authorized(
+                    user,
+                    ObjectType.Scene,
+                    sceneId,
+                    ActionType.Edit
+                  ) map {
+                  _.toBoolean
+                },
+                SceneDao.isValidPermission(acr, user)
+              ).tupled
+                .map(authTup => authTup._1 && authTup._2)
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              complete {
+                SceneDao
+                  .addPermission(sceneId, acr)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def listUserSceneActions(sceneId: UUID): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
+          user
+        ) {
+          authorizeAsync {
+            SceneDao
+              .authQuery(user, ObjectType.Scene)
+              .filter(sceneId)
+              .exists
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            onSuccess(
+              SceneWithRelatedDao
+                .unsafeGetScene(sceneId)
+                .transact(xa)
+                .unsafeToFuture
+            ) { scene =>
+              scene.owner == user.id match {
+                case true => complete(List("*"))
+                case false =>
+                  complete {
+                    SceneDao
+                      .listUserActions(user, sceneId)
+                      .transact(xa)
+                      .unsafeToFuture
                   }
               }
             }
           }
         }
-      }
-    }
-
-  def listScenePermissions(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAuthResultAsync {
-          SceneDao
-            .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            SceneDao
-              .getPermissions(sceneId)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-
-  def replaceScenePermissions(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
-        entity(as[List[ObjectAccessControlRule]]) { acrList =>
-          authorizeAsync {
-            (
-              SceneDao
-                .authorized(
-                  user,
-                  ObjectType.Scene,
-                  sceneId,
-                  ActionType.Edit
-                ) map {
-                _.toBoolean
-              },
-              acrList traverse { acr =>
-                SceneDao.isValidPermission(acr, user)
-              } map {
-                _.foldLeft(true)(_ && _)
-              } map {
-                case true =>
-                  SceneDao.isReplaceWithinScopedLimit(
-                    Domain.Scenes,
-                    user,
-                    acrList
-                  )
-                case _ => false
-              }
-            ).tupled
-              .map({ authTup =>
-                authTup._1 && authTup._2
-              })
-              .transact(xa)
-              .unsafeToFuture
-          } {
-            complete {
-              SceneDao
-                .replacePermissions(sceneId, acrList)
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-    }
-
-  def addScenePermission(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
-        entity(as[ObjectAccessControlRule]) { acr =>
-          authorizeAsync {
-            (
-              SceneDao
-                .authorized(
-                  user,
-                  ObjectType.Scene,
-                  sceneId,
-                  ActionType.Edit
-                ) map {
-                _.toBoolean
-              },
-              SceneDao.isValidPermission(acr, user)
-            ).tupled
-              .map(authTup => authTup._1 && authTup._2)
-              .transact(xa)
-              .unsafeToFuture
-          } {
-            complete {
-              SceneDao
-                .addPermission(sceneId, acr)
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-    }
-
-  def listUserSceneActions(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
-        user
-      ) {
-        authorizeAsync {
-          SceneDao
-            .authQuery(user, ObjectType.Scene)
-            .filter(sceneId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            SceneWithRelatedDao
-              .unsafeGetScene(sceneId)
-              .transact(xa)
-              .unsafeToFuture
-          ) { scene =>
-            scene.owner == user.id match {
-              case true => complete(List("*"))
-              case false =>
-                complete {
-                  SceneDao
-                    .listUserActions(user, sceneId)
-                    .transact(xa)
-                    .unsafeToFuture
-                }
-            }
-          }
-        }
-      }
     }
 
   def deleteScenePermissions(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
-        authorizeAuthResultAsync {
-          SceneDao
-            .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
+          authorizeAuthResultAsync {
             SceneDao
-              .deletePermissions(sceneId)
+              .authorized(user, ObjectType.Scene, sceneId, ActionType.Edit)
               .transact(xa)
               .unsafeToFuture
+          } {
+            complete {
+              SceneDao
+                .deletePermissions(sceneId)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
-      }
     }
 
   def getSceneDatasource(sceneId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Datasources, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          SceneDao
-            .authQuery(user, ObjectType.Scene)
-            .filter(sceneId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            DatasourceDao
-              .getSceneDatasource(sceneId)
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Datasources, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            SceneDao
+              .authQuery(user, ObjectType.Scene)
+              .filter(sceneId)
+              .exists
               .transact(xa)
               .unsafeToFuture
-          ) { datasourceO =>
-            complete {
-              datasourceO
+          } {
+            onSuccess(
+              DatasourceDao
+                .getSceneDatasource(sceneId)
+                .transact(xa)
+                .unsafeToFuture
+            ) { datasourceO =>
+              complete {
+                datasourceO
+              }
             }
           }
         }
-      }
     }
 
   def getSentinelMetadata(sceneId: UUID, metadataUrl: String): Route =
-    authenticate { case MembershipAndUser(_, user) =>
-      authorizeScope(
-        ScopedAction(Domain.Scenes, Action.ReadSentinelMetadata, None),
-        user
-      ) {
-        authorizeAsync {
-          val authorizedIO = for {
-            auth <- SceneDao.authorized(
-              user,
-              ObjectType.Scene,
-              sceneId,
-              ActionType.View
-            ) map {
-              _.toBoolean
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(
+          ScopedAction(Domain.Scenes, Action.ReadSentinelMetadata, None),
+          user
+        ) {
+          authorizeAsync {
+            val authorizedIO = for {
+              auth <- SceneDao.authorized(
+                user,
+                ObjectType.Scene,
+                sceneId,
+                ActionType.View
+              ) map {
+                _.toBoolean
+              }
+              datasource <- DatasourceDao.getSceneDatasource(sceneId)
+            } yield {
+              auth && (datasource map { (ds: Datasource) =>
+                Some(ds.id) == Some(UUID.fromString(sentinel2DatasourceId))
+              } getOrElse {
+                false
+              })
             }
-            datasource <- DatasourceDao.getSceneDatasource(sceneId)
-          } yield {
-            auth && (datasource map { (ds: Datasource) =>
-              Some(ds.id) == Some(UUID.fromString(sentinel2DatasourceId))
-            } getOrElse {
-              false
-            })
-          }
-          authorizedIO.transact(xa).unsafeToFuture
-        } {
-          onSuccess(
-            SceneDao
-              .getSentinelMetadata(metadataUrl)
-              .transact(xa)
-              .unsafeToFuture
-          ) { (s3Object, metaData) =>
-            metaData.getContentType() match {
-              case "application/json" =>
-                complete(
-                  HttpResponse(
-                    entity =
-                      HttpEntity(ContentTypes.`application/json`, s3Object)
+            authorizedIO.transact(xa).unsafeToFuture
+          } {
+            onSuccess(
+              SceneDao
+                .getSentinelMetadata(metadataUrl)
+                .transact(xa)
+                .unsafeToFuture
+            ) { (s3Object, metaData) =>
+              metaData.getContentType() match {
+                case "application/json" =>
+                  complete(
+                    HttpResponse(
+                      entity =
+                        HttpEntity(ContentTypes.`application/json`, s3Object)
+                    )
                   )
-                )
-              case "application/xml" =>
-                complete(
-                  HttpResponse(
-                    entity =
-                      HttpEntity(ContentTypes.`text/xml(UTF-8)`, s3Object)
+                case "application/xml" =>
+                  complete(
+                    HttpResponse(
+                      entity =
+                        HttpEntity(ContentTypes.`text/xml(UTF-8)`, s3Object)
+                    )
                   )
-                )
-              case _ =>
-                complete(StatusCodes.UnsupportedMediaType)
+                case _ =>
+                  complete(StatusCodes.UnsupportedMediaType)
+              }
             }
           }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -124,7 +124,7 @@ trait SceneRoutes
   }
 
   def listScenes: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
         (withPagination & sceneQueryParameters) { (page, sceneParams) =>
           complete {
@@ -138,7 +138,7 @@ trait SceneRoutes
     }
 
   def createScene: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
         entity(as[Scene.Create]) { newScene =>
           val metadataIO = (sceneId: UUID) => {
@@ -211,7 +211,7 @@ trait SceneRoutes
     }
 
   def getScene(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
         authorizeAsync {
           SceneDao
@@ -231,7 +231,7 @@ trait SceneRoutes
     }
 
   def updateScene(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Update, None), user) {
         authorizeAuthResultAsync {
           SceneDao
@@ -254,7 +254,7 @@ trait SceneRoutes
     }
 
   def deleteScene(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Delete, None), user) {
         authorizeAuthResultAsync {
           SceneDao
@@ -274,7 +274,7 @@ trait SceneRoutes
     }
 
   def getDownloadUrl(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Download, None), user) {
         authorizeAuthResultAsync {
           SceneWithRelatedDao
@@ -318,7 +318,7 @@ trait SceneRoutes
     }
 
   def listScenePermissions(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
         user
@@ -340,7 +340,7 @@ trait SceneRoutes
     }
 
   def replaceScenePermissions(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
         entity(as[List[ObjectAccessControlRule]]) { acrList =>
           authorizeAsync {
@@ -386,7 +386,7 @@ trait SceneRoutes
     }
 
   def addScenePermission(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
         entity(as[ObjectAccessControlRule]) { acr =>
           authorizeAsync {
@@ -418,7 +418,7 @@ trait SceneRoutes
     }
 
   def listUserSceneActions(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
         user
@@ -453,7 +453,7 @@ trait SceneRoutes
     }
 
   def deleteScenePermissions(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
         authorizeAuthResultAsync {
           SceneDao
@@ -472,7 +472,7 @@ trait SceneRoutes
     }
 
   def getSceneDatasource(sceneId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Datasources, Action.Read, None),
         user
@@ -500,7 +500,7 @@ trait SceneRoutes
     }
 
   def getSentinelMetadata(sceneId: UUID, metadataUrl: String): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.Scenes, Action.ReadSentinelMetadata, None),
         user

--- a/app-backend/api/src/main/scala/scene/Routes.scala
+++ b/app-backend/api/src/main/scala/scene/Routes.scala
@@ -126,7 +126,7 @@ trait SceneRoutes
 
   def listScenes: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
           (withPagination & sceneQueryParameters) { (page, sceneParams) =>
             complete {
@@ -141,7 +141,7 @@ trait SceneRoutes
 
   def createScene: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Create, None), user) {
           entity(as[Scene.Create]) { newScene =>
             val metadataIO = (sceneId: UUID) => {
@@ -216,7 +216,7 @@ trait SceneRoutes
 
   def getScene(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Read, None), user) {
           authorizeAsync {
             SceneDao
@@ -240,7 +240,7 @@ trait SceneRoutes
 
   def updateScene(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Update, None), user) {
           authorizeAuthResultAsync {
             SceneDao
@@ -264,7 +264,7 @@ trait SceneRoutes
 
   def deleteScene(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Delete, None), user) {
           authorizeAuthResultAsync {
             SceneDao
@@ -285,7 +285,7 @@ trait SceneRoutes
 
   def getDownloadUrl(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Scenes, Action.Download, None),
           user
@@ -336,7 +336,7 @@ trait SceneRoutes
 
   def listScenePermissions(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
           user
@@ -359,7 +359,7 @@ trait SceneRoutes
 
   def replaceScenePermissions(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
           entity(as[List[ObjectAccessControlRule]]) { acrList =>
             authorizeAsync {
@@ -406,7 +406,7 @@ trait SceneRoutes
 
   def addScenePermission(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
           entity(as[ObjectAccessControlRule]) { acr =>
             authorizeAsync {
@@ -439,7 +439,7 @@ trait SceneRoutes
 
   def listUserSceneActions(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Scenes, Action.ReadPermissions, None),
           user
@@ -475,7 +475,7 @@ trait SceneRoutes
 
   def deleteScenePermissions(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Scenes, Action.Share, None), user) {
           authorizeAuthResultAsync {
             SceneDao
@@ -495,7 +495,7 @@ trait SceneRoutes
 
   def getSceneDatasource(sceneId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Datasources, Action.Read, None),
           user
@@ -524,7 +524,7 @@ trait SceneRoutes
 
   def getSentinelMetadata(sceneId: UUID, metadataUrl: String): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Scenes, Action.ReadSentinelMetadata, None),
           user

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -73,247 +73,257 @@ trait ShapeRoutes
       }
   }
 
-  def listShapes: Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
-      (withPagination & shapeQueryParams) {
-        (page: PageRequest, queryParams: ShapeQueryParameters) =>
-          complete {
-            ShapeDao
-              .authQuery(
-                user,
-                ObjectType.Shape,
-                queryParams.ownershipTypeParams.ownershipType,
-                queryParams.groupQueryParameters.groupType,
-                queryParams.groupQueryParameters.groupId
-              )
-              .filter(queryParams)
-              .page(page)
-              .transact(xa)
-              .unsafeToFuture()
-              .map { p =>
-                {
-                  fromPaginatedResponseToGeoJson[Shape, Shape.GeoJSON](p)
+  def listShapes: Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
+        (withPagination & shapeQueryParams) {
+          (page: PageRequest, queryParams: ShapeQueryParameters) =>
+            complete {
+              ShapeDao
+                .authQuery(
+                  user,
+                  ObjectType.Shape,
+                  queryParams.ownershipTypeParams.ownershipType,
+                  queryParams.groupQueryParameters.groupType,
+                  queryParams.groupQueryParameters.groupId
+                )
+                .filter(queryParams)
+                .page(page)
+                .transact(xa)
+                .unsafeToFuture()
+                .map { p =>
+                  {
+                    fromPaginatedResponseToGeoJson[Shape, Shape.GeoJSON](p)
+                  }
                 }
-              }
-          }
-      }
-    }
-  }
-
-  def getShape(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
-      authorizeAuthResultAsync {
-        ShapeDao
-          .authorized(user, ObjectType.Shape, shapeId, ActionType.View)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        rejectEmptyResponse {
-          complete {
-            ShapeDao.query
-              .filter(shapeId)
-              .selectOption
-              .transact(xa)
-              .unsafeToFuture()
-              .map {
-                _ map {
-                  _.toGeoJSONFeature
-                }
-              }
-          }
+            }
         }
       }
-    }
   }
 
-  def createShape: Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Create, None), user) {
-      entity(as[ShapeFeatureCollectionCreate]) { fc =>
-        val shapesCreate = fc.features map {
-          _.toShapeCreate
-        }
-        complete {
+  def getShape(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
+        authorizeAuthResultAsync {
           ShapeDao
-            .insertShapes(shapesCreate, user)
+            .authorized(user, ObjectType.Shape, shapeId, ActionType.View)
             .transact(xa)
-            .unsafeToFuture()
+            .unsafeToFuture
+        } {
+          rejectEmptyResponse {
+            complete {
+              ShapeDao.query
+                .filter(shapeId)
+                .selectOption
+                .transact(xa)
+                .unsafeToFuture()
+                .map {
+                  _ map {
+                    _.toGeoJSONFeature
+                  }
+                }
+            }
+          }
         }
       }
-    }
   }
 
-  def updateShape(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Update, None), user) {
-      authorizeAuthResultAsync {
-        ShapeDao
-          .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[Shape.GeoJSON]) { updatedShape: Shape.GeoJSON =>
-          onSuccess(
+  def createShape: Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Create, None), user) {
+        entity(as[ShapeFeatureCollectionCreate]) { fc =>
+          val shapesCreate = fc.features map {
+            _.toShapeCreate
+          }
+          complete {
             ShapeDao
-              .updateShape(updatedShape, shapeId)
+              .insertShapes(shapesCreate, user)
               .transact(xa)
               .unsafeToFuture()
+          }
+        }
+      }
+  }
+
+  def updateShape(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Update, None), user) {
+        authorizeAuthResultAsync {
+          ShapeDao
+            .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[Shape.GeoJSON]) { updatedShape: Shape.GeoJSON =>
+            onSuccess(
+              ShapeDao
+                .updateShape(updatedShape, shapeId)
+                .transact(xa)
+                .unsafeToFuture()
+            ) {
+              completeSingleOrNotFound
+            }
+          }
+        }
+      }
+  }
+
+  def deleteShape(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Delete, None), user) {
+        authorizeAuthResultAsync {
+          ShapeDao
+            .authorized(user, ObjectType.Shape, shapeId, ActionType.Delete)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess(
+            ShapeDao.query.filter(shapeId).delete.transact(xa).unsafeToFuture
           ) {
             completeSingleOrNotFound
           }
         }
       }
-    }
   }
 
-  def deleteShape(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Delete, None), user) {
-      authorizeAuthResultAsync {
-        ShapeDao
-          .authorized(user, ObjectType.Shape, shapeId, ActionType.Delete)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          ShapeDao.query.filter(shapeId).delete.transact(xa).unsafeToFuture
-        ) {
-          completeSingleOrNotFound
-        }
-      }
-    }
-  }
-
-  def listShapePermissions(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(
-      ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ShapeDao
-          .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
+  def listShapePermissions(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(
+        ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
           ShapeDao
-            .getPermissions(shapeId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def replaceShapePermissions(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
-        authorizeAsync {
-          (
-            ShapeDao
-              .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit) map {
-              _.toBoolean
-            },
-            acrList traverse { acr =>
-              ShapeDao.isValidPermission(acr, user)
-            } map {
-              _.foldLeft(true)(_ && _)
-            } map {
-              case true =>
-                ShapeDao.isReplaceWithinScopedLimit(
-                  Domain.Shapes,
-                  user,
-                  acrList
-                )
-              case _ => false
-            }
-          ).tupled
-            .map({ authTup =>
-              authTup._1 && authTup._2
-            })
+            .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
             .transact(xa)
             .unsafeToFuture
         } {
           complete {
             ShapeDao
-              .replacePermissions(shapeId, acrList)
+              .getPermissions(shapeId)
               .transact(xa)
               .unsafeToFuture
           }
         }
       }
-    }
   }
 
-  def addShapePermission(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
-      entity(as[ObjectAccessControlRule]) { acr =>
-        authorizeAsync {
-          (
-            ShapeDao
-              .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit) map {
-              _.toBoolean
-            },
-            ShapeDao.isValidPermission(acr, user)
-          ).tupled
-            .map({ authTup =>
-              authTup._1 && authTup._2
-            })
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            ShapeDao
-              .addPermission(shapeId, acr)
-              .transact(xa)
-              .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def listUserShapeActions(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(
-      ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ShapeDao
-          .authorized(user, ObjectType.Shape, shapeId, ActionType.View)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          ShapeDao.unsafeGetShapeById(shapeId).transact(xa).unsafeToFuture
-        ) { shape =>
-          shape.owner == user.id match {
-            case true => complete(List("*"))
-            case false =>
-              complete {
-                ShapeDao
-                  .listUserActions(user, shapeId)
-                  .transact(xa)
-                  .unsafeToFuture
+  def replaceShapePermissions(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
+        entity(as[List[ObjectAccessControlRule]]) { acrList =>
+          authorizeAsync {
+            (
+              ShapeDao
+                .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit) map {
+                _.toBoolean
+              },
+              acrList traverse { acr =>
+                ShapeDao.isValidPermission(acr, user)
+              } map {
+                _.foldLeft(true)(_ && _)
+              } map {
+                case true =>
+                  ShapeDao.isReplaceWithinScopedLimit(
+                    Domain.Shapes,
+                    user,
+                    acrList
+                  )
+                case _ => false
               }
+            ).tupled
+              .map({ authTup =>
+                authTup._1 && authTup._2
+              })
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              ShapeDao
+                .replacePermissions(shapeId, acrList)
+                .transact(xa)
+                .unsafeToFuture
+            }
           }
         }
       }
-    }
   }
 
-  def deleteShapePermissions(shapeId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
-      authorizeAuthResultAsync {
-        ShapeDao
-          .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          ShapeDao
-            .deletePermissions(shapeId)
-            .transact(xa)
-            .unsafeToFuture
+  def addShapePermission(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
+        entity(as[ObjectAccessControlRule]) { acr =>
+          authorizeAsync {
+            (
+              ShapeDao
+                .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit) map {
+                _.toBoolean
+              },
+              ShapeDao.isValidPermission(acr, user)
+            ).tupled
+              .map({ authTup =>
+                authTup._1 && authTup._2
+              })
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              ShapeDao
+                .addPermission(shapeId, acr)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
         }
       }
-    }
+  }
+
+  def listUserShapeActions(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(
+        ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          ShapeDao
+            .authorized(user, ObjectType.Shape, shapeId, ActionType.View)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess(
+            ShapeDao.unsafeGetShapeById(shapeId).transact(xa).unsafeToFuture
+          ) { shape =>
+            shape.owner == user.id match {
+              case true => complete(List("*"))
+              case false =>
+                complete {
+                  ShapeDao
+                    .listUserActions(user, shapeId)
+                    .transact(xa)
+                    .unsafeToFuture
+                }
+            }
+          }
+        }
+      }
+  }
+
+  def deleteShapePermissions(shapeId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
+        authorizeAuthResultAsync {
+          ShapeDao
+            .authorized(user, ObjectType.Shape, shapeId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            ShapeDao
+              .deletePermissions(shapeId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
   }
 }

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -73,7 +73,7 @@ trait ShapeRoutes
       }
   }
 
-  def listShapes: Route = authenticate { user =>
+  def listShapes: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
       (withPagination & shapeQueryParams) {
         (page: PageRequest, queryParams: ShapeQueryParameters) =>
@@ -100,7 +100,7 @@ trait ShapeRoutes
     }
   }
 
-  def getShape(shapeId: UUID): Route = authenticate { user =>
+  def getShape(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ShapeDao
@@ -126,7 +126,7 @@ trait ShapeRoutes
     }
   }
 
-  def createShape: Route = authenticate { user =>
+  def createShape: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Create, None), user) {
       entity(as[ShapeFeatureCollectionCreate]) { fc =>
         val shapesCreate = fc.features map {
@@ -142,7 +142,7 @@ trait ShapeRoutes
     }
   }
 
-  def updateShape(shapeId: UUID): Route = authenticate { user =>
+  def updateShape(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ShapeDao
@@ -164,7 +164,7 @@ trait ShapeRoutes
     }
   }
 
-  def deleteShape(shapeId: UUID): Route = authenticate { user =>
+  def deleteShape(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ShapeDao
@@ -181,7 +181,7 @@ trait ShapeRoutes
     }
   }
 
-  def listShapePermissions(shapeId: UUID): Route = authenticate { user =>
+  def listShapePermissions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
       user
@@ -202,7 +202,7 @@ trait ShapeRoutes
     }
   }
 
-  def replaceShapePermissions(shapeId: UUID): Route = authenticate { user =>
+  def replaceShapePermissions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -242,7 +242,7 @@ trait ShapeRoutes
     }
   }
 
-  def addShapePermission(shapeId: UUID): Route = authenticate { user =>
+  def addShapePermission(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
       entity(as[ObjectAccessControlRule]) { acr =>
         authorizeAsync {
@@ -270,7 +270,7 @@ trait ShapeRoutes
     }
   }
 
-  def listUserShapeActions(shapeId: UUID): Route = authenticate { user =>
+  def listUserShapeActions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
       user
@@ -299,7 +299,7 @@ trait ShapeRoutes
     }
   }
 
-  def deleteShapePermissions(shapeId: UUID): Route = authenticate { user =>
+  def deleteShapePermissions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ShapeDao

--- a/app-backend/api/src/main/scala/shape/Routes.scala
+++ b/app-backend/api/src/main/scala/shape/Routes.scala
@@ -73,7 +73,7 @@ trait ShapeRoutes
       }
   }
 
-  def listShapes: Route = authenticate { case MembershipAndUser(_, user) =>
+  def listShapes: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
       (withPagination & shapeQueryParams) {
         (page: PageRequest, queryParams: ShapeQueryParameters) =>
@@ -100,7 +100,7 @@ trait ShapeRoutes
     }
   }
 
-  def getShape(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def getShape(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ShapeDao
@@ -126,7 +126,7 @@ trait ShapeRoutes
     }
   }
 
-  def createShape: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createShape: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Create, None), user) {
       entity(as[ShapeFeatureCollectionCreate]) { fc =>
         val shapesCreate = fc.features map {
@@ -142,7 +142,7 @@ trait ShapeRoutes
     }
   }
 
-  def updateShape(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def updateShape(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ShapeDao
@@ -164,7 +164,7 @@ trait ShapeRoutes
     }
   }
 
-  def deleteShape(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteShape(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ShapeDao
@@ -181,7 +181,7 @@ trait ShapeRoutes
     }
   }
 
-  def listShapePermissions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listShapePermissions(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
       user
@@ -202,7 +202,7 @@ trait ShapeRoutes
     }
   }
 
-  def replaceShapePermissions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def replaceShapePermissions(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -242,7 +242,7 @@ trait ShapeRoutes
     }
   }
 
-  def addShapePermission(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def addShapePermission(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
       entity(as[ObjectAccessControlRule]) { acr =>
         authorizeAsync {
@@ -270,7 +270,7 @@ trait ShapeRoutes
     }
   }
 
-  def listUserShapeActions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listUserShapeActions(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Shapes, Action.ReadPermissions, None),
       user
@@ -299,7 +299,7 @@ trait ShapeRoutes
     }
   }
 
-  def deleteShapePermissions(shapeId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteShapePermissions(shapeId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Shapes, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ShapeDao

--- a/app-backend/api/src/main/scala/stac/Routes.scala
+++ b/app-backend/api/src/main/scala/stac/Routes.scala
@@ -73,140 +73,144 @@ trait StacRoutes
   }
 
   def listStacExports: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.StacExports, Action.Read, None),
-        user
-      ) {
-        (withPagination & stacExportQueryParameters) {
-          (page: PageRequest, params: StacExportQueryParameters) =>
-            complete {
-              StacExportDao
-                .list(page, params, user)
-                .map(
-                  p =>
-                    PaginatedResponse[StacExport.WithSignedDownload](
-                      p.count,
-                      p.hasPrevious,
-                      p.hasNext,
-                      p.page,
-                      p.pageSize,
-                      p.results.map(signExportUrl(_))
-                  ))
-                .transact(xa)
-                .unsafeToFuture
-            }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.StacExports, Action.Read, None),
+          user
+        ) {
+          (withPagination & stacExportQueryParameters) {
+            (page: PageRequest, params: StacExportQueryParameters) =>
+              complete {
+                StacExportDao
+                  .list(page, params, user)
+                  .map(
+                    p =>
+                      PaginatedResponse[StacExport.WithSignedDownload](
+                        p.count,
+                        p.hasPrevious,
+                        p.hasNext,
+                        p.page,
+                        p.pageSize,
+                        p.results.map(signExportUrl(_))
+                    ))
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+          }
         }
-      }
     }
 
   def createStacExport: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.StacExports, Action.Create, None),
-        user
-      ) {
-        entity(as[StacExport.Create]) { newStacExport =>
-          ((newStacExport.toStacExport(user).includesCOG match {
-            case true =>
-              authorizeScope(
-                ScopedAction(Domain.StacExports, Action.CreateCOG, None),
-                user
-              )
-            case false => authorize(_ => true)
-          }) & (authorizeAsync {
-            newStacExport match {
-              case StacExport
-                    .AnnotationProjectExport(_, _, _, annotationProjectId) =>
-                AnnotationProjectDao
-                  .authorized(
-                    user,
-                    ObjectType.AnnotationProject,
-                    annotationProjectId,
-                    ActionType.View
-                  )
-                  .map(_.toBoolean)
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.StacExports, Action.Create, None),
+          user
+        ) {
+          entity(as[StacExport.Create]) { newStacExport =>
+            ((newStacExport.toStacExport(user).includesCOG match {
+              case true =>
+                authorizeScope(
+                  ScopedAction(Domain.StacExports, Action.CreateCOG, None),
+                  user
+                )
+              case false => authorize(_ => true)
+            }) & (authorizeAsync {
+              newStacExport match {
+                case StacExport
+                      .AnnotationProjectExport(_, _, _, annotationProjectId) =>
+                  AnnotationProjectDao
+                    .authorized(
+                      user,
+                      ObjectType.AnnotationProject,
+                      annotationProjectId,
+                      ActionType.View
+                    )
+                    .map(_.toBoolean)
+                    .transact(xa)
+                    .unsafeToFuture
+                case StacExport.CampaignExport(_, _, _, _, campaignId) =>
+                  CampaignDao
+                    .authorized(
+                      user,
+                      ObjectType.Campaign,
+                      campaignId,
+                      ActionType.View
+                    )
+                    .map(_.toBoolean)
+                    .transact(xa)
+                    .unsafeToFuture
+              }
+            })) {
+              onSuccess(
+                StacExportDao
+                  .create(newStacExport, user)
                   .transact(xa)
                   .unsafeToFuture
-              case StacExport.CampaignExport(_, _, _, _, campaignId) =>
-                CampaignDao
-                  .authorized(
-                    user,
-                    ObjectType.Campaign,
-                    campaignId,
-                    ActionType.View
-                  )
-                  .map(_.toBoolean)
-                  .transact(xa)
-                  .unsafeToFuture
-            }
-          })) {
-            onSuccess(
-              StacExportDao
-                .create(newStacExport, user)
-                .transact(xa)
-                .unsafeToFuture
-            ) { stacExport =>
-              kickoffStacExport(stacExport.id)
-              complete((StatusCodes.Created, stacExport))
+              ) { stacExport =>
+                kickoffStacExport(stacExport.id)
+                complete((StatusCodes.Created, stacExport))
+              }
             }
           }
         }
-      }
     }
 
   def getStacExport(id: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.StacExports, Action.Read, None),
-        user
-      ) {
-        authorizeAsync {
-          StacExportDao
-            .isOwnerOrSuperUser(user, id)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              StacExportDao
-                .getById(id)
-                .map {
-                  case Some(export) =>
-                    Some(
-                      signExportUrl(export)
-                    )
-                  case _ => None
-                }
-                .transact(xa)
-                .unsafeToFuture
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.StacExports, Action.Read, None),
+          user
+        ) {
+          authorizeAsync {
+            StacExportDao
+              .isOwnerOrSuperUser(user, id)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                StacExportDao
+                  .getById(id)
+                  .map {
+                    case Some(export) =>
+                      Some(
+                        signExportUrl(export)
+                      )
+                    case _ => None
+                  }
+                  .transact(xa)
+                  .unsafeToFuture
+              }
             }
           }
         }
-      }
     }
 
   def deleteStacExport(id: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.StacExports, Action.Delete, None),
-        user
-      ) {
-        authorizeAsync {
-          StacExportDao
-            .isOwnerOrSuperUser(user, id)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.StacExports, Action.Delete, None),
+          user
+        ) {
+          authorizeAsync {
             StacExportDao
-              .delete(id)
+              .isOwnerOrSuperUser(user, id)
               .transact(xa)
               .unsafeToFuture
-          ) { count: Int =>
-            complete((StatusCodes.NoContent, s"$count stac export deleted"))
+          } {
+            onSuccess(
+              StacExportDao
+                .delete(id)
+                .transact(xa)
+                .unsafeToFuture
+            ) { count: Int =>
+              complete((StatusCodes.NoContent, s"$count stac export deleted"))
+            }
           }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/stac/Routes.scala
+++ b/app-backend/api/src/main/scala/stac/Routes.scala
@@ -73,7 +73,7 @@ trait StacRoutes
   }
 
   def listStacExports: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Read, None),
         user
@@ -101,7 +101,7 @@ trait StacRoutes
     }
 
   def createStacExport: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Create, None),
         user
@@ -156,7 +156,7 @@ trait StacRoutes
     }
 
   def getStacExport(id: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Read, None),
         user
@@ -187,7 +187,7 @@ trait StacRoutes
     }
 
   def deleteStacExport(id: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Delete, None),
         user

--- a/app-backend/api/src/main/scala/stac/Routes.scala
+++ b/app-backend/api/src/main/scala/stac/Routes.scala
@@ -73,7 +73,7 @@ trait StacRoutes
   }
 
   def listStacExports: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Read, None),
         user
@@ -101,7 +101,7 @@ trait StacRoutes
     }
 
   def createStacExport: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Create, None),
         user
@@ -156,7 +156,7 @@ trait StacRoutes
     }
 
   def getStacExport(id: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Read, None),
         user
@@ -187,7 +187,7 @@ trait StacRoutes
     }
 
   def deleteStacExport(id: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.StacExports, Action.Delete, None),
         user

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -98,7 +98,7 @@ trait TaskRoutes
   }
 
   def listTasks: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -136,7 +136,7 @@ trait TaskRoutes
   // - there should be no active sessions on the task
   // - the session type should match the current task status
   def createTaskSession(taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -184,7 +184,7 @@ trait TaskRoutes
     }
 
   def listTaskSessions(taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -213,7 +213,7 @@ trait TaskRoutes
     }
 
   def getTaskSession(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -241,7 +241,7 @@ trait TaskRoutes
     }
 
   def keepSessionAlive(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -286,7 +286,7 @@ trait TaskRoutes
     }
 
   def completeSession(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -365,7 +365,7 @@ trait TaskRoutes
     }
 
   def randomTaskSession: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -401,7 +401,7 @@ trait TaskRoutes
     }
 
   def listSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -430,7 +430,7 @@ trait TaskRoutes
     }
 
   def createLabel(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -467,7 +467,7 @@ trait TaskRoutes
     }
 
   def bulkCreateSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -509,7 +509,7 @@ trait TaskRoutes
     }
 
   def bulkUpdateSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -551,7 +551,7 @@ trait TaskRoutes
     }
 
   def getLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -582,7 +582,7 @@ trait TaskRoutes
     }
 
   def updateLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -621,7 +621,7 @@ trait TaskRoutes
     }
 
   def deleteLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -657,7 +657,7 @@ trait TaskRoutes
     }
 
   def getActiveTaskSession(taskId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -98,37 +98,41 @@ trait TaskRoutes
   }
 
   def listTasks: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
-        user
-      ) {
-        (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
-          'annotationProjectId.as[UUID].?
-        )) {
-          (page, annotationProjectParams, taskParams, annotationProjectIdOpt) =>
-            onComplete {
-              TaskDao
-                .getRandomTaskFromProjects(
-                  user,
-                  annotationProjectParams,
-                  annotationProjectIdOpt,
-                  page.limit,
-                  taskParams
-                )
-                .transact(xa)
-                .unsafeToFuture
-            } {
-              case Success(Some(task)) =>
-                complete { task }
-              case Success(None) =>
-                complete { HttpResponse(StatusCodes.OK) }
-              case Failure(e) =>
-                logger.error(e.getMessage)
-                complete { HttpResponse(StatusCodes.BadRequest) }
-            }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+          user
+        ) {
+          (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
+            'annotationProjectId.as[UUID].?
+          )) {
+            (page,
+             annotationProjectParams,
+             taskParams,
+             annotationProjectIdOpt) =>
+              onComplete {
+                TaskDao
+                  .getRandomTaskFromProjects(
+                    user,
+                    annotationProjectParams,
+                    annotationProjectIdOpt,
+                    page.limit,
+                    taskParams
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              } {
+                case Success(Some(task)) =>
+                  complete { task }
+                case Success(None) =>
+                  complete { HttpResponse(StatusCodes.OK) }
+                case Failure(e) =>
+                  logger.error(e.getMessage)
+                  complete { HttpResponse(StatusCodes.BadRequest) }
+              }
+          }
         }
-      }
     }
 
   // To create a task session:
@@ -136,557 +140,596 @@ trait TaskRoutes
   // - there should be no active sessions on the task
   // - the session type should match the current task status
   def createTaskSession(taskId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authorized(
-              taskId,
-              user,
-              ActionType.Annotate
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[TaskSession.Create]) { taskSessionCreate =>
-            onComplete {
-              (for {
-                hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
-                  taskId)
-                hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
-                  taskId,
-                  taskSessionCreate.sessionType
-                )
-              } yield (!hasActiveSession, hasValidStatus))
-                .transact(xa)
-                .unsafeToFuture
-
-            } {
-              case Success((true, true)) =>
-                complete {
-                  TaskSessionDao
-                    .insert(taskSessionCreate, user, taskId)
-                    .transact(xa)
-                    .unsafeToFuture
-                }
-              case Success((false, _)) =>
-                complete { StatusCodes.Conflict -> "ACTIVE_SESSION_EXISTS" }
-              case Success((_, false)) =>
-                complete { StatusCodes.BadRequest -> "STATUS_MISMATCH" }
-              case _ => complete { HttpResponse(StatusCodes.BadRequest) }
-            }
-          }
-        }
-      }
-    }
-
-  def listTaskSessions(taskId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authorized(
-              taskId,
-              user,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          (withPagination) { page =>
-            complete {
-              TaskSessionDao.query
-                .filter(fr"task_id = ${taskId}")
-                .page(page)
-                .transact(xa)
-                .unsafeToFuture()
-            }
-          }
-        }
-      }
-    }
-
-  def getTaskSession(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authorized(
-              taskId,
-              user,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              TaskSessionDao
-                .getTaskSessionById(sessionId)
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-    }
-
-  def keepSessionAlive(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          (
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
             TaskSessionDao
               .authorized(
                 taskId,
                 user,
                 ActionType.Annotate
-              ),
-            TaskSessionDao.isOwner(taskId, sessionId, user)
-          ).tupled
-            .map({ authed =>
-              authed._1 && authed._2
-            })
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onComplete {
-            TaskSessionDao
-              .isSessionActive(sessionId)
+              )
               .transact(xa)
               .unsafeToFuture
           } {
-            case Success(true) =>
-              complete {
-                TaskSessionDao
-                  .keepTaskSessionAlive(sessionId)
+            entity(as[TaskSession.Create]) { taskSessionCreate =>
+              onComplete {
+                (for {
+                  hasActiveSession <- TaskSessionDao.hasActiveSessionByTaskId(
+                    taskId)
+                  hasValidStatus <- TaskSessionDao.isSessionTypeMatchTaskStatus(
+                    taskId,
+                    taskSessionCreate.sessionType
+                  )
+                } yield (!hasActiveSession, hasValidStatus))
                   .transact(xa)
                   .unsafeToFuture
-              }
-            case Success(false) =>
-              complete { StatusCodes.Conflict -> "SESSION_EXPIRED" }
-            case _ =>
-              complete { HttpResponse(StatusCodes.BadRequest) }
 
+              } {
+                case Success((true, true)) =>
+                  complete {
+                    TaskSessionDao
+                      .insert(taskSessionCreate, user, taskId)
+                      .transact(xa)
+                      .unsafeToFuture
+                  }
+                case Success((false, _)) =>
+                  complete { StatusCodes.Conflict -> "ACTIVE_SESSION_EXISTS" }
+                case Success((_, false)) =>
+                  complete { StatusCodes.BadRequest -> "STATUS_MISMATCH" }
+                case _ => complete { HttpResponse(StatusCodes.BadRequest) }
+              }
+            }
           }
         }
-      }
     }
 
-  def completeSession(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          (
+  def listTaskSessions(taskId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+          user
+        ) {
+          authorizeAsync {
             TaskSessionDao
               .authorized(
                 taskId,
                 user,
-                ActionType.Annotate
-              ),
-            TaskSessionDao.isOwner(taskId, sessionId, user)
-          ).tupled
-            .map({ authed =>
-              authed._1 && authed._2
-            })
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[TaskSession.Complete]) { taskSessionComplete =>
-            {
-              onComplete {
-                (for {
-                  isActive <- TaskSessionDao.isSessionActive(sessionId)
-                  hasValidStatus <- TaskSessionDao.isToStatusMatchTaskSession(
-                    sessionId,
-                    taskSessionComplete.toStatus
-                  )
-                } yield (isActive, hasValidStatus)).transact(xa).unsafeToFuture
-              } {
-                case Success((true, true)) =>
-                  complete {
-                    (for {
-                      _ <- TaskSessionDao.completeTaskSession(
-                        sessionId,
-                        taskSessionComplete
-                      )
-                      prevSession <- TaskSessionDao.getLatestForTask(taskId)
-                      _ <- prevSession traverse { session =>
-                        AnnotationLabelDao.toggleBySessionId(
-                          session.id
-                        )
-                      }
-                      _ <- AnnotationLabelDao.toggleBySessionId(
-                        sessionId
-                      )
-                      taskOpt <- TaskDao.getTaskById(taskId)
-                      rowCount <- taskOpt traverse { task =>
-                        val taskToUpdate = Task.TaskFeatureCreate(
-                          properties = Task.TaskPropertiesCreate(
-                            status = taskSessionComplete.toStatus,
-                            annotationProjectId = task.annotationProjectId,
-                            note = taskSessionComplete.note,
-                            taskType = Some(task.taskType),
-                            parentTaskId = task.parentTaskId,
-                            reviews = Some(task.reviews)
-                          ),
-                          geometry = task.geometry
-                        )
-                        TaskDao.updateTask(taskId, taskToUpdate, user)
-                      }
-                    } yield rowCount).transact(xa).unsafeToFuture
-                  }
-                case Success((false, _)) =>
-                  complete { StatusCodes.Conflict -> "SESSION_EXPIRED" }
-                case Success((_, false)) =>
-                  complete { StatusCodes.BadRequest -> "STATUS_MISMATCH" }
-                case _ =>
-                  complete { HttpResponse(StatusCodes.BadRequest) }
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            (withPagination) { page =>
+              complete {
+                TaskSessionDao.query
+                  .filter(fr"task_id = ${taskId}")
+                  .page(page)
+                  .transact(xa)
+                  .unsafeToFuture()
               }
             }
           }
         }
-      }
     }
 
-  def randomTaskSession: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
-        user
-      ) {
-        (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
-          'annotationProjectId.as[UUID].?
-        )) {
-          (page, annotationProjectParams, taskParams, annotationProjectIdOpt) =>
+  def getTaskSession(taskId: UUID, sessionId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authorized(
+                taskId,
+                user,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                TaskSessionDao
+                  .getTaskSessionById(sessionId)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+            }
+          }
+        }
+    }
+
+  def keepSessionAlive(taskId: UUID, sessionId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            (
+              TaskSessionDao
+                .authorized(
+                  taskId,
+                  user,
+                  ActionType.Annotate
+                ),
+              TaskSessionDao.isOwner(taskId, sessionId, user)
+            ).tupled
+              .map({ authed =>
+                authed._1 && authed._2
+              })
+              .transact(xa)
+              .unsafeToFuture
+          } {
             onComplete {
               TaskSessionDao
-                .getRandomTaskSession(
-                  user,
-                  annotationProjectParams,
-                  annotationProjectIdOpt,
-                  page.limit,
-                  taskParams
-                )
+                .isSessionActive(sessionId)
                 .transact(xa)
                 .unsafeToFuture
             } {
-              case Success(Some(session)) =>
-                complete { session }
-              case Success(None) =>
+              case Success(true) =>
                 complete {
-                  StatusCodes.BadRequest -> "No matching task to create a session for"
+                  TaskSessionDao
+                    .keepTaskSessionAlive(sessionId)
+                    .transact(xa)
+                    .unsafeToFuture
                 }
-              case Failure(e) =>
-                logger.error(e.getMessage)
+              case Success(false) =>
+                complete { StatusCodes.Conflict -> "SESSION_EXPIRED" }
+              case _ =>
                 complete { HttpResponse(StatusCodes.BadRequest) }
+
             }
+          }
         }
-      }
     }
 
-  def listSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authorized(
-              taskId,
-              user,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            TaskSessionDao
-              .listActiveLabels(sessionId)
+  def completeSession(taskId: UUID, sessionId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            (
+              TaskSessionDao
+                .authorized(
+                  taskId,
+                  user,
+                  ActionType.Annotate
+                ),
+              TaskSessionDao.isOwner(taskId, sessionId, user)
+            ).tupled
+              .map({ authed =>
+                authed._1 && authed._2
+              })
               .transact(xa)
               .unsafeToFuture
-              .map { labels: List[AnnotationLabelWithClasses] =>
-                labels.map(_.toGeoJSONFeature)
+          } {
+            entity(as[TaskSession.Complete]) { taskSessionComplete =>
+              {
+                onComplete {
+                  (for {
+                    isActive <- TaskSessionDao.isSessionActive(sessionId)
+                    hasValidStatus <- TaskSessionDao.isToStatusMatchTaskSession(
+                      sessionId,
+                      taskSessionComplete.toStatus
+                    )
+                  } yield
+                    (isActive, hasValidStatus)).transact(xa).unsafeToFuture
+                } {
+                  case Success((true, true)) =>
+                    complete {
+                      (for {
+                        _ <- TaskSessionDao.completeTaskSession(
+                          sessionId,
+                          taskSessionComplete
+                        )
+                        prevSession <- TaskSessionDao.getLatestForTask(taskId)
+                        _ <- prevSession traverse { session =>
+                          AnnotationLabelDao.toggleBySessionId(
+                            session.id
+                          )
+                        }
+                        _ <- AnnotationLabelDao.toggleBySessionId(
+                          sessionId
+                        )
+                        taskOpt <- TaskDao.getTaskById(taskId)
+                        rowCount <- taskOpt traverse { task =>
+                          val taskToUpdate = Task.TaskFeatureCreate(
+                            properties = Task.TaskPropertiesCreate(
+                              status = taskSessionComplete.toStatus,
+                              annotationProjectId = task.annotationProjectId,
+                              note = taskSessionComplete.note,
+                              taskType = Some(task.taskType),
+                              parentTaskId = task.parentTaskId,
+                              reviews = Some(task.reviews)
+                            ),
+                            geometry = task.geometry
+                          )
+                          TaskDao.updateTask(taskId, taskToUpdate, user)
+                        }
+                      } yield rowCount).transact(xa).unsafeToFuture
+                    }
+                  case Success((false, _)) =>
+                    complete { StatusCodes.Conflict -> "SESSION_EXPIRED" }
+                  case Success((_, false)) =>
+                    complete { StatusCodes.BadRequest -> "STATUS_MISMATCH" }
+                  case _ =>
+                    complete { HttpResponse(StatusCodes.BadRequest) }
+                }
+              }
+            }
+          }
+        }
+    }
+
+  def randomTaskSession: Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+          user
+        ) {
+          (withPagination & annotationProjectQueryParameters & taskQueryParameters & parameters(
+            'annotationProjectId.as[UUID].?
+          )) {
+            (page,
+             annotationProjectParams,
+             taskParams,
+             annotationProjectIdOpt) =>
+              onComplete {
+                TaskSessionDao
+                  .getRandomTaskSession(
+                    user,
+                    annotationProjectParams,
+                    annotationProjectIdOpt,
+                    page.limit,
+                    taskParams
+                  )
+                  .transact(xa)
+                  .unsafeToFuture
+              } {
+                case Success(Some(session)) =>
+                  complete { session }
+                case Success(None) =>
+                  complete {
+                    StatusCodes.BadRequest -> "No matching task to create a session for"
+                  }
+                case Failure(e) =>
+                  logger.error(e.getMessage)
+                  complete { HttpResponse(StatusCodes.BadRequest) }
               }
           }
         }
-      }
+    }
+
+  def listSessionLabels(taskId: UUID, sessionId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authorized(
+                taskId,
+                user,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              TaskSessionDao
+                .listActiveLabels(sessionId)
+                .transact(xa)
+                .unsafeToFuture
+                .map { labels: List[AnnotationLabelWithClasses] =>
+                  labels.map(_.toGeoJSONFeature)
+                }
+            }
+          }
+        }
     }
 
   def createLabel(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authWriteLabelToSession(taskId, sessionId, user)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationLabelWithClasses.GeoJSONFeatureCreate]) {
-            featureCreate =>
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authWriteLabelToSession(taskId, sessionId, user)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationLabelWithClasses.GeoJSONFeatureCreate]) {
+              featureCreate =>
+                onSuccess(
+                  TaskSessionDao
+                    .insertLabels(
+                      taskId,
+                      sessionId,
+                      List(featureCreate.toAnnotationLabelWithClassesCreate),
+                      user
+                    )
+                    .transact(xa)
+                    .unsafeToFuture
+                    .map { labels: List[AnnotationLabelWithClasses] =>
+                      // the inserted annotation is just one feature
+                      // so we return the first feature from the returned list
+                      labels.headOption.map(_.toGeoJSONFeature)
+                    }
+                ) { createdLabel =>
+                  complete((StatusCodes.Created, createdLabel))
+                }
+            }
+          }
+        }
+    }
+
+  def bulkCreateSessionLabels(taskId: UUID, sessionId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authWriteLabelToSession(taskId, sessionId, user)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) {
+              fc =>
+                val labelWithClassesCreateList = fc.features map {
+                  _.toAnnotationLabelWithClassesCreate
+                }
+                onSuccess(
+                  TaskSessionDao
+                    .insertLabels(
+                      taskId,
+                      sessionId,
+                      labelWithClassesCreateList.toList,
+                      user
+                    )
+                    .transact(xa)
+                    .unsafeToFuture
+                    .map { labels: List[AnnotationLabelWithClasses] =>
+                      fromSeqToFeatureCollection[
+                        AnnotationLabelWithClasses,
+                        AnnotationLabelWithClasses.GeoJSON
+                      ](
+                        labels
+                      )
+                    }
+                ) { createdLabels =>
+                  complete((StatusCodes.Created, createdLabels))
+                }
+            }
+          }
+        }
+    }
+
+  def bulkUpdateSessionLabels(taskId: UUID, sessionId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authWriteLabelToSession(taskId, sessionId, user)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationLabelWithClassesFeatureCollection]) { fc =>
+              val labelWithClassesCreateList = fc.features map {
+                _.toAnnotationLabelWithClassesOpt
+              }
               onSuccess(
                 TaskSessionDao
-                  .insertLabels(
+                  .bulkReplaceLabelsInSession(
                     taskId,
                     sessionId,
-                    List(featureCreate.toAnnotationLabelWithClassesCreate),
+                    labelWithClassesCreateList.toList.flatten,
                     user
                   )
                   .transact(xa)
                   .unsafeToFuture
                   .map { labels: List[AnnotationLabelWithClasses] =>
-                    // the inserted annotation is just one feature
-                    // so we return the first feature from the returned list
-                    labels.headOption.map(_.toGeoJSONFeature)
+                    fromSeqToFeatureCollection[
+                      AnnotationLabelWithClasses,
+                      AnnotationLabelWithClasses.GeoJSON
+                    ](
+                      labels
+                    )
                   }
-              ) { createdLabel =>
-                complete((StatusCodes.Created, createdLabel))
+              ) { createdLabels =>
+                complete((StatusCodes.Created, createdLabels))
               }
-          }
-        }
-      }
-    }
-
-  def bulkCreateSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authWriteLabelToSession(taskId, sessionId, user)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationLabelWithClassesFeatureCollectionCreate]) { fc =>
-            val labelWithClassesCreateList = fc.features map {
-              _.toAnnotationLabelWithClassesCreate
-            }
-            onSuccess(
-              TaskSessionDao
-                .insertLabels(
-                  taskId,
-                  sessionId,
-                  labelWithClassesCreateList.toList,
-                  user
-                )
-                .transact(xa)
-                .unsafeToFuture
-                .map { labels: List[AnnotationLabelWithClasses] =>
-                  fromSeqToFeatureCollection[
-                    AnnotationLabelWithClasses,
-                    AnnotationLabelWithClasses.GeoJSON
-                  ](
-                    labels
-                  )
-                }
-            ) { createdLabels =>
-              complete((StatusCodes.Created, createdLabels))
             }
           }
         }
-      }
-    }
-
-  def bulkUpdateSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authWriteLabelToSession(taskId, sessionId, user)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationLabelWithClassesFeatureCollection]) { fc =>
-            val labelWithClassesCreateList = fc.features map {
-              _.toAnnotationLabelWithClassesOpt
-            }
-            onSuccess(
-              TaskSessionDao
-                .bulkReplaceLabelsInSession(
-                  taskId,
-                  sessionId,
-                  labelWithClassesCreateList.toList.flatten,
-                  user
-                )
-                .transact(xa)
-                .unsafeToFuture
-                .map { labels: List[AnnotationLabelWithClasses] =>
-                  fromSeqToFeatureCollection[
-                    AnnotationLabelWithClasses,
-                    AnnotationLabelWithClasses.GeoJSON
-                  ](
-                    labels
-                  )
-                }
-            ) { createdLabels =>
-              complete((StatusCodes.Created, createdLabels))
-            }
-          }
-        }
-      }
     }
 
   def getLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authorized(
-              taskId,
-              user,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authorized(
+                taskId,
+                user,
+                ActionType.View
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
+                TaskSessionDao
+                  .getLabel(sessionId, labelId)
+                  .transact(xa)
+                  .unsafeToFuture
+                  .map { labelOpt: Option[AnnotationLabelWithClasses] =>
+                    labelOpt.map(_.toGeoJSONFeature)
+                  }
+              }
+            }
+          }
+        }
+    }
+
+  def updateLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authWriteLabelToSession(taskId, sessionId, user)
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[AnnotationLabelWithClasses.GeoJSON]) { feature =>
+              onSuccess(
+                (feature.toAnnotationLabelWithClassesOpt traverse { label =>
+                  TaskSessionDao
+                    .updateLabel(
+                      taskId,
+                      sessionId,
+                      labelId,
+                      label,
+                      user
+                    )
+                }).transact(xa).unsafeToFuture
+              ) {
+                case Some(updatedLabel) =>
+                  complete(
+                    (StatusCodes.Created, updatedLabel.map(_.toGeoJSONFeature))
+                  )
+                case _ =>
+                  complete(
+                    (StatusCodes.BadRequest -> "NO MATCHING LABEL TO UPDATE")
+                  )
+              }
+            }
+          }
+        }
+    }
+
+  def deleteLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects,
+                       Action.CreateAnnotation,
+                       None),
+          user
+        ) {
+          authorizeAsync {
+            TaskSessionDao
+              .authWriteLabelToSession(
+                taskId,
+                sessionId,
+                user
+              )
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            onComplete {
               TaskSessionDao
-                .getLabel(sessionId, labelId)
+                .deleteLabel(taskId, sessionId, labelId)
                 .transact(xa)
                 .unsafeToFuture
-                .map { labelOpt: Option[AnnotationLabelWithClasses] =>
-                  labelOpt.map(_.toGeoJSONFeature)
+            } {
+              case Success(rowCount) =>
+                if (rowCount == -1) complete {
+                  StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
+                } else complete { StatusCodes.OK }
+              case Failure(e) =>
+                logger.error(e.getMessage)
+                complete {
+                  StatusCodes.BadRequest -> "ERROR IN LABEL DELETE"
                 }
             }
           }
         }
-      }
-    }
-
-  def updateLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authWriteLabelToSession(taskId, sessionId, user)
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[AnnotationLabelWithClasses.GeoJSON]) { feature =>
-            onSuccess(
-              (feature.toAnnotationLabelWithClassesOpt traverse { label =>
-                TaskSessionDao
-                  .updateLabel(
-                    taskId,
-                    sessionId,
-                    labelId,
-                    label,
-                    user
-                  )
-              }).transact(xa).unsafeToFuture
-            ) {
-              case Some(updatedLabel) =>
-                complete(
-                  (StatusCodes.Created, updatedLabel.map(_.toGeoJSONFeature))
-                )
-              case _ =>
-                complete(
-                  (StatusCodes.BadRequest -> "NO MATCHING LABEL TO UPDATE")
-                )
-            }
-          }
-        }
-      }
-    }
-
-  def deleteLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authWriteLabelToSession(
-              taskId,
-              sessionId,
-              user
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onComplete {
-            TaskSessionDao
-              .deleteLabel(taskId, sessionId, labelId)
-              .transact(xa)
-              .unsafeToFuture
-          } {
-            case Success(rowCount) =>
-              if (rowCount == -1) complete {
-                StatusCodes.BadRequest -> "NO MATCHING LABEL TO DELETE"
-              } else complete { StatusCodes.OK }
-            case Failure(e) =>
-              logger.error(e.getMessage)
-              complete {
-                StatusCodes.BadRequest -> "ERROR IN LABEL DELETE"
-              }
-          }
-        }
-      }
     }
 
   def getActiveTaskSession(taskId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(
-        ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
-        user
-      ) {
-        authorizeAsync {
-          TaskSessionDao
-            .authorized(
-              taskId,
-              user,
-              ActionType.View
-            )
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onComplete {
+    authenticate {
+      case (user, _) =>
+        authorizeScope(
+          ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
+          user
+        ) {
+          authorizeAsync {
             TaskSessionDao
-              .getActiveSessionByTaskId(taskId)
+              .authorized(
+                taskId,
+                user,
+                ActionType.View
+              )
               .transact(xa)
               .unsafeToFuture
           } {
-            case Success(Some(session)) =>
-              complete((StatusCodes.Created, session))
-            case Success(None) =>
-              complete(StatusCodes.NoContent)
-            case Failure(e) =>
-              logger.error(e.getMessage)
-              complete(StatusCodes.BadRequest, "ERROR IN LABEL DELETE")
+            onComplete {
+              TaskSessionDao
+                .getActiveSessionByTaskId(taskId)
+                .transact(xa)
+                .unsafeToFuture
+            } {
+              case Success(Some(session)) =>
+                complete((StatusCodes.Created, session))
+              case Success(None) =>
+                complete(StatusCodes.NoContent)
+              case Failure(e) =>
+                logger.error(e.getMessage)
+                complete(StatusCodes.BadRequest, "ERROR IN LABEL DELETE")
+            }
           }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/tasks/Routes.scala
+++ b/app-backend/api/src/main/scala/tasks/Routes.scala
@@ -98,7 +98,7 @@ trait TaskRoutes
   }
 
   def listTasks: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -136,7 +136,7 @@ trait TaskRoutes
   // - there should be no active sessions on the task
   // - the session type should match the current task status
   def createTaskSession(taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -184,7 +184,7 @@ trait TaskRoutes
     }
 
   def listTaskSessions(taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -213,7 +213,7 @@ trait TaskRoutes
     }
 
   def getTaskSession(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -241,7 +241,7 @@ trait TaskRoutes
     }
 
   def keepSessionAlive(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -286,7 +286,7 @@ trait TaskRoutes
     }
 
   def completeSession(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -365,7 +365,7 @@ trait TaskRoutes
     }
 
   def randomTaskSession: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user
@@ -401,7 +401,7 @@ trait TaskRoutes
     }
 
   def listSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -430,7 +430,7 @@ trait TaskRoutes
     }
 
   def createLabel(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -467,7 +467,7 @@ trait TaskRoutes
     }
 
   def bulkCreateSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -509,7 +509,7 @@ trait TaskRoutes
     }
 
   def bulkUpdateSessionLabels(taskId: UUID, sessionId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -551,7 +551,7 @@ trait TaskRoutes
     }
 
   def getLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -582,7 +582,7 @@ trait TaskRoutes
     }
 
   def updateLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -621,7 +621,7 @@ trait TaskRoutes
     }
 
   def deleteLabel(taskId: UUID, sessionId: UUID, labelId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.CreateAnnotation, None),
         user
@@ -657,7 +657,7 @@ trait TaskRoutes
     }
 
   def getActiveTaskSession(taskId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(
         ScopedAction(Domain.AnnotationProjects, Action.ReadTasks, None),
         user

--- a/app-backend/api/src/main/scala/team/Routes.scala
+++ b/app-backend/api/src/main/scala/team/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.database._

--- a/app-backend/api/src/main/scala/team/Routes.scala
+++ b/app-backend/api/src/main/scala/team/Routes.scala
@@ -41,7 +41,7 @@ trait TeamRoutes
 
   def getTeam(teamId: UUID): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
           authorizeAsync {
             val authIO = for {

--- a/app-backend/api/src/main/scala/team/Routes.scala
+++ b/app-backend/api/src/main/scala/team/Routes.scala
@@ -38,7 +38,7 @@ trait TeamRoutes
     }
   }
 
-  def getTeam(teamId: UUID): Route = authenticate { user =>
+  def getTeam(teamId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Teams, Action.Read, None), user) {
       authorizeAsync {
         val authIO = for {

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Config

--- a/app-backend/api/src/main/scala/thumbnail/Routes.scala
+++ b/app-backend/api/src/main/scala/thumbnail/Routes.scala
@@ -52,7 +52,7 @@ trait ThumbnailRoutes
   @SuppressWarnings(Array("AsInstanceOf"))
   def getThumbnailImage(thumbnailPath: String): Route =
     authenticateWithParameter {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Thumbnails, Action.Read, None),
           user
@@ -80,7 +80,7 @@ trait ThumbnailRoutes
   @SuppressWarnings(Array("AsInstanceOf"))
   def getProxiedThumbnailImage(thumbnailUri: String): Route =
     authenticateWithParameter {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Scenes, Action.ReadThumbnail, None),
           user

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -3,7 +3,6 @@ package com.rasterfoundry.api.token
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Auth0ErrorHandler

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -36,7 +36,7 @@ trait TokenRoutes
         }
     }
 
-  def listRefreshTokens: Route = authenticate { user =>
+  def listRefreshTokens: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Tokens, Action.Read, None), user) {
       complete {
         TokenService.listRefreshTokens(user)
@@ -52,7 +52,7 @@ trait TokenRoutes
     }
   }
 
-  def revokeRefreshToken(deviceId: String): Route = authenticate { user =>
+  def revokeRefreshToken(deviceId: String): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Tokens, Action.Delete, None), user) {
       complete {
         TokenService.revokeRefreshToken(user, deviceId)

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -3,6 +3,7 @@ package com.rasterfoundry.api.token
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
+  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Auth0ErrorHandler
@@ -36,13 +37,15 @@ trait TokenRoutes
         }
     }
 
-  def listRefreshTokens: Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Tokens, Action.Read, None), user) {
-      complete {
-        TokenService.listRefreshTokens(user)
-      }
+  def listRefreshTokens: Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Tokens, Action.Read, None), user) {
+          complete {
+            TokenService.listRefreshTokens(user)
+          }
+        }
     }
-  }
 
   def getAuthorizedToken: Route = {
     entity(as[RefreshToken]) { refreshToken =>
@@ -52,11 +55,13 @@ trait TokenRoutes
     }
   }
 
-  def revokeRefreshToken(deviceId: String): Route = authenticate { case MembershipAndUser(_, user) =>
-    authorizeScope(ScopedAction(Domain.Tokens, Action.Delete, None), user) {
-      complete {
-        TokenService.revokeRefreshToken(user, deviceId)
-      }
+  def revokeRefreshToken(deviceId: String): Route =
+    authenticate {
+      case MembershipAndUser(_, user) =>
+        authorizeScope(ScopedAction(Domain.Tokens, Action.Delete, None), user) {
+          complete {
+            TokenService.revokeRefreshToken(user, deviceId)
+          }
+        }
     }
-  }
 }

--- a/app-backend/api/src/main/scala/token/Routes.scala
+++ b/app-backend/api/src/main/scala/token/Routes.scala
@@ -39,7 +39,7 @@ trait TokenRoutes
 
   def listRefreshTokens: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Tokens, Action.Read, None), user) {
           complete {
             TokenService.listRefreshTokens(user)
@@ -57,7 +57,7 @@ trait TokenRoutes
 
   def revokeRefreshToken(deviceId: String): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Tokens, Action.Delete, None), user) {
           complete {
             TokenService.revokeRefreshToken(user, deviceId)

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -125,7 +125,7 @@ trait ToolRunRoutes
             }
           }
         case _ =>
-          authenticate { case MembershipAndUser(_, user) =>
+          authenticate { case (user, _) =>
             authorizeScope(
               ScopedAction(Domain.Analyses, Action.Read, None),
               user
@@ -150,7 +150,7 @@ trait ToolRunRoutes
       }
   }
 
-  def createToolRun: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createToolRun: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Create, None), user) {
       entity(as[ToolRun.Create]) { newRun =>
         onSuccess(
@@ -166,7 +166,7 @@ trait ToolRunRoutes
     }
   }
 
-  def getToolRun(runId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def getToolRun(runId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao
@@ -187,7 +187,7 @@ trait ToolRunRoutes
     }
   }
 
-  def updateToolRun(runId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def updateToolRun(runId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao
@@ -209,7 +209,7 @@ trait ToolRunRoutes
     }
   }
 
-  def deleteToolRun(runId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteToolRun(runId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao
@@ -226,7 +226,7 @@ trait ToolRunRoutes
     }
   }
 
-  def listToolRunPermissions(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listToolRunPermissions(toolRunId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
       user
@@ -247,7 +247,7 @@ trait ToolRunRoutes
     }
   }
 
-  def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -291,7 +291,7 @@ trait ToolRunRoutes
     }
   }
 
-  def addToolRunPermission(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def addToolRunPermission(toolRunId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
       entity(as[ObjectAccessControlRule]) { acr =>
         authorizeAsync {
@@ -319,7 +319,7 @@ trait ToolRunRoutes
     }
   }
 
-  def listUserAnalysisActions(analysisId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listUserAnalysisActions(analysisId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
       user
@@ -356,7 +356,7 @@ trait ToolRunRoutes
     }
   }
 
-  def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -125,7 +125,7 @@ trait ToolRunRoutes
             }
           }
         case _ =>
-          authenticate { user =>
+          authenticate { case MembershipAndUser(_, user) =>
             authorizeScope(
               ScopedAction(Domain.Analyses, Action.Read, None),
               user
@@ -150,7 +150,7 @@ trait ToolRunRoutes
       }
   }
 
-  def createToolRun: Route = authenticate { user =>
+  def createToolRun: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Create, None), user) {
       entity(as[ToolRun.Create]) { newRun =>
         onSuccess(
@@ -166,7 +166,7 @@ trait ToolRunRoutes
     }
   }
 
-  def getToolRun(runId: UUID): Route = authenticate { user =>
+  def getToolRun(runId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao
@@ -187,7 +187,7 @@ trait ToolRunRoutes
     }
   }
 
-  def updateToolRun(runId: UUID): Route = authenticate { user =>
+  def updateToolRun(runId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao
@@ -209,7 +209,7 @@ trait ToolRunRoutes
     }
   }
 
-  def deleteToolRun(runId: UUID): Route = authenticate { user =>
+  def deleteToolRun(runId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao
@@ -226,7 +226,7 @@ trait ToolRunRoutes
     }
   }
 
-  def listToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
+  def listToolRunPermissions(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
       user
@@ -247,7 +247,7 @@ trait ToolRunRoutes
     }
   }
 
-  def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
+  def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -291,7 +291,7 @@ trait ToolRunRoutes
     }
   }
 
-  def addToolRunPermission(toolRunId: UUID): Route = authenticate { user =>
+  def addToolRunPermission(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
       entity(as[ObjectAccessControlRule]) { acr =>
         authorizeAsync {
@@ -319,7 +319,7 @@ trait ToolRunRoutes
     }
   }
 
-  def listUserAnalysisActions(analysisId: UUID): Route = authenticate { user =>
+  def listUserAnalysisActions(analysisId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
       user
@@ -356,7 +356,7 @@ trait ToolRunRoutes
     }
   }
 
-  def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate { user =>
+  def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ToolRunDao

--- a/app-backend/api/src/main/scala/toolrun/Routes.scala
+++ b/app-backend/api/src/main/scala/toolrun/Routes.scala
@@ -125,252 +125,265 @@ trait ToolRunRoutes
             }
           }
         case _ =>
-          authenticate { case (user, _) =>
-            authorizeScope(
-              ScopedAction(Domain.Analyses, Action.Read, None),
-              user
-            ) {
-              complete {
-                ToolRunDao
-                  .authQuery(
-                    user,
-                    ObjectType.Analysis,
-                    runParams.ownershipTypeParams.ownershipType,
-                    runParams.groupQueryParameters.groupType,
-                    runParams.groupQueryParameters.groupId
-                  )
-                  .filter(runParams)
-                  .page(page)
-                  .transact(xa)
-                  .unsafeToFuture
+          authenticate {
+            case (user, _) =>
+              authorizeScope(
+                ScopedAction(Domain.Analyses, Action.Read, None),
+                user
+              ) {
+                complete {
+                  ToolRunDao
+                    .authQuery(
+                      user,
+                      ObjectType.Analysis,
+                      runParams.ownershipTypeParams.ownershipType,
+                      runParams.groupQueryParameters.groupType,
+                      runParams.groupQueryParameters.groupId
+                    )
+                    .filter(runParams)
+                    .page(page)
+                    .transact(xa)
+                    .unsafeToFuture
 
+                }
+              }
+          }
+      }
+  }
+
+  def createToolRun: Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Create, None), user) {
+        entity(as[ToolRun.Create]) { newRun =>
+          onSuccess(
+            ToolRunDao.insertToolRun(newRun, user).transact(xa).unsafeToFuture
+          ) { toolRun =>
+            {
+              complete {
+                (StatusCodes.Created, toolRun)
               }
             }
           }
+        }
       }
   }
 
-  def createToolRun: Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Create, None), user) {
-      entity(as[ToolRun.Create]) { newRun =>
-        onSuccess(
-          ToolRunDao.insertToolRun(newRun, user).transact(xa).unsafeToFuture
-        ) { toolRun =>
-          {
-            complete {
-              (StatusCodes.Created, toolRun)
+  def getToolRun(runId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Read, None), user) {
+        authorizeAuthResultAsync {
+          ToolRunDao
+            .authorized(user, ObjectType.Analysis, runId, ActionType.View)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          rejectEmptyResponse {
+            complete(
+              ToolRunDao.query
+                .filter(runId)
+                .selectOption
+                .transact(xa)
+                .unsafeToFuture
+            )
+          }
+        }
+      }
+  }
+
+  def updateToolRun(runId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Update, None), user) {
+        authorizeAuthResultAsync {
+          ToolRunDao
+            .authorized(user, ObjectType.Analysis, runId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[ToolRun]) { updatedRun =>
+            onSuccess(
+              ToolRunDao
+                .updateToolRun(updatedRun, runId)
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              completeSingleOrNotFound
             }
           }
         }
       }
-    }
   }
 
-  def getToolRun(runId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Read, None), user) {
-      authorizeAuthResultAsync {
-        ToolRunDao
-          .authorized(user, ObjectType.Analysis, runId, ActionType.View)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        rejectEmptyResponse {
-          complete(
-            ToolRunDao.query
-              .filter(runId)
-              .selectOption
-              .transact(xa)
-              .unsafeToFuture
-          )
-        }
-      }
-    }
-  }
-
-  def updateToolRun(runId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Update, None), user) {
-      authorizeAuthResultAsync {
-        ToolRunDao
-          .authorized(user, ObjectType.Analysis, runId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        entity(as[ToolRun]) { updatedRun =>
+  def deleteToolRun(runId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Delete, None), user) {
+        authorizeAuthResultAsync {
+          ToolRunDao
+            .authorized(user, ObjectType.Analysis, runId, ActionType.Delete)
+            .transact(xa)
+            .unsafeToFuture
+        } {
           onSuccess(
-            ToolRunDao
-              .updateToolRun(updatedRun, runId)
-              .transact(xa)
-              .unsafeToFuture
+            ToolRunDao.query.filter(runId).delete.transact(xa).unsafeToFuture
           ) {
             completeSingleOrNotFound
           }
         }
       }
-    }
   }
 
-  def deleteToolRun(runId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Delete, None), user) {
-      authorizeAuthResultAsync {
-        ToolRunDao
-          .authorized(user, ObjectType.Analysis, runId, ActionType.Delete)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        onSuccess(
-          ToolRunDao.query.filter(runId).delete.transact(xa).unsafeToFuture
-        ) {
-          completeSingleOrNotFound
-        }
-      }
-    }
-  }
-
-  def listToolRunPermissions(toolRunId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(
-      ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ToolRunDao
-          .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
+  def listToolRunPermissions(toolRunId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(
+        ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
           ToolRunDao
-            .getPermissions(toolRunId)
-            .transact(xa)
-            .unsafeToFuture
-        }
-      }
-    }
-  }
-
-  def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
-      entity(as[List[ObjectAccessControlRule]]) { acrList =>
-        authorizeAsync {
-          (
-            ToolRunDao.authorized(
-              user,
-              ObjectType.Analysis,
-              toolRunId,
-              ActionType.Edit
-            ) map {
-              _.toBoolean
-            },
-            acrList traverse { acr =>
-              ToolRunDao.isValidPermission(acr, user)
-            } map {
-              _.foldLeft(true)(_ && _)
-            } map {
-              case true =>
-                ToolRunDao.isReplaceWithinScopedLimit(
-                  Domain.Analyses,
-                  user,
-                  acrList
-                )
-              case _ => false
-            }
-          ).tupled
-            .map({ authTup =>
-              authTup._1 && authTup._2
-            })
+            .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit)
             .transact(xa)
             .unsafeToFuture
         } {
           complete {
             ToolRunDao
-              .replacePermissions(toolRunId, acrList)
+              .getPermissions(toolRunId)
               .transact(xa)
               .unsafeToFuture
           }
         }
       }
-    }
   }
 
-  def addToolRunPermission(toolRunId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
-      entity(as[ObjectAccessControlRule]) { acr =>
-        authorizeAsync {
-          (
-            ToolRunDao
-              .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit) map {
-              _.toBoolean
-            },
-            ToolRunDao.isValidPermission(acr, user)
-          ).tupled
-            .map({ authTup =>
-              authTup._1 && authTup._2
-            })
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          complete {
-            ToolRunDao
-              .addPermission(toolRunId, acr)
+  def replaceToolRunPermissions(toolRunId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
+        entity(as[List[ObjectAccessControlRule]]) { acrList =>
+          authorizeAsync {
+            (
+              ToolRunDao.authorized(
+                user,
+                ObjectType.Analysis,
+                toolRunId,
+                ActionType.Edit
+              ) map {
+                _.toBoolean
+              },
+              acrList traverse { acr =>
+                ToolRunDao.isValidPermission(acr, user)
+              } map {
+                _.foldLeft(true)(_ && _)
+              } map {
+                case true =>
+                  ToolRunDao.isReplaceWithinScopedLimit(
+                    Domain.Analyses,
+                    user,
+                    acrList
+                  )
+                case _ => false
+              }
+            ).tupled
+              .map({ authTup =>
+                authTup._1 && authTup._2
+              })
               .transact(xa)
               .unsafeToFuture
-          }
-        }
-      }
-    }
-  }
-
-  def listUserAnalysisActions(analysisId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(
-      ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
-      user
-    ) {
-      authorizeAuthResultAsync {
-        ToolRunDao
-          .authorized(user, ObjectType.Analysis, analysisId, ActionType.View)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        user.isSuperuser match {
-          case true => complete(List("*"))
-          case false =>
-            onSuccess(
-              ToolRunDao.query
-                .filter(analysisId)
-                .select
+          } {
+            complete {
+              ToolRunDao
+                .replacePermissions(toolRunId, acrList)
                 .transact(xa)
                 .unsafeToFuture
-            ) { analysis =>
-              analysis.owner == user.id match {
-                case true => complete(List("*"))
-                case false =>
-                  complete {
-                    ToolRunDao
-                      .listUserActions(user, analysisId)
-                      .transact(xa)
-                      .unsafeToFuture
-                  }
-              }
             }
+          }
         }
       }
-    }
   }
 
-  def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate { case (user, _) =>
-    authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
-      authorizeAuthResultAsync {
-        ToolRunDao
-          .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit)
-          .transact(xa)
-          .unsafeToFuture
-      } {
-        complete {
-          ToolRunDao
-            .deletePermissions(toolRunId)
-            .transact(xa)
-            .unsafeToFuture
+  def addToolRunPermission(toolRunId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
+        entity(as[ObjectAccessControlRule]) { acr =>
+          authorizeAsync {
+            (
+              ToolRunDao
+                .authorized(user,
+                            ObjectType.Analysis,
+                            toolRunId,
+                            ActionType.Edit) map {
+                _.toBoolean
+              },
+              ToolRunDao.isValidPermission(acr, user)
+            ).tupled
+              .map({ authTup =>
+                authTup._1 && authTup._2
+              })
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            complete {
+              ToolRunDao
+                .addPermission(toolRunId, acr)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
         }
       }
-    }
+  }
+
+  def listUserAnalysisActions(analysisId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(
+        ScopedAction(Domain.Analyses, Action.ReadPermissions, None),
+        user
+      ) {
+        authorizeAuthResultAsync {
+          ToolRunDao
+            .authorized(user, ObjectType.Analysis, analysisId, ActionType.View)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          user.isSuperuser match {
+            case true => complete(List("*"))
+            case false =>
+              onSuccess(
+                ToolRunDao.query
+                  .filter(analysisId)
+                  .select
+                  .transact(xa)
+                  .unsafeToFuture
+              ) { analysis =>
+                analysis.owner == user.id match {
+                  case true => complete(List("*"))
+                  case false =>
+                    complete {
+                      ToolRunDao
+                        .listUserActions(user, analysisId)
+                        .transact(xa)
+                        .unsafeToFuture
+                    }
+                }
+              }
+          }
+        }
+      }
+  }
+
+  def deleteToolRunPermissions(toolRunId: UUID): Route = authenticate {
+    case (user, _) =>
+      authorizeScope(ScopedAction(Domain.Analyses, Action.Share, None), user) {
+        authorizeAuthResultAsync {
+          ToolRunDao
+            .authorized(user, ObjectType.Analysis, toolRunId, ActionType.Edit)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          complete {
+            ToolRunDao
+              .deletePermissions(toolRunId)
+              .transact(xa)
+              .unsafeToFuture
+          }
+        }
+      }
   }
 }

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -84,7 +84,7 @@ trait ToolRoutes
       }
   }
 
-  def getToolSources(toolId: UUID): Route = authenticate { user =>
+  def getToolSources(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -110,7 +110,7 @@ trait ToolRoutes
     }
   }
 
-  def listTools: Route = authenticate { user =>
+  def listTools: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Read, None), user) {
       (withPagination & combinedToolQueryParams) {
         (page, combinedToolQueryParameters) =>
@@ -132,7 +132,7 @@ trait ToolRoutes
     }
   }
 
-  def createTool: Route = authenticate { user =>
+  def createTool: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Create, None), user) {
       entity(as[Tool.Create]) { newTool =>
         onSuccess(ToolDao.insert(newTool, user).transact(xa).unsafeToFuture) {
@@ -143,7 +143,7 @@ trait ToolRoutes
     }
   }
 
-  def getTool(toolId: UUID): Route = authenticate { user =>
+  def getTool(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -164,7 +164,7 @@ trait ToolRoutes
     }
   }
 
-  def updateTool(toolId: UUID): Route = authenticate { user =>
+  def updateTool(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -186,7 +186,7 @@ trait ToolRoutes
     }
   }
 
-  def deleteTool(toolId: UUID): Route = authenticate { user =>
+  def deleteTool(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -203,7 +203,7 @@ trait ToolRoutes
     }
   }
 
-  def listToolPermissions(toolId: UUID): Route = authenticate { user =>
+  def listToolPermissions(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Templates, Action.ReadPermissions, None),
       user
@@ -224,7 +224,7 @@ trait ToolRoutes
     }
   }
 
-  def replaceToolPermissions(toolId: UUID): Route = authenticate { user =>
+  def replaceToolPermissions(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -268,7 +268,7 @@ trait ToolRoutes
     }
   }
 
-  def addToolPermission(toolId: UUID): Route = authenticate { user =>
+  def addToolPermission(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Share, None), user) {
       entity(as[ObjectAccessControlRule]) { acr =>
         authorizeAsync {
@@ -300,7 +300,7 @@ trait ToolRoutes
     }
   }
 
-  def listUserTemplateActions(templateId: UUID): Route = authenticate { user =>
+  def listUserTemplateActions(templateId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Templates, Action.ReadPermissions, None),
       user
@@ -337,7 +337,7 @@ trait ToolRoutes
     }
   }
 
-  def deleteToolPermissions(toolId: UUID): Route = authenticate { user =>
+  def deleteToolPermissions(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ToolDao

--- a/app-backend/api/src/main/scala/tools/Routes.scala
+++ b/app-backend/api/src/main/scala/tools/Routes.scala
@@ -84,7 +84,7 @@ trait ToolRoutes
       }
   }
 
-  def getToolSources(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def getToolSources(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -110,7 +110,7 @@ trait ToolRoutes
     }
   }
 
-  def listTools: Route = authenticate { case MembershipAndUser(_, user) =>
+  def listTools: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Read, None), user) {
       (withPagination & combinedToolQueryParams) {
         (page, combinedToolQueryParameters) =>
@@ -132,7 +132,7 @@ trait ToolRoutes
     }
   }
 
-  def createTool: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createTool: Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Create, None), user) {
       entity(as[Tool.Create]) { newTool =>
         onSuccess(ToolDao.insert(newTool, user).transact(xa).unsafeToFuture) {
@@ -143,7 +143,7 @@ trait ToolRoutes
     }
   }
 
-  def getTool(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def getTool(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Read, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -164,7 +164,7 @@ trait ToolRoutes
     }
   }
 
-  def updateTool(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def updateTool(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Update, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -186,7 +186,7 @@ trait ToolRoutes
     }
   }
 
-  def deleteTool(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteTool(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Delete, None), user) {
       authorizeAuthResultAsync {
         ToolDao
@@ -203,7 +203,7 @@ trait ToolRoutes
     }
   }
 
-  def listToolPermissions(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listToolPermissions(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Templates, Action.ReadPermissions, None),
       user
@@ -224,7 +224,7 @@ trait ToolRoutes
     }
   }
 
-  def replaceToolPermissions(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def replaceToolPermissions(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Share, None), user) {
       entity(as[List[ObjectAccessControlRule]]) { acrList =>
         authorizeAsync {
@@ -268,7 +268,7 @@ trait ToolRoutes
     }
   }
 
-  def addToolPermission(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def addToolPermission(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Share, None), user) {
       entity(as[ObjectAccessControlRule]) { acr =>
         authorizeAsync {
@@ -300,7 +300,7 @@ trait ToolRoutes
     }
   }
 
-  def listUserTemplateActions(templateId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def listUserTemplateActions(templateId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(
       ScopedAction(Domain.Templates, Action.ReadPermissions, None),
       user
@@ -337,7 +337,7 @@ trait ToolRoutes
     }
   }
 
-  def deleteToolPermissions(toolId: UUID): Route = authenticate { case MembershipAndUser(_, user) =>
+  def deleteToolPermissions(toolId: UUID): Route = authenticate { case (user, _) =>
     authorizeScope(ScopedAction(Domain.Templates, Action.Share, None), user) {
       authorizeAuthResultAsync {
         ToolDao

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -57,7 +57,7 @@ trait UploadRoutes
   }
 
   def listUploads: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
         (withPagination & uploadQueryParams) {
           (page: PageRequest, queryParams: UploadQueryParameters) =>
@@ -74,7 +74,7 @@ trait UploadRoutes
     }
 
   def getUpload(uploadId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -97,7 +97,7 @@ trait UploadRoutes
     }
 
   def createUpload: Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       // check if user has already hit the storage quota
       val userBytesUploaded =
         UploadDao.getUserBytesUploaded(user).transact(xa).unsafeToFuture()
@@ -197,7 +197,7 @@ trait UploadRoutes
     }
 
   def updateUpload(uploadId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Update, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -266,7 +266,7 @@ trait UploadRoutes
     }
 
   def deleteUpload(uploadId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Delete, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -285,7 +285,7 @@ trait UploadRoutes
     }
 
   def getUploadCredentials(uploadId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Create, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -323,7 +323,7 @@ trait UploadRoutes
     }
 
   def getSignedUploadUrl(uploadId: UUID): Route =
-    authenticate { case MembershipAndUser(_, user) =>
+    authenticate { case (user, _) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
         authorizeAsync {
           UploadDao.query

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -57,7 +57,7 @@ trait UploadRoutes
   }
 
   def listUploads: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
         (withPagination & uploadQueryParams) {
           (page: PageRequest, queryParams: UploadQueryParameters) =>
@@ -74,7 +74,7 @@ trait UploadRoutes
     }
 
   def getUpload(uploadId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -97,7 +97,7 @@ trait UploadRoutes
     }
 
   def createUpload: Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       // check if user has already hit the storage quota
       val userBytesUploaded =
         UploadDao.getUserBytesUploaded(user).transact(xa).unsafeToFuture()
@@ -197,7 +197,7 @@ trait UploadRoutes
     }
 
   def updateUpload(uploadId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Update, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -266,7 +266,7 @@ trait UploadRoutes
     }
 
   def deleteUpload(uploadId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Delete, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -285,7 +285,7 @@ trait UploadRoutes
     }
 
   def getUploadCredentials(uploadId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Create, None), user) {
         authorizeAsync {
           UploadDao.query
@@ -323,7 +323,7 @@ trait UploadRoutes
     }
 
   def getSignedUploadUrl(uploadId: UUID): Route =
-    authenticate { user =>
+    authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
         authorizeAsync {
           UploadDao.query

--- a/app-backend/api/src/main/scala/uploads/Routes.scala
+++ b/app-backend/api/src/main/scala/uploads/Routes.scala
@@ -57,306 +57,317 @@ trait UploadRoutes
   }
 
   def listUploads: Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
-        (withPagination & uploadQueryParams) {
-          (page: PageRequest, queryParams: UploadQueryParameters) =>
-            complete {
-              UploadDao.query
-                .filter(user)
-                .filter(queryParams)
-                .page(page)
-                .transact(xa)
-                .unsafeToFuture
-            }
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
+          (withPagination & uploadQueryParams) {
+            (page: PageRequest, queryParams: UploadQueryParameters) =>
+              complete {
+                UploadDao.query
+                  .filter(user)
+                  .filter(queryParams)
+                  .page(page)
+                  .transact(xa)
+                  .unsafeToFuture
+              }
+          }
         }
-      }
     }
 
   def getUpload(uploadId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
-        authorizeAsync {
-          UploadDao.query
-            .ownedByOrSuperUser(user, uploadId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          rejectEmptyResponse {
-            complete {
-              UploadDao.query
-                .filter(uploadId)
-                .selectOption
-                .transact(xa)
-                .unsafeToFuture
-            }
-          }
-        }
-      }
-    }
-
-  def createUpload: Route =
-    authenticate { case (user, _) =>
-      // check if user has already hit the storage quota
-      val userBytesUploaded =
-        UploadDao.getUserBytesUploaded(user).transact(xa).unsafeToFuture()
-      authorizeScopeLimit(
-        userBytesUploaded,
-        Domain.Uploads,
-        Action.Create,
-        user
-      ) {
-        entity(as[Upload.Create]) { newUpload =>
-          logger.debug(
-            s"newUpload: ${newUpload.uploadType}, ${newUpload.source}, ${newUpload.fileType}"
-          )
-          // check the bytes uploaded to this S3 location
-          val bytesUploaded = Upload.getBytesUploaded(
-            s3.client,
-            dataBucket,
-            newUpload.files,
-            newUpload.uploadStatus,
-            newUpload.uploadType
-          )
-          // check the file size in bytes submitted by this request
-          // the potential size should be the max of
-          // the fileSize and the S3 file size check
-          val potentialNewBytes =
-            newUpload.fileSizeBytes.getOrElse(0.toLong).max(bytesUploaded)
-          val uploadToInsert =
-            (
-              newUpload.uploadType,
-              newUpload.source,
-              newUpload.fileType
-            ) match {
-              case (UploadType.S3, _, FileType.NonSpatial) => {
-                if (newUpload.files.nonEmpty) newUpload
-                else
-                  throw new IllegalStateException(
-                    "S3 upload must specify a source if no files are specified"
-                  )
-              }
-              case (UploadType.S3, Some(source), _) => {
-                if (newUpload.files.nonEmpty) newUpload
-                else {
-                  val files = listAllowedFilesInS3Source(source)
-                  if (files.nonEmpty) newUpload.copy(files = files)
-                  else
-                    throw new IllegalStateException(
-                      "No acceptable files found in the provided source"
-                    )
-                }
-              }
-              case (UploadType.S3, None, _) => {
-                if (newUpload.files.nonEmpty) newUpload
-                else
-                  throw new IllegalStateException(
-                    "S3 upload must specify a source if no files are specified"
-                  )
-              }
-              case (_, _, FileType.GeoJson) => {
-                throw new IllegalStateException(
-                  "Scene uploads must contain imagery, not GeoJson"
-                )
-              }
-              case (_, _, _) => {
-                if (newUpload.files.nonEmpty) newUpload
-                else
-                  throw new IllegalStateException(
-                    "Remote repository upload must specify some ids or files"
-                  )
-              }
-            }
-          authorizeScopeLimit(
-            Future.successful(potentialNewBytes),
-            Domain.Uploads,
-            Action.Create,
-            user
-          ) {
-            onComplete {
-              for {
-                upload <- UploadDao
-                  .insert(uploadToInsert, user, potentialNewBytes)
-                  .transact(xa)
-                  .unsafeToFuture
-              } yield upload
-            } {
-              case Success(upload) =>
-                if (upload.uploadStatus == UploadStatus.Uploaded) {
-                  kickoffSceneImport(upload.id)
-                }
-                complete((StatusCodes.Created, upload))
-              case _ =>
-                complete { HttpResponse(StatusCodes.BadRequest) }
-            }
-          }
-
-        }
-      }
-    }
-
-  def updateUpload(uploadId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Uploads, Action.Update, None), user) {
-        authorizeAsync {
-          UploadDao.query
-            .ownedByOrSuperUser(user, uploadId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          entity(as[Upload]) { updateUpload =>
-            // bytes of the files listed in the upload object to update
-            val updatedBytesUploaded = Upload.getBytesUploaded(
-              s3.client,
-              dataBucket,
-              updateUpload.files,
-              updateUpload.uploadStatus,
-              updateUpload.uploadType
-            )
-            onComplete {
-              (for {
-                uploadOpt <- UploadDao.getUploadById(uploadId)
-                usedBytes <- uploadOpt traverse { upload =>
-                  // get the bytes the user already used
-                  // excluding this upload to be updated
-                  UploadDao.getUserBytesUploaded(user, Some(upload.id))
-                }
-                updated <- usedBytes traverse { used =>
-                  // check if the existing bytes and the bytes to be updated
-                  // exceed the quota
-                  val isBelow = isBelowLimitCheck(
-                    used + updatedBytesUploaded,
-                    Domain.Uploads,
-                    Action.Create,
-                    user
-                  )
-                  if (isBelow == true) {
-                    UploadDao.update(
-                      updateUpload.copy(bytesUploaded = updatedBytesUploaded),
-                      uploadId
-                    )
-                  } else {
-                    -1.pure[ConnectionIO]
-                  }
-                }
-              } yield (uploadOpt, updated)).transact(xa).unsafeToFuture
-            } {
-              case Success((Some(upload), Some(rowsUpdated))) => {
-                if (rowsUpdated == -1) {
-                  return complete { HttpResponse(StatusCodes.Forbidden) }
-                }
-                if (rowsUpdated == 0) {
-                  return complete { HttpResponse(StatusCodes.NoContent) }
-                }
-                if (upload.uploadStatus != UploadStatus.Uploaded &&
-                    updateUpload.uploadStatus == UploadStatus.Uploaded) {
-                  kickoffSceneImport(upload.id)
-                }
-                complete { HttpResponse(StatusCodes.NoContent) }
-              }
-              case Success((None, _)) =>
-                complete { HttpResponse(StatusCodes.NotFound) }
-              case _ => complete { HttpResponse(StatusCodes.BadRequest) }
-            }
-          }
-        }
-      }
-    }
-
-  def deleteUpload(uploadId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Uploads, Action.Delete, None), user) {
-        authorizeAsync {
-          UploadDao.query
-            .ownedByOrSuperUser(user, uploadId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
-            UploadDao.query.filter(uploadId).delete.transact(xa).unsafeToFuture
-          ) {
-            completeSingleOrNotFound
-          }
-        }
-      }
-    }
-
-  def getUploadCredentials(uploadId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Uploads, Action.Create, None), user) {
-        authorizeAsync {
-          UploadDao.query
-            .ownedBy(user, uploadId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          extractTokenHeader {
-            case Some(jwt) =>
-              onSuccess(
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
+          authorizeAsync {
+            UploadDao.query
+              .ownedByOrSuperUser(user, uploadId)
+              .exists
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            rejectEmptyResponse {
+              complete {
                 UploadDao.query
                   .filter(uploadId)
                   .selectOption
                   .transact(xa)
                   .unsafeToFuture
-              ) {
-                case Some(upload) =>
-                  complete(
-                    CredentialsService
-                      .getCredentials(upload, jwt.split(" ").last)
-                  )
-                case None => complete(StatusCodes.NotFound)
               }
-            case _ =>
-              reject(
-                AuthenticationFailedRejection(
-                  AuthenticationFailedRejection.CredentialsMissing,
-                  HttpChallenge("Bearer", "https://rasterfoundry.com")
-                )
-              )
+            }
           }
         }
-      }
+    }
+
+  def createUpload: Route =
+    authenticate {
+      case (user, _) =>
+        // check if user has already hit the storage quota
+        val userBytesUploaded =
+          UploadDao.getUserBytesUploaded(user).transact(xa).unsafeToFuture()
+        authorizeScopeLimit(
+          userBytesUploaded,
+          Domain.Uploads,
+          Action.Create,
+          user
+        ) {
+          entity(as[Upload.Create]) { newUpload =>
+            logger.debug(
+              s"newUpload: ${newUpload.uploadType}, ${newUpload.source}, ${newUpload.fileType}"
+            )
+            // check the bytes uploaded to this S3 location
+            val bytesUploaded = Upload.getBytesUploaded(
+              s3.client,
+              dataBucket,
+              newUpload.files,
+              newUpload.uploadStatus,
+              newUpload.uploadType
+            )
+            // check the file size in bytes submitted by this request
+            // the potential size should be the max of
+            // the fileSize and the S3 file size check
+            val potentialNewBytes =
+              newUpload.fileSizeBytes.getOrElse(0.toLong).max(bytesUploaded)
+            val uploadToInsert =
+              (
+                newUpload.uploadType,
+                newUpload.source,
+                newUpload.fileType
+              ) match {
+                case (UploadType.S3, _, FileType.NonSpatial) => {
+                  if (newUpload.files.nonEmpty) newUpload
+                  else
+                    throw new IllegalStateException(
+                      "S3 upload must specify a source if no files are specified"
+                    )
+                }
+                case (UploadType.S3, Some(source), _) => {
+                  if (newUpload.files.nonEmpty) newUpload
+                  else {
+                    val files = listAllowedFilesInS3Source(source)
+                    if (files.nonEmpty) newUpload.copy(files = files)
+                    else
+                      throw new IllegalStateException(
+                        "No acceptable files found in the provided source"
+                      )
+                  }
+                }
+                case (UploadType.S3, None, _) => {
+                  if (newUpload.files.nonEmpty) newUpload
+                  else
+                    throw new IllegalStateException(
+                      "S3 upload must specify a source if no files are specified"
+                    )
+                }
+                case (_, _, FileType.GeoJson) => {
+                  throw new IllegalStateException(
+                    "Scene uploads must contain imagery, not GeoJson"
+                  )
+                }
+                case (_, _, _) => {
+                  if (newUpload.files.nonEmpty) newUpload
+                  else
+                    throw new IllegalStateException(
+                      "Remote repository upload must specify some ids or files"
+                    )
+                }
+              }
+            authorizeScopeLimit(
+              Future.successful(potentialNewBytes),
+              Domain.Uploads,
+              Action.Create,
+              user
+            ) {
+              onComplete {
+                for {
+                  upload <- UploadDao
+                    .insert(uploadToInsert, user, potentialNewBytes)
+                    .transact(xa)
+                    .unsafeToFuture
+                } yield upload
+              } {
+                case Success(upload) =>
+                  if (upload.uploadStatus == UploadStatus.Uploaded) {
+                    kickoffSceneImport(upload.id)
+                  }
+                  complete((StatusCodes.Created, upload))
+                case _ =>
+                  complete { HttpResponse(StatusCodes.BadRequest) }
+              }
+            }
+
+          }
+        }
+    }
+
+  def updateUpload(uploadId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Uploads, Action.Update, None), user) {
+          authorizeAsync {
+            UploadDao.query
+              .ownedByOrSuperUser(user, uploadId)
+              .exists
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            entity(as[Upload]) { updateUpload =>
+              // bytes of the files listed in the upload object to update
+              val updatedBytesUploaded = Upload.getBytesUploaded(
+                s3.client,
+                dataBucket,
+                updateUpload.files,
+                updateUpload.uploadStatus,
+                updateUpload.uploadType
+              )
+              onComplete {
+                (for {
+                  uploadOpt <- UploadDao.getUploadById(uploadId)
+                  usedBytes <- uploadOpt traverse { upload =>
+                    // get the bytes the user already used
+                    // excluding this upload to be updated
+                    UploadDao.getUserBytesUploaded(user, Some(upload.id))
+                  }
+                  updated <- usedBytes traverse { used =>
+                    // check if the existing bytes and the bytes to be updated
+                    // exceed the quota
+                    val isBelow = isBelowLimitCheck(
+                      used + updatedBytesUploaded,
+                      Domain.Uploads,
+                      Action.Create,
+                      user
+                    )
+                    if (isBelow == true) {
+                      UploadDao.update(
+                        updateUpload.copy(bytesUploaded = updatedBytesUploaded),
+                        uploadId
+                      )
+                    } else {
+                      -1.pure[ConnectionIO]
+                    }
+                  }
+                } yield (uploadOpt, updated)).transact(xa).unsafeToFuture
+              } {
+                case Success((Some(upload), Some(rowsUpdated))) => {
+                  if (rowsUpdated == -1) {
+                    return complete { HttpResponse(StatusCodes.Forbidden) }
+                  }
+                  if (rowsUpdated == 0) {
+                    return complete { HttpResponse(StatusCodes.NoContent) }
+                  }
+                  if (upload.uploadStatus != UploadStatus.Uploaded &&
+                      updateUpload.uploadStatus == UploadStatus.Uploaded) {
+                    kickoffSceneImport(upload.id)
+                  }
+                  complete { HttpResponse(StatusCodes.NoContent) }
+                }
+                case Success((None, _)) =>
+                  complete { HttpResponse(StatusCodes.NotFound) }
+                case _ => complete { HttpResponse(StatusCodes.BadRequest) }
+              }
+            }
+          }
+        }
+    }
+
+  def deleteUpload(uploadId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Uploads, Action.Delete, None), user) {
+          authorizeAsync {
+            UploadDao.query
+              .ownedByOrSuperUser(user, uploadId)
+              .exists
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            onSuccess(
+              UploadDao.query
+                .filter(uploadId)
+                .delete
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              completeSingleOrNotFound
+            }
+          }
+        }
+    }
+
+  def getUploadCredentials(uploadId: UUID): Route =
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Uploads, Action.Create, None), user) {
+          authorizeAsync {
+            UploadDao.query
+              .ownedBy(user, uploadId)
+              .exists
+              .transact(xa)
+              .unsafeToFuture
+          } {
+            extractTokenHeader {
+              case Some(jwt) =>
+                onSuccess(
+                  UploadDao.query
+                    .filter(uploadId)
+                    .selectOption
+                    .transact(xa)
+                    .unsafeToFuture
+                ) {
+                  case Some(upload) =>
+                    complete(
+                      CredentialsService
+                        .getCredentials(upload, jwt.split(" ").last)
+                    )
+                  case None => complete(StatusCodes.NotFound)
+                }
+              case _ =>
+                reject(
+                  AuthenticationFailedRejection(
+                    AuthenticationFailedRejection.CredentialsMissing,
+                    HttpChallenge("Bearer", "https://rasterfoundry.com")
+                  )
+                )
+            }
+          }
+        }
     }
 
   def getSignedUploadUrl(uploadId: UUID): Route =
-    authenticate { case (user, _) =>
-      authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
-        authorizeAsync {
-          UploadDao.query
-            .ownedBy(user, uploadId)
-            .exists
-            .transact(xa)
-            .unsafeToFuture
-        } {
-          onSuccess(
+    authenticate {
+      case (user, _) =>
+        authorizeScope(ScopedAction(Domain.Uploads, Action.Read, None), user) {
+          authorizeAsync {
             UploadDao.query
-              .filter(uploadId)
-              .selectOption
+              .ownedBy(user, uploadId)
+              .exists
               .transact(xa)
               .unsafeToFuture
-          ) {
-            case Some(upload) =>
-              complete {
-                // NOTE: We expect there to be exactly one file for this upload
-                upload.files.headOption match {
-                  case Some(filename) => {
-                    val signed = s3.getSignedUrl(
-                      dataBucket,
-                      s"${upload.s3Path}/$filename",
-                      method = HttpMethod.PUT
-                    )
-                    Upload.PutUrl(s"$signed")
+          } {
+            onSuccess(
+              UploadDao.query
+                .filter(uploadId)
+                .selectOption
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              case Some(upload) =>
+                complete {
+                  // NOTE: We expect there to be exactly one file for this upload
+                  upload.files.headOption match {
+                    case Some(filename) => {
+                      val signed = s3.getSignedUrl(
+                        dataBucket,
+                        s"${upload.s3Path}/$filename",
+                        method = HttpMethod.PUT
+                      )
+                      Upload.PutUrl(s"$signed")
+                    }
+                    case None => StatusCodes.BadRequest
                   }
-                  case None => StatusCodes.BadRequest
                 }
-              }
-            case None => complete(StatusCodes.NotFound)
+              case None => complete(StatusCodes.NotFound)
+            }
           }
         }
-      }
     }
 }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -82,7 +82,7 @@ trait UserRoutes
       }
   }
 
-  def updateOwnUser: Route = authenticate { user =>
+  def updateOwnUser: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.UpdateSelf, None), user) {
       entity(as[User]) { userToUpdate =>
         if (userToUpdate.id == user.id) {
@@ -98,7 +98,7 @@ trait UserRoutes
     }
   }
 
-  def getDbOwnUser: Route = authenticate { user =>
+  def getDbOwnUser: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.ReadSelf, None), user) {
       complete(
         UserDao
@@ -109,7 +109,7 @@ trait UserRoutes
     }
   }
 
-  def updateAuth0User: Route = authenticate { user =>
+  def updateAuth0User: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.UpdateSelf, None), user) {
       entity(as[Auth0UserUpdate]) { userUpdate =>
         complete {
@@ -119,7 +119,7 @@ trait UserRoutes
     }
   }
 
-  def getDropboxAccessToken: Route = authenticate { user =>
+  def getDropboxAccessToken: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.UpdateDropbox, None), user) {
       entity(as[DropboxAuthRequest]) { dbxAuthRequest =>
         val (dbxKey, dbxSecret) =
@@ -180,7 +180,7 @@ trait UserRoutes
       }
   }
 
-  def getUserTeams: Route = authenticate { user =>
+  def getUserTeams: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.Read, None), user) {
       complete {
         TeamDao.teamsForUser(user).transact(xa).unsafeToFuture
@@ -204,7 +204,7 @@ trait UserRoutes
       }
     }
 
-  def getUserRoles: Route = authenticate { user =>
+  def getUserRoles: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.ReadSelf, None), user) {
       complete {
         UserGroupRoleDao
@@ -216,7 +216,7 @@ trait UserRoutes
   }
 
   // Hard coded limits
-  def getUserLimits: Route = authenticate { user =>
+  def getUserLimits: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.ReadSelf, None), user) {
       val io = for {
         projectCount <- AnnotationProjectDao.countUserProjects(user)
@@ -303,7 +303,7 @@ trait UserRoutes
     }
   }
 
-  def searchUsers: Route = authenticate { user =>
+  def searchUsers: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(ScopedAction(Domain.Users, Action.Search, None), user) {
       searchParams { (searchParams) =>
         complete {
@@ -313,7 +313,7 @@ trait UserRoutes
     }
   }
 
-  def createUserBulk: Route = authenticate { user =>
+  def createUserBulk: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeScope(
       ScopedAction(Domain.Users, Action.BulkCreate, None),
       user

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -85,7 +85,7 @@ trait UserRoutes
 
   def updateOwnUser: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.UpdateSelf, None),
           user
@@ -109,7 +109,7 @@ trait UserRoutes
 
   def getDbOwnUser: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.ReadSelf, None),
           user
@@ -125,7 +125,7 @@ trait UserRoutes
 
   def updateAuth0User: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.UpdateSelf, None),
           user
@@ -140,7 +140,7 @@ trait UserRoutes
 
   def getDropboxAccessToken: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.UpdateDropbox, None),
           user
@@ -186,7 +186,7 @@ trait UserRoutes
 
   def getUserByEncodedAuthId(authIdEncoded: String): Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.ReadSelf, None),
           user
@@ -213,7 +213,7 @@ trait UserRoutes
 
   def getUserTeams: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Users, Action.Read, None), user) {
           complete {
             TeamDao.teamsForUser(user).transact(xa).unsafeToFuture
@@ -223,7 +223,7 @@ trait UserRoutes
 
   def updateUserByEncodedAuthId(authIdEncoded: String): Route =
     authenticateSuperUser {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Users, Action.Update, None), user) {
           entity(as[User]) { updatedUser =>
             onSuccess(
@@ -240,7 +240,7 @@ trait UserRoutes
 
   def getUserRoles: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.ReadSelf, None),
           user
@@ -257,7 +257,7 @@ trait UserRoutes
   // Hard coded limits
   def getUserLimits: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.ReadSelf, None),
           user
@@ -353,7 +353,7 @@ trait UserRoutes
 
   def searchUsers: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(ScopedAction(Domain.Users, Action.Search, None), user) {
           searchParams { (searchParams) =>
             complete {
@@ -368,7 +368,7 @@ trait UserRoutes
 
   def createUserBulk: Route =
     authenticate {
-      case MembershipAndUser(_, user) =>
+      case (user, _) =>
         authorizeScope(
           ScopedAction(Domain.Users, Action.BulkCreate, None),
           user

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.akkautil.PaginationDirectives
 import com.rasterfoundry.akkautil.{
   Authentication,
   CommonHandlers,
-  MembershipAndUser,
   UserErrorHandler
 }
 import com.rasterfoundry.api.utils.Config
@@ -264,87 +263,83 @@ trait UserRoutes
         ) {
           val io = for {
             projectCount <- AnnotationProjectDao.countUserProjects(user)
-            projectLimit =
-              Scopes
-                .resolveFor(
-                  Domain.AnnotationProjects,
-                  Action.Create,
-                  user.scope.actions
-                )
-                .flatMap(_.limit.map(_.toFloat))
+            projectLimit = Scopes
+              .resolveFor(
+                Domain.AnnotationProjects,
+                Action.Create,
+                user.scope.actions
+              )
+              .flatMap(_.limit.map(_.toFloat))
             uploadBytes <- UploadDao.getUserBytesUploaded(user)
-            uploadLimit =
-              Scopes
-                .resolveFor(Domain.Uploads, Action.Create, user.scope.actions)
-                .flatMap(_.limit.map(_.toFloat))
+            uploadLimit = Scopes
+              .resolveFor(Domain.Uploads, Action.Create, user.scope.actions)
+              .flatMap(_.limit.map(_.toFloat))
             projectShares <- AnnotationProjectDao.getAllShareCounts(user.id)
-            projectShareLimit =
-              Scopes
-                .resolveFor(
-                  Domain.AnnotationProjects,
-                  Action.Share,
-                  user.scope.actions
-                )
-                .flatMap(_.limit.map(_.toFloat))
-            campaignCount <- CampaignDao.countUserCampaigns(user)
-            campaignLimit =
-              Scopes
-                .resolveFor(
-                  Domain.Campaigns,
-                  Action.Create,
-                  user.scope.actions
-                )
-                .flatMap(_.limit.map(_.toFloat))
-            campaignShares <- CampaignDao.getAllShareCounts(user.id)
-            campaignShareLimit =
-              Scopes
-                .resolveFor(
-                  Domain.Campaigns,
-                  Action.Share,
-                  user.scope.actions
-                )
-                .flatMap(_.limit.map(_.toFloat))
-          } yield List(
-            ScopeUsage(
-              Domain.AnnotationProjects,
-              Action.Create,
-              None,
-              projectCount,
-              projectLimit
-            ),
-            ScopeUsage(
-              Domain.Uploads,
-              Action.Create,
-              None,
-              uploadBytes,
-              uploadLimit
-            ),
-            ScopeUsage(
-              Domain.Campaigns,
-              Action.Create,
-              None,
-              campaignCount,
-              campaignLimit
-            )
-          ) ++ (projectShares.toList.map {
-            case (id, count) =>
-              ScopeUsage(
+            projectShareLimit = Scopes
+              .resolveFor(
                 Domain.AnnotationProjects,
                 Action.Share,
-                Some(id.toString),
-                count,
-                projectShareLimit
+                user.scope.actions
               )
-          }) ++ (campaignShares.toList.map {
-            case (id, count) =>
-              ScopeUsage(
+              .flatMap(_.limit.map(_.toFloat))
+            campaignCount <- CampaignDao.countUserCampaigns(user)
+            campaignLimit = Scopes
+              .resolveFor(
+                Domain.Campaigns,
+                Action.Create,
+                user.scope.actions
+              )
+              .flatMap(_.limit.map(_.toFloat))
+            campaignShares <- CampaignDao.getAllShareCounts(user.id)
+            campaignShareLimit = Scopes
+              .resolveFor(
                 Domain.Campaigns,
                 Action.Share,
-                Some(id.toString),
-                count,
-                campaignShareLimit
+                user.scope.actions
               )
-          })
+              .flatMap(_.limit.map(_.toFloat))
+          } yield
+            List(
+              ScopeUsage(
+                Domain.AnnotationProjects,
+                Action.Create,
+                None,
+                projectCount,
+                projectLimit
+              ),
+              ScopeUsage(
+                Domain.Uploads,
+                Action.Create,
+                None,
+                uploadBytes,
+                uploadLimit
+              ),
+              ScopeUsage(
+                Domain.Campaigns,
+                Action.Create,
+                None,
+                campaignCount,
+                campaignLimit
+              )
+            ) ++ (projectShares.toList.map {
+              case (id, count) =>
+                ScopeUsage(
+                  Domain.AnnotationProjects,
+                  Action.Share,
+                  Some(id.toString),
+                  count,
+                  projectShareLimit
+                )
+            }) ++ (campaignShares.toList.map {
+              case (id, count) =>
+                ScopeUsage(
+                  Domain.Campaigns,
+                  Action.Share,
+                  Some(id.toString),
+                  count,
+                  campaignShareLimit
+                )
+            })
           complete {
             io.transact(xa).unsafeToFuture
           }
@@ -390,22 +385,21 @@ trait UserRoutes
                 users <- createdUsers
                 userWithCampaigns <- users traverse { auth0User =>
                   for {
-                    userWithCampaign <-
-                      (auth0User.user_id, auth0User.username).tupled traverse {
-                        case (userId, username) =>
-                          UserDao
-                            .createUserWithCampaign(
-                              UserInfo(
-                                userId,
-                                s"${username}@$auth0AnonymizedConnectionName.com",
-                                username
-                              ),
-                              userBulkCreate,
-                              user
-                            )
-                            .transact(xa)
-                            .unsafeToFuture
-                      }
+                    userWithCampaign <- (auth0User.user_id, auth0User.username).tupled traverse {
+                      case (userId, username) =>
+                        UserDao
+                          .createUserWithCampaign(
+                            UserInfo(
+                              userId,
+                              s"${username}@$auth0AnonymizedConnectionName.com",
+                              username
+                            ),
+                            userBulkCreate,
+                            user
+                          )
+                          .transact(xa)
+                          .unsafeToFuture
+                    }
                   } yield userWithCampaign
                 }
               } yield userWithCampaigns
@@ -414,9 +408,10 @@ trait UserRoutes
                 case false =>
                   for {
                     uwcs <- uwcsFuture
-                  } yield uwcs traverse { uwc =>
-                    uwc.map(_.user.name)
-                  }
+                  } yield
+                    uwcs traverse { uwc =>
+                      uwc.map(_.user.name)
+                    }
                 case true =>
                   for {
                     uwcs <- uwcsFuture
@@ -424,17 +419,18 @@ trait UserRoutes
                       uwc.map(_.user)
                     }
                     _ <- (userBulkCreate.campaignId traverse { campaignId =>
-                        CampaignDao
-                          .grantCloneChildrenAccessById(
-                            campaignId,
-                            ActionType.View
-                          )
-                      }).transact(xa).unsafeToFuture()
-                  } yield usersO map { users =>
-                    users map {
-                      _.name
+                      CampaignDao
+                        .grantCloneChildrenAccessById(
+                          campaignId,
+                          ActionType.View
+                        )
+                    }).transact(xa).unsafeToFuture()
+                  } yield
+                    usersO map { users =>
+                      users map {
+                        _.name
+                      }
                     }
-                  }
 
               }
             }

--- a/app-backend/api/src/main/scala/user/Routes.scala
+++ b/app-backend/api/src/main/scala/user/Routes.scala
@@ -157,8 +157,7 @@ trait UserRoutes
     }
   }
 
-  def getUserByEncodedAuthId(authIdEncoded: String): Route = authenticate {
-    user =>
+  def getUserByEncodedAuthId(authIdEncoded: String): Route = authenticate { case MembershipAndUser(_, user) =>
       authorizeScope(ScopedAction(Domain.Users, Action.ReadSelf, None), user) {
         rejectEmptyResponse {
           val authId = URLDecoder.decode(authIdEncoded, "UTF-8")

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/Authenticators.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/Authenticators.scala
@@ -34,8 +34,8 @@ class Authenticators(val xa: Transactor[IO])
           userFromMapToken(MapTokenDao.checkProject(projectId), mapTokenId)
 
         case req @ _ -> UUIDWrapper(analysisId) /: _
-            :? TokenQueryParamMatcher(tokenQP)
-            :? MapTokenQueryParamMatcher(mapTokenQP)
+              :? TokenQueryParamMatcher(tokenQP)
+              :? MapTokenQueryParamMatcher(mapTokenQP)
             if req.scriptName == "/tools" =>
           val authHeader: OptionT[IO, Header] =
             OptionT.fromOption(
@@ -52,8 +52,8 @@ class Authenticators(val xa: Transactor[IO])
             ) reduce { _ orElse _ }
 
         case req @ _ -> UUIDWrapper(projectId) /: _
-            :? TokenQueryParamMatcher(tokenQP)
-            :? MapTokenQueryParamMatcher(mapTokenQP) => {
+              :? TokenQueryParamMatcher(tokenQP)
+              :? MapTokenQueryParamMatcher(mapTokenQP) => {
           val authHeaderO: Option[Header] =
             req.headers.get(CaseInsensitiveString("Authorization"))
           val mapTokenO = mapTokenQP orElse (req.params

--- a/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/Authenticators.scala
+++ b/app-backend/backsplash-server/src/main/scala/com/rasterfoundry/backsplash/middleware/Authenticators.scala
@@ -2,8 +2,8 @@ package com.rasterfoundry.backsplash.server
 
 import com.rasterfoundry.backsplash.Parameters._
 import com.rasterfoundry.database.Implicits._
-import com.rasterfoundry.database.{MapTokenDao, ProjectDao}
-import com.rasterfoundry.datamodel.{MapToken, Project, User, Visibility}
+import com.rasterfoundry.database.{MapTokenDao, ProjectDao, UserMaybePlatform}
+import com.rasterfoundry.datamodel.{MapToken, Project, Visibility}
 import com.rasterfoundry.{http4s => RFHttp4s}
 
 import cats.data._
@@ -25,70 +25,73 @@ class Authenticators(val xa: Transactor[IO])
     extends LazyLogging
     with RFHttp4s.Authenticators {
 
-  val tokensAuthenticator = Kleisli[OptionT[IO, ?], Request[IO], User](
-    {
-      case _ -> Root / UUIDWrapper(projectId) / "map-token" / UUIDWrapper(
-            mapTokenId
-          ) =>
-        userFromMapToken(MapTokenDao.checkProject(projectId), mapTokenId)
+  val tokensAuthenticator =
+    Kleisli[OptionT[IO, ?], Request[IO], UserMaybePlatform](
+      {
+        case _ -> Root / UUIDWrapper(projectId) / "map-token" / UUIDWrapper(
+              mapTokenId
+            ) =>
+          userFromMapToken(MapTokenDao.checkProject(projectId), mapTokenId)
 
-      case req @ _ -> UUIDWrapper(analysisId) /: _
+        case req @ _ -> UUIDWrapper(analysisId) /: _
             :? TokenQueryParamMatcher(tokenQP)
             :? MapTokenQueryParamMatcher(mapTokenQP)
-          if req.scriptName == "/tools" =>
-        val authHeader: OptionT[IO, Header] =
-          OptionT.fromOption(
-            req.headers.get(CaseInsensitiveString("Authorization"))
-          )
-        checkTokenAndHeader(tokenQP, authHeader) :+
-          (
-            OptionT.fromOption[IO](mapTokenQP) flatMap { (mapToken: UUID) =>
-              userFromMapToken(MapTokenDao.checkAnalysis(analysisId), mapToken)
-            }
-          ) reduce { _ orElse _ }
+            if req.scriptName == "/tools" =>
+          val authHeader: OptionT[IO, Header] =
+            OptionT.fromOption(
+              req.headers.get(CaseInsensitiveString("Authorization"))
+            )
+          checkTokenAndHeader(tokenQP, authHeader) :+
+            (
+              OptionT.fromOption[IO](mapTokenQP) flatMap { (mapToken: UUID) =>
+                userFromMapToken(
+                  MapTokenDao.checkAnalysis(analysisId),
+                  mapToken
+                )
+              }
+            ) reduce { _ orElse _ }
 
-      case req @ _ -> UUIDWrapper(projectId) /: _
+        case req @ _ -> UUIDWrapper(projectId) /: _
             :? TokenQueryParamMatcher(tokenQP)
             :? MapTokenQueryParamMatcher(mapTokenQP) => {
-        val authHeaderO: Option[Header] =
-          req.headers.get(CaseInsensitiveString("Authorization"))
-        val mapTokenO = mapTokenQP orElse (req.params
-          .get("mapToken") map { UUID.fromString _ })
-        (authHeaderO, tokenQP, mapTokenO) match {
-          case (None, None, None) =>
-            userFromPublicProject(projectId)
-          case _ =>
-            val authHeader: OptionT[IO, Header] =
-              OptionT.fromOption(authHeaderO)
-            checkTokenAndHeader(tokenQP, authHeader) :+
-              (
-                OptionT.fromOption[IO](mapTokenO) flatMap { (mapToken: UUID) =>
-                  userFromMapToken(
-                    MapTokenDao.checkProject(projectId),
-                    mapToken
-                  )
-                }
-              ) reduce { _ orElse _ }
+          val authHeaderO: Option[Header] =
+            req.headers.get(CaseInsensitiveString("Authorization"))
+          val mapTokenO = mapTokenQP orElse (req.params
+            .get("mapToken") map { UUID.fromString _ })
+          (authHeaderO, tokenQP, mapTokenO) match {
+            case (None, None, None) =>
+              userFromPublicProject(projectId)
+            case _ =>
+              val authHeader: OptionT[IO, Header] =
+                OptionT.fromOption(authHeaderO)
+              checkTokenAndHeader(tokenQP, authHeader) :+
+                (
+                  OptionT.fromOption[IO](mapTokenO) flatMap {
+                    (mapToken: UUID) =>
+                      userFromMapToken(
+                        MapTokenDao.checkProject(projectId),
+                        mapToken
+                      )
+                  }
+                ) reduce { _ orElse _ }
+          }
         }
-      }
 
-      case _ =>
-        OptionT.none[IO, User]
-    }
-  )
+        case _ =>
+          OptionT.none[IO, UserMaybePlatform]
+      }
+    )
 
   private def checkTokenAndHeader(
       tokenQP: Option[String],
       authHeader: OptionT[IO, Header]
-  ): List[OptionT[IO, User]] = {
+  ): List[OptionT[IO, UserMaybePlatform]] = {
     List(
       authHeader flatMap { (header: Header) =>
-        userFromToken(header.value.replace("Bearer ", "")) map {
-          case (user, _) => user
-        }
+        userFromToken(header.value.replace("Bearer ", ""))
       },
       OptionT.fromOption[IO](tokenQP) flatMap { (token: String) =>
-        userFromToken(token) map { case (user, _) => user }
+        userFromToken(token)
       }
     )
   }
@@ -96,12 +99,12 @@ class Authenticators(val xa: Transactor[IO])
   private def userFromMapToken(
       func: UUID => ConnectionIO[Option[MapToken]],
       mapTokenId: UUID
-  ): OptionT[IO, User] =
+  ): OptionT[IO, UserMaybePlatform] =
     OptionT(func(mapTokenId).transact(xa)) flatMap { mapToken =>
-      OptionT(getUserFromJWTwithCache(mapToken.owner)) map { _._1 }
+      OptionT(getUserFromJWTwithCache(mapToken.owner))
     }
 
-  private def userFromPublicProject(id: UUID): OptionT[IO, User] =
+  private def userFromPublicProject(id: UUID): OptionT[IO, UserMaybePlatform] =
     for {
       project <- OptionT[IO, Project](
         ProjectDao.query
@@ -110,8 +113,15 @@ class Authenticators(val xa: Transactor[IO])
           .selectOption
           .transact(xa)
       )
-      (user, _) <- OptionT(getUserFromJWTwithCache(project.owner))
-    } yield user
+      userMaybePlatform <- OptionT(getUserFromJWTwithCache(project.owner))
+    } yield userMaybePlatform
 
-  val tokensAuthMiddleware = AuthMiddleware(tokensAuthenticator)
+  val tokensAuthMiddleware = AuthMiddleware(tokensAuthenticator map {
+    case (user, maybePlatform) => {
+      maybePlatform.map { platform =>
+        logger.info(s"platform = ${platform.id}")
+      }
+      user
+    }
+  })
 }

--- a/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
+++ b/app-backend/batch/src/main/scala/groundwork/CreateTaskGrid.scala
@@ -54,7 +54,7 @@ class CreateTaskGrid(
       _ <- OptionT.liftF {
         info(s"Got annotation project ${annotationProject.name}")
       }
-      owner <- OptionT {
+      (user, _) <- OptionT {
         UserDao.getUserById(annotationProject.createdBy)
       }
       footprint <- OptionT {
@@ -78,7 +78,11 @@ class CreateTaskGrid(
       )
       _ <- OptionT.liftF {
         TaskDao
-          .insertTasksByGrid(taskProperties, taskGridFeatureCreate, owner)
+          .insertTasksByGrid(
+            taskProperties,
+            taskGridFeatureCreate,
+            user
+          )
       }
       _ <- OptionT.liftF { info("Inserted tasks") }
       // even though the `aoi` and `taskSizeMeters` are updated when inserting tasks,

--- a/app-backend/db/src/main/scala/AnnotationDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationDao.scala
@@ -36,11 +36,10 @@ object AnnotationDao extends Dao[Annotation] {
       annotationId: UUID
   ): ConnectionIO[Option[AnnotationWithOwnerInfo]] =
     for {
-      annotationO <-
-        query
-          .filter(fr"project_id = ${projectId}")
-          .filter(annotationId)
-          .selectOption
+      annotationO <- query
+        .filter(fr"project_id = ${projectId}")
+        .filter(annotationId)
+        .selectOption
       ownerO <- annotationO match {
         case Some(annotation) => UserDao.getUserById(annotation.owner)
         case None             => None.pure[ConnectionIO]
@@ -96,12 +95,11 @@ object AnnotationDao extends Dao[Annotation] {
     for {
       project <- ProjectDao.unsafeGetProjectById(projectId)
       projectLayerId = ProjectDao.getProjectLayerId(projectLayerIdO, project)
-      annotations <-
-        AnnotationDao.query
-          .filter(fr"project_id=$projectId")
-          .filter(fr"project_layer_id=${projectLayerId}")
-          .filter(queryParams)
-          .page(page)
+      annotations <- AnnotationDao.query
+        .filter(fr"project_id=$projectId")
+        .filter(fr"project_layer_id=${projectLayerId}")
+        .filter(queryParams)
+        .page(page)
     } yield { annotations }
 
   // look for the default project layer
@@ -133,17 +131,17 @@ object AnnotationDao extends Dao[Annotation] {
               Some(projectLayerId)
             )
             .map(_.id)
-            .flatMap(defaultId =>
-              ProjectDao
-                .updateProject(
-                  project.copy(defaultAnnotationGroup = Some(defaultId)),
-                  project.id
-                )
-                .map(_ => defaultId)
-            )
+            .flatMap(
+              defaultId =>
+                ProjectDao
+                  .updateProject(
+                    project.copy(defaultAnnotationGroup = Some(defaultId)),
+                    project.id
+                  )
+                  .map(_ => defaultId))
       }
-      annotationFragments: List[Fragment] =
-        annotations.map((annotationCreate: Annotation.Create) => {
+      annotationFragments: List[Fragment] = annotations.map(
+        (annotationCreate: Annotation.Create) => {
           val annotation: Annotation = annotationCreate.toAnnotation(
             projectId,
             user,
@@ -158,9 +156,9 @@ object AnnotationDao extends Dao[Annotation] {
           ${annotation.projectLayerId}, ${annotation.taskId}
         )"""
         })
-      insertedAnnotations <-
-        annotationFragments.toNel
-          .map(fragments =>
+      insertedAnnotations <- annotationFragments.toNel
+        .map(
+          fragments =>
             (insertFragment ++ fragments.intercalate(fr",")).update
               .withGeneratedKeys[Annotation](
                 "id",
@@ -182,9 +180,8 @@ object AnnotationDao extends Dao[Annotation] {
                 "task_id"
               )
               .compile
-              .toList
-          )
-          .getOrElse(List[Annotation]().pure[ConnectionIO])
+              .toList)
+        .getOrElse(List[Annotation]().pure[ConnectionIO])
     } yield insertedAnnotations
   }
 
@@ -217,12 +214,11 @@ object AnnotationDao extends Dao[Annotation] {
     for {
       project <- ProjectDao.unsafeGetProjectById(projectId)
       projectLayerId = ProjectDao.getProjectLayerId(projectLayerIdO, project)
-      labelList <-
-        (fr"SELECT DISTINCT ON (label) label FROM" ++ tableF ++ Fragments
-          .whereAndOpt(
-            Some(fr"project_id = ${projectId}"),
-            Some(fr"project_layer_id = ${projectLayerId}")
-          )).query[String].to[List]
+      labelList <- (fr"SELECT DISTINCT ON (label) label FROM" ++ tableF ++ Fragments
+        .whereAndOpt(
+          Some(fr"project_id = ${projectId}"),
+          Some(fr"project_layer_id = ${projectLayerId}")
+        )).query[String].to[List]
     } yield { labelList }
   }
 
@@ -238,11 +234,10 @@ object AnnotationDao extends Dao[Annotation] {
     for {
       project <- ProjectDao.unsafeGetProjectById(projectId)
       projectLayerId = ProjectDao.getProjectLayerId(projectLayerIdO, project)
-      rowsDeleted <-
-        AnnotationDao.query
-          .filter(fr"project_id = ${projectId}")
-          .filter(fr"project_layer_id = ${projectLayerId}")
-          .delete
+      rowsDeleted <- AnnotationDao.query
+        .filter(fr"project_id = ${projectId}")
+        .filter(fr"project_layer_id = ${projectLayerId}")
+        .delete
     } yield { rowsDeleted }
 
   def deleteById(projectId: UUID, annotationId: UUID): ConnectionIO[Int] =
@@ -275,8 +270,7 @@ object AnnotationDao extends Dao[Annotation] {
         queryParams.bboxPolygon match {
           case Some(bboxPolygons) =>
             val fragments = bboxPolygons.map(bbox =>
-              fr"(_ST_Intersects(a.geometry, ${bbox}) AND a.geometry && ${bbox})"
-            )
+              fr"(_ST_Intersects(a.geometry, ${bbox}) AND a.geometry && ${bbox})")
             Some(fr"(" ++ Fragments.or(fragments: _*) ++ fr")")
           case _ => None
         }
@@ -311,20 +305,18 @@ object AnnotationDao extends Dao[Annotation] {
         projectLayerId,
         queryParams
       )
-      page <-
-        (selectF ++ fromF ++ Fragments.whereAndOpt(filters: _*) ++ Page(
-          pageRequest.copy(
-            sort = pageRequest.sort ++ Map(
-              "a.modified_at" -> Order.Desc,
-              "a.id" -> Order.Desc
-            )
+      page <- (selectF ++ fromF ++ Fragments.whereAndOpt(filters: _*) ++ Page(
+        pageRequest.copy(
+          sort = pageRequest.sort ++ Map(
+            "a.modified_at" -> Order.Desc,
+            "a.id" -> Order.Desc
           )
-        )).query[AnnotationWithOwnerInfo]
-          .to[List]
-      count <-
-        (countF ++ Fragments.whereAndOpt(filters: _*))
-          .query[Long]
-          .unique
+        )
+      )).query[AnnotationWithOwnerInfo]
+        .to[List]
+      count <- (countF ++ Fragments.whereAndOpt(filters: _*))
+        .query[Long]
+        .unique
     } yield {
       val hasPrevious = pageRequest.offset > 0
       val hasNext = (pageRequest.offset * pageRequest.limit) + 1 < count

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,15 +206,16 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-        case (classGroup, idx) =>
-          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-            classGroup,
-            Some(annotationProject),
-            None,
-            idx
-          )
-      }
+      labelClassGroups <-
+        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+          case (classGroup, idx) =>
+            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+              classGroup,
+              Some(annotationProject),
+              None,
+              idx
+            )
+        }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -230,8 +231,9 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <- AnnotationLabelClassGroupDao
-        .listByProjectId(id)
+      labelClassGroup <-
+        AnnotationLabelClassGroupDao
+          .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -378,11 +380,12 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <- (fr"select id from " ++ Fragment.const(
-        tableName
-      ) ++ fr" where owner = $userId")
-        .query[UUID]
-        .to[List]
+      projectIds <-
+        (fr"select id from " ++ Fragment.const(
+          tableName
+        ) ++ fr" where owner = $userId")
+          .query[UUID]
+          .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -414,14 +417,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(
-              classes =>
-                LabelClass(
-                  LabelClassName.VectorName(group.name),
-                  LabelClassClasses.NamedLabelClasses(
-                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                  )
-              ))
+            .map(classes =>
+              LabelClass(
+                LabelClassName.VectorName(group.name),
+                LabelClassClasses.NamedLabelClasses(
+                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                )
+              )
+            )
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -444,24 +447,30 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Annotate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
             .map(
-              _.map(UserThinWithActionType.fromUser(_, ActionType.Annotate))
+              _.map {
+                case (user, _) =>
+                  UserThinWithActionType.fromUser(user, ActionType.Annotate)
+              }
             )
         case ObjectAccessControlRule(
-            SubjectType.User,
-            Some(subjectId),
-            ActionType.Validate
+              SubjectType.User,
+              Some(subjectId),
+              ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
             .map(
-              _.map(UserThinWithActionType.fromUser(_, ActionType.Validate))
+              _.map {
+                case (user, _) =>
+                  UserThinWithActionType.fromUser(user, ActionType.Validate)
+              }
             )
         case _ =>
           Option.empty[UserThinWithActionType].pure[ConnectionIO]
@@ -507,37 +516,40 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <- insertQuery.update
-        .withUniqueGeneratedKeys[AnnotationProject](
-          fieldNames: _*
-        )
+      annotationProjectCopy <-
+        insertQuery.update
+          .withUniqueGeneratedKeys[AnnotationProject](
+            fieldNames: _*
+          )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <- AnnotationLabelClassDao
-            .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <- AnnotationLabelClassGroupDao
-            .insertAnnotationLabelClassGroup(
-              AnnotationLabelClassGroup.Create(
-                classGroup.name,
-                Some(classGroup.index),
-                labelClasses.map { labelClass =>
-                  AnnotationLabelClass.Create(
-                    labelClass.name,
-                    labelClass.colorHexCode,
-                    labelClass.default,
-                    labelClass.determinant,
-                    labelClass.index,
-                    labelClass.geometryType,
-                    labelClass.description
-                  )
-                }
-              ),
-              Some(annotationProjectCopy),
-              None,
-              0,
-              labelClasses
-            )
+          labelClasses <-
+            AnnotationLabelClassDao
+              .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <-
+            AnnotationLabelClassGroupDao
+              .insertAnnotationLabelClassGroup(
+                AnnotationLabelClassGroup.Create(
+                  classGroup.name,
+                  Some(classGroup.index),
+                  labelClasses.map { labelClass =>
+                    AnnotationLabelClass.Create(
+                      labelClass.name,
+                      labelClass.colorHexCode,
+                      labelClass.default,
+                      labelClass.determinant,
+                      labelClass.index,
+                      labelClass.geometryType,
+                      labelClass.description
+                    )
+                  }
+                ),
+                Some(annotationProjectCopy),
+                None,
+                0,
+                labelClasses
+              )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -568,20 +580,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())(
-            (acc, userId) =>
-              acc ++ List(
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.View
-                ),
-                ObjectAccessControlRule(
-                  SubjectType.User,
-                  Some(userId),
-                  ActionType.Annotate
-                )
-            ))
+          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
+            acc ++ List(
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.View
+              ),
+              ObjectAccessControlRule(
+                SubjectType.User,
+                Some(userId),
+                ActionType.Annotate
+              )
+            )
+          )
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/AnnotationProjectDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationProjectDao.scala
@@ -206,16 +206,15 @@ object AnnotationProjectDao
       tileLayers <- newAnnotationProject.tileLayers traverse { layer =>
         TileLayerDao.insertTileLayer(layer, annotationProject)
       }
-      labelClassGroups <-
-        newAnnotationProject.labelClassGroups.zipWithIndex traverse {
-          case (classGroup, idx) =>
-            AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
-              classGroup,
-              Some(annotationProject),
-              None,
-              idx
-            )
-        }
+      labelClassGroups <- newAnnotationProject.labelClassGroups.zipWithIndex traverse {
+        case (classGroup, idx) =>
+          AnnotationLabelClassGroupDao.insertAnnotationLabelClassGroup(
+            classGroup,
+            Some(annotationProject),
+            None,
+            idx
+          )
+      }
     } yield annotationProject.withRelated(tileLayers, labelClassGroups)
   }
 
@@ -231,9 +230,8 @@ object AnnotationProjectDao
     for {
       projectO <- getById(id)
       tileLayers <- TileLayerDao.listByProjectId(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByProjectId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByProjectId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -380,12 +378,11 @@ object AnnotationProjectDao
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      projectIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      projectIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       projectShareCounts <- projectIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -417,14 +414,14 @@ object AnnotationProjectDao
         labelGroups.flatMap { group =>
           groupToLabelClasses
             .get(group.id)
-            .map(classes =>
-              LabelClass(
-                LabelClassName.VectorName(group.name),
-                LabelClassClasses.NamedLabelClasses(
-                  classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
-                )
-              )
-            )
+            .map(
+              classes =>
+                LabelClass(
+                  LabelClassName.VectorName(group.name),
+                  LabelClassClasses.NamedLabelClasses(
+                    classes.map(_.name).toNel.getOrElse(NonEmptyList.of(""))
+                  )
+              ))
         },
         s"Labels for annotation project ${annotationProject.name}",
         LabelType.Vector,
@@ -447,9 +444,9 @@ object AnnotationProjectDao
       permissions <- getPermissions(projectId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -460,9 +457,9 @@ object AnnotationProjectDao
               }
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -516,40 +513,37 @@ object AnnotationProjectDao
            WHERE id = ${projectId}
         """)
     for {
-      annotationProjectCopy <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[AnnotationProject](
-            fieldNames: _*
-          )
+      annotationProjectCopy <- insertQuery.update
+        .withUniqueGeneratedKeys[AnnotationProject](
+          fieldNames: _*
+        )
       classGroups <- AnnotationLabelClassGroupDao.listByProjectId(projectId)
       _ <- classGroups traverse { classGroup =>
         for {
-          labelClasses <-
-            AnnotationLabelClassDao
-              .listAnnotationLabelClassByGroupId(classGroup.id)
-          newClassGroup <-
-            AnnotationLabelClassGroupDao
-              .insertAnnotationLabelClassGroup(
-                AnnotationLabelClassGroup.Create(
-                  classGroup.name,
-                  Some(classGroup.index),
-                  labelClasses.map { labelClass =>
-                    AnnotationLabelClass.Create(
-                      labelClass.name,
-                      labelClass.colorHexCode,
-                      labelClass.default,
-                      labelClass.determinant,
-                      labelClass.index,
-                      labelClass.geometryType,
-                      labelClass.description
-                    )
-                  }
-                ),
-                Some(annotationProjectCopy),
-                None,
-                0,
-                labelClasses
-              )
+          labelClasses <- AnnotationLabelClassDao
+            .listAnnotationLabelClassByGroupId(classGroup.id)
+          newClassGroup <- AnnotationLabelClassGroupDao
+            .insertAnnotationLabelClassGroup(
+              AnnotationLabelClassGroup.Create(
+                classGroup.name,
+                Some(classGroup.index),
+                labelClasses.map { labelClass =>
+                  AnnotationLabelClass.Create(
+                    labelClass.name,
+                    labelClass.colorHexCode,
+                    labelClass.default,
+                    labelClass.determinant,
+                    labelClass.index,
+                    labelClass.geometryType,
+                    labelClass.description
+                  )
+                }
+              ),
+              Some(annotationProjectCopy),
+              None,
+              0,
+              labelClasses
+            )
         } yield newClassGroup
       }
       _ <- TaskDao.copyAnnotationProjectTasks(
@@ -580,20 +574,20 @@ object AnnotationProjectDao
       )
       _ <- projects traverse { project =>
         val rules =
-          userIds.foldLeft(List[ObjectAccessControlRule]())((acc, userId) =>
-            acc ++ List(
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.View
-              ),
-              ObjectAccessControlRule(
-                SubjectType.User,
-                Some(userId),
-                ActionType.Annotate
-              )
-            )
-          )
+          userIds.foldLeft(List[ObjectAccessControlRule]())(
+            (acc, userId) =>
+              acc ++ List(
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.View
+                ),
+                ObjectAccessControlRule(
+                  SubjectType.User,
+                  Some(userId),
+                  ActionType.Annotate
+                )
+            ))
         AnnotationProjectDao.addPermissionsMany(
           project.id,
           rules

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -150,7 +150,7 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       video_link, partner_name, partner_logo, parent_campaign_id,
       continent, tags, resource_link
     )""" ++
-          fr"""VALUES
+        fr"""VALUES
       (uuid_generate_v4(), now(), ${ownerId}, ${campaignCreate.name},
        ${campaignCreate.campaignType}, ${campaignCreate.description},
        ${campaignCreate.videoLink}, ${campaignCreate.partnerName},
@@ -173,9 +173,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
   ): ConnectionIO[Option[Campaign.WithRelated]] =
     for {
       campaignO <- getCampaignById(id)
-      labelClassGroup <-
-        AnnotationLabelClassGroupDao
-          .listByCampaignId(id)
+      labelClassGroup <- AnnotationLabelClassGroupDao
+        .listByCampaignId(id)
       labelClassGroupWithClass <- labelClassGroup traverse { group =>
         AnnotationLabelClassDao
           .listAnnotationLabelClassByGroupId(group.id)
@@ -216,12 +215,11 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
 
   def getAllShareCounts(userId: String): ConnectionIO[Map[UUID, Long]] =
     for {
-      campaignIds <-
-        (fr"select id from " ++ Fragment.const(
-          tableName
-        ) ++ fr" where owner = $userId")
-          .query[UUID]
-          .to[List]
+      campaignIds <- (fr"select id from " ++ Fragment.const(
+        tableName
+      ) ++ fr" where owner = $userId")
+        .query[UUID]
+        .to[List]
       campaignShareCounts <- campaignIds traverse { id =>
         getShareCount(id, userId).map((id -> _))
       }
@@ -234,10 +232,10 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       copyResourceLink: Boolean = false
   ): ConnectionIO[Campaign] = {
     val tagCol = tagsO
-      .map(tags =>
-        Fragment
-          .const(s"ARRAY[${tags.map(t => s"'${t}'").mkString(",")}]::text[]")
-      )
+      .map(
+        tags =>
+          Fragment
+            .const(s"ARRAY[${tags.map(t => s"'${t}'").mkString(",")}]::text[]"))
       .getOrElse(Fragment.const("tags"))
     val resourceLinkF = if (copyResourceLink) fr"resource_link" else fr"null"
     val insertQuery = (fr"""
@@ -249,9 +247,8 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
            WHERE id = ${id}
         """)
     for {
-      campaignCopyId <-
-        insertQuery.update
-          .withUniqueGeneratedKeys[UUID]("id")
+      campaignCopyId <- insertQuery.update
+        .withUniqueGeneratedKeys[UUID]("id")
       campaignCopy <- unsafeGetCampaignById(campaignCopyId)
       annotationProjects <- AnnotationProjectDao.listByCampaign(id)
       _ <- annotationProjects traverse { project =>
@@ -445,9 +442,9 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       permissions <- getPermissions(campaignId)
       userThins <- permissions traverse {
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Annotate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Annotate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -458,9 +455,9 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
               }
             )
         case ObjectAccessControlRule(
-              SubjectType.User,
-              Some(subjectId),
-              ActionType.Validate
+            SubjectType.User,
+            Some(subjectId),
+            ActionType.Validate
             ) =>
           UserDao
             .getUserById(subjectId)
@@ -537,12 +534,11 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
       campaignId: UUID
   ): ConnectionIO[List[LabelClassGroupSummary]] =
     for {
-      labelClassGroups <-
-        AnnotationLabelClassGroupDao.listByCampaignId(campaignId)
-      projects <-
-        AnnotationProjectDao.query
-          .filter(fr"campaign_id = $campaignId")
-          .list
+      labelClassGroups <- AnnotationLabelClassGroupDao.listByCampaignId(
+        campaignId)
+      projects <- AnnotationProjectDao.query
+        .filter(fr"campaign_id = $campaignId")
+        .list
       labelClassSummaries <- projects.map(_.id).toNel match {
         case Some(projectIds) =>
           labelClassGroups traverse { labelClassGroup =>

--- a/app-backend/db/src/main/scala/ExportDao.scala
+++ b/app-backend/db/src/main/scala/ExportDao.scala
@@ -99,13 +99,13 @@ object ExportDao extends Dao[Export] {
     logger.debug("Decoded export options successfully")
 
     val outputDefinition: ConnectionIO[OutputDefinition] = for {
-      userMaybePlatform <- UserDao.getUserById(export.owner)
+      userMaybePlatformId <- UserDao.getUserById(export.owner)
     } yield {
       OutputDefinition(
         crs = exportOptions.getCrs,
         destination = exportOptions.source.toString,
         dropboxCredential =
-          userMaybePlatform.flatMap(_._1.dropboxCredential.token)
+          userMaybePlatformId.flatMap(_._1.dropboxCredential.token)
       )
     }
 

--- a/app-backend/db/src/main/scala/ExportDao.scala
+++ b/app-backend/db/src/main/scala/ExportDao.scala
@@ -156,10 +156,9 @@ object ExportDao extends Dao[Export] {
     for {
       _ <- logger.debug("Creating output definition").pure[ConnectionIO]
       outputDef <- outputDefinition
-      _ <-
-        logger
-          .info(s"Created output definition for ${exportOptions.source}")
-          .pure[ConnectionIO]
+      _ <- logger
+        .info(s"Created output definition for ${exportOptions.source}")
+        .pure[ConnectionIO]
       _ <- logger.debug(s"Creating input definition").pure[ConnectionIO]
       sourceDef <- exportSource
       _ <- logger.debug("Created input definition").pure[ConnectionIO]
@@ -193,10 +192,9 @@ object ExportDao extends Dao[Export] {
       }.pure[ConnectionIO]
       _ <- logger.debug("Fetched ast").pure[ConnectionIO]
       exportParameters <- getExportParameters(oldAST)
-      _ <-
-        logger
-          .debug("Found ingest locations for projects")
-          .pure[ConnectionIO]
+      _ <- logger
+        .debug("Found ingest locations for projects")
+        .pure[ConnectionIO]
     } yield {
       val mamlExpression = MamlConversion.fromDeprecatedAST(oldAST)
       exportOptions.mask.map(_.geom.reproject(WebMercator, LatLng)) match {
@@ -272,10 +270,9 @@ object ExportDao extends Dao[Export] {
       ) ++
         fr"GROUP BY projects.id"
     for {
-      projectSceneLocations <-
-        q
-          .query[(UUID, List[UUID], List[String])]
-          .to[List]
+      projectSceneLocations <- q
+        .query[(UUID, List[UUID], List[String])]
+        .to[List]
     } yield {
       projectSceneLocations.map {
         case (projectId, sceneIds, locations) =>
@@ -301,10 +298,9 @@ object ExportDao extends Dao[Export] {
       ) ++
         fr"GROUP BY stl.project_layer_id"
     for {
-      projectLayerSceneLocations <-
-        q
-          .query[(UUID, List[UUID], List[String])]
-          .to[List]
+      projectLayerSceneLocations <- q
+        .query[(UUID, List[UUID], List[String])]
+        .to[List]
     } yield {
       projectLayerSceneLocations.map {
         case (layerId, sceneIds, locations) =>

--- a/app-backend/db/src/main/scala/UserDao.scala
+++ b/app-backend/db/src/main/scala/UserDao.scala
@@ -53,14 +53,18 @@ object UserDao extends Dao[User] with Sanitization {
   ): ConnectionIO[Option[UserMaybePlatform]] =
     for {
       maybeUser <- query.filter(fr"id = ${id}").selectOption
-      maybePlatformRole <-
-        UserGroupRoleDao.getPlatformRoleForUserById(id).selectOption
+      maybePlatformRole <- UserGroupRoleDao
+        .getPlatformRoleForUserById(id)
+        .selectOption
       maybePlatform <- maybePlatformRole match {
         case Some(platformRole) =>
           PlatformDao.getPlatformById(platformRole.groupId)
         case _ => (None: Option[Platform]).pure[ConnectionIO]
       }
-    } yield maybeUser map { user => (user, maybePlatform) }
+    } yield
+      maybeUser map { user =>
+        (user, maybePlatform)
+      }
 
   def unsafeGetUserById(
       id: String,
@@ -118,10 +122,9 @@ object UserDao extends Dao[User] with Sanitization {
       scope: Scope
   ): ConnectionIO[(User, List[UserGroupRole])] = {
     for {
-      organization <-
-        OrganizationDao.query
-          .filter(jwtUser.organizationId)
-          .selectOption
+      organization <- OrganizationDao.query
+        .filter(jwtUser.organizationId)
+        .selectOption
       createdUser <- {
         organization match {
           case Some(_) =>
@@ -302,7 +305,7 @@ object UserDao extends Dao[User] with Sanitization {
     val planetCredential = user.planetCredential.token.getOrElse("")
     for {
       query <- (
-          sql"""
+        sql"""
         UPDATE users
         SET
           modified_at = ${updateTime},
@@ -311,7 +314,7 @@ object UserDao extends Dao[User] with Sanitization {
           visibility = ${user.visibility},
           personal_info = ${user.personalInfo}
           """ ++
-            Fragments.whereAndOpt(Some(fr"id = ${user.id}"))
+          Fragments.whereAndOpt(Some(fr"id = ${user.id}"))
       ).update.run
       _ <- remove(user.cacheKey)(
         userMaybePlatformCache,

--- a/app-backend/db/src/main/scala/UserGroupRoleDao.scala
+++ b/app-backend/db/src/main/scala/UserGroupRoleDao.scala
@@ -122,12 +122,10 @@ object UserGroupRoleDao extends Dao[UserGroupRole] {
           .selectOption
       }
       existingMembershipStatus = existingRoleO map { _.membershipStatus }
-      rolesMatch =
-        existingRoleO
-          .map((ugr: UserGroupRole) =>
-            ugr.groupRole == userGroupRoleCreate.groupRole
-          )
-          .getOrElse(false)
+      rolesMatch = existingRoleO
+        .map((ugr: UserGroupRole) =>
+          ugr.groupRole == userGroupRoleCreate.groupRole)
+        .getOrElse(false)
       isSameOrg <- isSameOrgIO
       createdOrReturned <- {
         (existingMembershipStatus, adminCheck, rolesMatch) match {

--- a/app-backend/db/src/main/scala/package.scala
+++ b/app-backend/db/src/main/scala/package.scala
@@ -4,7 +4,6 @@ import com.rasterfoundry.database.filter.Filterables
 import com.rasterfoundry.database.meta.RFMeta
 import com.rasterfoundry.datamodel.Credential
 import com.rasterfoundry.datamodel.ExportAssetType
-import com.rasterfoundry.datamodel.Platform
 import com.rasterfoundry.datamodel.User
 
 import cats.data.NonEmptyList
@@ -12,9 +11,11 @@ import doobie.Get
 import doobie.Meta
 import doobie.Put
 
+import java.util.UUID
+
 package object database {
 
-  type UserMaybePlatform = (User, Option[Platform])
+  type UserMaybePlatformId = (User, Option[UUID])
 
   object Implicits extends RFMeta with Filterables {
     def fromString(s: String): Credential = {

--- a/app-backend/db/src/main/scala/package.scala
+++ b/app-backend/db/src/main/scala/package.scala
@@ -4,6 +4,8 @@ import com.rasterfoundry.database.filter.Filterables
 import com.rasterfoundry.database.meta.RFMeta
 import com.rasterfoundry.datamodel.Credential
 import com.rasterfoundry.datamodel.ExportAssetType
+import com.rasterfoundry.datamodel.Platform
+import com.rasterfoundry.datamodel.User
 
 import cats.data.NonEmptyList
 import doobie.Get
@@ -11,6 +13,8 @@ import doobie.Meta
 import doobie.Put
 
 package object database {
+
+  type UserMaybePlatform = (User, Option[Platform])
 
   object Implicits extends RFMeta with Filterables {
     def fromString(s: String): Credential = {

--- a/app-backend/db/src/main/scala/util/Cache.scala
+++ b/app-backend/db/src/main/scala/util/Cache.scala
@@ -6,6 +6,7 @@ import com.rasterfoundry.common.{
   Config,
   SceneToLayerWithSceneType
 }
+import com.rasterfoundry.database.UserMaybePlatform
 import com.rasterfoundry.datamodel._
 
 import cats._
@@ -83,10 +84,16 @@ object Cache extends LazyLogging {
     }
   }
 
+  object UserMaybePlatformCache {
+    implicit val userMaybePlatformCache: Cache[UserMaybePlatform] = {
+      MemcachedCache[UserMaybePlatform](memcachedClient)
+    }
+  }
+
   object MosaicDefinitionCache {
     import scalacache.serialization.binary._
     implicit val mosaicDefinitionCache
-      : Cache[List[SceneToLayerWithSceneType]] = {
+        : Cache[List[SceneToLayerWithSceneType]] = {
       MemcachedCache[List[SceneToLayerWithSceneType]](memcachedClient)
     }
   }

--- a/app-backend/db/src/main/scala/util/Cache.scala
+++ b/app-backend/db/src/main/scala/util/Cache.scala
@@ -93,7 +93,7 @@ object Cache extends LazyLogging {
   object MosaicDefinitionCache {
     import scalacache.serialization.binary._
     implicit val mosaicDefinitionCache
-        : Cache[List[SceneToLayerWithSceneType]] = {
+      : Cache[List[SceneToLayerWithSceneType]] = {
       MemcachedCache[List[SceneToLayerWithSceneType]](memcachedClient)
     }
   }

--- a/app-backend/db/src/main/scala/util/Cache.scala
+++ b/app-backend/db/src/main/scala/util/Cache.scala
@@ -6,7 +6,7 @@ import com.rasterfoundry.common.{
   Config,
   SceneToLayerWithSceneType
 }
-import com.rasterfoundry.database.UserMaybePlatform
+import com.rasterfoundry.database.UserMaybePlatformId
 import com.rasterfoundry.datamodel._
 
 import cats._
@@ -84,16 +84,16 @@ object Cache extends LazyLogging {
     }
   }
 
-  object UserMaybePlatformCache {
-    implicit val userMaybePlatformCache: Cache[UserMaybePlatform] = {
-      MemcachedCache[UserMaybePlatform](memcachedClient)
+  object UserMaybePlatformIdCache {
+    implicit val userMaybePlatformIdCache: Cache[UserMaybePlatformId] = {
+      MemcachedCache[UserMaybePlatformId](memcachedClient)
     }
   }
 
   object MosaicDefinitionCache {
     import scalacache.serialization.binary._
     implicit val mosaicDefinitionCache
-      : Cache[List[SceneToLayerWithSceneType]] = {
+        : Cache[List[SceneToLayerWithSceneType]] = {
       MemcachedCache[List[SceneToLayerWithSceneType]](memcachedClient)
     }
   }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/UserDaoSpec.scala
@@ -92,7 +92,7 @@ class UserDaoSpec
           inserted <- UserDao.create(userCreate)
           byId <- UserDao.getUserById(inserted.id)
         } yield (byId)
-        userCreate.id == createdIdIO.transact(xa).unsafeRunSync.get.id
+        userCreate.id == createdIdIO.transact(xa).unsafeRunSync.get._1.id
       })
     )
   }

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Authenticators.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Authenticators.scala
@@ -1,7 +1,7 @@
 package com.rasterfoundry.http4s
 
 import com.rasterfoundry.database.UserDao
-import com.rasterfoundry.database.UserMaybePlatform
+import com.rasterfoundry.database.UserMaybePlatformId
 
 import cats.data.OptionT
 import cats.effect.IO
@@ -45,22 +45,22 @@ trait Authenticators extends LazyLogging {
 
   def getUserFromJWTwithCache(
       userIdFromJWT: String
-  )(implicit flags: Flags): IO[Option[UserMaybePlatform]] =
-    memoizeF[IO, Option[UserMaybePlatform]](Some(30.seconds)) {
+  )(implicit flags: Flags): IO[Option[UserMaybePlatformId]] =
+    memoizeF[IO, Option[UserMaybePlatformId]](Some(30.seconds)) {
       logger.debug(s"Authentication - Getting User ${userIdFromJWT} from DB")
       UserDao
         .getUserById(userIdFromJWT)
         .transact(xa)
     }
 
-  def userFromToken(token: String): OptionT[IO, UserMaybePlatform] = {
+  def userFromToken(token: String): OptionT[IO, UserMaybePlatformId] = {
     val userFromTokenIO = verifyJWT(token) match {
       case Right((_, jwtClaims)) => {
         val userIdFromJWT = jwtClaims.getStringClaim("sub")
         getUserFromJWTwithCache(userIdFromJWT)
       }
       case Left(_) =>
-        IO(None: Option[UserMaybePlatform])
+        IO(None: Option[UserMaybePlatformId])
     }
     OptionT(userFromTokenIO)
   }

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Cache.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Cache.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.http4s
 
-import com.rasterfoundry.datamodel.User
+import com.rasterfoundry.database.UserMaybePlatform
 
 import com.typesafe.scalalogging.LazyLogging
 import scalacache._
@@ -8,8 +8,10 @@ import scalacache.caffeine._
 
 object Cache extends LazyLogging {
 
-  val authenticationCacheFlags = Flags(Config.cache.authenticationCacheEnable,
-                                       Config.cache.authenticationCacheEnable)
-  val caffeineAuthenticationCache: Cache[Option[User]] =
-    CaffeineCache[Option[User]]
+  val authenticationCacheFlags = Flags(
+    Config.cache.authenticationCacheEnable,
+    Config.cache.authenticationCacheEnable
+  )
+  val caffeineAuthenticationCache: Cache[Option[UserMaybePlatform]] =
+    CaffeineCache[Option[UserMaybePlatform]]
 }

--- a/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Cache.scala
+++ b/app-backend/http4s-util/src/main/scala/com/rasterfoundry/http4s/Cache.scala
@@ -1,6 +1,6 @@
 package com.rasterfoundry.http4s
 
-import com.rasterfoundry.database.UserMaybePlatform
+import com.rasterfoundry.database.UserMaybePlatformId
 
 import com.typesafe.scalalogging.LazyLogging
 import scalacache._
@@ -12,6 +12,6 @@ object Cache extends LazyLogging {
     Config.cache.authenticationCacheEnable,
     Config.cache.authenticationCacheEnable
   )
-  val caffeineAuthenticationCache: Cache[Option[UserMaybePlatform]] =
-    CaffeineCache[Option[UserMaybePlatform]]
+  val caffeineAuthenticationCache: Cache[Option[UserMaybePlatformId]] =
+    CaffeineCache[Option[UserMaybePlatformId]]
 }

--- a/docs/architecture/adr-0025-user-access-scopes.md
+++ b/docs/architecture/adr-0025-user-access-scopes.md
@@ -29,7 +29,7 @@ The solutions below (except for the last) all treat scopes as access reduction m
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { user =>
+  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeAsync {
       UserDao
         .withoutScoping(ObjectType.Project)
@@ -70,7 +70,7 @@ This solution has almost no constraints.
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { user =>
+  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeAsync {
       UserDao
         .withoutScoping(ScopeType.ProjectReadOnly)
@@ -111,7 +111,7 @@ This solution is more constrained in order to solve the conflicting rules proble
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { user =>
+  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeAsync {
       UserDao
         .withoutScoping(ObjectType.Project, ScopeType.ReadOnly)
@@ -153,7 +153,7 @@ This solution is similar to _The Civilized Solution_ in that it would use an abs
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { user =>
+  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
     authorizeAsync {
       UserDao
         .hasScope(ObjectType.Project, ScopeType.Read)

--- a/docs/architecture/adr-0025-user-access-scopes.md
+++ b/docs/architecture/adr-0025-user-access-scopes.md
@@ -29,7 +29,7 @@ The solutions below (except for the last) all treat scopes as access reduction m
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createProject: Route = authenticate { case (user, _) =>
     authorizeAsync {
       UserDao
         .withoutScoping(ObjectType.Project)
@@ -70,7 +70,7 @@ This solution has almost no constraints.
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createProject: Route = authenticate { case (user, _) =>
     authorizeAsync {
       UserDao
         .withoutScoping(ScopeType.ProjectReadOnly)
@@ -111,7 +111,7 @@ This solution is more constrained in order to solve the conflicting rules proble
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createProject: Route = authenticate { case (user, _) =>
     authorizeAsync {
       UserDao
         .withoutScoping(ObjectType.Project, ScopeType.ReadOnly)
@@ -153,7 +153,7 @@ This solution is similar to _The Civilized Solution_ in that it would use an abs
 Usage at the endpoint level might look like:
 
 ```scala
-  def createProject: Route = authenticate { case MembershipAndUser(_, user) =>
+  def createProject: Route = authenticate { case (user, _) =>
     authorizeAsync {
       UserDao
         .hasScope(ObjectType.Project, ScopeType.Read)


### PR DESCRIPTION
## Overview
Include platform id in access logs

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] New tables and queries have appropriate indices added
- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

### Notes
This _should_ be working in its current state with separate logs for platform id per tile request:
```
backsplash_1              | [raster-io-36] INFO  c.r.b.s.Authenticators - platformId = 31277626-968b-4e40-840b-559d9c67863c
backsplash_1              | [raster-io-39] INFO  c.r.b.s.Authenticators - platformId = 31277626-968b-4e40-840b-559d9c67863c
backsplash_1              | [raster-io-36] INFO  i.j.Configuration - Initialized tracer=JaegerTracer(version=Java-1.0.0, serviceName=raster-foundry, reporter=CompositeReporter(reporters=[RemoteReporter(sender=UdpSender(), closeEnqueueTimeout=1000), LoggingReporter(logger=Logger[io.jaegertracing.internal.reporters.LoggingReporter])]), sampler=ConstSampler(decision=true, tags={sampler.type=const, sampler.param=true}), tags={hostname=17fde6bda7e3, jaeger.version=Java-1.0.0, ip=172.25.0.7}, zipkinSharedRpcSpan=false, expandExceptionLogs=false, useTraceId128Bit=false)
backsplash_1              | [raster-io-39] INFO  i.j.Configuration - Initialized tracer=JaegerTracer(version=Java-1.0.0, serviceName=raster-foundry, reporter=CompositeReporter(reporters=[RemoteReporter(sender=UdpSender(), closeEnqueueTimeout=1000), LoggingReporter(logger=Logger[io.jaegertracing.internal.reporters.LoggingReporter])]), sampler=ConstSampler(decision=true, tags={sampler.type=const, sampler.param=true}), tags={hostname=17fde6bda7e3, jaeger.version=Java-1.0.0, ip=172.25.0.7}, zipkinSharedRpcSpan=false, expandExceptionLogs=false, useTraceId128Bit=false)
```

This is a very big diff, but most of the changes are mechanically updating code that previously consumed a `User` instance to now accept a `(User, Option[UUID])` so that we can eventually log the platform id since we really only use it in one place.

The real meaningful changes to look at are in `UserDao`, `Main` (backsplash), and `Authenticators`. The actual logging of the platform id happens at the bottom of `Authenticators.scala` since everything's been changed to work with a `UserMaybePlatformId` but all of the downstream code will just want a `User`. It's at that point where we log the platform id as a side-effect and then only pass the user along. I'm not totally sure if that's the exact right place to be doing that, but it does seem to work and it does it for all of the tile server endpoints we care about. That said, I'm not totally sure what precisely constitutes a tile request in terms of use charging the client for it. We may want to do this a little differently -- another middleware for platform id logging may be preferable, or perhaps trying to incorporate this into the existing access log middleware -- but I think the general approach of "retrieve and cache a platform id if available along with the authenticated user and account for that everywhere" should serve our purposes regardless of whether the platform logging middleware implementation changes substantially. It's possible I got this wrong and we should definitely check we're logging the platform id based on the correct access event.

In one of the later commits I switched over to only caching the platform id instead of the whole platform due to a decoding runtime error I ran into:
```
api-server_1              | Caused by: io.circe.DecodingFailure$$anon$2: Attempt to decode value on failed cursor: DownField(privateSettings),DownN(1)
```
I did this mostly for expediency's sake given the fact that we likely only care about the platform id and nothing else about the platform. However, I think fixing the decoder could allow us to store the whole `Platform` instead of just the id if we're so inclined.

Lastly, I think this change will require busting the memcached cache.

## Testing Instructions

- How to test this PR
- Prefer bulleted description
- Start after checking out this branch
- Include any setup required, such as bundling scripts, restarting services, etc.
- Include test case, and expected output

Closes [#1370](https://app.zenhub.com/workspaces/raster-foundry-team-workspace-5878d68005907de543b50bbd/issues/azavea/raster-foundry-platform/1370)
