### PR TITLE
Switch to multipart upload for STAC export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Switched to use multipart upload for STAC export zipped catalog [#5640](https://github.com/raster-foundry/raster-foundry/pull/5640)
 
 ## [1.69.0] - 2022-01-06
 ### Added

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -250,8 +250,9 @@ case class ExportData private (
             .contains(link.rel)))
     (annotationProjectImageryItems.toList traverse {
       case (_, sceneItem) =>
-        imageryS3Links.get(newtypes.AnnotationProjectId(
-          UUID.fromString(sceneItem.value.id))) match {
+        imageryS3Links.get(
+          newtypes.AnnotationProjectId(UUID.fromString(sceneItem.value.id))
+        ) match {
           case Some(s3Link) =>
             val ingestLocation = s3Link.value
             writeCOGToFile(
@@ -268,7 +269,8 @@ case class ExportData private (
             encodableToFile(
               (withCollection `compose` withParentLinks)(sceneItem.value),
               file,
-              s"images/${sceneItem.value.id}/item.json")
+              s"images/${sceneItem.value.id}/item.json"
+            )
         }
     }).void
   }
@@ -596,8 +598,9 @@ class CampaignStacExport(
       tileLayers: List[TileLayer],
       exportAssetTypes: Option[NonEmptyList[ExportAssetType]],
       annotationProjectId: UUID
-  ): IO[(Map[String, StacAsset],
-         Map[newtypes.AnnotationProjectId, newtypes.S3URL])] = {
+  ): IO[
+    (Map[String, StacAsset], Map[newtypes.AnnotationProjectId, newtypes.S3URL])
+  ] = {
     val maybeIngestLocation = maybeScene flatMap { _.ingestLocation }
     val signedUrlDurationInDays = 7
     for {
@@ -618,7 +621,9 @@ class CampaignStacExport(
                 AssetTypesKey.signedURL,
                 StacAsset(
                   signedUrl,
-                  Some("Image download URL"), // The displayed title for clients and users
+                  Some(
+                    "Image download URL"
+                  ), // The displayed title for clients and users
                   Some(
                     s"Signed URL (expires ${java.time.LocalDateTime.now().plusDays(signedUrlDurationInDays)})"
                   ),
@@ -631,9 +636,9 @@ class CampaignStacExport(
         case _ =>
           IO.pure(None)
       }
-      maybeCOGAssetAndS3Link: Option[((String, StacAsset),
-      (newtypes.AnnotationProjectId,
-      newtypes.S3URL))] <- maybeIngestLocation match {
+      maybeCOGAssetAndS3Link: Option[
+        ((String, StacAsset), (newtypes.AnnotationProjectId, newtypes.S3URL))
+      ] <- maybeIngestLocation match {
         case Some(ingestLocation)
             if includeAssetTypeInExport(
               exportAssetTypes,
@@ -647,15 +652,19 @@ class CampaignStacExport(
                     AssetTypesKey.cog,
                     StacAsset(
                       s"./${new java.io.File(ingestLocation).getName}", // relative path to COG
-                      Some("Image local relative path"), // The displayed title for clients and users
+                      Some(
+                        "Image local relative path"
+                      ), // The displayed title for clients and users
                       Some("COG"),
                       Set(StacAssetRole.Data),
                       Some(`image/cog`)
                     )
                   )
                 ),
-                (newtypes.AnnotationProjectId(annotationProjectId),
-                 newtypes.S3URL(ingestLocation))
+                (
+                  newtypes.AnnotationProjectId(annotationProjectId),
+                  newtypes.S3URL(ingestLocation)
+                )
               )
             )
           )
@@ -700,15 +709,19 @@ class CampaignStacExport(
       annotationProject: AnnotationProject,
       exportAssetTypes: Option[NonEmptyList[ExportAssetType]],
       taskStatuses: List[String]
-  ): IO[(Option[newtypes.SceneItem],
-         Map[newtypes.AnnotationProjectId, newtypes.S3URL])] = {
+  ): IO[
+    (
+        Option[newtypes.SceneItem],
+        Map[newtypes.AnnotationProjectId, newtypes.S3URL]
+    )
+  ] = {
     for {
       _ <- IO(logger.info(s"Building imagery item from tile layers"))
       maybeScene <- AnnotationProjectDao
         .getFirstScene(annotationProject.id)
         .transact(xa)
       _ <- IO {
-        logger.debug(maybeScene match {
+        logger.info(maybeScene match {
           case Some(scene) => s"Found scene with id ${scene.id}"
           case _           => "No scene found"
         })
@@ -717,17 +730,19 @@ class CampaignStacExport(
         .listByProjectId(annotationProject.id)
         .transact(xa)
       _ <- IO {
-        logger.debug(
+        logger.info(
           s"Found ${tileLayers.size} tile layers"
         )
       }
       extentO <- TaskDao
         .createUnionedGeomExtent(annotationProject.id, taskStatuses)
         .transact(xa)
-      (assets, link) <- exportAssetsAndLinks(maybeScene,
-                                             tileLayers,
-                                             exportAssetTypes,
-                                             annotationProject.id)
+      (assets, link) <- exportAssetsAndLinks(
+        maybeScene,
+        tileLayers,
+        exportAssetTypes,
+        annotationProject.id
+      )
       item = extentO map { unionedGeom =>
         makeTileLayersItem(
           annotationProject.id,
@@ -737,12 +752,12 @@ class CampaignStacExport(
         )
       }
       _ <- IO {
-        logger.debug(
+        logger.info(
           s"Found assets $assets"
         )
       }
       _ <- IO {
-        logger.debug(
+        logger.info(
           s"Returning STAC item $item"
         )
       }
@@ -812,8 +827,9 @@ class CampaignStacExport(
         newtypes.AnnotationProjectId(annotationProject.id)
       ) `compose` appendImageryItem(
         imageryItemsAppend
-      ) `compose` appendLabelAssets(labelAssetAppend) `compose` appendImageS3Links(
-        imageS3Link))(
+      ) `compose` appendLabelAssets(
+        labelAssetAppend
+      ) `compose` appendImageS3Links(imageS3Link))(
         inputState
       )
     }

--- a/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
+++ b/app-backend/batch/src/main/scala/stacExport/v2/CampaignExport.scala
@@ -721,7 +721,7 @@ class CampaignStacExport(
         .getFirstScene(annotationProject.id)
         .transact(xa)
       _ <- IO {
-        logger.info(maybeScene match {
+        logger.debug(maybeScene match {
           case Some(scene) => s"Found scene with id ${scene.id}"
           case _           => "No scene found"
         })
@@ -730,7 +730,7 @@ class CampaignStacExport(
         .listByProjectId(annotationProject.id)
         .transact(xa)
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Found ${tileLayers.size} tile layers"
         )
       }
@@ -752,12 +752,12 @@ class CampaignStacExport(
         )
       }
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Found assets $assets"
         )
       }
       _ <- IO {
-        logger.info(
+        logger.debug(
           s"Returning STAC item $item"
         )
       }

--- a/app-backend/common/src/main/scala/S3.scala
+++ b/app-backend/common/src/main/scala/S3.scala
@@ -224,7 +224,7 @@ final case class S3(
   def putObject(putObjectRequest: PutObjectRequest): PutObjectResult =
     client.putObject(putObjectRequest)
 
-  def putObjectMultiPart(bucket: String, key: String, file: File) = {
+  def putObjectMultiPart(bucket: String, key: String, file: File): Unit = {
     // TransferManager processes all transfers asynchronously,
     // so this call returns immediately.
     val upload = transferManager.upload(bucket, key, file)


### PR DESCRIPTION
## Overview

This PR switches the `putObject` method of the zipped STAC catalog export to the multipart upload method from the java s3 sdk.

### Checklist

- [X] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions
- Review this one first: https://github.com/azavea/raster-foundry-deployment/pull/294
- Push a `test/` branch up to trigger a staging deploy for this PR
- Go to https://develop--raster-foundry-annotate.netlify.app/app and log in with your Azavea Google Account
- Ping me to share you a campaign with a lot of images and bump you to PRO account on staging
- Create a STAC export and select to download with images
- Make sure the export succeeds and the downloaded catalog contains the image COGs

Closes https://github.com/azavea/raster-foundry-platform/issues/1390
