### PR TITLE
Notify through Intercom of HITL job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Kick off HITL remote batch job in AWS on POST to `/api/hitl-jobs` [#5650](https://github.com/raster-foundry/raster-foundry/pull/5650)
   - Added Raster Vision training and prediction code for HITL [#5649](https://github.com/raster-foundry/raster-foundry/pull/5649)
   - Added HITL postprocessing steps [#5651](https://github.com/raster-foundry/raster-foundry/pull/5651)
+  - Added support of status update of HITL job and Intercom notifications [#5652](https://github.com/raster-foundry/raster-foundry/pull/)
 
 ## [1.70.1] - 2022-04-25
 ### Changed

--- a/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
+++ b/app-backend/api/src/main/scala/annotation-project/AnnotationProjectTaskRoutes.scala
@@ -422,8 +422,7 @@ trait AnnotationProjectTaskRoutes
                 .listWithClassesByProjectIdAndTaskId(
                   projectId,
                   taskId,
-                  params,
-                  user
+                  params
                 )
                 .transact(xa)
                 .unsafeToFuture

--- a/app-backend/db/src/main/scala/AnnotationLabelDao.scala
+++ b/app-backend/db/src/main/scala/AnnotationLabelDao.scala
@@ -154,8 +154,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
   def listWithClassesByProjectIdAndTaskId(
       projectId: UUID,
       taskId: UUID,
-      param: TaskLabelQueryParameters,
-      user: User
+      param: TaskLabelQueryParameters
   ): ConnectionIO[List[AnnotationLabelWithClasses.GeoJSON]] = {
     val qb = withClassesQB
       .filter(fr"annotation_project_id=$projectId")
@@ -164,8 +163,7 @@ object AnnotationLabelDao extends Dao[AnnotationLabelWithClasses] {
 
     val filtered = param.hitlVersionId match {
       case Some(hitlVersionId) =>
-        qb.filter(fr"created_by = ${user.id}")
-          .filter(fr"hitl_version_id = ${hitlVersionId}")
+        qb.filter(fr"hitl_version_id = ${hitlVersionId}")
       case _ =>
         qb.filter(fr"hitl_version_id is NULL")
     }

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -47,7 +47,7 @@ object HITLJobDao extends Dao[HITLJob] {
     query
       .filter(params)
       .filter(user.isSuperuser && user.isActive match {
-        case true  => fr""
+        case true  => fr"true"
         case false => fr"owner = ${user.id}"
       })
       .page(page)
@@ -84,11 +84,11 @@ object HITLJobDao extends Dao[HITLJob] {
       user: User
   ): ConnectionIO[HITLJob] =
     for {
-      version <- getNewVersion(user,
-                               newHITLJob.campaignId,
-                               newHITLJob.projectId)
-      inserted <- insertF(newHITLJob, user, version).update
-        .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
+      version <-
+        getNewVersion(user, newHITLJob.campaignId, newHITLJob.projectId)
+      inserted <-
+        insertF(newHITLJob, user, version).update
+          .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
     } yield inserted
 
   def update(hitlJob: HITLJob, id: UUID): ConnectionIO[Int] = {

--- a/app-backend/db/src/main/scala/HITLJobDao.scala
+++ b/app-backend/db/src/main/scala/HITLJobDao.scala
@@ -84,11 +84,11 @@ object HITLJobDao extends Dao[HITLJob] {
       user: User
   ): ConnectionIO[HITLJob] =
     for {
-      version <-
-        getNewVersion(user, newHITLJob.campaignId, newHITLJob.projectId)
-      inserted <-
-        insertF(newHITLJob, user, version).update
-          .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
+      version <- getNewVersion(user,
+                               newHITLJob.campaignId,
+                               newHITLJob.projectId)
+      inserted <- insertF(newHITLJob, user, version).update
+        .withUniqueGeneratedKeys[HITLJob](fieldNames: _*)
     } yield inserted
 
   def update(hitlJob: HITLJob, id: UUID): ConnectionIO[Int] = {

--- a/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
+++ b/app-backend/db/src/test/scala/com/azavea/rf/database/AnnotationLabelDaoSpec.scala
@@ -202,8 +202,7 @@ class AnnotationLabelDaoSpec
                 .listWithClassesByProjectIdAndTaskId(
                   annotationProject.id,
                   task.id,
-                  TaskLabelQueryParameters(hitlVersionId = None),
-                  user
+                  TaskLabelQueryParameters(hitlVersionId = None)
                 )
           } yield listedByTask
 
@@ -360,8 +359,7 @@ class AnnotationLabelDaoSpec
                 .listWithClassesByProjectIdAndTaskId(
                   annotationProject.id,
                   task.id,
-                  TaskLabelQueryParameters(hitlVersionId = None),
-                  user
+                  TaskLabelQueryParameters(hitlVersionId = None)
                 )
           } yield listedByTask
 
@@ -558,16 +556,14 @@ class AnnotationLabelDaoSpec
               AnnotationLabelDao.listWithClassesByProjectIdAndTaskId(
                 annotationProject.id,
                 task.id,
-                TaskLabelQueryParameters(hitlVersionId = None),
-                user
+                TaskLabelQueryParameters(hitlVersionId = None)
               )
             _ <- AnnotationLabelDao.toggleBySessionId(dbTaskSession.id)
             reactiveLabels <-
               AnnotationLabelDao.listWithClassesByProjectIdAndTaskId(
                 annotationProject.id,
                 task.id,
-                TaskLabelQueryParameters(hitlVersionId = None),
-                user
+                TaskLabelQueryParameters(hitlVersionId = None)
               )
           } yield (activeLabels, reactiveLabels)
 
@@ -751,15 +747,13 @@ class AnnotationLabelDaoSpec
               AnnotationLabelDao.listWithClassesByProjectIdAndTaskId(
                 annotationProject.id,
                 task.id,
-                TaskLabelQueryParameters(hitlVersionId = None),
-                user
+                TaskLabelQueryParameters(hitlVersionId = None)
               )
             listedMachine <-
               AnnotationLabelDao.listWithClassesByProjectIdAndTaskId(
                 annotationProject.id,
                 task.id,
-                TaskLabelQueryParameters(hitlVersionId = Some(hitlJob.id)),
-                user
+                TaskLabelQueryParameters(hitlVersionId = Some(hitlJob.id))
               )
             isHITLInProgress <- HITLJobDao.hasInProgressJob(
               campaign.id,

--- a/app-hitl/hitl/src/hitl/commands/run_hitl.py
+++ b/app-hitl/hitl/src/hitl/commands/run_hitl.py
@@ -10,6 +10,7 @@ from ..utils.get_hitl_input import get_input
 from ..utils.notify_intercom import notify
 from ..utils.persist_hitl_output import persist_hitl_output
 from ..utils.post_process import post_process
+from ..utils.notify_intercom import notify
 
 from ..rv.active_learning import active_learning_step
 from ..rv.io import get_class_config
@@ -18,6 +19,7 @@ logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 HOST = os.getenv("RF_HOST")
+GROUNDWORK_URL_BASE = os.getenv("GROUNDWORK_URL_BASE")
 JOB_ATTEMPT = int(os.getenv("AWS_BATCH_JOB_ATTEMPT", -1))
 OUTPUT_DIR = os.getenv("HITL_OUTPUT_BUCKET", "/tmp/hitl/out")
 
@@ -34,10 +36,8 @@ def run_hitl(job_id):
     # - Enhancement later: save task and label to a file
     # - labels as a GeoJSON URI
     # - grab previous iteration
-    logger.info("Grabbing HITL project data from GroundWork")
-    scene, tasks, labels, label_classes, job = get_input(job_id)
-
-    project_id = job.projectId
+    logger.info("Getting HITL project data from GroundWork")
+    scene, tasks, labels, label_classes, job, all_prev_jobs = get_input(job_id)
 
     # STEP 2 Train and predict with RV
     # * Output:
@@ -46,18 +46,25 @@ def run_hitl(job_id):
     #   - Enhancement later: save task and label to files
 
     # RV expects labels to be in a GeoJSON file
+    logger.info("Saving human labels to a file...")
     labels_uri = "labels.geojson"
     with open(labels_uri, "w") as f:
         json.dump(labels, f)
-
+    logger.info("Reading tasks into a GeoDataFrame...")
     task_grid_gdf = gpd.GeoDataFrame.from_features(tasks)
     task_grid_gdf["taskId"] = task_grid_gdf["id"]
 
     # task_grid_with_scores is a GeoDataFrame with a "priorityScore" column
     # pred_geojson_uri is the path (str) to the predictions GeoJSON file
-    iter_num = 0
+    logger.info("Starting the Raster Vision training and predicting...")
+    iter_num = job.version
     output_location = f"{OUTPUT_DIR}/{job_id}/{iter_num}/"
-
+    last_output_dir = None
+    if len(all_prev_jobs) != 0:
+        last_job = all_prev_jobs[-1]
+        version_num = last_job["version"]
+        prev_job_id = last_job["id"]
+        last_output_dir = f"{OUTPUT_DIR}/{prev_job_id}/{version_num}/"
     task_grid_with_scores, pred_geojson_uri = active_learning_step(
         iter_num=iter_num,
         class_config=get_class_config(label_classes),
@@ -65,11 +72,10 @@ def run_hitl(job_id):
         labels_uri=labels_uri,
         task_grid=task_grid_gdf,
         output_dir=output_location,
-        last_output_dir=None,
+        last_output_dir=last_output_dir,
         train_kw=dict(
             num_epochs=5, chip_sz=256, img_sz=256, external_model=True),
         predict_kw=dict(chip_sz=256, stride=256, denoise_radius=8))
-
     logger.info(f"Task grid with priority scores... {task_grid_with_scores.to_json()}")
     logger.info(f"Prediction labels location... {pred_geojson_uri}")
 
@@ -83,6 +89,7 @@ def run_hitl(job_id):
     #       - Tasks with priority scores
     #       - Tasks with prediction labels are marked as LABELED
     # - Enhancement later: save and read task and label to a file
+    logger.info("Processing the task grid and the labels...")
     updated_tasks_dict, labels_to_post_dict = post_process(
         task_grid_with_scores,
         pred_geojson_uri,
@@ -93,12 +100,26 @@ def run_hitl(job_id):
     # STEP 4 Persist data to DB
     # - Update tasks (PUT)
     # - Add prediction labels (POST)
+    logger.info("Updating labels and task grid to the API...")
     persist_hitl_output(
-        project_id,
+        job.projectId,
         updated_tasks_dict,
         labels_to_post_dict
     )
 
-    # STEP 5 Notify Intercom
+    # STEP 5 Update batch job status
+    logger.info("Updating job status...")
+    job.update_job_status("RAN")
 
-    # STEP 6 Update batch job status
+    # STEP 6 Notify Intercom
+    if HOST is not None:
+        project_uri = f"{GROUNDWORK_URL_BASE}/app/campaign/{job.campaignId}/overview?s={job.projectId}"
+        if GROUNDWORK_URL_BASE is None:
+            base = "https://groundwork.azavea.com/app"
+            if "staging" in HOST:
+                base = "https://develop--raster-foundry-annotate.netlify.app/app"
+            project_uri = f"{base}/app/campaign/{job.campaignId}/overview?s={job.projectId}"
+        logger.info("Notifying user of the HITL prediction labels...")
+        message = f"Your HITL prediction labels are ready at: {project_uri}"
+        notify(job.owner, message)
+    

--- a/app-hitl/hitl/src/hitl/utils/get_hitl_input.py
+++ b/app-hitl/hitl/src/hitl/utils/get_hitl_input.py
@@ -93,13 +93,14 @@ def get_scene(project_id):
     response.raise_for_status()
     scenes = response.json()
     scene = scenes["results"][0]
-    scene["ingestLocation"] = scene["ingestLocation"].replace("%7C", "|")
+    if "%7C" in scene["ingestLocation"]:
+        scene["ingestLocation"] = scene["ingestLocation"].replace("%7C", "|")
     return scene
 
 def list_all_jobs(user_id, campaign_id, project_id):
-    url = f"{HOST}/api/hitl-jobs?owner={user_id}&campaignId={campaign_id}&projectId={project_id}"
+    url = f"{HOST}/api/hitl-jobs"
     session = get_session()
-    response = session.get(url)
+    response = session.get(url, params=f"owner={user_id}&campaignId={campaign_id}&projectId={project_id}")
     response.raise_for_status()
     jobs = response.json()
     return jobs
@@ -113,8 +114,9 @@ def get_input(job_id):
     logger.info("Getting HITL job record")
     job = HITLJob.from_id(job_id)
     logger.info(f"Getting all HITL jobs for campaign {job.campaignId}, project {job.projectId}, user {job.owner}")
-    # all_jobs = list_all_jobs(job.owner, job.campaignId, job.projectId)
-    # all_jobs_sorted = sorted(all_jobs, key=lambda job: job.version, reverse=True)
+    all_jobs = list_all_jobs(job.owner, job.campaignId, job.projectId)
+    all_jobs_sorted = sorted(all_jobs["results"], key=lambda job: job["version"], reverse=True)
+    all_prev_jobs_sorted = [job for job in all_jobs_sorted if job["id"] != job_id]
     logger.info("Updating HITL job status to RUNNING")
     job.update_job_status("RUNNING")
     logger.info("Getting label classes")
@@ -126,4 +128,4 @@ def get_input(job_id):
     labels = get_labels(job.projectId, validated_task_ids)
     logger.info("Getting image")
     scene = get_scene(job.projectId)
-    return scene, tasks, labels, label_classes, job
+    return scene, tasks, labels, label_classes, job, all_prev_jobs_sorted

--- a/app-hitl/hitl/src/hitl/utils/notify_intercom.py
+++ b/app-hitl/hitl/src/hitl/utils/notify_intercom.py
@@ -37,7 +37,7 @@ def insert_convo(user_id, convo_id):
     }
     url = f"{HOST}/api/users/{user_id}/conversations/"
     session = get_session()
-    response = session.post(url, json = json.dumps(db_convo))
+    response = session.post(url, json=db_convo)
     try:
         response.raise_for_status()
     except:
@@ -60,7 +60,7 @@ def create_conversation(user_id, message):
     session.headers.update({"Authorization": f"Bearer {INTERCOM_TOKEN}"})
     session.headers.update({"Accept": "application/json"})
     session.headers.update({"Content-Type": "application/json"})
-    response = session.post(url, json = json.dumps(new_convo))
+    response = session.post(url, json=new_convo)
     try:
         response.raise_for_status()
     except:
@@ -82,7 +82,7 @@ def reply_conversation(convo_id, message):
     session.headers.update({"Authorization": f"Bearer {INTERCOM_TOKEN}"})
     session.headers.update({"Accept": "application/json"})
     session.headers.update({"Content-Type": "application/json"})
-    response = session.post(url, json = json.dumps(reply))
+    response = session.post(url, json=reply)
     try:
         response.raise_for_status()
     except:

--- a/app-hitl/hitl/src/hitl/utils/persist_hitl_output.py
+++ b/app-hitl/hitl/src/hitl/utils/persist_hitl_output.py
@@ -29,7 +29,6 @@ def update_tasks(project_id, tasks):
         task_id = task["properties"]["taskId"]
         url = f"{HOST}/api/annotation-projects/{project_id}/tasks/{task_id}"
         logger.info(f"Updating task with {url}")
-        logger.info(task)
         session = get_session()
         response = session.put(url, json=task)
         try:
@@ -49,7 +48,6 @@ def add_labels(project_id, labels):
             "features": [label]
         }
         logger.info(f"Adding labels with {url}")
-        logger.info(label_fc)
         session = get_session()
         response = session.post(url, json=label_fc)
         try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
     env_file: .env
     environment:
       - RF_HOST=http://rasterfoundry.com:9000
+      - GROUNDWORK_URL_BASE=http://localhost:3000
       - AWS_DEFAULT_PROFILE=raster-foundry
       - AWS_BATCH_JOB_ATTEMPT
       - HITL_OUTPUT_BUCKET


### PR DESCRIPTION
## Overview

This PR:
- fixes a bug in listing HITL jobs when the requesting user is a super-user
- uses model files from previous job if there is any
- updates job status
- notifies through Intercom of the job status with link to project

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~New tables and queries have appropriate indices added~
- ~Any new SQL strings have tests~
- ~Any new endpoints have scope validation and are included in the integration test csv~

## Testing Instructions

- Assemble your local API server jar
- Start your local API server
- Delete all existing HITL job records from `hitl_jobs`
- Spin up GW frontend
- POST to create a new HITL job with the campaign and project with validated labels
- `docker-compose build batch-hitl`
- `./scripts/console batch-hitl "hitl run <your hitl job ID>"` to run the entire job for the first time
- The job should run fine and should send notification to your local GW Intercom
- Check in the DB that the job status is marked as `RAN`.
- Check in GW project overview page from the task map- make sure task statuses are updated to `LABELED`
- Check in the DB that there are new labels persisted and have the HITL job ID attached
- Create a new HITL job and run ``./scripts/console batch-hitl "hitl run <your hitl job ID>"`` again. Make sure to check similar criteria listed above.
