### PR TITLE
Load params from file on S3 and fix bug with empty predictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - Added HITL postprocessing steps [#5651](https://github.com/raster-foundry/raster-foundry/pull/5651)
   - Added support of status update of HITL job and Intercom notifications [#5652](https://github.com/raster-foundry/raster-foundry/pull/)
   - Made sure that all machine-labeled tasks have "LABELED" status after hitl run [#5653](https://github.com/raster-foundry/raster-foundry/pull/5653)
+  - Made training and prediction configurable via a config file on S3 and fixed bug with empty predictions [#5655](https://github.com/raster-foundry/raster-foundry/pull/5655)
 
 ## [1.70.1] - 2022-04-25
 ### Changed

--- a/app-hitl/hitl/requirements.txt
+++ b/app-hitl/hitl/requirements.txt
@@ -1,2 +1,2 @@
-geopandas==0.9.0
+geopandas==0.10.2
 rtree==0.9.7

--- a/app-hitl/hitl/src/hitl/commands/run_hitl.py
+++ b/app-hitl/hitl/src/hitl/commands/run_hitl.py
@@ -73,7 +73,7 @@ def run_hitl(job_id: str):
         last_output_dir=last_output_dir,
         train_kw=dict(
             num_epochs=5, chip_sz=256, img_sz=256, external_model=True),
-        predict_kw=dict(chip_sz=256, stride=200, denoise_radius=32))
+        predict_kw=dict(chip_sz=256, stride=200, denoise_radius=16))
     logger.info(
         f"Task grid with priority scores... {task_grid_with_scores.to_json()}")
     logger.info(f"Prediction labels location... {pred_geojson_uri}")

--- a/app-hitl/hitl/src/hitl/commands/run_hitl.py
+++ b/app-hitl/hitl/src/hitl/commands/run_hitl.py
@@ -10,8 +10,13 @@ from ..utils.notify_intercom import notify
 from ..utils.persist_hitl_output import persist_hitl_output
 from ..utils.post_process import post_process
 
-from ..rv.active_learning import active_learning_step
-from ..rv.io import get_class_config
+from hitl.utils.get_hitl_input import get_input
+from hitl.utils.notify_intercom import notify
+from hitl.utils.persist_hitl_output import persist_hitl_output
+from hitl.utils.post_process import post_process
+
+from hitl.rv.active_learning import active_learning_step
+from hitl.rv.io import get_class_config
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/app-hitl/hitl/src/hitl/rv/active_learning.py
+++ b/app-hitl/hitl/src/hitl/rv/active_learning.py
@@ -5,11 +5,11 @@ import geopandas as gpd
 
 from rastervision.core.data import ClassConfig
 
-from .tasks import get_labeled_tasks
-from .data import make_scene
-from .train import train
-from .predict import predict
-from .score import compute_priority_scores
+from hitl.rv.tasks import get_labeled_tasks
+from hitl.rv.data import make_scene
+from hitl.rv.train import train
+from hitl.rv.predict import predict
+from hitl.rv.score import compute_priority_scores
 
 
 def active_learning_step(iter_num: int, class_config: ClassConfig,

--- a/app-hitl/hitl/src/hitl/rv/active_learning.py
+++ b/app-hitl/hitl/src/hitl/rv/active_learning.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import geopandas as gpd
 
 from rastervision.core.data import ClassConfig
+from rastervision.pipeline.file_system.utils import json_to_file
 
 from hitl.rv.tasks import get_labeled_tasks
 from hitl.rv.data import make_scene
@@ -12,11 +13,11 @@ from hitl.rv.predict import predict
 from hitl.rv.score import compute_priority_scores
 
 
-def active_learning_step(iter_num: int, class_config: ClassConfig,
-                         img_info: dict, labels_uri: str,
-                         task_grid: gpd.GeoDataFrame, output_dir: str,
-                         last_output_dir: str, train_kw: dict,
-                         predict_kw: dict) -> Tuple[gpd.GeoDataFrame, str]:
+def active_learning_step(
+        iter_num: int, class_config: ClassConfig, img_info: dict,
+        labels_uri: str, task_grid: gpd.GeoDataFrame, output_dir: str,
+        last_output_dir: str, train_kw: dict, predict_kw: dict,
+        score_kw: dict) -> Tuple[gpd.GeoDataFrame, str]:
     labeled_task_polygons = get_labeled_tasks(task_grid)
     scene = make_scene(
         scene_id=f'scene-iter-{iter_num}',
@@ -25,18 +26,32 @@ def active_learning_step(iter_num: int, class_config: ClassConfig,
         labels_uri=labels_uri,
         aoi_polygons=labeled_task_polygons)
 
+    # scale number of training chips linearly with number of labeled tasks
     nlabeled_tasks = len(labeled_task_polygons)
-    train_kw.update(dict(num_chips=(nlabeled_tasks * 20)))
+    chips_per_task = train_kw.get('chips_per_task', 20)
+    num_chips = nlabeled_tasks * chips_per_task
+    train_kw.update(dict(num_chips=num_chips))
+
+    # start from previous iteration's model weights
     if iter_num > 0 and last_output_dir is not None:
         prev_model_weights = join(last_output_dir, 'train', 'last-model.pth')
         train_kw.update(dict(init_weights=prev_model_weights))
+
+    # train
     train_dir = join(output_dir, 'train')
     learner = train(scene, class_config, output_dir=train_dir, **train_kw)
 
+    # predict
     pred_dir = join(output_dir, 'pred')
     labels, pred_geojson_uri = predict(
         learner, scene, class_config, output_dir=pred_dir, **predict_kw)
+
+    # score
     task_grid_with_scores = compute_priority_scores(task_grid, labels,
                                                     scene.raster_source)
+    if score_kw.get('save_task_grid_to_s3', False):
+        task_grid_geojson = task_grid_with_scores.to_json()
+        task_grid_path = join(pred_dir, 'task_grid_with_scores.json')
+        json_to_file(task_grid_geojson, task_grid_path)
 
     return task_grid_with_scores, pred_geojson_uri

--- a/app-hitl/hitl/src/hitl/rv/predict.py
+++ b/app-hitl/hitl/src/hitl/rv/predict.py
@@ -25,12 +25,12 @@ def predict(learner: SemanticSegmentationLearner,
         crs_transformer=scene.raster_source.get_crs_transformer(),
         class_config=class_config,
         smooth_output=True,
-        smooth_as_uint8=True,
+        smooth_as_uint8=kwargs.get('probabilities_as_uint8', True),
         vector_outputs=[
             PolygonVectorOutputConfig(
                 uri=vec_pred_uri,
                 class_id=1,
-                denoise=kwargs.get('denoise_radius'))
+                denoise=kwargs.get('denoise_radius', 8))
         ])
 
     base_tf, _ = learner.cfg.data.get_data_transforms()
@@ -43,7 +43,7 @@ def predict(learner: SemanticSegmentationLearner,
         raw_out=True,
         numpy_out=True,
         predict_kw=dict(out_shape=(chip_sz, chip_sz)),
-        dataloader_kw=dict(num_workers=0),
+        dataloader_kw=dict(num_workers=kwargs.get('num_workers', 4)),
         progress_bar=True)
 
     labels = SemanticSegmentationSmoothLabels.from_predictions(

--- a/app-hitl/hitl/src/hitl/utils/merge_labels.py
+++ b/app-hitl/hitl/src/hitl/utils/merge_labels.py
@@ -1,5 +1,8 @@
 import geopandas as gpd
 
 
-def merge_labels_with_task_grid(labels: gpd.GeoDataFrame, task_grid: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-    return gpd.overlay(labels, task_grid, how='intersection', keep_geom_type=True)
+def merge_labels_with_task_grid(
+        labels: gpd.GeoDataFrame,
+        task_grid: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    return gpd.overlay(
+        labels, task_grid, how='intersection', keep_geom_type=True)

--- a/app-hitl/hitl/src/hitl/utils/post_process.py
+++ b/app-hitl/hitl/src/hitl/utils/post_process.py
@@ -1,34 +1,39 @@
+from typing import Iterable, Tuple
 import json
 
 import geopandas as gpd
 
 from .merge_labels import merge_labels_with_task_grid
 
-def post_process(task_grid_with_scores, pred_geojson_uri, label_classes, job_id):
+
+def post_process(task_grid_with_scores: gpd.GeoDataFrame,
+                 pred_geojson_uri: str, label_classes: Iterable[str],
+                 job_id: str) -> Tuple[dict, dict]:
     updated_tasks_dict, merged_preds_gdf = process_tasks(
-        task_grid_with_scores,
-        pred_geojson_uri
-    )
-    labels_to_post_dict = process_labels(merged_preds_gdf, label_classes, job_id)
+        task_grid_with_scores, pred_geojson_uri)
+    labels_to_post_dict = process_labels(merged_preds_gdf, label_classes,
+                                         job_id)
     return updated_tasks_dict, labels_to_post_dict
 
-def process_tasks(task_grid_with_scores: gpd.GeoDataFrame, pred_geojson_uri: str):
+
+def process_tasks(task_grid_with_scores: gpd.GeoDataFrame,
+                  pred_geojson_uri: str) -> Tuple[dict, gpd.GeoDataFrame]:
     # keep task cells not of status "VALIDATED"
     tasks_to_update = task_grid_with_scores.loc[
-        task_grid_with_scores["status"] != "VALIDATED"
-    ]
+        task_grid_with_scores["status"] != "VALIDATED"]
     tasks_to_update.set_index('id', inplace=True)
     # read RV predictions
     preds_gdf = gpd.read_file(pred_geojson_uri)
     # join predictions to tasks
-    merged_preds_gdf = merge_labels_with_task_grid(
-        preds_gdf, tasks_to_update)
+    merged_preds_gdf = merge_labels_with_task_grid(preds_gdf, tasks_to_update)
     # update task status to "LABELED"
     tasks_to_update["status"] = "LABELED"
     updated_tasks_dict = json.loads(tasks_to_update.to_json())
     return updated_tasks_dict, merged_preds_gdf
 
-def process_labels(merged_preds_gdf, label_classes, job_id):
+
+def process_labels(merged_preds_gdf: gpd.GeoDataFrame,
+                   label_classes: Iterable[str], job_id: str) -> dict:
     dissolved = merged_preds_gdf.dissolve(by="taskId").reset_index()
     dissolved = dissolved[["taskId", "geometry"]]
     dissolved["description"] = None


### PR DESCRIPTION
## Overview

This PR
- Fixes https://github.com/azavea/foss4g-2022-hitl-groundwork-rastervision/issues/24
  - By updating `geopandas` from version `0.9.0` to `0.10.2`.
- Makes it so that training and prediction params are loaded from a file on S3.
  - File location: `s3://rasterfoundry-staging-hitl-output-us-east-1/config/params.json`.
  - This will allow us to modify these params without needing to make changes to this repo.
  - This is a temporary measure; eventually, we should let GW users set these params via the GW UI.

Other changes:
- Some parameter values have been changed. Most significantly:
  - `chips_per_task` has been increased from 20 to 40.
  - `fpn_channels` has been increased from 64 to 128 i.e. we're using a slightly bigger model.
  - We now start with ImageNet-pretrained weights in the first iteration. This should improve the quality of the results.
- `task_grid_with_scores` is now saved (if the param `predict.save_task_grid_to_s3` is `true`) to S3 in the same place as the prediction GeoJSON.
- Small code improvements.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~[ ] New tables and queries have appropriate indices added~
- ~[ ] Any new SQL strings have tests~
- ~[ ] Any new endpoints have scope validation and are included in the integration test csv~

### Demo

Improved results: predictions from the **first** iteration:
![image](https://user-images.githubusercontent.com/13014700/184957683-12155f48-0417-419e-98a4-4e5583411717.png)


### Notes

N/A

## Testing Instructions
- Test branch: `test/ah/fix-empty-pred`
- Logs from successful runs: 
  - [Round 1](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/jobStagingHitl$252Fdefault$252F2570e1bba69d43c8b035339f8cfebdad)
  - [Round 2](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Fbatch$252Fjob/log-events/jobStagingHitl$252Fdefault$252F767653de32584804869366a5cbfd9bcb)

Closes https://github.com/azavea/foss4g-2022-hitl-groundwork-rastervision/issues/24
