### PR TITLE
Move all tasks from unlabeled to labeled after prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Added Raster Vision training and prediction code for HITL [#5649](https://github.com/raster-foundry/raster-foundry/pull/5649)
   - Added HITL postprocessing steps [#5651](https://github.com/raster-foundry/raster-foundry/pull/5651)
   - Added support of status update of HITL job and Intercom notifications [#5652](https://github.com/raster-foundry/raster-foundry/pull/)
+  - Made sure that all machine-labeled tasks have "LABELED" status after hitl run [#5653](https://github.com/raster-foundry/raster-foundry/pull/5653)
 
 ## [1.70.1] - 2022-04-25
 ### Changed

--- a/app-hitl/hitl/src/hitl/utils/post_process.py
+++ b/app-hitl/hitl/src/hitl/utils/post_process.py
@@ -24,7 +24,7 @@ def process_tasks(task_grid_with_scores: gpd.GeoDataFrame, pred_geojson_uri: str
     merged_preds_gdf = merge_labels_with_task_grid(
         preds_gdf, tasks_to_update)
     # update task status to "LABELED" where predictions fall in
-    task_ids_to_update = list(set(merged_preds_gdf["taskId"]))
+    task_ids_to_update = list(set(tasks_to_update["taskId"]))
     tasks_to_update = tasks_to_update.loc[
         tasks_to_update["taskId"].isin(task_ids_to_update)
     ]

--- a/app-hitl/hitl/src/hitl/utils/post_process.py
+++ b/app-hitl/hitl/src/hitl/utils/post_process.py
@@ -20,14 +20,10 @@ def process_tasks(task_grid_with_scores: gpd.GeoDataFrame, pred_geojson_uri: str
     tasks_to_update.set_index('id', inplace=True)
     # read RV predictions
     preds_gdf = gpd.read_file(pred_geojson_uri)
-    # find predictions fall inside of these cells
+    # join predictions to tasks
     merged_preds_gdf = merge_labels_with_task_grid(
         preds_gdf, tasks_to_update)
-    # update task status to "LABELED" where predictions fall in
-    task_ids_to_update = list(set(tasks_to_update["taskId"]))
-    tasks_to_update = tasks_to_update.loc[
-        tasks_to_update["taskId"].isin(task_ids_to_update)
-    ]
+    # update task status to "LABELED"
     tasks_to_update["status"] = "LABELED"
     updated_tasks_dict = json.loads(tasks_to_update.to_json())
     return updated_tasks_dict, merged_preds_gdf


### PR DESCRIPTION
## Overview

This pr fixes a bug in which only tasks that have include labels get moved into the labeling category. No, after running the first round of a hitl job, all tasks that were not validated in the first round of human labeling will be moved to "labeled".

after running the hitl job, all tasks should be either labeled or validated
<img width="1062" alt="image" src="https://user-images.githubusercontent.com/20233324/183508760-b2a94f0d-f82e-4be8-9361-35b3ae813323.png">


### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] New tables and queries have appropriate indices added
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

## Testing Instructions

This may be a little hard to test because to really test it you need to generate at least one task that has been predicted on but does nat have any predicted labels within it. I have found that if you just draw a couple buildings, there is inevitably buildings in every grid cell, which is why this bug didn't show up until I did some significant labeling of cars. 

- create a new project
- go in and label something very small and specific on a few tasks
- run the hitl job
- once the predictions come back. Confirm that you have at least one grid cell that has not labels in it
- confirm that that grid cell has a "Labeled" status

Closes #XXX
