### PR TITLE
Update nginx config to allow larger payload for label endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated nginx config to allow 10 MB payload for label endpoint [#5641](https://github.com/raster-foundry/raster-foundry/pull/5641)
 
 ## [1.70.0] - 2022-03-29
 ### Changed

--- a/nginx/etc/nginx/templates/default.conf.template
+++ b/nginx/etc/nginx/templates/default.conf.template
@@ -66,6 +66,13 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
+    location ~* ^\/api/annotation-projects/.*/tasks/.*/labels {
+        client_max_body_size 10m;
+        include /etc/nginx/includes/proxy-settings.conf;
+
+        proxy_pass http://api-server-upstream;
+    }
+
     # Angular config
     location = /config {
         include /etc/nginx/includes/proxy-settings.conf;

--- a/nginx/etc/nginx/templates/default.conf.template
+++ b/nginx/etc/nginx/templates/default.conf.template
@@ -73,6 +73,13 @@ server {
         proxy_pass http://api-server-upstream;
     }
 
+    location ~* ^\/api/annotation-projects/.*/tasks/.*/validate {
+        client_max_body_size 10m;
+        include /etc/nginx/includes/proxy-settings.conf;
+
+        proxy_pass http://api-server-upstream;
+    }
+
     # Angular config
     location = /config {
         include /etc/nginx/includes/proxy-settings.conf;


### PR DESCRIPTION
## Overview

This PR updates the `client_max_body_size` config for the `/api/annotation-projects/<id>/tasks/<id>/labels` endpoint so that the POST body has a larger upper-bound of 10MB. 

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~New tables and queries have appropriate indices added~
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- [See here](https://azavea.slack.com/archives/CDB8M6W7M/p1650396170835869) for a demo of posting large amount of labels to a task on staging, as this change has been applied on staging through a `test` branch.

Closes https://github.com/azavea/raster-foundry-platform/issues/1393
