### PR TITLE
Use HITL specific image from dockerhub

### DIFF
--- a/app-hitl/Dockerfile
+++ b/app-hitl/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/azavea/raster-vision:pytorch-0.13
+FROM simonkassel/hitl-rv:latest
 
 COPY requirements.txt /tmp/
 

--- a/app-hitl/hitl/run_hitl.py
+++ b/app-hitl/hitl/run_hitl.py
@@ -1,9 +1,22 @@
 import click
+import geopandas as gpd
+
+from utils import merge_labels_with_task_grid
+
 
 @click.command()
 @click.argument('hitl_project_id')
 def run_hitl(hitl_project_id):
-    print(f'processing project: {hitl_project_id}')
+    print('PLACEHOLDER:')
+    print(f'Processing HITL project "{hitl_project_id}"')
+    tasks = gpd.read_file('/opt/src/data/hitl/hitl-tasks.json')
+    labels = gpd.read_file('/opt/src/data/hitl/hitl-predictions.geojson')
+    merged_labels = merge_labels_with_task_grid(labels, tasks)
+    print('merged labels (head):')
+    print(merged_labels.head())
+    print(
+        f'{labels.shape[0]} labels before intersection, {merged_labels.shape[0]} labels after')
+
 
 if __name__ == '__main__':
     run_hitl()

--- a/app-hitl/hitl/run_hitl.py
+++ b/app-hitl/hitl/run_hitl.py
@@ -7,16 +7,7 @@ from utils import merge_labels_with_task_grid
 @click.command()
 @click.argument('hitl_project_id')
 def run_hitl(hitl_project_id):
-    print('PLACEHOLDER:')
-    print(f'Processing HITL project "{hitl_project_id}"')
-    tasks = gpd.read_file('/opt/src/data/hitl/hitl-tasks.json')
-    labels = gpd.read_file('/opt/src/data/hitl/hitl-predictions.geojson')
-    merged_labels = merge_labels_with_task_grid(labels, tasks)
-    print('merged labels (head):')
-    print(merged_labels.head())
-    print(
-        f'{labels.shape[0]} labels before intersection, {merged_labels.shape[0]} labels after')
-
+    pass
 
 if __name__ == '__main__':
     run_hitl()

--- a/app-hitl/hitl/utils.py
+++ b/app-hitl/hitl/utils.py
@@ -1,0 +1,6 @@
+import geopandas as gpd
+
+
+def merge_labels_with_task_grid(labels: gpd.GeoDataFrame, task_grid: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    tasks = task_grid[['id', 'geometry']].rename(columns={'id': 'taskId'})
+    return gpd.overlay(labels, tasks, how='intersection', keep_geom_type=True)

--- a/app-hitl/requirements.txt
+++ b/app-hitl/requirements.txt
@@ -1,1 +1,2 @@
 geopandas==0.9.0
+rtree==0.9.7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,7 @@ services:
       - "9050:9050"
     volumes:
       - ./app-hitl/hitl/:/opt/src/hitl/
+      - ./data/:/opt/src/data/
       - $HOME/.aws:/root/.aws:ro
     build:
       context: ./app-hitl


### PR DESCRIPTION
## Overview

- Updates the Dockerfile to pull from the hitl-specific image on docker hub
- Mounts the `data` dir in RF into the container (this is useful for accessing sample data for testing)
- Installs `rtree` for spatial joining
- Adds a utils file with a function for clipping/joining labels to the task grid

### Notes

The contents of `hitl/run_hitl.py` are still just placeholders

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] New tables and queries have appropriate indices added
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

- Create a folder called `hitl` in `data`
- Move the sample files: `hitl-tasks.json` and `hitl-predictions.geojson` int `data/hitl`
- run `docker-compose build batch-hitl` to build the container
- run `docker-compose run batch-hitl python hitl/run_hitl.py FAKE_PROJECT_ID` to test out merging the two sample files
- You should see the following output:
```
✔ ~/files/rf/raster-foundry [sk/use-hitl-image|⚑ 8]
15:27 $ docker-compose run batch-hitl python hitl/run_hitl.py FAKE_PROJECT_ID
Creating raster-foundry_batch-hitl_run ... done
PLACEHOLDER:
Processing HITL project "FAKE_PROJECT_ID"
merged labels (head):
                                 taskId                                           geometry
0  68e051de-b6e1-4271-a6d1-f20efd281abc  POLYGON ((-13.25265 8.47526, -13.25265 8.47526...
1  68e051de-b6e1-4271-a6d1-f20efd281abc  POLYGON ((-13.25229 8.47526, -13.25229 8.47526...
2  68e051de-b6e1-4271-a6d1-f20efd281abc  POLYGON ((-13.25191 8.47525, -13.25191 8.47525...
3  68e051de-b6e1-4271-a6d1-f20efd281abc  POLYGON ((-13.25333 8.47523, -13.25333 8.47522...
4  68e051de-b6e1-4271-a6d1-f20efd281abc  POLYGON ((-13.25335 8.47521, -13.25335 8.47520...
638 labels before intersection, 675 labels after
```

