### PR TITLE
Add HITL Job CRUD endpoint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@ Brief description of what this PR does, and why it is needed.
 
 - [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
 - [ ] New tables and queries have appropriate indices added
-- [ ] Any content changes are properly templated using `BUILDCONFIG.APP_NAME`
 - [ ] Any new SQL strings have tests
 - [ ] Any new endpoints have scope validation and are included in the integration test csv
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CRUD endpoints for HITL jobs [#5642](https://github.com/raster-foundry/raster-foundry/pull/5642)
 
 ## [1.70.1] - 2022-04-25
 ### Changed

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -268,3 +268,8 @@ Path,Domain:Action,Verb
 /api/tasks/{taskId}/sessions/{sessionId}/labels/{labelId},annotationProjects:createAnnotation,delete
 /api/tasks/{taskId}/sessions/{sessionId}/labels/bulk,annotationProjects:createAnnotation,post
 /api/tasks/{taskId}/sessions/{sessionId}/labels/bulk,annotationProjects:createAnnotation,put
+/api/hitl-jobs/,campaigns:read,get
+/api/hitl-jobs/,campaigns:create,post
+/api/hitl-jobs/{jobId},campaigns:read,get
+/api/hitl-jobs/{jobId},campaigns:update,update
+/api/hitl-jobs/{jobId},campaigns:delete,delete

--- a/app-backend/api/src/main/scala/Router.scala
+++ b/app-backend/api/src/main/scala/Router.scala
@@ -7,6 +7,7 @@ import com.rasterfoundry.api.datasource.DatasourceRoutes
 import com.rasterfoundry.api.exports.ExportRoutes
 import com.rasterfoundry.api.featureflags.FeatureFlagRoutes
 import com.rasterfoundry.api.healthcheck._
+import com.rasterfoundry.api.hitlJobs.HITLJobRoutes
 import com.rasterfoundry.api.license.LicenseRoutes
 import com.rasterfoundry.api.maptoken.MapTokenRoutes
 import com.rasterfoundry.api.organization.OrganizationRoutes
@@ -54,7 +55,8 @@ trait Router
     with StacRoutes
     with AnnotationProjectRoutes
     with TaskRoutes
-    with CampaignRoutes {
+    with CampaignRoutes
+    with HITLJobRoutes {
 
   def notifier: IntercomNotifications
 
@@ -122,6 +124,9 @@ trait Router
           } ~
           pathPrefix("campaigns") {
             campaignRoutes
+          } ~
+          pathPrefix("hitl-jobs") {
+            hitlJobRoutes
           }
       } ~
       pathPrefix("config") {

--- a/app-backend/api/src/main/scala/hitl-jobs/Routes.scala
+++ b/app-backend/api/src/main/scala/hitl-jobs/Routes.scala
@@ -1,0 +1,176 @@
+package com.rasterfoundry.api.hitlJobs
+
+import com.rasterfoundry.akkautil._
+import com.rasterfoundry.api.utils.queryparams.QueryParametersCommon
+import com.rasterfoundry.database._
+import com.rasterfoundry.datamodel._
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
+import cats.effect.IO
+import cats.implicits._
+import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+import doobie._
+import doobie.implicits._
+
+import java.util.UUID
+
+trait HITLJobRoutes
+    extends Authentication
+    with PaginationDirectives
+    with UserErrorHandler
+    with CommonHandlers
+    with QueryParametersCommon {
+  val xa: Transactor[IO]
+
+  val hitlJobRoutes: Route = handleExceptions(userExceptionHandler) {
+    pathEndOrSingleSlash {
+      get { listHITLJobs } ~
+        post { createHITLJob }
+    } ~
+      pathPrefix(JavaUUID) { jobId =>
+        pathEndOrSingleSlash {
+          get { getHITLJob(jobId) } ~ put { updateHITLJob(jobId) } ~
+            delete { deleteHITLJob(jobId) }
+        }
+      }
+  }
+
+  def listHITLJobs: Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Read, None),
+        user
+      ) {
+        (withPagination & hitlJobQueryParameters) {
+          (page: PageRequest, params: HITLJobQueryParameters) =>
+            complete {
+              HITLJobDao
+                .list(page, params, user)
+                .transact(xa)
+                .unsafeToFuture
+            }
+        }
+      }
+    }
+
+  def createHITLJob: Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Create, None),
+        user
+      ) {
+        entity(as[HITLJob.Create]) { newHITLJob =>
+          ((authorizeAsync {
+            (
+              CampaignDao.isActiveCampaign(newHITLJob.campaignId),
+              CampaignDao
+                .authorized(
+                  user,
+                  ObjectType.Campaign,
+                  newHITLJob.campaignId,
+                  ActionType.View
+                ),
+              AnnotationProjectDao.authorized(
+                user,
+                ObjectType.AnnotationProject,
+                newHITLJob.projectId,
+                ActionType.View
+              )
+            ).tupled.transact(xa).unsafeToFuture map {
+              case (true, campaignResult, annotationProjectResult) =>
+                campaignResult.toBoolean || annotationProjectResult.toBoolean
+              case _ => false
+            }
+          })) {
+            onSuccess(
+              HITLJobDao
+                .create(newHITLJob, user)
+                .transact(xa)
+                .unsafeToFuture
+            ) { hitlJob =>
+              // TODO: kick off the job or lambda function
+              complete((StatusCodes.Created, hitlJob))
+            }
+          }
+        }
+      }
+    }
+
+  def getHITLJob(id: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Read, None),
+        user
+      ) {
+        authorizeAsync {
+          HITLJobDao
+            .isOwnerOrSuperUser(user, id)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          rejectEmptyResponse {
+            complete {
+              HITLJobDao
+                .getById(id)
+                .transact(xa)
+                .unsafeToFuture
+            }
+          }
+        }
+      }
+    }
+
+  def updateHITLJob(id: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Update, None),
+        user
+      ) {
+        authorizeAsync {
+          HITLJobDao
+            .isOwnerOrSuperUser(user, id)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          entity(as[HITLJob]) { hitlJobToUpdate =>
+            onSuccess(
+              HITLJobDao
+                .update(
+                  hitlJobToUpdate,
+                  id
+                )
+                .transact(xa)
+                .unsafeToFuture
+            ) {
+              completeSingleOrNotFound
+            }
+          }
+        }
+      }
+    }
+
+  def deleteHITLJob(id: UUID): Route =
+    authenticate { user =>
+      authorizeScope(
+        ScopedAction(Domain.Campaigns, Action.Delete, None),
+        user
+      ) {
+        authorizeAsync {
+          HITLJobDao
+            .isOwnerOrSuperUser(user, id)
+            .transact(xa)
+            .unsafeToFuture
+        } {
+          onSuccess(
+            HITLJobDao
+              .delete(id)
+              .transact(xa)
+              .unsafeToFuture
+          ) { count: Int =>
+            complete((StatusCodes.NoContent, s"$count HITL job deleted"))
+          }
+        }
+      }
+    }
+}

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-    : Unmarshaller[String, AnnotationProjectType] =
+      : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }
@@ -243,4 +243,16 @@ trait QueryParametersCommon extends QueryParameterDeserializers {
     parameters(
       'requestAction.as(deserializerActionType).*
     ).as(CampaignRandomTaskQueryParameters.apply _)
+
+  def hitlJobQueryParameters =
+    (
+      userAuditQueryParameters &
+        ownerQueryParameters &
+        parameters(
+          'status.as[String].?,
+          'projectId.as[UUID].?,
+          'campaignId.as[UUID].?,
+          'version.as[Int].?
+        )
+    ).as(HITLJobQueryParameters.apply _)
 }

