### PR TITLE
Update task; Add an endpoint to get prioritized task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CRUD endpoints for HITL jobs [#5642](https://github.com/raster-foundry/raster-foundry/pull/5642)
 - Added `hitl_version_id` to `annotation_labels` [#5643](https://github.com/raster-foundry/raster-foundry/pull/5643)
 - Added MVT endpoints for HITL labels [#5643](https://github.com/raster-foundry/raster-foundry/pull/5643)
+- Added an endpoint to get prioritized HITL task [#5644](https://github.com/raster-foundry/raster-foundry/pull/5644)
 
 ## [1.70.1] - 2022-04-25
 ### Changed

--- a/app-backend/api-it/src/test/resources/endpoint-scopes.csv
+++ b/app-backend/api-it/src/test/resources/endpoint-scopes.csv
@@ -220,6 +220,7 @@ Path,Domain:Action,Verb
 /api/users/search/,users:search,get
 /api/users/bulk-create/,users:bulkCreate,post
 /api/tasks/random,annotationProjects:readTasks,get
+/api/tasks/hitl,annotationProjects:readTasks,get
 /api/campaigns/,campaigns:read,get
 /api/campaigns/,campaigns:create,post
 /api/campaigns/{campaignId},campaigns:read,get

--- a/app-backend/common/src/test/scala/com/implicits/Generators.scala
+++ b/app-backend/common/src/test/scala/com/implicits/Generators.scala
@@ -1013,7 +1013,8 @@ object Generators extends ArbitraryInstances {
         taskType,
         None,
         reviews,
-        reviewStatus
+        reviewStatus,
+        None
       )
     }
 

--- a/app-backend/datamodel/src/main/scala/Task.scala
+++ b/app-backend/datamodel/src/main/scala/Task.scala
@@ -33,7 +33,8 @@ case class Task(
     taskType: TaskType,
     parentTaskId: Option[UUID],
     reviews: Map[UUID, Review],
-    reviewStatus: Option[TaskReviewStatus]
+    reviewStatus: Option[TaskReviewStatus],
+    priorityScore: Option[Float] = None
 ) {
   def toGeoJSONFeature(actions: List[TaskActionStamp]): Task.TaskFeature = {
     Task.TaskFeature(
@@ -73,7 +74,8 @@ case class Task(
       this.taskType,
       this.parentTaskId,
       this.reviews,
-      this.reviewStatus
+      this.reviewStatus,
+      this.priorityScore
     )
   }
 
@@ -115,7 +117,8 @@ object Task {
       taskType: TaskType,
       parentTaskId: Option[UUID],
       reviews: Map[UUID, Review],
-      reviewStatus: Option[TaskReviewStatus]
+      reviewStatus: Option[TaskReviewStatus],
+      priorityScore: Option[Float]
   ) {
     def toCreate: TaskPropertiesCreate = {
       TaskPropertiesCreate(
@@ -124,7 +127,9 @@ object Task {
         this.note,
         Some(this.taskType),
         this.parentTaskId,
-        Some(this.reviews)
+        Some(this.reviews),
+        reviewStatus,
+        this.priorityScore
       )
     }
   }
@@ -243,7 +248,8 @@ object Task {
       taskType: Option[TaskType],
       parentTaskId: Option[UUID],
       reviews: Option[Map[UUID, Review]],
-      reviewStatus: Option[TaskReviewStatus] = None
+      reviewStatus: Option[TaskReviewStatus] = None,
+      priorityScore: Option[Float] = None
   )
 
   object TaskPropertiesCreate {

--- a/app-backend/db/src/main/resources/migrations/V85__add_priority_to_task.sql
+++ b/app-backend/db/src/main/resources/migrations/V85__add_priority_to_task.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+    tasks
+ADD
+    COLUMN priority_score REAL DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS tasks_score_idx ON tasks (priority_score);

--- a/app-backend/db/src/main/scala/CampaignDao.scala
+++ b/app-backend/db/src/main/scala/CampaignDao.scala
@@ -338,7 +338,22 @@ object CampaignDao extends Dao[Campaign] with ObjectPermissions[Campaign] {
         AND
           owner <> ${user.id}
       )
-      SELECT tasks.*, annotation_projects.campaign_id
+      SELECT
+        tasks.id,
+        tasks.created_at,
+        tasks.created_by,
+        tasks.modified_at,
+        tasks.owner,
+        tasks.status,
+        tasks.locked_by,
+        tasks.locked_on,
+        tasks.geometry,
+        tasks.annotation_project_id,
+        tasks.task_type,
+        tasks.parent_task_id,
+        tasks.reviews,
+        tasks.review_status,
+        annotation_projects.campaign_id
       FROM tasks
       JOIN annotation_projects
         ON tasks.annotation_project_id = annotation_projects.id

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -133,4 +133,20 @@ object HITLJobDao extends Dao[HITLJob] {
         """
       )
       .exists
+
+  def hasSuccessfulJob(
+      campaignId: UUID,
+      projectId: UUID,
+      user: User
+  ): ConnectionIO[Boolean] =
+    query
+      .filter(fr"campaign_id = ${campaignId}")
+      .filter(fr"project_id = ${projectId}")
+      .filter(fr"owner = ${user.id}")
+      .filter(
+        fr"""
+        status = 'RAN'::public.hitl_job_status
+        """
+      )
+      .exists
 }


### PR DESCRIPTION
## Overview

This PR:
- adds `priority_score` field to `tasks`
- updates the related data models and dao methods
- adds an endpoint to get a hitl prioritized task

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [X] New tables and queries have appropriate indices added
- [X] Any new SQL strings have tests
- [x] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- will walk through in pairing

Closes https://github.com/azavea/foss4g-2022-hitl-groundwork-rastervision/issues/9
