### PR TITLE
Update HITL prediction params to improve prediction quality and performance

### DIFF
--- a/app-hitl/hitl/src/hitl/commands/run_hitl.py
+++ b/app-hitl/hitl/src/hitl/commands/run_hitl.py
@@ -75,7 +75,7 @@ def run_hitl(job_id):
         last_output_dir=last_output_dir,
         train_kw=dict(
             num_epochs=5, chip_sz=256, img_sz=256, external_model=True),
-        predict_kw=dict(chip_sz=256, stride=256, denoise_radius=8))
+        predict_kw=dict(chip_sz=256, stride=200, denoise_radius=32))
     logger.info(f"Task grid with priority scores... {task_grid_with_scores.to_json()}")
     logger.info(f"Prediction labels location... {pred_geojson_uri}")
 


### PR DESCRIPTION
## Overview

This PR tweaks a couple of params that control the prediction behavior in HITL jobs:
- higher denoise_radius discards noisy predictions and makes polygonization faster
- lower stride allows pixels to be visited multiple times, improving results

### Checklist

- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- [ ] New tables and queries have appropriate indices added
- [ ] Any new SQL strings have tests
- [ ] Any new endpoints have scope validation and are included in the integration test csv

### Demo

N/A

### Notes

N/A

## Testing Instructions

- Run as before