--- a/app-backend/api/src/main/scala/utils/QueryParameters.scala
+++ b/app-backend/api/src/main/scala/utils/QueryParameters.scala
@@ -34,7 +34,7 @@ trait QueryParameterDeserializers {
     }
 
   implicit val deserializerAnnotationProjectType
-      : Unmarshaller[String, AnnotationProjectType] =
+    : Unmarshaller[String, AnnotationProjectType] =
     Unmarshaller.strict[String, AnnotationProjectType] { s =>
       AnnotationProjectType.fromString(s)
     }

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1217,6 +1217,13 @@ object Generators extends ArbitraryInstances {
       note
     )
 
+  private def hitlJobCreateGen: Gen[HITLJob.Create] =
+    (
+      uuidGen,
+      uuidGen,
+      Gen.const[HITLJobStatus](HITLJobStatus.NotRun)
+    ).mapN(HITLJob.Create.apply _)
+
   object Implicits {
     implicit def arbCredential: Arbitrary[Credential] =
       Arbitrary {
@@ -1536,5 +1543,9 @@ object Generators extends ArbitraryInstances {
 
     implicit def arbTaskNextStatus: Arbitrary[TaskNextStatus] =
       Arbitrary { taskNextStatusGen }
+
+    implicit def arbHITLJobCreate: Arbitrary[HITLJob.Create] =
+      Arbitrary { hitlJobCreateGen }
+
   }
 }

--- a/app-backend/datamodel/src/main/scala/HITLJob.scala
+++ b/app-backend/datamodel/src/main/scala/HITLJob.scala
@@ -1,0 +1,37 @@
+package com.rasterfoundry.datamodel
+
+import io.circe._
+import io.circe.generic.JsonCodec
+import io.circe.generic.semiauto._
+
+import java.sql.Timestamp
+import java.util.UUID
+
+@JsonCodec
+final case class HITLJob(
+    id: UUID,
+    createdAt: Timestamp,
+    createdBy: String,
+    modifiedAt: Timestamp,
+    owner: String,
+    campaignId: UUID,
+    projectId: UUID,
+    status: HITLJobStatus,
+    version: Int
+)
+
+object HITLJob {
+
+  def tupled = (HITLJob.apply _).tupled
+
+  final case class Create(
+      campaignId: UUID,
+      projectId: UUID,
+      status: HITLJobStatus
+  )
+
+  object Create {
+    implicit val decCreate: Decoder[Create] = deriveDecoder
+  }
+
+}

--- a/app-backend/datamodel/src/main/scala/HITLJobStatus.scala
+++ b/app-backend/datamodel/src/main/scala/HITLJobStatus.scala
@@ -1,0 +1,33 @@
+package com.rasterfoundry.datamodel
+
+import cats.syntax.either._
+import io.circe._
+
+sealed abstract class HITLJobStatus(val repr: String) {
+  override def toString = repr
+}
+
+object HITLJobStatus {
+  case object NotRun extends HITLJobStatus("NOTRUN")
+  case object ToRun extends HITLJobStatus("TORUN")
+  case object Running extends HITLJobStatus("RUNNING")
+  case object Ran extends HITLJobStatus("RAN")
+  case object Failed extends HITLJobStatus("FAILED")
+
+  def fromString(s: String): HITLJobStatus =
+    s.toUpperCase match {
+      case "NOTRUN"  => NotRun
+      case "TORUN"   => ToRun
+      case "RUNNING" => Running
+      case "RAN"     => Ran
+      case "FAILED"  => Failed
+    }
+
+  implicit val hitlJobStatusEncoder: Encoder[HITLJobStatus] =
+    Encoder.encodeString.contramap[HITLJobStatus](_.toString)
+
+  implicit val hitlJobStatusDecoder: Decoder[HITLJobStatus] =
+    Decoder.decodeString.emap { str =>
+      Either.catchNonFatal(fromString(str)).leftMap(_ => "HITLJobStatus")
+    }
+}

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -755,10 +755,8 @@ final case class HITLJobQueryParameters(
 )
 
 object HITLJobQueryParameters {
-  implicit def encHITLJobQueryParameters
-    : Encoder[HITLJobQueryParameters] =
+  implicit def encHITLJobQueryParameters: Encoder[HITLJobQueryParameters] =
     deriveEncoder[HITLJobQueryParameters]
-  implicit def decHITLJobQueryParameters
-    : Decoder[HITLJobQueryParameters] =
+  implicit def decHITLJobQueryParameters: Decoder[HITLJobQueryParameters] =
     deriveDecoder[HITLJobQueryParameters]
 }

--- a/app-backend/datamodel/src/main/scala/QueryParameters.scala
+++ b/app-backend/datamodel/src/main/scala/QueryParameters.scala
@@ -744,3 +744,21 @@ object CampaignRandomTaskQueryParameters {
     : Decoder[CampaignRandomTaskQueryParameters] =
     deriveDecoder[CampaignRandomTaskQueryParameters]
 }
+
+final case class HITLJobQueryParameters(
+    userParams: UserAuditQueryParameters = UserAuditQueryParameters(),
+    ownerParams: OwnerQueryParameters = OwnerQueryParameters(),
+    status: Option[String] = None,
+    projectId: Option[UUID] = None,
+    campaignId: Option[UUID] = None,
+    version: Option[Int] = None
+)
+
+object HITLJobQueryParameters {
+  implicit def encHITLJobQueryParameters
+    : Encoder[HITLJobQueryParameters] =
+    deriveEncoder[HITLJobQueryParameters]
+  implicit def decHITLJobQueryParameters
+    : Decoder[HITLJobQueryParameters] =
+    deriveDecoder[HITLJobQueryParameters]
+}

--- a/app-backend/db/src/main/resources/migrations/V83__Add_hitl_jobs_table.sql
+++ b/app-backend/db/src/main/resources/migrations/V83__Add_hitl_jobs_table.sql
@@ -1,0 +1,35 @@
+-- Add a table for human-in-the-loop jobs
+
+CREATE TYPE public.hitl_job_status AS ENUM (
+    'NOTRUN',
+    'TORUN',
+    'RUNNING',
+    'RAN',
+    'FAILED'
+);
+
+ALTER TYPE public.hitl_job_status OWNER TO rasterfoundry;
+
+CREATE TABLE public.hitl_jobs (
+    id UUID PRIMARY KEY,
+    created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    created_by CHARACTER VARYING(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    modified_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    owner CHARACTER VARYING(255) NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    campaign_id UUID NOT NULL REFERENCES public.campaigns(id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES public.annotation_projects(id) ON DELETE CASCADE,
+    status public.hitl_job_status NOT NULL,
+    version int default 0 NOT NULL
+);
+
+CREATE INDEX hitl_jobs_owner_idx ON public.hitl_jobs USING btree(owner);
+
+CREATE INDEX hitl_jobs_created_by_idx ON public.hitl_jobs USING btree(created_by);
+
+CREATE INDEX hitl_jobs_status_idx ON public.hitl_jobs USING btree(status);
+
+CREATE INDEX hitl_jobs_campaign_id_idx ON public.hitl_jobs USING btree(campaign_id);
+
+CREATE INDEX hitl_jobs_project_id_idx ON public.hitl_jobs USING btree(project_id);
+
+CREATE INDEX hitl_jobs_version_idx ON public.hitl_jobs USING btree(version);

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -96,4 +96,15 @@ object HITLJobDao extends Dao[HITLJob] {
 
   def delete(id: UUID): ConnectionIO[Int] =
     query.filter(id).delete
+
+  def isOwnerOrSuperUser(user: User, id: UUID): ConnectionIO[Boolean] =
+    for {
+      jobO <- getById(id)
+      isSuperuser = user.isSuperuser && user.isActive
+    } yield {
+      jobO match {
+        case Some(job) => job.owner == user.id || isSuperuser
+        case _         => isSuperuser
+      }
+    }
 }

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -84,11 +84,11 @@ object HITLJobDao extends Dao[HITLJob] {
       user: User
   ): ConnectionIO[HITLJob] =
     for {
-      version <-
-        getNewVersion(user, newHITLJob.campaignId, newHITLJob.projectId)
-      inserted <-
-        insertF(newHITLJob, user, version).update
-          .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
+      version <- getNewVersion(user,
+                               newHITLJob.campaignId,
+                               newHITLJob.projectId)
+      inserted <- insertF(newHITLJob, user, version).update
+        .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
     } yield inserted
 
   def update(hitlJob: HITLJob, id: UUID): ConnectionIO[Int] = {

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -78,11 +78,11 @@ object HITLJobDao extends Dao[HITLJob] {
       user: User
   ): ConnectionIO[HITLJob] =
     for {
-      version <-
-        getNewVersion(user, newHITLJob.campaignId, newHITLJob.projectId)
-      inserted <-
-        insertF(newHITLJob, user, version).update
-          .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
+      version <- getNewVersion(user,
+                               newHITLJob.campaignId,
+                               newHITLJob.projectId)
+      inserted <- insertF(newHITLJob, user, version).update
+        .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
     } yield inserted
 
   def update(hitlJob: HITLJob, id: UUID): ConnectionIO[Int] = {

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -1,0 +1,99 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.database.Implicits._
+import com.rasterfoundry.datamodel.PageRequest
+import com.rasterfoundry.datamodel._
+
+import doobie._
+import doobie.implicits._
+import doobie.implicits.javasql._
+import doobie.postgres.implicits._
+
+import java.util.UUID
+
+object HITLJobDao extends Dao[HITLJob] {
+  val tableName = "hitl_jobs"
+
+  val selectF: Fragment = sql"""
+      SELECT
+        id, created_at, created_by, modified_at, owner,
+        campaign_id, project_id, status, version
+      FROM
+    """ ++ tableF
+
+  override val fieldNames = List(
+    "id",
+    "created_at",
+    "created_by",
+    "modified_at",
+    "owner",
+    "campaign_id",
+    "project_id",
+    "status",
+    "version"
+  )
+
+  def unsafeGetById(id: UUID): ConnectionIO[HITLJob] =
+    query.filter(id).select
+
+  def getById(id: UUID): ConnectionIO[Option[HITLJob]] =
+    query.filter(id).selectOption
+
+  def list(
+      page: PageRequest,
+      params: HITLJobQueryParameters,
+      user: User
+  ): ConnectionIO[PaginatedResponse[HITLJob]] =
+    query
+      .filter(params)
+      .filter(user.isSuperuser && user.isActive match {
+        case true  => fr""
+        case false => fr"owner = ${user.id}"
+      })
+      .page(page)
+
+  def getNewVersion(
+      user: User,
+      campaignId: UUID,
+      projectId: UUID
+  ): ConnectionIO[Int] =
+    query
+      .filter(fr"owner = ${user.id}")
+      .filter(fr"campaign_id = ${campaignId}")
+      .filter(fr"project_id = ${projectId}")
+      .list
+      .map { _.size }
+
+  def insertF(newHITLJob: HITLJob.Create, user: User, version: Int): Fragment =
+    fr"INSERT INTO" ++ tableF ++ fr"""
+      (id, created_at, created_by, modified_at, owner,
+        campaign_id, project_id, status, version)
+    VALUES
+      (uuid_generate_v4(), now(), ${user.id}, now(), ${user.id},
+      ${newHITLJob.campaignId}, ${newHITLJob.projectId}, ${newHITLJob.status}, ${version})
+    """
+
+  def create(
+      newHITLJob: HITLJob.Create,
+      user: User
+  ): ConnectionIO[HITLJob] =
+    for {
+      version <-
+        getNewVersion(user, newHITLJob.campaignId, newHITLJob.projectId)
+      inserted <-
+        insertF(newHITLJob, user, version).update
+          .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
+    } yield inserted
+
+  def update(hitlJob: HITLJob, id: UUID): ConnectionIO[Int] = {
+    (fr"UPDATE " ++ tableF ++ fr"""SET
+      modified_at = now(),
+      status = ${hitlJob.status}
+    WHERE
+      id = $id
+    """).update.run;
+  }
+
+  def delete(id: UUID): ConnectionIO[Int] =
+    query.filter(id).delete
+}

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -486,26 +486,24 @@ trait Filterables extends RFMeta with LazyLogging {
           )
     }
 
-  implicit val hitlJobQPFilter
-    : Filterable[Any, HITLJobQueryParameters] =
-    Filterable[Any, HITLJobQueryParameters] {
-      params: HITLJobQueryParameters =>
-        Filters.onlyUserQP(params.userParams) ++
-          Filters.ownerQP(params.ownerParams) ++
-          List(
-            params.status map { qp =>
-              fr"status = UPPER($qp)::public.hitl_job_status"
-            },
-            params.projectId map { qp =>
-              fr"project_id = ${qp}"
-            },
-            params.campaignId map { qp =>
-              fr"campaign_id = ${qp}"
-            },
-            params.version map { qp =>
-              fr"version = ${qp}"
-            },
-          )
+  implicit val hitlJobQPFilter: Filterable[Any, HITLJobQueryParameters] =
+    Filterable[Any, HITLJobQueryParameters] { params: HITLJobQueryParameters =>
+      Filters.onlyUserQP(params.userParams) ++
+        Filters.ownerQP(params.ownerParams) ++
+        List(
+          params.status map { qp =>
+            fr"status = UPPER($qp)::public.hitl_job_status"
+          },
+          params.projectId map { qp =>
+            fr"project_id = ${qp}"
+          },
+          params.campaignId map { qp =>
+            fr"campaign_id = ${qp}"
+          },
+          params.version map { qp =>
+            fr"version = ${qp}"
+          },
+        )
     }
 }
 

--- a/app-backend/db/src/main/scala/filters/Filterables.scala
+++ b/app-backend/db/src/main/scala/filters/Filterables.scala
@@ -485,6 +485,28 @@ trait Filterables extends RFMeta with LazyLogging {
             })
           )
     }
+
+  implicit val hitlJobQPFilter
+    : Filterable[Any, HITLJobQueryParameters] =
+    Filterable[Any, HITLJobQueryParameters] {
+      params: HITLJobQueryParameters =>
+        Filters.onlyUserQP(params.userParams) ++
+          Filters.ownerQP(params.ownerParams) ++
+          List(
+            params.status map { qp =>
+              fr"status = UPPER($qp)::public.hitl_job_status"
+            },
+            params.projectId map { qp =>
+              fr"project_id = ${qp}"
+            },
+            params.campaignId map { qp =>
+              fr"campaign_id = ${qp}"
+            },
+            params.version map { qp =>
+              fr"version = ${qp}"
+            },
+          )
+    }
 }
 
 object Filterables extends Filterables

