### PR TITLE
Improve task unlocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed and improved task unlocker [#5656](https://github.com/raster-foundry/raster-foundry/pull/5656)
 
 ## [1.71.0] - 2022-08-18
 ### Added

--- a/app-backend/db/src/main/scala/TaskDao.scala
+++ b/app-backend/db/src/main/scala/TaskDao.scala
@@ -763,7 +763,8 @@ object TaskDao extends Dao[Task] with ConnectionIOLogger {
               // very close to each other in time
               -instant.toEpochMilli
             })
-            .filter(stamp => stamp.toStatus != taskStatus)
+            .filter(stamp => stamp.toStatus != TaskStatus.LabelingInProgress)
+            .filter(stamp => stamp.toStatus != TaskStatus.ValidationInProgress)
           sorted.headOption map { secondMostRecentStamp =>
             val previousStatus = secondMostRecentStamp.toStatus
             val previousNote = secondMostRecentStamp.note


### PR DESCRIPTION
## Overview

This PR improves the task unlocker/regresser logic so that it takes care of the case when there are duplicated task action records.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) and grouped with similar changes if possible
- ~New tables and queries have appropriate indices added~
- [X] Any new SQL strings have tests
- ~Any new endpoints have scope validation and are included in the integration test csv~

### Notes

See investigation notes in https://github.com/raster-foundry/groundwork/issues/1104

## Testing Instructions

- CI should pass as a test is included to cover the fix of this case

Closes https://github.com/raster-foundry/groundwork/issues/1104