--- a/app-backend/db/src/main/scala/meta/EnumMeta.scala
+++ b/app-backend/db/src/main/scala/meta/EnumMeta.scala
@@ -130,4 +130,7 @@ trait EnumMeta {
 
   implicit val taskSessionTypeMeta: Meta[TaskSessionType] =
     pgEnumString("task_session_type", TaskSessionType.fromString, _.repr)
+
+  implicit val hitlJobStatusMeta: Meta[HITLJobStatus] =
+    pgEnumString("hitl_job_status", HITLJobStatus.fromString, _.repr)
 }

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/HITLJobDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/HITLJobDaoSpec.scala
@@ -98,7 +98,7 @@ class HITLJobDaoSpec
             "Inserted HITL job status should be the same as sent"
           )
           assert(
-            jobOne.version + 1 == jobTwo.version,
+            jobOne.version < jobTwo.version,
             "HITL jobs should have increasing version numbers for same user + campaign + project"
           )
           assert(

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/HITLJobDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/HITLJobDaoSpec.scala
@@ -1,0 +1,426 @@
+package com.rasterfoundry.database
+
+import com.rasterfoundry.common.Generators.Implicits._
+import com.rasterfoundry.datamodel._
+
+import doobie.implicits._
+import org.scalacheck.Prop.forAll
+
+import org.scalatestplus.scalacheck.Checkers
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class HITLJobDaoSpec
+    extends AnyFunSuite
+    with Matchers
+    with Checkers
+    with DBTestConfig
+    with PropTestHelpers {
+
+  test("creating HITL jobs") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            projectCreate: AnnotationProject.Create,
+            campaignCreate: Campaign.Create,
+            hitlJobCreate: HITLJob.Create
+        ) => {
+          val createHITLJobIO =
+            for {
+              dbUser <- UserDao.create(userCreate)
+              dbCampaign <-
+                CampaignDao
+                  .insertCampaign(
+                    campaignCreate.copy(parentCampaignId = None),
+                    dbUser
+                  )
+              dbCampaignAlt <-
+                CampaignDao
+                  .insertCampaign(
+                    campaignCreate.copy(parentCampaignId = None),
+                    dbUser
+                  )
+              dbProject <-
+                AnnotationProjectDao
+                  .insert(
+                    projectCreate.copy(campaignId = Option(dbCampaign.id)),
+                    dbUser
+                  )
+              dbProjectAlt <-
+                AnnotationProjectDao
+                  .insert(
+                    projectCreate.copy(campaignId = Option(dbCampaignAlt.id)),
+                    dbUser
+                  )
+              dbHITLJobOne <- HITLJobDao.create(
+                hitlJobCreate
+                  .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+                dbUser
+              )
+              dbHITLJobTwo <- HITLJobDao.create(
+                hitlJobCreate
+                  .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+                dbUser
+              )
+              dbHITLJobThree <- HITLJobDao.create(
+                hitlJobCreate.copy(
+                  campaignId = dbCampaignAlt.id,
+                  projectId = dbProjectAlt.id
+                ),
+                dbUser
+              )
+            } yield (
+              dbUser,
+              dbCampaign,
+              dbProject,
+              dbHITLJobOne,
+              dbHITLJobTwo,
+              dbHITLJobThree
+            )
+          val (user, campaign, project, jobOne, jobTwo, jobThree) =
+            createHITLJobIO.transact(xa).unsafeRunSync
+
+          assert(
+            user.id == jobOne.owner,
+            "Inserted HITL job owner should be the same as user"
+          )
+          assert(
+            campaign.id == jobOne.campaignId,
+            "Inserted HITL job campaign ID should be the same as the inserted campaign"
+          )
+          assert(
+            project.id == jobOne.projectId,
+            "Inserted HITL job project ID should be the same as the inserted project"
+          )
+          assert(
+            hitlJobCreate.status == jobOne.status,
+            "Inserted HITL job status should be the same as sent"
+          )
+          assert(
+            jobOne.version + 1 == jobTwo.version,
+            "HITL jobs should have increasing version numbers for same user + campaign + project"
+          )
+          assert(
+            jobTwo.version != jobThree.version,
+            "HITL jobs across campaign and project has no version relation"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("getting a HITL Job record by id") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            projectCreate: AnnotationProject.Create,
+            campaignCreate: Campaign.Create,
+            hitlJobCreate: HITLJob.Create
+        ) => {
+          val selectHITLJobIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbCampaign <-
+              CampaignDao
+                .insertCampaign(
+                  campaignCreate.copy(parentCampaignId = None),
+                  dbUser
+                )
+            dbProject <-
+              AnnotationProjectDao
+                .insert(
+                  projectCreate.copy(campaignId = Option(dbCampaign.id)),
+                  dbUser
+                )
+            dbHITLJob <- HITLJobDao.create(
+              hitlJobCreate
+                .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+              dbUser
+            )
+            selectedJobOption <- HITLJobDao.getById(dbHITLJob.id)
+          } yield (dbUser, dbHITLJob, selectedJobOption)
+
+          val (user, job, selectedJobO) =
+            selectHITLJobIO.transact(xa).unsafeRunSync
+
+          selectedJobO match {
+            case Some(selectedJob) =>
+              assert(
+                job.id == selectedJob.id,
+                "Inserted and selected job IDs should be the same"
+              )
+              assert(
+                user.id == selectedJob.owner,
+                "Selected job owner should be the same as user"
+              )
+              assert(
+                job.campaignId == selectedJob.campaignId,
+                "Inserted and selected job camapgin IDs should be the same"
+              )
+              assert(
+                job.projectId == selectedJob.projectId,
+                "Inserted and selected job project IDs should be the same"
+              )
+              assert(
+                job.status == selectedJob.status,
+                "Inserted and selected job statuses should be the same"
+              )
+              assert(
+                job.version == selectedJob.version,
+                "Inserted and selected job versions should be the same"
+              )
+              true
+            case _ => false
+          }
+        }
+      )
+    }
+  }
+
+  test("updating a HITL job") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            projectCreate: AnnotationProject.Create,
+            campaignCreate: Campaign.Create,
+            hitlJobCreate: HITLJob.Create
+        ) => {
+          val updateHITLJobIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbCampaign <-
+              CampaignDao
+                .insertCampaign(
+                  campaignCreate.copy(parentCampaignId = None),
+                  dbUser
+                )
+            dbProject <-
+              AnnotationProjectDao
+                .insert(
+                  projectCreate.copy(campaignId = Option(dbCampaign.id)),
+                  dbUser
+                )
+            dbHITLJob <- HITLJobDao.create(
+              hitlJobCreate
+                .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+              dbUser
+            )
+            _ <- HITLJobDao.update(
+              dbHITLJob.copy(status = HITLJobStatus.Running),
+              dbHITLJob.id
+            )
+            updatedJobOption <- HITLJobDao.getById(dbHITLJob.id)
+          } yield (dbUser, dbHITLJob, updatedJobOption)
+
+          val (user, job, updatedJobO) =
+            updateHITLJobIO.transact(xa).unsafeRunSync
+
+          updatedJobO match {
+            case Some(updatedJob) =>
+              assert(
+                job.id == updatedJob.id,
+                "Inserted and updated job IDs should be the same"
+              )
+              assert(
+                user.id == updatedJob.owner,
+                "Updated job owner should be the same as user"
+              )
+              assert(
+                job.campaignId == updatedJob.campaignId,
+                "Inserted and Updated job camapgin IDs should be the same"
+              )
+              assert(
+                job.projectId == updatedJob.projectId,
+                "Inserted and Updated job project IDs should be the same"
+              )
+              assert(
+                job.status != updatedJob.status,
+                "Inserted and Updated job statuses should not be the same"
+              )
+              assert(
+                updatedJob.status == HITLJobStatus.Running,
+                "Job status should be updated"
+              )
+              assert(
+                job.version == updatedJob.version,
+                "Inserted and updated job versions should be the same"
+              )
+              true
+            case _ => false
+          }
+        }
+      )
+    }
+  }
+
+  test("deleting a HITL job") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            projectCreate: AnnotationProject.Create,
+            campaignCreate: Campaign.Create,
+            hitlJobCreate: HITLJob.Create
+        ) => {
+          val deleteHITLJobIO = for {
+            dbUser <- UserDao.create(userCreate)
+            dbCampaign <-
+              CampaignDao
+                .insertCampaign(
+                  campaignCreate.copy(parentCampaignId = None),
+                  dbUser
+                )
+            dbProject <-
+              AnnotationProjectDao
+                .insert(
+                  projectCreate.copy(campaignId = Option(dbCampaign.id)),
+                  dbUser
+                )
+            dbHITLJob <- HITLJobDao.create(
+              hitlJobCreate
+                .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+              dbUser
+            )
+            deletedRowCount <- HITLJobDao.delete(dbHITLJob.id)
+            selectedJobOption <- HITLJobDao.getById(dbHITLJob.id)
+          } yield { (deletedRowCount, selectedJobOption) }
+
+          val (rowCount, selectedJobO) =
+            deleteHITLJobIO.transact(xa).unsafeRunSync
+
+          assert(
+            rowCount == 1,
+            "Should have one record deleted"
+          )
+          assert(
+            selectedJobO == None,
+            "Inserted HITL job should be deleted from DB"
+          )
+          true
+        }
+      )
+    }
+  }
+
+  test("listing HITL jobs") {
+    check {
+      forAll(
+        (
+            userCreate: User.Create,
+            projectCreate: AnnotationProject.Create,
+            campaignCreate: Campaign.Create,
+            hitlJobCreate: HITLJob.Create,
+            page: PageRequest
+        ) => {
+          val listHITLJobsIO =
+            for {
+              dbUser <- UserDao.create(userCreate)
+              dbCampaign <-
+                CampaignDao
+                  .insertCampaign(
+                    campaignCreate.copy(parentCampaignId = None),
+                    dbUser
+                  )
+              dbCampaignAlt <-
+                CampaignDao
+                  .insertCampaign(
+                    campaignCreate.copy(parentCampaignId = None),
+                    dbUser
+                  )
+              dbProject <-
+                AnnotationProjectDao
+                  .insert(
+                    projectCreate.copy(campaignId = Option(dbCampaign.id)),
+                    dbUser
+                  )
+              dbProjectAlt <-
+                AnnotationProjectDao
+                  .insert(
+                    projectCreate.copy(campaignId = Option(dbCampaignAlt.id)),
+                    dbUser
+                  )
+              dbHITLJobOne <- HITLJobDao.create(
+                hitlJobCreate
+                  .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+                dbUser
+              )
+              dbHITLJobTwo <- HITLJobDao.create(
+                hitlJobCreate
+                  .copy(campaignId = dbCampaign.id, projectId = dbProject.id),
+                dbUser
+              )
+              dbHITLJobThree <- HITLJobDao.create(
+                hitlJobCreate.copy(
+                  campaignId = dbCampaignAlt.id,
+                  projectId = dbProjectAlt.id
+                ),
+                dbUser
+              )
+              jobsBatchOne <- HITLJobDao.list(
+                page,
+                HITLJobQueryParameters(
+                  campaignId = Some(dbCampaign.id),
+                  projectId = Some(dbProject.id)
+                ),
+                dbUser
+              )
+              jobsBatchTwo <- HITLJobDao.list(
+                page,
+                HITLJobQueryParameters(
+                  campaignId = Some(dbCampaignAlt.id),
+                  projectId = Some(dbProjectAlt.id)
+                ),
+                dbUser
+              )
+              jobsBatchThree <- HITLJobDao.list(
+                page,
+                HITLJobQueryParameters(
+                  campaignId = Some(dbCampaign.id),
+                  projectId = Some(dbProjectAlt.id)
+                ),
+                dbUser
+              )
+            } yield (
+              dbHITLJobOne,
+              dbHITLJobTwo,
+              dbHITLJobThree,
+              jobsBatchOne,
+              jobsBatchTwo,
+              jobsBatchThree
+            )
+
+          val (jobOne, jobTwo, jobThree, batchOne, batchTwo, batchThree) =
+            listHITLJobsIO.transact(xa).unsafeRunSync
+
+          assert(
+            batchOne.count == 2,
+            "Should have two records matching the job list filters combo 1"
+          )
+          assert(
+            batchTwo.count == 1,
+            "Should have one record matching the job list filters combo 2"
+          )
+          assert(
+            batchThree.count == 0,
+            "Should have no record matching the job list filters combo 3"
+          )
+          assert(
+            batchOne.results.map(_.id).toSet == Set(jobOne.id, jobTwo.id),
+            "Listing with param combo 1 should return job 1 and 2"
+          )
+          assert(
+            batchTwo.results.map(_.id).toSet == Set(jobThree.id),
+            "Listing with param combo 2 should return job 3"
+          )
+          assert(
+            batchThree.results.map(_.id).size == 0,
+            "Listing with param combo 3 should have empty result"
+          )
+          true
+        }
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This PR adds CRUD API endpoints for `hitl-jobs`.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [X] New tables and queries have appropriate indices added
- ~Any content changes are properly templated using `BUILDCONFIG.APP_NAME`~
- [X] Any new SQL strings have tests
- [X] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- CI should pass
- Pair to test all new endpoints.

https://github.com/azavea/foss4g-2022-hitl-groundwork-rastervision/issues/1